### PR TITLE
chore(docs): throw an error when a wildcard map field is missing its description

### DIFF
--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -218,6 +218,7 @@ pub struct S3Options {
     pub storage_class: Option<S3StorageClass>,
 
     /// The tag-set for the object.
+    #[configurable(metadata(docs::additional_props_description = "A single tag."))]
     pub tags: Option<BTreeMap<String, String>>,
 }
 
@@ -248,6 +249,7 @@ pub struct GcsConfig {
     /// For more information, see [Custom metadata][custom_metadata].
     ///
     /// [custom_metadata]: https://cloud.google.com/storage/docs/metadata#custom-metadata
+    #[configurable(metadata(docs::additional_props_description = "A key/value pair."))]
     metadata: Option<HashMap<String, String>>,
 
     #[serde(flatten)]

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -120,6 +120,7 @@ pub struct ElasticsearchConfig {
     pub auth: Option<ElasticsearchAuth>,
 
     /// Custom parameters to add to the query string of each request sent to Elasticsearch.
+    #[configurable(metadata(docs::additional_props_description = "A query string parameter."))]
     pub query: Option<HashMap<String, String>>,
 
     #[configurable(derived)]

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -75,6 +75,7 @@ pub struct GcsSinkConfig {
     /// For more information, see [Custom metadata][custom_metadata].
     ///
     /// [custom_metadata]: https://cloud.google.com/storage/docs/metadata#custom-metadata
+    #[configurable(metadata(docs::additional_props_description = "A key/value pair."))]
     metadata: Option<HashMap<String, String>>,
 
     /// A prefix to apply to all object keys.

--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -26,6 +26,7 @@ pub struct GcpTypedResource {
 
     /// Type-specific labels.
     #[serde(flatten)]
+    #[configurable(metadata(docs::additional_props_description = "A type-specific label."))]
     pub labels: std::collections::HashMap<String, String>,
 }
 

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -168,6 +168,7 @@ pub struct StackdriverResource {
 
     /// Type-specific labels.
     #[serde(flatten)]
+    #[configurable(metadata(docs::additional_props_description = "A type-specific label."))]
     pub labels: HashMap<String, Template>,
 }
 

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -45,6 +45,7 @@ pub struct HttpSinkConfig {
 
     /// A list of custom headers to add to each request.
     #[configurable(deprecated)]
+    #[configurable(metadata(docs::additional_props_description = "An HTTP request header."))]
     pub headers: Option<IndexMap<String, String>>,
 
     #[configurable(derived)]

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -81,6 +81,7 @@ pub struct InfluxDbConfig {
     pub request: TowerRequestConfig,
 
     /// A map of additional tags, in the form of key/value pairs, to add to each measurement.
+    #[configurable(metadata(docs::additional_props_description = "A tag key/value pair."))]
     pub tags: Option<HashMap<String, String>>,
 
     #[configurable(derived)]

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -70,6 +70,9 @@ pub struct KafkaSinkConfig {
     ///
     /// [config_props_docs]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
     #[serde(default)]
+    #[configurable(metadata(
+        docs::additional_props_description = "A librdkafka configuration option."
+    ))]
     pub librdkafka_options: HashMap<String, String>,
 
     /// The log field name to use for the Kafka headers.

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -80,6 +80,7 @@ pub struct S3Options {
     pub storage_class: Option<S3StorageClass>,
 
     /// The tag-set for the object.
+    #[configurable(metadata(docs::additional_props_description = "A single tag."))]
     pub tags: Option<BTreeMap<String, String>>,
 
     /// Specifies what content encoding has been applied to the object.

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -537,6 +537,7 @@ pub struct RequestConfig {
 
     /// Additional HTTP headers to add to every HTTP request.
     #[serde(default)]
+    #[configurable(metadata(docs::additional_props_description = "An HTTP request header."))]
     pub headers: IndexMap<String, String>,
 }
 

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -53,6 +53,7 @@ pub struct HttpClientConfig {
     /// One or more values for the same parameter key can be provided. The parameters provided in this option are
     /// appended to any parameters manually provided in the `endpoint` option.
     #[serde(default)]
+    #[configurable(metadata(docs::additional_props_description = "A query string parameter."))]
     pub query: HashMap<String, Vec<String>>,
 
     /// Decoder to use on the HTTP responses.
@@ -66,8 +67,10 @@ pub struct HttpClientConfig {
     pub framing: FramingConfig,
 
     /// Headers to apply to the HTTP requests.
+    ///
     /// One or more values for the same header can be provided.
     #[serde(default)]
+    #[configurable(metadata(docs::additional_props_description = "An HTTP request header."))]
     pub headers: HashMap<String, Vec<String>>,
 
     /// Specifies the action of the HTTP request.

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -124,11 +124,13 @@ pub struct JournaldConfig {
     /// A list of sets of field/value pairs to monitor.
     ///
     /// If empty or not present, all journal fields are accepted. If `include_units` is specified, it will be merged into this list.
+    #[configurable(metadata(docs::additional_props_description = "A field/value pair."))]
     pub include_matches: Matches,
 
     /// A list of sets of field/value pairs that, if any are present in a journal entry, will cause the entry to be excluded from this source.
     ///
     /// If `exclude_units` is specified, it will be merged into this list.
+    #[configurable(metadata(docs::additional_props_description = "A field/value pair."))]
     pub exclude_matches: Matches,
 
     /// The directory used to persist file checkpoint positions.

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -141,6 +141,9 @@ pub struct KafkaSourceConfig {
     /// Advanced options set directly on the underlying `librdkafka` client.
     ///
     /// See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for details.
+    #[configurable(metadata(
+        docs::additional_props_description = "A librdkafka configuration option."
+    ))]
     librdkafka_options: Option<HashMap<String, String>>,
 
     #[serde(flatten)]

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -80,6 +80,7 @@ pub struct PrometheusScrapeConfig {
     /// appended to any parameters manually provided in the `endpoints` option. This option is especially useful when
     /// scraping the `/federate` endpoint.
     #[serde(default)]
+    #[configurable(metadata(docs::additional_props_description = "A query string parameter."))]
     query: HashMap<String, Vec<String>>,
 
     #[configurable(derived)]

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -64,6 +64,7 @@ pub struct MetricConfig {
     pub namespace: Option<Template>,
 
     /// Tags to apply to the metric.
+    #[configurable(metadata(docs::additional_props_description = "A metric tag."))]
     pub tags: Option<IndexMap<String, TagConfig>>,
 
     #[configurable(derived)]

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -78,6 +78,9 @@ pub struct ReduceConfig {
     ///   the last received timestamp value.
     /// - Numeric values are summed.
     #[serde(default)]
+    #[configurable(metadata(
+        docs::additional_props_description = "An individual merge strategy."
+    ))]
     pub merge_strategies: IndexMap<String, MergeStrategy>,
 
     /// A condition used to distinguish the final event of a transaction.

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -386,7 +386,8 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				description: "Additional HTTP headers to add to every HTTP request."
 				required:    false
 				type: object: options: "*": {
-					required: true
+					description: "An HTTP request header."
+					required:    true
 					type: string: {}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -687,7 +687,8 @@ base: components: sinks: aws_s3: configuration: {
 		description: "The tag-set for the object."
 		required:    false
 		type: object: options: "*": {
-			required: true
+			description: "A single tag."
+			required:    true
 			type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -145,7 +145,8 @@ base: components: sinks: axiom: configuration: {
 				description: "Additional HTTP headers to add to every HTTP request."
 				required:    false
 				type: object: options: "*": {
-					required: true
+					description: "An HTTP request header."
+					required:    true
 					type: string: {}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -207,7 +207,8 @@ base: components: sinks: datadog_logs: configuration: {
 				description: "Additional HTTP headers to add to every HTTP request."
 				required:    false
 				type: object: options: "*": {
-					required: true
+					description: "An HTTP request header."
+					required:    true
 					type: string: {}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -437,7 +437,8 @@ base: components: sinks: elasticsearch: configuration: {
 		description: "Custom parameters to add to the query string of each request sent to Elasticsearch."
 		required:    false
 		type: object: options: "*": {
-			required: true
+			description: "A query string parameter."
+			required:    true
 			type: string: {}
 		}
 	}
@@ -521,7 +522,8 @@ base: components: sinks: elasticsearch: configuration: {
 				description: "Additional HTTP headers to add to every HTTP request."
 				required:    false
 				type: object: options: "*": {
-					required: true
+					description: "An HTTP request header."
+					required:    true
 					type: string: {}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -373,7 +373,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A key/value pair."
+			required:    true
 			type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -280,20 +280,8 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 		required:    true
 		type: object: options: {
 			"*": {
-				description: """
-					A templated field.
-
-					In many cases, components can be configured in such a way where some portion of the component's functionality can be
-					customized on a per-event basis. An example of this might be a sink that writes events to a file, where we want to
-					provide the flexibility to specify which file an event should go to by using an event field itself as part of the
-					input to the filename we use.
-
-					By using `Template`, users can specify either fixed strings or "templated" strings, which use a common syntax to
-					refer to fields in an event that will serve as the input data when rendering the template.  While a fixed string may
-					look something like `my-file.log`, a template string could look something like `my-file-{{key}}.log`, and the `key`
-					field of the event being processed would serve as the value when rendering the template into a string.
-					"""
-				required: true
+				description: "A type-specific label."
+				required:    true
 				type: string: syntax: "template"
 			}
 			type: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -232,7 +232,8 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 		required:    true
 		type: object: options: {
 			"*": {
-				required: true
+				description: "A type-specific label."
+				required:    true
 				type: string: {}
 			}
 			type: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -274,7 +274,8 @@ base: components: sinks: http: configuration: {
 		description: "A list of custom headers to add to each request."
 		required:    false
 		type: object: options: "*": {
-			required: true
+			description: "An HTTP request header."
+			required:    true
 			type: string: {}
 		}
 	}
@@ -404,7 +405,8 @@ base: components: sinks: http: configuration: {
 				description: "Additional HTTP headers to add to every HTTP request."
 				required:    false
 				type: object: options: "*": {
-					required: true
+					description: "An HTTP request header."
+					required:    true
 					type: string: {}
 				}
 			}

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -259,7 +259,8 @@ base: components: sinks: influxdb_metrics: configuration: {
 		description: "A map of additional tags, in the form of key/value pairs, to add to each measurement."
 		required:    false
 		type: object: options: "*": {
-			required: true
+			description: "A tag key/value pair."
+			required:    true
 			type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -222,7 +222,8 @@ base: components: sinks: kafka: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A librdkafka configuration option."
+			required:    true
 			type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -172,11 +172,13 @@ base: components: sources: http_client: configuration: {
 	headers: {
 		description: """
 			Headers to apply to the HTTP requests.
+
 			One or more values for the same header can be provided.
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "An HTTP request header."
+			required:    true
 			type: array: items: type: string: {}
 		}
 	}
@@ -204,7 +206,8 @@ base: components: sources: http_client: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A query string parameter."
+			required:    true
 			type: array: items: type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sources/base/journald.cue
+++ b/website/cue/reference/components/sources/base/journald.cue
@@ -46,7 +46,8 @@ base: components: sources: journald: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A field/value pair."
+			required:    true
 			type: array: items: type: string: {}
 		}
 	}
@@ -70,7 +71,8 @@ base: components: sources: journald: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A field/value pair."
+			required:    true
 			type: array: items: type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -209,7 +209,8 @@ base: components: sources: kafka: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A librdkafka configuration option."
+			required:    true
 			type: string: {}
 		}
 	}

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -97,7 +97,8 @@ base: components: sources: prometheus_scrape: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			required: true
+			description: "A query string parameter."
+			required:    true
 			type: array: items: type: string: {}
 		}
 	}

--- a/website/cue/reference/components/transforms/base/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/base/log_to_metric.cue
@@ -55,12 +55,8 @@ base: components: transforms: log_to_metric: configuration: metrics: {
 			description: "Tags to apply to the metric."
 			required:    false
 			type: object: options: "*": {
-				description: """
-					Specification of the value of a created tag.
-
-					This may be a single value, a `null` for a bare tag, or an array of either.
-					"""
-				required: true
+				description: "A metric tag."
+				required:    true
 				type: string: syntax: "template"
 			}
 		}

--- a/website/cue/reference/components/transforms/base/reduce.cue
+++ b/website/cue/reference/components/transforms/base/reduce.cue
@@ -63,7 +63,7 @@ base: components: transforms: reduce: configuration: {
 			"""
 		required: false
 		type: object: options: "*": {
-			description: "Strategies for merging events."
+			description: "An individual merge strategy."
 			required:    true
 			type: string: enum: {
 				array:          "Append each value to an array."


### PR DESCRIPTION
This PR enforces a particular edge case: when a field represents a free-form map and does not have a dedicated description provided via `docs::additional_props_description`.

Using `Configurable` ensures that all fields in a struct/enum are documented with a description. However, in one particular case, we need to add an additional description: free-form maps. This would be any field with an unfettered map type, such as `HashMap<String, ...>`. Let's look at a quick example below:

```
in Rust:

struct Foo {
  /// A map of tags.
  tags: HashMap<String, String>
}

in pseudo Cue output:

tags:
  type: object
  description: A map of tags.
  options:
    "*":
      type: string
```

In the example, you can see that we map the description of `tags` to the `tags` field in the Cue output, but we've added an additional `*` field that is used in the rendering phase as a placeholder for "any additional field can be specified on `tags`". With the way Cue works, we also need to provide a description for that "field", and doing so is good practice: it gives us a spot to provide a more human-centric description of what each map entry should be.

We already have a mechanism to provide the "additional" description for the wildcard field: `#[configurable(metadata(docs::additional_props_description = "...."))]i`. This applies a description to the wildcard field directly, which we can see after updating our above example:

```
in Rust:

struct Foo {
  /// A map of tags.
  #[configurable(metadata(docs::additional_props_description = "A single tag."))]
  tags: HashMap<String, String>
}

in pseudo Cue output:

tags:
  type: object
  description: A map of tags.
  options:
    "*":
      type: string
      description: A single tag.
```

Now everything on the Cue side is happy. However, if someone forgets to do this, they end up generating output that breaks Cue's schema validation step and leads to very obtuse and impenetrable error messages, such as this:

```
components.sources.kafka.configuration.librdkafka_options.type: 1 errors in empty disjunction::
    ./cue/reference.cue:294:5
```

Since we can't make the Cue errors better, I've chosen to make the generation script emit an error when we know there should be an additional description provided but one is not provided. We additionally emit the responsible schema to help track down where it needs to be applied. This isn't an incredibly clear/concise error message, but it's far better than the Cue error by itself.

## Reviewer Notes

As the script now enforces this, I've had to fix violations of this across all of the components.