### PR TITLE
chore(deps): migrate away from deprecated chrono functions

### DIFF
--- a/benches/enrichment_tables.rs
+++ b/benches/enrichment_tables.rs
@@ -25,7 +25,11 @@ fn column(col: usize, row: usize) -> Value {
     } else if col == 1 {
         // And a final column with a date, each of the above duplicated row should have
         // a unique date.
-        Value::Timestamp(Utc.ymd(2013, row as u32 % 10 + 1, 15).and_hms(0, 0, 0))
+        Value::Timestamp(
+            Utc.ymd(2013, row as u32 % 10 + 1, 15)
+                .and_hms_opt(0, 0, 0)
+                .expect("invalid timestamp"),
+        )
     } else {
         Value::from(format!("data-{}-{}", col, row))
     }
@@ -62,8 +66,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
                     },
                     Condition::BetweenDates {
                         field: "field-1",
-                        from: Utc.ymd(2013, 6, 1).and_hms(0, 0, 0),
-                        to: Utc.ymd(2013, 7, 1).and_hms(0, 0, 0),
+                        from: Utc
+                            .ymd(2013, 6, 1)
+                            .and_hms_opt(0, 0, 0)
+                            .expect("invalid timestamp"),
+                        to: Utc
+                            .ymd(2013, 7, 1)
+                            .and_hms_opt(0, 0, 0)
+                            .expect("invalid timestamp"),
                     },
                 ],
                 file.add_index(case, &["field-0"]).unwrap(),

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -99,10 +99,11 @@ impl GelfDeserializer {
         }
 
         if let Some(timestamp) = parsed.timestamp {
-            let naive = NaiveDateTime::from_timestamp(
+            let naive = NaiveDateTime::from_timestamp_opt(
                 f64::trunc(timestamp) as i64,
                 f64::fract(timestamp) as u32,
-            );
+            )
+            .expect("invalid timestamp");
             log.insert(
                 log_schema().timestamp_key(),
                 DateTime::<Utc>::from_utc(naive, Utc),
@@ -272,7 +273,7 @@ mod tests {
             )))
         );
         // Vector does not use the nanos
-        let naive = NaiveDateTime::from_timestamp(1385053862, 0);
+        let naive = NaiveDateTime::from_timestamp_opt(1385053862, 0).expect("invalid timestamp");
         assert_eq!(
             log.get(TIMESTAMP),
             Some(&Value::Timestamp(DateTime::<Utc>::from_utc(naive, Utc)))

--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -121,7 +121,11 @@ mod tests {
                 "key1" => "value1",
                 "Key3" => "Value3",
             )))
-            .with_timestamp(Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11))),
+            .with_timestamp(Some(
+                Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+                    .single()
+                    .expect("invalid datetime"),
+            )),
         );
 
         let bytes = serialize(JsonSerializerConfig::default(), event);

--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -122,9 +122,9 @@ mod tests {
                 "Key3" => "Value3",
             )))
             .with_timestamp(Some(
-                Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-                    .single()
-                    .expect("invalid datetime"),
+                Utc.ymd(2018, 11, 14)
+                    .and_hms_nano_opt(8, 9, 10, 11)
+                    .expect("invalid timestamp"),
             )),
         );
 

--- a/lib/enrichment/src/vrl_util.rs
+++ b/lib/enrichment/src/vrl_util.rs
@@ -121,13 +121,21 @@ mod tests {
                     BTreeMap::from([
                         (
                             "from".into(),
-                            (expression::Literal::from(Utc.ymd(2015, 5, 15).and_hms(0, 0, 0)))
-                                .into(),
+                            (expression::Literal::from(
+                                Utc.ymd(2015, 5, 15)
+                                    .and_hms_opt(0, 0, 0)
+                                    .expect("invalid timestamp"),
+                            ))
+                            .into(),
                         ),
                         (
                             "to".into(),
-                            (expression::Literal::from(Utc.ymd(2015, 6, 15).and_hms(0, 0, 0)))
-                                .into(),
+                            (expression::Literal::from(
+                                Utc.ymd(2015, 6, 15)
+                                    .and_hms_opt(0, 0, 0)
+                                    .expect("invalid timestamp"),
+                            ))
+                            .into(),
                         ),
                     ])
                     .into(),

--- a/lib/loki-logproto/src/lib.rs
+++ b/lib/loki-logproto/src/lib.rs
@@ -99,9 +99,15 @@ mod tests {
 
     #[test]
     fn encode_batch() {
-        let ts1 = Utc.timestamp(1640244790, 0);
+        let ts1 = Utc
+            .timestamp_opt(1640244790, 0)
+            .single()
+            .expect("invalid timestamp");
         let entry1 = Entry(ts1.timestamp_nanos(), "hello".into());
-        let ts2 = Utc.timestamp(1640244791, 0);
+        let ts2 = Utc
+            .timestamp_opt(1640244791, 0)
+            .single()
+            .expect("invalid timestamp");
         let entry2 = Entry(ts2.timestamp_nanos(), "world".into());
         let labels = vec![("source".into(), "protobuf-test".into())]
             .into_iter()

--- a/lib/value/src/value/arbitrary.rs
+++ b/lib/value/src/value/arbitrary.rs
@@ -17,7 +17,10 @@ fn datetime(g: &mut Gen) -> DateTime<Utc> {
     // are. We just sort of arbitrarily restrict things.
     let secs = i64::arbitrary(g) % 32_000;
     let nanosecs = u32::arbitrary(g) % 32_000;
-    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(secs, nanosecs), Utc)
+    DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp_opt(secs, nanosecs).expect("invalid timestamp"),
+        Utc,
+    )
 }
 
 impl Arbitrary for Value {

--- a/lib/value/src/value/lua.rs
+++ b/lib/value/src/value/lua.rs
@@ -107,7 +107,10 @@ pub fn table_to_timestamp(t: LuaTable<'_>) -> LuaResult<DateTime<Utc>> {
     let min = t.raw_get("min")?;
     let sec = t.raw_get("sec")?;
     let nano = t.raw_get::<_, Option<u32>>("nanosec")?.unwrap_or(0);
-    Ok(Utc.ymd(year, month, day).and_hms_nano(hour, min, sec, nano))
+    Ok(Utc
+        .ymd(year, month, day)
+        .and_hms_opt(hour, min, sec)
+        .expect("invalid datetime"))
 }
 
 #[cfg(test)]
@@ -149,15 +152,27 @@ mod test {
             ),
             (
                 "os.date('!*t', 1584297428)",
-                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
+                Value::Timestamp(
+                    Utc.ymd(2020, 3, 15)
+                        .and_hms_opt(18, 37, 8)
+                        .expect("invalid timestamp"),
+                ),
             ),
             (
                 "{year=2020, month=3, day=15, hour=18, min=37, sec=8}",
-                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms(18, 37, 8)),
+                Value::Timestamp(
+                    Utc.ymd(2020, 3, 15)
+                        .and_hms_opt(18, 37, 8)
+                        .expect("invalid timestamp"),
+                ),
             ),
             (
                 "{year=2020, month=3, day=15, hour=18, min=37, sec=8, nanosec=666666666}",
-                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms_nano(18, 37, 8, 666_666_666)),
+                Value::Timestamp(
+                    Utc.with_ymd_and_hms(2020, 3, 15, 18, 37, 8)
+                        .single()
+                        .expect("invalid datetime"),
+                ),
             ),
         ];
 
@@ -239,7 +254,11 @@ mod test {
                 "#,
             ),
             (
-                Value::Timestamp(Utc.ymd(2020, 3, 15).and_hms_nano(18, 37, 8, 666_666_666)),
+                Value::Timestamp(
+                    Utc.with_ymd_and_hms(2020, 3, 15, 18, 37, 8)
+                        .single()
+                        .expect("invalid datetime"),
+                ),
                 r#"
                 function (value)
                     local expected = os.date("!*t", 1584297428)

--- a/lib/value/src/value/lua.rs
+++ b/lib/value/src/value/lua.rs
@@ -110,7 +110,7 @@ pub fn table_to_timestamp(t: LuaTable<'_>) -> LuaResult<DateTime<Utc>> {
     Ok(Utc
         .ymd(year, month, day)
         .and_hms_nano_opt(hour, min, sec, nano)
-        .expect("invalid datetime"))
+        .expect("invalid timestamp"))
 }
 
 #[cfg(test)]
@@ -169,9 +169,9 @@ mod test {
             (
                 "{year=2020, month=3, day=15, hour=18, min=37, sec=8, nanosec=666666666}",
                 Value::Timestamp(
-                    Utc.with_ymd_and_hms(2020, 3, 15, 18, 37, 8)
-                        .single()
-                        .expect("invalid datetime"),
+                    Utc.ymd(2020, 3, 15)
+                        .and_hms_nano_opt(18, 37, 8, 666_666_666)
+                        .expect("invalid timestamp"),
                 ),
             ),
         ];
