### PR TITLE
chore(ci); Run same setup scripts for cross jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,6 +203,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - run: echo "::add-matcher::.github/matchers/rust.json"
+      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
       # Why is this build, not check? Because we need to make sure the linking phase works.
       # aarch64 and musl in particular are notoriously hard to link.
       # While it may be tempting to slot a `check` in here for quickness, please don't.


### PR DESCRIPTION
The autoinstall of `cross` by the `Makefile` started failing for these recently which caused me to
realize it was installing the latest `cross`. This adds the same setup scripts that run on other CI
jobs to ensure a consistent environment.

We could improve this some since this job really only needs `cross` and not the rest of the setup by
breaking up the setup scripts or using the enivironment image we package as the CI image to save on
CI job run time.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
