### PR TITLE
fix(config): Allow secrets to be reused multiple times

### DIFF
--- a/src/config/secret.rs
+++ b/src/config/secret.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use enum_dispatch::enum_dispatch;
 use vector_config::NamedComponent;
@@ -10,7 +10,7 @@ use crate::signal;
 pub trait SecretBackend: NamedComponent + core::fmt::Debug + Send + Sync {
     fn retrieve(
         &mut self,
-        secret_keys: Vec<String>,
+        secret_keys: HashSet<String>,
         signal_rx: &mut signal::SignalRx,
     ) -> crate::Result<HashMap<String, String>>;
 }

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bytes::BytesMut;
 use futures::executor;
@@ -41,10 +41,10 @@ const fn default_timeout_secs() -> u64 {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ExecQuery {
     version: String,
-    secrets: Vec<String>,
+    secrets: HashSet<String>,
 }
 
-fn new_query(secrets: Vec<String>) -> ExecQuery {
+fn new_query(secrets: HashSet<String>) -> ExecQuery {
     ExecQuery {
         version: "1.0".to_string(),
         secrets,
@@ -60,7 +60,7 @@ struct ExecResponse {
 impl SecretBackend for ExecBackend {
     fn retrieve(
         &mut self,
-        secret_keys: Vec<String>,
+        secret_keys: HashSet<String>,
         signal_rx: &mut signal::SignalRx,
     ) -> crate::Result<HashMap<String, String>> {
         let mut output = executor::block_on(async {
@@ -82,7 +82,7 @@ impl SecretBackend for ExecBackend {
                     if v.is_empty() {
                         return Err(format!("secret for key '{}' was empty", k).into());
                     }
-                    secrets.insert(k, v);
+                    secrets.insert(k.to_string(), v);
                 } else {
                     return Err(format!("secret for key '{}' was empty", k).into());
                 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use enum_dispatch::enum_dispatch;
 use vector_config::{configurable_component, NamedComponent};

--- a/src/secrets/test.rs
+++ b/src/secrets/test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use vector_config::configurable_component;
 
@@ -17,7 +17,7 @@ impl_generate_config_from_default!(TestBackend);
 impl SecretBackend for TestBackend {
     fn retrieve(
         &mut self,
-        secret_keys: Vec<String>,
+        secret_keys: HashSet<String>,
         _: &mut signal::SignalRx,
     ) -> crate::Result<HashMap<String, String>> {
         Ok(secret_keys


### PR DESCRIPTION
Previously it was "consuming" the secret for each place it appeared as a placeholder in the
configuration causing it to fail to find the secret a second time.

Closes: #15795

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