@@ -255,9 +255,9 @@ mod test {
             ),
             (
                 Value::Timestamp(
-                    Utc.with_ymd_and_hms(2020, 3, 15, 18, 37, 8)
-                        .single()
-                        .expect("invalid datetime"),
+                    Utc.ymd(2020, 3, 15)
+                        .and_hms_nano_opt(18, 37, 8, 666_666_666)
+                        .expect("invalid timestamp"),
                 ),
                 r#"
                 function (value)

--- a/lib/value/src/value/lua.rs
+++ b/lib/value/src/value/lua.rs
@@ -109,7 +109,7 @@ pub fn table_to_timestamp(t: LuaTable<'_>) -> LuaResult<DateTime<Utc>> {
     let nano = t.raw_get::<_, Option<u32>>("nanosec")?.unwrap_or(0);
     Ok(Utc
         .ymd(year, month, day)
-        .and_hms_opt(hour, min, sec)
+        .and_hms_nano_opt(hour, min, sec, nano)
         .expect("invalid datetime"))
 }
 

--- a/lib/vector-common/src/conversion/tests/unix.rs
+++ b/lib/vector-common/src/conversion/tests/unix.rs
@@ -52,7 +52,9 @@ fn timestamp_param_conversion() {
 }
 
 fn dateref() -> DateTime<Utc> {
-    Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(981_173_106, 0))
+    Utc.from_utc_datetime(
+        &NaiveDateTime::from_timestamp_opt(981_173_106, 0).expect("invalid timestamp"),
+    )
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // appears to be a false positive

--- a/lib/vector-common/src/datetime.rs
+++ b/lib/vector-common/src/datetime.rs
@@ -68,7 +68,9 @@ impl TimeZone {
 
 /// Convert a timestamp with a non-UTC time zone into UTC
 pub(super) fn datetime_to_utc<TZ: chrono::TimeZone>(ts: &DateTime<TZ>) -> DateTime<Utc> {
-    Utc.timestamp(ts.timestamp(), ts.timestamp_subsec_nanos())
+    Utc.timestamp_opt(ts.timestamp(), ts.timestamp_subsec_nanos())
+        .single()
+        .expect("invalid timestamp")
 }
 
 impl From<TimeZone> for String {

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -381,7 +381,11 @@ mod test {
         )
         .with_namespace(Some("namespace_example"))
         .with_tags(Some(crate::metric_tags!("example tag" => "example value")))
-        .with_timestamp(Some(Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)));
+        .with_timestamp(Some(
+            Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+                .single()
+                .expect("invalid datetime"),
+        ));
 
         assert_metric(
             metric.clone(),
@@ -643,7 +647,11 @@ mod test {
         )
         .with_namespace(Some("example_namespace"))
         .with_tags(Some(crate::metric_tags!("example tag" => "example value")))
-        .with_timestamp(Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10)));
+        .with_timestamp(Some(
+            Utc.ymd(2018, 11, 14)
+                .and_hms_opt(8, 9, 10)
+                .expect("invalid timestamp"),
+        ));
         assert_event_data_eq!(Lua::new().load(value).eval::<Metric>().unwrap(), expected);
     }
 
@@ -681,7 +689,11 @@ mod test {
                 TagValue::from("b".to_string()),
             ]),
         )]))))
