### PR TITLE
chore(config): remove need to manually mark newtype fields as `derived`/`transparent`

### DIFF
--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -322,10 +322,10 @@ impl BufferType {
 )]
 pub enum BufferConfig {
     /// A single stage buffer topology.
-    Single(#[configurable(transparent)] BufferType),
+    Single(BufferType),
 
     /// A chained buffer topology.
-    Chained(#[configurable(transparent)] Vec<BufferType>),
+    Chained(Vec<BufferType>),
 }
 
 impl Default for BufferConfig {

--- a/lib/vector-config-macros/src/ast/container.rs
+++ b/lib/vector-config-macros/src/ast/container.rs
@@ -199,9 +199,17 @@ impl<'a> Container<'a> {
                         serde_ast::Style::Struct
                         | serde_ast::Style::Tuple
                         | serde_ast::Style::Newtype => {
+                            let is_newtype_wrapper_field =
+                                matches!(style, serde_ast::Style::Newtype);
                             let fields = fields
                                 .iter()
-                                .map(|field| Field::from_ast(field, virtual_newtype.is_some()))
+                                .map(|field| {
+                                    Field::from_ast(
+                                        field,
+                                        virtual_newtype.is_some(),
+                                        is_newtype_wrapper_field,
+                                    )
+                                })
                                 .collect_darling_results(&mut accumulator);
 
                             (Data::Struct(style.into(), fields), false)

--- a/lib/vector-config-macros/src/ast/field.rs
+++ b/lib/vector-config-macros/src/ast/field.rs
@@ -1,12 +1,16 @@
-use darling::{util::Flag, FromAttributes};
+use darling::{
+    util::{Flag, SpannedValue},
+    FromAttributes,
+};
+use proc_macro2::Span;
 use serde_derive_internals::ast as serde_ast;
 use syn::{parse_quote, spanned::Spanned, ExprPath, Ident};
 use vector_config_common::validation::Validation;
 
 use super::{
     util::{
-        err_field_missing_description, find_delegated_serde_deser_ty, get_serde_default_value,
-        try_extract_doc_title_description,
+        err_field_implicit_transparent, err_field_missing_description,
+        find_delegated_serde_deser_ty, get_serde_default_value, try_extract_doc_title_description,
     },
     LazyCustomAttribute, Metadata,
 };
@@ -24,6 +28,7 @@ impl<'a> Field<'a> {
     pub fn from_ast(
         serde: &serde_ast::Field<'a>,
         is_virtual_newtype: bool,
+        is_newtype_wrapper_field: bool,
     ) -> darling::Result<Field<'a>> {
         let original = serde.original;
 
@@ -31,7 +36,14 @@ impl<'a> Field<'a> {
         let default_value = get_serde_default_value(serde.attrs.default());
 
         Attributes::from_attributes(&original.attrs)
-            .and_then(|attrs| attrs.finalize(serde, &original.attrs, is_virtual_newtype))
+            .and_then(|attrs| {
+                attrs.finalize(
+                    serde,
+                    &original.attrs,
+                    is_virtual_newtype,
+                    is_newtype_wrapper_field,
+                )
+            })
             .map(|attrs| Field {
                 original,
                 name,
@@ -230,8 +242,8 @@ impl<'a> Spanned for Field<'a> {
 struct Attributes {
     title: Option<String>,
     description: Option<String>,
-    derived: Flag,
-    transparent: Flag,
+    derived: SpannedValue<Flag>,
+    transparent: SpannedValue<Flag>,
     deprecated: Flag,
     #[darling(skip)]
     visible: bool,
@@ -251,6 +263,7 @@ impl Attributes {
         field: &serde_ast::Field<'_>,
         forwarded_attrs: &[syn::Attribute],
         is_virtual_newtype: bool,
+        is_newtype_wrapper_field: bool,
     ) -> darling::Result<Self> {
         // Derive any of the necessary fields from the `serde` side of things.
         self.visible = !field.attrs.skip_deserializing() || !field.attrs.skip_serializing();
@@ -263,6 +276,30 @@ impl Attributes {
         self.title = self.title.or(doc_title);
         self.description = self.description.or(doc_description);
 
+        // If the field is part of a newtype wrapper -- it has the be the only field, and unnamed,
+        // like `struct Foo(usize)` -- then we simply mark it as transparent.
+        //
+        // We do this because the container -- struct or enum variant -- will itself be required to
+        // have a description. We never show the description of unnamed fields, anyways, as we defer
+        // to using the description of the container. Simply marking this field as transparent will
+        // keep the schema generation happy and avoid having to constantly specify `derived` or
+        // `transparent` all over the place.
+        if is_newtype_wrapper_field {
+            // We additionally check here to see if transparent/derived as already set, as we want
+            // to throw an error if they are. As we're going to forcefully mark the field as
+            // transparent, there's no reason to allow setting derived/transparent manually, as it
+            // only leads to boilerplate and potential confusion.
+            if self.transparent.is_some() {
+                return Err(err_field_implicit_transparent(&self.transparent));
+            }
+
+            if self.derived.is_some() {
+                return Err(err_field_implicit_transparent(&self.derived));
+            }
+
+            self.transparent = SpannedValue::new(Flag::present(), Span::call_site());
+        }
+
         // If no description was provided for the field, it is typically an error. There are few situations when this is
         // fine/valid, though:
         //
@@ -271,8 +308,9 @@ impl Attributes {
         // - the field is not visible (`#[serde(skip)]`, or `skip_serializing` plus `skip_deserializing`)
         // - the field is flattened (`#[serde(flatten)]`)
         // - the field is part of a virtual newtype
+        // - the field is part of a newtype wrapper (struct/enum variant with a single unnamed field)
         //
-        // If a field is derived, it means we're taking the description/title from the `Configurable` implementation of
+        // If the field is derived, it means we're taking the description/title from the `Configurable` implementation of
         // the field type, which we can only do at runtime so we ignore it here. Similarly, if a field is transparent,
         // we're explicitly saying that our container is meant to essentially take on the schema of the field, rather
         // than the container being defined by the fields, if that makes sense. Derived and transparent fields are most
@@ -284,7 +322,7 @@ impl Attributes {
         // we're lifting up all the fields from the type of the field itself, so again, requiring a description or title
         // makes no sense.
         //
-        // Finally, if a field is part of a virtual newtype, this means the container has instructed `serde` to
+        // If the field is part of a virtual newtype, this means the container has instructed `serde` to
         // (de)serialize it as some entirely different type. This means the original field will never show up in a
         // schema, because the schema of the thing being (de)esrialized is some `T`, not `ContainerType`. Simply put,
         // like a field that is flattened or not visible, it makes no sense to require a description or title for fields

--- a/lib/vector-config-macros/src/ast/util.rs
+++ b/lib/vector-config-macros/src/ast/util.rs
@@ -3,6 +3,8 @@ use serde_derive_internals::{attr as serde_attr, Ctxt};
 use syn::{spanned::Spanned, Attribute, ExprPath, Lit, Meta, MetaNameValue, NestedMeta};
 
 const ERR_FIELD_MISSING_DESCRIPTION: &str = "field must have a description -- i.e. `/// This is a widget...` or `#[configurable(description = \"...\")] -- or derive it from the underlying type of the field by specifying `#[configurable(derived)]`";
+const ERR_FIELD_IMPLICIT_TRANSPARENT: &str =
+    "field in a newtype wrapper should not be manually marked as `derived`/`transparent`";
 
 pub fn try_extract_doc_title_description(
     attributes: &[Attribute],
@@ -142,6 +144,10 @@ pub fn get_default_exprpath() -> ExprPath {
 
 pub fn err_field_missing_description<T: Spanned>(field: &T) -> darling::Error {
     darling::Error::custom(ERR_FIELD_MISSING_DESCRIPTION).with_span(field)
+}
+
+pub fn err_field_implicit_transparent<T: Spanned>(field: &T) -> darling::Error {
+    darling::Error::custom(ERR_FIELD_IMPLICIT_TRANSPARENT).with_span(field)
 }
 
 pub fn get_serde_default_value(default: &serde_attr::Default) -> Option<ExprPath> {

--- a/lib/vector-config-macros/src/ast/variant.rs
+++ b/lib/vector-config-macros/src/ast/variant.rs
@@ -28,6 +28,7 @@ impl<'a> Variant<'a> {
         let original = serde.original;
         let name = serde.attrs.name().deserialize_name();
         let style = serde.style.into();
+        let is_newtype_wrapper_field = style == Style::Newtype;
 
         let attrs = Attributes::from_attributes(&original.attrs)
             .and_then(|attrs| attrs.finalize(serde, &original.attrs))?;
@@ -36,7 +37,7 @@ impl<'a> Variant<'a> {
         let fields = serde
             .fields
             .iter()
-            .map(|field| Field::from_ast(field, is_virtual_newtype))
+            .map(|field| Field::from_ast(field, is_virtual_newtype, is_newtype_wrapper_field))
             .collect_darling_results(&mut accumulator);
 
         let variant = Variant {

--- a/lib/vector-config/tests/integration/configurable_string.rs
+++ b/lib/vector-config/tests/integration/configurable_string.rs
@@ -6,7 +6,7 @@ use vector_config::{configurable_component, schema::generate_root_schema, Config
 /// A type that pretends to be `ConfigurableString` but has a non-string-like schema.
 #[configurable_component]
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct FakeString(#[configurable(transparent)] u64);
+pub struct FakeString(u64);
 
 impl ConfigurableString for FakeString {}
 

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -62,7 +62,7 @@ impl From<Template> for String {
 /// A period of time.
 #[derive(Clone)]
 #[configurable_component]
-pub struct SpecialDuration(#[configurable(transparent)] u64);
+pub struct SpecialDuration(u64);
 
 /// Controls the batching behavior of events.
 #[derive(Clone)]
@@ -157,11 +157,11 @@ pub struct TlsConfig {
 #[serde(untagged)]
 pub enum SocketListenAddr {
     /// A literal socket address.
-    SocketAddr(#[configurable(derived)] SocketAddr),
+    SocketAddr(SocketAddr),
 
     /// A file descriptor identifier passed by systemd.
     #[serde(deserialize_with = "parse_systemd_fd")]
-    SystemdFd(#[configurable(transparent)] usize),
+    SystemdFd(usize),
 }
 
 fn parse_systemd_fd<'de, D>(des: D) -> Result<usize, D::Error>
@@ -320,10 +320,10 @@ pub struct AdvancedSinkConfig {
 #[serde(untagged)]
 pub enum TagConfig {
     /// A single tag value.
-    Plain(#[configurable(transparent)] Option<Template>),
+    Plain(Option<Template>),
 
     /// An array of values to give to the same tag name.
-    Multi(#[configurable(transparent)] Vec<Option<Template>>),
+    Multi(Vec<Option<Template>>),
 }
 
 impl GenerateConfig for AdvancedSinkConfig {
@@ -422,7 +422,7 @@ pub struct VectorConfigV2 {
 #[serde(untagged)]
 pub enum VectorSourceConfig {
     /// Configuration for version two.
-    V2(#[configurable(derived)] VectorConfigV2),
+    V2(VectorConfigV2),
 }
 
 impl GenerateConfig for VectorSourceConfig {
@@ -445,10 +445,10 @@ impl GenerateConfig for VectorSourceConfig {
 #[serde(tag = "type")]
 pub enum SourceConfig {
     /// Simple source.
-    Simple(#[configurable(derived)] SimpleSourceConfig),
+    Simple(SimpleSourceConfig),
 
     /// Vector source.
-    Vector(#[configurable(derived)] VectorSourceConfig),
+    Vector(VectorSourceConfig),
 }
 
 /// Collection of various sinks available in Vector.
@@ -457,10 +457,10 @@ pub enum SourceConfig {
 #[serde(tag = "type")]
 pub enum SinkConfig {
     /// Simple sink.
-    Simple(#[configurable(derived)] SimpleSinkConfig),
+    Simple(SimpleSinkConfig),
 
     /// Advanced sink.
-    Advanced(#[configurable(derived)] AdvancedSinkConfig),
+    Advanced(AdvancedSinkConfig),
 }
 
 #[derive(Clone)]

--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -19,8 +19,9 @@ use vrl_lib::prelude::fmt::Formatter;
 pub enum TagValue {
     /// Bare tag value.
     Bare,
+
     /// Tag value containing a string.
-    Value(#[configurable(transparent)] String),
+    Value(String),
 }
 
 impl From<String> for TagValue {
@@ -96,15 +97,17 @@ type TagValueRef<'a> = Option<&'a str>;
 pub enum TagValueSet {
     /// This represents a set containing no value.
     Empty,
+
     /// This represents a set containing a single value. This is stored separately to avoid the
     /// overhead of allocating a hash table for the common case of a single value for a tag.
-    Single(#[configurable(transparent)] TagValue),
+    Single(TagValue),
+
     /// This holds an actual set of values. This variant will be automatically created when a single
     /// value is added to, and reduced down to a single value when the length is reduced to 1.  An
     /// index set is used for this set, as it preserves the insertion order of the contained
     /// elements. This allows us to retrieve the last element inserted which in turn allows us to
     /// emulate the set having a single value.
-    Set(#[configurable(transparent)] IndexSet<TagValue>),
+    Set(IndexSet<TagValue>),
 }
 
 impl Default for TagValueSet {
@@ -455,9 +458,7 @@ impl Serialize for TagValueSet {
 /// Tags for a metric series.
 #[configurable_component]
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct MetricTags(
-    #[configurable(transparent)] pub(in crate::event) BTreeMap<String, TagValueSet>,
-);
+pub struct MetricTags(pub(in crate::event) BTreeMap<String, TagValueSet>);
 
 impl MetricTags {
     pub fn is_empty(&self) -> bool {

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -537,7 +537,7 @@ pub enum MetricSketch {
     ///
     /// [ddsketch]: https://www.vldb.org/pvldb/vol12/p2195-masson.pdf
     /// [ddagent]: https://github.com/DataDog/datadog-agent
-    AgentDDSketch(#[configurable(derived)] AgentDDSketch),
+    AgentDDSketch(AgentDDSketch),
 }
 
 impl MetricSketch {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -105,10 +105,10 @@ pub enum ConditionConfig {
     IsTrace,
 
     /// Matches an event with a [Vector Remap Language](https://vector.dev/docs/reference/vrl) (VRL) [boolean expression](https://vector.dev/docs/reference/vrl#boolean-expressions).
-    Vrl(#[configurable(derived)] VrlConfig),
+    Vrl(VrlConfig),
 
     /// Matches an event with a [Datadog Search](https://docs.datadoghq.com/logs/explorer/search_syntax/) query.
-    DatadogSearch(#[configurable(derived)] DatadogSearchConfig),
+    DatadogSearch(DatadogSearchConfig),
 }
 
 impl ConditionConfig {
@@ -173,10 +173,10 @@ dyn_clone::clone_trait_object!(ConditionalConfig);
 #[serde(untagged)]
 pub enum AnyCondition {
     /// A [Vector Remap Language](https://vector.dev/docs/reference/vrl) (VRL) [boolean expression](https://vector.dev/docs/reference/vrl#boolean-expressions).
-    String(#[configurable(transparent)] String),
+    String(String),
 
     /// A fully-specified condition.
-    Map(#[configurable(derived)] ConditionConfig),
+    Map(ConditionConfig),
 }
 
 impl AnyCondition {

--- a/src/config/id.rs
+++ b/src/config/id.rs
@@ -18,7 +18,7 @@ pub use vector_core::config::ComponentKey;
     docs::examples = "prefix-*"
 ))]
 #[derive(Clone, Debug)]
-pub struct Inputs<T>(#[configurable(transparent)] Vec<T>);
+pub struct Inputs<T>(Vec<T>);
 
 impl<T> Inputs<T> {
     /// Returns `true` if no inputs are present.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -475,16 +475,16 @@ impl TestDefinition<OutputId> {
 #[serde(untagged)]
 pub enum TestInputValue {
     /// A string.
-    String(#[configurable(transparent)] String),
+    String(String),
 
     /// An integer.
-    Integer(#[configurable(transparent)] i64),
+    Integer(i64),
 
     /// A floating-point number.
-    Float(#[configurable(transparent)] f64),
+    Float(f64),
 
     /// A boolean.
-    Boolean(#[configurable(transparent)] bool),
+    Boolean(bool),
 }
 
 /// A unit test input.

--- a/src/enrichment_tables/mod.rs
+++ b/src/enrichment_tables/mod.rs
@@ -16,11 +16,11 @@ pub mod geoip;
 #[enum_dispatch(EnrichmentTableConfig)]
 pub enum EnrichmentTables {
     /// File.
-    File(#[configurable(derived)] file::FileConfig),
+    File(file::FileConfig),
 
     /// GeoIP.
     #[cfg(feature = "enrichment-tables-geoip")]
-    Geoip(#[configurable(derived)] geoip::GeoipConfig),
+    Geoip(geoip::GeoipConfig),
 }
 
 // We can't use `enum_dispatch` here because it doesn't support associated constants.

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -17,7 +17,7 @@ pub type BuildResult = std::result::Result<ConfigBuilder, Vec<String>>;
 #[enum_dispatch(ProviderConfig)]
 pub enum Providers {
     /// HTTP.
-    Http(#[configurable(derived)] http::HttpConfig),
+    Http(http::HttpConfig),
 }
 
 // We can't use `enum_dispatch` here because it doesn't support associated constants.

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -15,11 +15,11 @@ mod test;
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SecretBackends {
     /// Exec.
-    Exec(#[configurable(derived)] exec::ExecBackend),
+    Exec(exec::ExecBackend),
 
     /// Test.
     #[configurable(metadata(docs::hidden))]
-    Test(#[configurable(derived)] test::TestBackend),
+    Test(test::TestBackend),
 }
 
 // We can't use `enum_dispatch` here because it doesn't support associated constants.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -101,8 +101,8 @@ impl<V: 'static> Fields<V> {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[serde(untagged)]
 pub enum OneOrMany<T> {
-    One(#[configurable(transparent)] T),
-    Many(#[configurable(transparent)] Vec<T>),
+    One(T),
+    Many(Vec<T>),
 }
 
 impl<T> OneOrMany<T> {

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -47,7 +47,7 @@ pub enum ElasticsearchAuth {
     },
 
     /// Amazon OpenSearch Service-specific authentication.
-    Aws(#[configurable(derived)] AwsAuthentication),
+    Aws(AwsAuthentication),
 }
 
 /// Indexing mode.

--- a/src/sinks/gcp/stackdriver_logs.rs
+++ b/src/sinks/gcp/stackdriver_logs.rs
@@ -119,7 +119,7 @@ const MAX_BATCH_PAYLOAD_SIZE: usize = 10_000_000;
 pub enum StackdriverLogName {
     /// The billing account ID to which to publish logs.
     #[serde(rename = "billing_account_id")]
-    BillingAccount(#[configurable(transparent)] String),
+    BillingAccount(String),
 
     /// The folder ID to which to publish logs.
     ///
@@ -127,13 +127,13 @@ pub enum StackdriverLogName {
     ///
     /// [folder_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-folders
     #[serde(rename = "folder_id")]
-    Folder(#[configurable(transparent)] String),
+    Folder(String),
 
     /// The organization ID to which to publish logs.
     ///
     /// This would be the identifier assigned to your organization on Google Cloud Platform.
     #[serde(rename = "organization_id")]
-    Organization(#[configurable(transparent)] String),
+    Organization(String),
 
     /// The project ID to which to publish logs.
     ///
@@ -142,7 +142,7 @@ pub enum StackdriverLogName {
     /// [project_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
     #[derivative(Default)]
     #[serde(rename = "project_id")]
-    Project(#[configurable(transparent)] String),
+    Project(String),
 }
 
 /// A monitored resource.

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -33,10 +33,10 @@ pub enum ExtendedCompression {
 #[serde(untagged)]
 pub enum CompressionConfigAdapter {
     /// Basic compression.
-    Original(#[configurable(derived)] Compression),
+    Original(Compression),
 
     /// Loki-specific compression.
-    Extended(#[configurable(derived)] ExtendedCompression),
+    Extended(ExtendedCompression),
 }
 
 impl CompressionConfigAdapter {

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -135,238 +135,233 @@ pub enum HealthcheckError {
 pub enum Sinks {
     /// AMQP.
     #[cfg(feature = "sinks-amqp")]
-    Amqp(#[configurable(derived)] amqp::AmqpSinkConfig),
+    Amqp(amqp::AmqpSinkConfig),
 
     /// Apex Logs.
     #[cfg(feature = "sinks-apex")]
-    Apex(#[configurable(derived)] apex::ApexSinkConfig),
+    Apex(apex::ApexSinkConfig),
 
     /// AWS CloudWatch Logs.
     #[cfg(feature = "sinks-aws_cloudwatch_logs")]
-    AwsCloudwatchLogs(#[configurable(derived)] aws_cloudwatch_logs::CloudwatchLogsSinkConfig),
+    AwsCloudwatchLogs(aws_cloudwatch_logs::CloudwatchLogsSinkConfig),
 
     /// AWS CloudWatch Metrics.
     #[cfg(feature = "sinks-aws_cloudwatch_metrics")]
-    AwsCloudwatchMetrics(
-        #[configurable(derived)] aws_cloudwatch_metrics::CloudWatchMetricsSinkConfig,
-    ),
+    AwsCloudwatchMetrics(aws_cloudwatch_metrics::CloudWatchMetricsSinkConfig),
 
     /// AWS Kinesis Firehose.
     #[cfg(feature = "sinks-aws_kinesis_firehose")]
-    AwsKinesisFirehose(#[configurable(derived)] aws_kinesis::firehose::KinesisFirehoseSinkConfig),
+    AwsKinesisFirehose(aws_kinesis::firehose::KinesisFirehoseSinkConfig),
+
     /// AWS Kinesis Streams.
     #[cfg(feature = "sinks-aws_kinesis_streams")]
-    AwsKinesisStreams(#[configurable(derived)] aws_kinesis::streams::KinesisStreamsSinkConfig),
+    AwsKinesisStreams(aws_kinesis::streams::KinesisStreamsSinkConfig),
 
     /// AWS S3.
     #[cfg(feature = "sinks-aws_s3")]
-    AwsS3(#[configurable(derived)] aws_s3::S3SinkConfig),
+    AwsS3(aws_s3::S3SinkConfig),
 
     /// AWS SQS.
     #[cfg(feature = "sinks-aws_sqs")]
-    AwsSqs(#[configurable(derived)] aws_sqs::SqsSinkConfig),
+    AwsSqs(aws_sqs::SqsSinkConfig),
 
     /// Axiom.
     #[cfg(feature = "sinks-axiom")]
-    Axiom(#[configurable(derived)] axiom::AxiomConfig),
+    Axiom(axiom::AxiomConfig),
 
     /// Azure Blob Storage.
     #[cfg(feature = "sinks-azure_blob")]
-    AzureBlob(#[configurable(derived)] azure_blob::AzureBlobSinkConfig),
+    AzureBlob(azure_blob::AzureBlobSinkConfig),
 
     /// Azure Monitor Logs.
     #[cfg(feature = "sinks-azure_monitor_logs")]
-    AzureMonitorLogs(#[configurable(derived)] azure_monitor_logs::AzureMonitorLogsConfig),
+    AzureMonitorLogs(azure_monitor_logs::AzureMonitorLogsConfig),
 
     /// Blackhole.
     #[cfg(feature = "sinks-blackhole")]
-    Blackhole(#[configurable(derived)] blackhole::BlackholeConfig),
+    Blackhole(blackhole::BlackholeConfig),
 
     /// Clickhouse.
     #[cfg(feature = "sinks-clickhouse")]
-    Clickhouse(#[configurable(derived)] clickhouse::ClickhouseConfig),
+    Clickhouse(clickhouse::ClickhouseConfig),
 
     /// Console.
     #[cfg(feature = "sinks-console")]
-    Console(#[configurable(derived)] console::ConsoleSinkConfig),
+    Console(console::ConsoleSinkConfig),
 
     /// Datadog Archives.
     #[cfg(feature = "sinks-datadog_archives")]
-    DatadogArchives(#[configurable(derived)] datadog_archives::DatadogArchivesSinkConfig),
+    DatadogArchives(datadog_archives::DatadogArchivesSinkConfig),
 
     /// Datadog Events.
     #[cfg(feature = "sinks-datadog_events")]
-    DatadogEvents(#[configurable(derived)] datadog::events::DatadogEventsConfig),
+    DatadogEvents(datadog::events::DatadogEventsConfig),
 
     /// Datadog Logs.
     #[cfg(feature = "sinks-datadog_logs")]
-    DatadogLogs(#[configurable(derived)] datadog::logs::DatadogLogsConfig),
+    DatadogLogs(datadog::logs::DatadogLogsConfig),
 
     /// Datadog Metrics.
     #[cfg(feature = "sinks-datadog_metrics")]
-    DatadogMetrics(#[configurable(derived)] datadog::metrics::DatadogMetricsConfig),
+    DatadogMetrics(datadog::metrics::DatadogMetricsConfig),
 
     /// Datadog Traces.
     #[cfg(feature = "sinks-datadog_traces")]
-    DatadogTraces(#[configurable(derived)] datadog::traces::DatadogTracesConfig),
+    DatadogTraces(datadog::traces::DatadogTracesConfig),
 
     /// Elasticsearch.
     #[cfg(feature = "sinks-elasticsearch")]
-    Elasticsearch(#[configurable(derived)] elasticsearch::ElasticsearchConfig),
+    Elasticsearch(elasticsearch::ElasticsearchConfig),
 
     /// File.
     #[cfg(feature = "sinks-file")]
-    File(#[configurable(derived)] file::FileSinkConfig),
+    File(file::FileSinkConfig),
 
     /// Google Chronicle (unstructured).
     #[cfg(feature = "sinks-gcp")]
-    GcpChronicleUnstructured(
-        #[configurable(derived)] gcp::chronicle_unstructured::ChronicleUnstructuredConfig,
-    ),
+    GcpChronicleUnstructured(gcp::chronicle_unstructured::ChronicleUnstructuredConfig),
 
     /// GCP Stackdriver Logs.
     #[cfg(feature = "sinks-gcp")]
-    GcpStackdriverLogs(#[configurable(derived)] gcp::stackdriver_logs::StackdriverConfig),
+    GcpStackdriverLogs(gcp::stackdriver_logs::StackdriverConfig),
 
     /// GCP Stackdriver Metrics.
     #[cfg(feature = "sinks-gcp")]
-    GcpStackdriverMetrics(#[configurable(derived)] gcp::stackdriver_metrics::StackdriverConfig),
+    GcpStackdriverMetrics(gcp::stackdriver_metrics::StackdriverConfig),
 
     /// GCP Cloud Storage.
     #[cfg(feature = "sinks-gcp")]
-    GcpCloudStorage(#[configurable(derived)] gcp::cloud_storage::GcsSinkConfig),
+    GcpCloudStorage(gcp::cloud_storage::GcsSinkConfig),
 
     /// GCP Pub/Sub.
     #[cfg(feature = "sinks-gcp")]
-    GcpPubsub(#[configurable(derived)] gcp::pubsub::PubsubConfig),
+    GcpPubsub(gcp::pubsub::PubsubConfig),
 
     /// Honeycomb.
     #[cfg(feature = "sinks-honeycomb")]
-    Honeycomb(#[configurable(derived)] honeycomb::HoneycombConfig),
+    Honeycomb(honeycomb::HoneycombConfig),
 
     /// HTTP.
     #[cfg(feature = "sinks-http")]
-    Http(#[configurable(derived)] http::HttpSinkConfig),
+    Http(http::HttpSinkConfig),
 
     /// Humio Logs.
     #[cfg(feature = "sinks-humio")]
-    HumioLogs(#[configurable(derived)] humio::logs::HumioLogsConfig),
+    HumioLogs(humio::logs::HumioLogsConfig),
 
     /// Humio Metrics.
     #[cfg(feature = "sinks-humio")]
-    HumioMetrics(#[configurable(derived)] humio::metrics::HumioMetricsConfig),
+    HumioMetrics(humio::metrics::HumioMetricsConfig),
 
     /// InfluxDB Logs.
     #[cfg(any(feature = "sinks-influxdb", feature = "prometheus-integration-tests"))]
-    InfluxdbLogs(#[configurable(derived)] influxdb::logs::InfluxDbLogsConfig),
+    InfluxdbLogs(influxdb::logs::InfluxDbLogsConfig),
 
     /// InfluxDB Metrics.
     #[cfg(any(feature = "sinks-influxdb", feature = "prometheus-integration-tests"))]
-    InfluxdbMetrics(#[configurable(derived)] influxdb::metrics::InfluxDbConfig),
+    InfluxdbMetrics(influxdb::metrics::InfluxDbConfig),
 
     /// Kafka.
     #[cfg(feature = "sinks-kafka")]
-    Kafka(#[configurable(derived)] kafka::KafkaSinkConfig),
+    Kafka(kafka::KafkaSinkConfig),
 
     /// LogDNA.
     #[cfg(feature = "sinks-logdna")]
-    Logdna(#[configurable(derived)] logdna::LogdnaConfig),
+    Logdna(logdna::LogdnaConfig),
 
     /// Loki.
     #[cfg(feature = "sinks-loki")]
-    Loki(#[configurable(derived)] loki::LokiConfig),
+    Loki(loki::LokiConfig),
 
     /// NATS.
     #[cfg(feature = "sinks-nats")]
-    Nats(#[configurable(derived)] self::nats::NatsSinkConfig),
+    Nats(self::nats::NatsSinkConfig),
 
     /// New Relic.
     #[cfg(feature = "sinks-new_relic")]
-    NewRelic(#[configurable(derived)] new_relic::NewRelicConfig),
+    NewRelic(new_relic::NewRelicConfig),
 
     /// Papertrail.
     #[cfg(feature = "sinks-papertrail")]
-    Papertrail(#[configurable(derived)] papertrail::PapertrailConfig),
+    Papertrail(papertrail::PapertrailConfig),
 
     /// Prometheus Exporter.
     #[cfg(feature = "sinks-prometheus")]
-    PrometheusExporter(#[configurable(derived)] prometheus::exporter::PrometheusExporterConfig),
+    PrometheusExporter(prometheus::exporter::PrometheusExporterConfig),
 
     /// Prometheus Remote Write.
     #[cfg(feature = "sinks-prometheus")]
-    PrometheusRemoteWrite(#[configurable(derived)] prometheus::remote_write::RemoteWriteConfig),
+    PrometheusRemoteWrite(prometheus::remote_write::RemoteWriteConfig),
 
     /// Apache Pulsar.
     #[cfg(feature = "sinks-pulsar")]
-    Pulsar(#[configurable(derived)] pulsar::PulsarSinkConfig),
+    Pulsar(pulsar::PulsarSinkConfig),
 
     /// Redis.
     #[cfg(feature = "sinks-redis")]
-    Redis(#[configurable(derived)] redis::RedisSinkConfig),
+    Redis(redis::RedisSinkConfig),
 
     /// Sematext Logs.
     #[cfg(feature = "sinks-sematext")]
-    SematextLogs(#[configurable(derived)] sematext::logs::SematextLogsConfig),
+    SematextLogs(sematext::logs::SematextLogsConfig),
 
     /// Sematext Metrics.
     #[cfg(feature = "sinks-sematext")]
-    SematextMetrics(#[configurable(derived)] sematext::metrics::SematextMetricsConfig),
+    SematextMetrics(sematext::metrics::SematextMetricsConfig),
 
     /// Socket.
     #[cfg(feature = "sinks-socket")]
-    Socket(#[configurable(derived)] socket::SocketSinkConfig),
+    Socket(socket::SocketSinkConfig),
 
     /// Splunk HEC Logs.
     #[cfg(feature = "sinks-splunk_hec")]
-    SplunkHecLogs(#[configurable(derived)] splunk_hec::logs::config::HecLogsSinkConfig),
+    SplunkHecLogs(splunk_hec::logs::config::HecLogsSinkConfig),
 
     /// Splunk HEC Metrics.
     #[cfg(feature = "sinks-splunk_hec")]
-    SplunkHecMetrics(#[configurable(derived)] splunk_hec::metrics::config::HecMetricsSinkConfig),
+    SplunkHecMetrics(splunk_hec::metrics::config::HecMetricsSinkConfig),
 
     /// StatsD.
     #[cfg(feature = "sinks-statsd")]
-    Statsd(#[configurable(derived)] statsd::StatsdSinkConfig),
+    Statsd(statsd::StatsdSinkConfig),
 
     /// Test (adaptive concurrency).
     #[cfg(all(test, feature = "sources-demo_logs"))]
-    TestArc(#[configurable(derived)] self::util::adaptive_concurrency::tests::TestConfig),
+    TestArc(self::util::adaptive_concurrency::tests::TestConfig),
 
     /// Test (backpressure).
     #[cfg(test)]
-    TestBackpressure(
-        #[configurable(derived)] crate::test_util::mock::sinks::BackpressureSinkConfig,
-    ),
+    TestBackpressure(crate::test_util::mock::sinks::BackpressureSinkConfig),
 
     /// Test (basic).
     #[cfg(test)]
-    TestBasic(#[configurable(derived)] crate::test_util::mock::sinks::BasicSinkConfig),
+    TestBasic(crate::test_util::mock::sinks::BasicSinkConfig),
 
     /// Test (error).
     #[cfg(test)]
-    TestError(#[configurable(derived)] crate::test_util::mock::sinks::ErrorSinkConfig),
+    TestError(crate::test_util::mock::sinks::ErrorSinkConfig),
 
     /// Test (oneshot).
     #[cfg(test)]
-    TestOneshot(#[configurable(derived)] crate::test_util::mock::sinks::OneshotSinkConfig),
+    TestOneshot(crate::test_util::mock::sinks::OneshotSinkConfig),
 
     /// Test (panic).
     #[cfg(test)]
-    TestPanic(#[configurable(derived)] crate::test_util::mock::sinks::PanicSinkConfig),
+    TestPanic(crate::test_util::mock::sinks::PanicSinkConfig),
 
     /// Unit test.
-    UnitTest(#[configurable(derived)] UnitTestSinkConfig),
+    UnitTest(UnitTestSinkConfig),
 
     /// Unit test stream.
-    UnitTestStream(#[configurable(derived)] UnitTestStreamSinkConfig),
+    UnitTestStream(UnitTestStreamSinkConfig),
 
     /// Vector.
     #[cfg(feature = "sinks-vector")]
-    Vector(#[configurable(derived)] vector::VectorConfig),
+    Vector(vector::VectorConfig),
 
     /// Websocket.
     #[cfg(feature = "sinks-websocket")]
-    Websocket(#[configurable(derived)] websocket::WebSocketSinkConfig),
+    Websocket(websocket::WebSocketSinkConfig),
 }
 
 impl NamedComponent for Sinks {

--- a/src/sinks/prometheus/mod.rs
+++ b/src/sinks/prometheus/mod.rs
@@ -34,7 +34,7 @@ pub enum PrometheusRemoteWriteAuth {
     },
 
     /// Amazon Prometheus Service-specific authentication.
-    Aws(#[configurable(derived)] AwsAuthentication),
+    Aws(AwsAuthentication),
 }
 
 fn default_histogram_buckets() -> Vec<f64> {

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -35,14 +35,14 @@ pub struct SocketSinkConfig {
 #[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum Mode {
     /// Send over TCP.
-    Tcp(#[configurable(transparent)] TcpMode),
+    Tcp(TcpMode),
 
     /// Send over UDP.
-    Udp(#[configurable(transparent)] UdpMode),
+    Udp(UdpMode),
 
     /// Send over a Unix domain socket (UDS).
     #[cfg(unix)]
-    Unix(#[configurable(transparent)] UnixMode),
+    Unix(UnixMode),
 }
 
 /// TCP configuration.

--- a/src/sinks/statsd.rs
+++ b/src/sinks/statsd.rs
@@ -65,14 +65,14 @@ pub struct StatsdSinkConfig {
 #[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum Mode {
     /// Send over TCP.
-    Tcp(#[configurable(transparent)] TcpSinkConfig),
+    Tcp(TcpSinkConfig),
 
     /// Send over UDP.
-    Udp(#[configurable(transparent)] StatsdUdpConfig),
+    Udp(StatsdUdpConfig),
 
     /// Send over a Unix domain socket (UDS).
     #[cfg(unix)]
-    Unix(#[configurable(transparent)] UnixSinkConfig),
+    Unix(UnixSinkConfig),
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -39,7 +39,7 @@ use crate::{
 #[configurable_component(source("http"))]
 #[configurable(metadata(deprecated))]
 #[derive(Clone, Debug)]
-pub struct HttpConfig(#[configurable(derived)] SimpleHttpConfig);
+pub struct HttpConfig(SimpleHttpConfig);
 
 impl GenerateConfig for HttpConfig {
     fn generate_config() -> toml::Value {

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -108,197 +108,193 @@ enum BuildError {
 pub enum Sources {
     /// AMQP.
     #[cfg(feature = "sources-amqp")]
-    Amqp(#[configurable(derived)] amqp::AmqpSourceConfig),
+    Amqp(amqp::AmqpSourceConfig),
 
     /// Apache HTTP Server (HTTPD) Metrics.
     #[cfg(feature = "sources-apache_metrics")]
-    ApacheMetrics(#[configurable(derived)] apache_metrics::ApacheMetricsConfig),
+    ApacheMetrics(apache_metrics::ApacheMetricsConfig),
 
     /// AWS ECS Metrics.
     #[cfg(feature = "sources-aws_ecs_metrics")]
-    AwsEcsMetrics(#[configurable(derived)] aws_ecs_metrics::AwsEcsMetricsSourceConfig),
+    AwsEcsMetrics(aws_ecs_metrics::AwsEcsMetricsSourceConfig),
 
     /// AWS Kinesis Firehose.
     #[cfg(feature = "sources-aws_kinesis_firehose")]
-    AwsKinesisFirehose(#[configurable(derived)] aws_kinesis_firehose::AwsKinesisFirehoseConfig),
+    AwsKinesisFirehose(aws_kinesis_firehose::AwsKinesisFirehoseConfig),
 
     /// AWS S3.
     #[cfg(feature = "sources-aws_s3")]
-    AwsS3(#[configurable(derived)] aws_s3::AwsS3Config),
+    AwsS3(aws_s3::AwsS3Config),
 
     /// AWS SQS.
     #[cfg(feature = "sources-aws_sqs")]
-    AwsSqs(#[configurable(derived)] aws_sqs::AwsSqsConfig),
+    AwsSqs(aws_sqs::AwsSqsConfig),
 
     /// Datadog Agent.
     #[cfg(feature = "sources-datadog_agent")]
-    DatadogAgent(#[configurable(derived)] datadog_agent::DatadogAgentConfig),
+    DatadogAgent(datadog_agent::DatadogAgentConfig),
 
     /// Demo logs.
     #[cfg(feature = "sources-demo_logs")]
-    DemoLogs(#[configurable(derived)] demo_logs::DemoLogsConfig),
+    DemoLogs(demo_logs::DemoLogsConfig),
 
     /// DNSTAP.
     #[cfg(all(unix, feature = "sources-dnstap"))]
-    Dnstap(#[configurable(derived)] dnstap::DnstapConfig),
+    Dnstap(dnstap::DnstapConfig),
 
     /// Docker Logs.
     #[cfg(feature = "sources-docker_logs")]
-    DockerLogs(#[configurable(derived)] docker_logs::DockerLogsConfig),
+    DockerLogs(docker_logs::DockerLogsConfig),
 
     /// EventStoreDB Metrics.
     #[cfg(feature = "sources-eventstoredb_metrics")]
-    EventstoredbMetrics(#[configurable(derived)] eventstoredb_metrics::EventStoreDbConfig),
+    EventstoredbMetrics(eventstoredb_metrics::EventStoreDbConfig),
 
     /// Exec.
     #[cfg(feature = "sources-exec")]
-    Exec(#[configurable(derived)] exec::ExecConfig),
+    Exec(exec::ExecConfig),
 
     /// File.
     #[cfg(feature = "sources-file")]
-    File(#[configurable(derived)] file::FileConfig),
+    File(file::FileConfig),
 
     /// File descriptor.
     #[cfg(all(unix, feature = "sources-file-descriptor"))]
-    FileDescriptor(
-        #[configurable(derived)] file_descriptors::file_descriptor::FileDescriptorSourceConfig,
-    ),
+    FileDescriptor(file_descriptors::file_descriptor::FileDescriptorSourceConfig),
 
     /// Fluent.
     #[cfg(feature = "sources-fluent")]
-    Fluent(#[configurable(derived)] fluent::FluentConfig),
+    Fluent(fluent::FluentConfig),
 
     /// GCP Pub/Sub.
     #[cfg(feature = "sources-gcp_pubsub")]
-    GcpPubsub(#[configurable(derived)] gcp_pubsub::PubsubConfig),
+    GcpPubsub(gcp_pubsub::PubsubConfig),
 
     /// Heroku Logs.
     #[cfg(feature = "sources-heroku_logs")]
-    HerokuLogs(#[configurable(derived)] heroku_logs::LogplexConfig),
+    HerokuLogs(heroku_logs::LogplexConfig),
 
     /// Host Metrics.
     #[cfg(feature = "sources-host_metrics")]
-    HostMetrics(#[configurable(derived)] host_metrics::HostMetricsConfig),
+    HostMetrics(host_metrics::HostMetricsConfig),
 
     /// HTTP.
     #[cfg(feature = "sources-http_server")]
-    Http(#[configurable(derived)] http_server::HttpConfig),
+    Http(http_server::HttpConfig),
 
     /// HTTP Client.
     #[cfg(feature = "sources-http_client")]
-    HttpClient(#[configurable(derived)] http_client::HttpClientConfig),
+    HttpClient(http_client::HttpClientConfig),
 
     /// HTTP Server.
     #[cfg(feature = "sources-http_server")]
-    HttpServer(#[configurable(derived)] http_server::SimpleHttpConfig),
+    HttpServer(http_server::SimpleHttpConfig),
 
     /// Internal Logs.
     #[cfg(feature = "sources-internal_logs")]
-    InternalLogs(#[configurable(derived)] internal_logs::InternalLogsConfig),
+    InternalLogs(internal_logs::InternalLogsConfig),
 
     /// Internal Metrics.
     #[cfg(feature = "sources-internal_metrics")]
-    InternalMetrics(#[configurable(derived)] internal_metrics::InternalMetricsConfig),
+    InternalMetrics(internal_metrics::InternalMetricsConfig),
 
     /// Journald.
     #[cfg(all(unix, feature = "sources-journald"))]
-    Journald(#[configurable(derived)] journald::JournaldConfig),
+    Journald(journald::JournaldConfig),
 
     /// Kafka.
     #[cfg(feature = "sources-kafka")]
-    Kafka(#[configurable(derived)] kafka::KafkaSourceConfig),
+    Kafka(kafka::KafkaSourceConfig),
 
     /// Kubernetes Logs.
     #[cfg(feature = "sources-kubernetes_logs")]
-    KubernetesLogs(#[configurable(derived)] kubernetes_logs::Config),
+    KubernetesLogs(kubernetes_logs::Config),
 
     /// Logstash.
     #[cfg(all(feature = "sources-logstash"))]
-    Logstash(#[configurable(derived)] logstash::LogstashConfig),
+    Logstash(logstash::LogstashConfig),
 
     /// MongoDB Metrics.
     #[cfg(feature = "sources-mongodb_metrics")]
-    MongodbMetrics(#[configurable(derived)] mongodb_metrics::MongoDbMetricsConfig),
+    MongodbMetrics(mongodb_metrics::MongoDbMetricsConfig),
 
     /// NATS.
     #[cfg(all(feature = "sources-nats"))]
-    Nats(#[configurable(derived)] nats::NatsSourceConfig),
+    Nats(nats::NatsSourceConfig),
 
     /// NGINX Metrics.
     #[cfg(feature = "sources-nginx_metrics")]
-    NginxMetrics(#[configurable(derived)] nginx_metrics::NginxMetricsConfig),
+    NginxMetrics(nginx_metrics::NginxMetricsConfig),
 
     /// OpenTelemetry.
     #[cfg(feature = "sources-opentelemetry")]
-    Opentelemetry(#[configurable(derived)] opentelemetry::OpentelemetryConfig),
+    Opentelemetry(opentelemetry::OpentelemetryConfig),
 
     /// PostgreSQL Metrics.
     #[cfg(feature = "sources-postgresql_metrics")]
-    PostgresqlMetrics(#[configurable(derived)] postgresql_metrics::PostgresqlMetricsConfig),
+    PostgresqlMetrics(postgresql_metrics::PostgresqlMetricsConfig),
 
     /// Prometheus Scrape.
     #[cfg(feature = "sources-prometheus")]
-    PrometheusScrape(#[configurable(derived)] prometheus::PrometheusScrapeConfig),
+    PrometheusScrape(prometheus::PrometheusScrapeConfig),
 
     /// Prometheus Remote Write.
     #[cfg(feature = "sources-prometheus")]
-    PrometheusRemoteWrite(#[configurable(derived)] prometheus::PrometheusRemoteWriteConfig),
+    PrometheusRemoteWrite(prometheus::PrometheusRemoteWriteConfig),
 
     /// Redis.
     #[cfg(feature = "sources-redis")]
-    Redis(#[configurable(derived)] redis::RedisSourceConfig),
+    Redis(redis::RedisSourceConfig),
 
     /// Test (backpressure).
     #[cfg(test)]
-    TestBackpressure(
-        #[configurable(derived)] crate::test_util::mock::sources::BackpressureSourceConfig,
-    ),
+    TestBackpressure(crate::test_util::mock::sources::BackpressureSourceConfig),
 
     /// Test (basic).
     #[cfg(test)]
-    TestBasic(#[configurable(derived)] crate::test_util::mock::sources::BasicSourceConfig),
+    TestBasic(crate::test_util::mock::sources::BasicSourceConfig),
 
     /// Test (error).
     #[cfg(test)]
-    TestError(#[configurable(derived)] crate::test_util::mock::sources::ErrorSourceConfig),
+    TestError(crate::test_util::mock::sources::ErrorSourceConfig),
 
     /// Test (panic).
     #[cfg(test)]
-    TestPanic(#[configurable(derived)] crate::test_util::mock::sources::PanicSourceConfig),
+    TestPanic(crate::test_util::mock::sources::PanicSourceConfig),
 
     /// Test (tripwire).
     #[cfg(test)]
-    TestTripwire(#[configurable(derived)] crate::test_util::mock::sources::TripwireSourceConfig),
+    TestTripwire(crate::test_util::mock::sources::TripwireSourceConfig),
 
     /// Socket.
     #[cfg(feature = "sources-socket")]
-    Socket(#[configurable(derived)] socket::SocketConfig),
+    Socket(socket::SocketConfig),
 
     /// Splunk HEC.
     #[cfg(feature = "sources-splunk_hec")]
-    SplunkHec(#[configurable(derived)] splunk_hec::SplunkConfig),
+    SplunkHec(splunk_hec::SplunkConfig),
 
     /// Statsd.
     #[cfg(feature = "sources-statsd")]
-    Statsd(#[configurable(derived)] statsd::StatsdConfig),
+    Statsd(statsd::StatsdConfig),
 
     /// Stdin.
     #[cfg(feature = "sources-stdin")]
-    Stdin(#[configurable(derived)] file_descriptors::stdin::StdinConfig),
+    Stdin(file_descriptors::stdin::StdinConfig),
 
     /// Syslog.
     #[cfg(feature = "sources-syslog")]
-    Syslog(#[configurable(derived)] syslog::SyslogConfig),
+    Syslog(syslog::SyslogConfig),
 
     /// Unit test.
-    UnitTest(#[configurable(derived)] UnitTestSourceConfig),
+    UnitTest(UnitTestSourceConfig),
 
     /// Unit test stream.
-    UnitTestStream(#[configurable(derived)] UnitTestStreamSourceConfig),
+    UnitTestStream(UnitTestStreamSourceConfig),
 
     /// Vector.
     #[cfg(feature = "sources-vector")]
-    Vector(#[configurable(derived)] vector::VectorConfig),
+    Vector(vector::VectorConfig),
 }
 
 // We can't use `enum_dispatch` here because it doesn't support associated constants.

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -34,19 +34,19 @@ pub struct SocketConfig {
 #[allow(clippy::large_enum_variant)] // just used for configuration
 pub enum Mode {
     /// Listen on TCP.
-    Tcp(#[configurable(derived)] tcp::TcpConfig),
+    Tcp(tcp::TcpConfig),
 
     /// Listen on UDP.
-    Udp(#[configurable(derived)] udp::UdpConfig),
+    Udp(udp::UdpConfig),
 
     /// Listen on a Unix domain socket (UDS), in datagram mode.
     #[cfg(unix)]
-    UnixDatagram(#[configurable(derived)] unix::UnixConfig),
+    UnixDatagram(unix::UnixConfig),
 
     /// Listen on a Unix domain socket (UDS), in stream mode.
     #[cfg(unix)]
     #[serde(alias = "unix")]
-    UnixStream(#[configurable(derived)] unix::UnixConfig),
+    UnixStream(unix::UnixConfig),
 }
 
 impl SocketConfig {

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -45,14 +45,14 @@ use vector_core::config::LogNamespace;
 #[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
 pub enum StatsdConfig {
     /// Listen on TCP.
-    Tcp(#[configurable(derived)] TcpConfig),
+    Tcp(TcpConfig),
 
     /// Listen on UDP.
-    Udp(#[configurable(derived)] UdpConfig),
+    Udp(UdpConfig),
 
     /// Listen on UDS. (Unix domain socket)
     #[cfg(unix)]
-    Unix(#[configurable(derived)] UnixConfig),
+    Unix(UnixConfig),
 }
 
 /// UDP configuration for the `statsd` source.

--- a/src/sources/util/net/mod.rs
+++ b/src/sources/util/net/mod.rs
@@ -21,11 +21,11 @@ pub use self::udp::try_bind_udp_socket;
 #[serde(untagged)]
 pub enum SocketListenAddr {
     /// An IPv4/IPv6 address and port.
-    SocketAddr(#[configurable(derived)] SocketAddr),
+    SocketAddr(SocketAddr),
 
     /// A file descriptor identifier that is given from, and managed by, the socket activation feature of `systemd`.
     #[serde(deserialize_with = "parse_systemd_fd")]
-    SystemdFd(#[configurable(transparent)] usize),
+    SystemdFd(usize),
 }
 
 impl SocketListenAddr {

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -42,7 +42,6 @@ pub enum FieldMatchConfig {
             docs::examples = "field1",
             docs::examples = "parent.child_field"
         ))]
-        #[configurable(transparent)]
         Vec<String>,
     ),
 
@@ -55,7 +54,6 @@ pub enum FieldMatchConfig {
             docs::examples = "host",
             docs::examples = "hostname"
         ))]
-        #[configurable(transparent)]
         Vec<String>,
     ),
 }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -80,9 +80,10 @@ pub struct MetricConfig {
 #[serde(untagged)]
 pub enum TagConfig {
     /// A single tag value.
-    Plain(#[configurable(transparent)] Option<Template>),
+    Plain(Option<Template>),
+
     /// An array of values to give to the same tag name.
-    Multi(#[configurable(transparent)] Vec<Option<Template>>),
+    Multi(Vec<Option<Template>>),
 }
 
 /// Specification of the type of an individual metric, and any associated data.
@@ -92,7 +93,7 @@ pub enum TagConfig {
 #[configurable(metadata(docs::enum_tag_description = "The type of metric to create."))]
 pub enum MetricTypeConfig {
     /// A counter.
-    Counter(#[configurable(derived)] CounterConfig),
+    Counter(CounterConfig),
 
     /// A histogram.
     Histogram,

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -67,10 +67,10 @@ pub struct LuaConfigV2 {
 #[serde(untagged)]
 pub enum LuaConfig {
     /// Configuration for version one.
-    V1(#[configurable(derived)] LuaConfigV1),
+    V1(LuaConfigV1),
 
     /// Configuration for version two.
-    V2(#[configurable(derived)] LuaConfigV2),
+    V2(LuaConfigV2),
 }
 
 impl GenerateConfig for LuaConfig {

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -59,62 +59,62 @@ enum BuildError {
 pub enum Transforms {
     /// Aggregate.
     #[cfg(feature = "transforms-aggregate")]
-    Aggregate(#[configurable(derived)] aggregate::AggregateConfig),
+    Aggregate(aggregate::AggregateConfig),
 
     /// AWS EC2 metadata.
     #[cfg(feature = "transforms-aws_ec2_metadata")]
-    AwsEc2Metadata(#[configurable(derived)] aws_ec2_metadata::Ec2Metadata),
+    AwsEc2Metadata(aws_ec2_metadata::Ec2Metadata),
 
     /// Dedupe.
     #[cfg(feature = "transforms-dedupe")]
-    Dedupe(#[configurable(derived)] dedupe::DedupeConfig),
+    Dedupe(dedupe::DedupeConfig),
 
     /// Filter.
     #[cfg(feature = "transforms-filter")]
-    Filter(#[configurable(derived)] filter::FilterConfig),
+    Filter(filter::FilterConfig),
 
     /// Log to metric.
-    LogToMetric(#[configurable(derived)] log_to_metric::LogToMetricConfig),
+    LogToMetric(log_to_metric::LogToMetricConfig),
 
     /// Lua.
     #[cfg(feature = "transforms-lua")]
-    Lua(#[configurable(derived)] lua::LuaConfig),
+    Lua(lua::LuaConfig),
 
     /// Metric to log.
     #[cfg(feature = "transforms-metric_to_log")]
-    MetricToLog(#[configurable(derived)] metric_to_log::MetricToLogConfig),
+    MetricToLog(metric_to_log::MetricToLogConfig),
 
     /// Reduce.
     #[cfg(feature = "transforms-reduce")]
-    Reduce(#[configurable(derived)] reduce::ReduceConfig),
+    Reduce(reduce::ReduceConfig),
 
     /// Remap.
     #[cfg(feature = "transforms-remap")]
-    Remap(#[configurable(derived)] remap::RemapConfig),
+    Remap(remap::RemapConfig),
 
     /// Route.
     #[cfg(feature = "transforms-route")]
-    Route(#[configurable(derived)] route::RouteConfig),
+    Route(route::RouteConfig),
 
     /// Sample.
     #[cfg(feature = "transforms-sample")]
-    Sample(#[configurable(derived)] sample::SampleConfig),
+    Sample(sample::SampleConfig),
 
     /// Tag cardinality limit.
     #[cfg(feature = "transforms-tag_cardinality_limit")]
-    TagCardinalityLimit(#[configurable(derived)] tag_cardinality_limit::TagCardinalityLimitConfig),
+    TagCardinalityLimit(tag_cardinality_limit::TagCardinalityLimitConfig),
 
     /// Test (basic).
     #[cfg(test)]
-    TestBasic(#[configurable(derived)] crate::test_util::mock::transforms::BasicTransformConfig),
+    TestBasic(crate::test_util::mock::transforms::BasicTransformConfig),
 
     /// Test (noop).
     #[cfg(test)]
-    TestNoop(#[configurable(derived)] crate::test_util::mock::transforms::NoopTransformConfig),
+    TestNoop(crate::test_util::mock::transforms::NoopTransformConfig),
 
     /// Throttle.
     #[cfg(feature = "transforms-throttle")]
-    Throttle(#[configurable(derived)] throttle::ThrottleConfig),
+    Throttle(throttle::ThrottleConfig),
 }
 
 // We can't use `enum_dispatch` here because it doesn't support associated constants.

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -41,7 +41,7 @@ pub enum Mode {
     /// events to pass through the transform even when they contain new tags that exceed the
     /// configured limit. The rate at which this happens can be controlled by changing the value of
     /// `cache_size_per_tag`.
-    Probabilistic(#[configurable(derived)] BloomFilterConfig),
+    Probabilistic(BloomFilterConfig),
 }
 
 /// Bloom filter configuration in probabilistic mode.


### PR DESCRIPTION
## Context

Prior to this PR, when working with `Configurable`, one would have to annotate fields in a special way to relax the requirements imposed by the `Configurable` derive macro, specifically around fields requiring a description.

Normally, this would look like requiring that a struct field has a description, like the following:

```rust
#[configurable_component]
pub struct Foo {
  /// The whoosywhatsits amount.
  amount: usize,
}
```

Additionally, however, this logic also applied to fields in tuple structs (`struct Foo(usize)`) and enum tuple variants (`enum Foo { Variant(usize) }`) since they share the same syntactical structure when parsed by `syn`.

In some cases, it doesn't make sense to describe the field, because it's already described by the required description on the struct or enum variant itself. In order to deal with this, and situations like this, two helper attributes were introduced -- `#[configurable(transparent)]` and `#[configurable(derived)]` -- that instructed the derive macro to not throw an error about a missing description on a field.

This, as you might naturally expect, lead to a lot of boilerplate, and there are quite a few newtype structs and enum variants.

## Solution

In this PR, we've added logic that marks a field as transparent automatically if we detect it's the single unnamed field in a struct or enum tuple variant aka newtype wrappers.

This is always the desired behavior, anyways: as mentioned above, the struct or enum variant itself will always be required to carry a description, which otherwise replaces the description that might be provided by that single unnamed field. It doesn't matter if the field is a complex type or a scalar: we have the struct/enum variant description.

Additionally, we now emit an error if the two aforementioned helper attributes are manually applied to such as a field, as it could lead to confusion about what is taking precedence, and is generally unnecessary boilerplate. While we could potentially leave out such logic, given that the existing code serves as the blueprint for how to use `Configurable`, and if we simply remove all such usages, then the blueprint is now de facto not instructing people to do such a thing... it felt slightly better to ensure that muscle memory from the past doesn't creep in and allow the aforementioned helper attributes to be misapplied in the future.

As such, we also had to remove all instances that are now considered invalid... which lead to a lot of enums being able to be made much more succinct. :D

Closes #15365.