### PR TITLE
bug(core): fix bug in component validation runner

### DIFF
--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -447,9 +447,10 @@ fn spawn_component_topology(
             let pieces = topology::build_or_log_errors(&config, &config_diff, HashMap::new())
                 .await
                 .unwrap();
-            let (topology, mut crash_rx) = topology::start_validated(config, config_diff, pieces)
-                .await
-                .unwrap();
+            let (topology, (_, mut crash_rx)) =
+                topology::start_validated(config, config_diff, pieces)
+                    .await
+                    .unwrap();
 
             debug!("Component topology built and spawned.");
             topology_started.mark_as_done();


### PR DESCRIPTION
This PR fixes a bug introduced with the merging of #15140 where the latest `master` was not merged in prior to merging the RFC PR, such that the code in the RFC PR was out of sync with the changes made in #15087.