### PR TITLE
feat(aws_cloudwatch_metrics sink): Allow up to 30 metric dimensions

### DIFF
--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -196,9 +196,9 @@ impl RetryLogic for CloudWatchMetricsRetryLogic {
 }
 
 fn tags_to_dimensions(tags: &MetricTags) -> Vec<Dimension> {
-    // according to the API, up to 10 dimensions per metric can be provided
+    // according to the API, up to 30 dimensions per metric can be provided
     tags.iter_single()
-        .take(10)
+        .take(30)
         .map(|(k, v)| Dimension::builder().name(k).value(v).build())
         .collect()
 }

--- a/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
@@ -1,0 +1,29 @@
+---
+date: "2023-01-17"
+title: "0.27 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.27.0"
+authors: ["spencergilbert"]
+release: "0.26.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.26.0 release includes **breaking changes**:
+
+1. [Increase in possible tags sent with `aws_cloudwatch_metrics` sink](#increase-possible-tags)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Breaking changes
+
+#### Increase in possible tags sent with `aws_cloudwatch_metrics` sink {#increase-possible-tags}
+
+Before this release, the `aws_cloudwatch_metrics` sink would only send up to ten
+tags to AWS as metric dimensions. This limit has been increased to thirty based
+on the [current documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Metric.html).
+
+While not strictly a breaking change, this could increase the cardinality of your
+metrics by including previously dropped tags.

--- a/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
@@ -26,3 +26,17 @@ tags to AWS as metric dimensions. This limit has been increased to thirty based
 on the [current documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Metric.html).
 
 This could increase the cardinality of your metrics by including previously dropped tags.
+The following VRL program would allow you to drop tags when there are more than ten,
+maintaining the original behavior.
+
+```coffeescript
+count = 10
+tags = {}
+for_each(object!(.tags)) ->|key, value| {
+    if count > 0 {
+        count = count - 1
+        tags = set!(tags, [key], value)
+    }
+}
+.tags = tags
+```

--- a/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
@@ -3,13 +3,13 @@ date: "2023-01-17"
 title: "0.27 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.27.0"
 authors: ["spencergilbert"]
-release: "0.26.0"
+release: "0.27.0"
 hide_on_release_notes: false
 badges:
   type: breaking change
 ---
 
-Vector's 0.26.0 release includes **breaking changes**:
+Vector's 0.27.0 release includes **breaking changes**:
 
 1. [Increase in possible tags sent with `aws_cloudwatch_metrics` sink](#increase-possible-tags)
 

--- a/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
@@ -9,7 +9,7 @@ badges:
   type: breaking change
 ---
 
-Vector's 0.27.0 release includes **breaking changes**:
+Vector's 0.27.0 release includes **potentially impactful changes**:
 
 1. [Increase in possible tags sent with `aws_cloudwatch_metrics` sink](#increase-possible-tags)
 
@@ -17,7 +17,7 @@ We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
 
-### Breaking changes
+### Potentially impactful changes
 
 #### Increase in possible tags sent with `aws_cloudwatch_metrics` sink {#increase-possible-tags}
 
@@ -25,5 +25,4 @@ Before this release, the `aws_cloudwatch_metrics` sink would only send up to ten
 tags to AWS as metric dimensions. This limit has been increased to thirty based
 on the [current documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Metric.html).
 
-While not strictly a breaking change, this could increase the cardinality of your
-metrics by including previously dropped tags.
+This could increase the cardinality of your metrics by including previously dropped tags.


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Noticed as part of #15522, the Metric API now is documented with a limit of 30 dimensions

https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Metric.html

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
