### PR TITLE
enhancement(aws config): Make IMDS client configurable for AWS authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,7 +452,8 @@ aws-core = [
   "dep:aws-smithy-client",
   "dep:aws-smithy-http",
   "dep:aws-smithy-http-tower",
-  "dep:aws-smithy-types"
+  "dep:aws-smithy-types",
+  "dep:serde_with",
 ]
 
 # Anything that requires Protocol Buffers.

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -284,8 +284,6 @@ mod tests {
         )
         .unwrap();
 
-        const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-        const READ_TIMEOUT: Duration = Duration::from_secs(10);
         match config.auth {
             AwsAuthentication::Role {
                 assume_role,

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -26,12 +26,14 @@ pub struct ImdsAuthentication {
 
     /// Connect timeout for IMDS.
     #[serde(default = "default_timeout")]
+    #[serde(rename = "connect_timeout_seconds")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[derivative(Default(value = "default_timeout()"))]
     connect_timeout: Duration,
 
     /// Read timeout for IMDS.
     #[serde(default = "default_timeout")]
+    #[serde(rename = "read_timeout_seconds")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[derivative(Default(value = "default_timeout()"))]
     read_timeout: Duration,
@@ -182,6 +184,9 @@ mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
 
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
     #[derive(Serialize, Deserialize, Clone, Debug)]
     struct ComponentConfig {
         assume_role: Option<String>,
@@ -222,21 +227,19 @@ mod tests {
     fn parsing_default_with_imds_client() {
         let config = toml::from_str::<ComponentConfig>(
             r#"
-            auth.imds.max_attempts = 10
-            auth.imds.connect_timeout = 60
-            auth.imds.read_timeout = 30
+            auth.imds.max_attempts = 5
+            auth.imds.connect_timeout_seconds = 30
+            auth.imds.read_timeout_seconds = 10
         "#,
         )
         .unwrap();
 
-        const CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
-        const READ_TIMEOUT: Duration = Duration::from_secs(30);
         assert!(matches!(
             config.auth,
             AwsAuthentication::Default {
                 load_timeout_secs: None,
                 imds: ImdsAuthentication {
-                    max_attempts: 10,
+                    max_attempts: 5,
                     connect_timeout: CONNECT_TIMEOUT,
                     read_timeout: READ_TIMEOUT,
                 },
@@ -275,8 +278,8 @@ mod tests {
             r#"
             auth.assume_role = "root"
             auth.imds.max_attempts = 5
-            auth.imds.connect_timeout = 30
-            auth.imds.read_timeout = 10
+            auth.imds.connect_timeout_seconds = 30
+            auth.imds.read_timeout_seconds = 10
         "#,
         )
         .unwrap();

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
 
-pub use auth::AwsAuthentication;
+pub use auth::{AwsAuthentication, ImdsAuthentication};
 use aws_config::meta::region::ProvideRegion;
 use aws_sigv4::http_request::{SignableRequest, SigningSettings};
 use aws_sigv4::SigningParams;

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -10,7 +10,7 @@ use tokio::time::{sleep, Duration};
 
 use super::{config::KinesisFirehoseClientBuilder, *};
 use crate::{
-    aws::{create_client, AwsAuthentication, RegionOrEndpoint},
+    aws::{create_client, AwsAuthentication, ImdsAuthentication, RegionOrEndpoint},
     config::{ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         elasticsearch::{BulkConfig, ElasticsearchAuth, ElasticsearchCommon, ElasticsearchConfig},
@@ -73,7 +73,7 @@ async fn firehose_put_records() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
-            imds: None,
+            imds: ImdsAuthentication::default(),
         })),
         endpoints: vec![elasticsearch_address()],
         bulk: Some(BulkConfig {

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -73,6 +73,7 @@ async fn firehose_put_records() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
+            imds: None,
         })),
         endpoints: vec![elasticsearch_address()],
         bulk: Some(BulkConfig {

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -14,7 +14,7 @@ use vector_core::{
 
 use super::{config::DATA_STREAM_TIMESTAMP_KEY, *};
 use crate::{
-    aws::RegionOrEndpoint,
+    aws::{ImdsAuthentication, RegionOrEndpoint},
     config::{ProxyConfig, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
@@ -252,7 +252,7 @@ async fn auto_version_aws() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
-            imds: None,
+            imds: ImdsAuthentication::default(),
         })),
         endpoints: vec![aws_server()],
         aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -332,7 +332,7 @@ async fn insert_events_on_aws() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
-                imds: None,
+                imds: ImdsAuthentication::default(),
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -353,7 +353,7 @@ async fn insert_events_on_aws_with_compression() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
-                imds: None,
+                imds: ImdsAuthentication::default(),
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -252,6 +252,7 @@ async fn auto_version_aws() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
+            imds: None,
         })),
         endpoints: vec![aws_server()],
         aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -331,6 +332,7 @@ async fn insert_events_on_aws() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
+                imds: None,
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -351,6 +353,7 @@ async fn insert_events_on_aws_with_compression() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
+                imds: None,
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -60,6 +60,33 @@ components: _aws: {
 							examples: [30]
 						}
 					}
+					imds: {
+						description: "Configuration for authenticating with AWS through IMDS."
+						required:    false
+						type: object: options: {
+							connect_timeout: {
+								description: "Connect timeout for IMDS, in seconds."
+								required:    true
+								type: uint: {
+									examples: [30]
+								}
+							}
+							max_attempts: {
+								description: "Number of IMDS retries for fetching tokens & metadata"
+								required:    true
+								type: uint: {
+									examples: [5]
+								}
+							}
+							read_timeout: {
+								description: "Read timeout for IMDS, in seconds."
+								required:    true
+								type: uint: {
+									examples: [15]
+								}
+							}
+						}
+					}
 					profile: {
 						category:    "Auth"
 						common:      false

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -63,26 +63,28 @@ components: _aws: {
 					imds: {
 						description: "Configuration for authenticating with AWS through IMDS."
 						required:    false
-						type: object: options: {
-							connect_timeout: {
-								description: "Connect timeout for IMDS, in seconds."
-								required:    true
-								type: uint: {
-									examples: [30]
+						type: object: {
+							options: {
+								connect_timeout: {
+									description: "Connect timeout for IMDS."
+									required:    false
+									type: uint: {
+										default: 1
+										unit:    "seconds"
+									}
 								}
-							}
-							max_attempts: {
-								description: "Number of IMDS retries for fetching tokens & metadata"
-								required:    true
-								type: uint: {
-									examples: [5]
+								max_attempts: {
+									description: "Number of IMDS retries for fetching tokens and metadata."
+									required:    false
+									type: uint: default: 4
 								}
-							}
-							read_timeout: {
-								description: "Read timeout for IMDS, in seconds."
-								required:    true
-								type: uint: {
-									examples: [15]
+								read_timeout: {
+									description: "Read timeout for IMDS."
+									required:    false
+									type: uint: {
+										default: 1
+										unit:    "seconds"
+									}
 								}
 							}
 						}

--- a/website/cue/reference/components/aws.cue
+++ b/website/cue/reference/components/aws.cue
@@ -65,7 +65,7 @@ components: _aws: {
 						required:    false
 						type: object: {
 							options: {
-								connect_timeout: {
+								connect_timeout_seconds: {
 									description: "Connect timeout for IMDS."
 									required:    false
 									type: uint: {
@@ -78,7 +78,7 @@ components: _aws: {
 									required:    false
 									type: uint: default: 4
 								}
-								read_timeout: {
+								read_timeout_seconds: {
 									description: "Read timeout for IMDS."
 									required:    false
 									type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -60,12 +60,12 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -78,7 +78,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -58,21 +58,34 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -55,6 +55,27 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -55,6 +55,27 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -58,21 +58,34 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -60,12 +60,12 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -78,7 +78,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -49,21 +49,34 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -51,12 +51,12 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -69,7 +69,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -46,6 +46,27 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -51,12 +51,12 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -69,7 +69,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -46,6 +46,27 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -49,21 +49,34 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -122,12 +122,12 @@ base: components: sinks: aws_s3: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -140,7 +140,7 @@ base: components: sinks: aws_s3: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -117,6 +117,27 @@ base: components: sinks: aws_s3: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -120,21 +120,34 @@ base: components: sinks: aws_s3: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -60,12 +60,12 @@ base: components: sinks: aws_sqs: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -78,7 +78,7 @@ base: components: sinks: aws_sqs: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -58,21 +58,34 @@ base: components: sinks: aws_sqs: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -55,6 +55,27 @@ base: components: sinks: aws_sqs: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -68,19 +68,25 @@ base: components: sinks: elasticsearch: configuration: {
 				required:      false
 				type: object: options: {
 					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+						description: "Connect timeout for IMDS."
+						required:    false
+						type: uint: {
+							default: 1
+							unit:    "seconds"
+						}
 					}
 					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
+						description: "Number of IMDS retries for fetching tokens and metadata."
+						required:    false
+						type: uint: default: 4
 					}
 					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+						description: "Read timeout for IMDS."
+						required:    false
+						type: uint: {
+							default: 1
+							unit:    "seconds"
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -67,7 +67,7 @@ base: components: sinks: elasticsearch: configuration: {
 				relevant_when: "strategy = \"aws\""
 				required:      false
 				type: object: options: {
-					connect_timeout: {
+					connect_timeout_seconds: {
 						description: "Connect timeout for IMDS."
 						required:    false
 						type: uint: {
@@ -80,7 +80,7 @@ base: components: sinks: elasticsearch: configuration: {
 						required:    false
 						type: uint: default: 4
 					}
-					read_timeout: {
+					read_timeout_seconds: {
 						description: "Read timeout for IMDS."
 						required:    false
 						type: uint: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -62,6 +62,28 @@ base: components: sinks: elasticsearch: configuration: {
 				required:      true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description:   "Configuration for authenticating with AWS through IMDS."
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description:   "Timeout for successfully loading any credentials, in seconds."
 				relevant_when: "strategy = \"aws\""

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -49,6 +49,28 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				required:      true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description:   "Configuration for authenticating with AWS through IMDS."
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description:   "Timeout for successfully loading any credentials, in seconds."
 				relevant_when: "strategy = \"aws\""

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -55,19 +55,25 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				required:      false
 				type: object: options: {
 					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+						description: "Connect timeout for IMDS."
+						required:    false
+						type: uint: {
+							default: 1
+							unit:    "seconds"
+						}
 					}
 					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
+						description: "Number of IMDS retries for fetching tokens and metadata."
+						required:    false
+						type: uint: default: 4
 					}
 					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+						description: "Read timeout for IMDS."
+						required:    false
+						type: uint: {
+							default: 1
+							unit:    "seconds"
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -54,7 +54,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				relevant_when: "strategy = \"aws\""
 				required:      false
 				type: object: options: {
-					connect_timeout: {
+					connect_timeout_seconds: {
 						description: "Connect timeout for IMDS."
 						required:    false
 						type: uint: {
@@ -67,7 +67,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 						required:    false
 						type: uint: default: 4
 					}
-					read_timeout: {
+					read_timeout_seconds: {
 						description: "Read timeout for IMDS."
 						required:    false
 						type: uint: {

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -36,7 +36,11 @@ base: components: sources: aws_s3: configuration: {
 		required:    false
 		type: object: {
 			default: {
-				imds:              null
+				imds: {
+					connect_timeout: 1
+					max_attempts:    4
+					read_timeout:    1
+				}
 				load_timeout_secs: null
 			}
 			options: {
@@ -58,21 +62,34 @@ base: components: sources: aws_s3: configuration: {
 				imds: {
 					description: "Configuration for authenticating with AWS through IMDS."
 					required:    false
-					type: object: options: {
-						connect_timeout: {
-							description: "Connect timeout for IMDS, in seconds."
-							required:    true
-							type: uint: {}
+					type: object: {
+						default: {
+							connect_timeout: 1
+							max_attempts:    4
+							read_timeout:    1
 						}
-						max_attempts: {
-							description: "Number of IMDS retries for fetching tokens & metadata"
-							required:    true
-							type: uint: {}
-						}
-						read_timeout: {
-							description: "Read timeout for IMDS, in seconds."
-							required:    true
-							type: uint: {}
+						options: {
+							connect_timeout: {
+								description: "Connect timeout for IMDS."
+								required:    false
+								type: uint: {
+									default: 1
+									unit:    "seconds"
+								}
+							}
+							max_attempts: {
+								description: "Number of IMDS retries for fetching tokens and metadata."
+								required:    false
+								type: uint: default: 4
+							}
+							read_timeout: {
+								description: "Read timeout for IMDS."
+								required:    false
+								type: uint: {
+									default: 1
+									unit:    "seconds"
+								}
+							}
 						}
 					}
 				}

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -35,7 +35,10 @@ base: components: sources: aws_s3: configuration: {
 		description: "Configuration of the authentication strategy for interacting with AWS services."
 		required:    false
 		type: object: {
-			default: load_timeout_secs: null
+			default: {
+				imds:              null
+				load_timeout_secs: null
+			}
 			options: {
 				access_key_id: {
 					description: "The AWS access key ID."
@@ -51,6 +54,27 @@ base: components: sources: aws_s3: configuration: {
 					description: "Path to the credentials file."
 					required:    true
 					type: string: syntax: "literal"
+				}
+				imds: {
+					description: "Configuration for authenticating with AWS through IMDS."
+					required:    false
+					type: object: options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS, in seconds."
+							required:    true
+							type: uint: {}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens & metadata"
+							required:    true
+							type: uint: {}
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS, in seconds."
+							required:    true
+							type: uint: {}
+						}
+					}
 				}
 				load_timeout_secs: {
 					description: "Timeout for successfully loading any credentials, in seconds."

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -37,9 +37,9 @@ base: components: sources: aws_s3: configuration: {
 		type: object: {
 			default: {
 				imds: {
-					connect_timeout: 1
-					max_attempts:    4
-					read_timeout:    1
+					connect_timeout_seconds: 1
+					max_attempts:            4
+					read_timeout_seconds:    1
 				}
 				load_timeout_secs: null
 			}
@@ -64,12 +64,12 @@ base: components: sources: aws_s3: configuration: {
 					required:    false
 					type: object: {
 						default: {
-							connect_timeout: 1
-							max_attempts:    4
-							read_timeout:    1
+							connect_timeout_seconds: 1
+							max_attempts:            4
+							read_timeout_seconds:    1
 						}
 						options: {
-							connect_timeout: {
+							connect_timeout_seconds: {
 								description: "Connect timeout for IMDS."
 								required:    false
 								type: uint: {
@@ -82,7 +82,7 @@ base: components: sources: aws_s3: configuration: {
 								required:    false
 								type: uint: default: 4
 							}
-							read_timeout: {
+							read_timeout_seconds: {
 								description: "Read timeout for IMDS."
 								required:    false
 								type: uint: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -41,21 +41,34 @@ base: components: sources: aws_sqs: configuration: {
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false
-				type: object: options: {
-					connect_timeout: {
-						description: "Connect timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+				type: object: {
+					default: {
+						connect_timeout: 1
+						max_attempts:    4
+						read_timeout:    1
 					}
-					max_attempts: {
-						description: "Number of IMDS retries for fetching tokens & metadata"
-						required:    true
-						type: uint: {}
-					}
-					read_timeout: {
-						description: "Read timeout for IMDS, in seconds."
-						required:    true
-						type: uint: {}
+					options: {
+						connect_timeout: {
+							description: "Connect timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
+						max_attempts: {
+							description: "Number of IMDS retries for fetching tokens and metadata."
+							required:    false
+							type: uint: default: 4
+						}
+						read_timeout: {
+							description: "Read timeout for IMDS."
+							required:    false
+							type: uint: {
+								default: 1
+								unit:    "seconds"
+							}
+						}
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -38,6 +38,27 @@ base: components: sources: aws_sqs: configuration: {
 				required:    true
 				type: string: syntax: "literal"
 			}
+			imds: {
+				description: "Configuration for authenticating with AWS through IMDS."
+				required:    false
+				type: object: options: {
+					connect_timeout: {
+						description: "Connect timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+					max_attempts: {
+						description: "Number of IMDS retries for fetching tokens & metadata"
+						required:    true
+						type: uint: {}
+					}
+					read_timeout: {
+						description: "Read timeout for IMDS, in seconds."
+						required:    true
+						type: uint: {}
+					}
+				}
+			}
 			load_timeout_secs: {
 				description: "Timeout for successfully loading any credentials, in seconds."
 				required:    false

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -43,12 +43,12 @@ base: components: sources: aws_sqs: configuration: {
 				required:    false
 				type: object: {
 					default: {
-						connect_timeout: 1
-						max_attempts:    4
-						read_timeout:    1
+						connect_timeout_seconds: 1
+						max_attempts:            4
+						read_timeout_seconds:    1
 					}
 					options: {
-						connect_timeout: {
+						connect_timeout_seconds: {
 							description: "Connect timeout for IMDS."
 							required:    false
 							type: uint: {
@@ -61,7 +61,7 @@ base: components: sources: aws_sqs: configuration: {
 							required:    false
 							type: uint: default: 4
 						}
-						read_timeout: {
+						read_timeout_seconds: {
 							description: "Read timeout for IMDS."
 							required:    false
 							type: uint: {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Problem
If AWS authentication through IMDS request fail, Vector drops the event. This allows users to configure retry attempts & timeout by exposing parameters that is already built-in to the `aws-sdk-rust` library.

## Solution
New configurable IMDS client parameters for authenticating with AWS
```rust
pub struct ImdsAuthentication {
    /// Number of IMDS retries for fetching tokens & metadata
    max_attempts: u32,

    /// Connect timeout for IMDS, in seconds.
    connect_timeout: Duration,

    /// Read timeout for IMDS, in seconds.
    read_timeout: Duration,
}
```

**Example**
```toml
auth.imds.max_attempts = 5
auth.imds.connect_timeout_seconds = 10
auth.imds.read_timeout_seconds = 10
```

## Checklist
- [x] Code change
- [x] Generate component docs
- [x] Update `website/cue/reference/components/aws.cue`
- [x] Unit tests

Resolves #14671