### PR TITLE
feat(ci): Update Regression Detector lading, smp versions

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -41,8 +41,8 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.6.3"
-          export LADING_VERSION="0.11.2"
+          export SMP_CRATE_VERSION="0.6.5"
+          export LADING_VERSION="0.11.3"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"
           echo "replicas: ${REPLICAS}"
@@ -350,6 +350,7 @@ jobs:
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
             --wait \
             --wait-delay-seconds 60 \
+            --wait-timeout-minutes 90 \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Handle cancellation if necessary


### PR DESCRIPTION
This commit upgrades `smp` to 0.6.5 and lading to 0.11.3. The most salient changes are these:

* `smp` now supports a 'timeout' flag, allowing analysis to proceed even if not all regression replicates are finished
* `lading` fixes an OTEL gRPC bug, which impacted some versions of datadog-agent and Vector

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
