### PR TITLE
docs(vector source): Source doesn't support tls client metadata enrichment

### DIFF
--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -81,7 +81,6 @@ components: sources: vector: {
 		logs: event: {
 			description: "A Vector event"
 			fields: {
-				client_metadata: fields._client_metadata
 				source_type: {
 					description: "The name of the source type."
 					required:    true


### PR DESCRIPTION
As part of #15635

The original PR, https://github.com/vectordotdev/vector/pull/11905, added support for the v1 source but not v2.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
