### PR TITLE
chore(deps): Revert update Rust to 1.66.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.66.0"
 profile = "default"


### PR DESCRIPTION
Reverts vectordotdev/vector#15893