-        .with_timestamp(Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10)));
+        .with_timestamp(Some(
+            Utc.ymd(2018, 11, 14)
+                .and_hms_opt(8, 9, 10)
+                .expect("invalid timestamp"),
+        ));
         assert_event_data_eq!(Lua::new().load(value).eval::<Metric>().unwrap(), expected);
     }
 

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -382,9 +382,9 @@ mod test {
         .with_namespace(Some("namespace_example"))
         .with_tags(Some(crate::metric_tags!("example tag" => "example value")))
         .with_timestamp(Some(
-            Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-                .single()
-                .expect("invalid datetime"),
+            Utc.ymd(2018, 11, 14)
+                .and_hms_nano_opt(8, 9, 10, 11)
+                .expect("invalid timestamp"),
         ));
 
         assert_metric(

--- a/lib/vector-core/src/event/lua/util.rs
+++ b/lib/vector-core/src/event/lua/util.rs
@@ -53,5 +53,5 @@ pub fn table_to_timestamp(t: LuaTable<'_>) -> LuaResult<DateTime<Utc>> {
     Ok(Utc
         .ymd(year, month, day)
         .and_hms_nano_opt(hour, min, sec, nano)
-        .expect("invalid datetime"))
+        .expect("invalid timestamp"))
 }

--- a/lib/vector-core/src/event/lua/util.rs
+++ b/lib/vector-core/src/event/lua/util.rs
@@ -49,6 +49,8 @@ pub fn table_to_timestamp(t: LuaTable<'_>) -> LuaResult<DateTime<Utc>> {
     let hour = t.raw_get("hour")?;
     let min = t.raw_get("min")?;
     let sec = t.raw_get("sec")?;
-    let nano = t.raw_get::<_, Option<u32>>("nanosec")?.unwrap_or(0);
-    Ok(Utc.ymd(year, month, day).and_hms_nano(hour, min, sec, nano))
+    Ok(Utc
+        .ymd(year, month, day)
+        .and_hms_opt(hour, min, sec)
+        .expect("invalid datetime"))
 }

--- a/lib/vector-core/src/event/lua/util.rs
+++ b/lib/vector-core/src/event/lua/util.rs
@@ -49,8 +49,9 @@ pub fn table_to_timestamp(t: LuaTable<'_>) -> LuaResult<DateTime<Utc>> {
     let hour = t.raw_get("hour")?;
     let min = t.raw_get("min")?;
     let sec = t.raw_get("sec")?;
+    let nano = t.raw_get::<_, Option<u32>>("nanosec")?.unwrap_or(0);
     Ok(Utc
         .ymd(year, month, day)
-        .and_hms_opt(hour, min, sec)
+        .and_hms_nano_opt(hour, min, sec, nano)
         .expect("invalid datetime"))
 }

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -646,9 +646,9 @@ mod test {
     use super::*;
 
     fn ts() -> DateTime<Utc> {
-        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-            .single()
-            .expect("invalid datetime")
+        Utc.ymd(2018, 11, 14)
+            .and_hms_nano_opt(8, 9, 10, 11)
+            .expect("invalid timestamp")
     }
 
     fn tags() -> MetricTags {

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -646,7 +646,9 @@ mod test {
     use super::*;
 
     fn ts() -> DateTime<Utc> {
-        Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)
+        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+            .single()
+            .expect("invalid datetime")
     }
 
     fn tags() -> MetricTags {

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -203,9 +203,12 @@ impl From<Metric> for event::Metric {
 
         let namespace = (!metric.namespace.is_empty()).then_some(metric.namespace);
 
-        let timestamp = metric
-            .timestamp
-            .map(|ts| chrono::Utc.timestamp(ts.seconds, ts.nanos as u32));
+        let timestamp = metric.timestamp.map(|ts| {
+            chrono::Utc
+                .timestamp_opt(ts.seconds, ts.nanos as u32)
+                .single()
+                .expect("invalid timestamp")
+        });
 
         let mut tags = MetricTags(
             metric
@@ -538,7 +541,10 @@ fn decode_value(input: Value) -> Option<event::Value> {
     match input.kind {
         Some(value::Kind::RawBytes(data)) => Some(event::Value::Bytes(data)),
         Some(value::Kind::Timestamp(ts)) => Some(event::Value::Timestamp(
-            chrono::Utc.timestamp(ts.seconds, ts.nanos as u32),
+            chrono::Utc
+                .timestamp_opt(ts.seconds, ts.nanos as u32)
+                .single()
+                .expect("invalid timestamp"),
         )),
         Some(value::Kind::Integer(value)) => Some(event::Value::Integer(value)),
         Some(value::Kind::Float(value)) => Some(event::Value::Float(NotNan::new(value).unwrap())),

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -55,7 +55,10 @@ fn datetime(g: &mut Gen) -> DateTime<Utc> {
     // are. We just sort of arbitrarily restrict things.
     let secs = i64::arbitrary(g) % 32_000;
     let nanosecs = u32::arbitrary(g) % 32_000;
-    DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(secs, nanosecs), Utc)
+    DateTime::<Utc>::from_utc(
+        NaiveDateTime::from_timestamp_opt(secs, nanosecs).expect("invalid timestamp"),
+        Utc,
+    )
 }
 
 impl Arbitrary for Event {

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -939,7 +939,11 @@ mod test {
         )
         .with_namespace(Some("zoob"))
         .with_tags(Some(metric_tags!("tig" => "tog")))
-        .with_timestamp(Some(Utc.ymd(2020, 12, 10).and_hms(12, 0, 0)));
+        .with_timestamp(Some(
+            Utc.ymd(2020, 12, 10)
+                .and_hms_opt(12, 0, 0)
+                .expect("invalid timestamp"),
+        ));
 
         let info = ProgramInfo {
             fallible: false,
@@ -961,7 +965,7 @@ mod test {
                 btreemap! {
                     "name" => "zub",
                     "namespace" => "zoob",
-                    "timestamp" => Utc.ymd(2020, 12, 10).and_hms(12, 0, 0),
+                    "timestamp" => Utc.ymd(2020, 12, 10).and_hms_opt(12, 0, 0).expect("invalid timestamp"),
                     "tags" => btreemap! { "tig" => "tog" },
                     "kind" => "absolute",
                     "type" => "counter",
@@ -999,7 +1003,10 @@ mod test {
             (
                 owned_value_path!("timestamp"),
                 None,
-                Utc.ymd(2020, 12, 8).and_hms(12, 0, 0).into(),
+                Utc.ymd(2020, 12, 8)
+                    .and_hms_opt(12, 0, 0)
+                    .expect("invalid timestamp")
+                    .into(),
                 true,
             ),
             (

--- a/lib/vrl/compiler/src/value/kind.rs
+++ b/lib/vrl/compiler/src/value/kind.rs
@@ -58,7 +58,11 @@ impl DefaultValue for Kind {
         }
 
         if self.is_timestamp() {
-            return Utc.timestamp(0, 0).into();
+            return Utc
+                .timestamp_opt(0, 0)
+                .single()
+                .expect("invalid timestamp")
+                .into();
         }
 
         if self.is_regex() {

--- a/lib/vrl/proptests/src/main.rs
+++ b/lib/vrl/proptests/src/main.rs
@@ -93,7 +93,7 @@ prop_compose! {
 prop_compose! {
     fn timestamp_literal() (secs in 0..i64::MAX) -> Literal {
         use chrono::{Utc, TimeZone};
-        Literal::Timestamp(Utc.timestamp(secs, 0).to_string())
+        Literal::Timestamp(Utc.timestamp_opt(secs, 0).single().expect("invalid timestamp").to_string())
     }
 }
 

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -544,7 +544,7 @@ bench_function! {
     format_timestamp => vrl_stdlib::FormatTimestamp;
 
     iso_6801 {
-        args: func_args![value: Utc.timestamp(10, 0), format: "%+"],
+        args: func_args![value: Utc.timestamp_opt(10, 0).single().expect("invalid timestamp"), format: "%+"],
         want: Ok("1970-01-01T00:00:10+00:00"),
     }
 }
@@ -1335,11 +1335,11 @@ bench_function! {
             "subscription_filters":  ["Destination"],
             "log_events": [{
                 "id":  "35683658089614582423604394983260738922885519999578275840",
-                "timestamp":  (Utc.timestamp(1600110569, 39000000)),
+                "timestamp":  (Utc.timestamp_opt(1600110569, 39000000).single().expect("invalid timestamp")),
                 "message":  r#"{"bytes":26780,"datetime":"14/Sep/2020:11:45:41 -0400","host":"157.130.216.193","method":"PUT","protocol":"HTTP/1.0","referer":"https://www.principalcross-platform.io/markets/ubiquitous","request":"/expedite/convergence","source_type":"stdin","status":301,"user-identifier":"-"}"#,
             }, {
                 "id":  "35683658089659183914001456229543810359430816722590236673",
-                "timestamp":  (Utc.timestamp(1600110569, 41000000)),
+                "timestamp":  (Utc.timestamp_opt(1600110569, 41000000).single().expect("invalid timestamp")),
                 "message":  r#"{"bytes":17707,"datetime":"14/Sep/2020:11:45:41 -0400","host":"109.81.244.252","method":"GET","protocol":"HTTP/2.0","referer":"http://www.investormission-critical.io/24/7/vortals","request":"/scale/functionalities/optimize","source_type":"stdin","status":502,"user-identifier":"feeney1708"}"#,
             }]
         }))

--- a/lib/vrl/stdlib/src/format_timestamp.rs
+++ b/lib/vrl/stdlib/src/format_timestamp.rs
@@ -97,21 +97,21 @@ mod tests {
         format_timestamp => FormatTimestamp;
 
         invalid {
-            args: func_args![value: Utc.timestamp(10, 0),
+            args: func_args![value: Utc.timestamp_opt(10, 0).single().expect("invalid timestamp"),
                              format: "%Q INVALID"],
             want: Err("invalid format"),
             tdef: TypeDef::bytes().fallible(),
         }
 
         valid_secs {
-            args: func_args![value: Utc.timestamp(10, 0),
+            args: func_args![value: Utc.timestamp_opt(10, 0).single().expect("invalid timestamp"),
                              format: "%s"],
             want: Ok(value!("10")),
             tdef: TypeDef::bytes().fallible(),
         }
 
         date {
-            args: func_args![value: Utc.timestamp(10, 0),
+            args: func_args![value: Utc.timestamp_opt(10, 0).single().expect("invalid timestamp"),
                              format: "%+"],
             want: Ok(value!("1970-01-01T00:00:10+00:00")),
             tdef: TypeDef::bytes().fallible(),

--- a/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
+++ b/lib/vrl/stdlib/src/parse_aws_cloudwatch_log_subscription_message.rs
@@ -192,11 +192,11 @@ mod tests {
                 (String::from("subscription_filters"), Value::from(vec![Value::from("Destination")])),
                 (String::from("log_events"), Value::from(vec![Value::from(BTreeMap::from([
                     (String::from("id"), Value::from( "35683658089614582423604394983260738922885519999578275840")),
-                    (String::from("timestamp"), Value::from(Utc.timestamp(1_600_110_569, 39_000_000))),
+                    (String::from("timestamp"), Value::from(Utc.timestamp_opt(1_600_110_569, 39_000_000).single().expect("invalid timestamp"))),
                     (String::from("message"), Value::from("{\"bytes\":26780,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"157.130.216.193\",\"method\":\"PUT\",\"protocol\":\"HTTP/1.0\",\"referer\":\"https://www.principalcross-platform.io/markets/ubiquitous\",\"request\":\"/expedite/convergence\",\"source_type\":\"stdin\",\"status\":301,\"user-identifier\":\"-\"}")),
                 ])), Value::from(BTreeMap::from([
                     (String::from("id"), Value::from("35683658089659183914001456229543810359430816722590236673")),
-                    (String::from("timestamp"), Value::from(Utc.timestamp(1_600_110_569, 41_000_000))),
+                    (String::from("timestamp"), Value::from(Utc.timestamp_opt(1_600_110_569, 41_000_000).single().expect("invalid timestamp"))),
                     (String::from("message"), Value::from("{\"bytes\":17707,\"datetime\":\"14/Sep/2020:11:45:41 -0400\",\"host\":\"109.81.244.252\",\"method\":\"GET\",\"protocol\":\"HTTP/2.0\",\"referer\":\"http://www.investormission-critical.io/24/7/vortals\",\"request\":\"/scale/functionalities/optimize\",\"source_type\":\"stdin\",\"status\":502,\"user-identifier\":\"feeney1708\"}")),
                 ]))])),
                 ]))),

--- a/lib/vrl/stdlib/src/to_timestamp.rs
+++ b/lib/vrl/stdlib/src/to_timestamp.rs
@@ -314,7 +314,7 @@ mod tests {
 
         integer {
              args: func_args![value: 1_431_648_000],
-             want: Ok(chrono::Utc.ymd(2015, 5, 15).and_hms(0, 0, 0)),
+             want: Ok(chrono::Utc.ymd(2015, 5, 15).and_hms_opt(0, 0, 0).expect("invalid timestamp")),
              tdef: TypeDef::timestamp().fallible(),
         }
 

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -135,7 +135,8 @@ impl FileConfig {
 
                 match (split.next(), split.next()) {
                     (Some("date"), None) => Value::Timestamp(
-                        chrono::FixedOffset::east(0)
+                        chrono::FixedOffset::east_opt(0)
+                            .expect("invalid timestamp")
                             .from_utc_datetime(
                                 &chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
                                     .map_err(|_| {
@@ -144,12 +145,14 @@ impl FileConfig {
                                             value, row
                                         )
                                     })?
-                                    .and_hms(0, 0, 0),
+                                    .and_hms_opt(0, 0, 0)
+                                    .expect("invalid timestamp"),
                             )
                             .into(),
                     ),
                     (Some("date"), Some(format)) => Value::Timestamp(
-                        chrono::FixedOffset::east(0)
+                        chrono::FixedOffset::east_opt(0)
+                            .expect("invalid timestamp")
                             .from_utc_datetime(
                                 &chrono::NaiveDate::parse_from_str(value, format)
                                     .map_err(|_| {
@@ -158,7 +161,8 @@ impl FileConfig {
                                             value, row
                                         )
                                     })?
-                                    .and_hms(0, 0, 0),
+                                    .and_hms_opt(0, 0, 0)
+                                    .expect("invalid timestamp"),
                             )
                             .into(),
                     ),
@@ -607,17 +611,32 @@ mod tests {
         );
 
         assert_eq!(
-            Ok(Value::from(chrono::Utc.ymd(2020, 3, 5).and_hms(0, 0, 0))),
+            Ok(Value::from(
+                chrono::Utc
+                    .ymd(2020, 3, 5)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp")
+            )),
             config.parse_column(Default::default(), "col2", 1, "2020-03-05")
         );
 
         assert_eq!(
-            Ok(Value::from(chrono::Utc.ymd(2020, 3, 5).and_hms(0, 0, 0))),
+            Ok(Value::from(
+                chrono::Utc
+                    .ymd(2020, 3, 5)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp")
+            )),
             config.parse_column(Default::default(), "col3", 1, "03/05/2020")
         );
 
         assert_eq!(
-            Ok(Value::from(chrono::Utc.ymd(2020, 3, 5).and_hms(0, 0, 0))),
+            Ok(Value::from(
+                chrono::Utc
+                    .ymd(2020, 3, 5)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp")
+            )),
             config.parse_column(Default::default(), "col3-spaces", 1, "03 05 2020")
         );
 
@@ -924,11 +943,21 @@ mod tests {
             vec![
                 vec![
                     "zip".into(),
-                    Value::Timestamp(chrono::Utc.ymd(2015, 12, 7).and_hms(0, 0, 0)),
+                    Value::Timestamp(
+                        chrono::Utc
+                            .ymd(2015, 12, 7)
+                            .and_hms_opt(0, 0, 0)
+                            .expect("invalid timestamp"),
+                    ),
                 ],
                 vec![
                     "zip".into(),
-                    Value::Timestamp(chrono::Utc.ymd(2016, 12, 7).and_hms(0, 0, 0)),
+                    Value::Timestamp(
+                        chrono::Utc
+                            .ymd(2016, 12, 7)
+                            .and_hms_opt(0, 0, 0)
+                            .expect("invalid timestamp"),
+                    ),
                 ],
             ],
             vec!["field1".to_string(), "field2".to_string()],
@@ -943,8 +972,14 @@ mod tests {
             },
             Condition::BetweenDates {
                 field: "field2",
-                from: chrono::Utc.ymd(2016, 1, 1).and_hms(0, 0, 0),
-                to: chrono::Utc.ymd(2017, 1, 1).and_hms(0, 0, 0),
+                from: chrono::Utc
+                    .ymd(2016, 1, 1)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp"),
+                to: chrono::Utc
+                    .ymd(2017, 1, 1)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp"),
             },
         ];
 
@@ -953,7 +988,12 @@ mod tests {
                 (String::from("field1"), Value::from("zip")),
                 (
                     String::from("field2"),
-                    Value::Timestamp(chrono::Utc.ymd(2016, 12, 7).and_hms(0, 0, 0))
+                    Value::Timestamp(
+                        chrono::Utc
+                            .ymd(2016, 12, 7)
+                            .and_hms_opt(0, 0, 0)
+                            .expect("invalid timestamp")
+                    )
                 )
             ])),
             file.find_table_row(Case::Sensitive, &conditions, None, Some(handle))

--- a/src/sinks/aws_cloudwatch_metrics/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_metrics/integration_tests.rs
@@ -83,7 +83,9 @@ async fn cloudwatch_metrics_put_data() {
                 },
             )
             .with_timestamp(Some(
-                Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789),
+                Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+                    .single()
+                    .expect("invalid datetime"),
             )),
         );
         events.push(event);

--- a/src/sinks/aws_cloudwatch_metrics/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_metrics/integration_tests.rs
@@ -83,9 +83,9 @@ async fn cloudwatch_metrics_put_data() {
                 },
             )
             .with_timestamp(Some(
-                Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-                    .single()
-                    .expect("invalid datetime"),
+                Utc.ymd(2018, 11, 14)
+                    .and_hms_nano_opt(8, 9, 10, 123456789)
+                    .expect("invalid timestamp"),
             )),
         );
         events.push(event);

--- a/src/sinks/aws_cloudwatch_metrics/tests.rs
+++ b/src/sinks/aws_cloudwatch_metrics/tests.rs
@@ -52,9 +52,9 @@ async fn encode_events_basic_counter() {
             MetricValue::Counter { value: 2.5 },
         )
         .with_timestamp(Some(
-            Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-                .single()
-                .expect("invalid datetime"),
+            Utc.ymd(2018, 11, 14)
+                .and_hms_nano_opt(8, 9, 10, 123456789)
+                .expect("invalid timestamp"),
         )),
         Metric::new(
             "healthcheck",
@@ -63,9 +63,9 @@ async fn encode_events_basic_counter() {
         )
         .with_tags(Some(metric_tags!("region" => "local")))
         .with_timestamp(Some(
-            Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-                .single()
-                .expect("invalid datetime"),
+            Utc.ymd(2018, 11, 14)
+                .and_hms_nano_opt(8, 9, 10, 123456789)
+                .expect("invalid timestamp"),
         )),
     ];
 

--- a/src/sinks/aws_cloudwatch_metrics/tests.rs
+++ b/src/sinks/aws_cloudwatch_metrics/tests.rs
@@ -52,7 +52,9 @@ async fn encode_events_basic_counter() {
             MetricValue::Counter { value: 2.5 },
         )
         .with_timestamp(Some(
-            Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789),
+            Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+                .single()
+                .expect("invalid datetime"),
         )),
         Metric::new(
             "healthcheck",
@@ -61,7 +63,9 @@ async fn encode_events_basic_counter() {
         )
         .with_tags(Some(metric_tags!("region" => "local")))
         .with_timestamp(Some(
-            Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 123456789),
+            Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+                .single()
+                .expect("invalid datetime"),
         )),
     ];
 

--- a/src/sinks/datadog/metrics/encoder.rs
+++ b/src/sinks/datadog/metrics/encoder.rs
@@ -722,9 +722,9 @@ mod tests {
     }
 
     fn ts() -> DateTime<Utc> {
-        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-            .single()
-            .expect("invalid datetime")
+        Utc.ymd(2018, 11, 14)
+            .and_hms_nano_opt(8, 9, 10, 11)
+            .expect("invalid timestamp")
     }
 
     fn tags() -> MetricTags {

--- a/src/sinks/datadog/metrics/encoder.rs
+++ b/src/sinks/datadog/metrics/encoder.rs
@@ -722,7 +722,9 @@ mod tests {
     }
 
     fn ts() -> DateTime<Utc> {
-        Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)
+        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+            .single()
+            .expect("invalid datetime")
     }
 
     fn tags() -> MetricTags {

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -34,7 +34,9 @@ async fn sets_create_action_when_configured() {
     let mut log = LogEvent::from("hello there");
     log.insert(
         log_schema().timestamp_key(),
-        Utc.ymd(2020, 12, 1).and_hms(1, 2, 3),
+        Utc.ymd(2020, 12, 1)
+            .and_hms_opt(1, 2, 3)
+            .expect("invalid timestamp"),
     );
     log.insert("action", "crea");
 
@@ -83,7 +85,9 @@ async fn encode_datastream_mode() {
     let mut log = LogEvent::from("hello there");
     log.insert(
         log_schema().timestamp_key(),
-        Utc.ymd(2020, 12, 1).and_hms(1, 2, 3),
+        Utc.ymd(2020, 12, 1)
+            .and_hms_opt(1, 2, 3)
+            .expect("invalid timestamp"),
     );
     log.insert("data_stream", data_stream_body());
 
@@ -131,7 +135,9 @@ async fn encode_datastream_mode_no_routing() {
     log.insert("data_stream", data_stream_body());
     log.insert(
         log_schema().timestamp_key(),
-        Utc.ymd(2020, 12, 1).and_hms(1, 2, 3),
+        Utc.ymd(2020, 12, 1)
+            .and_hms_opt(1, 2, 3)
+            .expect("invalid timestamp"),
     );
     let mut encoded = vec![];
     let encoded_size = es
@@ -258,7 +264,9 @@ async fn encode_datastream_mode_no_sync() {
     log.insert("data_stream", data_stream_body());
     log.insert(
         log_schema().timestamp_key(),
-        Utc.ymd(2020, 12, 1).and_hms(1, 2, 3),
+        Utc.ymd(2020, 12, 1)
+            .and_hms_opt(1, 2, 3)
+            .expect("invalid timestamp"),
     );
 
     let mut encoded = vec![];

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -493,7 +493,11 @@ mod tests {
         log.insert("anumber", Value::Bytes("100".into()));
         log.insert(
             "timestamp",
-            Value::Timestamp(Utc.ymd(2020, 1, 1).and_hms(12, 30, 0)),
+            Value::Timestamp(
+                Utc.ymd(2020, 1, 1)
+                    .and_hms_opt(12, 30, 0)
+                    .expect("invalid timestamp"),
+            ),
         );
 
         let json = encoder.encode_event(Event::from(log)).unwrap();

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -264,7 +264,11 @@ mod tests {
                     MetricValue::Counter { value: 42.0 },
                 )
                 .with_tags(Some(metric_tags!("os.host" => "somehost")))
-                .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms(21, 0, 1))),
+                .with_timestamp(Some(
+                    Utc.ymd(2020, 8, 18)
+                        .and_hms_opt(21, 0, 1)
+                        .expect("invalid timestamp"),
+                )),
             ),
             Event::from(
                 Metric::new(
@@ -276,7 +280,11 @@ mod tests {
                     },
                 )
                 .with_tags(Some(metric_tags!("os.host" => "somehost")))
-                .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms(21, 0, 2))),
+                .with_timestamp(Some(
+                    Utc.ymd(2020, 8, 18)
+                        .and_hms_opt(21, 0, 2)
+                        .expect("invalid timestamp"),
+                )),
             ),
         ];
 
@@ -325,7 +333,11 @@ mod tests {
                 "code" => "200",
                 "code" => "success"
             )))
-            .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms(21, 0, 1))),
+            .with_timestamp(Some(
+                Utc.ymd(2020, 8, 18)
+                    .and_hms_opt(21, 0, 1)
+                    .expect("invalid timestamp"),
+            )),
         )];
 
         let len = metrics.len();

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -683,7 +683,10 @@ mod tests {
             let mut event = LogEvent::from(line.to_string()).with_batch_notifier(&batch);
             event.insert(format!("key{}", i).as_str(), format!("value{}", i));
 
-            let timestamp = Utc.ymd(1970, 1, 1).and_hms_nano(0, 0, (i as u32) + 1, 0);
+            let timestamp = Utc
+                .with_ymd_and_hms(1970, 1, 1, 0, 0, (i as u32) + 1)
+                .single()
+                .expect("invalid datetime");
             event.insert("timestamp", timestamp);
             event.insert("source_type", "file");
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -684,9 +684,9 @@ mod tests {
             event.insert(format!("key{}", i).as_str(), format!("value{}", i));
 
             let timestamp = Utc
-                .with_ymd_and_hms(1970, 1, 1, 0, 0, (i as u32) + 1)
-                .single()
-                .expect("invalid datetime");
+                .ymd(1970, 1, 1)
+                .and_hms_nano_opt(0, 0, (i as u32) + 1, 0)
+                .expect("invalid timestamp");
             event.insert("timestamp", timestamp);
             event.insert("source_type", "file");
 

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -330,9 +330,9 @@ mod tests {
         )
         .with_namespace(Some("jvm"))
         .with_timestamp(Some(
-            Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
-                .single()
-                .expect("invalid datetime"),
+            Utc.ymd(2020, 8, 18)
+                .and_hms_nano_opt(21, 0, 0, 0)
+                .expect("invalid timestamp"),
         ))];
 
         assert_eq!(
@@ -349,9 +349,9 @@ mod tests {
             MetricValue::Counter { value: 42.0 },
         )
         .with_timestamp(Some(
-            Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
-                .single()
-                .expect("invalid datetime"),
+            Utc.ymd(2020, 8, 18)
+                .and_hms_nano_opt(21, 0, 0, 0)
+                .expect("invalid timestamp"),
         ))];
 
         assert_eq!(
@@ -370,9 +370,9 @@ mod tests {
             )
             .with_namespace(Some("jvm"))
             .with_timestamp(Some(
-                Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
-                    .single()
-                    .expect("invalid datetime"),
+                Utc.ymd(2020, 8, 18)
+                    .and_hms_nano_opt(21, 0, 0, 0)
+                    .expect("invalid timestamp"),
             )),
             Metric::new(
                 "pool.committed",
@@ -381,9 +381,9 @@ mod tests {
             )
             .with_namespace(Some("jvm"))
             .with_timestamp(Some(
-                Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
-                    .single()
-                    .expect("invalid datetime"),
+                Utc.ymd(2020, 8, 18)
+                    .and_hms_nano_opt(21, 0, 0, 1)
+                    .expect("invalid timestamp"),
             )),
         ];
 
@@ -441,7 +441,7 @@ mod tests {
                 )
                 .with_namespace(Some(*namespace))
                 .with_tags(Some(metric_tags!("os.host" => "somehost")))
-                .with_timestamp(Some(Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0).single().expect("invalid datetime"))),
+                .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano_opt(21, 0, 0, i as u32).expect("invalid timestamp"))),
             );
             events.push(event);
         }

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -329,7 +329,11 @@ mod tests {
             MetricValue::Counter { value: 42.0 },
         )
         .with_namespace(Some("jvm"))
