### PR TITLE
fix(ci): Correct check names in trusted Regression Detector workflow

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -453,7 +453,7 @@ jobs:
             /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
             -f state='failure' \
             -f description='Analyze experimental results from Regression Detector cancelled.' \
-            -f context='Regression Detector / analyze-experiment' \
+            -f context='Regression Detector / detect-regression' \
             -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Check status, success
@@ -466,7 +466,7 @@ jobs:
             /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
             -f state='success' \
             -f description='Analyze experimental results from Regression Detector succeeded.' \
-            -f context='Regression Detector / analyze-experiment' \
+            -f context='Regression Detector / detect-regression' \
             -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Check status, failure
@@ -480,10 +480,10 @@ jobs:
             /repos/${{ github.repository }}/statuses/${{ needs.compute-metadata.outputs.head-sha }} \
             -f state='success' \
             -f description='Analyze experimental results from Regression Detector failed.' \
-            -f context='Regression Detector / analyze-experiment' \
+            -f context='Regression Detector / detect-regression' \
             -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-  download-analysis:
+  analyze-experiment:
     name: Download regression analysis & upload report
     runs-on: ubuntu-22.04
     needs:


### PR DESCRIPTION
This commit adjusts the names of the detect-regression check to `detect-regression` and adjusts the name of the `download-analysis` to `analyze-experiment`, to more accruate reflect its purpose. This change will require the required check to be adjusted to point to `Regression Detector / detect-regression`

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
