### PR TITLE
chore(x86_64 platform): Build packages with an older glibc to reenable centos7 and others.

### DIFF
--- a/scripts/cross/bootstrap-centos.sh
+++ b/scripts/cross/bootstrap-centos.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -o errexit
+
+yum install -y unzip centos-release-scl
+yum install -y llvm-toolset-7

--- a/scripts/cross/entrypoint-centos.sh
+++ b/scripts/cross/entrypoint-centos.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# shellcheck source=/dev/null
+source scl_source enable llvm-toolset-7
+exec "$@"

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4-centos
 
-COPY scripts/cross/bootstrap-ubuntu.sh scripts/environment/install-protoc.sh /
-RUN /bootstrap-ubuntu.sh && bash /install-protoc.sh
+COPY scripts/cross/bootstrap-centos.sh scripts/cross/entrypoint-centos.sh scripts/environment/install-protoc.sh /
+RUN /bootstrap-centos.sh && bash /install-protoc.sh
+
+ENTRYPOINT [ "/entrypoint-centos.sh" ]


### PR DESCRIPTION
Fixes #13183