### PR TITLE
chore(deps): Update Rust to 1.66.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.66.1"
 profile = "default"


### PR DESCRIPTION
Reverts vectordotdev/vector#15913

Looks like the Docker images exist now.