### PR TITLE
fix(docs): apply object examples to the correct part of the docs output

### DIFF
--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -1513,7 +1513,7 @@ def reconcile_resolved_schema!(resolved_schema)
   # Only works if `type` is an object, which it won't be in some cases, such as a schema that maps
   # to a cycle entrypoint, or is hidden, and so on.
   if !resolved_schema['type'].is_a?(Hash)
-    @logger.debug "Schema was not an full resolved schema; reconciliation not applicable."
+    @logger.debug "Schema was not a fully resolved schema; reconciliation not applicable."
     return
   end
 
@@ -1523,30 +1523,6 @@ def reconcile_resolved_schema!(resolved_schema)
   object_properties = resolved_schema.dig('type', 'object', 'options')
   if !object_properties.nil?
     object_properties.values.each { |resolved_property| reconcile_resolved_schema!(resolved_property) }
-
-    # Reconcile examples for wildcard object schemas.
-    #
-    # In some cases, a field may be set to an object schema with only "additional properties" set,
-    # which implies the type on the Rust side is just a map that can have any number of free-form
-    # key/value pairs.
-    #
-    # When specifying examples for that field, the examples land on the field's object type itself,
-    # when we actually need them to land on the schema for the object's wildcard property. We simply
-    # check if the object has a single property, `*`, which signals that we're dealing purely with a
-    # map field, and move any examples on the object itself down to the property's schema.
-    object_schema = resolved_schema.dig('type', 'object')
-    has_examples = object_schema.has_key?('examples')
-    is_map_field = object_properties.keys == ['*']
-
-    if has_examples && is_map_field
-      object_examples = object_schema.delete('examples')
-
-      # TODO: We blindly grab the first type field we can find, because we don't expect to handle
-      # this for map values that have multiple type representations.
-      wildcard_property_schema = object_properties['*']
-      wildcard_type_field = wildcard_property_schema['type'].values.first
-      wildcard_type_field['examples'] = object_examples
-    end
   else
     # Look for required/default value inconsistencies.
     #

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -97,11 +97,7 @@ pub struct LokiConfig {
     /// Note: If the set of labels has high cardinality, this can cause drastic performance issues
     /// with Loki. To prevent this from happening, reduce the number of unique label keys and
     /// values.
-    #[configurable(metadata(
-        docs::examples = "vector",
-        docs::examples = "{{ event_field }}",
-        docs::examples = "{{ kubernetes.pod_labels }}",
-    ))]
+    #[configurable(metadata(docs::examples = "loki_labels_examples()"))]
     #[configurable(metadata(docs::additional_props_description = "A Loki label."))]
     pub labels: HashMap<Template, Template>,
 
@@ -144,6 +140,20 @@ pub struct LokiConfig {
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     acknowledgements: AcknowledgementsConfig,
+}
+
+fn loki_labels_examples() -> HashMap<String, String> {
+    let mut examples = HashMap::new();
+    examples.insert("source".to_string(), "vector".to_string());
+    examples.insert(
+        "labels".to_string(),
+        "{{ kubernetes.pod_labels }}".to_string(),
+    );
+    examples.insert(
+        "{{ event_field }}".to_string(),
+        "{{ some_other_event_field }}".to_string(),
+    );
+    examples
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -264,12 +264,16 @@ base: components: sinks: loki: configuration: {
 			values.
 			"""
 		required: false
-		type: object: options: "*": {
-			description: "A Loki label."
-			required:    true
-			type: string: {
-				examples: ["vector", "{{ event_field }}", "{{ kubernetes.pod_labels }}"]
-				syntax: "template"
+		type: object: {
+			examples: [{
+				labels:              "{{ kubernetes.pod_labels }}"
+				source:              "vector"
+				"{{ event_field }}": "{{ some_other_event_field }}"
+			}]
+			options: "*": {
+				description: "A Loki label."
+				required:    true
+				type: string: syntax: "template"
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue with all examples for an `object` being applied to the fields of that object directly when generating the documention output from the configuration schema.

This made sense when metadata could only be string values, but now that we support all `serde_json`-capable types, trying to use the proper metadata (like objects for object fields, etc) results in setting example values that do not have the expected data type.

Now, when doing the above -- setting an object as the example value for an `object` field -- it will be correctly applied such that it shows that object an example for the overall object field, rather than any of its properties.

As a consequence of this change, we had to change the `loki` sink to emit an object for the example value rather than an array of strings.