### PR TITLE
feat(kafka): synchronous consumer offset commit on shutdown

### DIFF
--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -15,7 +15,7 @@ use futures::{Stream, StreamExt};
 use lookup::{lookup_v2::OptionalValuePath, owned_value_path, path, OwnedValuePath};
 use once_cell::sync::OnceCell;
 use rdkafka::{
-    consumer::{Consumer, ConsumerContext, Rebalance, StreamConsumer},
+    consumer::{CommitMode, Consumer, ConsumerContext, Rebalance, StreamConsumer},
     message::{BorrowedMessage, Headers as _, Message},
     ClientConfig, ClientContext, Statistics,
 };
@@ -346,6 +346,13 @@ async fn kafka_source(
         }
     }
 
+    // Since commits are async internally, we try one last sync commit inside the interval
+    // in case there have been acks.
+    if let Ok(current_assignment) = consumer.assignment() {
+        // not logging on error because it will error if there are no offsets stored for a partition,
+        // and this is best-effort cleanup anyway
+        let _ = consumer.commit(&current_assignment, CommitMode::Sync);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Make one final attempt to commit stored offsets on kafka source shutdown.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
