### PR TITLE
fix(http_server source, heroku_logs source): use configured `LogNamespace` in `DecoderConfig` construction

### DIFF
--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -153,14 +153,10 @@ impl GenerateConfig for LogplexConfig {
 #[async_trait::async_trait]
 impl SourceConfig for LogplexConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let decoder = DecodingConfig::new(
-            self.framing.clone(),
-            self.decoding.clone(),
-            LogNamespace::Legacy,
-        )
-        .build();
-
         let log_namespace = cx.log_namespace(self.log_namespace);
+
+        let decoder =
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
 
         let source = LogplexSource {
             query_parameters: self.query_parameters.clone(),

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -211,7 +211,11 @@ impl SimpleHttpConfig {
             (framing, decoding)
         };
 
-        Ok(DecodingConfig::new(framing, decoding, LogNamespace::Legacy))
+        Ok(DecodingConfig::new(
+            framing,
+            decoding,
+            self.log_namespace.unwrap_or(false).into(),
+        ))
     }
 }
 


### PR DESCRIPTION
Same reasoning behind #15510