### PR TITLE
docs(aws_ecs_metrics source): Use generated configuration docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,7 +513,7 @@ sources-metrics = [
 
 sources-amqp = ["lapin"]
 sources-apache_metrics = []
-sources-aws_ecs_metrics = []
+sources-aws_ecs_metrics = ["dep:serde_with"]
 sources-aws_kinesis_firehose = ["dep:base64", "dep:infer"]
 sources-aws_s3 = ["aws-core", "dep:aws-sdk-sqs", "dep:aws-sdk-s3", "dep:semver", "dep:async-compression", "sources-aws_sqs", "tokio-util/io"]
 sources-aws_sqs = ["aws-core", "dep:aws-sdk-sqs"]

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -93,8 +93,8 @@ pub struct AwsEcsMetricsSourceConfig {
     namespace: String,
 }
 
-const METADATA_URI_V4: &str = "ECS_CONTAINER_METADATA_URI_V4";
-const METADATA_URI_V3: &str = "ECS_CONTAINER_METADATA_URI";
+const METADATA_URI_V4: &str = "ECS_CONTAINER_METADATA_URI";
+const METADATA_URI_V3: &str = "ECS_CONTAINER_METADATA_URI_V4";
 
 pub fn default_endpoint() -> String {
     env::var(METADATA_URI_V4)

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -1,13 +1,13 @@
-use std::{env, time::Instant};
+use std::{env, time::Duration, time::Instant};
 
 use futures::StreamExt;
 use hyper::{Body, Client, Request};
+use serde_with::serde_as;
 use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vector_core::EstimatedJsonEncodedSizeOf;
+use vector_core::{config::LogNamespace, EstimatedJsonEncodedSizeOf};
 
 use crate::{
     config::{self, GenerateConfig, Output, SourceConfig, SourceContext},
@@ -24,29 +24,35 @@ mod parser;
 /// Version of the AWS ECS task metadata endpoint to use.
 ///
 /// More information about the different versions can be found
-/// (here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html].
+/// [here][meta_endpoint].
+///
+/// [meta_endpoint]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum Version {
     /// Version 2.
     ///
-    /// More information about version 2 of the task metadata endpoint can be found
-    /// (here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html].
+    /// More information about version 2 of the task metadata endpoint can be found [here][endpoint_v2].
+    ///
+    /// [endpoint_v2]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html
     V2,
     /// Version 3.
     ///
-    /// More information about version 3 of the task metadata endpoint can be found
-    /// (here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html].
+    /// More information about version 3 of the task metadata endpoint can be found [here][endpoint_v3].
+    ///
+    /// [endpoint_v3]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html
     V3,
     /// Version 4.
     ///
-    /// More information about version 4 of the task metadata endpoint can be found
-    /// (here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html].
+    /// More information about version 4 of the task metadata endpoint can be found [here][endpoint_v4].
+    ///
+    /// [endpoint_v4]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
     V4,
 }
 
 /// Configuration for the `aws_ecs_metrics` source.
+#[serde_as]
 #[configurable_component(source("aws_ecs_metrics"))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -56,9 +62,9 @@ pub struct AwsEcsMetricsSourceConfig {
     /// If empty, the URI will be automatically discovered based on the latest version detected.
     ///
     /// By default:
-    /// - The version 2 endpoint base URI is `169.254.170.2/v2/`.
-    /// - The version 3 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI`.
     /// - The version 4 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI_V4`.
+    /// - The version 3 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI`.
+    /// - The version 2 endpoint base URI is `169.254.170.2/v2/`.
     #[serde(default = "default_endpoint")]
     endpoint: String,
 
@@ -77,7 +83,8 @@ pub struct AwsEcsMetricsSourceConfig {
 
     /// The interval between scrapes, in seconds.
     #[serde(default = "default_scrape_interval_secs")]
-    scrape_interval_secs: u64,
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    scrape_interval_secs: Duration,
 
     /// The namespace of the metric.
     ///
@@ -86,8 +93,8 @@ pub struct AwsEcsMetricsSourceConfig {
     namespace: String,
 }
 
-const METADATA_URI_V4: &str = "ECS_CONTAINER_METADATA_URI";
-const METADATA_URI_V3: &str = "ECS_CONTAINER_METADATA_URI_V4";
+const METADATA_URI_V4: &str = "ECS_CONTAINER_METADATA_URI_V4";
+const METADATA_URI_V3: &str = "ECS_CONTAINER_METADATA_URI";
 
 pub fn default_endpoint() -> String {
     env::var(METADATA_URI_V4)
@@ -105,8 +112,8 @@ pub fn default_version() -> Version {
     }
 }
 
-pub const fn default_scrape_interval_secs() -> u64 {
-    15
+pub const fn default_scrape_interval_secs() -> Duration {
+    Duration::from_secs(15)
 }
 
 pub fn default_namespace() -> String {
@@ -159,12 +166,11 @@ impl SourceConfig for AwsEcsMetricsSourceConfig {
 
 async fn aws_ecs_metrics(
     url: String,
-    interval: u64,
+    interval: Duration,
     namespace: Option<String>,
     mut out: SourceSender,
     shutdown: ShutdownSignal,
 ) -> Result<(), ()> {
-    let interval = time::Duration::from_secs(interval);
     let mut interval = IntervalStream::new(time::interval(interval)).take_until(shutdown);
     let bytes_received = register!(BytesReceived::from(Protocol::HTTP));
     while interval.next().await.is_some() {
@@ -567,7 +573,7 @@ mod test {
         let config = AwsEcsMetricsSourceConfig {
             endpoint: format!("http://{}", in_addr),
             version: Version::V4,
-            scrape_interval_secs: 1,
+            scrape_interval_secs: Duration::from_secs(1),
             namespace: default_namespace(),
         };
 
@@ -610,7 +616,7 @@ mod integration_tests {
     use crate::test_util::components::{run_and_assert_source_compliance, SOURCE_TAGS};
 
     fn ecs_address() -> String {
-        std::env::var("ECS_ADDRESS").unwrap_or_else(|_| "http://localhost:9088".into())
+        env::var("ECS_ADDRESS").unwrap_or_else(|_| "http://localhost:9088".into())
     }
 
     fn ecs_url(version: &str) -> String {
@@ -621,7 +627,7 @@ mod integration_tests {
         let config = AwsEcsMetricsSourceConfig {
             endpoint,
             version,
-            scrape_interval_secs: 1,
+            scrape_interval_secs: Duration::from_secs(1),
             namespace: default_namespace(),
         };
 

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -18,6 +18,7 @@ components: sources: aws_ecs_metrics: {
 	}
 
 	features: {
+		auto_generated:   true
 		acknowledgements: false
 		collect: {
 			checkpoint: enabled: false
@@ -50,55 +51,7 @@ components: sources: aws_ecs_metrics: {
 		platform_name: null
 	}
 
-	configuration: {
-		endpoint: {
-			description: """
-				Base URI of the task metadata endpoint.
-				If empty, the URI will be automatically discovered based on the latest version detected.
-				The version 2 endpoint base URI is `169.254.170.2/v2/`.
-				The version 3 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI`.
-				The version 4 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI_V4`.
-				"""
-			common:   false
-			required: false
-			type: string: {
-				default: "${ECS_CONTAINER_METADATA_URI_V4}"
-			}
-		}
-		namespace: {
-			description: "The namespace of the metric. Disabled if empty."
-			common:      true
-			required:    false
-			type: string: {
-				default: "awsecs"
-			}
-		}
-		scrape_interval_secs: {
-			description: "The interval between scrapes, in seconds."
-			common:      true
-			required:    false
-			type: uint: {
-				default: 15
-				unit:    "seconds"
-			}
-		}
-		version: {
-			description: """
-				The version of the metadata endpoint. If empty, the version is automatically discovered based on
-				environment variables.
-				"""
-			common:   false
-			required: false
-			type: string: {
-				default: "v4"
-				enum: {
-					v4: "When the environment variable `ECS_CONTAINER_METADATA_URI_V4` is defined."
-					v3: "When the v4 check fails but the environment variable `ECS_CONTAINER_METADATA_URI` is defined."
-					v2: "When the v4 and v3 checks fail."
-				}
-			}
-		}
-	}
+	configuration: base.components.sources.aws_ecs_metrics.configuration
 
 	output: metrics: {
 		_awsecs: {

--- a/website/cue/reference/components/sources/base/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/base/aws_ecs_metrics.cue
@@ -8,9 +8,9 @@ base: components: sources: aws_ecs_metrics: configuration: {
 			If empty, the URI will be automatically discovered based on the latest version detected.
 
 			By default:
-			- The version 2 endpoint base URI is `169.254.170.2/v2/`.
-			- The version 3 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI`.
 			- The version 4 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI_V4`.
+			- The version 3 endpoint base URI is stored in the environment variable `ECS_CONTAINER_METADATA_URI`.
+			- The version 2 endpoint base URI is `169.254.170.2/v2/`.
 			"""
 		required: false
 		type: string: default: "http://169.254.170.2/v2"
@@ -27,7 +27,10 @@ base: components: sources: aws_ecs_metrics: configuration: {
 	scrape_interval_secs: {
 		description: "The interval between scrapes, in seconds."
 		required:    false
-		type: uint: default: 15
+		type: uint: {
+			default: 15
+			unit:    "seconds"
+		}
 	}
 	version: {
 		description: """
@@ -49,20 +52,23 @@ base: components: sources: aws_ecs_metrics: configuration: {
 				v2: """
 					Version 2.
 
-					More information about version 2 of the task metadata endpoint can be found
-					(here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html].
+					More information about version 2 of the task metadata endpoint can be found [here][endpoint_v2].
+
+					[endpoint_v2]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html
 					"""
 				v3: """
 					Version 3.
 
-					More information about version 3 of the task metadata endpoint can be found
-					(here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html].
+					More information about version 3 of the task metadata endpoint can be found [here][endpoint_v3].
+
+					[endpoint_v3]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html
 					"""
 				v4: """
 					Version 4.
 
-					More information about version 4 of the task metadata endpoint can be found
-					(here)[https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html].
+					More information about version 4 of the task metadata endpoint can be found [here][endpoint_v4].
+
+					[endpoint_v4]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
 					"""
 			}
 		}


### PR DESCRIPTION
Closes #15669
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
