### PR TITLE
docs: Remove null fields from example configs on website

### DIFF
--- a/website/scripts/create-config-examples.js
+++ b/website/scripts/create-config-examples.js
@@ -83,7 +83,10 @@ Object.makeExampleParams = (params, filter, deepFilter) => {
     .keys(params)
     .filter(k => filter(params[k]))
     .forEach(k => {
-      obj[k] = getExampleValue(params[k], deepFilter);
+      let value = getExampleValue(params[k], deepFilter);
+      if (value) {
+        obj[k] = value;
+      }
     });
 
   return obj;


### PR DESCRIPTION
This fixes the issue on the website where null fields are showing as null in the example configs for YAML and JSON. They should not show at all.

Compare the advanced YAML config between [here](https://deploy-preview-16071--vector-project.netlify.app/docs/reference/configuration/sources/dnstap/) and the [live Vector website](https://vector.dev/docs/reference/configuration/sources/dnstap/#event-fields).

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
