### PR TITLE
chore(dev): Replace `app::exec*` with a more generic framework in `vdev`

### DIFF
--- a/vdev/src/commands/build.rs
+++ b/vdev/src/commands/build.rs
@@ -24,7 +24,8 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let mut command = Command::with_path("cargo");
+        let mut command = Command::new("cargo");
+        command.in_repo();
         command.args(["build", "--no-default-features"]);
 
         if self.release {
@@ -38,16 +39,13 @@ impl Cli {
             command.arg("default-msvc");
         } else {
             command.arg("default");
-        };
+        }
 
-        if let Some(target) = self.target.as_deref() {
-            command.args(["--target", target]);
-        } else {
-            command.args(["--target", &platform::default_target()]);
-        };
+        let target = self.target.unwrap_or_else(platform::default_target);
+        command.args(["--target", &target]);
 
         waiting!("Building Vector");
-        command.run()?;
+        command.check_run()?;
 
         Ok(())
     }

--- a/vdev/src/commands/check/deny.rs
+++ b/vdev/src/commands/check/deny.rs
@@ -9,7 +9,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec_in_repo(
+        app::exec(
             "cargo",
             [
                 "deny",
@@ -19,6 +19,7 @@ impl Cli {
                 "check",
                 "all",
             ],
+            true,
         )
     }
 }

--- a/vdev/src/commands/check/fmt.rs
+++ b/vdev/src/commands/check/fmt.rs
@@ -9,6 +9,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec_in_repo("cargo", ["fmt", "--", "--check"])
+        app::exec::<&str>("check-style.sh", [], true)?;
+        app::exec("cargo", ["fmt", "--", "--check"], true)
     }
 }

--- a/vdev/src/commands/check/markdown.rs
+++ b/vdev/src/commands/check/markdown.rs
@@ -9,7 +9,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec_in_repo(
+        app::exec(
             "markdownlint",
             [
                 "--config",
@@ -22,6 +22,7 @@ impl Cli {
                 "target",
                 ".",
             ],
+            true,
         )
     }
 }

--- a/vdev/src/commands/exec.rs
+++ b/vdev/src/commands/exec.rs
@@ -15,12 +15,10 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let mut command = Command::with_path(&self.args[0]);
-        if self.args.len() > 1 {
-            command.args(&self.args[1..]);
-        }
-
-        let status = command.status()?;
+        let status = Command::new(&self.args[0])
+            .in_repo()
+            .args(&self.args[1..])
+            .run()?;
         std::process::exit(status.code().unwrap_or(1));
     }
 }

--- a/vdev/src/commands/fmt.rs
+++ b/vdev/src/commands/fmt.rs
@@ -9,7 +9,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec_script("check-style.sh", ["--fix"])?;
-        app::exec_in_repo("cargo", ["fmt"])
+        app::exec("scripts/check-style.sh", ["--fix"], true)?;
+        app::exec("cargo", ["fmt"], true)
     }
 }

--- a/vdev/src/commands/integration/start.rs
+++ b/vdev/src/commands/integration/start.rs
@@ -46,7 +46,7 @@ impl Cli {
         }
 
         waiting!("Starting environment {}", &self.environment);
-        command.run()?;
+        command.check_run()?;
 
         state::save_env(&envs_dir, &self.environment, &json)?;
         Ok(())

--- a/vdev/src/commands/integration/stop.rs
+++ b/vdev/src/commands/integration/stop.rs
@@ -49,7 +49,7 @@ impl Cli {
         }
 
         waiting!("Stopping environment {}", &self.environment);
-        command.run()?;
+        command.check_run()?;
 
         state::remove_env(&envs_dir, &self.environment)?;
         if state::active_envs(&envs_dir)?.is_empty() {

--- a/vdev/src/commands/integration/test.rs
+++ b/vdev/src/commands/integration/test.rs
@@ -68,7 +68,7 @@ impl Cli {
                 }
 
                 waiting!("Starting environment {}", env_name);
-                command.run()?;
+                command.check_run()?;
 
                 state::save_env(&envs_dir, &env_name, &json)?;
             }
@@ -92,7 +92,7 @@ impl Cli {
                 }
 
                 waiting!("Stopping environment {}", env_name);
-                command.run()?;
+                command.check_run()?;
 
                 state::remove_env(&envs_dir, &env_name)?;
             }

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -103,8 +103,7 @@ macro_rules! script_wrapper {
 
                 impl Cli {
                     pub(super) fn exec(self) -> anyhow::Result<()> {
-                        $crate::app::set_repo_dir()?;
-                        $crate::app::exec_script($script, &self.args)
+                        $crate::app::exec(concat!("scripts/", $script), self.args, true)
                     }
                 }
             }

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -1,6 +1,8 @@
+use std::process::Command;
+
 use anyhow::Result;
 
-use crate::app;
+use crate::app::CommandExt as _;
 
 /// Update Kubernetes manifests from latest stable release and create a new Cue file for the new
 /// release
@@ -10,7 +12,11 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec_in_repo::<&str>("scripts/generate-manifests.sh", [])?;
-        app::exec_in_repo::<&str>("scripts/generate-release-cue.rb", [])
+        Command::script("generate-manifests.sh")
+            .in_repo()
+            .check_run()?;
+        Command::script("generate-release-cue.rb")
+            .in_repo()
+            .check_run()
     }
 }

--- a/vdev/src/git.rs
+++ b/vdev/src/git.rs
@@ -45,10 +45,7 @@ pub fn changed_files() -> Result<Vec<String>> {
 }
 
 fn capture_output(args: &[&str]) -> Result<String> {
-    let mut command = Command::with_path("git");
-    command.args(args);
-
-    command.capture_output()
+    Command::new("git").in_repo().args(args).capture_output()
 }
 
 fn is_warning_line(line: &str) -> bool {

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -175,7 +175,7 @@ trait ContainerTestRunner: ContainerTestRunnerBase {
         ]);
 
         waiting!("Building image {}", self.image_name());
-        command.run()
+        command.check_run()
     }
 
     fn start(&self) -> Result<()> {
@@ -266,7 +266,7 @@ impl TestRunner for IntegrationTestRunner {
         command.args(TEST_COMMAND);
         command.args(args);
 
-        command.run()
+        command.check_run()
     }
 }
 
@@ -322,7 +322,7 @@ impl TestRunner for DockerTestRunner {
         command.args(TEST_COMMAND);
         command.args(args);
 
-        command.run()
+        command.check_run()
     }
 }
 
@@ -360,6 +360,6 @@ impl TestRunner for LocalTestRunner {
             command.env(key, value);
         }
 
-        command.run()
+        command.check_run()
     }
 }


### PR DESCRIPTION
There are a number of functions that execute programs that do similar things in slightly different ways. This moves more of that functionality into the `Command` extensions and adds one more generic wrapper for the simple cases.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
