### PR TITLE
chore(prometheus_exporter sink): allow duplicate tags

### DIFF
--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -273,8 +273,8 @@ impl StringCollector {
             (None, Some(tag)) => write!(result, "{{{}}}", Self::format_tag(tag.0, &tag.1)),
             (Some(tags), ref tag) => {
                 let mut parts = tags
-                    .iter_single()
-                    .map(|(key, value)| Self::format_tag(key, value))
+                    .iter_all()
+                    .filter_map(|(key, value)| value.map(|value| Self::format_tag(key, value)))
                     .collect::<Vec<_>>();
 
                 if let Some((key, value)) = tag {


### PR DESCRIPTION
Closes #15581 
Epic #15420 

The sink version of #15579. This is a controversial PR that allows us to export duplicate tags. Previously if there were multiple values for a tag, it would take the first value, now the duplicate tags are exported. 

According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115):

> Label names MUST be unique within a LabelSet.

So it is perfectly reasonable for us to decide not to merge this PR.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
