### PR TITLE
docs(internal_logs source): use auto-generated config docs

### DIFF
--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -28,6 +28,7 @@ pub struct InternalLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
+    ///
     /// Set to `""` to suppress this key.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
@@ -37,6 +38,7 @@ pub struct InternalLogsConfig {
     /// Overrides the name of the log field used to add the current process ID to each event.
     ///
     /// By default, `"pid"` is used.
+    ///
     /// Set to `""` to suppress this key.
     #[serde(default = "pid_key")]
     pid_key: OptionalValuePath,

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use codecs::BytesDeserializerConfig;
 use futures::{stream, StreamExt};
-use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
+use lookup::lookup_v2::OptionalValuePath;
 use lookup::{owned_value_path, path, OwnedValuePath};
 use value::Kind;
 use vector_config::{configurable_component, NamedComponent};
@@ -11,7 +11,7 @@ use vector_core::{
 };
 
 use crate::{
-    config::{log_schema, DataType, Output, SourceConfig, SourceContext},
+    config::{DataType, Output, SourceConfig, SourceContext},
     event::{EstimatedJsonEncodedSizeOf, Event},
     internal_events::{InternalLogsBytesReceived, InternalLogsEventsReceived, StreamClosedError},
     shutdown::ShutdownSignal,
@@ -21,7 +21,7 @@ use crate::{
 
 /// Configuration for the `internal_logs` source.
 #[configurable_component(source("internal_logs"))]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct InternalLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
@@ -30,15 +30,15 @@ pub struct InternalLogsConfig {
     /// Set to `""` to suppress this key.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    #[serde(default)]
-    host_key: Option<OptionalValuePath>,
+    #[serde(default = "host_key")]
+    host_key: OptionalValuePath,
 
     /// Overrides the name of the log field used to add the current process ID to each event.
     ///
     /// By default, `"pid"` is used.
     /// Set to `""` to suppress this key.
-    #[serde(default)]
-    pid_key: Option<OptionalValuePath>,
+    #[serde(default = "pid_key")]
+    pid_key: OptionalValuePath,
 
     /// The namespace to use for logs. This overrides the global setting.
     #[configurable(metadata(docs::hidden))]
@@ -46,26 +46,31 @@ pub struct InternalLogsConfig {
     log_namespace: Option<bool>,
 }
 
+fn host_key() -> OptionalValuePath {
+    OptionalValuePath::from(owned_value_path!("host"))
+}
+
+fn pid_key() -> OptionalValuePath {
+    OptionalValuePath::from(owned_value_path!("pid"))
+}
+
 impl_generate_config_from_default!(InternalLogsConfig);
+
+impl Default for InternalLogsConfig {
+    fn default() -> InternalLogsConfig {
+        InternalLogsConfig {
+            host_key: host_key(),
+            pid_key: pid_key(),
+            log_namespace: None,
+        }
+    }
+}
 
 impl InternalLogsConfig {
     /// Generates the `schema::Definition` for this component.
     fn schema_definition(&self, log_namespace: LogNamespace) -> Definition {
-        // `host_key` defaults to the `log_schema().host_key()` if it's not configured in the source.
-        let host_key = self
-            .host_key
-            .clone()
-            .map_or_else(
-                || parse_value_path(log_schema().host_key()).ok(),
-                |k| k.path,
-            )
-            .map(LegacyKey::Overwrite);
-
-        let pid_key = self
-            .pid_key
-            .clone()
-            .and_then(|k| k.path)
-            .map(LegacyKey::Overwrite);
+        let host_key = self.host_key.clone().path.map(LegacyKey::Overwrite);
+        let pid_key = self.pid_key.clone().path.map(LegacyKey::Overwrite);
 
         // There is a global and per-source `log_namespace` config.
         // The source config overrides the global setting and is merged here.
@@ -92,12 +97,8 @@ impl InternalLogsConfig {
 #[async_trait::async_trait]
 impl SourceConfig for InternalLogsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let host_key = self.host_key.clone().map_or_else(
-            || parse_value_path(log_schema().host_key()).ok(),
-            |k| k.path,
-        );
-
-        let pid_key = self.pid_key.clone().and_then(|k| k.path);
+        let host_key = self.host_key.clone().path;
+        let pid_key = self.pid_key.clone().path;
 
         let subscription = TraceSubscription::subscribe();
 
@@ -362,7 +363,7 @@ mod tests {
 
         let pid_key = "pid_a_pid_a_pid_pid_pid";
 
-        config.pid_key = Some(OptionalValuePath::from(owned_value_path!(pid_key)));
+        config.pid_key = OptionalValuePath::from(owned_value_path!(pid_key));
 
         let definition = config.outputs(LogNamespace::Legacy)[0]
             .clone()

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -26,8 +26,8 @@ use crate::{
 pub struct InternalLogsConfig {
     /// Overrides the name of the log field used to add the current hostname to each event.
     ///
-    ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
+    /// Set to `""` to suppress this key.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[serde(default)]
@@ -35,8 +35,8 @@ pub struct InternalLogsConfig {
 
     /// Overrides the name of the log field used to add the current process ID to each event.
     ///
-    ///
     /// By default, `"pid"` is used.
+    /// Set to `""` to suppress this key.
     #[serde(default)]
     pid_key: Option<OptionalValuePath>,
 

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -5,6 +5,7 @@ use lookup::lookup_v2::OptionalValuePath;
 use lookup::{owned_value_path, path, OwnedValuePath};
 use value::Kind;
 use vector_config::{configurable_component, NamedComponent};
+use vector_core::config::log_schema;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     schema::Definition,
@@ -47,7 +48,7 @@ pub struct InternalLogsConfig {
 }
 
 fn host_key() -> OptionalValuePath {
-    OptionalValuePath::from(owned_value_path!("host"))
+    OptionalValuePath::from(owned_value_path!(log_schema().host_key()))
 }
 
 fn pid_key() -> OptionalValuePath {

--- a/website/cue/reference/components/sources/base/internal_logs.cue
+++ b/website/cue/reference/components/sources/base/internal_logs.cue
@@ -6,6 +6,7 @@ base: components: sources: internal_logs: configuration: {
 			Overrides the name of the log field used to add the current hostname to each event.
 
 			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+			Set to `""` to suppress this key.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
@@ -17,6 +18,7 @@ base: components: sources: internal_logs: configuration: {
 			Overrides the name of the log field used to add the current process ID to each event.
 
 			By default, `"pid"` is used.
+			Set to `""` to suppress this key.
 			"""
 		required: false
 		type: string: {}

--- a/website/cue/reference/components/sources/base/internal_logs.cue
+++ b/website/cue/reference/components/sources/base/internal_logs.cue
@@ -11,7 +11,7 @@ base: components: sources: internal_logs: configuration: {
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
 		required: false
-		type: string: {}
+		type: string: default: "host"
 	}
 	pid_key: {
 		description: """
@@ -21,6 +21,6 @@ base: components: sources: internal_logs: configuration: {
 			Set to `""` to suppress this key.
 			"""
 		required: false
-		type: string: {}
+		type: string: default: "pid"
 	}
 }

--- a/website/cue/reference/components/sources/base/internal_logs.cue
+++ b/website/cue/reference/components/sources/base/internal_logs.cue
@@ -6,6 +6,7 @@ base: components: sources: internal_logs: configuration: {
 			Overrides the name of the log field used to add the current hostname to each event.
 
 			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+
 			Set to `""` to suppress this key.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
@@ -18,6 +19,7 @@ base: components: sources: internal_logs: configuration: {
 			Overrides the name of the log field used to add the current process ID to each event.
 
 			By default, `"pid"` is used.
+
 			Set to `""` to suppress this key.
 			"""
 		required: false

--- a/website/cue/reference/components/sources/internal_logs.cue
+++ b/website/cue/reference/components/sources/internal_logs.cue
@@ -37,35 +37,7 @@ components: sources: internal_logs: {
 		platform_name: null
 	}
 
-	configuration: {
-		host_key: {
-			category:    "Context"
-			common:      false
-			description: """
-				The key name added to each event representing the current host. This can also be globally set via the
-				[global `host_key` option](\(urls.vector_configuration)/global-options#log_schema.host_key).
-
-				Set to "" to suppress this key.
-				"""
-			required:    false
-			type: string: {
-				default: "host"
-			}
-		}
-		pid_key: {
-			category: "Context"
-			common:   false
-			description: """
-				The key name added to each event representing the current process ID.
-
-				Set to "" to suppress this key.
-				"""
-			required: false
-			type: string: {
-				default: "pid"
-			}
-		}
-	}
+	configuration: base.components.sources.internal_logs.configuration
 
 	output: logs: line: {
 		description: "An individual log or trace message."


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vector/issues/15894
epic: https://github.com/vectordotdev/vector/issues/14998
