### PR TITLE
docs(aws_kinesis_firehose source): Use generated docs for configuration

### DIFF
--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -42,12 +42,15 @@ pub struct AwsKinesisFirehoseConfig {
 
     /// The compression scheme to use for decompressing records within the Firehose message.
     ///
-    /// Some services, like AWS CloudWatch Logs, will [compress the events with
-    /// gzip](\(urls.aws_cloudwatch_logs_firehose)), before sending them AWS Kinesis Firehose. This option can be used
-    /// to automatically decompress them before forwarding them to the next component.
+    /// Some services, like AWS CloudWatch Logs, will [compress the events with gzip][events_with_gzip],
+    /// before sending them AWS Kinesis Firehose. This option can be used to automatically decompress
+    /// them before forwarding them to the next component.
     ///
-    /// Note that this is different from [Content encoding option](\(urls.aws_kinesis_firehose_http_protocol)) of the
+    /// Note that this is different from [Content encoding option][encoding_option] of the
     /// Firehose HTTP endpoint destination. That option controls the content encoding of the entire HTTP request.
+    ///
+    /// [events_with_gzip]: https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html
+    /// [encoding_option]: https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http
     #[serde(default)]
     record_compression: Compression,
 
@@ -81,11 +84,13 @@ pub enum Compression {
     /// Automatically attempt to determine the compression scheme.
     ///
     /// The compression scheme of the object is determined by looking at its file signature, also known
-    /// as [magic bytes](\(urls.magic_bytes)).
+    /// as [magic bytes][magic_bytes].
     ///
     /// If the record fails to decompress with the discovered format, the record is forwarded as is.
     /// Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
     /// set `gzip` in this field so that any records that are not-gzipped are rejected.
+    ///
+    /// [magic_bytes]: https://en.wikipedia.org/wiki/List_of_file_signatures
     #[derivative(Default)]
     Auto,
     /// Uncompressed.

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -29,12 +29,15 @@ mod models;
 #[derive(Clone, Debug)]
 pub struct AwsKinesisFirehoseConfig {
     /// The address to listen for connections on.
+    #[configurable(metadata(docs::examples = "0.0.0.0:443"))]
+    #[configurable(metadata(docs::examples = "localhost:443"))]
     address: SocketAddr,
 
     /// An optional access key to authenticate requests against.
     ///
     /// AWS Kinesis Firehose can be configured to pass along a user-configurable access key with each request. If
     /// configured, `access_key` should be set to the same value. Otherwise, all requests will be allowed.
+    #[configurable(metadata(docs::examples = "A94A8FE5CCB19BA61C4C08"))]
     access_key: Option<SensitiveString>,
 
     /// The compression scheme to use for decompressing records within the Firehose message.

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -15,7 +15,7 @@ components: sources: aws_kinesis_firehose: {
 	}
 
 	features: {
-		auto_generated: true
+		auto_generated:   true
 		acknowledgements: true
 		multiline: enabled: false
 		receive: {

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -15,6 +15,7 @@ components: sources: aws_kinesis_firehose: {
 	}
 
 	features: {
+		auto_generated: true
 		acknowledgements: true
 		multiline: enabled: false
 		receive: {
@@ -57,61 +58,7 @@ components: sources: aws_kinesis_firehose: {
 		platform_name: null
 	}
 
-	configuration: {
-		address: {
-			description: "The address to listen for connections on"
-			required:    true
-			type: string: {
-				examples: ["0.0.0.0:443", "localhost:443"]
-			}
-		}
-		access_key: {
-			common: true
-			description: """
-				AWS Kinesis Firehose can be configured to pass along an access
-				key to authenticate requests. If configured, `access_key` should
-				be set to the same value. If not specified, vector will treat
-				all requests as authenticated.
-				"""
-			required: false
-			type: string: {
-				default: null
-				examples: ["A94A8FE5CCB19BA61C4C08"]
-			}
-		}
-		acknowledgements: configuration._source_acknowledgements
-		record_compression: {
-			common:      true
-			description: """
-				The compression of records within the Firehose message.
-
-				Some services, like AWS CloudWatch Logs, will [compress the events with
-				gzip](\(urls.aws_cloudwatch_logs_firehose)), before sending them AWS Kinesis Firehose. This option
-				can be used to automatically decompress them before forwarding them to the next component.
-
-				Note that this is different from [Content encoding option](\(urls.aws_kinesis_firehose_http_protocol))
-				of the Firehose HTTP endpoint destination. That option controls the content encoding of the entire HTTP
-				request.
-				"""
-			required:    false
-			type: string: {
-				default: "text"
-				enum: {
-					auto: """
-					Vector will try to determine the compression format of the object by looking at its file signature,
-					also known as [magic bytes](\(urls.magic_bytes)).
-
-					Given that determining the encoding using magic bytes is not a perfect check, if the record fails to
-					decompress with the discovered format, the record will be forwarded as-is. Thus, if you know the
-					records will always be gzip encoded (for example if they are coming from AWS CloudWatch Logs) then
-					you should prefer to set `gzip` here to have Vector reject any records that are not-gziped.
-					"""
-					gzip: "GZIP format."
-					none: "Uncompressed."
-				}
-			}
-		}
-	}
+	configuration: base.components.sources.aws_kinesis_firehose.configuration
 
 	output: logs: {
 		line: {

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -9,7 +9,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 			configured, `access_key` should be set to the same value. Otherwise, all requests will be allowed.
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["A94A8FE5CCB19BA61C4C08"]
 	}
 	acknowledgements: {
 		description: """
@@ -32,7 +32,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 	address: {
 		description: "The address to listen for connections on."
 		required:    true
-		type: string: {}
+		type: string: examples: ["0.0.0.0:443", "localhost:443"]
 	}
 	decoding: {
 		description: "Configures how events are decoded from raw bytes."

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -170,19 +170,22 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 			Firehose HTTP endpoint destination. That option controls the content encoding of the entire HTTP request.
 			"""
 		required: false
-		type: string: enum: {
-			auto: """
-				Automatically attempt to determine the compression scheme.
+		type: string: {
+			default: "auto"
+			enum: {
+				auto: """
+					Automatically attempt to determine the compression scheme.
 
-				The compression scheme of the object is determined by looking at its file signature, also known
-				as [magic bytes](\\(urls.magic_bytes)).
+					The compression scheme of the object is determined by looking at its file signature, also known
+					as [magic bytes](\\(urls.magic_bytes)).
 
-				If the record fails to decompress with the discovered format, the record is forwarded as is.
-				Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
-				set `gzip` in this field so that any records that are not-gzipped are rejected.
-				"""
-			gzip: "GZIP."
-			none: "Uncompressed."
+					If the record fails to decompress with the discovered format, the record is forwarded as is.
+					Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
+					set `gzip` in this field so that any records that are not-gzipped are rejected.
+					"""
+				gzip: "GZIP."
+				none: "Uncompressed."
+			}
 		}
 	}
 	tls: {

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -162,12 +162,15 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 		description: """
 			The compression scheme to use for decompressing records within the Firehose message.
 
-			Some services, like AWS CloudWatch Logs, will [compress the events with
-			gzip](\\(urls.aws_cloudwatch_logs_firehose)), before sending them AWS Kinesis Firehose. This option can be used
-			to automatically decompress them before forwarding them to the next component.
+			Some services, like AWS CloudWatch Logs, will [compress the events with gzip][events_with_gzip],
+			before sending them AWS Kinesis Firehose. This option can be used to automatically decompress
+			them before forwarding them to the next component.
 
-			Note that this is different from [Content encoding option](\\(urls.aws_kinesis_firehose_http_protocol)) of the
+			Note that this is different from [Content encoding option][encoding_option] of the
 			Firehose HTTP endpoint destination. That option controls the content encoding of the entire HTTP request.
+
+			[events_with_gzip]: https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html
+			[encoding_option]: https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http
 			"""
 		required: false
 		type: string: {
@@ -177,11 +180,13 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					Automatically attempt to determine the compression scheme.
 
 					The compression scheme of the object is determined by looking at its file signature, also known
-					as [magic bytes](\\(urls.magic_bytes)).
+					as [magic bytes][magic_bytes].
 
 					If the record fails to decompress with the discovered format, the record is forwarded as is.
 					Thus, if you know the records are always gzip encoded (for example, if they are coming from AWS CloudWatch Logs),
 					set `gzip` in this field so that any records that are not-gzipped are rejected.
+
+					[magic_bytes]: https://en.wikipedia.org/wiki/List_of_file_signatures
 					"""
 				gzip: "GZIP."
 				none: "Uncompressed."


### PR DESCRIPTION
- docs(aws_kinesis_firehose source): Use generated docs for configuration
- +un-option the compression config

Closes #15670

This _should_ be compatible, `vector-old` was generated with v0.26 and `vector-new` was generated with these changes.

```toml
data_dir = "/var/lib/vector/"

[sources.source0]
address = "0.0.0.0:443"
type = "aws_kinesis_firehose"

[sources.source0.acknowledgements]

[sources.source0.decoding]
codec = "bytes"

[sources.source0.framing]
method = "bytes"

[sinks.sink0]
inputs = ["source0"]
print_interval_secs = 1
type = "blackhole"

[sinks.sink0.healthcheck]
enabled = true

[sinks.sink0.buffer]
type = "memory"
max_events = 500
when_full = "block"
```

```toml
data_dir = "/var/lib/vector/"

[sources.source0]
address = "0.0.0.0:443"
record_compression = "auto"
type = "aws_kinesis_firehose"

[sources.source0.acknowledgements]

[sources.source0.decoding]
codec = "bytes"

[sources.source0.framing]
method = "bytes"

[sinks.sink0]
inputs = ["source0"]
print_interval_secs = 1
type = "blackhole"

[sinks.sink0.healthcheck]
enabled = true

[sinks.sink0.buffer]
type = "memory"
max_events = 500
when_full = "block"
```

```shell
vector on  spencer/15670-aws_kinesis_firehose-docs [!] is 📦 v0.27.0 via 🦀 v1.64.0
❯ vector validate /tmp/vector-old.toml --no-environment
√ Loaded ["/tmp/vector-old.toml"]
---------------------------------
                        Validated

vector on  spencer/15670-aws_kinesis_firehose-docs [!] is 📦 v0.27.0 via 🦀 v1.64.0
❯ vector validate /tmp/vector-new.toml --no-environment
√ Loaded ["/tmp/vector-new.toml"]
---------------------------------
                        Validated

vector on  spencer/15670-aws_kinesis_firehose-docs [!] is 📦 v0.27.0 via 🦀 v1.64.0
❯ target/debug/vector validate /tmp/vector-new.toml --no-environment
√ Loaded ["/tmp/vector-new.toml"]
---------------------------------
                        Validated

vector on  spencer/15670-aws_kinesis_firehose-docs [!] is 📦 v0.27.0 via 🦀 v1.64.0
❯ target/debug/vector validate /tmp/vector-old.toml --no-environment
√ Loaded ["/tmp/vector-old.toml"]
---------------------------------
                        Validated
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
