### PR TITLE
chore(docs): generate better schema for `Compression` that leads to better docs output

### DIFF
--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -537,6 +537,26 @@ fn generate_variant_metadata(
     }
 }
 
+fn generate_variant_tag_metadata(
+    meta_ident: &Ident,
+    variant: &Variant<'_>,
+) -> proc_macro2::TokenStream {
+    // For enum variant tags, all we care about is shuttling the title/description of the variant
+    // itself along with the tag field to make downstream consumption and processing easier.
+    let maybe_title = get_metadata_title(meta_ident, variant.title());
+    let maybe_description = get_metadata_description(meta_ident, variant.description());
+
+    // We specifically use `()` as the type here because we need to generate the metadata for this
+    // variant, but there's no unique concrete type for a variant, only the type of the enum
+    // container it exists within. We also don't want to use the metadata of the enum container, as
+    // it might have values that would conflict with the metadata of this specific variant.
+    quote! {
+        let mut #meta_ident = ::vector_config::Metadata::<()>::default();
+        #maybe_title
+        #maybe_description
+    }
+}
+
 fn get_metadata_title(
     meta_ident: &Ident,
     title: Option<&String>,
@@ -700,18 +720,20 @@ fn generate_enum_struct_named_variant_schema(
     let mapped_fields = variant.fields().iter().map(generate_named_enum_field);
 
     quote! {
-        let mut properties = ::vector_config::indexmap::IndexMap::new();
-        let mut required = ::std::collections::BTreeSet::new();
+        {
+            let mut properties = ::vector_config::indexmap::IndexMap::new();
+            let mut required = ::std::collections::BTreeSet::new();
 
-        #(#mapped_fields)*
+            #(#mapped_fields)*
 
-        #post_fields
+            #post_fields
 
-        let mut subschema = ::vector_config::schema::generate_struct_schema(
-            properties,
-            required,
-            None
-        );
+            ::vector_config::schema::generate_struct_schema(
+                properties,
+                required,
+                None
+            )
+        }
     }
 }
 
@@ -721,14 +743,26 @@ fn generate_enum_newtype_struct_variant_schema(variant: &Variant<'_>) -> proc_ma
     // metadata or anything, since things like defaults can't travel from the enum
     // container to a specific variant anyways.
     let field = variant.fields().first().expect("must exist");
-    generate_struct_field(field)
-}
-
-fn generate_enum_unit_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStream {
-    let variant_name = variant.name();
+    let field_schema = generate_struct_field(field);
 
     quote! {
-        let mut subschema = ::vector_config::schema::generate_const_string_schema(#variant_name.to_string());
+        {
+            #field_schema
+            subschema
+        }
+    }
+}
+
+fn generate_enum_variant_tag_schema(variant: &Variant<'_>) -> proc_macro2::TokenStream {
+    let variant_name = variant.name();
+    let apply_variant_tag_metadata = generate_enum_variant_tag_apply_metadata(variant);
+
+    quote! {
+        {
+            let mut tag_subschema = ::vector_config::schema::generate_const_string_schema(#variant_name.to_string());
+            #apply_variant_tag_metadata
+            tag_subschema
+        }
     }
 }
 
@@ -742,9 +776,7 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
     //   Unit,
     // }
     let variant_name = variant.name();
-    let apply_variant_metadata = generate_enum_variant_apply_metadata(variant);
-
-    match variant.tagging() {
+    let variant_schema = match variant.tagging() {
         // The variant is represented "externally" by wrapping the contents of the variant as an
         // object pointed to by a property whose name is the name of the variant.
         //
@@ -766,7 +798,7 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
                 ),
                 Style::Tuple => panic!("tuple variants should be rejected during AST parsing"),
                 Style::Newtype => (true, generate_enum_newtype_struct_variant_schema(variant)),
-                Style::Unit => (false, generate_enum_unit_variant_schema(variant)),
+                Style::Unit => (false, generate_enum_variant_tag_schema(variant)),
             };
 
             // In external mode, we don't wrap the schema for unit variants, because they're
@@ -774,27 +806,11 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
             //
             // TODO: we can maybe reuse the existing struct schema gen stuff here, but we'd need
             // a way to force being required + customized metadata
-            let variant_schema = if wrapped {
-                quote! {
-                    #variant_schema
-
-                    let mut wrapper_properties = ::vector_config::indexmap::IndexMap::new();
-                    let mut wrapper_required = ::std::collections::BTreeSet::new();
-
-                    wrapper_properties.insert(#variant_name.to_string(), subschema);
-                    wrapper_required.insert(#variant_name.to_string());
-
-                    let mut subschema = ::vector_config::schema::generate_struct_schema(
-                        wrapper_properties,
-                        wrapper_required,
-                        None
-                    );
-                }
+            if wrapped {
+                generate_single_field_struct_schema(variant_name, variant_schema)
             } else {
                 variant_schema
-            };
-
-            generate_enum_variant_subschema(variant, variant_schema)
+            }
         }
         // The variant is represented "internally" by adding a new property to the contents of the
         // variant whose name is the value of `tag` and must match the name of the variant.
@@ -814,12 +830,10 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
 
                 // Just generate the tag field directly and pass it along to be included in the
                 // struct schema.
+                let tag_schema = generate_enum_variant_tag_schema(variant);
                 let tag_field = quote! {
                     {
-                        let mut subschema = ::vector_config::schema::generate_const_string_schema(#variant_name.to_string());
-                        #apply_variant_metadata
-
-                        if let Some(_) = properties.insert(#tag.to_string(), subschema) {
+                        if let Some(_) = properties.insert(#tag.to_string(), #tag_schema) {
                             panic!(#tag_already_contained);
                         }
 
@@ -828,10 +842,7 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
                         }
                     }
                 };
-                let variant_schema =
-                    generate_enum_struct_named_variant_schema(variant, Some(tag_field));
-
-                generate_enum_variant_subschema(variant, variant_schema)
+                generate_enum_struct_named_variant_schema(variant, Some(tag_field))
             }
             Style::Tuple => panic!("tuple variants should be rejected during AST parsing"),
             Style::Newtype => {
@@ -842,47 +853,27 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
                 // As such, we generate the schema for the single field, like we would normally do for a newtype
                 // variant, and then we follow the struct flattening logic where we layer on our tag field schema on the
                 // schema of the wrapped field... and since it has to be a struct or map to be valid for `serde`, that
-                // means it will also be an object schema in both cases, which means our flatteneing logic will be
+                // means it will also be an object schema in both cases, which means our flattening logic will be
                 // correct if the caller is doing The Right Thing (tm).
-                let wrapped_variant_schema = generate_enum_newtype_struct_variant_schema(variant);
+                let newtype_schema = generate_enum_newtype_struct_variant_schema(variant);
+                let tag_schema = generate_enum_variant_tag_schema(variant);
 
-                let variant_schema = quote! {
-                    let mut subschema = {
-                        let tag_schema = ::vector_config::schema::generate_internal_tagged_variant_schema(#tag.to_string(), #variant_name.to_string());
-                        let mut flattened_subschemas = ::std::vec::Vec::new();
-                        flattened_subschemas.push(tag_schema);
+                quote! {
+                    let tag_schema = ::vector_config::schema::generate_internal_tagged_variant_schema(#tag.to_string(), #tag_schema);
+                    let mut flattened_subschemas = ::std::vec::Vec::new();
+                    flattened_subschemas.push(tag_schema);
 
-                        #wrapped_variant_schema
+                    let mut newtype_schema = #newtype_schema;
+                    ::vector_config::schema::convert_to_flattened_schema(&mut newtype_schema, flattened_subschemas);
 
-                        ::vector_config::schema::convert_to_flattened_schema(&mut subschema, flattened_subschemas);
-
-                        subschema
-                    };
-                };
-
-                generate_enum_variant_subschema(variant, variant_schema)
+                    newtype_schema
+                }
             }
             Style::Unit => {
                 // Internally-tagged unit variants are basically just a play on externally-tagged
                 // struct variants.
-                let variant_schema = generate_enum_unit_variant_schema(variant);
-                let variant_schema = quote! {
-                    #variant_schema
-
-                    let mut wrapper_properties = ::vector_config::indexmap::IndexMap::new();
-                    let mut wrapper_required = ::std::collections::BTreeSet::new();
-
-                    wrapper_properties.insert(#tag.to_string(), subschema);
-                    wrapper_required.insert(#tag.to_string());
-
-                    let mut subschema = ::vector_config::schema::generate_struct_schema(
-                        wrapper_properties,
-                        wrapper_required,
-                        None
-                    );
-                };
-
-                generate_enum_variant_subschema(variant, variant_schema)
+                let variant_schema = generate_enum_variant_tag_schema(variant);
+                generate_single_field_struct_schema(tag, variant_schema)
             }
         },
         // The variant is represented "adjacent" to the content, such that the variant name is in a
@@ -903,43 +894,34 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
             // For struct-type variants, just generate their schema as normal, and we'll wrap it up
             // in a new object.  For unit variants, adjacent tagging is identical to internal
             // tagging, so we handle that one by hand.
-            let tag_schema = generate_enum_unit_variant_schema(variant);
-            let maybe_variant_schema = match variant.style() {
+            let tag_schema = generate_enum_variant_tag_schema(variant);
+            let maybe_content_schema = match variant.style() {
                 Style::Struct => Some(generate_enum_struct_named_variant_schema(variant, None)),
                 Style::Tuple => panic!("tuple variants should be rejected during AST parsing"),
                 Style::Newtype => Some(generate_enum_newtype_struct_variant_schema(variant)),
                 Style::Unit => None,
             }
-            .map(|schema| {
+            .map(|content_schema| {
                 quote! {
-                    #schema
-                    wrapper_properties.insert(#content.to_string(), subschema);
+                    wrapper_properties.insert(#content.to_string(), #content_schema);
                     wrapper_required.insert(#content.to_string());
                 }
             });
 
-            let apply_variant_metadata = generate_enum_variant_apply_metadata(variant);
-
             quote! {
-                {
-                    let mut wrapper_properties = ::vector_config::indexmap::IndexMap::new();
-                    let mut wrapper_required = ::std::collections::BTreeSet::new();
+                let mut wrapper_properties = ::vector_config::indexmap::IndexMap::new();
+                let mut wrapper_required = ::std::collections::BTreeSet::new();
 
-                    #tag_schema
-                    wrapper_properties.insert(#tag.to_string(), subschema);
-                    wrapper_required.insert(#tag.to_string());
+                wrapper_properties.insert(#tag.to_string(), #tag_schema);
+                wrapper_required.insert(#tag.to_string());
 
-                    #maybe_variant_schema
+                #maybe_content_schema
 
-                    let mut subschema = ::vector_config::schema::generate_struct_schema(
-                        wrapper_properties,
-                        wrapper_required,
-                        None
-                    );
-                    #apply_variant_metadata
-
-                    subschemas.push(subschema);
-                }
+                ::vector_config::schema::generate_struct_schema(
+                    wrapper_properties,
+                    wrapper_required,
+                    None
+                )
             }
         }
         Tagging::None => {
@@ -966,16 +948,35 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
             //
             // TODO: actually implement the aforementioned higher-level check
 
-            let variant_schema = match variant.style() {
+            match variant.style() {
                 Style::Struct => generate_enum_struct_named_variant_schema(variant, None),
                 Style::Tuple => panic!("tuple variants should be rejected during AST parsing"),
                 Style::Newtype => generate_enum_newtype_struct_variant_schema(variant),
-                Style::Unit => {
-                    quote! { let mut subschema = ::vector_config::schema::generate_null_schema(); }
-                }
-            };
+                Style::Unit => quote! { ::vector_config::schema::generate_null_schema() },
+            }
+        }
+    };
 
-            generate_enum_variant_subschema(variant, variant_schema)
+    generate_enum_variant_subschema(variant, variant_schema)
+}
+
+fn generate_single_field_struct_schema(
+    property_name: &str,
+    property_schema: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    quote! {
+        {
+            let mut wrapper_properties = ::vector_config::indexmap::IndexMap::new();
+            let mut wrapper_required = ::std::collections::BTreeSet::new();
+
+            wrapper_properties.insert(#property_name.to_string(), #property_schema);
+            wrapper_required.insert(#property_name.to_string());
+
+            ::vector_config::schema::generate_struct_schema(
+                wrapper_properties,
+                wrapper_required,
+                None
+            )
         }
     }
 }
@@ -990,6 +991,16 @@ fn generate_enum_variant_apply_metadata(variant: &Variant<'_>) -> proc_macro2::T
     }
 }
 
+fn generate_enum_variant_tag_apply_metadata(variant: &Variant<'_>) -> proc_macro2::TokenStream {
+    let variant_tag_metadata_ref = Ident::new("variant_tag_metadata", Span::call_site());
+    let variant_tag_metadata = generate_variant_tag_metadata(&variant_tag_metadata_ref, variant);
+
+    quote! {
+        #variant_tag_metadata
+        ::vector_config::schema::apply_metadata(&mut tag_subschema, #variant_tag_metadata_ref);
+    }
+}
+
 fn generate_enum_variant_subschema(
     variant: &Variant<'_>,
     variant_schema: proc_macro2::TokenStream,
@@ -998,7 +1009,7 @@ fn generate_enum_variant_subschema(
 
     quote! {
         {
-            #variant_schema
+            let mut subschema = { #variant_schema };
             #apply_variant_metadata
 
             subschemas.push(subschema);

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -390,9 +390,12 @@ pub fn generate_const_string_schema(value: String) -> SchemaObject {
     }
 }
 
-pub fn generate_internal_tagged_variant_schema(tag: String, value: String) -> SchemaObject {
+pub fn generate_internal_tagged_variant_schema(
+    tag: String,
+    value_schema: SchemaObject,
+) -> SchemaObject {
     let mut properties = IndexMap::new();
-    properties.insert(tag.clone(), generate_const_string_schema(value));
+    properties.insert(tag.clone(), value_schema);
 
     let mut required = BTreeSet::new();
     required.insert(tag);

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -22,12 +22,12 @@ pub enum Compression {
 
     /// [Gzip][gzip] compression.
     ///
-    /// [gzip]: https://en.wikipedia.org/wiki/Gzip
+    /// [gzip]: https://www.gzip.org/
     Gzip(CompressionLevel),
 
     /// [Zlib][zlib] compression.
     ///
-    /// [zlib]: https://en.wikipedia.org/wiki/Zlib
+    /// [zlib]: https://zlib.net/
     Zlib(CompressionLevel),
 }
 
@@ -240,12 +240,12 @@ impl Configurable for Compression {
         let gzip_string_subschema = generate_string_schema(
             "Gzip",
             Some("[Gzip][gzip] compression."),
-            "[gzip]: https://en.wikipedia.org/wiki/Gzip",
+            "[gzip]: https://www.gzip.org/",
         );
         let zlib_string_subschema = generate_string_schema(
             "Zlib",
             Some("[Zlib]][zlib] compression."),
-            "[zlib]: https://en.wikipedia.org/wiki/Zlib",
+            "[zlib]: https://zlib.net/",
         );
 
         let mut all_string_oneof_subschema = generate_one_of_schema(&[

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -4,9 +4,8 @@ use indexmap::IndexMap;
 use serde::{de, ser};
 use vector_config::{
     schema::{
-        apply_metadata, generate_const_string_schema, generate_enum_schema,
-        generate_internal_tagged_variant_schema, generate_one_of_schema, generate_struct_schema,
-        get_or_generate_schema,
+        apply_metadata, generate_const_string_schema, generate_enum_schema, generate_one_of_schema,
+        generate_struct_schema, get_or_generate_schema,
     },
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
     Configurable, GenerateError, Metadata,
@@ -170,31 +169,31 @@ impl ser::Serialize for Compression {
     {
         use ser::SerializeMap;
 
-        let mut map = serializer.serialize_map(None)?;
-        let mut level = None;
+        let default_level = CompressionLevel::const_default();
+
         match self {
-            Compression::None => map.serialize_entry("algorithm", "none")?,
+            Compression::None => serializer.serialize_str("none"),
             Compression::Gzip(gzip_level) => {
-                map.serialize_entry("algorithm", "gzip")?;
-                level = Some(*gzip_level);
+                if *gzip_level != default_level {
+                    let mut map = serializer.serialize_map(None)?;
+                    map.serialize_entry("algorithm", "gzip")?;
+                    map.serialize_entry("level", &gzip_level)?;
+                    map.end()
+                } else {
+                    serializer.serialize_str("gzip")
+                }
             }
             Compression::Zlib(zlib_level) => {
-                map.serialize_entry("algorithm", "zlib")?;
-                level = Some(*zlib_level);
+                if *zlib_level != default_level {
+                    let mut map = serializer.serialize_map(None)?;
+                    map.serialize_entry("algorithm", "zlib")?;
+                    map.serialize_entry("level", &zlib_level)?;
+                    map.end()
+                } else {
+                    serializer.serialize_str("zlib")
+                }
             }
         }
-
-        // If there's a level present, and it's _not_ the default compression level, then serialize it. We already
-        // handle deserializing as the default level when the level isn't explicitly specified (but `algorithm` is) so
-        // serializing the default would just clutter the serialized output.
-        if let Some(level) = level {
-            let default = CompressionLevel::const_default();
-            if level != default {
-                map.serialize_entry("level", &level)?
-            }
-        }
-
-        map.end()
     }
 }
 
@@ -206,7 +205,8 @@ impl Configurable for Compression {
 
     fn metadata() -> Metadata<Self> {
         let mut metadata = Metadata::default();
-        metadata.set_description("Compression configuration.");
+        metadata.set_title("Compression configuration.");
+        metadata.set_description("All compression algorithms use the default compression level unless otherwise specified.");
         metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
         metadata
     }
@@ -214,18 +214,60 @@ impl Configurable for Compression {
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         const ALGORITHM_NAME: &str = "algorithm";
         const LEVEL_NAME: &str = "level";
-        const NONE_NAME: &str = "none";
-        const GZIP_NAME: &str = "gzip";
-        const ZLIB_NAME: &str = "zlib";
+        const LOGICAL_NAME: &str = "logical_name";
+        const ENUM_TAGGING_MODE: &str = "docs::enum_tagging";
 
-        // First, we need to be able to handle all of the string-only variants.
-        let const_values = [NONE_NAME, GZIP_NAME, ZLIB_NAME]
-            .iter()
-            .map(|s| serde_json::Value::from(*s))
-            .collect();
+        let generate_string_schema = |logical_name: &str,
+                                      title: Option<&'static str>,
+                                      description: &'static str|
+         -> SchemaObject {
+            let mut const_schema = generate_const_string_schema(logical_name.to_lowercase());
+            let mut const_metadata = Metadata::<()>::with_description(description);
+            if let Some(title) = title {
+                const_metadata.set_title(title);
+            }
+            const_metadata.add_custom_attribute(CustomAttribute::kv(LOGICAL_NAME, logical_name));
+            apply_metadata(&mut const_schema, const_metadata);
+            const_schema
+        };
 
-        // Now we need to handle when the user specifies the full object-based notation in order to
-        // specify the compression level, and so on.
+        // First, we'll create the string-only subschemas for each algorithm, and wrap those up
+        // within a one-of schema.
+        let mut string_metadata = Metadata::<()>::with_description("Compression algorithm.");
+        string_metadata.add_custom_attribute(CustomAttribute::kv(ENUM_TAGGING_MODE, "external"));
+
+        let none_string_subschema = generate_string_schema("None", None, "No compression.");
+        let gzip_string_subschema = generate_string_schema(
+            "Gzip",
+            Some("[Gzip][gzip] compression."),
+            "[gzip]: https://en.wikipedia.org/wiki/Gzip",
+        );
+        let zlib_string_subschema = generate_string_schema(
+            "Zlib",
+            Some("[Zlib]][zlib] compression."),
+            "[zlib]: https://en.wikipedia.org/wiki/Zlib",
+        );
+
+        let mut all_string_oneof_subschema = generate_one_of_schema(&[
+            none_string_subschema,
+            gzip_string_subschema,
+            zlib_string_subschema,
+        ]);
+        apply_metadata(&mut all_string_oneof_subschema, string_metadata.clone());
+
+        // Next we'll create a full schema for the given algorithms.
+        //
+        // TODO: We're currently using all three algorithms in the enum subschema for `algorithm`,
+        // but in reality, `level` is never used when the algorithm is `none`. This is _currently_
+        // fine because the field is optional, and we don't use `deny_unknown_fields`, so if users
+        // specify it when the algorithm is `none`: no harm, no foul.
+        //
+        // However, it does lead to a suboptimal schema being generated, one that sort of implies it
+        // may have value when set, even if the algorithm is `none`. We do this because, otherwise,
+        // it's very hard to reconcile the resolved schemas during component documentation
+        // generation, where we need to be able to generate the right enum key/value pair for the
+        // `none` algorithm as part of the overall set of enum values declared for the `algorithm`
+        // field in the "full" schema version.
         let mut compression_level_metadata = Metadata::default();
         compression_level_metadata.set_transparent();
         let compression_level_schema =
@@ -234,59 +276,22 @@ impl Configurable for Compression {
         let mut required = BTreeSet::new();
         required.insert(ALGORITHM_NAME.to_string());
 
-        // Build the None schema.
-        let mut none_schema = generate_internal_tagged_variant_schema(
+        let mut properties = IndexMap::new();
+        properties.insert(
             ALGORITHM_NAME.to_string(),
-            NONE_NAME.to_string(),
+            all_string_oneof_subschema.clone(),
         );
-        let mut none_metadata = Metadata::<()>::with_description("No compression.");
-        none_metadata.add_custom_attribute(CustomAttribute::KeyValue {
-            key: "logical_name".to_string(),
-            value: "None".to_string(),
-        });
-        apply_metadata(&mut none_schema, none_metadata);
+        properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
 
-        // Build the Gzip schema.
-        let mut gzip_properties = IndexMap::new();
-        gzip_properties.insert(
-            ALGORITHM_NAME.to_string(),
-            generate_const_string_schema(GZIP_NAME.to_string()),
-        );
-        gzip_properties.insert(LEVEL_NAME.to_string(), compression_level_schema.clone());
+        let mut full_subschema = generate_struct_schema(properties, required, None);
+        let mut full_metadata = Metadata::<()>::with_description("");
+        full_metadata.add_custom_attribute(CustomAttribute::flag("docs::hidden"));
+        apply_metadata(&mut full_subschema, full_metadata);
 
-        let mut gzip_schema = generate_struct_schema(gzip_properties, required.clone(), None);
-        let mut gzip_metadata = Metadata::<()>::with_title("[Gzip][gzip] compression.");
-        gzip_metadata.set_description("[gzip]: https://en.wikipedia.org/wiki/Gzip");
-        gzip_metadata.add_custom_attribute(CustomAttribute::KeyValue {
-            key: "logical_name".to_string(),
-            value: "Gzip".to_string(),
-        });
-        apply_metadata(&mut gzip_schema, gzip_metadata);
-
-        // Build the Zlib schema.
-        let mut zlib_properties = IndexMap::new();
-        zlib_properties.insert(
-            ALGORITHM_NAME.to_string(),
-            generate_const_string_schema(ZLIB_NAME.to_string()),
-        );
-        zlib_properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
-
-        let mut zlib_schema = generate_struct_schema(zlib_properties, required, None);
-        let mut zlib_metadata = Metadata::<()>::with_title("[Zlib]][zlib] compression.");
-        zlib_metadata.set_description("[zlib]: https://en.wikipedia.org/wiki/Zlib");
-        zlib_metadata.add_custom_attribute(CustomAttribute::KeyValue {
-            key: "logical_name".to_string(),
-            value: "Zlib".to_string(),
-        });
-        apply_metadata(&mut zlib_schema, zlib_metadata);
-
+        // Finally, we zip both schemas together.
         Ok(generate_one_of_schema(&[
-            // Handle the condensed string form.
-            generate_enum_schema(const_values),
-            // Handle the expanded object form.
-            none_schema,
-            gzip_schema,
-            zlib_schema,
+            all_string_oneof_subschema,
+            full_subschema,
         ]))
     }
 }

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -140,10 +140,7 @@ impl Configurable for Concurrency {
         let mut none_schema = generate_const_string_schema("none".to_string());
         let mut none_metadata = Metadata::<()>::with_title("A fixed concurrency of 1.");
         none_metadata.set_description("Only one request can be outstanding at any given time.");
-        none_metadata.add_custom_attribute(CustomAttribute::KeyValue {
-            key: "logical_name".to_string(),
-            value: "None".to_string(),
-        });
+        none_metadata.add_custom_attribute(CustomAttribute::kv("logical_name", "None"));
         apply_metadata(&mut none_schema, none_metadata);
 
         let mut adaptive_schema = generate_const_string_schema("adaptive".to_string());
@@ -152,20 +149,15 @@ impl Configurable for Concurrency {
         );
         adaptive_metadata
             .set_description("[arc]: https://vector.dev/docs/about/under-the-hood/networking/arc/");
-        adaptive_metadata.add_custom_attribute(CustomAttribute::KeyValue {
-            key: "logical_name".to_string(),
-            value: "Adaptive".to_string(),
-        });
+        adaptive_metadata.add_custom_attribute(CustomAttribute::kv("logical_name", "Adaptive"));
         apply_metadata(&mut adaptive_schema, adaptive_metadata);
 
         let mut fixed_schema = generate_number_schema::<usize>();
         let mut fixed_metadata =
             Metadata::<()>::with_description("A fixed amount of concurrency will be allowed.");
         fixed_metadata.set_transparent();
-        fixed_metadata.add_custom_attribute(CustomAttribute::KeyValue {
-            key: "logical_name".to_string(),
-            value: "Fixed".to_string(),
-        });
+        fixed_metadata.add_custom_attribute(CustomAttribute::kv("docs::numeric_type", "uint"));
+        fixed_metadata.add_custom_attribute(CustomAttribute::kv("logical_name", "Fixed"));
         apply_metadata(&mut fixed_schema, fixed_metadata);
 
         Ok(generate_one_of_schema(&[

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -44,7 +44,7 @@ pub struct VectorConfig {
     ///
     /// If set to `true`, requests will be compressed with [`gzip`][gzip_docs].
     ///
-    /// [gzip_docs]: https://en.wikipedia.org/wiki/Gzip
+    /// [gzip_docs]: https://www.gzip.org/
     #[serde(default)]
     compression: bool,
 

--- a/website/cue/reference/components/sinks/base/apex.cue
+++ b/website/cue/reference/components/sinks/base/apex.cue
@@ -132,11 +132,11 @@ base: components: sinks: apex: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -109,27 +109,27 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	create_missing_group: {
@@ -326,11 +326,11 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -121,13 +121,13 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -109,27 +109,27 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	default_namespace: {
@@ -221,11 +221,11 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -121,13 +121,13 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -100,27 +100,27 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	encoding: {
@@ -291,11 +291,11 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -112,13 +112,13 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -112,13 +112,13 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -100,27 +100,27 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	encoding: {
@@ -300,11 +300,11 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -180,27 +180,27 @@ base: components: sinks: aws_s3: configuration: {
 		type: string: syntax: "literal"
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "gzip"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "gzip"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	content_encoding: {
@@ -519,11 +519,11 @@ base: components: sinks: aws_s3: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -192,13 +192,13 @@ base: components: sinks: aws_s3: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -276,11 +276,11 @@ base: components: sinks: aws_sqs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -40,13 +40,13 @@ base: components: sinks: axiom: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -28,27 +28,27 @@ base: components: sinks: axiom: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	dataset: {
@@ -130,11 +130,11 @@ base: components: sinks: axiom: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -114,13 +114,13 @@ base: components: sinks: azure_blob: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -102,27 +102,27 @@ base: components: sinks: azure_blob: configuration: {
 		type: string: syntax: "literal"
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "gzip"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "gzip"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	connection_string: {
@@ -328,11 +328,11 @@ base: components: sinks: azure_blob: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -187,11 +187,11 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -112,13 +112,13 @@ base: components: sinks: clickhouse: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -100,27 +100,27 @@ base: components: sinks: clickhouse: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "gzip"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "gzip"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	database: {
@@ -226,11 +226,11 @@ base: components: sinks: clickhouse: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -125,11 +125,11 @@ base: components: sinks: datadog_events: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -64,13 +64,13 @@ base: components: sinks: datadog_logs: configuration: {
 			gzip: """
 				[Gzip][gzip] compression.
 
-				[gzip]: https://en.wikipedia.org/wiki/Gzip
+				[gzip]: https://www.gzip.org/
 				"""
 			none: "No compression."
 			zlib: """
 				[Zlib]][zlib] compression.
 
-				[zlib]: https://en.wikipedia.org/wiki/Zlib
+				[zlib]: https://zlib.net/
 				"""
 		}
 	}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -54,24 +54,24 @@ base: components: sinks: datadog_logs: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: true
-					type: string: const: "zlib"
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
-			}
-			string: enum: ["none", "gzip", "zlib"]
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: enum: {
+			gzip: """
+				[Gzip][gzip] compression.
+
+				[gzip]: https://en.wikipedia.org/wiki/Gzip
+				"""
+			none: "No compression."
+			zlib: """
+				[Zlib]][zlib] compression.
+
+				[zlib]: https://en.wikipedia.org/wiki/Zlib
+				"""
 		}
 	}
 	default_api_key: {
@@ -196,11 +196,11 @@ base: components: sinks: datadog_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -161,11 +161,11 @@ base: components: sinks: datadog_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -54,24 +54,24 @@ base: components: sinks: datadog_traces: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: true
-					type: string: const: "zlib"
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
-			}
-			string: enum: ["none", "gzip", "zlib"]
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: enum: {
+			gzip: """
+				[Gzip][gzip] compression.
+
+				[gzip]: https://en.wikipedia.org/wiki/Gzip
+				"""
+			none: "No compression."
+			zlib: """
+				[Zlib]][zlib] compression.
+
+				[zlib]: https://en.wikipedia.org/wiki/Zlib
+				"""
 		}
 	}
 	default_api_key: {
@@ -160,11 +160,11 @@ base: components: sinks: datadog_traces: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -64,13 +64,13 @@ base: components: sinks: datadog_traces: configuration: {
 			gzip: """
 				[Gzip][gzip] compression.
 
-				[gzip]: https://en.wikipedia.org/wiki/Gzip
+				[gzip]: https://www.gzip.org/
 				"""
 			none: "No compression."
 			zlib: """
 				[Zlib]][zlib] compression.
 
-				[zlib]: https://en.wikipedia.org/wiki/Zlib
+				[zlib]: https://zlib.net/
 				"""
 		}
 	}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -171,27 +171,27 @@ base: components: sinks: elasticsearch: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	data_stream: {
@@ -461,11 +461,11 @@ base: components: sinks: elasticsearch: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -183,13 +183,13 @@ base: components: sinks: elasticsearch: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -270,11 +270,11 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -128,27 +128,27 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 		type: string: syntax: "literal"
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	credentials_path: {
@@ -425,11 +425,11 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -140,13 +140,13 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -249,11 +249,11 @@ base: components: sinks: gcp_pubsub: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -219,11 +219,11 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -174,11 +174,11 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -156,11 +156,11 @@ base: components: sinks: honeycomb: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -100,27 +100,27 @@ base: components: sinks: http: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	encoding: {
@@ -333,11 +333,11 @@ base: components: sinks: http: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -112,13 +112,13 @@ base: components: sinks: http: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -54,27 +54,27 @@ base: components: sinks: humio_logs: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	encoding: {
@@ -294,11 +294,11 @@ base: components: sinks: humio_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -66,13 +66,13 @@ base: components: sinks: humio_logs: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -54,27 +54,27 @@ base: components: sinks: humio_metrics: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	endpoint: {
@@ -220,11 +220,11 @@ base: components: sinks: humio_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -66,13 +66,13 @@ base: components: sinks: humio_metrics: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -212,11 +212,11 @@ base: components: sinks: influxdb_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -190,11 +190,11 @@ base: components: sinks: influxdb_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -181,11 +181,11 @@ base: components: sinks: logdna: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -108,7 +108,7 @@ base: components: sinks: loki: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				snappy: """
@@ -119,7 +119,7 @@ base: components: sinks: loki: configuration: {
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -102,27 +102,24 @@ base: components: sinks: loki: configuration: {
 	compression: {
 		description: "Compose with basic compression and Loki-specific compression."
 		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: true
-					type: string: const: "zlib"
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
-			}
-			string: {
-				default: "snappy"
-				enum: snappy: """
+		type: string: {
+			default: "snappy"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				snappy: """
 					Snappy compression.
 
 					This implies sending push requests as Protocol Buffers.
+					"""
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
 					"""
 			}
 		}
@@ -380,11 +377,11 @@ base: components: sinks: loki: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -68,27 +68,27 @@ base: components: sinks: new_relic: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "gzip"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "gzip"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	encoding: {
@@ -197,11 +197,11 @@ base: components: sinks: new_relic: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -80,13 +80,13 @@ base: components: sinks: new_relic: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -264,11 +264,11 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -259,11 +259,11 @@ base: components: sinks: redis: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -159,11 +159,11 @@ base: components: sinks: sematext_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -145,11 +145,11 @@ base: components: sinks: sematext_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -101,13 +101,13 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -89,27 +89,27 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	default_token: {
@@ -346,11 +346,11 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -90,13 +90,13 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 				gzip: """
 					[Gzip][gzip] compression.
 
-					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					[gzip]: https://www.gzip.org/
 					"""
 				none: "No compression."
 				zlib: """
 					[Zlib]][zlib] compression.
 
-					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					[zlib]: https://zlib.net/
 					"""
 			}
 		}

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -78,27 +78,27 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: {
-				algorithm: {
-					required: false
-					type: string: {
-						const:   "zlib"
-						default: "none"
-					}
-				}
-				level: {
-					description: "Compression level."
-					required:    false
-					type: {
-						string: enum: ["none", "fast", "best", "default"]
-						uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-					}
-				}
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://en.wikipedia.org/wiki/Gzip
+					"""
+				none: "No compression."
+				zlib: """
+					[Zlib]][zlib] compression.
+
+					[zlib]: https://en.wikipedia.org/wiki/Zlib
+					"""
 			}
-			string: enum: ["none", "gzip", "zlib"]
 		}
 	}
 	default_namespace: {
@@ -217,11 +217,11 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -68,7 +68,7 @@ base: components: sinks: vector: configuration: {
 
 			If set to `true`, requests will be compressed with [`gzip`][gzip_docs].
 
-			[gzip_docs]: https://en.wikipedia.org/wiki/Gzip
+			[gzip_docs]: https://www.gzip.org/
 			"""
 		required: false
 		type: bool: default: false

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -142,11 +142,11 @@ base: components: sinks: vector: configuration: {
 				description: "Configuration for outbound request concurrency."
 				required:    false
 				type: {
-					number: {}
 					string: {
 						const:   "adaptive"
 						default: "none"
 					}
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {


### PR DESCRIPTION
This PR is an incremental chunk of work needed before moving over sources and sinks to the new machine-generated Cue documentation.

In particular, this PR is mostly focused on:

- simplifying the `Configurable` codegen logic for enums
- generating a better schema for `Compression` so we can generate appropriate docs for it

In terms of the enum-related changed, this is mostly cleanup around duplicated/overlapping logic, spurred by needing to make some small changes to carry enum variant data around in the resulting JSON Schema differently. The enum variant data stuff will be needed to properly generate valid Cue output for some particular components where the complexity of their schema forces us to use fallback schema resolution, essentially, where we're past the point of extracting all the necessary title, such as title/description.

As far as the `Compression` stuff, basically: we generate a simpler output schema that is still _technically_ valid compared to how we (de)serialize `Compression`, but in a way that lets us generate documentation output for it that is at parity with what is currently in the documentation for compression-related configuration settings.

We've also had to tweak how we serialize `Compression` somewhat to control what the resulting default value is, in the configuration schema output, so that we can use it in the machine-generated documentation. Essentially, instead of serializing `<algorithm X using default compression level>` as `{ algorithm: X }`, we serialize it as `"algorithm_x"` -- mirroring the string deserialization path -- as we actually generate the _documentation_ for `Compression` to reflect the string deserialization path.

Again, `Compression` can still be deserialized in the same ways as before, but we've tweaked serialization, and the resulting configuration schema, to make it easier to generate documentation that matches what we have. In the future, hopefully we can figure out a better solution either around generating more robust documentation for these complex schemas, or refactor the spots where we do these complex deserialization schemes, or something else... who knows.