### PR TITLE
fix(vrl): add positive value guard for limit in split fn

### DIFF
--- a/lib/vrl/stdlib/src/split.rs
+++ b/lib/vrl/stdlib/src/split.rs
@@ -3,7 +3,11 @@ use vrl::prelude::*;
 
 fn split(value: Value, limit: Value, pattern: Value) -> Resolved {
     let string = value.try_bytes_utf8_lossy()?;
-    let limit = limit.try_integer()? as usize;
+    let limit = match limit.try_integer()? {
+        x if x < 0 => return Err(format!("limit requires a positive integer got {}", x).into()),
+        x => x as usize,
+    };
+
     match pattern {
         Value::Regex(pattern) => Ok(pattern
             .splitn(string.as_ref(), limit as usize)
@@ -169,6 +173,33 @@ mod test {
              want: Ok(value!(["˙ƃuᴉɹʇs", "ƃuol", "ɐ", "sᴉ", "sᴉɥ┴"])),
              tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
          }
+
+        limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: 2
+            ],
+            want: Ok(value!(["This", "is a long string."])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        over_length_limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: 2000
+            ],
+            want: Ok(value!(["This", "is", "a", "long", "string."])),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
+
+        negative_limit {
+            args: func_args![value: "This is a long string.",
+                             pattern: " ",
+                             limit: -1
+            ],
+            want: Err("limit requires a positive integer got -1"),
+            tdef: TypeDef::array(Collection::from_unknown(Kind::bytes())),
+        }
 
     ];
 }


### PR DESCRIPTION
Fixes https://github.com/vectordotdev/vector/issues/13891

- adds guard for limit to be a positive value
- adds unit tests around limit values

Before:
```
$ split("This is a long string", " ",  -10000)
["This", "is", "a", "long", "string"]
```

After:
```
$ split("This is a long string", " ",  -10000)
function call error for "split" at (0:44): limit requires a positive integer got -10000
```
