### PR TITLE
chore(config): properly enforce specifying `docs::enum_tag_description` for internally tagged enums

### DIFF
--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -55,6 +55,7 @@ impl From<std::io::Error> for Error {
 #[configurable_component]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[serde(tag = "method", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The framing method."))]
 pub enum FramingConfig {
     /// Event data is not delimited at all.
     Bytes,

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -19,30 +19,35 @@ pub enum NatsConfigError {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(
+    docs::enum_tag_description = "The strategy used to authenticate with the NATS server.
+
+More information on NATS authentication, and the various authentication strategies, can be found in the
+NATS [documentation][nats_auth_docs]. For TLS client certificate authentication specifically, see the
+`tls` settings.
+
+[nats_auth_docs]: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro"
+))]
 pub(crate) enum NatsAuthConfig {
-    /// Username and password authentication.
-    /// ([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/username_password))
+    /// Username/password authentication.
     UserPassword {
         #[configurable(derived)]
         user_password: NatsAuthUserPassword,
     },
 
     /// Token authentication.
-    /// ([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tokens))
     Token {
         #[configurable(derived)]
         token: NatsAuthToken,
     },
 
-    /// Credentials file authentication.
-    /// ([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt))
+    /// Credentials file authentication. (JWT-based)
     CredentialsFile {
         #[configurable(derived)]
         credentials_file: NatsAuthCredentialsFile,
     },
 
     /// NKey authentication.
-    /// ([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth))
     Nkey {
         #[configurable(derived)]
         nkey: NatsAuthNKey,

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -35,6 +35,7 @@ use crate::{
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
 pub enum ElasticsearchAuth {
     /// HTTP Basic Authentication.
     Basic {

--- a/src/sinks/prometheus/mod.rs
+++ b/src/sinks/prometheus/mod.rs
@@ -14,6 +14,7 @@ use crate::aws::AwsAuthentication;
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
 pub enum PrometheusRemoteWriteAuth {
     /// HTTP Basic Authentication.
     Basic {

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -32,14 +32,15 @@ pub struct SocketSinkConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum Mode {
-    /// TCP.
+    /// Send over TCP.
     Tcp(#[configurable(transparent)] TcpMode),
 
-    /// UDP.
+    /// Send over UDP.
     Udp(#[configurable(transparent)] UdpMode),
 
-    /// Unix Domain Socket.
+    /// Send over a Unix domain socket (UDS).
     #[cfg(unix)]
     Unix(#[configurable(transparent)] UnixMode),
 }

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -62,14 +62,15 @@ pub struct StatsdSinkConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum Mode {
-    /// TCP.
+    /// Send over TCP.
     Tcp(#[configurable(transparent)] TcpSinkConfig),
 
-    /// UDP.
+    /// Send over UDP.
     Udp(#[configurable(transparent)] StatsdUdpConfig),
 
-    /// Unix Domain Socket.
+    /// Send over a Unix domain socket (UDS).
     #[cfg(unix)]
     Unix(#[configurable(transparent)] UnixSinkConfig),
 }

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -81,6 +81,9 @@ pub enum DemoLogsConfigError {
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default)]
 #[serde(tag = "format", rename_all = "snake_case")]
+#[configurable(metadata(
+    docs::enum_tag_description = "The format of the randomly generated output."
+))]
 pub enum OutputFormat {
     /// Lines are chosen at random from the list specified using `lines`.
     Shuffle {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -243,13 +243,15 @@ fn default_line_delimiter() -> String {
 #[configurable_component]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[serde(tag = "strategy", rename_all = "snake_case")]
+#[configurable(metadata(
+    docs::enum_tag_description = "The strategy used to uniquely identify files.\n\nThis is important for checkpointing when file rotation is used."
+))]
 pub enum FingerprintConfig {
     /// Read lines from the beginning of the file and compute a checksum over them.
     Checksum {
         /// Maximum number of bytes to use, from the lines that are read, for generating the checksum.
-        ///
-        /// TODO: Should we properly expose this in the documentation? There could definitely be value in allowing more
-        /// bytes to be used for the checksum generation, but we should commit to exposing it rather than hiding it.
+        // TODO: Should we properly expose this in the documentation? There could definitely be value in allowing more
+        // bytes to be used for the checksum generation, but we should commit to exposing it rather than hiding it.
         #[serde(alias = "fingerprint_bytes")]
         bytes: Option<usize>,
 
@@ -267,7 +269,9 @@ pub enum FingerprintConfig {
         lines: usize,
     },
 
-    /// Use the [device and inode](https://en.wikipedia.org/wiki/Inode) as the identifier.
+    /// Use the [device and inode][inode] as the identifier.
+    ///
+    /// [inode]: https://en.wikipedia.org/wiki/Inode
     #[serde(rename = "device_and_inode")]
     DevInode,
 }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -30,6 +30,7 @@ pub struct SocketConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 #[allow(clippy::large_enum_variant)] // just used for configuration
 pub enum Mode {
     /// Listen on TCP.
@@ -38,11 +39,11 @@ pub enum Mode {
     /// Listen on UDP.
     Udp(#[configurable(derived)] udp::UdpConfig),
 
-    /// Listen on UDS, in datagram mode. (Unix domain socket)
+    /// Listen on a Unix domain socket (UDS), in datagram mode.
     #[cfg(unix)]
     UnixDatagram(#[configurable(derived)] unix::UnixConfig),
 
-    /// Listen on UDS, in stream mode. (Unix domain socket)
+    /// Listen on a Unix domain socket (UDS), in stream mode.
     #[cfg(unix)]
     #[serde(alias = "unix")]
     UnixStream(#[configurable(derived)] unix::UnixConfig),

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -42,6 +42,7 @@ use vector_core::config::LogNamespace;
 #[configurable_component(source("statsd"))]
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum StatsdConfig {
     /// Listen on TCP.
     Tcp(#[configurable(derived)] TcpConfig),

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -67,6 +67,7 @@ pub struct SyslogConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum Mode {
     /// Listen on TCP.
     Tcp {

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -88,6 +88,7 @@ pub enum TagConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[configurable(metadata(docs::enum_tag_description = "The type of metric to create."))]
 pub enum MetricTypeConfig {
     /// A counter.
     Counter(#[configurable(derived)] CounterConfig),

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -25,6 +25,9 @@ pub struct TagCardinalityLimitConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+#[configurable(metadata(
+    docs::enum_tag_description = "Controls the approach taken for tracking tag cardinality."
+))]
 pub enum Mode {
     /// Tracks cardinality exactly.
     ///

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -429,7 +429,8 @@ base: components: sinks: aws_s3: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -272,7 +272,8 @@ base: components: sinks: azure_blob: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -158,7 +158,8 @@ base: components: sinks: console: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -126,7 +126,8 @@ base: components: sinks: elasticsearch: configuration: {
 				type: string: {}
 			}
 			strategy: {
-				required: true
+				description: "The authentication strategy to use."
+				required:    true
 				type: string: enum: {
 					aws:   "Amazon OpenSearch Service-specific authentication."
 					basic: "HTTP Basic Authentication."

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -170,7 +170,8 @@ base: components: sinks: file: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -337,7 +337,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -255,7 +255,8 @@ base: components: sinks: http: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -67,24 +67,21 @@ base: components: sinks: nats: configuration: {
 				}
 			}
 			strategy: {
+				description: """
+					The strategy used to authenticate with the NATS server.
+
+					More information on NATS authentication, and the various authentication strategies, can be found in the
+					NATS [documentation][nats_auth_docs]. For TLS client certificate authentication specifically, see the
+					`tls` settings.
+
+					[nats_auth_docs]: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro
+					"""
 				required: true
 				type: string: enum: {
-					credentials_file: """
-						Credentials file authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt))
-						"""
-					nkey: """
-						NKey authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth))
-						"""
-					token: """
-						Token authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tokens))
-						"""
-					user_password: """
-						Username and password authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/username_password))
-						"""
+					credentials_file: "Credentials file authentication. (JWT-based)"
+					nkey:             "NKey authentication."
+					token:            "Token authentication."
+					user_password:    "Username/password authentication."
 				}
 			}
 			token: {

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -113,7 +113,8 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				type: string: {}
 			}
 			strategy: {
-				required: true
+				description: "The authentication strategy to use."
+				required:    true
 				type: string: enum: {
 					aws:   "Amazon Prometheus Service-specific authentication."
 					basic: "HTTP Basic Authentication."

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -169,7 +169,8 @@ base: components: sinks: socket: configuration: {
 				}
 			}
 			method: {
-				required: true
+				description: "The framing method."
+				required:    true
 				type: string: enum: {
 					bytes:               "Event data is not delimited at all."
 					character_delimited: "Event data is delimited by a single ASCII (7-bit) character."
@@ -194,11 +195,12 @@ base: components: sinks: socket: configuration: {
 		}
 	}
 	mode: {
-		required: true
+		description: "The type of socket to use."
+		required:    true
 		type: string: enum: {
-			tcp:  "TCP."
-			udp:  "UDP."
-			unix: "Unix Domain Socket."
+			tcp:  "Send over TCP."
+			udp:  "Send over UDP."
+			unix: "Send over a Unix domain socket (UDS)."
 		}
 	}
 	path: {

--- a/website/cue/reference/components/sinks/base/statsd.cue
+++ b/website/cue/reference/components/sinks/base/statsd.cue
@@ -85,11 +85,12 @@ base: components: sinks: statsd: configuration: {
 		}
 	}
 	mode: {
-		required: true
+		description: "The type of socket to use."
+		required:    true
 		type: string: enum: {
-			tcp:  "TCP."
-			udp:  "UDP."
-			unix: "Unix Domain Socket."
+			tcp:  "Send over TCP."
+			udp:  "Send over UDP."
+			unix: "Send over a Unix domain socket (UDS)."
 		}
 	}
 	path: {

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -60,7 +60,8 @@ base: components: sources: demo_logs: configuration: {
 		}
 	}
 	format: {
-		required: false
+		description: "The format of the randomly generated output."
+		required:    false
 		type: string: {
 			default: "json"
 			enum: {

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -83,12 +83,7 @@ base: components: sources: file: configuration: {
 		required: false
 		type: object: options: {
 			bytes: {
-				description: """
-					Maximum number of bytes to use, from the lines that are read, for generating the checksum.
-
-					TODO: Should we properly expose this in the documentation? There could definitely be value in allowing more
-					bytes to be used for the checksum generation, but we should commit to exposing it rather than hiding it.
-					"""
+				description:   "Maximum number of bytes to use, from the lines that are read, for generating the checksum."
 				relevant_when: "strategy = \"checksum\""
 				required:      false
 				type: uint: {}
@@ -116,12 +111,21 @@ base: components: sources: file: configuration: {
 				type: uint: default: 1
 			}
 			strategy: {
+				description: """
+					The strategy used to uniquely identify files.
+
+					This is important for checkpointing when file rotation is used.
+					"""
 				required: false
 				type: string: {
 					default: "checksum"
 					enum: {
-						checksum:         "Read lines from the beginning of the file and compute a checksum over them."
-						device_and_inode: "Use the [device and inode](https://en.wikipedia.org/wiki/Inode) as the identifier."
+						checksum: "Read lines from the beginning of the file and compute a checksum over them."
+						device_and_inode: """
+															Use the [device and inode][inode] as the identifier.
+
+															[inode]: https://en.wikipedia.org/wiki/Inode
+															"""
 					}
 				}
 			}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -41,24 +41,21 @@ base: components: sources: nats: configuration: {
 				}
 			}
 			strategy: {
+				description: """
+					The strategy used to authenticate with the NATS server.
+
+					More information on NATS authentication, and the various authentication strategies, can be found in the
+					NATS [documentation][nats_auth_docs]. For TLS client certificate authentication specifically, see the
+					`tls` settings.
+
+					[nats_auth_docs]: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro
+					"""
 				required: true
 				type: string: enum: {
-					credentials_file: """
-						Credentials file authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt))
-						"""
-					nkey: """
-						NKey authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth))
-						"""
-					token: """
-						Token authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/tokens))
-						"""
-					user_password: """
-						Username and password authentication.
-						([documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/username_password))
-						"""
+					credentials_file: "Credentials file authentication. (JWT-based)"
+					nkey:             "NKey authentication."
+					token:            "Token authentication."
+					user_password:    "Username/password authentication."
 				}
 			}
 			token: {

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -175,12 +175,13 @@ base: components: sources: socket: configuration: {
 		type: uint: {}
 	}
 	mode: {
-		required: true
+		description: "The type of socket to use."
+		required:    true
 		type: string: enum: {
 			tcp:           "Listen on TCP."
 			udp:           "Listen on UDP."
-			unix_datagram: "Listen on UDS, in datagram mode. (Unix domain socket)"
-			unix_stream:   "Listen on UDS, in stream mode. (Unix domain socket)"
+			unix_datagram: "Listen on a Unix domain socket (UDS), in datagram mode."
+			unix_stream:   "Listen on a Unix domain socket (UDS), in stream mode."
 		}
 	}
 	path: {

--- a/website/cue/reference/components/sources/base/statsd.cue
+++ b/website/cue/reference/components/sources/base/statsd.cue
@@ -27,7 +27,8 @@ base: components: sources: statsd: configuration: {
 		}
 	}
 	mode: {
-		required: true
+		description: "The type of socket to use."
+		required:    true
 		type: string: enum: {
 			tcp:  "Listen on TCP."
 			udp:  "Listen on UDP."

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -50,7 +50,8 @@ base: components: sources: syslog: configuration: {
 		type: uint: default: 102400
 	}
 	mode: {
-		required: true
+		description: "The type of socket to use."
+		required:    true
 		type: string: enum: {
 			tcp:  "Listen on TCP."
 			udp:  "Listen on UDP."

--- a/website/cue/reference/components/transforms/base/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/base/log_to_metric.cue
@@ -65,7 +65,8 @@ base: components: transforms: log_to_metric: configuration: metrics: {
 			}
 		}
 		type: {
-			required: true
+			description: "The type of metric to create."
+			required:    true
 			type: string: enum: {
 				counter:   "A counter."
 				gauge:     "A gauge."

--- a/website/cue/reference/components/transforms/base/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/base/tag_cardinality_limit.cue
@@ -27,7 +27,8 @@ base: components: transforms: tag_cardinality_limit: configuration: {
 		}
 	}
 	mode: {
-		required: true
+		description: "Controls the approach taken for tracking tag cardinality."
+		required:    true
 		type: string: enum: {
 			exact: """
 				Tracks cardinality exactly.

--- a/website/cue/reference/components/transforms/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/log_to_metric.cue
@@ -24,11 +24,7 @@ components: transforms: log_to_metric: {
 		notices: []
 	}
 
-	// TODO: It'd be nice to have a way to define the description of the enum tag field on the Rust
-	// side and propagate it forward, since this is a common pattern that gets used.
-	configuration: base.components.transforms.log_to_metric.configuration & {
-		metrics: type: array: items: type: object: options: type: description: "The metric type."
-	}
+	configuration: base.components.transforms.log_to_metric.configuration
 
 	input: {
 		logs:    true


### PR DESCRIPTION
## Context

Currently, when building the machine-generated documentation from Vector's configuration schema, we use a number of heuristics to attempt to reverse engineer the Rust type based on the given schema. We do this in order to then generate a more human-friendly and intuitive description of the Rust type. As the most complex type, we have a significant amount of logic for decoding enums, as the various ways that exist to control how they're (de)serialized can lead to meaningful differences in the resulting schema.

Normally, the `configurable_component` macro (and by extension, the `Configurable` derive macro) enforce that all types, and fields, have a description, whether specified directly or derived. This also applies to enums. However, in many cases, enums are configured to be (de)serialized such that a standalone field (the "tag" field) is exposed that controls selecting which enum variant to use, while we expose/flatten any "internal" fields from any of the variants that have named/unnamed fields: think `Variant { foo: String }` or `Variant(String)`.

As all type definitions in the documentation output must have a description, this leaves us in a weird position. The description of an enum itself is usually high-level, along the lines of "Decoding configuration" or "Authentication configuration". Applying _that_ description to the tag field usually doesn't make much sense, because it doesn't indicate that the field itself is specifically for choosing the specific decoding, or authentication strategy, to use.

We handle this by looking for a special metadata attribute on enum schemas, `docs::enum_tag_description`, which indicates the specific description to give to the tag field. As an example, for a field called `decoding`, with a type of `DecodingConfig`, that has its tag field set to `codec`:

- the description of `DecodingConfig` gets used for the description of the `decoding` field in the docs
- the value of the `docs::enum_tag_description` metadata attribute, if it exists on `DecodingConfig`, gets used for the description of the `decoding.codec` field in the docs

However, we don't currently emit an error if that metadata attribute is missing, and when it's missing, no description is applied to the tag field at all. This leads to a logical error during Cue validation, which is obtuse and requires prior knowledge to figure out without a ton of digging.

## Solution

As we know exactly where we need this description to be present, we've tweaked the documentation generation script to emit an error when this metadata attribute is emitted.

The error message tries to be verbose enough to explain the problem, as well as providing an example of the full helper attribute that must be added to fix the issue. As the script doesn't have a great way to track the logical Rust type that the schema represents, we can't trivially say "add this to the `X` type", so we emit the responsible schema definition from the overall configuration schema document. This generally provides enough context that relevant strings/constants can be searched for in the Rust source to find the responsible enum.

Additionally, as this is now a requirement, we had to backport many missing instances of this metadata attribute to get the script to run cleanly.