### PR TITLE
fix(heroku_logs source): Fix schema def for the host key path

### DIFF
--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -92,7 +92,10 @@ impl LogplexConfig {
             )
             .with_source_metadata(
                 LogplexConfig::NAME,
-                Some(LegacyKey::InsertIfEmpty(owned_value_path!("host"))),
+                Some(LegacyKey::InsertIfEmpty(owned_value_path!(
+                    log_schema().
+                    ()
+                ))),
                 &owned_value_path!("host"),
                 Kind::bytes(),
                 Some("host"),

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -93,8 +93,7 @@ impl LogplexConfig {
             .with_source_metadata(
                 LogplexConfig::NAME,
                 Some(LegacyKey::InsertIfEmpty(owned_value_path!(
-                    log_schema().
-                    ()
+                    log_schema().host_key()
                 ))),
                 &owned_value_path!("host"),
                 Kind::bytes(),


### PR DESCRIPTION
Noticed as part of https://github.com/vectordotdev/vector/issues/15635

The legacy path was hardcoded to "host" but it could have been overwritten by the global schema.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
