### PR TITLE
chore(docs): remove mentions of Vector from sinks and transforms descriptions

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -156,7 +156,7 @@ impl Output {
     description = "This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. \
 Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 [global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 [e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/"

--- a/src/sinks/apex/mod.rs
+++ b/src/sinks/apex/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 pub struct ApexSinkConfig {
     /// The base URI of the Apex instance.
     ///
-    /// Vector will append `/add_events` to this.
+    /// `/add_events` is appended to this.
     uri: UriSerde,
 
     /// The ID of the project to associate reported logs with.

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -58,9 +58,9 @@ pub struct CloudwatchLogsSinkConfig {
 
     /// The [stream name][stream_name] of the target CloudWatch Logs stream.
     ///
-    /// Note that there can only be one writer to a log stream at a time. If you have multiple
-    /// instances of Vector writing to the same log group, you must include an identifier in the
-    /// stream name that is guaranteed to be unique per Vector instance.
+    /// There can only be one writer to a log stream at a time. If you have multiple
+    /// instances writing to the same log group, you must include an identifier in the
+    /// stream name that is guaranteed to be unique per instance.
     ///
     /// For example, you might choose `host`.
     ///

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -53,7 +53,7 @@ pub struct S3SinkConfig {
     ///
     /// Prefixes are useful for partitioning objects, such as by creating an object key that
     /// stores objects under a particular "directory". If using a prefix for this purpose, it must end
-    /// in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+    /// in `/` to act as a directory path. A trailing `/` is **not** automatically added.
     #[configurable(metadata(docs::templateable))]
     pub key_prefix: Option<String>,
 

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -57,7 +57,7 @@ pub struct AzureBlobSinkConfig {
     ///
     /// Prefixes are useful for partitioning objects, such as by creating an blob key that
     /// stores blobs under a particular "directory". If using a prefix for this purpose, it must end
-    /// in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+    /// in `/` to act as a directory path. A trailing `/` is **not** automatically added.
     pub blob_prefix: Option<String>,
 
     /// The timestamp format for the time component of the blob key.

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -103,7 +103,7 @@ pub struct DatadogArchivesSinkConfig {
     ///
     /// Prefixes are useful for partitioning objects, such as by creating an object key that
     /// stores objects under a particular "directory". If using a prefix for this purpose, it must end
-    /// in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+    /// in `/` to act as a directory path. A trailing `/` is **not** added automatically.
     pub key_prefix: Option<String>,
 
     #[configurable(derived)]

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -103,7 +103,7 @@ pub struct DatadogArchivesSinkConfig {
     ///
     /// Prefixes are useful for partitioning objects, such as by creating an object key that
     /// stores objects under a particular "directory". If using a prefix for this purpose, it must end
-    /// in `/` to act as a directory path. A trailing `/` is **not** added automatically.
+    /// in `/` to act as a directory path. A trailing `/` is **not** automatically added.
     pub key_prefix: Option<String>,
 
     #[configurable(derived)]

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -83,9 +83,8 @@ pub struct ElasticsearchConfig {
 
     /// The name of the event key that should map to Elasticsearch’s [`_id` field][es_id].
     ///
-    /// By default, Vector does not set the `_id` field, which allows Elasticsearch to set this
-    /// automatically. You should think carefully about setting your own Elasticsearch IDs, since
-    /// this can [hinder performance][perf_doc].
+    /// By default, the `_id` field is not set, which allows Elasticsearch to set this
+    /// automatically. Setting your own Elasticsearch IDs can [hinder performance][perf_doc].
     ///
     /// [es_id]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html
     /// [perf_doc]: https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html#_use_auto_generated_ids

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -26,7 +26,7 @@ pub struct HoneycombConfig {
     /// The team key that will be used to authenticate against Honeycomb.
     api_key: SensitiveString,
 
-    /// The dataset that Vector will send logs to.
+    /// The dataset to which logs are sent.
     // TODO: we probably want to make this a template
     // but this limits us in how we can do our healthcheck.
     dataset: String,

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -64,7 +64,7 @@ fn default_loki_path() -> String {
 pub struct LokiConfig {
     /// The base URL of the Loki instance.
     ///
-    /// Vector will append the value of `path` to this.
+    /// The `path` value is appended to this.
     pub endpoint: UriSerde,
 
     /// The path to use in the URL of the Loki instance.

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -101,8 +101,8 @@ pub struct PrometheusExporterConfig {
 
     /// Whether or not to render [distributions][dist_metric_docs] as an [aggregated histogram][prom_agg_hist_docs] or  [aggregated summary][prom_agg_summ_docs].
     ///
-    /// While Vector supports distributions as a lossless way to represent a set of samples for a
-    /// metric, Prometheus clients (the application being scraped, which is this sink) must
+    /// While distributions as a lossless way to represent a set of samples for a
+    /// metric is supported, Prometheus clients (the application being scraped, which is this sink) must
     /// aggregate locally into either an aggregated histogram or aggregated summary.
     ///
     /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -35,7 +35,7 @@ pub struct VectorConfig {
     /// Version of the configuration.
     version: Option<super::VectorConfigVersion>,
 
-    /// The downstream address to which to connect.
+    /// The downstream Vector address to which to connect.
     ///
     /// The address _must_ include a port.
     address: String,

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -35,7 +35,7 @@ pub struct VectorConfig {
     /// Version of the configuration.
     version: Option<super::VectorConfigVersion>,
 
-    /// The downstream Vector address to connect to.
+    /// The downstream address to which to connect.
     ///
     /// The address _must_ include a port.
     address: String,

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -124,7 +124,7 @@ pub struct Ec2Metadata {
     )]
     proxy: ProxyConfig,
 
-    /// Requires the transform to be able to successfully query the EC2 metadata before Vector can start.
+    /// Requires the transform to be able to successfully query the EC2 metadata before starting to process the data.
     #[serde(default = "default_required")]
     #[derivative(Default(value = "default_required()"))]
     required: bool,

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -32,7 +32,7 @@ enum V1 {
 pub struct LuaConfigV1 {
     /// Transform API version.
     ///
-    /// Specifying this version ensures that Vector does not break backward compatibility.
+    /// Specifying this version ensures that backward compatibility does not break.
     version: Option<V1>,
 
     #[serde(flatten)]
@@ -54,7 +54,7 @@ enum V2 {
 pub struct LuaConfigV2 {
     /// Transform API version.
     ///
-    /// Specifying this version ensures that Vector does not break backward compatibility.
+    /// Specifying this version ensures that backward compatibility does not break.
     version: V2,
 
     #[serde(flatten)]

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -32,7 +32,7 @@ enum V1 {
 pub struct LuaConfigV1 {
     /// Transform API version.
     ///
-    /// Specifying this version ensures that backward compatibility does not break.
+    /// Specifying this version ensures that backward compatibility is not broken.
     version: Option<V1>,
 
     #[serde(flatten)]
@@ -54,7 +54,7 @@ enum V2 {
 pub struct LuaConfigV2 {
     /// Transform API version.
     ///
-    /// Specifying this version ensures that backward compatibility does not break.
+    /// Specifying this version ensures that backward compatibility is not broken.
     version: V2,
 
     #[serde(flatten)]

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -30,7 +30,7 @@ pub struct LuaConfig {
 
     /// A list of directories to search when loading a Lua file via the `require` function.
     ///
-    /// If not specified, the modules are looked up in the directories of Vector’s configs.
+    /// If not specified, the modules are looked up in the configuration directories.
     #[serde(default)]
     search_dirs: Vec<String>,
 }

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -64,7 +64,7 @@ pub struct LuaConfig {
 
     /// A list of directories to search when loading a Lua file via the `require` function.
     ///
-    /// If not specified, the modules are looked up in the directories of Vector’s configs.
+    /// If not specified, the modules are looked up in the configuration directories.
     #[serde(default = "default_config_paths")]
     #[configurable(metadata(docs::examples = "/etc/vector/lua"))]
     search_dirs: Vec<PathBuf>,
@@ -110,7 +110,7 @@ fn default_config_paths() -> Vec<PathBuf> {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct HooksConfig {
-    /// A function which is called when the first event comes, before calling `hooks.process`.
+    /// The function called when the first event comes in, before `hooks.process` is called.
     ///
     /// It can produce new events using the `emit` function.
     ///
@@ -122,7 +122,7 @@ struct HooksConfig {
     ))]
     init: Option<String>,
 
-    /// A function which is called for each incoming event.
+    /// The function called for each incoming event.
     ///
     /// It can produce new events using the `emit` function.
     ///
@@ -135,7 +135,7 @@ struct HooksConfig {
     ))]
     process: String,
 
-    /// A function which is called when Vector is stopped.
+    /// The function called when the transform is stopped.
     ///
     /// It can produce new events using the `emit` function.
     ///

--- a/website/cue/reference/components/sinks/base/apex.cue
+++ b/website/cue/reference/components/sinks/base/apex.cue
@@ -192,7 +192,7 @@ base: components: sinks: apex: configuration: {
 		description: """
 			The base URI of the Apex instance.
 
-			Vector will append `/add_events` to this.
+			`/add_events` is appended to this.
 			"""
 		required: true
 		type: string: {}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -417,9 +417,9 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		description: """
 			The [stream name][stream_name] of the target CloudWatch Logs stream.
 
-			Note that there can only be one writer to a log stream at a time. If you have multiple
-			instances of Vector writing to the same log group, you must include an identifier in the
-			stream name that is guaranteed to be unique per Vector instance.
+			There can only be one writer to a log stream at a time. If you have multiple
+			instances writing to the same log group, you must include an identifier in the
+			stream name that is guaranteed to be unique per instance.
 
 			For example, you might choose `host`.
 

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -472,7 +472,7 @@ base: components: sinks: aws_s3: configuration: {
 
 			Prefixes are useful for partitioning objects, such as by creating an object key that
 			stores objects under a particular "directory". If using a prefix for this purpose, it must end
-			in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+			in `/` to act as a directory path. A trailing `/` is **not** automatically added.
 			"""
 		required: false
 		type: string: syntax: "template"

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -74,7 +74,7 @@ base: components: sinks: azure_blob: configuration: {
 
 			Prefixes are useful for partitioning objects, such as by creating an blob key that
 			stores blobs under a particular "directory". If using a prefix for this purpose, it must end
-			in `/` in order to act as a directory path: Vector will **not** add a trailing `/` automatically.
+			in `/` to act as a directory path. A trailing `/` is **not** automatically added.
 			"""
 		required: false
 		type: string: {}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -350,9 +350,8 @@ base: components: sinks: elasticsearch: configuration: {
 		description: """
 			The name of the event key that should map to Elasticsearch’s [`_id` field][es_id].
 
-			By default, Vector does not set the `_id` field, which allows Elasticsearch to set this
-			automatically. You should think carefully about setting your own Elasticsearch IDs, since
-			this can [hinder performance][perf_doc].
+			By default, the `_id` field is not set, which allows Elasticsearch to set this
+			automatically. Setting your own Elasticsearch IDs can [hinder performance][perf_doc].
 
 			[es_id]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html
 			[perf_doc]: https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html#_use_auto_generated_ids

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -59,7 +59,7 @@ base: components: sinks: honeycomb: configuration: {
 		}
 	}
 	dataset: {
-		description: "The dataset that Vector will send logs to."
+		description: "The dataset to which logs are sent."
 		required:    true
 		type: string: {}
 	}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -223,7 +223,7 @@ base: components: sinks: loki: configuration: {
 		description: """
 			The base URL of the Loki instance.
 
-			Vector will append the value of `path` to this.
+			The `path` value is appended to this.
 			"""
 		required: true
 		type: string: examples: ["http://localhost:3100"]

--- a/website/cue/reference/components/sinks/base/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_exporter.cue
@@ -113,8 +113,8 @@ base: components: sinks: prometheus_exporter: configuration: {
 		description: """
 			Whether or not to render [distributions][dist_metric_docs] as an [aggregated histogram][prom_agg_hist_docs] or  [aggregated summary][prom_agg_summ_docs].
 
-			While Vector supports distributions as a lossless way to represent a set of samples for a
-			metric, Prometheus clients (the application being scraped, which is this sink) must
+			While distributions as a lossless way to represent a set of samples for a
+			metric is supported, Prometheus clients (the application being scraped, which is this sink) must
 			aggregate locally into either an aggregated histogram or aggregated summary.
 
 			[dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -29,7 +29,7 @@ base: components: sinks: vector: configuration: {
 	}
 	address: {
 		description: """
-			The downstream Vector address to connect to.
+			The downstream Vector address to which to connect.
 
 			The address _must_ include a port.
 			"""

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -7,7 +7,7 @@ base: components: sources: amqp: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -17,7 +17,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -7,7 +7,7 @@ base: components: sources: aws_s3: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -7,7 +7,7 @@ base: components: sources: aws_sqs: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -7,7 +7,7 @@ base: components: sources: datadog_agent: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -7,7 +7,7 @@ base: components: sources: file: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -7,7 +7,7 @@ base: components: sources: fluent: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -21,7 +21,7 @@ base: components: sources: gcp_pubsub: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -7,7 +7,7 @@ base: components: sources: heroku_logs: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -7,7 +7,7 @@ base: components: sources: http: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -7,7 +7,7 @@ base: components: sources: http_server: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/journald.cue
+++ b/website/cue/reference/components/sources/base/journald.cue
@@ -7,7 +7,7 @@ base: components: sources: journald: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -7,7 +7,7 @@ base: components: sources: kafka: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -7,7 +7,7 @@ base: components: sources: logstash: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -232,10 +232,7 @@ base: components: sources: nats: configuration: {
 	subject_key_field: {
 		description: "The `NATS` subject key."
 		required:    false
-		type: string: {
-			default: "subject"
-			syntax:  "literal"
-		}
+		type: string: default: "subject"
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -7,7 +7,7 @@ base: components: sources: opentelemetry: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -7,7 +7,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/sources/base/vector.cue
+++ b/website/cue/reference/components/sources/base/vector.cue
@@ -7,7 +7,7 @@ base: components: sources: vector: configuration: {
 
 			This setting is **deprecated** in favor of enabling `acknowledgements` at the [global][global_acks] or sink level. Enabling or disabling acknowledgements at the source level has **no effect** on acknowledgement behavior.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/

--- a/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
@@ -93,7 +93,7 @@ base: components: transforms: aws_ec2_metadata: configuration: {
 		}
 	}
 	required: {
-		description: "Requires the transform to be able to successfully query the EC2 metadata before Vector can start."
+		description: "Requires the transform to be able to successfully query the EC2 metadata before starting to process the data."
 		required:    false
 		type: bool: default: true
 	}

--- a/website/cue/reference/components/transforms/base/lua.cue
+++ b/website/cue/reference/components/transforms/base/lua.cue
@@ -11,7 +11,7 @@ base: components: transforms: lua: configuration: {
 		type: object: options: {
 			init: {
 				description: """
-					A function which is called when the first event comes, before calling `hooks.process`.
+					The function called when the first event comes in, before `hooks.process` is called.
 
 					It can produce new events using the `emit` function.
 
@@ -27,7 +27,7 @@ base: components: transforms: lua: configuration: {
 			}
 			process: {
 				description: """
-					A function which is called for each incoming event.
+					The function called for each incoming event.
 
 					It can produce new events using the `emit` function.
 
@@ -48,7 +48,7 @@ base: components: transforms: lua: configuration: {
 			}
 			shutdown: {
 				description: """
-					A function which is called when Vector is stopped.
+					The function called when the transform is stopped.
 
 					It can produce new events using the `emit` function.
 
@@ -90,7 +90,7 @@ base: components: transforms: lua: configuration: {
 		description: """
 			A list of directories to search when loading a Lua file via the `require` function.
 
-			If not specified, the modules are looked up in the directories of Vector’s configs.
+			If not specified, the modules are looked up in the configuration directories.
 			"""
 		required: false
 		type: array: {
@@ -171,7 +171,7 @@ base: components: transforms: lua: configuration: {
 		description: """
 			Transform API version.
 
-			Specifying this version ensures that Vector does not break backward compatibility.
+			Specifying this version ensures that backward compatibility is not broken.
 			"""
 		required: true
 		type: string: enum: {


### PR DESCRIPTION
This PR removes `vector` from sinks' and transforms' descriptions because they will be getting pulled into the Reference section in the Observability Pipelines docs.

ref: DOCS-4569