### PR TITLE
chore(dev): Drop the separate `vdev check style` subcommand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -336,10 +336,7 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Enable Rust matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
-      - name: Check style
-        run: make check-style
-      - name: Check code format || needs.changes.outputs.source == 'true'
-        if: needs.changes.outputs.source == 'true'
+      - name: Check code format
         run: make check-fmt
       - name: Check clippy
         if: needs.changes.outputs.source == 'true'

--- a/Makefile
+++ b/Makefile
@@ -445,7 +445,7 @@ check: ## Run prerequisite code checks
 
 .PHONY: check-all
 check-all: ## Check everything
-check-all: check-fmt check-clippy check-style check-docs
+check-all: check-fmt check-clippy check-docs
 check-all: check-version check-examples check-component-features
 check-all: check-scripts check-deny check-component-docs
 
@@ -464,10 +464,6 @@ check-docs: ## Check that all /docs file are valid
 .PHONY: check-fmt
 check-fmt: ## Check that all files are formatted properly
 	${MAYBE_ENVIRONMENT_EXEC} cargo vdev check fmt
-
-.PHONY: check-style
-check-style: ## Check that all files are styled properly
-	${MAYBE_ENVIRONMENT_EXEC} cargo vdev check style
 
 .PHONY: check-markdown
 check-markdown: ## Check that markdown is styled properly
@@ -653,7 +649,6 @@ clean: environment-clean ## Clean everything
 .PHONY: fmt
 fmt: ## Format code
 	${MAYBE_ENVIRONMENT_EXEC} cargo fmt
-	${MAYBE_ENVIRONMENT_EXEC} cargo vdev check style --fix
 
 .PHONY: generate-kubernetes-manifests
 generate-kubernetes-manifests: ## Generate Kubernetes manifests from latest Helm chart

--- a/vdev/src/commands/check/mod.rs
+++ b/vdev/src/commands/check/mod.rs
@@ -9,7 +9,6 @@ crate::cli_subcommands! {
     mod fmt,
     mod markdown,
     scripts,
-    style,
     version,
 }
 
@@ -43,11 +42,6 @@ crate::script_wrapper! {
 crate::script_wrapper! {
     scripts = "Check that scripts do not have common mistakes"
         => "check-scripts.sh"
-}
-
-crate::script_wrapper! {
-    style = "Check that all files are styled properly"
-        => "check-style.sh"
 }
 
 crate::script_wrapper! {


### PR DESCRIPTION
We now have a `vdev check style` that runs some file format checks on the source code, as well as `vdev check fmt` that runs `cargo fmt --check` _as well as_ doing the style check (in addition to `vdev fmt` that does style check fixes and runs `cargo fmt`). This PR removes the redundancy and references to it.

This was previously separated out in #8862 for the purpose of allowing to run the style check on all changes but still avoid running `cargo fmt` when not necessary. However, `cargo fmt` is quite light, rarely taking more than a second or two, so I don't see this as a particularly large obstacle.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
