### PR TITLE
chore: Fix scrape duration for nginx_metrics integration test

### DIFF
--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -297,7 +297,7 @@ mod integration_tests {
     async fn test_nginx(endpoint: String, auth: Option<Auth>, proxy: ProxyConfig) {
         let config = NginxMetricsConfig {
             endpoints: vec![endpoint],
-            scrape_interval_secs: Duration::from_secs(1),
+            scrape_interval_secs: Duration::from_secs(15),
             namespace: "vector_nginx".to_owned(),
             tls: None,
             auth,


### PR DESCRIPTION
This duration had been changed while updating it from a `u64` to a `Duration`, causing us to collect more metrics than we had expected in the test.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
