### PR TITLE
chore(data model): Wrap metric tag mapping with `Arc`

### DIFF
--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -6,6 +6,7 @@ use std::{
         NonZeroU8, NonZeroUsize,
     },
     path::PathBuf,
+    sync::Arc,
     time::Duration,
 };
 
@@ -300,5 +301,27 @@ impl Configurable for Duration {
         Ok(crate::schema::generate_struct_schema(
             properties, required, None,
         ))
+    }
+}
+
+impl<T: Configurable> Configurable for Arc<T> {
+    fn is_optional() -> bool {
+        T::is_optional()
+    }
+
+    fn referenceable_name() -> Option<&'static str> {
+        T::referenceable_name()
+    }
+
+    fn metadata() -> Metadata<Self> {
+        todo!("FIXME T::metadata().into()")
+    }
+
+    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+        T::generate_schema(gen)
+    }
+
+    fn validate_metadata(_metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        todo!("FIXME T::validate_metadata(metadata)")
     }
 }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::TimeZone;
 use ordered_float::NotNan;
 
@@ -207,7 +209,7 @@ impl From<Metric> for event::Metric {
             .timestamp
             .map(|ts| chrono::Utc.timestamp(ts.seconds, ts.nanos as u32));
 
-        let mut tags = MetricTags(
+        let mut tags = MetricTags(Arc::new(
             metric
                 .tags_v2
                 .into_iter()
@@ -222,7 +224,7 @@ impl From<Metric> for event::Metric {
                     )
                 })
                 .collect(),
-        );
+        ));
         // The current Vector encoding includes copies of the "single" values of tags in `tags_v2`
         // above. This `extend` will re-add those values, forcing them to become the last added in
         // the value set.
@@ -426,7 +428,7 @@ impl From<event::Metric> for WithMetadata<Metric> {
             .collect();
         // These are the full tag values.
         let tags_v2 = tags
-            .0
+            .into_inner()
             .into_iter()
             .map(|(tag, values)| {
                 let values = values


### PR DESCRIPTION
The tag key:value mappings in a metric is the most expensive data structure in that type. This change wraps that data in a reference counted allocation, under the assumption that it will change little once it is initially created though the surrounding metric may be cloned repeatedly.

This is a proposed optimization similar to #11166

Note that the config bits include two very prominent bits that need fixing in the handling of metadata for `Arc`-wrapped data types.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
