### PR TITLE
docs(prometheus_scrape source, prometheus_remote_write source, prometheus_exporter sink, prometheus_remote_write sink): document handling of duplicate tags

### DIFF
--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -380,5 +380,13 @@ components: sinks: prometheus_exporter: {
 				frequently.
 				"""
 		}
+
+		multi_value_tags: {
+			title: "Multivalue Tags"
+			body: """
+				Duplicate tag name are invalid within Prometheus and Prometheus will reject a metric with duplicate
+				tags. When sending a tag with multiple values, Vector will send the last value specified.
+				"""
+		}
 	}
 }

--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -384,7 +384,7 @@ components: sinks: prometheus_exporter: {
 		multi_value_tags: {
 			title: "Multivalue Tags"
 			body: """
-				Duplicate tag name are invalid within Prometheus and Prometheus will reject a metric with duplicate
+				Duplicate tag names are invalid within Prometheus and Prometheus will reject a metric with duplicate
 				tags. When sending a tag with multiple values, Vector will send the last value specified.
 				"""
 		}

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -193,6 +193,16 @@ components: sinks: prometheus_remote_write: {
 		traces: false
 	}
 
+	how_it_works: {
+		multi_value_tags: {
+			title: "Multivalue Tags"
+			body: """
+				Duplicate tag name are invalid within Prometheus and Prometheus will reject a metric with duplicate
+				tags. When sending a tag with multiple values, Vector will send the last value specified.
+				"""
+		}
+	}
+
 	telemetry: metrics: {
 		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -197,7 +197,7 @@ components: sinks: prometheus_remote_write: {
 		multi_value_tags: {
 			title: "Multivalue Tags"
 			body: """
-				Duplicate tag name are invalid within Prometheus and Prometheus will reject a metric with duplicate
+				Duplicate tag names are invalid within Prometheus and Prometheus will reject a metric with duplicate
 				tags. When sending a tag with multiple values, Vector will send the last value specified.
 				"""
 		}

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -81,6 +81,14 @@ components: sources: prometheus_remote_write: {
 				are emitted as gauges.
 				"""
 		}
+
+		duplicate_tags: {
+			title: "Duplicate Tags"
+			body: """
+				Duplicate tag names are invalid within Prometheus. Prometheus itself will reject a metric with duplicate
+				tags. Vector will accept the metric, but will only take the last tag specified.
+				"""
+		}
 	}
 
 	telemetry: metrics: {

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -150,6 +150,16 @@ components: sources: prometheus_scrape: {
 		}}
 	}
 
+	how_it_works: {
+		duplicate_tags: {
+			title: "Duplicate Tags"
+			body: """
+				Duplicate tag names are invalid within Prometheus. Prometheus itself will reject a metric with duplicate
+				tags. Vector will accept the metric, but will only take the last tag specified.
+				"""
+		}
+	}
+
 	output: metrics: {
 		_extra_tags: {
 			"instance": {


### PR DESCRIPTION
Ref #15581
Ref #15582 
Epic #15420 

Ref #15516 
Ref #15517 
Epic #15419 

This documents our handling of duplicate tags for Prometheus.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
