### PR TITLE
chore(ci): Use codegen-units = 1 for Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,4 +27,4 @@ rustflags = ["-C", "link-args=-rdynamic"]
 
 [target.x86_64-pc-windows-msvc]
 # https://github.com/dtolnay/inventory/issues/58
-codegen-units = 1
+rustflags = ["-C", "codegen-units=1"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,3 +24,7 @@ rustflags = ["-C", "link-args=-rdynamic"]
 
 [target.aarch64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-rdynamic"]
+
+[target.x86_64-pc-windows-msvc]
+# https://github.com/dtolnay/inventory/issues/58
+codegen-units = 1


### PR DESCRIPTION
To workaround issue in inventory crate when upgrading to Rust 1.65.0.

Just curious to see the difference in CI time here.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