-        .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)))];
+        .with_timestamp(Some(
+            Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
+                .single()
+                .expect("invalid datetime"),
+        ))];
 
         assert_eq!(
             "jvm,metric_type=counter,token=aaa pool.used=42 1597784400000000000",
@@ -344,7 +348,11 @@ mod tests {
             MetricKind::Incremental,
             MetricValue::Counter { value: 42.0 },
         )
-        .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0)))];
+        .with_timestamp(Some(
+            Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
+                .single()
+                .expect("invalid datetime"),
+        ))];
 
         assert_eq!(
             "ns,metric_type=counter,token=aaa used=42 1597784400000000000",
@@ -361,14 +369,22 @@ mod tests {
                 MetricValue::Counter { value: 42.0 },
             )
             .with_namespace(Some("jvm"))
-            .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 0))),
+            .with_timestamp(Some(
+                Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
+                    .single()
+                    .expect("invalid datetime"),
+            )),
             Metric::new(
                 "pool.committed",
                 MetricKind::Incremental,
                 MetricValue::Counter { value: 18874368.0 },
             )
             .with_namespace(Some("jvm"))
-            .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, 1))),
+            .with_timestamp(Some(
+                Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0)
+                    .single()
+                    .expect("invalid datetime"),
+            )),
         ];
 
         assert_eq!(
@@ -425,7 +441,7 @@ mod tests {
                 )
                 .with_namespace(Some(*namespace))
                 .with_tags(Some(metric_tags!("os.host" => "somehost")))
-                .with_timestamp(Some(Utc.ymd(2020, 8, 18).and_hms_nano(21, 0, 0, i as u32))),
+                .with_timestamp(Some(Utc.with_ymd_and_hms(2020, 8, 18, 21, 0, 0).single().expect("invalid datetime"))),
             );
             events.push(event);
         }

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -429,7 +429,11 @@ async fn splunk_auto_extracted_timestamp() {
 
         event.insert(
             "timestamp",
-            Value::from(Utc.ymd(2020, 3, 5).and_hms(0, 0, 0)),
+            Value::from(
+                Utc.ymd(2020, 3, 5)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp"),
+            ),
         );
 
         run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
@@ -471,7 +475,11 @@ async fn splunk_non_auto_extracted_timestamp() {
         // With auto_extract_timestamp switched off the timestamp comes from the event timestamp.
         event.insert(
             "timestamp",
-            Value::from(Utc.ymd(2020, 3, 5).and_hms(0, 0, 0)),
+            Value::from(
+                Utc.ymd(2020, 3, 5)
+                    .and_hms_opt(0, 0, 0)
+                    .expect("invalid timestamp"),
+            ),
         );
 
         run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;

--- a/src/sources/aws_ecs_metrics/parser.rs
+++ b/src/sources/aws_ecs_metrics/parser.rs
@@ -555,9 +555,9 @@ mod test {
     use crate::event::metric::{Metric, MetricKind, MetricValue};
 
     fn ts() -> DateTime<Utc> {
-        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-            .single()
-            .expect("invalid datetime")
+        Utc.ymd(2018, 11, 14)
+            .and_hms_nano_opt(8, 9, 10, 11)
+            .expect("invalid timestamp")
     }
 
     fn namespace() -> String {

--- a/src/sources/aws_ecs_metrics/parser.rs
+++ b/src/sources/aws_ecs_metrics/parser.rs
@@ -555,7 +555,9 @@ mod test {
     use crate::event::metric::{Metric, MetricKind, MetricValue};
 
     fn ts() -> DateTime<Utc> {
-        Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)
+        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+            .single()
+            .expect("invalid datetime")
     }
 
     fn namespace() -> String {

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -459,9 +459,11 @@ impl IngestorProcess {
 
         let metadata = object.metadata;
 
-        let timestamp = object
-            .last_modified
-            .map(|ts| Utc.timestamp(ts.secs(), ts.subsec_nanos()));
+        let timestamp = object.last_modified.map(|ts| {
+            Utc.timestamp_opt(ts.secs(), ts.subsec_nanos())
+                .single()
+                .expect("invalid timestamp")
+        });
 
         let (batch, receiver) = BatchNotifier::maybe_new_with_receiver(self.acknowledgements);
         let object_reader = super::s3_object_decoder(

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -191,7 +191,11 @@ fn get_timestamp(
 ) -> Option<DateTime<Utc>> {
     attributes.as_ref().and_then(|attributes| {
         let sent_time_str = attributes.get(&MessageSystemAttributeName::SentTimestamp)?;
-        Some(Utc.timestamp_millis(i64::from_str(sent_time_str).ok()?))
+        Some(
+            Utc.timestamp_millis_opt(i64::from_str(sent_time_str).ok()?)
+                .single()
+                .expect("invalid timestamp"),
+        )
     })
 }
 
@@ -335,7 +339,11 @@ mod tests {
 
         assert_eq!(
             get_timestamp(&Some(attributes)),
-            Some(Utc.timestamp_millis(1636408546018))
+            Some(
+                Utc.timestamp_millis_opt(1636408546018)
+                    .single()
+                    .expect("invalid timestamp")
+            )
         );
     }
 }

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -271,7 +271,7 @@ pub(crate) fn decode_ddseries_v2(
                                 value: dd_point.value,
                             },
                         )
-                        .with_timestamp(Some(Utc.timestamp_opt(dd_point.timestamp, 0).single().expect("invalid timestamp")))
+                        .with_timestamp(Some(Utc.timestamp(dd_point.timestamp, 0)))
                         .with_tags(Some(tags.clone()))
                         .with_namespace(namespace)
                     })
@@ -287,7 +287,7 @@ pub(crate) fn decode_ddseries_v2(
                                 value: dd_point.value,
                             },
                         )
-                        .with_timestamp(Some(Utc.timestamp_opt(dd_point.timestamp, 0).single().expect("invalid timestamp")))
+                        .with_timestamp(Some(Utc.timestamp(dd_point.timestamp, 0)))
                         .with_tags(Some(tags.clone()))
                         .with_namespace(namespace)
                     })
