### PR TITLE
docs(splunk_hec sink): update docs re duplicate tags

### DIFF
--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -144,5 +144,12 @@ components: sinks: splunk_hec_metrics: {
 
 	telemetry: components.sinks.splunk_hec_logs.telemetry
 
-	how_it_works: sinks._splunk_hec.how_it_works
+	how_it_works: sinks._splunk_hec.how_it_works & {
+		multi_value_tags: {
+			title: "Multivalue Tags"
+			body: """
+				If Splunk recieves a tag with multiple values it will only take the last value specified,
+				so Vector only sends this last value.
+				"""
+		}	}
 }

--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -151,5 +151,5 @@ components: sinks: splunk_hec_metrics: {
 				If Splunk recieves a tag with multiple values it will only take the last value specified,
 				so Vector only sends this last value.
 				"""
-		}	}
+		}}
 }


### PR DESCRIPTION
Closes #15621
Epic #15420 

Testing Splunk with duplicate tag names shows that Splunk just ignores all but the last value. Since this is the current behaviour of Vector, this PR just updates the documentation to reflect this.