### PR TITLE
chore(metric_to_log transform): Rename option to `metric_tag_values`

### DIFF
--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -28,3 +28,18 @@ pub use encoding::{
     RawMessageSerializerConfig, TextSerializer, TextSerializerConfig,
 };
 pub use gelf::{gelf_fields, VALID_FIELD_REGEX};
+use vector_config::configurable_component;
+
+/// The user configuration to choose the metric tag strategy.
+#[configurable_component]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricTagValues {
+    /// Tag values will be exposed as single strings, the
+    /// same as they were before this config option. Tags with multiple values will show the last assigned value, and null values
+    /// will be ignored.
+    #[default]
+    Single,
+    /// All tags will be exposed as arrays of either string or null values.
+    Full,
+}

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -121,7 +121,7 @@ impl ElasticsearchCommon {
             metric_config.host_tag.as_deref(),
             metric_config.timezone.unwrap_or_default(),
             LogNamespace::Legacy,
-            metric_config.enhanced_tags,
+            metric_config.metric_tag_values,
         );
 
         let region = config.aws.as_ref().and_then(|config| config.region());

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, time::Duration};
 
+use codecs::MetricTagValues;
 use serde_with::serde_as;
 use snafu::{ResultExt, Snafu};
 use vector_config::configurable_component;
@@ -8,7 +9,6 @@ use vector_core::transform::runtime_transform::{RuntimeTransform, Timer};
 
 use crate::event::lua::event::LuaEvent;
 use crate::schema::Definition;
-use crate::transforms::MetricTagsValues;
 use crate::{
     config::{self, DataType, Input, Output, CONFIG_PATHS},
     event::Event,
@@ -83,7 +83,7 @@ pub struct LuaConfig {
     /// When set to `full`, all metric tags will be exposed as arrays of either string or null
     /// values.
     #[serde(default)]
-    metric_tag_values: MetricTagsValues,
+    metric_tag_values: MetricTagValues,
 }
 
 fn default_config_paths() -> Vec<PathBuf> {
@@ -269,7 +269,7 @@ impl Lua {
             timers.push((timer, handler_key));
         }
 
-        let multi_value_tags = config.metric_tag_values == MetricTagsValues::Full;
+        let multi_value_tags = config.metric_tag_values == MetricTagValues::Full;
 
         Ok(Self {
             lua,

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -55,7 +55,7 @@ pub struct MetricToLogConfig {
     ///
     /// When set to `single`, only the last non-bare value of tags will be displayed with the
     /// metric.  When set to `full`, all metric tags will be exposed as separate assignments as
-    /// described by [the `native_json` codec][vector_native_json]?
+    /// described by [the `native_json` codec][vector_native_json].
     #[serde(default)]
     pub metric_tag_values: MetricTagValues,
 }

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use codecs::MetricTagValues;
 use lookup::lookup_v2::parse_value_path;
 use lookup::{event_path, owned_value_path, path, PathPrefix};
 use serde_json::Value;
@@ -50,13 +51,13 @@ pub struct MetricToLogConfig {
     #[configurable(metadata(docs::hidden))]
     pub log_namespace: Option<bool>,
 
-    /// Controls if this transform should encode tags using the enhanced encoding of [the
-    /// `native_json` codec][vector_native_json]?
+    /// Controls how metric tag values are encoded.
     ///
-    /// If set to `false`, tags will always be encoded as single string values using the last value
-    /// assigned to the tag.
-    #[serde(default = "crate::serde::default_false")]
-    pub enhanced_tags: bool,
+    /// When set to `single`, only the last non-bare value of tags will be displayed with the
+    /// metric.  When set to `full`, all metric tags will be exposed as separate assignments as
+    /// described by [the `native_json` codec][vector_native_json]?
+    #[serde(default)]
+    pub metric_tag_values: MetricTagValues,
 }
 
 impl GenerateConfig for MetricToLogConfig {
@@ -65,7 +66,7 @@ impl GenerateConfig for MetricToLogConfig {
             host_tag: Some("host-tag".to_string()),
             timezone: None,
             log_namespace: None,
-            enhanced_tags: false,
+            metric_tag_values: MetricTagValues::Single,
         })
         .unwrap()
     }
@@ -78,7 +79,7 @@ impl TransformConfig for MetricToLogConfig {
             self.host_tag.as_deref(),
             self.timezone.unwrap_or_else(|| context.globals.timezone()),
             context.log_namespace(self.log_namespace),
-            self.enhanced_tags,
+            self.metric_tag_values,
         )))
     }
 
