### PR TITLE
chore(data model): Add some metric tag model documentation

### DIFF
--- a/lib/codecs/tests/data/native_encoding/schema.cue
+++ b/lib/codecs/tests/data/native_encoding/schema.cue
@@ -5,19 +5,19 @@
 #Trace: {...}
 
 #Metric: {
-	name:       string
-	namespace?: string
-	tags?: {[string]: string}
-	timestamp?: #Timestamp
-	kind:       "incremental" | "absolute"
+	name:         string
+	namespace?:   string
+	tags?: {[string]: #TagValueSet}
+	timestamp?:   #Timestamp
+	interval_ms?: int
+	kind:         "incremental" | "absolute"
 	{counter: value: number} |
 	{gauge: value: number} |
 	{set: values: [...string]} |
 	{distribution: {
 		samples: [...{value: number, rate: int}]
 		statistic: "histogram" | "summary"
-	}
-	} |
+	}} |
 	{aggregated_histogram: {
 		buckets: [...{upper_limit: number, count: int}]
 		count: int
@@ -40,7 +40,11 @@
 			sum:   number
 			avg:   number
 		}
+	}
 }
-}
+
+#TagValueSet: { #TagValue | [...#TagValue] }
+
+#TagValue: { string | null }
 
 #Timestamp: =~"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d+)?Z"

--- a/rfcs/2022-10-12-14742-flexible-metric-tags.md
+++ b/rfcs/2022-10-12-14742-flexible-metric-tags.md
@@ -1,7 +1,7 @@
 # RFC 14742 - Support for Duplicate and Bare Tags on Metrics
 
 Vector's current metric model supports only a single value for each tag. Several sources, however,
-however, may send metrics that contain multiple values for a given tag name, or bare tags with no
+may send metrics that contain multiple values for a given tag name, or bare tags with no
 value. Vector's tag support should be enhanced to handle this data.
 
 ## Context

--- a/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
+++ b/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
@@ -27,7 +27,7 @@ The scripting components of `lua` and `remap` have been extended with a configur
 `metric_tag_values`. This controls how these tag values are exposed to scripts. In the default
 setting of `single`, tag values will be exposed as the single value described above. This behavior
 matches the existing behavior of scripts so that no script changes will be needed. When set to
-`full`, however, all tag values are exposed as an array at each element. In either case, scripts may
+`full`, however, all tag values are exposed as an array for each element. In either case, scripts may
 assign either a single value or an array of values to a tag.
 
 For example:
