### PR TITLE
chore(prometheus_scrape source, prometheus_remote_write source, prometheus_exporter sink, prometheus_remote_write sink): add tests for duplicate labels

### DIFF
--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -938,4 +938,31 @@ mod tests {
             "#}
         );
     }
+
+    /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
+    /// > Label names MUST be unique within a LabelSet.
+    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
+    /// we only pushlish the last tag in the list.
+    #[test]
+    fn encodes_duplicate_tags() {
+        let tags = metric_tags!(
+            "code" => "200",
+            "code" => "success",
+        );
+        let metric = Metric::new(
+            "something".to_owned(),
+            MetricKind::Absolute,
+            MetricValue::Counter { value: 1.0 },
+        )
+        .with_tags(Some(tags));
+        let encoded = encode_one::<StringCollector>(None, &[], &[], &metric);
+        assert_eq!(
+            encoded,
+            indoc! {r#"
+                # HELP something something
+                # TYPE something counter
+                something{code="success"} 1
+            "#}
+        );
+    }
 }

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -941,8 +941,8 @@ mod tests {
 
     /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
     /// > Label names MUST be unique within a LabelSet.
-    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
-    /// we only pushlish the last tag in the list.
+    /// Prometheus itself will reject the metric with an error. Largely to remain backward compatible with older versions of Vector,
+    /// we only publish the last tag in the list.
     #[test]
     fn encodes_duplicate_tags() {
         let tags = metric_tags!(

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -602,7 +602,10 @@ mod tests {
         finalization::{BatchNotifier, BatchStatus},
         sensitive_string::SensitiveString,
     };
-    use vector_core::{event::StatisticKind, metric_tags, samples};
+    use vector_core::{
+        event::{MetricTags, StatisticKind},
+        metric_tags, samples,
+    };
 
     use super::*;
     use crate::{
@@ -828,6 +831,35 @@ mod tests {
         );
     }
 
+    /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
+    /// > Label names MUST be unique within a LabelSet.
+    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
+    /// we only pushlish the last tag in the list.
+    #[tokio::test]
+    async fn prometheus_duplicate_labels() {
+        let (name, event) = create_metric_with_tags(
+            None,
+            MetricValue::Gauge { value: 123.4 },
+            Some(metric_tags!("code" => "200", "code" => "success")),
+        );
+        let events = vec![event];
+
+        let response_result = export_and_fetch_with_auth(None, None, events, false).await;
+
+        assert!(response_result.is_ok());
+
+        let body = response_result.expect("Cannot extract body from the response");
+
+        assert!(body.contains(&format!(
+            indoc! {r#"
+               # HELP {name} {name}
+               # TYPE {name} gauge
+               {name}{{code="success"}} 123.4
+            "# },
+            name = name
+        )));
+    }
+
     async fn export_and_fetch(
         tls_config: Option<TlsEnableableConfig>,
         mut events: Vec<Event>,
@@ -1000,9 +1032,17 @@ mod tests {
     }
 
     pub(self) fn create_metric(name: Option<String>, value: MetricValue) -> (String, Event) {
+        create_metric_with_tags(name, value, Some(metric_tags!("some_tag" => "some_value")))
+    }
+
+    pub(self) fn create_metric_with_tags(
+        name: Option<String>,
+        value: MetricValue,
+        tags: Option<MetricTags>,
+    ) -> (String, Event) {
         let name = name.unwrap_or_else(|| format!("vector_set_{}", random_string(16)));
         let event = Metric::new(name.clone(), MetricKind::Incremental, value)
-            .with_tags(Some(metric_tags!("some_tag" => "some_value")))
+            .with_tags(tags)
             .into();
         (name, event)
     }

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -833,8 +833,8 @@ mod tests {
 
     /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
     /// > Label names MUST be unique within a LabelSet.
-    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
-    /// we only pushlish the last tag in the list.
+    /// Prometheus itself will reject the metric with an error. Largely to remain backward compatible with older versions of Vector,
+    /// we only publish the last tag in the list.
     #[tokio::test]
     async fn prometheus_duplicate_labels() {
         let (name, event) = create_metric_with_tags(

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -267,7 +267,7 @@ mod test {
 
     /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
     /// > Label names MUST be unique within a LabelSet.
-    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
+    /// Prometheus itself will reject the metric with an error. Largely to remain backward compatible with older versions of Vector,
     /// we accept the metric, but take the last label in the list.
     #[tokio::test]
     async fn receives_metrics_duplicate_labels() {

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -139,7 +139,10 @@ impl HttpSource for RemoteWriteSource {
 #[cfg(test)]
 mod test {
     use chrono::{SubsecRound as _, Utc};
-    use vector_core::event::{EventStatus, Metric, MetricKind, MetricValue};
+    use vector_core::{
+        event::{EventStatus, Metric, MetricKind, MetricValue},
+        metric_tags,
+    };
 
     use super::*;
     use crate::{
@@ -260,6 +263,77 @@ mod test {
             .with_timestamp(Some(timestamp()))
             .into(),
         ]
+    }
+
+    /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
+    /// > Label names MUST be unique within a LabelSet.
+    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
+    /// we accept the metric, but take the last label in the list.
+    #[tokio::test]
+    async fn receives_metrics_duplicate_labels() {
+        assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+            let address = test_util::next_addr();
+            let (tx, rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+
+            let source = PrometheusRemoteWriteConfig {
+                address,
+                auth: None,
+                tls: None,
+                acknowledgements: SourceAcknowledgementsConfig::default(),
+            };
+            let source = source
+                .build(SourceContext::new_test(tx, None))
+                .await
+                .unwrap();
+            tokio::spawn(source);
+            wait_for_tcp(address).await;
+
+            let sink = RemoteWriteConfig {
+                endpoint: format!("http://localhost:{}/", address.port()),
+                ..Default::default()
+            };
+            let (sink, _) = sink
+                .build(SinkContext::new_test())
+                .await
+                .expect("Error building config.");
+
+            let timestamp = Utc::now().trunc_subsecs(3);
+
+            let events = vec![Metric::new(
+                "gauge_2",
+                MetricKind::Absolute,
+                MetricValue::Gauge { value: 41.0 },
+            )
+            .with_timestamp(Some(timestamp))
+            .with_tags(Some(metric_tags! {
+                "code" => "200".to_string(),
+                "code" => "success".to_string(),
+            }))
+            .into()];
+
+            let expected = vec![Metric::new(
+                "gauge_2",
+                MetricKind::Absolute,
+                MetricValue::Gauge { value: 41.0 },
+            )
+            .with_timestamp(Some(timestamp))
+            .with_tags(Some(metric_tags! {
+                "code" => "success".to_string(),
+            }))
+            .into()];
+
+            let output = test_util::spawn_collect_ready(
+                async move {
+                    sink.run_events(events).await.unwrap();
+                },
+                rx,
+                1,
+            )
+            .await;
+
+            vector_common::assert_event_data_eq!(expected, output);
+        })
+        .await;
     }
 }
 

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -468,7 +468,7 @@ mod test {
 
         let dummy_endpoint = warp::path!("metrics").map(|| {
             r#"
-                    metric_label{code="200", code="success"} 100 1612411516789
+                    metric_label{code="200",code="success"} 100 1612411516789
             "#
         });
 

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -458,6 +458,62 @@ mod test {
         }
     }
 
+    /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
+    /// > Label names MUST be unique within a LabelSet.
+    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
+    /// we accept the metric, but take the last label in the list.
+    #[tokio::test]
+    async fn test_prometheus_duplicate_tags() {
+        let in_addr = next_addr();
+
+        let dummy_endpoint = warp::path!("metrics").map(|| {
+            r#"
+                    metric_label{code="200", code="success"} 100 1612411516789
+            "#
+        });
+
+        tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+        wait_for_tcp(in_addr).await;
+
+        let config = PrometheusScrapeConfig {
+            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            scrape_interval_secs: 1,
+            instance_tag: Some("instance".to_string()),
+            endpoint_tag: Some("endpoint".to_string()),
+            honor_labels: true,
+            query: HashMap::new(),
+            auth: None,
+            tls: None,
+        };
+
+        let events = run_and_assert_source_compliance(
+            config,
+            Duration::from_secs(3),
+            &HTTP_PULL_SOURCE_TAGS,
+        )
+        .await;
+        assert!(!events.is_empty());
+
+        let metrics: Vec<vector_core::event::Metric> = events
+            .into_iter()
+            .map(|event| event.into_metric())
+            .collect();
+        let metric = &metrics[0];
+
+        assert_eq!(metric.name(), "metric_label");
+
+        let code_tag = metric
+            .tags()
+            .unwrap()
+            .iter_all()
+            .filter(|(name, _value)| *name == "code")
+            .map(|(_name, value)| value)
+            .collect::<Vec<_>>();
+
+        assert_eq!(1, code_tag.len());
+        assert_eq!("success", code_tag[0].unwrap());
+    }
+
     #[tokio::test]
     async fn test_prometheus_request_query() {
         let in_addr = next_addr();

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -460,7 +460,7 @@ mod test {
 
     /// According to the [spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md?plain=1#L115)
     /// > Label names MUST be unique within a LabelSet.
-    /// Prometheus itself will reject the metrict with an error. Largely to remain backward compatible with older versions of Vecotr,
+    /// Prometheus itself will reject the metric with an error. Largely to remain backward compatible with older versions of Vector,
     /// we accept the metric, but take the last label in the list.
     #[tokio::test]
     async fn test_prometheus_duplicate_tags() {


### PR DESCRIPTION
Closes #15581
Closes #15582 
Epic #15420 

Closes #15516 
Closes #15517 
Epic #15419 

Prometheus considers duplicate tags to be invalid. Sending a metric to Prometheus with a duplicate tag results in an error. 
Vector doesn't reject the error, but will take the last tag sent. Largely to maintain backward compatibility with current versions of Vector we have decided to maintain this behaviour. This PR adds some tests to codify it.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
