### PR TITLE
chore(deps): 'cannot find -lsasl' in some environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,7 @@ postgres-openssl = { version = "0.5.0", default-features = false, features = ["r
 pulsar = { version = "5.0.0", default-features = false, features = ["tokio-runtime", "auth-oauth2", "flate2", "lz4", "snap", "zstd"], optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rand_distr = { version = "0.4.3", default-features = false }
-rdkafka = { version = "0.29.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd"], optional = true }
+rdkafka = { version = "0.29.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd", "cmake-build"], optional = true }
 redis = { version = "0.22.1", default-features = false, features = ["connection-manager", "tokio-comp", "tokio-native-tls-comp"], optional = true }
 regex = { version = "1.7.0", default-features = false, features = ["std", "perf"] }
 roaring = { version = "0.10.1", default-features = false, optional = true }


### PR DESCRIPTION
When trying to build `vector` on Fedora 37, I encounter following error:
`/usr/bin/ld: cannot find -lsasl`
even though I have `cyrus-sasl` installed. `rdkafka` official recommendation is to use `cmake` to fix such issues

This PR switches rdkafka's build system to cmake to allow for better compatibility