@@ -232,7 +233,7 @@ pub struct MetricToLog {
     host_tag: String,
     timezone: TimeZone,
     log_namespace: LogNamespace,
-    enhanced_tags: bool,
+    tag_values: MetricTagValues,
 }
 
 impl MetricToLog {
@@ -240,7 +241,7 @@ impl MetricToLog {
         host_tag: Option<&str>,
         timezone: TimeZone,
         log_namespace: LogNamespace,
-        enhanced_tags: bool,
+        tag_values: MetricTagValues,
     ) -> Self {
         Self {
             host_tag: format!(
@@ -249,12 +250,12 @@ impl MetricToLog {
             ),
             timezone,
             log_namespace,
-            enhanced_tags,
+            tag_values,
         }
     }
 
     pub fn transform_one(&self, mut metric: Metric) -> Option<LogEvent> {
-        if !self.enhanced_tags {
+        if self.tag_values == MetricTagValues::Single {
             if let Some(tags) = metric.tags_mut() {
                 tags.retain(|_, values| match std::mem::take(values).into_single() {
                     Some(tag) => {
@@ -598,13 +599,13 @@ mod tests {
         assert_eq!(log.metadata(), &metadata);
     }
 
-    // Test the encoding of tag values with the `enhanced_tags` flag.
+    // Test the encoding of tag values with the `metric_tag_values` flag.
     proptest! {
         #[test]
         fn transform_tag_single_encoding(values: TagValueSet) {
             let name = random_string(16);
             let tags = block_on(transform_tags(
-                false,
+                MetricTagValues::Single,
                 values.iter()
                     .map(|value| (name.clone(), TagValue::from(value.map(String::from))))
                     .collect(),
@@ -618,7 +619,7 @@ mod tests {
         fn transform_tag_full_encoding(values: TagValueSet) {
             let name = random_string(16);
             let tags = block_on(transform_tags(
-                true,
+                MetricTagValues::Full,
                 values.iter()
                     .map(|value| (name.clone(), TagValue::from(value.map(String::from))))
                     .collect(),
@@ -639,7 +640,7 @@ mod tests {
         tag.into_option().into()
     }
 
-    async fn transform_tags(enhanced_tags: bool, tags: MetricTags) -> Value {
+    async fn transform_tags(metric_tag_values: MetricTagValues, tags: MetricTags) -> Value {
         let counter = Metric::new(
             "counter",
             MetricKind::Absolute,
@@ -651,7 +652,7 @@ mod tests {
         let mut output = OutputBuffer::with_capacity(1);
 
         MetricToLogConfig {
-            enhanced_tags,
+            metric_tag_values,
             ..Default::default()
         }
         .build(&TransformContext::default())

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -51,20 +51,6 @@ enum BuildError {
     InvalidSubstring { name: String },
 }
 
-/// The user configuration to choose the metric tag strategy.
-#[configurable_component]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum MetricTagsValues {
-    /// Tag values will be exposed as single strings, the
-    /// same as they were before this config option. Tags with multiple values will show the last assigned value, and null values
-    /// will be ignored.
-    #[default]
-    Single,
-    /// All tags will be exposed as arrays of either string or null values.
-    Full,
-}
-
 /// Configurable transforms in Vector.
 #[configurable_component]
 #[derive(Clone, Debug)]

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -6,6 +6,7 @@ use std::{
     path::PathBuf,
 };
 
+use codecs::MetricTagValues;
 use lookup::lookup_v2::{parse_value_path, ValuePath};
 use lookup::{metadata_path, owned_value_path, path, PathPrefix};
 use snafu::{ResultExt, Snafu};
@@ -15,7 +16,6 @@ use vector_config::configurable_component;
 use vector_core::compile_vrl;
 use vector_core::config::LogNamespace;
 use vector_core::schema::Definition;
-
 use vector_vrl_functions::set_semantic_meaning::MeaningList;
 use vrl::prelude::state::TypeState;
 use vrl::{
@@ -24,7 +24,6 @@ use vrl::{
     CompileConfig, Program, Runtime, Terminate, VrlRuntime,
 };
 
-use crate::transforms::MetricTagsValues;
 use crate::{
     config::{
         log_schema, ComponentKey, DataType, Input, Output, TransformConfig, TransformContext,
@@ -72,7 +71,7 @@ pub struct RemapConfig {
     /// When set to `full`, all metric tags will be exposed as arrays of either string or null
     /// values.
     #[serde(default)]
-    pub metric_tag_values: MetricTagsValues,
+    pub metric_tag_values: MetricTagValues,
 
     /// The name of the timezone to apply to timestamp conversions that do not contain an explicit
     /// time zone.
@@ -326,7 +325,7 @@ where
     default_schema_definition: Arc<schema::Definition>,
     dropped_schema_definition: Arc<schema::Definition>,
     runner: Runner,
-    metric_tag_values: MetricTagsValues,
+    metric_tag_values: MetricTagValues,
 }
 
 pub trait VrlRunner {
@@ -515,8 +514,8 @@ where
             event,
             self.program.info(),
             match self.metric_tag_values {
-                MetricTagsValues::Single => false,
-                MetricTagsValues::Full => true,
+                MetricTagValues::Single => false,
+                MetricTagValues::Full => true,
             },
         );
         let result = self.run_vrl(&mut target);

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -363,17 +363,6 @@ base: components: sinks: elasticsearch: configuration: {
 		description: "Configuration for the `metric_to_log` transform."
 		required:    false
 		type: object: options: {
-			enhanced_tags: {
-				description: """
-					Controls if this transform should encode tags using the enhanced encoding of [the
-					`native_json` codec][vector_native_json]?
-
-					If set to `false`, tags will always be encoded as single string values using the last value
-					assigned to the tag.
-					"""
-				required: false
-				type: bool: default: false
-			}
 			host_tag: {
 				description: """
 					Name of the tag in the metric to use for the source host.
@@ -385,6 +374,27 @@ base: components: sinks: elasticsearch: configuration: {
 					"""
 				required: false
 				type: string: examples: ["host", "hostname"]
+			}
+			metric_tag_values: {
+				description: """
+					Controls how metric tag values are encoded.
+
+					When set to `single`, only the last non-bare value of tags will be displayed with the
+					metric.  When set to `full`, all metric tags will be exposed as separate assignments as
+					described by [the `native_json` codec][vector_native_json]?
+					"""
+				required: false
+				type: string: {
+					default: "single"
+					enum: {
+						full: "All tags will be exposed as arrays of either string or null values."
+						single: """
+															Tag values will be exposed as single strings, the
+															same as they were before this config option. Tags with multiple values will show the last assigned value, and null values
+															will be ignored.
+															"""
+					}
+				}
 			}
 			timezone: {
 				description: """

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -381,7 +381,7 @@ base: components: sinks: elasticsearch: configuration: {
 
 					When set to `single`, only the last non-bare value of tags will be displayed with the
 					metric.  When set to `full`, all metric tags will be exposed as separate assignments as
-					described by [the `native_json` codec][vector_native_json]?
+					described by [the `native_json` codec][vector_native_json].
 					"""
 				required: false
 				type: string: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -151,7 +151,7 @@ base: components: sinks: humio_metrics: configuration: {
 
 			When set to `single`, only the last non-bare value of tags will be displayed with the
 			metric.  When set to `full`, all metric tags will be exposed as separate assignments as
-			described by [the `native_json` codec][vector_native_json]?
+			described by [the `native_json` codec][vector_native_json].
 			"""
 		required: false
 		type: string: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -82,17 +82,6 @@ base: components: sinks: humio_metrics: configuration: {
 		required:    false
 		type: string: {}
 	}
-	enhanced_tags: {
-		description: """
-			Controls if this transform should encode tags using the enhanced encoding of [the
-			`native_json` codec][vector_native_json]?
-
-			If set to `false`, tags will always be encoded as single string values using the last value
-			assigned to the tag.
-			"""
-		required: false
-		type: bool: default: false
-	}
 	event_type: {
 		description: """
 			The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
@@ -154,6 +143,27 @@ base: components: sinks: humio_metrics: configuration: {
 		type: array: {
 			default: []
 			items: type: string: {}
+		}
+	}
+	metric_tag_values: {
+		description: """
+			Controls how metric tag values are encoded.
+
+			When set to `single`, only the last non-bare value of tags will be displayed with the
+			metric.  When set to `full`, all metric tags will be exposed as separate assignments as
+			described by [the `native_json` codec][vector_native_json]?
+			"""
+		required: false
+		type: string: {
+			default: "single"
+			enum: {
+				full: "All tags will be exposed as arrays of either string or null values."
+				single: """
+					Tag values will be exposed as single strings, the
+					same as they were before this config option. Tags with multiple values will show the last assigned value, and null values
+					will be ignored.
+					"""
+			}
 		}
 	}
 	request: {

--- a/website/cue/reference/components/transforms/base/metric_to_log.cue
+++ b/website/cue/reference/components/transforms/base/metric_to_log.cue
@@ -1,17 +1,6 @@
 package metadata
 
 base: components: transforms: metric_to_log: configuration: {
-	enhanced_tags: {
-		description: """
-			Controls if this transform should encode tags using the enhanced encoding of [the
-			`native_json` codec][vector_native_json]?
-
-			If set to `false`, tags will always be encoded as single string values using the last value
-			assigned to the tag.
-			"""
-		required: false
-		type: bool: default: false
-	}
 	host_tag: {
 		description: """
 			Name of the tag in the metric to use for the source host.
@@ -23,6 +12,27 @@ base: components: transforms: metric_to_log: configuration: {
 			"""
 		required: false
 		type: string: examples: ["host", "hostname"]
+	}
+	metric_tag_values: {
+		description: """
+			Controls how metric tag values are encoded.
+
+			When set to `single`, only the last non-bare value of tags will be displayed with the
+			metric.  When set to `full`, all metric tags will be exposed as separate assignments as
+			described by [the `native_json` codec][vector_native_json]?
+			"""
+		required: false
+		type: string: {
+			default: "single"
+			enum: {
+				full: "All tags will be exposed as arrays of either string or null values."
+				single: """
+					Tag values will be exposed as single strings, the
+					same as they were before this config option. Tags with multiple values will show the last assigned value, and null values
+					will be ignored.
+					"""
+			}
+		}
 	}
 	timezone: {
 		description: """

--- a/website/cue/reference/components/transforms/base/metric_to_log.cue
+++ b/website/cue/reference/components/transforms/base/metric_to_log.cue
@@ -19,7 +19,7 @@ base: components: transforms: metric_to_log: configuration: {
 
 			When set to `single`, only the last non-bare value of tags will be displayed with the
 			metric.  When set to `full`, all metric tags will be exposed as separate assignments as
-			described by [the `native_json` codec][vector_native_json]?
+			described by [the `native_json` codec][vector_native_json].
 			"""
 		required: false
 		type: string: {


### PR DESCRIPTION
This is the only component that configures the behavior of tags with an option
named something other than `metric_tag_values`, so rename it to get with the
program.

This is going to conflict with #15716 as they both touch the same bits of code, but they are functionally independent.

Epic: #14742 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
