### PR TITLE
docs(apache_metrics): Use generated docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -505,7 +505,7 @@ sources-metrics = [
 ]
 
 sources-amqp = ["lapin"]
-sources-apache_metrics = []
+sources-apache_metrics = ["dep:serde_with"]
 sources-aws_ecs_metrics = ["dep:serde_with"]
 sources-aws_kinesis_firehose = ["dep:base64", "dep:infer"]
 sources-aws_s3 = ["aws-core", "dep:aws-sdk-sqs", "dep:aws-sdk-s3", "dep:semver", "dep:async-compression", "sources-aws_sqs", "tokio-util/io"]

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -34,9 +34,11 @@ use vector_core::config::LogNamespace;
 #[derive(Clone, Debug)]
 pub struct ApacheMetricsConfig {
     /// The list of `mod_status` endpoints to scrape metrics from.
+    #[configurable(metadata(docs::examples = "http://localhost:8080/server-status/?auto"))]
     endpoints: Vec<String>,
 
     /// The interval between scrapes, in seconds.
+    #[configurable(metadata(docs::type_unit = "seconds"))]
     #[serde(default = "default_scrape_interval_secs")]
     scrape_interval_secs: u64,
 

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use futures::{stream, FutureExt, StreamExt, TryFutureExt};
 use http::uri::Scheme;
 use hyper::{Body, Request};
+use serde_with::serde_as;
 use snafu::ResultExt;
 use tokio_stream::wrappers::IntervalStream;
 use vector_config::configurable_component;
@@ -30,6 +31,7 @@ pub use parser::ParseError;
 use vector_core::config::LogNamespace;
 
 /// Configuration for the `apache_metrics` source.
+#[serde_as]
 #[configurable_component(source("apache_metrics"))]
 #[derive(Clone, Debug)]
 pub struct ApacheMetricsConfig {
@@ -37,10 +39,11 @@ pub struct ApacheMetricsConfig {
     #[configurable(metadata(docs::examples = "http://localhost:8080/server-status/?auto"))]
     endpoints: Vec<String>,
 
-    /// The interval between scrapes, in seconds.
+    /// The interval between scrapes.
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[serde(default = "default_scrape_interval_secs")]
-    scrape_interval_secs: u64,
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    scrape_interval_secs: Duration,
 
     /// The namespace of the metric.
     ///
@@ -49,8 +52,8 @@ pub struct ApacheMetricsConfig {
     namespace: String,
 }
 
-pub const fn default_scrape_interval_secs() -> u64 {
-    15
+pub const fn default_scrape_interval_secs() -> Duration {
+    Duration::from_secs(15)
 }
 
 pub fn default_namespace() -> String {
@@ -143,14 +146,14 @@ impl UriExt for http::Uri {
 
 fn apache_metrics(
     urls: Vec<http::Uri>,
-    interval: u64,
+    interval: Duration,
     namespace: Option<String>,
     shutdown: ShutdownSignal,
     mut out: SourceSender,
     proxy: ProxyConfig,
 ) -> super::Source {
     Box::pin(async move {
-        let mut stream = IntervalStream::new(tokio::time::interval(Duration::from_secs(interval)))
+        let mut stream = IntervalStream::new(tokio::time::interval(interval))
             .take_until(shutdown)
             .map(move |_| stream::iter(urls.clone()))
             .flatten()

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -364,7 +364,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
 
         let config = ApacheMetricsConfig {
             endpoints: vec![format!("http://foo:bar@{}/metrics", in_addr)],
-            scrape_interval_secs: 1,
+            scrape_interval_secs: Duration::from_secs(1),
             namespace: "custom".to_string(),
         };
 
@@ -424,7 +424,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
 
         let source = ApacheMetricsConfig {
             endpoints: vec![format!("http://{}", in_addr)],
-            scrape_interval_secs: 1,
+            scrape_interval_secs: Duration::from_secs(1),
             namespace: "apache".to_string(),
         }
         .build(SourceContext::new_test(tx, None))
@@ -458,7 +458,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
 
         let source = ApacheMetricsConfig {
             endpoints: vec![format!("http://{}", in_addr)],
-            scrape_interval_secs: 1,
+            scrape_interval_secs: Duration::from_secs(1),
             namespace: "custom".to_string(),
         }
         .build(SourceContext::new_test(tx, None))

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -40,7 +40,6 @@ pub struct ApacheMetricsConfig {
     endpoints: Vec<String>,
 
     /// The interval between scrapes.
-    #[configurable(metadata(docs::type_unit = "seconds"))]
     #[serde(default = "default_scrape_interval_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     scrape_interval_secs: Duration,

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -50,34 +50,7 @@ components: sources: apache_metrics: {
 		platform_name: null
 	}
 
-	configuration: {
-		endpoints: {
-			description: "`mod_status` endpoints to scrape metrics from."
-			required:    true
-			type: array: {
-				items: type: string: {
-					examples: ["http://localhost:8080/server-status/?auto"]
-				}
-			}
-		}
-		scrape_interval_secs: {
-			description: "The interval between scrapes."
-			common:      true
-			required:    false
-			type: uint: {
-				default: 15
-				unit:    "seconds"
-			}
-		}
-		namespace: {
-			description: "The namespace of the metric. Disabled if empty."
-			required:    false
-			common:      false
-			type: string: {
-				default: "apache"
-			}
-		}
-	}
+	configuration: base.components.sources.apache_metrics.configuration
 
 	output: metrics: {
 		// Default Apache metrics tags

--- a/website/cue/reference/components/sources/base/apache_metrics.cue
+++ b/website/cue/reference/components/sources/base/apache_metrics.cue
@@ -4,7 +4,7 @@ base: components: sources: apache_metrics: configuration: {
 	endpoints: {
 		description: "The list of `mod_status` endpoints to scrape metrics from."
 		required:    true
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["http://localhost:8080/server-status/?auto"]
 	}
 	namespace: {
 		description: """
@@ -18,6 +18,9 @@ base: components: sources: apache_metrics: configuration: {
 	scrape_interval_secs: {
 		description: "The interval between scrapes, in seconds."
 		required:    false
-		type: uint: default: 15
+		type: uint: {
+			default: 15
+			unit:    "seconds"
+		}
 	}
 }

--- a/website/cue/reference/components/sources/base/apache_metrics.cue
+++ b/website/cue/reference/components/sources/base/apache_metrics.cue
@@ -16,7 +16,7 @@ base: components: sources: apache_metrics: configuration: {
 		type: string: default: "apache"
 	}
 	scrape_interval_secs: {
-		description: "The interval between scrapes, in seconds."
+		description: "The interval between scrapes."
 		required:    false
 		type: uint: {
 			default: 15


### PR DESCRIPTION
Very straightforward. Biggest changes: added units to a field, then an example to another.