### PR TITLE
fix(host_metrics source): support generating Linux-specific docs on all platforms

### DIFF
--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -425,6 +425,9 @@ pub fn generate_root_schema<T>() -> Result<RootSchema, GenerateError>
 where
     T: Configurable + Serialize,
 {
+    // Set env variable to enable generating all schemas, including platform-specific ones.
+    std::env::set_var("VECTOR_GENERATE_SCHEMA", "true");
+
     let mut schema_gen = SchemaSettings::draft2019_09().into_generator();
 
     let schema = get_or_generate_schema::<T>(&mut schema_gen, T::metadata())?;

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -9,6 +9,9 @@ rescue LoadError => e
   exit 1
 end
 
+# Enable CGroups in order to generate Linux-specific docs on all platforms.
+ENV['VECTOR_USE_CGROUPS'] = 'true'
+
 DEBUG_LEVEL = 1
 INFO_LEVEL = 2
 ERROR_LEVEL = 3

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -9,9 +9,6 @@ rescue LoadError => e
   exit 1
 end
 
-# Enable CGroups in order to generate Linux-specific docs on all platforms.
-ENV['VECTOR_USE_CGROUPS'] = 'true'
-
 DEBUG_LEVEL = 1
 INFO_LEVEL = 2
 ERROR_LEVEL = 3

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -63,17 +63,19 @@ struct CGroupRecurser<'a> {
     buffer: String,
     load_cpu: bool,
     load_memory: bool,
-    config: &'a CGroupsConfig,
+    config: CGroupsConfig,
 }
 
 impl<'a> CGroupRecurser<'a> {
     fn new(host: &'a HostMetrics, output: &'a mut MetricsBuffer) -> Self {
+        let cgroups = host.config.cgroups.clone().unwrap_or_default();
+
         Self {
             output,
             buffer: String::new(),
             load_cpu: true,
             load_memory: true,
-            config: &host.config.cgroups,
+            config: cgroups,
         }
     }
 
@@ -119,7 +121,7 @@ impl<'a> CGroupRecurser<'a> {
             }
 
             if level < self.config.levels {
-                let groups = &self.config.groups;
+                let groups = self.config.groups.clone();
                 if let Some(children) =
                     filter_result_sync(cgroup.children().await, "Failed to load cgroups children.")
                 {

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -6,12 +6,9 @@ use tokio::{
     fs::{self, File},
     io::AsyncReadExt,
 };
-use vector_config::configurable_component;
 use vector_core::metric_tags;
 
-use super::{
-    default_all_devices, filter_result_sync, CGroupsConfig, FilterList, HostMetrics, MetricsBuffer,
-};
+use super::{filter_result_sync, CGroupsConfig, HostMetrics, MetricsBuffer};
 use crate::event::MetricTags;
 
 const MICROSECONDS: f64 = 1.0 / 1_000_000.0;

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -9,44 +9,12 @@ use tokio::{
 use vector_config::configurable_component;
 use vector_core::metric_tags;
 
-use super::{default_all_devices, filter_result_sync, FilterList, HostMetrics, MetricsBuffer};
+use super::{
+    default_all_devices, filter_result_sync, CGroupsConfig, FilterList, HostMetrics, MetricsBuffer,
+};
 use crate::event::MetricTags;
 
 const MICROSECONDS: f64 = 1.0 / 1_000_000.0;
-
-/// Options for the “cgroups” (controller groups) metrics collector.
-///
-/// This collector is only available on Linux systems, and only supports either version 2 or hybrid cgroups.
-#[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
-#[serde(default)]
-pub(crate) struct CGroupsConfig {
-    /// The number of levels of the cgroups hierarchy for which to report metrics.
-    ///
-    /// A value of `1` means just the root or named cgroup.
-    #[derivative(Default(value = "default_levels()"))]
-    #[serde(default = "default_levels")]
-    #[configurable(metadata(docs::examples = 1))]
-    #[configurable(metadata(docs::examples = 3))]
-    levels: usize,
-
-    /// The base cgroup name to provide metrics for.
-    #[configurable(metadata(docs::examples = "/"))]
-    #[configurable(metadata(docs::examples = "system.slice/snapd.service"))]
-    pub(super) base: Option<PathBuf>,
-
-    /// Lists of cgroup name patterns to include or exclude in gathering
-    /// usage metrics.
-    #[configurable(metadata(docs::examples = "example_cgroups()"))]
-    #[serde(default = "default_all_devices")]
-    groups: FilterList,
-
-    /// Base cgroup directory, for testing use only
-    #[serde(skip_serializing)]
-    #[configurable(metadata(docs::hidden))]
-    base_dir: Option<PathBuf>,
-}
 
 #[derive(Debug, Snafu)]
 enum CGroupsError {
@@ -68,17 +36,6 @@ enum CGroupsError {
 }
 
 type CGroupsResult<T> = Result<T, CGroupsError>;
-
-const fn default_levels() -> usize {
-    100
-}
-
-fn example_cgroups() -> FilterList {
-    FilterList {
-        includes: Some(vec!["user.slice/*".try_into().unwrap()]),
-        excludes: Some(vec!["*.service".try_into().unwrap()]),
-    }
-}
 
 impl HostMetrics {
     pub(super) async fn cgroups_metrics(&self, output: &mut MetricsBuffer) {

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -168,8 +168,17 @@ pub fn default_namespace() -> Option<String> {
     Some(String::from("host"))
 }
 
-const fn example_collectors() -> [&'static str; 2] {
-    ["cpu", "load"]
+const fn example_collectors() -> [&'static str; 8] {
+    [
+        "cgroups",
+        "cpu",
+        "disk",
+        "filesystem",
+        "load",
+        "host",
+        "memory",
+        "network",
+    ]
 }
 
 fn default_collectors() -> Option<Vec<Collector>> {

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -210,10 +210,13 @@ fn default_cgroups_config() -> Option<CGroupsConfig> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        return None;
+        None
     }
 
-    Some(CGroupsConfig::default())
+    #[cfg(target_os = "linux")]
+    {
+        Some(CGroupsConfig::default())
+    }
 }
 
 impl_generate_config_from_default!(HostMetricsConfig);

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -226,11 +226,10 @@ impl SourceConfig for HostMetricsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         init_roots();
 
-        // if !cfg!(unix) {
-        //     if self.cgroups.is_some() {
-        //         return Err("cgroups collector is only available on Unix systems".into());
-        //     }
-        // };
+        #[cfg(not(target_os = "linux"))]
+        if self.cgroups.is_some() {
+            return Err("cgroups collector is only available on Linux systems".into());
+        }
 
         let mut config = self.clone();
         config.namespace = config.namespace.filter(|namespace| !namespace.is_empty());

--- a/website/cue/reference/components/sources/base/host_metrics.cue
+++ b/website/cue/reference/components/sources/base/host_metrics.cue
@@ -88,7 +88,7 @@ base: components: sources: host_metrics: configuration: {
 					memory:     "Metrics related to memory utilization."
 					network:    "Metrics related to network utilization."
 				}
-				examples: ["cpu", "load"]
+				examples: ["cgroups", "cpu", "disk", "filesystem", "load", "host", "memory", "network"]
 			}
 		}
 	}

--- a/website/cue/reference/components/sources/base/host_metrics.cue
+++ b/website/cue/reference/components/sources/base/host_metrics.cue
@@ -71,18 +71,25 @@ base: components: sources: host_metrics: configuration: {
 			Defaults to all collectors.
 			"""
 		required: false
-		type: array: items: type: string: {
-			enum: {
-				cgroups:    "Metrics related to Linux control groups."
-				cpu:        "Metrics related to CPU utilization."
-				disk:       "Metrics related to disk I/O utilization."
-				filesystem: "Metrics related to filesystem space utilization."
-				host:       "Metrics related to the host."
-				load:       "Metrics related to the system load average."
-				memory:     "Metrics related to memory utilization."
-				network:    "Metrics related to network utilization."
+		type: array: {
+			default: ["cpu", "disk", "filesystem", "load", "host", "memory", "network", "cgroups"]
+			items: type: string: {
+				enum: {
+					cgroups: """
+						Metrics related to Linux control groups.
+
+						Only available on Linux.
+						"""
+					cpu:        "Metrics related to CPU utilization."
+					disk:       "Metrics related to disk I/O utilization."
+					filesystem: "Metrics related to filesystem space utilization."
+					host:       "Metrics related to the host."
+					load:       "Metrics related to the system load average."
+					memory:     "Metrics related to memory utilization."
+					network:    "Metrics related to network utilization."
+				}
+				examples: ["cpu", "load"]
 			}
-			examples: ["cgroups", "cpu", "disk", "filesystem", "load", "host", "memory", "network"]
 		}
 	}
 	disk: {


### PR DESCRIPTION
This change moves Linux-specific CGroups configuration types into the root module in the host_metrics crate. This enables us to generate Cue docs for the source on all platforms. Note: the cgroups config options will do nothing on non-Linux platforms. They're only available for the sake of generating the docs. 

I also introduced the env variable `VECTOR_GENERATE_SCHEMA`. It's used to enable the CGroups defaults on non-Linux machines for the sake of generating the docs. When the env variable isn't set, `CGroupsConfig` is only allowed on Linux machines, and an error is thrown if it's used on non-Linux machines. I think that this introduces a decent pattern for when this situation pops up again. 

I tested this on my Mac and an Ubuntu machine. The expected behavior of not triggering any CGroups-related docs changes with `make generate-component-docs` was confirmed on both platforms. I also verified that errors are thrown on Macs when specifying the `cgroups` collector on `host_metrics`. 