### PR TITLE
feat(socket): Use OptionalValuePath in the tcp socket config

### DIFF
--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -7,7 +7,7 @@ use codecs::{decoding::DeserializerConfig, NewlineDelimitedDecoderConfig};
 use lookup::{lookup_v2::parse_value_path, owned_value_path};
 use value::{kind::Collection, Kind};
 use vector_config::{configurable_component, NamedComponent};
-use vector_core::config::{LegacyKey, LogNamespace};
+use vector_core::config::{log_schema, LegacyKey, LogNamespace};
 
 #[cfg(unix)]
 use crate::serde::default_framing_message_based;
@@ -229,23 +229,20 @@ impl SourceConfig for SocketConfig {
 
         let schema_definition = match &self.mode {
             Mode::Tcp(config) => {
-                let host_key_path = config
+                let legacy_host_key = config
                     .host_key()
                     .as_ref()
-                    .and_then(|x| parse_value_path(x).ok())
                     .map_or_else(
-                        || LegacyKey::InsertIfEmpty(owned_value_path!("host")),
-                        LegacyKey::InsertIfEmpty,
-                    );
+                        || parse_value_path(log_schema().host_key()).ok(),
+                        |k| k.path.clone(),
+                    )
+                    .map(LegacyKey::InsertIfEmpty);
 
-                let port_key_path = config
+                let legacy_port_key = config
                     .port_key()
                     .as_ref()
-                    .and_then(|x| parse_value_path(x).ok())
-                    .map_or_else(
-                        || LegacyKey::InsertIfEmpty(owned_value_path!("port")),
-                        LegacyKey::InsertIfEmpty,
-                    );
+                    .map_or_else(|| parse_value_path("port").ok(), |k| k.path.clone())
+                    .map(LegacyKey::InsertIfEmpty);
 
                 let tls_client_metadata_path = config
                     .tls()
@@ -257,14 +254,14 @@ impl SourceConfig for SocketConfig {
                 schema_definition
                     .with_source_metadata(
                         Self::NAME,
-                        Some(host_key_path),
+                        legacy_host_key,
                         &owned_value_path!("host"),
                         Kind::bytes(),
                         None,
                     )
                     .with_source_metadata(
                         Self::NAME,
-                        Some(port_key_path),
+                        legacy_port_key,
                         &owned_value_path!("port"),
                         Kind::bytes(),
                         None,

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -1,7 +1,9 @@
 use chrono::Utc;
 use codecs::decoding::{DeserializerConfig, FramingConfig};
-use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
-use lookup::{owned_value_path, path};
+use lookup::{
+    lookup_v2::{parse_value_path, OptionalValuePath},
+    owned_value_path, path,
+};
 use smallvec::SmallVec;
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::{LegacyKey, LogNamespace};

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -209,7 +209,7 @@ impl TcpSource for RawTcpSource {
                     now,
                 );
 
-                let host_key_path = self.config.host_key.as_ref().map_or_else(
+                let legacy_host_key = self.config.host_key.as_ref().map_or_else(
                     || parse_value_path(log_schema().host_key()).ok(),
                     |k| k.path.clone(),
                 );
@@ -217,12 +217,12 @@ impl TcpSource for RawTcpSource {
                 self.log_namespace.insert_source_metadata(
                     SocketConfig::NAME,
                     log,
-                    host_key_path.as_ref().map(LegacyKey::InsertIfEmpty),
+                    legacy_host_key.as_ref().map(LegacyKey::InsertIfEmpty),
                     path!("host"),
                     host.ip().to_string(),
                 );
 
-                let port_key_path = self
+                let legacy_port_key = self
                     .config
                     .port_key
                     .as_ref()
@@ -231,7 +231,7 @@ impl TcpSource for RawTcpSource {
                 self.log_namespace.insert_source_metadata(
                     SocketConfig::NAME,
                     log,
-                    port_key_path.as_ref().map(LegacyKey::InsertIfEmpty),
+                    legacy_port_key.as_ref().map(LegacyKey::InsertIfEmpty),
                     path!("port"),
                     host.port(),
                 );

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -226,7 +226,7 @@ impl TcpSource for RawTcpSource {
                     .config
                     .port_key
                     .as_ref()
-                    .map_or_else(|| parse_value_path("path").ok(), |k| k.path.clone());
+                    .map_or_else(|| parse_value_path("port").ok(), |k| k.path.clone());
 
                 self.log_namespace.insert_source_metadata(
                     SocketConfig::NAME,

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use codecs::decoding::{DeserializerConfig, FramingConfig};
-use lookup::{lookup_v2::BorrowedSegment, path};
+use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
+use lookup::{owned_value_path, path};
 use smallvec::SmallVec;
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::{LegacyKey, LogNamespace};
@@ -43,14 +44,14 @@ pub struct TcpConfig {
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    host_key: Option<String>,
+    host_key: Option<OptionalValuePath>,
 
     /// Overrides the name of the log field used to add the peer host's port to each event.
     ///
     /// The value will be the peer host's port i.e. `9000`.
     ///
     /// By default, `"port"` is used.
-    port_key: Option<String>,
+    port_key: Option<OptionalValuePath>,
 
     #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
@@ -87,7 +88,7 @@ impl TcpConfig {
             max_length: Some(crate::serde::default_max_length()),
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
             host_key: None,
-            port_key: Some(String::from("port")),
+            port_key: Some(OptionalValuePath::from(owned_value_path!("port"))),
             tls: None,
             receive_buffer_bytes: None,
             framing: None,
@@ -97,11 +98,11 @@ impl TcpConfig {
         }
     }
 
-    pub const fn host_key(&self) -> &Option<String> {
+    pub const fn host_key(&self) -> &Option<OptionalValuePath> {
         &self.host_key
     }
 
-    pub const fn port_key(&self) -> &Option<String> {
+    pub const fn port_key(&self) -> &Option<OptionalValuePath> {
         &self.port_key
     }
 
@@ -207,27 +208,28 @@ impl TcpSource for RawTcpSource {
                 );
 
                 let host_key_path = self.config.host_key.as_ref().map_or_else(
-                    || [BorrowedSegment::from(log_schema().host_key())],
-                    |key| [BorrowedSegment::from(key)],
+                    || parse_value_path(log_schema().host_key()).ok(),
+                    |k| k.path.clone(),
                 );
 
                 self.log_namespace.insert_source_metadata(
                     SocketConfig::NAME,
                     log,
-                    Some(LegacyKey::InsertIfEmpty(&host_key_path)),
+                    host_key_path.as_ref().map(LegacyKey::InsertIfEmpty),
                     path!("host"),
                     host.ip().to_string(),
                 );
 
-                let port_key_path = self.config.port_key.as_ref().map_or_else(
-                    || [BorrowedSegment::from("port")],
-                    |key| [BorrowedSegment::from(key)],
-                );
+                let port_key_path = self
+                    .config
+                    .port_key
+                    .as_ref()
+                    .map_or_else(|| parse_value_path("path").ok(), |k| k.path.clone());
 
                 self.log_namespace.insert_source_metadata(
                     SocketConfig::NAME,
                     log,
-                    Some(LegacyKey::InsertIfEmpty(&port_key_path)),
+                    port_key_path.as_ref().map(LegacyKey::InsertIfEmpty),
                     path!("port"),
                     host.port(),
                 );


### PR DESCRIPTION
Part of #15635

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
