### PR TITLE
chore(vrl): Fix year-dependent tests for 2023

### DIFF
--- a/lib/vrl/stdlib/src/parse_klog.rs
+++ b/lib/vrl/stdlib/src/parse_klog.rs
@@ -92,7 +92,7 @@ impl Function for ParseKlog {
                     "level": "info",
                     "line": 70,
                     "message": "hello from klog",
-                    "timestamp": "2022-05-05T17:59:40.692994Z"
+                    "timestamp": "2023-05-05T17:59:40.692994Z"
                 }"#}),
         }]
     }

--- a/lib/vrl/stdlib/src/parse_linux_authorization.rs
+++ b/lib/vrl/stdlib/src/parse_linux_authorization.rs
@@ -28,7 +28,7 @@ impl Function for ParseLinuxAuthorization {
                 "hostname": "localhost",
                 "message": "Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar",
                 "procid": 1111,
-                "timestamp": "2022-03-23T01:49:58Z"
+                "timestamp": "2023-03-23T01:49:58Z"
             }"#}),
         }]
     }

--- a/website/cue/reference/remap/functions/parse_klog.cue
+++ b/website/cue/reference/remap/functions/parse_klog.cue
@@ -29,7 +29,7 @@ remap: functions: parse_klog: {
 				level:     "info"
 				line:      70
 				message:   "hello from klog"
-				timestamp: "2022-05-05T17:59:40.692994Z"
+				timestamp: "2023-05-05T17:59:40.692994Z"
 			}
 		},
 	]

--- a/website/cue/reference/remap/functions/parse_linux_authorization.cue
+++ b/website/cue/reference/remap/functions/parse_linux_authorization.cue
@@ -39,7 +39,7 @@ remap: functions: parse_linux_authorization: {
 				hostname:  "localhost"
 				message:   "Accepted publickey for eng from 10.1.1.1 port 8888 ssh2: RSA SHA256:foobar"
 				procid:    1111
-				timestamp: "2022-03-23T01:49:58Z"
+				timestamp: "2023-03-23T01:49:58Z"
 			}
 		},
 	]


### PR DESCRIPTION
The code side of this could potentially be fixed by formatting the timestamps involved. However, all the strings involved have a fixed type of `&'static str` which cannot be dynamically formatted. As a result, resolving this involves a cascade of type refactoring into either `String` or `Cow<'static, str>`, and the return from `examples` into something other than `&'static [Example]` since that too is no longer static.

That will not help the documentation tests, though.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
