### PR TITLE
chore: Fix vdev check fmt command

### DIFF
--- a/vdev/src/commands/check/fmt.rs
+++ b/vdev/src/commands/check/fmt.rs
@@ -9,7 +9,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec::<&str>("check-style.sh", [], true)?;
+        app::exec::<&str>("scripts/check-style.sh", [], true)?;
         app::exec("cargo", ["fmt", "--", "--check"], true)
     }
 }


### PR DESCRIPTION
Recent PR caused this not to be running the file from the `scripts/` directory.

https://github.com/vectordotdev/vector/blob/master/vdev/src/app.rs#L117-L120

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
