### PR TITLE
chore(prometheus_scrape source,  prometheus_remote_write source): allow duplicate labels

### DIFF
--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -375,7 +375,7 @@ impl MetricGroupSet {
     fn insert_sample(
         &mut self,
         name: &str,
-        labels: &Vec<(String, String)>,
+        labels: &[(String, String)],
         sample: proto::Sample,
     ) -> Result<(), ParserError> {
         let (_, basename, group) = self.get_group(name);
@@ -383,7 +383,7 @@ impl MetricGroupSet {
             basename.len(),
             Metric {
                 name: name.into(),
-                labels: labels.clone(),
+                labels: labels.to_vec(),
                 value: sample.value,
                 timestamp: Some(sample.timestamp),
             },
@@ -479,9 +479,9 @@ mod test {
     macro_rules! labels {
         () => { Vec::new() };
         ( $( $name:ident => $value:literal ),* ) => {{
-            let mut result = Vec::<(String, String)>::new();
-            $( result.push((stringify!($name).into(), $value.to_string())); )*
-            result
+            vec![
+                $( (stringify!($name).into(), $value.to_string()), )*
+            ]
         }};
     }
 

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -532,6 +532,12 @@ impl<const N: usize> From<[(String, String); N]> for MetricTags {
     }
 }
 
+impl From<Vec<(String, String)>> for MetricTags {
+    fn from(tags: Vec<(String, String)>) -> Self {
+        tags.into_iter().collect()
+    }
+}
+
 impl FromIterator<(String, String)> for MetricTags {
     fn from_iter<T: IntoIterator<Item = (String, String)>>(tags: T) -> Self {
         let mut result = Self::default();


### PR DESCRIPTION
Closes #15516 
Closes #15517 
Epic #15419 

This updates the Prometheus parser, for both the Prometheus scrape and Prometheus Remote Write sources, to allow them to handle duplicate labels. This is a potentially controversial change since according to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115):

> Label names MUST be unique within a LabelSet.

So theoretically we should never need to handle duplicate labels. However, in practice this could potentially occur, so we may decide to prefer to retain this information and allow the downstream component to decide how to handle the duplicates.