### PR TITLE
chore(kafka): Update Kafka support

### DIFF
--- a/scripts/integration/docker-compose.kafka.yml
+++ b/scripts/integration/docker-compose.kafka.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - 2181:2181
   kafka:
-    image: docker.io/wurstmeister/kafka:2.13-2.6.0
+    image: docker.io/wurstmeister/kafka:2.12-2.4.1
     depends_on:
       - zookeeper
     environment:

--- a/website/cue/reference/services/kafka.cue
+++ b/website/cue/reference/services/kafka.cue
@@ -4,7 +4,7 @@ services: kafka: {
 	name:     "Kafka"
 	thing:    "\(name) topics"
 	url:      urls.kafka
-	versions: ">= 0.8"
+	versions: ">= 2.4"
 
 	description: "[Apache Kafka](\(urls.kafka)) is an open-source project for a distributed publish-subscribe messaging system rethought as a distributed commit log. Kafka stores messages in topics that are partitioned and replicated across multiple brokers in a cluster. Producers send messages to topics from which consumers read. These features make it an excellent candidate for durably storing logs and metrics data."
 }


### PR DESCRIPTION
Updating integration tests to target oldest non-EOL Kafka version (using Confluent as the benchmark) and docs to match.

Closes: #1984

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
