### PR TITLE
enhancement(http sink): allow overriding content-type header

### DIFF
--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -335,7 +335,8 @@ impl util::http::HttpSink for HttpSink {
         }
 
         for (header, value) in self.request.headers.iter() {
-            builder = builder.header(header.as_str(), value.as_str());
+            builder.headers_mut().expect("Failed to access headers")
+                .insert(HeaderName::try_from(header)?, HeaderValue::try_from(value)?);
         }
 
         let mut request = builder.body(body.freeze()).unwrap();

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -337,7 +337,8 @@ impl util::http::HttpSink for HttpSink {
         for (header, value) in self.request.headers.iter() {
             builder
                 .headers_mut()
-                .expect("Failed to access headers")
+                // The request builder should not have errors at this point, and if it did it would fail in the call to `body()` also.
+                .expect("Failed to access headers in http::Request builder- builder has errors.")
                 .insert(HeaderName::try_from(header)?, HeaderValue::try_from(value)?);
         }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -335,7 +335,9 @@ impl util::http::HttpSink for HttpSink {
         }
 
         for (header, value) in self.request.headers.iter() {
-            builder.headers_mut().expect("Failed to access headers")
+            builder
+                .headers_mut()
+                .expect("Failed to access headers")
                 .insert(HeaderName::try_from(header)?, HeaderValue::try_from(value)?);
         }
 


### PR DESCRIPTION
Changes the logic within http sink, to `insert` user-configured headers in the request instead of adding them.

This allows, among other things, to override the `Content-Type` header generated by the sink, which is useful e.g. to solve the problems detailed in https://github.com/vectordotdev/vector/issues/3378.

There is no negative impact, as the `request.headers` http sink configuration property already is a map, so does not allow for duplicate headers.