### PR TITLE
chore(releasing): Do not publish nightlies to CloudSmith

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -660,6 +660,8 @@ jobs:
 
   publish-cloudsmith:
     name: Publish to Cloudsmith
+    # We only publish to CloudSmith for versioned releases, not nightlies.
+    if: ${{ inputs.mode == 'Release' }}
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata


### PR DESCRIPTION
Nightlies are failing to publish recently with:

>  Reason given: A package with architecture ‘amd64’,  distro version ‘any-distro/any-version’,
> name ‘vector’ and package type ‘Binary’ already exists in the ‘timber/vector-nightly:
> vector@0.27.0-1 (vB0T33WkKxiK)’ package. “Replace Package w/ Same Version” was enabled for your
> package. - This package should be deleted.

While looking at this I noticed that the download counts for the nightly packages are typically 0 or
single digits though so I’m inclined to just delete the repository. I don’t think we should really
be overwriting the packages if we did support it, anyway. We should be separately versioning with
a date-based scheme like we do for the docker images.

The nightly packages _are_ available via packages.timber.io.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
