### PR TITLE
docs(sinks): Remove partitioning docs

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -570,28 +570,6 @@ components: sinks: [Name=string]: {
 
 		if features.send != _|_ {
 			if features.send.request.enabled {
-				partitioning: _ | *{
-					title: "Partitioning"
-					body: """
-						Vector supports dynamic configuration values through a simple
-						template syntax. If an option supports templating, it will be
-						noted with a badge and you can use event fields to create dynamic
-						values. For example:
-
-						```toml title="vector.toml"
-						[sinks.my-sink]
-						dynamic_option = "application={{ application_id }}"
-						```
-
-						In the above example, the `application_id` for each event will be
-						used to partition outgoing data.
-						"""
-				}
-			}
-		}
-
-		if features.send != _|_ {
-			if features.send.request.enabled {
 				rate_limits: {
 					title: "Rate limits & adaptive concurrency"
 					body:  null

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -41,6 +41,8 @@
           {{ with $v.syntax }}
           {{ if eq . "remap_program" }}
           {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/vrl#program") }}
+          {{ else if eq . "template" }}
+          {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/configuration/template-syntax/") }}
           {{ else }}
           {{ partial "badge.html" (dict "word" . "color" "gray") }}
           {{ end }}
@@ -1961,6 +1963,8 @@
         {{ with $v.syntax }}
         {{ if eq . "remap_program" }}
         {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/vrl#program") }}
+        {{ else if eq . "template" }}
+        {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/configuration/template-syntax/") }}
         {{ else }}
         {{ partial "badge.html" (dict "word" . "color" "gray") }}
         {{ end }}
@@ -1976,6 +1980,14 @@
     <div class="mt-4 prose dark:prose-dark max-w-none leading-snug">
       {{ $v.description | markdownify }}
     </div>
+
+    {{ if eq $v.type.string.syntax "template" }}
+    <div class="mt-4 text-sm">
+      <strong>Note</strong>: This parameter supports Vector's
+      <a href="/docs/reference/configuration/template-syntax">template syntax</a>, which enables you to use
+      dynamic per-event values.
+    </div>
+    {{ end }}
 
     {{ with $v.relevant_when }}
     <div class="mt-2">


### PR DESCRIPTION
They were incorrectly showing up on all request-based sinks even though not all support dynamic
partitioning. Instead I just added additional pointers to the template docs with the options that
support templating.

Closes: #11242

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