@@ -307,7 +307,7 @@ pub(crate) fn decode_ddseries_v2(
                                 value: dd_point.value * (i as f64),
                             },
                         )
-                        .with_timestamp(Some(Utc.timestamp_opt(dd_point.timestamp, 0).single().expect("invalid timestamp")))
+                        .with_timestamp(Some(Utc.timestamp(dd_point.timestamp, 0)))
                         // serie.interval is in seconds, convert to ms
                         .with_interval_ms(NonZeroU32::new(i * 1000))
                         .with_tags(Some(tags.clone()))
@@ -409,7 +409,7 @@ fn into_vector_metric(
                     MetricKind::Incremental,
                     MetricValue::Counter { value: dd_point.1 },
                 )
-                .with_timestamp(Some(Utc.timestamp_opt(dd_point.0, 0).single().expect("invalid timestamp")))
+                .with_timestamp(Some(Utc.timestamp(dd_point.0, 0)))
                 .with_tags(Some(tags.clone()))
                 .with_namespace(namespace)
             })
@@ -423,7 +423,7 @@ fn into_vector_metric(
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: dd_point.1 },
                 )
-                .with_timestamp(Some(Utc.timestamp_opt(dd_point.0, 0).single().expect("invalid timestamp")))
+                .with_timestamp(Some(Utc.timestamp(dd_point.0, 0)))
                 .with_tags(Some(tags.clone()))
                 .with_namespace(namespace)
             })

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -271,7 +271,7 @@ pub(crate) fn decode_ddseries_v2(
                                 value: dd_point.value,
                             },
                         )
