### PR TITLE
enhancement(datadog_logs sink): Add custom header configuration

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -26,7 +26,7 @@ use crate::{
     http::{HttpClient, HttpError},
     sinks::{
         datadog::{logs::DatadogLogsConfig, metrics::DatadogMetricsConfig},
-        util::{retries::ExponentialBackoff, http::RequestConfig},
+        util::{http::RequestConfig, retries::ExponentialBackoff},
     },
     sources::{
         host_metrics::{Collector, HostMetricsConfig},
@@ -483,7 +483,10 @@ fn setup_logs_reporting(
         site: datadog.site.clone(),
         region: datadog.region,
         request: RequestConfig {
-            headers: IndexMap::from([("DD-EVP-ORIGIN".to_string(), "vector-enterprise".to_string())]),
+            headers: IndexMap::from([(
+                "DD-EVP-ORIGIN".to_string(),
+                "vector-enterprise".to_string(),
+            )]),
             ..Default::default()
         },
         ..Default::default()

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -482,7 +482,6 @@ fn setup_logs_reporting(
         endpoint: datadog.endpoint.clone(),
         site: datadog.site.clone(),
         region: datadog.region,
-        enterprise: true,
         ..Default::default()
     };
 

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -26,7 +26,7 @@ use crate::{
     http::{HttpClient, HttpError},
     sinks::{
         datadog::{logs::DatadogLogsConfig, metrics::DatadogMetricsConfig},
-        util::retries::ExponentialBackoff,
+        util::{retries::ExponentialBackoff, http::RequestConfig},
     },
     sources::{
         host_metrics::{Collector, HostMetricsConfig},
@@ -482,6 +482,10 @@ fn setup_logs_reporting(
         endpoint: datadog.endpoint.clone(),
         site: datadog.site.clone(),
         region: datadog.region,
+        request: RequestConfig {
+            headers: IndexMap::from([("DD-EVP-ORIGIN".to_string(), "vector-enterprise".to_string())]),
+            ..Default::default()
+        },
         ..Default::default()
     };
 

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -154,7 +154,11 @@ impl DatadogLogsConfig {
 
         let service = ServiceBuilder::new()
             .settings(request_limits, LogApiRetry)
-            .service(LogApiService::new(client, self.get_uri(), self.request.headers.clone()));
+            .service(LogApiService::new(
+                client,
+                self.get_uri(),
+                self.request.headers.clone(),
+            )?);
 
         let encoding = self.encoding.clone();
         let protocol = self.get_protocol();

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -154,7 +154,7 @@ impl DatadogLogsConfig {
 
         let service = ServiceBuilder::new()
             .settings(request_limits, LogApiRetry)
-            .service(LogApiService::new(client, self.get_uri()));
+            .service(LogApiService::new(client, self.get_uri(), self.request.headers.clone()));
 
         let encoding = self.encoding.clone();
         let protocol = self.get_protocol();

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -17,8 +17,8 @@ use crate::{
     sinks::{
         datadog::{get_api_validate_endpoint, healthcheck, logs::service::LogApiService, Region},
         util::{
-            service::ServiceBuilderExt, BatchConfig, Compression, SinkBatchSettings,
-            http::RequestConfig,
+            http::RequestConfig, service::ServiceBuilderExt, BatchConfig, Compression,
+            SinkBatchSettings,
         },
         Healthcheck, VectorSink,
     },
@@ -103,9 +103,6 @@ pub struct DatadogLogsConfig {
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
-
-    #[serde(skip)]
-    pub enterprise: bool,
 }
 
 impl GenerateConfig for DatadogLogsConfig {
@@ -157,7 +154,7 @@ impl DatadogLogsConfig {
 
         let service = ServiceBuilder::new()
             .settings(request_limits, LogApiRetry)
-            .service(LogApiService::new(client, self.get_uri(), self.enterprise));
+            .service(LogApiService::new(client, self.get_uri()));
 
         let encoding = self.encoding.clone();
         let protocol = self.get_protocol();

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -18,7 +18,7 @@ use crate::{
         datadog::{get_api_validate_endpoint, healthcheck, logs::service::LogApiService, Region},
         util::{
             service::ServiceBuilderExt, BatchConfig, Compression, SinkBatchSettings,
-            TowerRequestConfig,
+            http::RequestConfig,
         },
         Healthcheck, VectorSink,
     },
@@ -94,7 +94,7 @@ pub struct DatadogLogsConfig {
 
     #[configurable(derived)]
     #[serde(default)]
-    pub request: TowerRequestConfig,
+    pub request: RequestConfig,
 
     #[configurable(derived)]
     #[serde(
@@ -144,7 +144,7 @@ impl DatadogLogsConfig {
 
     pub fn build_processor(&self, client: HttpClient) -> crate::Result<VectorSink> {
         let default_api_key: Arc<str> = Arc::from(self.default_api_key.inner());
-        let request_limits = self.request.unwrap_with(&Default::default());
+        let request_limits = self.request.tower.unwrap_with(&Default::default());
 
         // We forcefully cap the provided batch configuration to the size/log line limits imposed by
         // the Datadog Logs API, but we still allow them to be lowered if need be.

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -23,8 +23,8 @@ use vector_core::{
 
 use crate::{
     http::HttpClient,
-    sinks::datadog::DatadogApiError,
     sinks::util::{retries::RetryLogic, Compression},
+    sinks::{datadog::DatadogApiError, util::http::validate_headers},
 };
 
 #[derive(Debug, Default, Clone)]
@@ -101,29 +101,13 @@ impl LogApiService {
         uri: Uri,
         headers: IndexMap<String, String>,
     ) -> crate::Result<Self> {
-        let headers = Self::validate_headers(&headers)?;
+        let headers = validate_headers(&headers)?;
 
         Ok(Self {
             client,
             uri,
             user_provided_headers: headers,
         })
-    }
-
-    fn validate_headers(
-        headers: &IndexMap<String, String>,
-    ) -> crate::Result<IndexMap<HeaderName, HeaderValue>> {
-        let mut parsed_headers = IndexMap::new();
-        for (name, value) in headers {
-            let name = HeaderName::from_bytes(name.as_bytes())
-                .map_err(|error| format!("{}: {}", error, name))?;
-            let value = HeaderValue::from_bytes(value.as_bytes())
-                .map_err(|error| format!("{}: {}", error, value))?;
-
-            parsed_headers.insert(name, value);
-        }
-
-        Ok(parsed_headers)
     }
 }
 

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -112,16 +112,18 @@ impl LogApiService {
 
     fn validate_headers(headers: &IndexMap<String, String>) -> crate::Result<()> {
         for (name, value) in headers {
-            let name = HeaderName::from_bytes(name.as_bytes())?;
+            let name = HeaderName::from_bytes(name.as_bytes())
+                .map_err(|error| format!("{}: {}", error, name))?;
 
             if name == CONTENT_TYPE
                 || name == CONTENT_LENGTH
                 || name == HeaderName::from_static("DD-API-KEY")
             {
-                return Err(format!("{} header can not be customized", name).into());
+                return Err(format!("{} header can not be configured", name).into());
             }
 
-            HeaderValue::from_bytes(value.as_bytes())?;
+            HeaderValue::from_bytes(value.as_bytes())
+                .map_err(|error| format!("{}: {}", error, value))?;
         }
 
         Ok(())

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -90,16 +90,11 @@ impl DriverResponse for LogApiResponse {
 pub struct LogApiService {
     client: HttpClient,
     uri: Uri,
-    enterprise: bool,
 }
 
 impl LogApiService {
-    pub const fn new(client: HttpClient, uri: Uri, enterprise: bool) -> Self {
-        Self {
-            client,
-            uri,
-            enterprise,
-        }
+    pub const fn new(client: HttpClient, uri: Uri) -> Self {
+        Self { client, uri }
     }
 }
 
@@ -118,14 +113,7 @@ impl Service<LogApiRequest> for LogApiService {
         let mut client = self.client.clone();
         let http_request = Request::post(&self.uri)
             .header(CONTENT_TYPE, "application/json")
-            .header(
-                "DD-EVP-ORIGIN",
-                if self.enterprise {
-                    "vector-enterprise"
-                } else {
-                    "vector"
-                },
-            )
+            .header("DD-EVP-ORIGIN", "vector")
             .header("DD-EVP-ORIGIN-VERSION", crate::get_version())
             .header("DD-API-KEY", request.api_key.to_string());
 

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -498,17 +498,3 @@ async fn error_is_retriable() {
     //       but are not straightforward to instantiate due to the design of
     //       the crates they originate from.
 }
-
-#[tokio::test]
-async fn cannot_configure_restricted_headers() {
-    let (config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
-            default_api_key = "atoken"
-            compression = "none"
-
-            [request]
-            headers.DD-API-KEY = "key"
-        "#})
-    .unwrap();
-
-    assert!(config.build(cx).await.is_err());
-}

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -394,7 +394,7 @@ mod tests {
         assert_downcast_matches,
         config::SinkContext,
         sinks::util::{
-            http::HttpSink,
+            http::{HeaderValidationError, HttpSink},
             test::{build_test_server, build_test_server_generic, build_test_server_status},
         },
         test_util::{
@@ -458,7 +458,7 @@ mod tests {
         "#;
         let config: HttpSinkConfig = toml::from_str(config).unwrap();
 
-        assert!(super::validate_headers(&config.request.headers, &None).is_ok());
+        assert!(super::validate_headers(&config.request.headers, false).is_ok());
     }
 
     #[test]
@@ -472,9 +472,9 @@ mod tests {
         let config: HttpSinkConfig = toml::from_str(config).unwrap();
 
         assert_downcast_matches!(
-            super::validate_headers(&config.request.headers, &None).unwrap_err(),
-            BuildError,
-            BuildError::InvalidHeaderName { .. }
+            super::validate_headers(&config.request.headers, false).unwrap_err(),
+            HeaderValidationError,
+            HeaderValidationError::InvalidHeaderName { .. }
         );
     }
 

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -550,7 +550,7 @@ impl RequestConfig {
 }
 
 #[derive(Debug, Snafu)]
-enum HeaderValidationError {
+pub enum HeaderValidationError {
     #[snafu(display("{}: {}", source, name))]
     InvalidHeaderName {
         name: String,

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -11,10 +11,12 @@ use std::{
 
 use bytes::{Buf, Bytes};
 use futures::{future::BoxFuture, Sink};
-use http::StatusCode;
+use headers::HeaderName;
+use http::{header, HeaderValue, StatusCode};
 use hyper::{body, Body};
 use indexmap::IndexMap;
 use pin_project::pin_project;
+use snafu::{ResultExt, Snafu};
 use tower::{Service, ServiceBuilder};
 use tower_http::decompression::DecompressionLayer;
 use vector_config::configurable_component;
@@ -545,6 +547,36 @@ impl RequestConfig {
             self.headers.extend(headers);
         }
     }
+}
+
+#[derive(Debug, Snafu)]
+enum HeaderValidationError {
+    #[snafu(display("{}: {}", source, name))]
+    InvalidHeaderName {
+        name: String,
+        source: header::InvalidHeaderName,
+    },
+    #[snafu(display("{}: {}", source, value))]
+    InvalidHeaderValue {
+        value: String,
+        source: header::InvalidHeaderValue,
+    },
+}
+
+pub fn validate_headers(
+    headers: &IndexMap<String, String>,
+) -> crate::Result<IndexMap<HeaderName, HeaderValue>> {
+    let mut validated_headers = IndexMap::new();
+    for (name, value) in headers {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .with_context(|_| InvalidHeaderNameSnafu { name })?;
+        let value = HeaderValue::from_bytes(value.as_bytes())
+            .with_context(|_| InvalidHeaderValueSnafu { value })?;
+
+        validated_headers.insert(name, value);
+    }
+
+    Ok(validated_headers)
 }
 
 #[cfg(test)]

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -128,12 +128,8 @@ base: components: sinks: datadog_logs: configuration: {
 		}
 	}
 	request: {
-		description: """
-			Middleware settings for outbound requests.
-
-			Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
-			"""
-		required: false
+		description: "Outbound HTTP request settings."
+		required:    false
 		type: object: options: {
 			adaptive_concurrency: {
 				description: """
@@ -205,6 +201,14 @@ base: components: sinks: datadog_logs: configuration: {
 						}
 					}
 					uint: {}
+				}
+			}
+			headers: {
+				description: "Additional HTTP headers to add to every HTTP request."
+				required:    false
+				type: object: options: "*": {
+					required: true
+					type: string: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/datadog_logs.cue
@@ -29,7 +29,7 @@ components: sinks: datadog_logs: {
 			proxy: enabled: true
 			request: {
 				enabled: true
-				headers: false
+				headers: true
 			}
 			tls: {
 				enabled:                true

--- a/website/cue/reference/components/sources/base/host_metrics.cue
+++ b/website/cue/reference/components/sources/base/host_metrics.cue
@@ -1,51 +1,6 @@
 package metadata
 
 base: components: sources: host_metrics: configuration: {
-	cgroups: {
-		description: """
-			Options for the “cgroups” (controller groups) metrics collector.
-
-			This collector is only available on Linux systems, and only supports either version 2 or hybrid cgroups.
-			"""
-		required: false
-		type: object: options: {
-			base: {
-				description: "The base cgroup name to provide metrics for."
-				required:    false
-				type: string: {}
-			}
-			base_dir: {
-				description: "Base cgroup directory, for testing use only"
-				required:    false
-				type: string: {}
-			}
-			groups: {
-				description: "Lists of group name patterns to include or exclude."
-				required:    false
-				type: object: options: {
-					excludes: {
-						description: "Any patterns which should be excluded."
-						required:    false
-						type: array: items: type: string: {}
-					}
-					includes: {
-						description: "Any patterns which should be included."
-						required:    false
-						type: array: items: type: string: {}
-					}
-				}
-			}
-			levels: {
-				description: """
-					The number of levels of the cgroups hierarchy for which to report metrics.
-
-					A value of `1` means just the root or named cgroup.
-					"""
-				required: false
-				type: uint: default: 100
-			}
-		}
-	}
 	collectors: {
 		description: """
 			The list of host metric collector services to use.
@@ -54,7 +9,6 @@ base: components: sources: host_metrics: configuration: {
 			"""
 		required: false
 		type: array: items: type: string: enum: {
-			cgroups:    "CGroups."
 			cpu:        "CPU."
 			disk:       "Disk."
 			filesystem: "Filesystem."

--- a/website/cue/reference/components/sources/base/host_metrics.cue
+++ b/website/cue/reference/components/sources/base/host_metrics.cue
@@ -1,6 +1,51 @@
 package metadata
 
 base: components: sources: host_metrics: configuration: {
+	cgroups: {
+		description: """
+			Options for the “cgroups” (controller groups) metrics collector.
+
+			This collector is only available on Linux systems, and only supports either version 2 or hybrid cgroups.
+			"""
+		required: false
+		type: object: options: {
+			base: {
+				description: "The base cgroup name to provide metrics for."
+				required:    false
+				type: string: {}
+			}
+			base_dir: {
+				description: "Base cgroup directory, for testing use only"
+				required:    false
+				type: string: {}
+			}
+			groups: {
+				description: "Lists of group name patterns to include or exclude."
+				required:    false
+				type: object: options: {
+					excludes: {
+						description: "Any patterns which should be excluded."
+						required:    false
+						type: array: items: type: string: {}
+					}
+					includes: {
+						description: "Any patterns which should be included."
+						required:    false
+						type: array: items: type: string: {}
+					}
+				}
+			}
+			levels: {
+				description: """
+					The number of levels of the cgroups hierarchy for which to report metrics.
+
+					A value of `1` means just the root or named cgroup.
+					"""
+				required: false
+				type: uint: default: 100
+			}
+		}
+	}
 	collectors: {
 		description: """
 			The list of host metric collector services to use.
@@ -9,6 +54,7 @@ base: components: sources: host_metrics: configuration: {
 			"""
 		required: false
 		type: array: items: type: string: enum: {
+			cgroups:    "CGroups."
 			cpu:        "CPU."
 			disk:       "Disk."
 			filesystem: "Filesystem."


### PR DESCRIPTION
Closes OPB-509

This PR
- Adds user customizable headers to Datadog Logs sink configuration, similar to the `http` sink.
  - Meanwhile, removes an internal `enterprise` flag. All enterprise logic will be removed at some point, but since it's unclear when, we use the new configuration to preserve current functionality. 
- This is required for migrating enterprise features.