### PR TITLE
feat(fluent source, logstash source, socket source, statsd source, syslog source): Use OptionalValuePath instead of String for client_metadata_key

### DIFF
--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use lookup::lookup_v2::OptionalValuePath;
 use openssl::{
     pkcs12::{ParsedPkcs12, Pkcs12},
     pkey::{PKey, Private},
@@ -71,7 +72,7 @@ impl TlsEnableableConfig {
 #[derive(Clone, Debug, Default)]
 pub struct TlsSourceConfig {
     /// Event field for client certificate metadata.
-    pub client_metadata_key: Option<String>,
+    pub client_metadata_key: Option<OptionalValuePath>,
 
     #[serde(flatten)]
     pub tls_config: TlsEnableableConfig,

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -89,7 +89,8 @@ impl SourceConfig for FluentConfig {
         let tls_client_metadata_key = self
             .tls
             .as_ref()
-            .and_then(|tls| tls.client_metadata_key.clone());
+            .and_then(|tls| tls.client_metadata_key.clone())
+            .and_then(|k| k.path);
         let tls = MaybeTlsSettings::from_config(&tls_config, true)?;
         source.run(
             self.address,
@@ -136,7 +137,7 @@ impl FluentConfig {
             .tls
             .as_ref()
             .and_then(|tls| tls.client_metadata_key.as_ref())
-            .and_then(|x| parse_value_path(x).ok())
+            .and_then(|k| k.path.clone())
             .map(LegacyKey::Overwrite);
 
         // There is a global and per-source `log_namespace` config.

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -77,7 +77,7 @@ impl LogstashConfig {
             .tls
             .as_ref()
             .and_then(|tls| tls.client_metadata_key.as_ref())
-            .and_then(|x| parse_value_path(x).ok())
+            .and_then(|k| k.path.clone())
             .map(LegacyKey::Overwrite);
 
         BytesDeserializerConfig
@@ -141,7 +141,8 @@ impl SourceConfig for LogstashConfig {
         let tls_client_metadata_key = self
             .tls
             .as_ref()
-            .and_then(|tls| tls.client_metadata_key.clone());
+            .and_then(|tls| tls.client_metadata_key.clone())
+            .and_then(|k| k.path);
 
         let tls = MaybeTlsSettings::from_config(&tls_config, true)?;
         source.run(

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -141,7 +141,8 @@ impl SourceConfig for SocketConfig {
                 let tls_client_metadata_key = config
                     .tls()
                     .as_ref()
-                    .and_then(|tls| tls.client_metadata_key.clone());
+                    .and_then(|tls| tls.client_metadata_key.clone())
+                    .and_then(|k| k.path);
                 let tls = MaybeTlsSettings::from_config(&tls_config, true)?;
                 tcp.run(
                     config.address(),
@@ -251,7 +252,7 @@ impl SourceConfig for SocketConfig {
                     .tls()
                     .as_ref()
                     .and_then(|tls| tls.client_metadata_key.as_ref())
-                    .and_then(|x| parse_value_path(x).ok())
+                    .and_then(|k| k.path.clone())
                     .map(LegacyKey::Overwrite);
 
                 schema_definition
@@ -390,7 +391,8 @@ mod test {
     #[cfg(unix)]
     use codecs::{decoding::CharacterDelimitedDecoderOptions, CharacterDelimitedDecoderConfig};
     use futures::{stream, StreamExt};
-    use lookup::path;
+    use lookup::lookup_v2::OptionalValuePath;
+    use lookup::{owned_value_path, path};
     use tokio::{
         task::JoinHandle,
         time::{timeout, Duration, Instant},
@@ -611,7 +613,7 @@ mod test {
                         ..Default::default()
                     },
                 },
-                client_metadata_key: Some("tls_peer".into()),
+                client_metadata_key: Some(OptionalValuePath::from(owned_value_path!("tls_peer"))),
             }));
 
             let server = SocketConfig::from(config)

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -391,8 +391,7 @@ mod test {
     #[cfg(unix)]
     use codecs::{decoding::CharacterDelimitedDecoderOptions, CharacterDelimitedDecoderConfig};
     use futures::{stream, StreamExt};
-    use lookup::lookup_v2::OptionalValuePath;
-    use lookup::{owned_value_path, path};
+    use lookup::{lookup_v2::OptionalValuePath, owned_value_path, path};
     use tokio::{
         task::JoinHandle,
         time::{timeout, Duration, Instant},

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -145,7 +145,8 @@ impl SourceConfig for StatsdConfig {
                 let tls_client_metadata_key = config
                     .tls
                     .as_ref()
-                    .and_then(|tls| tls.client_metadata_key.clone());
+                    .and_then(|tls| tls.client_metadata_key.clone())
+                    .and_then(|k| k.path);
                 let tls = MaybeTlsSettings::from_config(&tls_config, true)?;
                 StatsdTcpSource.run(
                     config.address,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -174,8 +174,10 @@ impl SourceConfig for SyslogConfig {
                 };
                 let shutdown_secs = 30;
                 let tls_config = tls.as_ref().map(|tls| tls.tls_config.clone());
-                let tls_client_metadata_key =
-                    tls.as_ref().and_then(|tls| tls.client_metadata_key.clone());
+                let tls_client_metadata_key = tls
+                    .as_ref()
+                    .and_then(|tls| tls.client_metadata_key.clone())
+                    .and_then(|k| k.path);
                 let tls = MaybeTlsSettings::from_config(&tls_config, true)?;
                 source.run(
                     address,

--- a/src/sources/util/net/tcp/mod.rs
+++ b/src/sources/util/net/tcp/mod.rs
@@ -1,8 +1,6 @@
 mod request_limiter;
 
-use std::collections::BTreeMap;
-use std::net::SocketAddr;
-use std::{io, mem::drop, time::Duration};
+use std::{collections::BTreeMap, io, mem::drop, net::SocketAddr, time::Duration};
 
 use bytes::Bytes;
 use codecs::StreamDecodingError;
@@ -19,8 +17,10 @@ use tokio::{
 use tokio_util::codec::{Decoder, FramedRead};
 use tracing::Instrument;
 use vector_common::finalization::AddBatchNotifier;
-use vector_core::config::{LegacyKey, LogNamespace};
-use vector_core::{config::SourceAcknowledgementsConfig, EstimatedJsonEncodedSizeOf};
+use vector_core::{
+    config::{LegacyKey, LogNamespace, SourceAcknowledgementsConfig},
+    EstimatedJsonEncodedSizeOf,
+};
 
 use self::request_limiter::RequestLimiter;
 use super::SocketListenAddr;

--- a/src/sources/util/net/tcp/mod.rs
+++ b/src/sources/util/net/tcp/mod.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use codecs::StreamDecodingError;
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use listenfd::ListenFd;
-use lookup::metadata_path;
+use lookup::{path, OwnedValuePath};
 use smallvec::SmallVec;
 use socket2::SockRef;
 use tokio::{
@@ -19,7 +19,7 @@ use tokio::{
 use tokio_util::codec::{Decoder, FramedRead};
 use tracing::Instrument;
 use vector_common::finalization::AddBatchNotifier;
-use vector_core::config::LogNamespace;
+use vector_core::config::{LegacyKey, LogNamespace};
 use vector_core::{config::SourceAcknowledgementsConfig, EstimatedJsonEncodedSizeOf};
 
 use self::request_limiter::RequestLimiter;
@@ -110,7 +110,7 @@ where
         keepalive: Option<TcpKeepaliveConfig>,
         shutdown_timeout_secs: u64,
         tls: MaybeTlsSettings,
-        tls_client_metadata_key: Option<String>,
+        tls_client_metadata_key: Option<OwnedValuePath>,
         receive_buffer_bytes: Option<usize>,
         cx: SourceContext,
         acknowledgements: SourceAcknowledgementsConfig,
@@ -238,7 +238,7 @@ async fn handle_stream<T>(
     mut out: SourceSender,
     acknowledgements: bool,
     request_limiter: RequestLimiter,
-    tls_client_metadata_key: Option<String>,
+    tls_client_metadata_key: Option<OwnedValuePath>,
     source_name: &'static str,
     log_namespace: LogNamespace,
 ) where
@@ -351,16 +351,13 @@ async fn handle_stream<T>(
                             for event in &mut events {
                                 let log = event.as_mut_log();
 
-                                match log_namespace {
-                                    LogNamespace::Vector => {
-                                        log.insert(metadata_path!(source_name, "tls_client_metadata"), metadata.clone());
-                                    }
-                                    LogNamespace::Legacy => {
-                                        if let Some(tls_client_metadata_key) = &tls_client_metadata_key {
-                                            log.insert(&tls_client_metadata_key[..], metadata.clone());
-                                        }
-                                    }
-                                }
+                                log_namespace.insert_source_metadata(
+                                    source_name,
+                                    log,
+                                    tls_client_metadata_key.as_ref().map(LegacyKey::Overwrite),
+                                    path!("tls_client_metadata"),
+                                    metadata.clone()
+                                );
                             }
                         }
 


### PR DESCRIPTION
Part of #15635

Going to try and split the changes to `socket` into as many PRs as possible, as the changes end up touching a number of files.

Welcome suggestions to make this less awful, but I wanted to get this up in a functional state.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
