### PR TITLE
feat(vrl): add `decode_base16`, `encode_base16` functions

### DIFF
--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -16,6 +16,7 @@ datadog-search-syntax = { path = "../../datadog/search-syntax", optional = true 
 lookup_lib = {package = "lookup", path = "../../lookup", optional = true }
 vector-common = { path = "../../vector-common", default-features = false, optional = true }
 
+base16 = { version = "0.2", optional = true }
 base64 = { version = "0.20", optional = true }
 bytes = { version = "1.3.0", optional = true }
 charset = { version = "0.1.3", optional = true }
@@ -83,12 +84,14 @@ default = [
     "chunks",
     "compact",
     "contains",
+    "decode_base16",
     "decode_base64",
     "decode_percent",
     "decode_mime_q",
     "decrypt",
     "del",
     "downcase",
+    "encode_base16",
     "encode_base64",
     "encode_json",
     "encode_key_value",
@@ -228,12 +231,14 @@ chunks = []
 compact = []
 contains = []
 cryptography = ["dep:aes", "dep:ctr", "dep:cbc", "dep:cfb-mode", "dep:ofb"]
+decode_base16 = ["dep:base16"]
 decode_base64 = ["dep:base64"]
 decode_percent = ["dep:percent-encoding"]
 decode_mime_q = ["dep:data-encoding","dep:charset","dep:quoted_printable"]
 decrypt = ["cryptography", "random_bytes", "encrypt"]
 del = []
 downcase = []
+encode_base16 = ["dep:base16"]
 encode_base64 = ["dep:base64"]
 encode_json = ["dep:serde_json", "value/json", "dep:chrono", "dep:regex"]
 encode_key_value = ["vector-common/encoding", "value/json"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -18,12 +18,14 @@ criterion_group!(
               chunks,
               compact,
               contains,
+              decode_base16,
               decode_base64,
               decode_percent,
               decrypt,
               // TODO: Cannot pass a Path to bench_function
               //del,
               downcase,
+              encode_base16,
               encode_base64,
               encode_key_value,
               encode_json,
@@ -261,6 +263,15 @@ bench_function! {
 }
 
 bench_function! {
+    decode_base16 => vrl_stdlib::DecodeBase16;
+
+    literal {
+        args: func_args![value: "736f6d652b3d737472696e672f76616c7565"],
+        want: Ok("some+=string/value"),
+    }
+}
+
+bench_function! {
     decode_base64 => vrl_stdlib::DecodeBase64;
 
     literal {
@@ -298,6 +309,15 @@ bench_function! {
     literal {
         args: func_args![value: "FOO"],
         want: Ok("foo")
+    }
+}
+
+bench_function! {
+    encode_base16 => vrl_stdlib::EncodeBase16;
+
+    literal {
+        args: func_args![value: "some+=string/value"],
+        want: Ok("736f6d652b3d737472696e672f76616c7565"),
     }
 }
 

--- a/lib/vrl/stdlib/src/decode_base16.rs
+++ b/lib/vrl/stdlib/src/decode_base16.rs
@@ -1,0 +1,83 @@
+use std::str;
+use nom::AsBytes;
+use ::value::Value;
+use vrl::prelude::expression::FunctionExpression;
+use vrl::prelude::*;
+
+fn decode_base16(value: Value) -> Resolved {
+    match base16::decode(&value.try_bytes_utf8_lossy()?.to_string()) {
+        Ok(s) => Ok((s.as_bytes()).into()),
+        Err(_) => Err("unable to decode value to base16".into()),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DecodeBase16;
+
+impl Function for DecodeBase16 {
+    fn identifier(&self) -> &'static str {
+        "decode_base16"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(DecodeBase16Fn { value }.as_expr())
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "demo string",
+            source: r#"decode_base16!("736F6D6520737472696E672076616C7565")"#,
+            result: Ok(r#"some string value"#),
+        }]
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DecodeBase16Fn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for DecodeBase16Fn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+
+        decode_base16(value)
+    }
+
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        // Always fallible due to the possibility of decoding errors that VRL can't detect in
+        TypeDef::bytes().fallible()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    test_function![
+        decode_base16 => DecodeBase16;
+
+        standard {
+            args: func_args![value: value!("736F6D652B3D737472696E672F76616C7565")],
+            want: Ok(value!("some+=string/value")),
+            tdef: TypeDef::bytes().fallible(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/decode_base16.rs
+++ b/lib/vrl/stdlib/src/decode_base16.rs
@@ -1,6 +1,6 @@
 use ::value::Value;
-use std::str;
 use nom::AsBytes;
+use std::str;
 use vrl::prelude::expression::FunctionExpression;
 use vrl::prelude::*;
 

--- a/lib/vrl/stdlib/src/decode_base16.rs
+++ b/lib/vrl/stdlib/src/decode_base16.rs
@@ -1,6 +1,6 @@
+use ::value::Value;
 use std::str;
 use nom::AsBytes;
-use ::value::Value;
 use vrl::prelude::expression::FunctionExpression;
 use vrl::prelude::*;
 
@@ -20,13 +20,11 @@ impl Function for DecodeBase16 {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[
-            Parameter {
-                keyword: "value",
-                kind: kind::BYTES,
-                required: true,
-            },
-        ]
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
     }
 
     fn compile(

--- a/lib/vrl/stdlib/src/decode_base16.rs
+++ b/lib/vrl/stdlib/src/decode_base16.rs
@@ -62,7 +62,7 @@ impl FunctionExpression for DecodeBase16Fn {
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        // Always fallible due to the possibility of decoding errors that VRL can't detect in
+        // Always fallible due to the possibility of decoding errors that VRL can't detect in `base16`
         TypeDef::bytes().fallible()
     }
 }

--- a/lib/vrl/stdlib/src/encode_base16.rs
+++ b/lib/vrl/stdlib/src/encode_base16.rs
@@ -1,0 +1,82 @@
+use ::value::Value;
+use vrl::prelude::expression::FunctionExpression;
+use vrl::prelude::*;
+
+fn encode_base16(value: Value) -> Resolved {
+    let value = value.try_bytes()?;
+    Ok(base16::encode_lower(&value).into())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EncodeBase16;
+
+impl Function for EncodeBase16 {
+    fn identifier(&self) -> &'static str {
+        "encode_base16"
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[
+            Parameter {
+                keyword: "value",
+                kind: kind::BYTES,
+                required: true,
+            }
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(EncodeBase16Fn {
+            value
+        }
+        .as_expr())
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[Example {
+            title: "demo string",
+            source: r#"encode_base16("some string value")"#,
+            result: Ok("736f6d6520737472696e672076616c7565"),
+        }]
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EncodeBase16Fn {
+    value: Box<dyn Expression>
+}
+
+impl FunctionExpression for EncodeBase16Fn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+
+        encode_base16(value)
+    }
+
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        TypeDef::bytes().infallible()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    test_function![
+        encode_base16 => EncodeBase16;
+
+        with_defaults {
+            args: func_args![value: value!("some+=string/value")],
+            want: Ok(value!("736f6d652b3d737472696e672f76616c7565")),
+            tdef: TypeDef::bytes().infallible(),
+        }
+
+    ];
+}

--- a/lib/vrl/stdlib/src/encode_base16.rs
+++ b/lib/vrl/stdlib/src/encode_base16.rs
@@ -16,13 +16,11 @@ impl Function for EncodeBase16 {
     }
 
     fn parameters(&self) -> &'static [Parameter] {
-        &[
-            Parameter {
-                keyword: "value",
-                kind: kind::BYTES,
-                required: true,
-            }
-        ]
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
     }
 
     fn compile(
@@ -33,10 +31,7 @@ impl Function for EncodeBase16 {
     ) -> Compiled {
         let value = arguments.required("value");
 
-        Ok(EncodeBase16Fn {
-            value
-        }
-        .as_expr())
+        Ok(EncodeBase16Fn { value }.as_expr())
     }
 
     fn examples(&self) -> &'static [Example] {
@@ -50,7 +45,7 @@ impl Function for EncodeBase16 {
 
 #[derive(Clone, Debug)]
 struct EncodeBase16Fn {
-    value: Box<dyn Expression>
+    value: Box<dyn Expression>,
 }
 
 impl FunctionExpression for EncodeBase16Fn {

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -48,6 +48,8 @@ mod chunks;
 mod compact;
 #[cfg(feature = "contains")]
 mod contains;
+#[cfg(feature = "decode_base16")]
+mod decode_base16;
 #[cfg(feature = "decode_base64")]
 mod decode_base64;
 #[cfg(feature = "decode_mime_q")]
@@ -60,6 +62,8 @@ mod decrypt;
 mod del;
 #[cfg(feature = "downcase")]
 mod downcase;
+#[cfg(feature = "encode_base16")]
+mod encode_base16;
 #[cfg(feature = "encode_base64")]
 mod encode_base64;
 #[cfg(feature = "encode_json")]
@@ -341,6 +345,8 @@ pub use chunks::Chunks;
 pub use compact::Compact;
 #[cfg(feature = "contains")]
 pub use contains::Contains;
+#[cfg(feature = "decode_base16")]
+pub use decode_base16::DecodeBase16;
 #[cfg(feature = "decode_base64")]
 pub use decode_base64::DecodeBase64;
 #[cfg(feature = "decode_mime_q")]
@@ -353,6 +359,8 @@ pub use decrypt::Decrypt;
 pub use del::Del;
 #[cfg(feature = "downcase")]
 pub use downcase::Downcase;
+#[cfg(feature = "encode_base16")]
+pub use encode_base16::EncodeBase16;
 #[cfg(feature = "encode_base64")]
 pub use encode_base64::EncodeBase64;
 #[cfg(feature = "encode_json")]
@@ -634,6 +642,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Compact),
         #[cfg(feature = "contains")]
         Box::new(Contains),
+        #[cfg(feature = "decode_base16")]
+        Box::new(DecodeBase16),
         #[cfg(feature = "decode_base64")]
         Box::new(DecodeBase64),
         #[cfg(feature = "decode_percent")]
@@ -646,6 +656,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(Del),
         #[cfg(feature = "downcase")]
         Box::new(Downcase),
+        #[cfg(feature = "encode_base16")]
+        Box::new(EncodeBase16),
         #[cfg(feature = "encode_base64")]
         Box::new(EncodeBase64),
         #[cfg(feature = "encode_json")]

--- a/website/cue/reference/remap/functions/decode_base16.cue
+++ b/website/cue/reference/remap/functions/decode_base16.cue
@@ -1,0 +1,31 @@
+package metadata
+
+remap: functions: decode_base16: {
+	category:    "Codec"
+	description: """
+		Decodes the `value` (a [Base16](\(urls.base16)) string) into its original string.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The [Base16](\(urls.base16)) data to decode."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: [
+		"`value` isn't a valid encoded Base16 string.",
+	]
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Decode Base16 data"
+			source: """
+				decode_base16!("796f752068617665207375636365737366756c6c79206465636f646564206d65")
+				"""
+			return: "you have successfully decoded me"
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/encode_base16.cue
+++ b/website/cue/reference/remap/functions/encode_base16.cue
@@ -1,0 +1,29 @@
+package metadata
+
+remap: functions: encode_base16: {
+	category:    "Codec"
+	description: """
+		Encodes the `value` to [Base16](\(urls.base16)).
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The string to encode."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: []
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Encode to Base16"
+			source: """
+				encode_base16("please encode me")
+				"""
+			return: "706c6561736520656e636f6465206d65"
+		},
+	]
+}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -94,6 +94,7 @@ urls: {
 	azure_blob_endpoints:                       "https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api"
 	azure_monitor:                              "https://azure.microsoft.com/en-us/services/monitor/"
 	azure_monitor_logs_endpoints:               "https://docs.microsoft.com/en-us/rest/api/monitor/"
+	base16:                                     "\(wikipedia)/wiki/Hexadecimal"
 	base64:                                     "\(wikipedia)/wiki/Base64"
 	base64_padding:                             "\(wikipedia)/wiki/Base64#Output_padding"
 	base64_standard:                            "https://tools.ietf.org/html/rfc4648#section-4"


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

These encode/decode functions enable Vector to work with logs produced with strings encoded with base16 (or hex).

`encode_base16` `decode_base16` are similar to the base64 functions - however less complex due to base16 being more simple than base64.

```
$ decode_base16!("some string")
function call error for "decode_base16" at (0:29): unable to decode value to base16

$ decode_base16!("736f6d6520737472696e67")
"some string"

$ encode_base16("some string")
"736f6d6520737472696e67"
```
