### PR TITLE
feat(file_descriptor source,stdin source): Use OptionalValuePath for host_key

### DIFF
--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -5,6 +5,7 @@ use std::os::unix::io::FromRawFd;
 use super::{outputs, FileDescriptorConfig};
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use indoc::indoc;
+use lookup::lookup_v2::OptionalValuePath;
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::LogNamespace;
 
@@ -28,7 +29,7 @@ pub struct FileDescriptorSourceConfig {
     /// The value will be the current hostname for wherever Vector is running.
     ///
     /// By default, the [global `host_key` option](https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key) is used.
-    pub host_key: Option<String>,
+    pub host_key: Option<OptionalValuePath>,
 
     #[configurable(derived)]
     pub framing: Option<FramingConfig>,
@@ -47,7 +48,7 @@ pub struct FileDescriptorSourceConfig {
 }
 
 impl FileDescriptorConfig for FileDescriptorSourceConfig {
-    fn host_key(&self) -> Option<String> {
+    fn host_key(&self) -> Option<OptionalValuePath> {
         self.host_key.clone()
     }
 

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -1,6 +1,4 @@
-use std::fs::File;
-use std::io;
-use std::os::unix::io::FromRawFd;
+use std::{fs::File, io, os::unix::io::FromRawFd};
 
 use super::{outputs, FileDescriptorConfig};
 use codecs::decoding::{DeserializerConfig, FramingConfig};

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -8,17 +8,21 @@ use codecs::{
     StreamDecodingError,
 };
 use futures::{channel::mpsc, executor, SinkExt, StreamExt};
-use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
-use lookup::{owned_value_path, path, OwnedValuePath};
+use lookup::{
+    lookup_v2::{parse_value_path, OptionalValuePath},
+    owned_value_path, path, OwnedValuePath,
+};
 use tokio_util::{codec::FramedRead, io::StreamReader};
 use value::Kind;
 use vector_common::internal_event::{
     ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol,
 };
 use vector_config::NamedComponent;
-use vector_core::config::{LegacyKey, LogNamespace, Output};
-use vector_core::event::Event;
-use vector_core::EstimatedJsonEncodedSizeOf;
+use vector_core::{
+    config::{LegacyKey, LogNamespace, Output},
+    event::Event,
+    EstimatedJsonEncodedSizeOf,
+};
 
 use crate::{
     codecs::{Decoder, DecodingConfig},

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -8,7 +8,8 @@ use codecs::{
     StreamDecodingError,
 };
 use futures::{channel::mpsc, executor, SinkExt, StreamExt};
-use lookup::{owned_value_path, path};
+use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
+use lookup::{owned_value_path, path, OwnedValuePath};
 use tokio_util::{codec::FramedRead, io::StreamReader};
 use value::Kind;
 use vector_common::internal_event::{
@@ -33,7 +34,7 @@ pub mod file_descriptor;
 pub mod stdin;
 
 pub trait FileDescriptorConfig: NamedComponent {
-    fn host_key(&self) -> Option<String>;
+    fn host_key(&self) -> Option<OptionalValuePath>;
     fn framing(&self) -> Option<FramingConfig>;
     fn decoding(&self) -> DeserializerConfig;
     fn description(&self) -> String;
@@ -48,9 +49,10 @@ pub trait FileDescriptorConfig: NamedComponent {
     where
         R: Send + io::BufRead + 'static,
     {
-        let host_key = self
-            .host_key()
-            .unwrap_or_else(|| log_schema().host_key().to_string());
+        let host_key = self.host_key().map_or_else(
+            || parse_value_path(log_schema().host_key()).ok(),
+            |k| k.path,
+        );
         let hostname = crate::get_hostname().ok();
 
         let description = self.description();
@@ -86,7 +88,7 @@ pub trait FileDescriptorConfig: NamedComponent {
     }
 }
 
-type Sender = mpsc::Sender<std::result::Result<bytes::Bytes, std::io::Error>>;
+type Sender = mpsc::Sender<Result<Bytes, io::Error>>;
 
 fn read_from_fd<R>(mut reader: R, mut sender: Sender)
 where
@@ -96,7 +98,7 @@ where
         let (buffer, len) = match reader.fill_buf() {
             Ok(buffer) if buffer.is_empty() => break, // EOF.
             Ok(buffer) => (Ok(Bytes::copy_from_slice(buffer)), buffer.len()),
-            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
             Err(error) => (Err(error), 0),
         };
 
@@ -109,7 +111,7 @@ where
     }
 }
 
-type Receiver = mpsc::Receiver<std::result::Result<bytes::Bytes, std::io::Error>>;
+type Receiver = mpsc::Receiver<Result<Bytes, io::Error>>;
 
 #[allow(clippy::too_many_arguments)]
 async fn process_stream(
@@ -117,7 +119,7 @@ async fn process_stream(
     decoder: Decoder,
     mut out: SourceSender,
     shutdown: ShutdownSignal,
-    host_key: String,
+    host_key: Option<OwnedValuePath>,
     source_type: &'static str,
     hostname: Option<String>,
     log_namespace: LogNamespace,
@@ -158,7 +160,7 @@ async fn process_stream(
                                     log_namespace.insert_source_metadata(
                                         source_type,
                                         log,
-                                        Some(LegacyKey::InsertIfEmpty(host_key.as_str())),
+                                        host_key.as_ref().map(LegacyKey::InsertIfEmpty),
                                         path!("host"),
                                         hostname.clone()
                                     );
@@ -201,20 +203,20 @@ async fn process_stream(
 /// file_descriptor sources.
 fn outputs(
     log_namespace: LogNamespace,
-    host_key: &Option<String>,
+    host_key: &Option<OptionalValuePath>,
     decoding: &DeserializerConfig,
     source_name: &'static str,
 ) -> Vec<Output> {
-    let host_key_path = host_key.as_ref().map_or_else(
-        || owned_value_path!(log_schema().host_key()),
-        |x| owned_value_path!(x),
-    );
+    let legacy_host_key = host_key
+        .clone()
+        .and_then(|k| k.path)
+        .map(LegacyKey::InsertIfEmpty);
 
     let schema_definition = decoding
         .schema_definition(log_namespace)
         .with_source_metadata(
             source_name,
-            Some(LegacyKey::InsertIfEmpty(host_key_path)),
+            legacy_host_key,
             &owned_value_path!("host"),
             Kind::bytes(),
             None,

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use codecs::decoding::{DeserializerConfig, FramingConfig};
+use lookup::lookup_v2::OptionalValuePath;
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::LogNamespace;
 
@@ -29,7 +30,7 @@ pub struct StdinConfig {
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    pub host_key: Option<String>,
+    pub host_key: Option<OptionalValuePath>,
 
     #[configurable(derived)]
     pub framing: Option<FramingConfig>,
@@ -45,7 +46,7 @@ pub struct StdinConfig {
 }
 
 impl FileDescriptorConfig for StdinConfig {
-    fn host_key(&self) -> Option<String> {
+    fn host_key(&self) -> Option<OptionalValuePath> {
         self.host_key.clone()
     }
 


### PR DESCRIPTION
Replace `Option<String>` with `Option<OptionalValuePath>` to better handle path parsing.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
