### PR TITLE
chore(ci): Update OS test targets for packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -313,7 +313,14 @@ jobs:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
     strategy:
       matrix:
-        container: ["ubuntu:16.04","ubuntu:18.04","ubuntu:20.04","ubuntu:22.04","debian:9","debian:10","debian:11"]
+        container:
+          - ubuntu:14.04
+          - ubuntu:16.04
+          - ubuntu:18.04
+          - ubuntu:20.04
+          - ubuntu:22.04
+          - debian:10
+          - debian:11
     container:
       image: ${{ matrix.container }}
     steps:
@@ -358,6 +365,7 @@ jobs:
         container:
           - "quay.io/centos/centos:stream8"
           - "quay.io/centos/centos:stream9"
+          - "amazonlinux:1"
           - "amazonlinux:2"
           - "fedora:34"
           - "fedora:35"


### PR DESCRIPTION
Remove debian:9 since it is EOL and add back amazonlinux:1 and ubuntu:14.04 now that we've re-added support for older
glibcs on x86_64.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
