### PR TITLE
fix(gcp sink): Separated healthcheck and regenerate token spawn

### DIFF
--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -166,7 +166,7 @@ pub fn build_healthcheck(
         auth.apply(&mut request);
 
         let response = client.send(request).await?;
-        healthcheck_response(response, auth, GcsHealthcheckError::NotFound.into())
+        healthcheck_response(response, GcsHealthcheckError::NotFound.into())
     };
 
     Ok(Box::pin(healthcheck))
@@ -192,8 +192,9 @@ impl SinkConfig for ChronicleUnstructuredConfig {
 
         // For the healthcheck we see if we can fetch the list of available log types.
         let healthcheck_endpoint = self.create_endpoint("v2/logtypes")?;
-
+ 
         let healthcheck = build_healthcheck(client.clone(), &healthcheck_endpoint, creds.clone())?;
+        creds.spawn_regenerate_token();
         let sink = self.build_sink(client, endpoint, creds)?;
 
         Ok((sink, healthcheck))

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -192,7 +192,7 @@ impl SinkConfig for ChronicleUnstructuredConfig {
 
         // For the healthcheck we see if we can fetch the list of available log types.
         let healthcheck_endpoint = self.create_endpoint("v2/logtypes")?;
- 
+
         let healthcheck = build_healthcheck(client.clone(), &healthcheck_endpoint, creds.clone())?;
         creds.spawn_regenerate_token();
         let sink = self.build_sink(client, endpoint, creds)?;

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -191,6 +191,7 @@ impl SinkConfig for GcsSinkConfig {
             base_url.clone(),
             auth.clone(),
         )?;
+        auth.spawn_regenerate_token();
         let sink = self.build_sink(client, base_url, auth)?;
 
         Ok((sink, healthcheck))
@@ -228,7 +229,6 @@ impl GcsSinkConfig {
         let request_settings = RequestSettings::new(self)?;
 
         let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings);
-
         Ok(VectorSink::from_event_streamsink(sink))
     }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -231,8 +231,8 @@ impl GcsSinkConfig {
 
         let request_settings = RequestSettings::new(self)?;
 
-        let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings, protocol);
-
+        let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings);
+        
         Ok(VectorSink::from_event_streamsink(sink))
     }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -230,7 +230,7 @@ impl GcsSinkConfig {
             .service(GcsService::new(client, base_url, auth));
 
         let request_settings = RequestSettings::new(self)?;
-        
+
         let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings, protocol);
 
         Ok(VectorSink::from_event_streamsink(sink))

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -192,6 +192,7 @@ impl SinkConfig for GcsSinkConfig {
             base_url.clone(),
             auth.clone(),
         )?;
+        auth.spawn_regenerate_token();
         let sink = self.build_sink(client, base_url, auth)?;
 
         Ok((sink, healthcheck))

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -232,7 +232,7 @@ impl GcsSinkConfig {
         let request_settings = RequestSettings::new(self)?;
 
         let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings);
-        
+
         Ok(VectorSink::from_event_streamsink(sink))
     }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -230,8 +230,8 @@ impl GcsSinkConfig {
             .service(GcsService::new(client, base_url, auth));
 
         let request_settings = RequestSettings::new(self)?;
-
-        let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings);
+        
+        let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings, protocol);
 
         Ok(VectorSink::from_event_streamsink(sink))
     }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -109,6 +109,7 @@ impl SinkConfig for PubsubConfig {
         let client = HttpClient::new(tls_settings, cx.proxy())?;
 
         let healthcheck = healthcheck(client.clone(), sink.uri("")?, sink.auth.clone()).boxed();
+        sink.auth.spawn_regenerate_token();
 
         let sink = BatchedHttpSink::new(
             sink,
@@ -221,7 +222,7 @@ async fn healthcheck(client: HttpClient, uri: Uri, auth: GcpAuthenticator) -> cr
     auth.apply(&mut request);
 
     let response = client.send(request).await?;
-    healthcheck_response(response, auth, HealthcheckError::TopicNotFound.into())
+    healthcheck_response(response, HealthcheckError::TopicNotFound.into())
 }
 
 #[cfg(test)]

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -360,10 +360,7 @@ async fn healthcheck(client: HttpClient, sink: StackdriverSink) -> crate::Result
     let request = sink.build_request(vec![]).await?.map(Body::from);
 
     let response = client.send(request).await?;
-    healthcheck_response(
-        response,
-        HealthcheckError::NotFound.into(),
-    )
+    healthcheck_response(response, HealthcheckError::NotFound.into())
 }
 
 impl StackdriverConfig {

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -124,7 +124,6 @@ pub fn build_healthcheck(
     Ok(healthcheck.boxed())
 }
 
-// Use this to map a healthcheck response, as it handles setting up the renewal task.
 pub fn healthcheck_response(
     response: http::Response<hyper::Body>,
     not_found_error: crate::Error,


### PR DESCRIPTION
Hi there, 

This PR is intended to fix the issue mentioned in https://github.com/vectordotdev/vector/issues/13058. 

I've moved out `auth.spawn_regenerate_token()` from the `healthcheck_response` function and spawned the regeneration token right after healthcheck where it is needed. I was able to build and test the version I am suggesting on my local development k8s cluster and it works as expected - disabled healthcheck doesn't prevent a regeneration token to be spawned. 

I am neither familiar with the vector codebase nor with the Rust language, so I'll appreciate any feedback and suggestions and will try my best to make this PR merged, thanks in advance. 

@bruceg @spencergilbert 