### PR TITLE
enhancement(performance): try out mimalloc without secure mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,12 +2985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,6 +4316,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d1c67deb83e6b75fa4fe3309e09cfeade12e7721d95322af500d3814ea60c9"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4661,6 +4665,15 @@ dependencies = [
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2374e2999959a7b583e1811a1ddbf1d3a4b9496eceb9746f1192a59d871eca"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -7764,27 +7777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.2+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8857,6 +8849,7 @@ dependencies = [
  "md-5",
  "metrics",
  "metrics-tracing-context",
+ "mimalloc",
  "mlua",
  "mongodb",
  "nats",
@@ -8912,7 +8905,6 @@ dependencies = [
  "strip-ansi-escapes",
  "syslog",
  "tempfile",
- "tikv-jemallocator",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",
@@ -9377,11 +9369,11 @@ dependencies = [
  "enrichment",
  "glob",
  "lookup",
+ "mimalloc",
  "prettydiff",
  "regex",
  "serde",
  "serde_json",
- "tikv-jemallocator",
  "tracing-subscriber 0.3.16",
  "value",
  "vector-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,7 @@ logfmt = { version = "0.0.2", default-features = false, optional = true }
 lru = { version = "0.8.1", default-features = false, optional = true }
 maxminddb = { version = "0.23.0", default-features = false, optional = true }
 md-5 = { version = "0.10", default-features = false, optional = true }
+mimalloc = { version = "0.1.32", default-features = false, optional = true }
 mongodb = { version = "2.3.1", default-features = false, features = ["tokio-runtime"], optional = true }
 nats = { version = "0.23.1", default-features = false, optional = true }
 nkeys = { version = "0.2.0", default-features = false, optional = true }
@@ -316,7 +317,6 @@ socket2 = { version = "0.4.7", default-features = false }
 stream-cancel = { version = "0.8.1", default-features = false }
 strip-ansi-escapes = { version = "0.1.1", default-features = false }
 syslog = { version = "6.0.1", default-features = false, optional = true }
-tikv-jemallocator = { version = "0.5.0", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.7", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = {version = "0.18.0", default-features = false, features = ["connect"], optional = true}
 toml = { version = "0.5.9", default-features = false }
@@ -387,7 +387,7 @@ tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-ut
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise"]
+default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "mimalloc", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise"]
 # Default features for *-pc-windows-msvc
@@ -416,7 +416,7 @@ target-powerpc64le-unknown-linux-gnu = ["api", "api-client", "enrichment-tables"
 target-powerpc-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "vrl-cli", "enterprise"]
 
 # Enables features that work only on systems providing `cfg(unix)`
-unix = ["tikv-jemallocator", "allocation-tracing"]
+unix = ["allocation-tracing"]
 allocation-tracing = []
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,

--- a/lib/vrl/tests/Cargo.toml
+++ b/lib/vrl/tests/Cargo.toml
@@ -19,14 +19,12 @@ chrono = "0.4"
 chrono-tz = "0.8"
 clap = { version = "4.0.29", features = ["derive"] }
 glob = "0.3"
+mimalloc = { version = "0.1.32", default-features = false }
 prettydiff = "0.6"
 regex = "1"
 serde = "1"
 serde_json = "1"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["fmt"] }
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.5.0" }
 
 [features]
 default = []

--- a/lib/vrl/tests/src/main.rs
+++ b/lib/vrl/tests/src/main.rs
@@ -21,9 +21,8 @@ use vrl::{
 };
 use vrl_tests::{docs, Test};
 
-#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[derive(Parser, Debug)]
 #[clap(name = "VRL Tests", about = "Vector Remap Language Tests")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,14 @@ extern crate tracing;
 #[macro_use]
 extern crate derivative;
 
-#[cfg(all(feature = "tikv-jemallocator", not(feature = "allocation-tracing")))]
+#[cfg(not(feature = "allocation-tracing"))]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(all(feature = "tikv-jemallocator", feature = "allocation-tracing"))]
+#[cfg(feature = "allocation-tracing")]
 #[global_allocator]
-static ALLOC: self::internal_telemetry::allocations::Allocator<tikv_jemallocator::Jemalloc> =
-    self::internal_telemetry::allocations::get_grouped_tracing_allocator(
-        tikv_jemallocator::Jemalloc,
-    );
+static ALLOC: self::internal_telemetry::allocations::Allocator<mimalloc::MiMalloc> =
+    self::internal_telemetry::allocations::get_grouped_tracing_allocator(mimalloc::MiMalloc);
 
 #[allow(unreachable_pub)]
 pub mod internal_telemetry;


### PR DESCRIPTION
In #10444, we tried switching to the `mimalloc` allocator which showed a disappointing and large regression compared to `jemalloc`. As pointed out in #14991, the `mimalloc` crate builds `mimalloc` in "secure mode" by default -- encrypted heap allocations, guard pages, etc etc -- and that it might make a difference to test without secure mode.

I tend to agree, and our regression testing infrastructure is a bit more reliably and accurate now, so it felt worth trying out.