### PR TITLE
chore(file source): avoid duplicate span enter in message stream map

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -616,9 +616,7 @@ pub fn file_source(
         // Once file server ends this will run until it has finished processing remaining
         // logs in the queue.
         let span = Span::current();
-        let span2 = span.clone();
         let mut messages = messages.map(move |line| {
-            let _enter = span2.enter();
             let mut event = create_event(
                 line.text,
                 line.start_offset,


### PR DESCRIPTION
This PR removes a duplicate span enter operation in the `file` source, which should improve performance slightly. As we already instrument the `SourceSender::send_event_stream(&mut messages)` operation, entering the span for each `map` operation on the `messages` stream is a no-op functionally, but incurs the performance overhead regardless.