### PR TITLE
chore(docs): remove vector from component descriptions that were missed

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -205,7 +205,7 @@ impl From<SourceAcknowledgementsConfig> for AcknowledgementsConfig {
 #[configurable_component]
 #[configurable(title = "Controls how acknowledgements are handled for this sink.")]
 #[configurable(
-    description = "See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+    description = "See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 [e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/"
 )]

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -39,7 +39,7 @@ impl NoProxyInterceptor {
 
 /// Proxy configuration.
 ///
-/// Vector can be configured to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+/// Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
 /// proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
 /// as well as set specific hosts that should not be proxied.
 #[configurable_component]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -25,7 +25,7 @@ pub enum Error {
 ///
 /// Only relevant when connecting to Docker via an HTTPS URL.
 ///
-/// If not configured, Vector will try to use environment variable `DOCKER_CERT_PATH` and then` DOCKER_CONFIG`. If both environment variables are absent, Vector will try to read certificates in `~/.docker/`.
+/// If not configured, the environment variable `DOCKER_CERT_PATH` is used. If `DOCKER_CERT_PATH` is absent, then` DOCKER_CONFIG` is used. If both environment variables are absent, the certificates in `~/.docker/` are read.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -74,9 +74,9 @@ pub struct GcpAuthConfig {
     ///
     /// Either an API key, or a path to a service account credentials JSON file can be specified.
     ///
-    /// If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-    /// filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-    /// running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+    /// If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+    /// filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+    /// running on. If this is not on a GCE instance, then you must define it with an API key or service account
     /// credentials JSON file.
     pub api_key: Option<SensitiveString>,
 
@@ -84,9 +84,9 @@ pub struct GcpAuthConfig {
     ///
     /// Either an API key, or a path to a service account credentials JSON file can be specified.
     ///
-    /// If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-    /// filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-    /// running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+    /// If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+    /// filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+    /// running on. If this is not on a GCE instance, then you must define it with an API key or service account
     /// credentials JSON file.
     pub credentials_path: Option<String>,
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -29,7 +29,7 @@ pub struct InternalMetricsConfig {
 
     /// Overrides the default namespace for the metrics emitted by the source.
     ///
-    /// By default, `vector` is used.
+    /// Overrides the default namespace.
     pub namespace: Option<String>,
 }
 

--- a/src/sources/util/encoding_config.rs
+++ b/src/sources/util/encoding_config.rs
@@ -10,11 +10,11 @@ pub struct EncodingConfig {
     /// Takes one of the encoding [label strings](https://encoding.spec.whatwg.org/#concept-encoding-get) defined as
     /// part of the [Encoding Standard](https://encoding.spec.whatwg.org/).
     ///
-    /// When set, the messages are transcoded from the specified encoding to UTF-8, which is the encoding that Vector
-    /// assumes internally for string-like data. You should enable this transcoding operation if you need your data to
-    /// be in UTF-8 for further processing. At the time of transcoding, any malformed sequences (that can’t be mapped to
-    /// UTF-8) will be replaced with the Unicode [REPLACEMENT
-    /// CHARACTER](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) and warnings will be
+    /// When set, the messages are transcoded from the specified encoding to UTF-8, which is the encoding that is
+    /// assumed internally for string-like data. Enable this transcoding operation if you need your data to
+    /// be in UTF-8 for further processing. At the time of transcoding, any malformed sequences (that can't be mapped to
+    /// UTF-8) is replaced with the Unicode [REPLACEMENT
+    /// CHARACTER](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) and warnings are
     /// logged.
     pub charset: &'static encoding_rs::Encoding,
 }

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -122,7 +122,7 @@ base: components: sinks: configuration: {
 		description: """
 			Proxy configuration.
 
-			Vector can be configured to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+			Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
 			proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
 			as well as set specific hosts that should not be proxied.
 			"""

--- a/website/cue/reference/components/base/sources.cue
+++ b/website/cue/reference/components/base/sources.cue
@@ -4,7 +4,7 @@ base: components: sources: configuration: proxy: {
 	description: """
 		Proxy configuration.
 
-		Vector can be configured to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+		Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
 		proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
 		as well as set specific hosts that should not be proxied.
 		"""

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -5,7 +5,7 @@ base: components: sinks: amqp: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/apex.cue
+++ b/website/cue/reference/components/sinks/base/apex.cue
@@ -5,7 +5,7 @@ base: components: sinks: apex: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -5,7 +5,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -5,7 +5,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -5,7 +5,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -5,7 +5,7 @@ base: components: sinks: aws_s3: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -5,7 +5,7 @@ base: components: sinks: aws_sqs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -5,7 +5,7 @@ base: components: sinks: axiom: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -5,7 +5,7 @@ base: components: sinks: azure_blob: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/blackhole.cue
+++ b/website/cue/reference/components/sinks/base/blackhole.cue
@@ -5,7 +5,7 @@ base: components: sinks: blackhole: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -5,7 +5,7 @@ base: components: sinks: clickhouse: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -5,7 +5,7 @@ base: components: sinks: console: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -5,7 +5,7 @@ base: components: sinks: datadog_events: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: datadog_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -5,7 +5,7 @@ base: components: sinks: datadog_metrics: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -5,7 +5,7 @@ base: components: sinks: datadog_traces: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -5,7 +5,7 @@ base: components: sinks: elasticsearch: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -5,7 +5,7 @@ base: components: sinks: file: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -5,7 +5,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""
@@ -33,9 +33,9 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false
@@ -73,9 +73,9 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -5,7 +5,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""
@@ -88,9 +88,9 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false
@@ -157,9 +157,9 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -5,7 +5,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""
@@ -33,9 +33,9 @@ base: components: sinks: gcp_pubsub: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false
@@ -73,9 +73,9 @@ base: components: sinks: gcp_pubsub: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""
@@ -33,9 +33,9 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false
@@ -78,9 +78,9 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -5,7 +5,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""
@@ -33,9 +33,9 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false
@@ -73,9 +73,9 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -5,7 +5,7 @@ base: components: sinks: honeycomb: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -5,7 +5,7 @@ base: components: sinks: http: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: humio_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -5,7 +5,7 @@ base: components: sinks: humio_metrics: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: influxdb_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -5,7 +5,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -5,7 +5,7 @@ base: components: sinks: kafka: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -5,7 +5,7 @@ base: components: sinks: logdna: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -5,7 +5,7 @@ base: components: sinks: loki: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -5,7 +5,7 @@ base: components: sinks: nats: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -10,7 +10,7 @@ base: components: sinks: new_relic: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -5,7 +5,7 @@ base: components: sinks: papertrail: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_exporter.cue
@@ -5,7 +5,7 @@ base: components: sinks: prometheus_exporter: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -5,7 +5,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -5,7 +5,7 @@ base: components: sinks: pulsar: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -5,7 +5,7 @@ base: components: sinks: redis: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -5,7 +5,7 @@ base: components: sinks: sematext_logs: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -5,7 +5,7 @@ base: components: sinks: sematext_metrics: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -5,7 +5,7 @@ base: components: sinks: socket: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/statsd.cue
+++ b/website/cue/reference/components/sinks/base/statsd.cue
@@ -5,7 +5,7 @@ base: components: sinks: statsd: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -5,7 +5,7 @@ base: components: sinks: vector: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -5,7 +5,7 @@ base: components: sinks: websocket: configuration: {
 		description: """
 			Controls how acknowledgements are handled for this sink.
 
-			See [End-to-end Acknowledgements][e2e_acks] for more information on how Vector handles event acknowledgement.
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
 
 			[e2e_acks]: https://vector.dev/docs/about/under-the-hood/architecture/end-to-end-acknowledgements/
 			"""

--- a/website/cue/reference/components/sources/base/docker_logs.cue
+++ b/website/cue/reference/components/sources/base/docker_logs.cue
@@ -168,7 +168,7 @@ base: components: sources: docker_logs: configuration: {
 
 			Only relevant when connecting to Docker via an HTTPS URL.
 
-			If not configured, Vector will try to use environment variable `DOCKER_CERT_PATH` and then` DOCKER_CONFIG`. If both environment variables are absent, Vector will try to read certificates in `~/.docker/`.
+			If not configured, the environment variable `DOCKER_CERT_PATH` is used. If `DOCKER_CERT_PATH` is absent, then` DOCKER_CONFIG` is used. If both environment variables are absent, the certificates in `~/.docker/` are read.
 			"""
 		required: false
 		type: object: options: {

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -38,11 +38,11 @@ base: components: sources: file: configuration: {
 				Takes one of the encoding [label strings](https://encoding.spec.whatwg.org/#concept-encoding-get) defined as
 				part of the [Encoding Standard](https://encoding.spec.whatwg.org/).
 
-				When set, the messages are transcoded from the specified encoding to UTF-8, which is the encoding that Vector
-				assumes internally for string-like data. You should enable this transcoding operation if you need your data to
-				be in UTF-8 for further processing. At the time of transcoding, any malformed sequences (that can’t be mapped to
-				UTF-8) will be replaced with the Unicode [REPLACEMENT
-				CHARACTER](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) and warnings will be
+				When set, the messages are transcoded from the specified encoding to UTF-8, which is the encoding that is
+				assumed internally for string-like data. Enable this transcoding operation if you need your data to
+				be in UTF-8 for further processing. At the time of transcoding, any malformed sequences (that can't be mapped to
+				UTF-8) is replaced with the Unicode [REPLACEMENT
+				CHARACTER](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) and warnings are
 				logged.
 				"""
 			required: true

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -39,9 +39,9 @@ base: components: sources: gcp_pubsub: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false
@@ -53,9 +53,9 @@ base: components: sources: gcp_pubsub: configuration: {
 
 			Either an API key, or a path to a service account credentials JSON file can be specified.
 
-			If both are unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename. If no
-			filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is
-			running on. If Vector is not running on a GCE instance, then you must define eith an API key or service account
+			If both are unset, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable is checked for a filename. If no
+			filename is named, an attempt is made to fetch an instance service account for the compute instance the program is
+			running on. If this is not on a GCE instance, then you must define it with an API key or service account
 			credentials JSON file.
 			"""
 		required: false

--- a/website/cue/reference/components/sources/base/internal_metrics.cue
+++ b/website/cue/reference/components/sources/base/internal_metrics.cue
@@ -5,7 +5,7 @@ base: components: sources: internal_metrics: configuration: {
 		description: """
 			Overrides the default namespace for the metrics emitted by the source.
 
-			By default, `vector` is used.
+			Overrides the default namespace.
 			"""
 		required: false
 		type: string: {}

--- a/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
@@ -23,7 +23,7 @@ base: components: transforms: aws_ec2_metadata: configuration: {
 		description: """
 			Proxy configuration.
 
-			Vector can be configured to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+			Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
 			proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
 			as well as set specific hosts that should not be proxied.
 			"""


### PR DESCRIPTION
This PR removes `vector` from component descriptions that I missed in the previous PRs. Removing `vector` because the descriptions will be getting pulled into the Reference section in Observability Pipelines docs.

ref: DOCS-4600