### PR TITLE
Revert "chore(deps): bump rustyline from 10.0.0 to 10.1.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5119,6 +5119,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
@@ -6920,9 +6931,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "10.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc2d30f0bb29c4308f902d4a147b2d6cb022b59771463d9785f37e21f544df7"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -6931,7 +6942,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.26.1",
+ "nix 0.24.2",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",


### PR DESCRIPTION
Reverts vectordotdev/vector#15975

CI "passed" with a failed cross test and the remainder cancelling