-                        .with_timestamp(Some(Utc.timestamp(dd_point.timestamp, 0)))
+                        .with_timestamp(Some(Utc.timestamp_opt(dd_point.timestamp, 0).single().expect("invalid timestamp")))
                         .with_tags(Some(tags.clone()))
                         .with_namespace(namespace)
                     })
@@ -287,7 +287,7 @@ pub(crate) fn decode_ddseries_v2(
                                 value: dd_point.value,
                             },
                         )
-                        .with_timestamp(Some(Utc.timestamp(dd_point.timestamp, 0)))
+                        .with_timestamp(Some(Utc.timestamp_opt(dd_point.timestamp, 0).single().expect("invalid timestamp")))
                         .with_tags(Some(tags.clone()))
                         .with_namespace(namespace)
                     })
@@ -307,7 +307,7 @@ pub(crate) fn decode_ddseries_v2(
                                 value: dd_point.value * (i as f64),
                             },
                         )
-                        .with_timestamp(Some(Utc.timestamp(dd_point.timestamp, 0)))
+                        .with_timestamp(Some(Utc.timestamp_opt(dd_point.timestamp, 0).single().expect("invalid timestamp")))
                         // serie.interval is in seconds, convert to ms
                         .with_interval_ms(NonZeroU32::new(i * 1000))
                         .with_tags(Some(tags.clone()))
@@ -409,7 +409,7 @@ fn into_vector_metric(
                     MetricKind::Incremental,
                     MetricValue::Counter { value: dd_point.1 },
                 )
-                .with_timestamp(Some(Utc.timestamp(dd_point.0, 0)))
+                .with_timestamp(Some(Utc.timestamp_opt(dd_point.0, 0).single().expect("invalid timestamp")))
                 .with_tags(Some(tags.clone()))
                 .with_namespace(namespace)
             })
@@ -423,7 +423,7 @@ fn into_vector_metric(
                     MetricKind::Absolute,
                     MetricValue::Gauge { value: dd_point.1 },
                 )
-                .with_timestamp(Some(Utc.timestamp(dd_point.0, 0)))
+                .with_timestamp(Some(Utc.timestamp_opt(dd_point.0, 0).single().expect("invalid timestamp")))
                 .with_tags(Some(tags.clone()))
                 .with_namespace(namespace)
             })
@@ -442,7 +442,11 @@ fn into_vector_metric(
                         value: dd_point.1 * (i as f64),
                     },
                 )
-                .with_timestamp(Some(Utc.timestamp(dd_point.0, 0)))
+                .with_timestamp(Some(
+                    Utc.timestamp_opt(dd_point.0, 0)
+                        .single()
+                        .expect("invalid timestamp"),
+                ))
                 // dd_metric.interval is in seconds, convert to ms
                 .with_interval_ms(NonZeroU32::new(i * 1000))
                 .with_tags(Some(tags.clone()))
