### PR TITLE
chore(docs): remove mentions of Vector from source descriptions

### DIFF
--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -79,7 +79,7 @@ pub enum Compression {
     /// The compression scheme of the object is determined by looking at its file signature, also known
     /// as [magic bytes](\(urls.magic_bytes)).
     ///
-    ///If the record fails to decompress with the discovered format, the record is forwarded as is.
+    /// If the record fails to decompress with the discovered format, the record is forwarded as is.
     /// Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
     /// set `gzip` in this field so that any records that are not-gzipped are rejected.
     #[derivative(Default)]

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -76,13 +76,12 @@ pub struct AwsKinesisFirehoseConfig {
 pub enum Compression {
     /// Automatically attempt to determine the compression scheme.
     ///
-    /// Vector will try to determine the compression scheme of the object by looking at its file signature, also known
+    /// The compression scheme of the object is determined by looking at its file signature, also known
     /// as [magic bytes](\(urls.magic_bytes)).
     ///
-    /// Given that determining the encoding using magic bytes is not a perfect check, if the record fails to decompress
-    /// with the discovered format, the record will be forwarded as-is. Thus, if you know the records will always be
-    /// gzip encoded (for example if they are coming from AWS CloudWatch Logs) then you should prefer to set `gzip` here
-    /// to have Vector reject any records that are not-gziped.
+    ///If the record fails to decompress with the discovered format, the record is forwarded as is.
+    /// Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
+    /// set `gzip` in this field so that any records that are not-gzipped are rejected.
     #[derivative(Default)]
     Auto,
     /// Uncompressed.

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -31,10 +31,10 @@ pub mod sqs;
 pub enum Compression {
     /// Automatically attempt to determine the compression scheme.
     ///
-    /// Vector will try to determine the compression scheme of the object from its: `Content-Encoding` and
-    /// `Content-Type` metadata, as well as the key suffix (e.g. `.gz`).
+    /// The compression scheme of the object is determined from its `Content-Encoding` and
+    /// `Content-Type` metadata, as well as the key suffix (for example, `.gz`).
     ///
-    /// It will fallback to 'none' if the compression scheme cannot be determined.
+    /// It is set to 'none' if the compression scheme cannot be determined.
     #[derivative(Default)]
     Auto,
     /// Uncompressed.

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -66,20 +66,20 @@ pub(super) struct Config {
     #[derivative(Default(value = "default_poll_secs()"))]
     pub(super) poll_secs: u32,
 
-    /// The visibility timeout to use for messages, in secords.
+    /// The visibility timeout to use for messages, in seconds.
     ///
-    /// This controls how long a message is left unavailable after Vector receives it. If Vector receives a message, and
-    /// takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it will be made reavailable for another consumer.
+    /// This controls how long a message is left unavailable after it is received. If a message is received, and
+    /// takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it is made available again for another consumer.
     ///
-    /// This can happen if, for example, if Vector crashes between consuming a message and deleting it.
+    /// This can happen if there is an issue between consuming a message and deleting it.
     // NOTE: We restrict this to u32 for safe conversion to i64 later.
     #[serde(default = "default_visibility_timeout_secs")]
     #[derivative(Default(value = "default_visibility_timeout_secs()"))]
     pub(super) visibility_timeout_secs: u32,
 
-    /// Whether to delete the message once Vector processes it.
+    /// Whether to delete the message once it is processed.
     ///
-    /// It can be useful to set this to `false` to debug or during initial Vector setup.
+    /// It can be useful to set this to `false` for debugging or during the initial setup.
     #[serde(default = "default_true")]
     #[derivative(Default(value = "default_true()"))]
     pub(super) delete_message: bool,
@@ -90,7 +90,7 @@ pub(super) struct Config {
     ///
     /// Should not typically need to be changed, but it can sometimes be beneficial to raise this value when there is a
     /// high rate of messages being pushed into the queue and the objects being fetched are small. In these cases,
-    /// Vector may not fully utilize system resources without fetching more messages per second, as the SQS message
+    /// System resources may not be fully utilized without fetching more messages per second, as the SQS message
     /// consumption rate affects the S3 object retrieval rate.
     pub(super) client_concurrency: Option<NonZeroUsize>,
 

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -42,21 +42,21 @@ pub struct AwsSqsConfig {
     #[derivative(Default(value = "default_poll_secs()"))]
     pub poll_secs: u32,
 
-    /// The visibility timeout to use for messages, in secords.
+    /// The visibility timeout to use for messages, in seconds.
     ///
-    /// This controls how long a message is left unavailable after Vector receives it. If Vector receives a message, and
-    /// takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it will be made reavailable for another consumer.
+    /// This controls how long a message is left unavailable after it is received. If a message is received, and
+    /// takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it is made available again for another consumer.
     ///
-    /// This can happen if, for example, if Vector crashes between consuming a message and deleting it.
+    /// This can happen if there is an issue between consuming a message and deleting it.
     // NOTE: We restrict this to u32 for safe conversion to i64 later.
     // restricted to u32 for safe conversion to i64 later
     #[serde(default = "default_visibility_timeout_secs")]
     #[derivative(Default(value = "default_visibility_timeout_secs()"))]
     pub(super) visibility_timeout_secs: u32,
 
-    /// Whether to delete the message once Vector processes it.
+    /// Whether to delete the message once it is processed.
     ///
-    /// It can be useful to set this to `false` to debug or during initial Vector setup.
+    /// It can be useful to set this to `false` for debugging or during the initial setup.
     #[serde(default = "default_true")]
     #[derivative(Default(value = "default_true()"))]
     pub(super) delete_message: bool,
@@ -67,7 +67,7 @@ pub struct AwsSqsConfig {
     ///
     /// Should not typically need to be changed, but it can sometimes be beneficial to raise this value when there is a
     /// high rate of messages being pushed into the queue and the messages being fetched are small. In these cases,
-    /// Vector may not fully utilize system resources without fetching more messages per second, as it spends more time
+    /// System resources may not be fully utilized without fetching more messages per second, as it spends more time
     /// fetching the messages than processing them.
     pub client_concurrency: Option<NonZeroUsize>,
 

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -66,7 +66,6 @@ static CONSOLE: Lazy<Bytes> = Lazy::new(|| "console".into());
 pub struct DockerLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -66,7 +66,7 @@ static CONSOLE: Lazy<Bytes> = Lazy::new(|| "console".into());
 pub struct DockerLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value will be the current hostname for wherever Vector is running.
+    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
@@ -78,7 +78,7 @@ pub struct DockerLogsConfig {
     ///
     /// Use an HTTPS URL to enable TLS encryption.
     ///
-    /// If absent, Vector will try to use `DOCKER_HOST` environment variable. If `DOCKER_HOST` is also absent, Vector will use default Docker local socket (`/var/run/docker.sock` on Unix platforms, `//./pipe/docker_engine` on Windows).
+    /// If absent, the `DOCKER_HOST` environment variable is used. If `DOCKER_HOST` is also absent, the default Docker local socket (`/var/run/docker.sock` on Unix platforms, `//./pipe/docker_engine` on Windows) is used.
     docker_host: Option<String>,
 
     /// A list of container IDs or names of containers to exclude from log collection.

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -77,9 +77,9 @@ pub struct FileConfig {
 
     /// Array of file patterns to exclude. [Globbing](https://vector.dev/docs/reference/configuration/sources/file/#globbing) is supported.
     ///
-    /// Takes precedence over the `include` option. Note that the `exclude` patterns are applied _after_ Vector attempts to glob everything
-    /// in `include`. That is, Vector will still try to list all of the files matched by `include` and then filter them by the `exclude`
-    /// patterns. This can be impactful if `include` contains directories with contents that vector does not have access to.
+    /// Takes precedence over the `include` option. Note: The `exclude` patterns are applied _after_ the attempt to glob everything
+    /// in `include`. This means that all files are first matched by `include` and then filtered by the `exclude`
+    /// patterns. This can be impactful if `include` contains directories with contents that are not accessible.
     #[serde(default)]
     pub exclude: Vec<PathBuf>,
 
@@ -120,7 +120,7 @@ pub struct FileConfig {
 
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value will be the current hostname for wherever Vector is running.
+    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
@@ -130,7 +130,7 @@ pub struct FileConfig {
 
     /// The directory used to persist file checkpoint positions.
     ///
-    /// By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+    /// By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
     #[serde(default)]
     pub data_dir: Option<PathBuf>,
 
@@ -144,7 +144,7 @@ pub struct FileConfig {
 
     /// Delay between file discovery calls, in milliseconds.
     ///
-    /// This controls the interval at which Vector searches for files. Higher value result in greater chances of some short living files being missed between searches, but lower value increases the performance impact of file discovery.
+    /// This controls the interval at which files are searched. A higher value results in greater chances of some short-lived files being missed between searches, but a lower value increases the performance impact of file discovery.
     #[serde(
         alias = "glob_minimum_cooldown",
         default = "default_glob_minimum_cooldown_ms"

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -24,7 +24,7 @@ pub struct FileDescriptorSourceConfig {
 
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value will be the current hostname for wherever Vector is running.
+    /// The value is the current hostname.
     ///
     /// By default, the [global `host_key` option](https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key) is used.
     pub host_key: Option<OptionalValuePath>,

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -24,7 +24,6 @@ pub struct FileDescriptorSourceConfig {
 
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value is the current hostname.
     ///
     /// By default, the [global `host_key` option](https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key) is used.
     pub host_key: Option<OptionalValuePath>,

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -25,7 +25,6 @@ pub struct StdinConfig {
 
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -25,7 +25,7 @@ pub struct StdinConfig {
 
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value will be the current hostname for wherever Vector is running.
+    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -26,7 +26,6 @@ use crate::{
 pub struct InternalLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
@@ -36,7 +35,6 @@ pub struct InternalLogsConfig {
 
     /// Overrides the name of the log field used to add the current process ID to each event.
     ///
-    /// The value is the current process ID.
     ///
     /// By default, `"pid"` is used.
     #[serde(default)]

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -26,7 +26,7 @@ use crate::{
 pub struct InternalLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    /// The value will be the current hostname for wherever Vector is running.
+    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
@@ -36,7 +36,7 @@ pub struct InternalLogsConfig {
 
     /// Overrides the name of the log field used to add the current process ID to each event.
     ///
-    /// The value will be the current process ID for Vector itself.
+    /// The value is the current process ID.
     ///
     /// By default, `"pid"` is used.
     #[serde(default)]

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -48,14 +48,12 @@ impl InternalMetricsConfig {
 pub struct TagsConfig {
     /// Sets the name of the tag to use to add the current hostname to each metric.
     ///
-    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     pub host_key: Option<String>,
 
     /// Sets the name of the tag to use to add the current process ID to each metric.
     ///
-    /// The value is the current process ID.
     ///
     /// By default, this is not set and the tag will not be automatically added.
     pub pid_key: Option<String>,

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -48,14 +48,14 @@ impl InternalMetricsConfig {
 pub struct TagsConfig {
     /// Sets the name of the tag to use to add the current hostname to each metric.
     ///
-    /// The value will be the current hostname for wherever Vector is running.
+    /// The value is the current hostname.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     pub host_key: Option<String>,
 
     /// Sets the name of the tag to use to add the current process ID to each metric.
     ///
-    /// The value will be the current process ID for Vector itself.
+    /// The value is the current process ID.
     ///
     /// By default, this is not set and the tag will not be automatically added.
     pub pid_key: Option<String>,

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -98,7 +98,7 @@ type Matches = HashMap<String, HashSet<String>>;
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct JournaldConfig {
-    /// Only include entries that appended to the journal after starting.
+    /// Only include entries that appended to the journal after the entries have been read.
     pub since_now: Option<bool>,
 
     /// Only include entries that occurred after the current boot of the system.

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -98,7 +98,7 @@ type Matches = HashMap<String, HashSet<String>>;
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct JournaldConfig {
-    /// Only include entries that appended to the journal after Vector starts reading it.
+    /// Only include entries that appended to the journal after starting.
     pub since_now: Option<bool>,
 
     /// Only include entries that occurred after the current boot of the system.
@@ -133,7 +133,7 @@ pub struct JournaldConfig {
 
     /// The directory used to persist file checkpoint positions.
     ///
-    /// By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+    /// By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
     pub data_dir: Option<PathBuf>,
 
     /// The `systemd` journal is read in batches, and a checkpoint is set at the end of each batch. This option limits the size of the batch.
@@ -141,7 +141,7 @@ pub struct JournaldConfig {
 
     /// The full path of the `journalctl` executable.
     ///
-    /// If not set, Vector will search the path for `journalctl`.
+    /// If not set, a search is done for the journalctl` path.
     pub journalctl_path: Option<PathBuf>,
 
     /// The full path of the journal directory.

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -82,13 +82,13 @@ const SELF_NODE_NAME_ENV_KEY: &str = "VECTOR_SELF_NODE_NAME";
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
-    /// Specifies the label selector to filter `Pod`s with, to be used in addition to the built-in `vector.dev/exclude` filter.
+    /// Specifies the label selector to filter `Pod`s with, to be used in addition to the built-in `exclude` filter.
     extra_label_selector: String,
 
-    /// Specifies the label selector to filter `Namespace`s with, to be used in  addition to the built-in `vector.dev/exclude` filter.
+    /// Specifies the label selector to filter `Namespace`s with, to be used in addition to the built-in `exclude` filter.
     extra_namespace_label_selector: String,
 
-    /// The `name` of the Kubernetes `Node` that Vector runs at.
+    /// The `name` of the Kubernetes `Node` that is running.
     ///
     /// Configured to use an environment var by default, to be evaluated to a value provided by Kubernetes at `Pod` deploy time.
     self_node_name: String,
@@ -101,7 +101,7 @@ pub struct Config {
 
     /// The directory used to persist file checkpoint positions.
     ///
-    /// By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+    /// By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
     data_dir: Option<PathBuf>,
 
     #[configurable(derived)]
@@ -138,17 +138,17 @@ pub struct Config {
     /// a significant overhead.
     glob_minimum_cooldown_ms: usize,
 
-    /// A field to use to set the timestamp when Vector ingested the event.
+    /// This field sets the timestamp when an event is ingested.
     /// This is useful to compute the latency between important event processing
-    /// stages, i.e. the time delta between log line was written and when it was
+    /// stages. For example, the time delta between when a log line was written and when it was
     /// processed by the `kubernetes_logs` source.
     ingestion_timestamp_field: Option<String>,
 
     /// The default time zone for timestamps without an explicit zone.
     timezone: Option<TimeZone>,
 
-    /// Optional path to a kubeconfig file readable by Vector. If not set,
-    /// Vector will try to connect to Kubernetes using in-cluster configuration.
+    /// Optional path to a readable kubeconfig file. If not set,
+    /// a connection to Kubernetes is made using the in-cluster configuration.
     kube_config_file: Option<PathBuf>,
 
     /// How long to delay removing entries from our map when we receive a deletion

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -138,10 +138,15 @@ pub struct Config {
     /// a significant overhead.
     glob_minimum_cooldown_ms: usize,
 
-    /// This field sets the timestamp when an event is ingested.
+    /// Overrides the name of the log field used to add the ingestion timestamp to each event.
+    ///
     /// This is useful to compute the latency between important event processing
     /// stages. For example, the time delta between when a log line was written and when it was
     /// processed by the `kubernetes_logs` source.
+    ///
+    /// By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+    ///
+    /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     ingestion_timestamp_field: Option<String>,
 
     /// The default time zone for timestamps without an explicit zone.

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -65,10 +65,9 @@ pub struct PrometheusScrapeConfig {
     /// By default, `"endpoint"` is used.
     endpoint_tag: Option<String>,
 
-    /// Controls how tag conflicts are handled if the scraped source has tags that Vector would add.
+    /// Controls how tag conflicts are handled if the scraped source has tags to be added.
     ///
-    /// If `true`, Vector will not add the new tag if the scraped metric has the tag already. If `false`, Vector will
-    /// rename the conflicting tag by prepending `exported_` to the name.
+    /// If `true`, the new tag is not added if the scraped metric has the tag already. If `false`, the conflicting tag is renamed by prepending `exported_` to the original name.
     ///
     /// This matches Prometheus’ `honor_labels` configuration.
     #[serde(default = "crate::serde::default_false")]

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -67,7 +67,8 @@ pub struct PrometheusScrapeConfig {
 
     /// Controls how tag conflicts are handled if the scraped source has tags to be added.
     ///
-    /// If `true`, the new tag is not added if the scraped metric has the tag already. If `false`, the conflicting tag is renamed by prepending `exported_` to the original name.
+    /// If `true`, the new tag is not added if the scraped metric has the tag already. If `false`, the conflicting tag
+    /// is renamed by prepending `exported_` to the original name.
     ///
     /// This matches Prometheus’ `honor_labels` configuration.
     #[serde(default = "crate::serde::default_false")]

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -756,7 +756,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         Ok(log.into())
     }
 
-    /// Build the log event for the vector namespace.
+    /// Build the log event for the namespace.
     /// In this namespace the log event is created entirely from the event field.
     /// No renaming of the `line` field is done.
     fn build_log_vector(&mut self, json: &mut JsonValue) -> Result<LogEvent, Rejection> {

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -756,7 +756,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         Ok(log.into())
     }
 
-    /// Build the log event for the namespace.
+    /// Build the log event for the vector namespace.
     /// In this namespace the log event is created entirely from the event field.
     /// No renaming of the `line` field is done.
     fn build_log_vector(&mut self, json: &mut JsonValue) -> Result<LogEvent, Rejection> {

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -168,13 +168,12 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 			auto: """
 				Automatically attempt to determine the compression scheme.
 
-				Vector will try to determine the compression scheme of the object by looking at its file signature, also known
+				The compression scheme of the object is determined by looking at its file signature, also known
 				as [magic bytes](\\(urls.magic_bytes)).
 
-				Given that determining the encoding using magic bytes is not a perfect check, if the record fails to decompress
-				with the discovered format, the record will be forwarded as-is. Thus, if you know the records will always be
-				gzip encoded (for example if they are coming from AWS CloudWatch Logs) then you should prefer to set `gzip` here
-				to have Vector reject any records that are not-gziped.
+				If the record fails to decompress with the discovered format, the record is forwarded as is.
+				Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
+				set `gzip` in this field so that any records that are not-gzipped are rejected.
 				"""
 			gzip: "GZIP."
 			none: "Uncompressed."

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -130,10 +130,10 @@ base: components: sources: aws_s3: configuration: {
 				auto: """
 					Automatically attempt to determine the compression scheme.
 
-					Vector will try to determine the compression scheme of the object from its: `Content-Encoding` and
-					`Content-Type` metadata, as well as the key suffix (e.g. `.gz`).
+					The compression scheme of the object is determined from its `Content-Encoding` and
+					`Content-Type` metadata, as well as the key suffix (for example, `.gz`).
 
-					It will fallback to 'none' if the compression scheme cannot be determined.
+					It is set to 'none' if the compression scheme cannot be determined.
 					"""
 				gzip: "GZIP."
 				none: "Uncompressed."
@@ -234,7 +234,7 @@ base: components: sources: aws_s3: configuration: {
 
 					Should not typically need to be changed, but it can sometimes be beneficial to raise this value when there is a
 					high rate of messages being pushed into the queue and the objects being fetched are small. In these cases,
-					Vector may not fully utilize system resources without fetching more messages per second, as the SQS message
+					System resources may not be fully utilized without fetching more messages per second, as the SQS message
 					consumption rate affects the S3 object retrieval rate.
 					"""
 				required: false
@@ -242,9 +242,9 @@ base: components: sources: aws_s3: configuration: {
 			}
 			delete_message: {
 				description: """
-					Whether to delete the message once Vector processes it.
+					Whether to delete the message once it is processed.
 
-					It can be useful to set this to `false` to debug or during initial Vector setup.
+					It can be useful to set this to `false` for debugging or during the initial setup.
 					"""
 				required: false
 				type: bool: default: true
@@ -351,12 +351,12 @@ base: components: sources: aws_s3: configuration: {
 			}
 			visibility_timeout_secs: {
 				description: """
-					The visibility timeout to use for messages, in secords.
+					The visibility timeout to use for messages, in seconds.
 
-					This controls how long a message is left unavailable after Vector receives it. If Vector receives a message, and
-					takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it will be made reavailable for another consumer.
+					This controls how long a message is left unavailable after it is received. If a message is received, and
+					takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it is made available again for another consumer.
 
-					This can happen if, for example, if Vector crashes between consuming a message and deleting it.
+					This can happen if there is an issue between consuming a message and deleting it.
 					"""
 				required: false
 				type: uint: default: 300

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -107,7 +107,7 @@ base: components: sources: aws_sqs: configuration: {
 
 			Should not typically need to be changed, but it can sometimes be beneficial to raise this value when there is a
 			high rate of messages being pushed into the queue and the messages being fetched are small. In these cases,
-			Vector may not fully utilize system resources without fetching more messages per second, as it spends more time
+			System resources may not be fully utilized without fetching more messages per second, as it spends more time
 			fetching the messages than processing them.
 			"""
 		required: false
@@ -159,9 +159,9 @@ base: components: sources: aws_sqs: configuration: {
 	}
 	delete_message: {
 		description: """
-			Whether to delete the message once Vector processes it.
+			Whether to delete the message once it is processed.
 
-			It can be useful to set this to `false` to debug or during initial Vector setup.
+			It can be useful to set this to `false` for debugging or during the initial setup.
 			"""
 		required: false
 		type: bool: default: true
@@ -352,12 +352,12 @@ base: components: sources: aws_sqs: configuration: {
 	}
 	visibility_timeout_secs: {
 		description: """
-			The visibility timeout to use for messages, in secords.
+			The visibility timeout to use for messages, in seconds.
 
-			This controls how long a message is left unavailable after Vector receives it. If Vector receives a message, and
-			takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it will be made reavailable for another consumer.
+			This controls how long a message is left unavailable after it is received. If a message is received, and
+			takes longer than `visibility_timeout_secs` to process and delete the message from the queue, it is made available again for another consumer.
 
-			This can happen if, for example, if Vector crashes between consuming a message and deleting it.
+			This can happen if there is an issue between consuming a message and deleting it.
 			"""
 		required: false
 		type: uint: default: 300

--- a/website/cue/reference/components/sources/base/docker_logs.cue
+++ b/website/cue/reference/components/sources/base/docker_logs.cue
@@ -12,7 +12,7 @@ base: components: sources: docker_logs: configuration: {
 
 			Use an HTTPS URL to enable TLS encryption.
 
-			If absent, Vector will try to use `DOCKER_HOST` environment variable. If `DOCKER_HOST` is also absent, Vector will use default Docker local socket (`/var/run/docker.sock` on Unix platforms, `//./pipe/docker_engine` on Windows).
+			If absent, the `DOCKER_HOST` environment variable is used. If `DOCKER_HOST` is also absent, the default Docker local socket (`/var/run/docker.sock` on Unix platforms, `//./pipe/docker_engine` on Windows) is used.
 			"""
 		required: false
 		type: string: syntax: "literal"
@@ -37,8 +37,6 @@ base: components: sources: docker_logs: configuration: {
 	host_key: {
 		description: """
 			Overrides the name of the log field used to add the current hostname to each event.
-
-			The value will be the current hostname for wherever Vector is running.
 
 			By default, the [global `log_schema.host_key` option][global_host_key] is used.
 

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -23,7 +23,7 @@ base: components: sources: file: configuration: {
 		description: """
 			The directory used to persist file checkpoint positions.
 
-			By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+			By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
 			"""
 		required: false
 		type: string: syntax: "literal"
@@ -53,9 +53,9 @@ base: components: sources: file: configuration: {
 		description: """
 			Array of file patterns to exclude. [Globbing](https://vector.dev/docs/reference/configuration/sources/file/#globbing) is supported.
 
-			Takes precedence over the `include` option. Note that the `exclude` patterns are applied _after_ Vector attempts to glob everything
-			in `include`. That is, Vector will still try to list all of the files matched by `include` and then filter them by the `exclude`
-			patterns. This can be impactful if `include` contains directories with contents that vector does not have access to.
+			Takes precedence over the `include` option. Note: The `exclude` patterns are applied _after_ the attempt to glob everything
+			in `include`. This means that all files are first matched by `include` and then filtered by the `exclude`
+			patterns. This can be impactful if `include` contains directories with contents that are not accessible.
 			"""
 		required: false
 		type: array: {
@@ -134,7 +134,7 @@ base: components: sources: file: configuration: {
 		description: """
 			Delay between file discovery calls, in milliseconds.
 
-			This controls the interval at which Vector searches for files. Higher value result in greater chances of some short living files being missed between searches, but lower value increases the performance impact of file discovery.
+			This controls the interval at which files are searched. A higher value results in greater chances of some short-lived files being missed between searches, but a lower value increases the performance impact of file discovery.
 			"""
 		required: false
 		type: uint: default: 1000
@@ -143,7 +143,7 @@ base: components: sources: file: configuration: {
 		description: """
 			Overrides the name of the log field used to add the current hostname to each event.
 
-			The value will be the current hostname for wherever Vector is running.
+			The value is the current hostname.
 
 			By default, the [global `log_schema.host_key` option][global_host_key] is used.
 

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -125,8 +125,6 @@ base: components: sources: file_descriptor: configuration: {
 		description: """
 			Overrides the name of the log field used to add the current hostname to each event.
 
-			The value will be the current hostname for wherever Vector is running.
-
 			By default, the [global `host_key` option](https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key) is used.
 			"""
 		required: false

--- a/website/cue/reference/components/sources/base/internal_logs.cue
+++ b/website/cue/reference/components/sources/base/internal_logs.cue
@@ -5,8 +5,6 @@ base: components: sources: internal_logs: configuration: {
 		description: """
 			Overrides the name of the log field used to add the current hostname to each event.
 
-			The value will be the current hostname for wherever Vector is running.
-
 			By default, the [global `log_schema.host_key` option][global_host_key] is used.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
@@ -17,8 +15,6 @@ base: components: sources: internal_logs: configuration: {
 	pid_key: {
 		description: """
 			Overrides the name of the log field used to add the current process ID to each event.
-
-			The value will be the current process ID for Vector itself.
 
 			By default, `"pid"` is used.
 			"""

--- a/website/cue/reference/components/sources/base/internal_metrics.cue
+++ b/website/cue/reference/components/sources/base/internal_metrics.cue
@@ -28,8 +28,6 @@ base: components: sources: internal_metrics: configuration: {
 					description: """
 						Sets the name of the tag to use to add the current hostname to each metric.
 
-						The value will be the current hostname for wherever Vector is running.
-
 						By default, the [global `log_schema.host_key` option][global_host_key] is used.
 						"""
 					required: false
@@ -38,8 +36,6 @@ base: components: sources: internal_metrics: configuration: {
 				pid_key: {
 					description: """
 						Sets the name of the tag to use to add the current process ID to each metric.
-
-						The value will be the current process ID for Vector itself.
 
 						By default, this is not set and the tag will not be automatically added.
 						"""

--- a/website/cue/reference/components/sources/base/journald.cue
+++ b/website/cue/reference/components/sources/base/journald.cue
@@ -36,7 +36,7 @@ base: components: sources: journald: configuration: {
 		description: """
 			The directory used to persist file checkpoint positions.
 
-			By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+			By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
 			"""
 		required: false
 		type: string: syntax: "literal"
@@ -118,7 +118,7 @@ base: components: sources: journald: configuration: {
 		description: """
 			The full path of the `journalctl` executable.
 
-			If not set, Vector will search the path for `journalctl`.
+			If not set, a search is done for the journalctl` path.
 			"""
 		required: false
 		type: string: syntax: "literal"
@@ -133,7 +133,7 @@ base: components: sources: journald: configuration: {
 		type: bool: default: false
 	}
 	since_now: {
-		description: "Only include entries that appended to the journal after Vector starts reading it."
+		description: "Only include entries that appended to the journal after the entries have been read."
 		required:    false
 		type: bool: {}
 	}

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -10,7 +10,7 @@ base: components: sources: kubernetes_logs: configuration: {
 		description: """
 			The directory used to persist file checkpoint positions.
 
-			By default, the global `data_dir` option is used. Please make sure the user Vector is running as has write permissions to this directory.
+			By default, the global `data_dir` option is used. Make sure the running user has write permissions to this directory.
 			"""
 		required: false
 		type: string: syntax: "literal"
@@ -40,7 +40,7 @@ base: components: sources: kubernetes_logs: configuration: {
 		}
 	}
 	extra_label_selector: {
-		description: "Specifies the label selector to filter `Pod`s with, to be used in addition to the built-in `vector.dev/exclude` filter."
+		description: "Specifies the label selector to filter `Pod`s with, to be used in addition to the built-in `exclude` filter."
 		required:    false
 		type: string: {
 			default: ""
@@ -48,7 +48,7 @@ base: components: sources: kubernetes_logs: configuration: {
 		}
 	}
 	extra_namespace_label_selector: {
-		description: "Specifies the label selector to filter `Namespace`s with, to be used in  addition to the built-in `vector.dev/exclude` filter."
+		description: "Specifies the label selector to filter `Namespace`s with, to be used in addition to the built-in `exclude` filter."
 		required:    false
 		type: string: {
 			default: ""
@@ -74,18 +74,23 @@ base: components: sources: kubernetes_logs: configuration: {
 	}
 	ingestion_timestamp_field: {
 		description: """
-			A field to use to set the timestamp when Vector ingested the event.
+			Overrides the name of the log field used to add the ingestion timestamp to each event.
+
 			This is useful to compute the latency between important event processing
-			stages, i.e. the time delta between log line was written and when it was
+			stages. For example, the time delta between when a log line was written and when it was
 			processed by the `kubernetes_logs` source.
+
+			By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+
+			[global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
 			"""
 		required: false
 		type: string: syntax: "literal"
 	}
 	kube_config_file: {
 		description: """
-			Optional path to a kubeconfig file readable by Vector. If not set,
-			Vector will try to connect to Kubernetes using in-cluster configuration.
+			Optional path to a readable kubeconfig file. If not set,
+			a connection to Kubernetes is made using the in-cluster configuration.
 			"""
 		required: false
 		type: string: syntax: "literal"
@@ -258,7 +263,7 @@ base: components: sources: kubernetes_logs: configuration: {
 	}
 	self_node_name: {
 		description: """
-			The `name` of the Kubernetes `Node` that Vector runs at.
+			The `name` of the Kubernetes `Node` that is running.
 
 			Configured to use an environment var by default, to be evaluated to a value provided by Kubernetes at `Pod` deploy time.
 			"""

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -65,10 +65,10 @@ base: components: sources: prometheus_scrape: configuration: {
 	}
 	honor_labels: {
 		description: """
-			Controls how tag conflicts are handled if the scraped source has tags that Vector would add.
+			Controls how tag conflicts are handled if the scraped source has tags to be added.
 
-			If `true`, Vector will not add the new tag if the scraped metric has the tag already. If `false`, Vector will
-			rename the conflicting tag by prepending `exported_` to the name.
+			If `true`, the new tag is not added if the scraped metric has the tag already. If `false`, the conflicting tag
+			is renamed by prepending `exported_` to the original name.
 
 			This matches Prometheus’ `honor_labels` configuration.
 			"""

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -123,8 +123,6 @@ base: components: sources: stdin: configuration: {
 		description: """
 			Overrides the name of the log field used to add the current hostname to each event.
 
-			The value will be the current hostname for wherever Vector is running.
-
 			By default, the [global `log_schema.host_key` option][global_host_key] is used.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key


### PR DESCRIPTION
This PR removes `vector` from source descriptions because they will be getting pulled into the Reference section in Observability Pipelines docs.

ref: DOCS-4568