@@ -38,9 +38,9 @@ For example:
 .tags.complex = ["remotehost", null, "otherhost"] # Creates three tag values
 ```
 
-This setting also shows up in the `codec` configuration of sinks and controls how metric tags are
-exposed in codecs that can encode metrics. As above, when set to `full`, these codecs will expose
-all values of tags either as arrays (for the `json` codec) or as repeated instances of each tag (for
-the `text` codec). This setting does not apply to the `native` and `native_json` codecs which
-_always_ expose all tag values in order to seamlessly transport the values to other Vector
-instances.
+This `metric_tag_values` setting also shows up in the `codec` configuration of sinks and controls
+how metric tags are exposed in codecs that can encode metrics. As above, when set to `full`, these
+codecs will expose all values of tags either as arrays (for the `json` codec) or as repeated
+instances of each tag (for the `text` codec). This setting does not apply to the `native` and
+`native_json` codecs which _always_ expose all tag values in order to seamlessly transport the
+values to other Vector instances.

--- a/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
+++ b/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
@@ -12,12 +12,13 @@ badges:
 
 The existing set of tags that have been available on metrics was a simple mapping of string values
 to single string keys. Some sources, however, may produce metrics that contain tags that don't fit
-into this model.
+into this model, such as tags that are bare strings (rather than a key/value pair) or have multiple
+values for a given key.
 
-With this release, tag values may now contain a set of values, each of which may be a string value
-or `null`, which represents a "bare" tag (ie a tag with no value, as distinct from an empty string
-value). This new tag set only stores unique values, as duplicated tags are not useful for any
-component, and so each tag name/value pair will appear only once across all tags.
+With this release, tag values for a given key may now contain a set of values, each of which may be
+a string value or `null`, which represents a "bare" tag (i.e. a tag with no value, as distinct from
+an empty string value). This new tag set only stores unique values, as duplicated tags are not
+useful for any component, and so each tag name/value pair will appear only once across all tags.
 
 For compatibility with previous releases, this value set also tracks the last seen or assigned value
 for each tag. Since most components, in particular sinks, can only make use of a single value for

--- a/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
+++ b/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
@@ -20,8 +20,8 @@ value). This new tag set only stores unique values, as duplicated tags are not u
 component, and so each tag name/value pair will appear only once across all tags.
 
 For compatibility with previous releases, this value set also tracks the last seen or assigned value
-for each tag. Since most components can only make use of a single value for each tag, this last
-value is used by those components.
+for each tag. Since most components, in particular sinks, can only make use of a single value for
+each tag, this last value is used by those components.
 
 The scripting components of `lua` and `remap` have been extended with a configuration option of
 `metric_tag_values`. This controls how these tag values are exposed to scripts. In the default

--- a/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
+++ b/website/content/en/highlights/2022-12-22-enhanced-metric-tags.md
@@ -1,0 +1,46 @@
+---
+date: "2022-12-22"
+title: "Enhanced Metric Tags"
+description: "The metric data model now supports an enhanced representation of tag values"
+authors: ["bruceg"]
+pr_numbers: [14742]
+release: "0.27.0"
+hide_on_release_notes: false
+badges:
+  type: enhancement
+---
+
+The existing set of tags that have been available on metrics was a simple mapping of string values
+to single string keys. Some sources, however, may produce metrics that contain tags that don't fit
+into this model.
+
+With this release, tag values may now contain a set of values, each of which may be a string value
+or `null`, which represents a "bare" tag (ie a tag with no value, as distinct from an empty string
+value). This new tag set only stores unique values, as duplicated tags are not useful for any
+component, and so each tag name/value pair will appear only once across all tags.
+
+For compatibility with previous releases, this value set also tracks the last seen or assigned value
+for each tag. Since most components can only make use of a single value for each tag, this last
+value is used by those components.
+
+The scripting components of `lua` and `remap` have been extended with a configuration option of
+`metric_tag_values`. This controls how these tag values are exposed to scripts. In the default
+setting of `single`, tag values will be exposed as the single value described above. This behavior
+matches the existing behavior of scripts so that no script changes will be needed. When set to
+`full`, however, all tag values are exposed as an array at each element. In either case, scripts may
+assign either a single value or an array of values to a tag.
+
+For example:
+
+```coffee
+.tags.host = "localhost" # Assign a single string value
+.tags.bare = null # Create a single-valued bare tag
+.tags.complex = ["remotehost", null, "otherhost"] # Creates three tag values
+```
+
+This setting also shows up in the `codec` configuration of sinks and controls how metric tags are
+exposed in codecs that can encode metrics. As above, when set to `full`, these codecs will expose
+all values of tags either as arrays (for the `json` codec) or as repeated instances of each tag (for
+the `text` codec). This setting does not apply to the `native` and `native_json` codecs which
+_always_ expose all tag values in order to seamlessly transport the values to other Vector
+instances.

--- a/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
@@ -12,6 +12,7 @@ badges:
 Vector's 0.27.0 release includes **breaking changes**:
 
 1. [`statsd` components now support enhanced metric tags](#statsd-enhanced-metrics)
+1. [Changes to `native_json` codec](#vector-native-json-codec)
 
 and **potentially impactful changes**:
 
@@ -35,6 +36,18 @@ Similarly, prior to this release, the `statsd` sink encoded metric tags with a b
 of "true", to being an empty tag.
 With this release, the `statsd` sink now correctly encodes a value or "true" to "true", and
 empty tags as empty tags.
+
+#### Changes to `native_json` codec {#vector-native-json-codec}
+
+The `native_json` codec has been modified to include support for enhanced tags (bare tags or
+multi-valued tags) on metrics by optionally encoding tag values as arrays of values.  This will
+cause Vector, when using this codec and a metric source or transform that generates enhanced tags,
+to emit metrics that are not backwards compatible with previous versions. Vector can continue to
+load in events emitted by older versions.
+
+When upgrading Vector to Vector communication using the `native_json` codec, make sure you upgrade
+the consumers first followed by the producers to ensure newer versions of Vector aren't sending data
+to older versions, which may not be able to be read.
 
 ### Potentially impactful changes
 

--- a/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-01-17-0-27-0-upgrade-guide.md
@@ -12,7 +12,7 @@ badges:
 Vector's 0.27.0 release includes **breaking changes**:
 
 1. [`statsd` components now support enhanced metric tags](#statsd-enhanced-metrics)
-1. [Changes to `native_json` codec](#vector-native-json-codec)
+1. [Changes to `native` and `native_json` codecs](#vector-native-codecs)
 
 and **potentially impactful changes**:
 
@@ -37,17 +37,25 @@ of "true", to being an empty tag.
 With this release, the `statsd` sink now correctly encodes a value or "true" to "true", and
 empty tags as empty tags.
 
-#### Changes to `native_json` codec {#vector-native-json-codec}
+#### Changes to `native` and `native_json` codecs {#vector-native-codecs}
 
-The `native_json` codec has been modified to include support for enhanced tags (bare tags or
-multi-valued tags) on metrics by optionally encoding tag values as arrays of values.  This will
-cause Vector, when using this codec and a metric source or transform that generates enhanced tags,
-to emit metrics that are not backwards compatible with previous versions. Vector can continue to
-load in events emitted by older versions.
+The `native` and `native_json` codecs have been modified to include support for enhanced tags (bare
+tags or multi-valued tags) on metrics by optionally encoding tag values as arrays of values.  This
+will cause Vector, when using these codecs and a metric source or transform that generates enhanced
+tags, to emit metrics that are not backwards compatible with previous versions. Vector can continue
+to load in events emitted by older versions.
 
-When upgrading Vector to Vector communication using the `native_json` codec, make sure you upgrade
-the consumers first followed by the producers to ensure newer versions of Vector aren't sending data
-to older versions, which may not be able to be read.
+This has two potential implications that you should consider:
+
+1. Disk buffers should be backed up if you want to be able to roll back to an older Vector version
+   since new disk buffer entries may not be readable by older Vector versions. The disk buffers
+   location can be found under the
+   [Vector data directory](/docs/reference/configuration/global-options/#data_dir).
+
+2. When upgrading Vector to Vector communication using the `vector` source and sink or the `native`
+   or `native_json` codecs, make sure you upgrade the consumers first followed by the producers to
+   ensure newer versions of Vector aren't sending data to older versions, which may not be able to
+   be read.
 
 ### Potentially impactful changes
 

--- a/website/cue/reference/data_model/schema.cue
+++ b/website/cue/reference/data_model/schema.cue
@@ -210,6 +210,12 @@ data_model: schema: {
 					}
 				}
 
+				interval_ms: {
+					description: "The time interval represented by the value of this metric."
+					required:    false
+					type: uint: {}
+				}
+
 				"kind": {
 					description: "The metric value kind."
 					required:    true
@@ -321,7 +327,7 @@ data_model: schema: {
 				}
 
 				tags: {
-					description: "The metric tags. Key/value pairs, nesting is not allowed."
+					description: "The metric tags, represented as a mapping of tag names to either a single value or a list of values, where each value is either a string or `null`."
 					required:    true
 					type: object: {
 						examples: [
@@ -333,7 +339,7 @@ data_model: schema: {
 						options: {
 							"*": {
 								common:      true
-								description: "Key/value pairs, nesting is not allowed."
+								description: "A mapping of tag names to either a single value or a list of values, where each value is either a string or `null`."
 								required:    false
 								type: "*": {}
 							}


### PR DESCRIPTION
Adds some docs for the metric tag model, largely unlinked though.

Epic: #14742 

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