@@ -510,7 +514,11 @@ pub(crate) fn decode_ddsketch(
                 let (namespace, name) = namespace_name_from_dd_metric(&sketch_series.metric);
                 let mut metric = Metric::new(name.to_string(), MetricKind::Incremental, val)
                     .with_tags(Some(tags.clone()))
-                    .with_timestamp(Some(Utc.timestamp(sketch.ts, 0)))
+                    .with_timestamp(Some(
+                        Utc.timestamp_opt(sketch.ts, 0)
+                            .single()
+                            .expect("invalid timestamp"),
+                    ))
                     .with_namespace(namespace);
                 if let Some(k) = &api_key {
                     metric.metadata_mut().set_datadog_api_key(Arc::clone(k));

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -71,7 +71,10 @@ impl Arbitrary for LogMsg {
         LogMsg {
             message: Bytes::from(String::arbitrary(g)),
             status: Bytes::from(String::arbitrary(g)),
-            timestamp: Utc.timestamp_millis(u32::arbitrary(g) as i64),
+            timestamp: Utc
+                .timestamp_millis_opt(u32::arbitrary(g) as i64)
+                .single()
+                .expect("invalid timestamp"),
             hostname: Bytes::from(String::arbitrary(g)),
             service: Bytes::from(String::arbitrary(g)),
             ddsource: Bytes::from(String::arbitrary(g)),
@@ -208,7 +211,10 @@ async fn full_payload_v1() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("foo"),
-                            timestamp: Utc.timestamp(123, 0),
+                            timestamp: Utc
+                                .timestamp_opt(123, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -231,7 +237,13 @@ async fn full_payload_v1() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "foo".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -261,7 +273,10 @@ async fn full_payload_v2() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("foo"),
-                            timestamp: Utc.timestamp(123, 0),
+                            timestamp: Utc
+                                .timestamp_opt(123, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -284,7 +299,13 @@ async fn full_payload_v2() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "foo".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -314,7 +335,10 @@ async fn no_api_key() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("foo"),
-                            timestamp: Utc.timestamp(123, 0),
+                            timestamp: Utc
+                                .timestamp_opt(123, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -337,7 +361,13 @@ async fn no_api_key() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "foo".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(123, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -367,7 +397,10 @@ async fn api_key_in_url() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("bar"),
-                            timestamp: Utc.timestamp(456, 0),
+                            timestamp: Utc
+                                .timestamp_opt(456, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -390,7 +423,13 @@ async fn api_key_in_url() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "bar".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(456, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(456, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -423,7 +462,10 @@ async fn api_key_in_query_params() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("bar"),
-                            timestamp: Utc.timestamp(456, 0),
+                            timestamp: Utc
+                                .timestamp_opt(456, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -446,7 +488,13 @@ async fn api_key_in_query_params() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "bar".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(456, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(456, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -485,7 +533,10 @@ async fn api_key_in_header() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("baz"),
-                            timestamp: Utc.timestamp(789, 0),
+                            timestamp: Utc
+                                .timestamp_opt(789, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -508,7 +559,13 @@ async fn api_key_in_header() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "baz".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(789, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -541,7 +598,10 @@ async fn delivery_failure() {
                     addr,
                     &serde_json::to_string(&[LogMsg {
                         message: Bytes::from("foo"),
-                        timestamp: Utc.timestamp(123, 0),
+                        timestamp: Utc
+                            .timestamp_opt(123, 0)
+                            .single()
+                            .expect("invalid timestamp"),
                         hostname: Bytes::from("festeburg"),
                         status: Bytes::from("notice"),
                         service: Bytes::from("vector"),
@@ -574,7 +634,10 @@ async fn ignores_disabled_acknowledgements() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("foo"),
-                            timestamp: Utc.timestamp(123, 0),
+                            timestamp: Utc
+                                .timestamp_opt(123, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -617,7 +680,10 @@ async fn ignores_api_key() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("baz"),
-                            timestamp: Utc.timestamp(789, 0),
+                            timestamp: Utc
+                                .timestamp_opt(789, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -640,7 +706,13 @@ async fn ignores_api_key() {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["message"], "baz".into());
-            assert_eq!(log["timestamp"], Utc.timestamp(789, 0).into());
+            assert_eq!(
+                log["timestamp"],
+                Utc.timestamp_opt(789, 0)
+                    .single()
+                    .expect("invalid timestamp")
+                    .into()
+            );
             assert_eq!(log["hostname"], "festeburg".into());
             assert_eq!(log["status"], "notice".into());
             assert_eq!(log["service"], "vector".into());
@@ -923,7 +995,11 @@ async fn decode_sketches() {
             assert_eq!(metric.name(), "dd_sketch");
             assert_eq!(
                 metric.timestamp(),
-                Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10))
+                Some(
+                    Utc.ymd(2018, 11, 14)
+                        .and_hms_opt(8, 9, 10)
+                        .expect("invalid timestamp")
+                )
             );
             assert_eq!(metric.kind(), MetricKind::Incremental);
             assert_tags(
@@ -1229,7 +1305,10 @@ async fn split_outputs() {
                         addr,
                         &serde_json::to_string(&[LogMsg {
                             message: Bytes::from("baz"),
-                            timestamp: Utc.timestamp(789, 0),
+                            timestamp: Utc
+                                .timestamp_opt(789, 0)
+                                .single()
+                                .expect("invalid timestamp"),
                             hostname: Bytes::from("festeburg"),
                             status: Bytes::from("notice"),
                             service: Bytes::from("vector"),
@@ -1865,7 +1944,11 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.name(), "dd_gauge");
             assert_eq!(
                 metric.timestamp(),
-                Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10))
+                Some(
+                    Utc.ymd(2018, 11, 14)
+                        .and_hms_opt(8, 9, 10)
+                        .expect("invalid timestamp")
+                )
             );
             assert_eq!(metric.kind(), MetricKind::Absolute);
             assert_eq!(*metric.value(), MetricValue::Gauge { value: 3.14 });
@@ -1888,7 +1971,11 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.name(), "dd_gauge");
             assert_eq!(
                 metric.timestamp(),
-                Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 11))
+                Some(
+                    Utc.ymd(2018, 11, 14)
+                        .and_hms_opt(8, 9, 11)
+                        .expect("invalid timestamp")
+                )
             );
             assert_eq!(metric.kind(), MetricKind::Absolute);
             assert_eq!(*metric.value(), MetricValue::Gauge { value: 3.1415 });
@@ -1911,7 +1998,11 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.name(), "dd_rate");
             assert_eq!(
                 metric.timestamp(),
-                Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 10))
+                Some(
+                    Utc.ymd(2018, 11, 14)
+                        .and_hms_opt(8, 9, 10)
+                        .expect("invalid timestamp")
+                )
             );
             assert_eq!(metric.kind(), MetricKind::Incremental);
             assert_eq!(
@@ -1940,7 +2031,11 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.name(), "dd_count");
             assert_eq!(
                 metric.timestamp(),
-                Some(Utc.ymd(2018, 11, 14).and_hms(8, 9, 15))
+                Some(
+                    Utc.ymd(2018, 11, 14)
+                        .and_hms_opt(8, 9, 15)
+                        .expect("invalid timestamp")
+                )
             );
             assert_eq!(metric.kind(), MetricKind::Incremental);
             assert_eq!(

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -352,7 +352,10 @@ impl<'a> DnstapParser<'a> {
                 "ns",
             );
 
-            let timestamp = Utc.timestamp(time_sec.try_into().unwrap(), query_time_nsec);
+            let timestamp = Utc
+                .timestamp_opt(time_sec.try_into().unwrap(), query_time_nsec)
+                .single()
+                .expect("invalid timestamp");
             self.insert(
                 self.event_schema.dnstap_root_data_schema().timestamp(),
                 timestamp,

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -117,7 +117,11 @@ impl<'de> serde::de::Deserialize<'de> for FluentEventTime {
                 let nanoseconds =
                     u32::from_be_bytes(bytes[4..].try_into().expect("exactly 4 bytes"));
 
-                Ok(FluentEventTime(Utc.timestamp(seconds.into(), nanoseconds)))
+                Ok(FluentEventTime(
+                    Utc.timestamp_opt(seconds.into(), nanoseconds)
+                        .single()
+                        .expect("invalid timestamp"),
+                ))
             }
         }
 

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -657,7 +657,8 @@ impl PubsubSource {
             &message.data,
             message.publish_time.map(|dt| {
                 DateTime::from_utc(
-                    NaiveDateTime::from_timestamp(dt.seconds, dt.nanos as u32),
+                    NaiveDateTime::from_timestamp_opt(dt.seconds, dt.nanos as u32)
+                        .expect("invalid timestamp"),
                     Utc,
                 )
             }),
@@ -977,7 +978,10 @@ mod integration_tests {
     fn now_trunc() -> DateTime<Utc> {
         let start = Utc::now().timestamp();
         // Truncate the milliseconds portion, the hard way.
-        DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(start, 0), Utc)
+        DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp_opt(start, 0).expect("invalid timestamp"),
+            Utc,
+        )
     }
 
     struct Tester {

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -655,7 +655,12 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
                 .parse::<u64>()
                 .ok()
         })
-        .map(|ts| chrono::Utc.timestamp((ts / 1_000_000) as i64, (ts % 1_000_000) as u32 * 1_000));
+        .map(|ts| {
+            chrono::Utc
+                .timestamp_opt((ts / 1_000_000) as i64, (ts % 1_000_000) as u32 * 1_000)
+                .single()
+                .expect("invalid timestamp")
+        });
 
     // Add timestamp.
     match log_namespace {
@@ -1387,7 +1392,12 @@ mod tests {
     }
 
     fn value_ts(secs: i64, usecs: u32) -> Value {
-        Value::Timestamp(chrono::Utc.timestamp(secs, usecs))
+        Value::Timestamp(
+            chrono::Utc
+                .timestamp_opt(secs, usecs)
+                .single()
+                .expect("invalid timestamp"),
+        )
     }
 
     fn priority(event: &Event) -> Value {

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -769,7 +769,9 @@ mod test {
             let expected = expected.as_mut_log();
             expected.insert(
                 log_schema().timestamp_key(),
-                Utc.ymd(2019, 2, 13).and_hms(19, 48, 34),
+                Utc.ymd(2019, 2, 13)
+                    .and_hms_opt(19, 48, 34)
+                    .expect("invalid timestamp"),
             );
             expected.insert(log_schema().source_type_key(), "syslog");
             expected.insert("host", "74794bfb6795");
@@ -807,7 +809,9 @@ mod test {
             let expected = expected.as_mut_log();
             expected.insert(
                 log_schema().timestamp_key(),
-                Utc.ymd(2019, 2, 13).and_hms(19, 48, 34),
+                Utc.ymd(2019, 2, 13)
+                    .and_hms_opt(19, 48, 34)
+                    .expect("invalid timestamp"),
             );
             expected.insert(log_schema().host_key(), "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
@@ -918,7 +922,11 @@ mod test {
             let year = value.as_timestamp().unwrap().naive_local().year();
 
             let expected = expected.as_mut_log();
-            let expected_date: DateTime<Utc> = Local.ymd(year, 2, 13).and_hms(20, 7, 26).into();
+            let expected_date: DateTime<Utc> = Local
+                .ymd(year, 2, 13)
+                .and_hms_opt(20, 7, 26)
+                .expect("invalid timestamp")
+                .into();
             expected.insert(log_schema().timestamp_key(), expected_date);
             expected.insert(log_schema().host_key(), "74794bfb6795");
             expected.insert(log_schema().source_type_key(), "syslog");
@@ -947,7 +955,11 @@ mod test {
             let year = value.as_timestamp().unwrap().naive_local().year();
 
             let expected = expected.as_mut_log();
-            let expected_date: DateTime<Utc> = Local.ymd(year, 2, 13).and_hms(21, 31, 56).into();
+            let expected_date: DateTime<Utc> = Local
+                .ymd(year, 2, 13)
+                .and_hms_opt(21, 31, 56)
+                .expect("invalid timestamp")
+                .into();
             expected.insert(log_schema().timestamp_key(), expected_date);
             expected.insert(log_schema().source_type_key(), "syslog");
             expected.insert("host", "74794bfb6795");

--- a/src/template.rs
+++ b/src/template.rs
@@ -472,7 +472,10 @@ mod tests {
 
     #[test]
     fn render_log_timestamp_strftime_style() {
-        let ts = Utc.ymd(2001, 2, 3).and_hms(4, 5, 6);
+        let ts = Utc
+            .ymd(2001, 2, 3)
+            .and_hms_opt(4, 5, 6)
+            .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert(log_schema().timestamp_key(), ts);
@@ -484,7 +487,10 @@ mod tests {
 
     #[test]
     fn render_log_timestamp_multiple_strftime_style() {
-        let ts = Utc.ymd(2001, 2, 3).and_hms(4, 5, 6);
+        let ts = Utc
+            .ymd(2001, 2, 3)
+            .and_hms_opt(4, 5, 6)
+            .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert(log_schema().timestamp_key(), ts);
@@ -499,7 +505,10 @@ mod tests {
 
     #[test]
     fn render_log_dynamic_with_strftime() {
-        let ts = Utc.ymd(2001, 2, 3).and_hms(4, 5, 6);
+        let ts = Utc
+            .ymd(2001, 2, 3)
+            .and_hms_opt(4, 5, 6)
+            .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert("foo", "butts");
@@ -515,7 +524,10 @@ mod tests {
 
     #[test]
     fn render_log_dynamic_with_nested_strftime() {
-        let ts = Utc.ymd(2001, 2, 3).and_hms(4, 5, 6);
+        let ts = Utc
+            .ymd(2001, 2, 3)
+            .and_hms_opt(4, 5, 6)
+            .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert("format", "%F");
@@ -531,7 +543,10 @@ mod tests {
 
     #[test]
     fn render_log_dynamic_with_reverse_nested_strftime() {
-        let ts = Utc.ymd(2001, 2, 3).and_hms(4, 5, 6);
+        let ts = Utc
+            .ymd(2001, 2, 3)
+            .and_hms_opt(4, 5, 6)
+            .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert("\"%F\"", "foo");
@@ -607,7 +622,11 @@ mod tests {
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.1 },
         )
-        .with_timestamp(Some(Utc.ymd(2002, 3, 4).and_hms(5, 6, 7)))
+        .with_timestamp(Some(
+            Utc.ymd(2002, 3, 4)
+                .and_hms_opt(5, 6, 7)
+                .expect("invalid timestamp"),
+        ))
     }
 
     #[test]

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -425,7 +425,9 @@ mod tests {
     }
 
     fn ts() -> DateTime<Utc> {
-        Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)
+        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+            .single()
+            .expect("invalid datetime")
     }
 
     fn create_event(key: &str, value: impl Into<Value> + std::fmt::Debug) -> Event {

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -425,9 +425,9 @@ mod tests {
     }
 
     fn ts() -> DateTime<Utc> {
-        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-            .single()
-            .expect("invalid datetime")
+        Utc.ymd(2018, 11, 14)
+            .and_hms_nano_opt(8, 9, 10, 11)
+            .expect("invalid timestamp")
     }
 
     fn create_event(key: &str, value: impl Into<Value> + std::fmt::Debug) -> Event {

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -361,7 +361,9 @@ mod tests {
     }
 
     fn ts() -> DateTime<Utc> {
-        Utc.ymd(2018, 11, 14).and_hms_nano(8, 9, 10, 11)
+        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
+            .single()
+            .expect("invalid datetime")
     }
 
     fn tags() -> MetricTags {

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -361,9 +361,9 @@ mod tests {
     }
 
     fn ts() -> DateTime<Utc> {
-        Utc.with_ymd_and_hms(2018, 11, 14, 8, 9, 10)
-            .single()
-            .expect("invalid datetime")
+        Utc.ymd(2018, 11, 14)
+            .and_hms_nano_opt(8, 9, 10, 11)
+            .expect("invalid timestamp")
     }
 
     fn tags() -> MetricTags {


### PR DESCRIPTION
This is 99% mechanical changes (using comby, see patterns below) towards `_opt` versions of chrono functions in place of deprecated ones which would panic when an input (e.g. month, day, hour, etc) was out of range. The resulting `Option`, is then `expect`'d, which is the same behavior we had in the first place. There may be places where it'd be better to handle that different, but I haven't looked in depth.

We aren't actually upgrading `chrono` yet because there is one remaining issue to be addressed, but this is by far the bulk of the changes that need to be made.

One behavioral change is that there doesn't seem to be an easy way to construct a `DateTime` with the new API that includes nanoseconds. That one affects the `lua` transform, and does not seem to be major enough to warrant calling this a real breaking change (though we could, I don't feel strongly). 

Comby patterns:
```toml
[native]
match='''NaiveDateTime::from_timestamp(:[secs], :[nanos])'''
rewrite='''NaiveDateTime::from_timestamp_opt(:[secs], :[nanos]).expect("invalid timestamp")'''

[utc-ymd]
match='''Utc.ymd(:[year], :[month], :[day]).and_hms_nano(:[hour], :[min], :[sec], :[nano])'''
rewrite='''Utc.ymd(:[year], :[month], :[day]).and_hms_nano_opt(:[hour], :[min], :[sec], :[nano]).expect("invalid timestamp")'''

[utc-ts]
match='''Utc.timestamp(:[ts], :[nanos])'''
rewrite='''Utc.timestamp_opt(:[ts], :[nanos]).single().expect("invalid timestamp")'''

[naive-ymd]
match='''NaiveDate::from_ymd(:[y], :[m], :[d])'''
rewrite='''NaiveDate::from_ymd_opt(:[y], :[m], :[d]).expect("invalid date")'''

[naive-time]
match='''NaiveTime::from_hms(:[h], :[m], :[s])'''
rewrite='''NaiveTime::from_hms_opt(:[h], :[m], :[s]).expect("invalid timestamp")'''

[east]
match='''FixedOffset::east(:[exp])'''
rewrite='''FixedOffset::east_opt(:[exp]).expect("invalid timestamp")'''

[ts-milli]
match='''Utc.timestamp_millis(:[ts])'''
rewrite='''Utc.timestamp_millis_opt(:[ts]).single().expect("invalid timestamp")'''

[and-hms]
match='''.and_hms(:[h], :[m], :[s])'''
rewrite='''.and_hms_opt(:[h], :[m], :[s]).expect("invalid timestamp")'''
```