### PR TITLE
 docs(various sources): specify "socket" in descriptions of socket addresses.

### DIFF
--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -371,7 +371,7 @@ pub mod vector_v2 {
     #[derive(Clone, Debug)]
     #[serde(deny_unknown_fields)]
     pub struct VectorConfig {
-        /// The address to listen for connections on.
+        /// The socket address to listen for connections on.
         ///
         /// It _must_ include a port.
         pub address: SocketAddr,

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -28,7 +28,7 @@ mod models;
 #[configurable_component(source("aws_kinesis_firehose"))]
 #[derive(Clone, Debug)]
 pub struct AwsKinesisFirehoseConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     #[configurable(metadata(docs::examples = "0.0.0.0:443"))]
     #[configurable(metadata(docs::examples = "localhost:443"))]
     address: SocketAddr,

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -38,7 +38,7 @@ use self::message::{FluentEntry, FluentMessage, FluentRecord, FluentTag, FluentT
 #[configurable_component(source("fluent"))]
 #[derive(Clone, Debug)]
 pub struct FluentConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     address: SocketListenAddr,
 
     /// The maximum number of TCP connections that will be allowed at any given time.

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -70,7 +70,7 @@ impl SourceConfig for HttpConfig {
 #[configurable_component(source("http_server"))]
 #[derive(Clone, Debug)]
 pub struct SimpleHttpConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     address: SocketAddr,
 
     /// The expected encoding of received data.

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -38,7 +38,7 @@ use crate::{
 #[configurable_component(source("logstash"))]
 #[derive(Clone, Debug)]
 pub struct LogstashConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     address: SocketListenAddr,
 
     #[configurable(derived)]

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -69,7 +69,7 @@ pub struct OpentelemetryConfig {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct GrpcConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     ///
     /// It _must_ include a port.
     #[configurable(metadata(docs::examples = "0.0.0.0:4317", docs::examples = "localhost:4317"))]
@@ -93,7 +93,7 @@ fn example_grpc_config() -> GrpcConfig {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 struct HttpConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     ///
     /// It _must_ include a port.
     #[configurable(metadata(docs::examples = "0.0.0.0:4318", docs::examples = "localhost:4318"))]

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -59,7 +59,7 @@ pub const SOURCETYPE: &str = "splunk_sourcetype";
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields, default)]
 pub struct SplunkConfig {
-    /// The address to listen for connections on.
+    /// The socket address to listen for connections on.
     ///
     /// The address _must_ include a port.
     #[serde(default = "default_socket_address")]

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -71,7 +71,7 @@ pub struct SyslogConfig {
 pub enum Mode {
     /// Listen on TCP.
     Tcp {
-        /// The address to listen for connections on.
+        /// The socket address to listen for connections on.
         address: SocketListenAddr,
 
         #[configurable(derived)]
@@ -91,7 +91,7 @@ pub enum Mode {
 
     /// Listen on UDP.
     Udp {
-        /// The address to listen for messages on.
+        /// The socket address to listen for messages on.
         address: SocketListenAddr,
 
         /// The size, in bytes, of the receive buffer used for the listening socket.

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -42,7 +42,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 		}
 	}
 	address: {
-		description: "The address to listen for connections on."
+		description: "The socket address to listen for connections on."
 		required:    true
 		type: string: examples: ["0.0.0.0:443", "localhost:443"]
 	}

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -20,7 +20,7 @@ base: components: sources: fluent: configuration: {
 		}
 	}
 	address: {
-		description: "The address to listen for connections on."
+		description: "The socket address to listen for connections on."
 		required:    true
 		type: {
 			number: {}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -20,7 +20,7 @@ base: components: sources: http: configuration: {
 		}
 	}
 	address: {
-		description: "The address to listen for connections on."
+		description: "The socket address to listen for connections on."
 		required:    true
 		type: string: {}
 	}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -20,7 +20,7 @@ base: components: sources: http_server: configuration: {
 		}
 	}
 	address: {
-		description: "The address to listen for connections on."
+		description: "The socket address to listen for connections on."
 		required:    true
 		type: string: {}
 	}

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -20,7 +20,7 @@ base: components: sources: logstash: configuration: {
 		}
 	}
 	address: {
-		description: "The address to listen for connections on."
+		description: "The socket address to listen for connections on."
 		required:    true
 		type: {
 			number: {}

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -29,7 +29,7 @@ base: components: sources: opentelemetry: configuration: {
 			options: {
 				address: {
 					description: """
-						The address to listen for connections on.
+						The socket address to listen for connections on.
 
 						It _must_ include a port.
 						"""
@@ -144,7 +144,7 @@ base: components: sources: opentelemetry: configuration: {
 			options: {
 				address: {
 					description: """
-						The address to listen for connections on.
+						The socket address to listen for connections on.
 
 						It _must_ include a port.
 						"""

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -65,7 +65,7 @@ base: components: sources: splunk_hec: configuration: {
 	}
 	address: {
 		description: """
-			The address to listen for connections on.
+			The socket address to listen for connections on.
 
 			The address _must_ include a port.
 			"""

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -2,7 +2,7 @@ package metadata
 
 base: components: sources: syslog: configuration: {
 	address: {
-		description:   "The address to listen for connections on."
+		description:   "The socket address to listen for connections on."
 		relevant_when: "mode = \"tcp\" or mode = \"udp\""
 		required:      true
 		type: {


### PR DESCRIPTION
ref: https://github.com/vectordotdev/vector/pull/15985#discussion_r1072868818

epic: https://github.com/vectordotdev/vector/issues/14998

Notes:

- skipped the socket and statsd since covered in another PR of mine.
- Those using `SocketListenAddr` will actually get updated to use the derived from that struct once my PR goes in / that component is undertaken. 