### PR TITLE
docs: Update config example due to breaking changes

### DIFF
--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -44,15 +44,15 @@ source = '''
 # Sample the data to save on cost
 [transforms.apache_sampler]
 inputs = ["apache_parser"]
-type   = "sampler"
+type   = "sample"
 rate   = 2                    # only keep 50% (1/`rate`)
 
 # Send structured data to a short-term storage
 [sinks.es_cluster]
-inputs = ["apache_sampler"]             # only take sampled data
-type   = "elasticsearch"
-host   = "http://79.12.221.222:9200"    # local or external host
-index  = "vector-%Y-%m-%d"              # daily indices
+inputs     = ["apache_sampler"]             # only take sampled data
+type       = "elasticsearch"
+endpoints  = ["http://79.12.221.222:9200"]  # local or external host
+bulk.index = "vector-%Y-%m-%d"              # daily indices
 
 # Send structured data to a cost-effective long-term storage
 [sinks.s3_archives]
@@ -79,7 +79,7 @@ sources:
       - /var/log/apache2/*.log
     ignore_older: 86400
 transforms:
-  remap:
+  apache_parser:
     inputs:
       - apache_logs
     type: remap
@@ -88,15 +88,16 @@ transforms:
   apache_sampler:
     inputs:
       - apache_parser
-    type: sampler
+    type: sample
     rate: 50
 sinks:
   es_cluster:
     inputs:
       - apache_sampler
     type: elasticsearch
-    host: 'http://79.12.221.222:9200'
-    index: vector-%Y-%m-%d
+    endpoints: ['http://79.12.221.222:9200']
+    bulk:
+      index: vector-%Y-%m-%d
   s3_archives:
     inputs:
       - apache_parser
@@ -129,7 +130,7 @@ sinks:
     }
   },
   "transforms": {
-    "remap": {
+    "apache_parser": {
       "inputs": [
         "apache_logs"
       ],
@@ -140,7 +141,7 @@ sinks:
       "inputs": [
         "apache_parser"
       ],
-      "type": "sampler",
+      "type": "sample",
       "rate": 50
     }
   },
@@ -150,8 +151,10 @@ sinks:
         "apache_sampler"
       ],
       "type": "elasticsearch",
-      "host": "http://79.12.221.222:9200",
-      "index": "vector-%Y-%m-%d"
+      "endpoints": ["http://79.12.221.222:9200"],
+      "bulk": {
+        "index": "vector-%Y-%m-%d"
+      }
     },
     "s3_archives": {
       "inputs": [
@@ -348,10 +351,10 @@ rate   = 2                    # only keep 50% (1/`rate`)
 
 ```toml
 # Send structured data to a short-term storage
-inputs = ["apache_sampler"]             # only take sampled data
-type   = "elasticsearch"
-host   = "http://79.12.221.222:9200"    # local or external host
-index  = "vector-%Y-%m-%d"              # daily indices
+inputs     = ["apache_sampler"]             # only take sampled data
+type       = "elasticsearch"
+endpoints  = ["http://79.12.221.222:9200"]  # local or external host
+bulk.index = "vector-%Y-%m-%d"              # daily indices
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

A user pointed out the config at the Configuration index had become out of date, which has happened before.

This PR updates all of the examples to be valid as of `v0.26.0`, verified with `vector validate --no-environment` locally.

Longer term we could look into templating a known-good file from our `config/` directory that is validated during CI rather than keep an isolated config directly in the MD.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
