### PR TITLE
chore(ci): Lock nextest install on Windows

### DIFF
--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -9,7 +9,7 @@ echo "CARGO_BUILD_JOBS=$N_JOBS" | Out-File -FilePath $env:GITHUB_ENV -Encoding u
 
 if ($env:RELEASE_BUILDER -ne "true") {
     # Ensure we have cargo-next test installed.
-    rustup run stable cargo install cargo-nextest --version 0.9.8
+    rustup run stable cargo install cargo-nextest --version 0.9.8 --locked
 }
 
 # Install some required dependencies / tools.


### PR DESCRIPTION
CI started pulling in newer, incompatible, versions of dependencies.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
