### PR TITLE
chore(vrl): remove panic from filter fn

### DIFF
--- a/lib/vrl/stdlib/src/filter.rs
+++ b/lib/vrl/stdlib/src/filter.rs
@@ -35,7 +35,7 @@ where
             .collect::<Result<Vec<_>>>()
             .map(Into::into),
 
-        _ => unreachable!("function requires collection types as input"),
+        _ => Err("function requires collection types as input".into()),
     }
 }
 

--- a/lib/vrl/tests/tests/functions/filter/invalid_input.vrl
+++ b/lib/vrl/tests/tests/functions/filter/invalid_input.vrl
@@ -1,0 +1,5 @@
+# result: ["foo", "bar", null]
+
+. = ["foo", "bar", null]
+filter(.) -> |_index, value| { is_string(value) }
+.


### PR DESCRIPTION
The REPL would panic with the input
```coffee
 . = ["foo", "bar", null]
["foo", "bar", null]

$ type_def(.)
{ "array": { "0": { "bytes": true }, "1": { "bytes": true }, "2": { "null": true } } }

$ filter(.) -> |_index, value| { is_string(value) }

thread 'main' panicked at 'internal error: entered unreachable code: function requires collection types as input', lib/vrl/stdlib/src/filter.rs:38:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is because the REPL has a "validator" that runs while a user is typing input and it runs the program with a "dummy" event (null) to see if it's valid. The `filter` function will panic with a `null` input.

This changes the function to return an error rather than panic.
A test was also added, although it would not fail previously since this "validator" doesn't run in the test environment.