### PR TITLE
docs(nats source): fix documentation errors

### DIFF
--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -51,8 +51,7 @@ pub struct NatsSourceConfig {
     #[serde(alias = "name")]
     connection_name: String,
 
-    /// The NATS subject to publish messages to.
-    #[configurable(metadata(docs::templateable))]
+    /// The NATS subject to pull messages from.
     subject: String,
 
     /// NATS Queue Group to join.

--- a/website/cue/reference/components/nats.cue
+++ b/website/cue/reference/components/nats.cue
@@ -48,23 +48,6 @@ components: _nats: {
 				examples: ["nats://demo.nats.io", "nats://127.0.0.1:4222"]
 			}
 		}
-		subject: {
-			description: "The NATS subject to publish messages to."
-			required:    true
-			type: string: {
-				examples: ["{{ host }}", "foo", "time.us.east", "time.*.east", "time.>", ">"]
-				syntax: "template"
-			}
-		}
-		connection_name: {
-			common:      false
-			description: "A name assigned to the NATS connection."
-			required:    false
-			type: string: {
-				default: "vector"
-				examples: ["foo", "API Name Option Example"]
-			}
-		}
 		auth: {
 			common:      false
 			description: "Configuration for how Vector should authenticate to NATS."

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -52,7 +52,25 @@ components: sinks: nats: {
 		notices: []
 	}
 
-	configuration: components._nats.configuration & {}
+	configuration: components._nats.configuration & {
+		connection_name: {
+			common:      false
+			description: "A name assigned to the NATS connection."
+			required:    false
+			type: string: {
+				default: "vector"
+				examples: ["foo", "API Name Option Example"]
+			}
+		}
+		subject: {
+			description: "The NATS subject to publish messages to."
+			required:    true
+			type: string: {
+				examples: ["{{ host }}", "foo", "time.us.east", "time.*.east", "time.>", ">"]
+				syntax: "template"
+			}
+		}
+	}
 
 	input: {
 		logs:    true

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -225,9 +225,9 @@ base: components: sources: nats: configuration: {
 		type: string: {}
 	}
 	subject: {
-		description: "The NATS subject to publish messages to."
+		description: "The NATS subject to pull messages from."
 		required:    true
-		type: string: syntax: "template"
+		type: string: {}
 	}
 	subject_key_field: {
 		description: "The `NATS` subject key."

--- a/website/cue/reference/components/sources/nats.cue
+++ b/website/cue/reference/components/sources/nats.cue
@@ -39,19 +39,33 @@ components: sources: nats: {
 	}
 
 	configuration: components._nats.configuration & {
+		connection_name: {
+			description: "A name assigned to the NATS connection."
+			required:    true
+			type: string: {
+				examples: ["foo", "API Name Option Example"]
+			}
+		}
 		queue: {
 			common:      false
-			description: "NATS Queue Group to join"
+			description: "NATS Queue Group to join."
 			required:    false
 			type: string: {
 				default: "vector"
 				examples: ["foo", "API Name Option Example"]
 			}
 		}
+		subject: {
+			description: "The NATS subject to pull messages from."
+			required:    true
+			type: string: {
+				examples: ["foo", "time.us.east", "time.*.east", "time.>", ">"]
+			}
+		}
 	}
 
 	output: logs: record: {
-		description: "An individual NATS record"
+		description: "An individual NATS record."
 		fields: {
 			message: {
 				description: "The raw line from the NATS message."


### PR DESCRIPTION
A couple of errors were in the NATS source documentation as a result of both the source and sink sharing some documentation.

- The `subject` field is not templateable in the source.
- The `connection_name` field is mandatory. In the sink this defaults to `vector` if not specified. Arguably we could change the functionality of the source to match the sink - but I'm going for minimal impact here.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
