### PR TITLE
docs(statsd): update source description

### DIFF
--- a/website/content/en/docs/reference/configuration/sources/statsd.md
+++ b/website/content/en/docs/reference/configuration/sources/statsd.md
@@ -1,6 +1,6 @@
 ---
 title: StatsD
-description: Collect metrics emitted by the [StatsD](https://github.com/statsd/statsd) aggregator
+description: Collect metrics emitted via [StatsD](https://github.com/statsd/statsd) protocol
 kind: source
 layout: component
 tags: ["statsd", "component", "source", "metrics"]


### PR DESCRIPTION
Clarify a little bit the documentation regarding Statsd. Even if the linked repo consists implementation of the Statsd server, now should be clear that Vector could be used instead of Statsd server as a one more Statsd server implementation.