### PR TITLE
fix(config): compare serialized JSON Values instead of string

### DIFF
--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -74,10 +74,13 @@ impl Difference {
             .filter(|&n| {
                 // This is a hack around the issue of comparing two
                 // trait objects. Json is used here over toml since
-                // toml does not support serializing `None`.
-                let old_json = serde_json::to_vec(&old[n]).unwrap();
-                let new_json = serde_json::to_vec(&new[n]).unwrap();
-                old_json != new_json
+                // toml does not support serializing `None`
+                // to_value is used specifically (instead of string)
+                // to avoid problems comparing serialized HashMaps,
+                // which can iterate in varied orders.
+                let old_value = serde_json::to_value(&old[n]).unwrap();
+                let new_value = serde_json::to_value(&new[n]).unwrap();
+                old_value != new_value
             })
             .cloned()
             .collect::<HashSet<_>>();


### PR DESCRIPTION
Fixes an issue where components would be falsely flagged as different because of the way HashMaps can iterate in different order. Because of this unchanging components would be needlessly cycled on every reload.

Closes: #13716

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
