### PR TITLE
docs: fix examples of automatic namespacing

### DIFF
--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -310,8 +310,6 @@ data_dir = "/var/lib/vector"
 [api]
 enabled = false
 # address = "127.0.0.1:8686"
-
-'''
 ```
 
 {{< /tab >}}
@@ -343,7 +341,6 @@ source = '''
 inputs = ["apache_parser"]
 type   = "sample"
 rate   = 2                    # only keep 50% (1/`rate`)
-. = parse_apache_log(.message)
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
