### PR TITLE
chore(dev): Add support for alternate container tools in `vdev`

### DIFF
--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -21,7 +21,7 @@ mod test;
     infer_subcommands = true,
     disable_help_subcommand = true,
     after_help = r#"Environment variables:
-  $CONTAINER_TOOL  Set the tool used to run containers (Defaults to "docker")
+  $CONTAINER_TOOL  Set the tool used to run containers (Defaults to autodetect)
 "#
 )]
 pub struct Cli {

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -19,7 +19,10 @@ mod test;
     version,
     bin_name = "vdev",
     infer_subcommands = true,
-    disable_help_subcommand = true
+    disable_help_subcommand = true,
+    after_help = r#"Environment variables:
+  $CONTAINER_TOOL  Set the tool used to run containers (Defaults to "docker")
+"#
 )]
 pub struct Cli {
     #[clap(flatten)]

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -22,6 +22,7 @@ mod test;
     disable_help_subcommand = true,
     after_help = r#"Environment variables:
   $CONTAINER_TOOL  Set the tool used to run containers (Defaults to autodetect)
+                   Valid values are either "docker" or "podman".
 "#
 )]
 pub struct Cli {

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -23,6 +23,9 @@ const TEST_COMMAND: &[&str] = &[
     "--no-fail-fast",
     "--no-default-features",
 ];
+// The upstream container we publish artifacts to on a successful master build.
+const UPSTREAM_IMAGE: &str =
+    "docker.io/timberio/vector-dev:sha-3eadc96742a33754a5859203b58249f6a806972a";
 
 fn dockercmd<'a>(args: impl IntoIterator<Item = &'a str>) -> Command {
     let command = env::var_os("CONTAINER_TOOL").unwrap_or_else(|| DEFAULT_CONTAINER_TOOL.into());
@@ -311,8 +314,7 @@ impl ContainerTestRunnerBase for DockerTestRunner {
     }
 
     fn image_name(&self) -> String {
-        // The upstream container we publish artifacts to on a successful master build.
-        "docker.io/timberio/vector-dev:sha-3eadc96742a33754a5859203b58249f6a806972a".to_string()
+        env::var("ENVIRONMENT_UPSTREAM").unwrap_or_else(|_| UPSTREAM_IMAGE.to_string())
     }
 }
 


### PR DESCRIPTION
Just like in the `Makefile`, this allows for the use of, for example, `podman` by setting `$CONTAINER_TOOL`. It also autodetects which one is installed in the same way.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
