### PR TITLE
docs(prometheus_scrape source, prometheus_remote_write source, promet… …heus_exporter sink, prometheus_remote_write sink): improve document handling of duplicate tags

### DIFF
--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -381,11 +381,12 @@ components: sinks: prometheus_exporter: {
 				"""
 		}
 
-		multi_value_tags: {
-			title: "Multivalue Tags"
+		duplicate_tag_names: {
+			title: "Duplicate tag names"
 			body: """
-				Duplicate tag names are invalid within Prometheus and Prometheus will reject a metric with duplicate
-				tags. When sending a tag with multiple values, Vector will send the last value specified.
+				Multiple tags with the same name are invalid within Prometheus and Prometheus
+				will reject a metric with duplicate tag names. When sending a tag with multiple
+				values for each name, Vector will only send the last value specified.
 				"""
 		}
 	}

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -194,11 +194,12 @@ components: sinks: prometheus_remote_write: {
 	}
 
 	how_it_works: {
-		multi_value_tags: {
-			title: "Multivalue Tags"
+		duplicate_tag_names: {
+			title: "Duplicate tag names"
 			body: """
-				Duplicate tag names are invalid within Prometheus and Prometheus will reject a metric with duplicate
-				tags. When sending a tag with multiple values, Vector will send the last value specified.
+				Multiple tags with the same name are invalid within Prometheus and Prometheus
+				will reject a metric with duplicate tag names. When sending a tag with multiple
+				values for each name, Vector will only send the last value specified.
 				"""
 		}
 	}

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -82,11 +82,12 @@ components: sources: prometheus_remote_write: {
 				"""
 		}
 
-		duplicate_tags: {
-			title: "Duplicate Tags"
+		duplicate_tag_names: {
+			title: "Duplicate tag names"
 			body: """
-				Duplicate tag names are invalid within Prometheus. Prometheus itself will reject a metric with duplicate
-				tags. Vector will accept the metric, but will only take the last tag specified.
+				Multiple tags with the same name are invalid within Prometheus. Prometheus
+				itself will reject a metric with duplicate tags. Vector will accept the metric,
+				but will only take the last value for each tag name specified.
 				"""
 		}
 	}

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -151,11 +151,12 @@ components: sources: prometheus_scrape: {
 	}
 
 	how_it_works: {
-		duplicate_tags: {
-			title: "Duplicate Tags"
+		duplicate_tag_names: {
+			title: "Duplicate tag names"
 			body: """
-				Duplicate tag names are invalid within Prometheus. Prometheus itself will reject a metric with duplicate
-				tags. Vector will accept the metric, but will only take the last tag specified.
+				Multiple tags with the same name are invalid within Prometheus. Prometheus
+				itself will reject a metric with duplicate tags. Vector will accept the metric,
+				but will only take the last value for each tag name specified.
 				"""
 		}
 	}


### PR DESCRIPTION
Ref #15606 

I just merged that PR to document Prometheus' handling of duplicate tags, but given [this suggestion](https://github.com/vectordotdev/vector/pull/15618#discussion_r1050856749) from @bruceg on a separate PR, I feel the wording could be much better.  Hence, this PR.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
