### PR TITLE
docs(enriching): Remove misleading documentation about supported databases

### DIFF
--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -228,11 +228,9 @@ configuration: {
 					type: object: options: {
 						path: {
 							description: """
-								Path to the [MaxMind GeoIP2](\(urls.maxmind_geoip2)) or [GeoLite2 binary city
-								database](\(urls.maxmind_geolite2_city)) file (`GeoLite2-City.mmdb`). Other
-								databases, such as the country database, are not supported.
+								Path to the database file.
 								"""
-							required:    true
+							required: true
 							type: string: {
 								examples: ["/path/to/GeoLite2-City.mmdb", "/path/to/GeoLite2-ISP.mmdb"]
 							}


### PR DESCRIPTION
The supported databases are already listed under the `geoip` type for enrichment tables.

Closes: #15686 

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
