### PR TITLE
fix(config): properly combine field metadata with type metadata for optional fields

### DIFF
--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -167,14 +167,13 @@ fn generate_struct_field(field: &Field<'_>) -> proc_macro2::TokenStream {
     let field_metadata = generate_field_metadata(&field_metadata_ref, field);
 
     let spanned_generate_schema = quote_spanned! {field.span()=>
-        ::vector_config::schema::get_or_generate_schema(schema_gen, #field_metadata_ref.as_subschema())?
+        ::vector_config::schema::get_or_generate_schema(schema_gen, #field_metadata_ref)?
     };
 
     quote! {
         #field_metadata
 
         let mut subschema = #spanned_generate_schema;
-        ::vector_config::schema::apply_metadata(&mut subschema, #field_metadata_ref);
     }
 }
 

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -57,7 +57,7 @@ where
         // Said another way, this allows callers to use `#[configurable(derived)]` on a field of `Option<T>` so long as
         // `T` has a description, and both the optional field and the schema for `T` will get the description... but the
         // description for the optional field can still be overridden independently, etc.
-        T::metadata().convert().as_subschema()
+        T::metadata().convert()
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -74,6 +74,7 @@ pub struct BatchConfig {
     max_events: Option<NonZeroU64>,
 
     /// The maximum number of bytes in a batch before it is flushed.
+    #[configurable(metadata(docs::type_unit = "bytes"))]
     max_bytes: Option<NonZeroU64>,
 
     /// The maximum amount of time a batch can exist before it is flushed.

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -70,6 +70,7 @@ pub struct DnstapConfig {
     /// The size, in bytes, of the receive buffer used for the socket.
     ///
     /// This should not typically needed to be changed.
+    #[configurable(metadata(docs::type_unit = "bytes"))]
     pub socket_receive_buffer_size: Option<usize>,
 
     /// The size, in bytes, of the send buffer used for the socket.

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -71,7 +71,7 @@ base: components: sources: dnstap: configuration: {
 			This should not typically needed to be changed.
 			"""
 		required: false
-		type: uint: {}
+		type: uint: unit: "bytes"
 	}
 	socket_send_buffer_size: {
 		description: """


### PR DESCRIPTION
This PR fixes an issue with apply metadata to optional fields i.e. `Option<T>`.

Previously, if a field of type `Option<T>` had metadata defined on `T` itself, that metadata would correctly make it to the resulting configuration schema. However, if custom metadata was added at the callsite (i.e. `#[configurable(metadata(...)] field_here: Option<T>`) then the callsite metadata would entirely override the type metadata, which lead to an annoying either-or issue of the baseline metadata for `T` being present, but then disappearing as soon as further metadata was added.

I tested and verified that this behavior change works correctly primarily using the integration tests in `vector-config`, but I've included one small smoke test change in the `dnstap` source to ensure it triggers a corresponding change in the output.