### PR TITLE
feat(vrl): add `seahash` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9603,6 +9603,7 @@ dependencies = [
  "regex",
  "roxmltree",
  "rust_decimal",
+ "seahash",
  "serde",
  "serde_json",
  "sha-1",

--- a/lib/vrl/stdlib/Cargo.toml
+++ b/lib/vrl/stdlib/Cargo.toml
@@ -37,6 +37,7 @@ quoted_printable = {version = "0.4.6", optional = true }
 rand = { version = "0.8.5", optional = true }
 regex = { version = "1", optional = true }
 rust_decimal = { version = "1", optional = true }
+seahash = { version = "4.1.0", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 sha-1 = { version = "0.10", optional = true }
@@ -186,6 +187,7 @@ default = [
     "replace",
     "reverse_dns",
     "round",
+    "seahash",
     "set",
     "sha1",
     "sha2",
@@ -334,6 +336,7 @@ remove = ["dep:lookup_lib"]
 replace = ["dep:regex"]
 reverse_dns = ["dep:dns-lookup"]
 round = []
+seahash = ["dep:seahash"]
 set = ["dep:lookup_lib"]
 sha1 = ["dep:sha-1", "dep:hex"]
 sha2 = ["dep:sha-2", "dep:hex"]

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -583,7 +583,7 @@ bench_function! {
 
     literal {
         args: func_args![value: "foo"],
-        want: Ok(4413582353838009230 as i64),
+        want: Ok(4_413_582_353_838_009_230_i64),
     }
 }
 

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -583,7 +583,7 @@ bench_function! {
 
     literal {
         args: func_args![value: "foo"],
-        want: Ok("4413582353838009230"),
+        want: Ok(4413582353838009230 as i64),
     }
 }
 

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -114,6 +114,7 @@ criterion_group!(
               replace,
               reverse_dns,
               round,
+              seahash,
               set,
               sha1,
               sha2,
@@ -574,6 +575,15 @@ bench_function! {
     mixed_included_string {
         args: func_args![value: value!(["foo", 1, true, [1,2,3]]), item: value!("foo")],
         want: Ok(value!(true)),
+    }
+}
+
+bench_function! {
+    seahash => vrl_stdlib::Seahash;
+
+    literal {
+        args: func_args![value: "foo"],
+        want: Ok("4413582353838009230"),
     }
 }
 

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -260,6 +260,8 @@ mod replace;
 mod reverse_dns;
 #[cfg(feature = "round")]
 mod round;
+#[cfg(feature = "seahash")]
+mod seahash;
 #[cfg(feature = "set")]
 mod set;
 #[cfg(feature = "sha1")]
@@ -549,6 +551,8 @@ pub use replace::Replace;
 pub use reverse_dns::ReverseDns;
 #[cfg(feature = "round")]
 pub use round::Round;
+#[cfg(feature = "seahash")]
+pub use seahash::Seahash;
 #[cfg(feature = "set")]
 pub use set::Set;
 #[cfg(feature = "sha2")]
@@ -850,6 +854,8 @@ pub fn all() -> Vec<Box<dyn vrl::Function>> {
         Box::new(ReverseDns),
         #[cfg(feature = "round")]
         Box::new(Round),
+        #[cfg(feature = "seahash")]
+        Box::new(Seahash),
         #[cfg(feature = "set")]
         Box::new(Set),
         #[cfg(feature = "sha1")]

--- a/lib/vrl/stdlib/src/lib.rs
+++ b/lib/vrl/stdlib/src/lib.rs
@@ -551,8 +551,6 @@ pub use replace::Replace;
 pub use reverse_dns::ReverseDns;
 #[cfg(feature = "round")]
 pub use round::Round;
-#[cfg(feature = "seahash")]
-pub use seahash::Seahash;
 #[cfg(feature = "set")]
 pub use set::Set;
 #[cfg(feature = "sha2")]
@@ -620,6 +618,8 @@ pub use values::Values;
 pub use crate::array::Array;
 #[cfg(feature = "md5")]
 pub use crate::md5::Md5;
+#[cfg(feature = "seahash")]
+pub use crate::seahash::Seahash;
 #[cfg(feature = "sha1")]
 pub use crate::sha1::Sha1;
 

--- a/lib/vrl/stdlib/src/seahash.rs
+++ b/lib/vrl/stdlib/src/seahash.rs
@@ -1,6 +1,7 @@
 use ::value::Value;
 use vrl::prelude::*;
 
+#[allow(clippy::cast_possible_wrap)]
 fn seahash(value: Value) -> Resolved {
     let value = value.try_bytes()?;
     Ok(Value::Integer(seahash::hash(&value) as i64))
@@ -74,13 +75,13 @@ mod tests {
 
         seahash {
              args: func_args![value: "foo"],
-             want: Ok(4413582353838009230 as i64),
+             want: Ok(4_413_582_353_838_009_230_i64),
              tdef: TypeDef::integer().infallible(),
         }
 
         seahash_buffer_overflow {
              args: func_args![value: "bar"],
-             want: Ok(-2796170501982571315 as i64),
+             want: Ok(-2_796_170_501_982_571_315_i64),
              tdef: TypeDef::integer().infallible(),
         }
     ];

--- a/lib/vrl/stdlib/src/seahash.rs
+++ b/lib/vrl/stdlib/src/seahash.rs
@@ -1,0 +1,89 @@
+use nom::Parser;
+use ::value::Value;
+use value::Value::Integer;
+use vrl::prelude::*;
+
+fn seahash(value: Value) -> Resolved {
+    let value = value.try_bytes()?;
+    Ok(Integer(seahash::hash(&value) as i64))
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Seahash;
+
+impl Function for Seahash {
+    fn identifier(&self) -> &'static str {
+        "seahash"
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            Example {
+                title: "seahash",
+                source: r#"seahash("foobar")"#,
+                result: Ok("5348458858952426560"),
+            },
+            Example {
+                title: "seahash above i64.MAX",
+                source: r#"seahash("bar")"#,
+                result: Ok("-2796170501982571315"),
+            }
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: &state::TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+
+        Ok(SeahashFn { value }.as_expr())
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        &[Parameter {
+            keyword: "value",
+            kind: kind::BYTES,
+            required: true,
+        }]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SeahashFn {
+    value: Box<dyn Expression>,
+}
+
+impl FunctionExpression for SeahashFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        seahash(value)
+    }
+
+    fn type_def(&self, _: &state::TypeState) -> TypeDef {
+        TypeDef::bytes().infallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_function![
+        seahash => Seahash;
+
+        seahash {
+             args: func_args![value: "foo"],
+             want: Ok("4413582353838009230"),
+             tdef: TypeDef::bytes().infallible(),
+        }
+
+        seahash_buffer_overflow {
+             args: func_args![value: "bar"],
+             want: Ok("-2796170501982571315"),
+             tdef: TypeDef::bytes().infallible(),
+        }
+    ];
+}

--- a/lib/vrl/stdlib/src/seahash.rs
+++ b/lib/vrl/stdlib/src/seahash.rs
@@ -61,7 +61,7 @@ impl FunctionExpression for SeahashFn {
     }
 
     fn type_def(&self, _: &state::TypeState) -> TypeDef {
-        TypeDef::bytes().infallible()
+        TypeDef::integer().infallible()
     }
 }
 
@@ -74,14 +74,14 @@ mod tests {
 
         seahash {
              args: func_args![value: "foo"],
-             want: Ok("4413582353838009230"),
-             tdef: TypeDef::bytes().infallible(),
+             want: Ok(4413582353838009230 as i64),
+             tdef: TypeDef::integer().infallible(),
         }
 
         seahash_buffer_overflow {
              args: func_args![value: "bar"],
-             want: Ok("-2796170501982571315"),
-             tdef: TypeDef::bytes().infallible(),
+             want: Ok(-2796170501982571315 as i64),
+             tdef: TypeDef::integer().infallible(),
         }
     ];
 }

--- a/lib/vrl/stdlib/src/seahash.rs
+++ b/lib/vrl/stdlib/src/seahash.rs
@@ -1,11 +1,9 @@
-use nom::Parser;
 use ::value::Value;
-use value::Value::Integer;
 use vrl::prelude::*;
 
 fn seahash(value: Value) -> Resolved {
     let value = value.try_bytes()?;
-    Ok(Integer(seahash::hash(&value) as i64))
+    Ok(Value::Integer(seahash::hash(&value) as i64))
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/lib/vrl/stdlib/src/seahash.rs
+++ b/lib/vrl/stdlib/src/seahash.rs
@@ -25,7 +25,7 @@ impl Function for Seahash {
                 title: "seahash above i64.MAX",
                 source: r#"seahash("bar")"#,
                 result: Ok("-2796170501982571315"),
-            }
+            },
         ]
     }
 

--- a/lib/vrl/stdlib/src/seahash.rs
+++ b/lib/vrl/stdlib/src/seahash.rs
@@ -43,7 +43,7 @@ impl Function for Seahash {
     fn parameters(&self) -> &'static [Parameter] {
         &[Parameter {
             keyword: "value",
-            kind: kind::BYTES,
+            kind: kind::ANY,
             required: true,
         }]
     }

--- a/website/cue/reference/remap/functions/seahash.cue
+++ b/website/cue/reference/remap/functions/seahash.cue
@@ -16,7 +16,7 @@ remap: functions: seahash: {
 		},
 	]
 	internal_failure_reasons: []
-	return: types: ["string"]
+	return: types: ["integer"]
 
 	examples: [
 		{

--- a/website/cue/reference/remap/functions/seahash.cue
+++ b/website/cue/reference/remap/functions/seahash.cue
@@ -4,7 +4,7 @@ remap: functions: seahash: {
 	category:    "Cryptography"
 	description: """
 		Calculates a [Seahash](\(urls.seahash)) hash of the `value`.
-		Note: function converts unsigned int-64 seahash to signed int-64 to met vrl standards, so integer overflow happens when calculated hash is higher than signed int-64 max value. Depending on the use-case this might or mightn't be an issue.
+		Note: Due to limitations in the underlying VRL data types, this function converts the unsigned 64-bit integer seahash result to a signed 64-bit integer. Results higher than the signed 64-bit integer maximum value wrap around to negative values.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/seahash.cue
+++ b/website/cue/reference/remap/functions/seahash.cue
@@ -1,0 +1,37 @@
+package metadata
+
+remap: functions: seahash: {
+	category:    "Cryptography"
+	description: """
+		Calculates a [Seahash](\(urls.seahash)) hash of the `value`.
+		Note: function converts unsigned int-64 seahash to signed int-64 to met vrl standards, so integer overflow happens when calculated hash is higher than signed int-64 max value. Depending on the use-case this might or mightn't be an issue.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The string to calculate the hash for."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: []
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Calculate seahash"
+			source: #"""
+				seahash("foobar")
+				"""#
+			return: "5348458858952426560"
+		},
+		{
+			title: "Calculate negative seahash"
+			source: #"""
+				seahash("bar")
+				"""#
+			return: "-2796170501982571315"
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/seahash.cue
+++ b/website/cue/reference/remap/functions/seahash.cue
@@ -24,14 +24,14 @@ remap: functions: seahash: {
 			source: #"""
 				seahash("foobar")
 				"""#
-			return: "5348458858952426560"
+			return: 5348458858952426560
 		},
 		{
 			title: "Calculate negative seahash"
 			source: #"""
 				seahash("bar")
 				"""#
-			return: "-2796170501982571315"
+			return: -2796170501982571315
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/sha1.cue
+++ b/website/cue/reference/remap/functions/sha1.cue
@@ -15,7 +15,7 @@ remap: functions: sha1: {
 		},
 	]
 	internal_failure_reasons: []
-	return: types: ["integer"]
+	return: types: ["string"]
 
 	examples: [
 		{

--- a/website/cue/reference/remap/functions/sha1.cue
+++ b/website/cue/reference/remap/functions/sha1.cue
@@ -15,7 +15,7 @@ remap: functions: sha1: {
 		},
 	]
 	internal_failure_reasons: []
-	return: types: ["string"]
+	return: types: ["integer"]
 
 	examples: [
 		{

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -444,6 +444,7 @@ urls: {
 	rustup:                                     "https://rustup.rs"
 	redis:                                      "https://redis.io"
 	redis_rs:                                   "https://github.com/mitsuhiko/redis-rs"
+	seahash:                                    "https://docs.rs/seahash/latest/seahash/"
 	sematext:                                   "https://sematext.com"
 	sematext_create_logs_app:                   "https://apps.sematext.com/ui/integrations"
 	sematext_es:                                "https://sematext.com/docs/logs/index-events-via-elasticsearch-api/"


### PR DESCRIPTION
Resolves [16072](https://github.com/vectordotdev/vector/issues/16072)

Rationale in the linked issue. 

Note that function converts unsigned int-64 seahash to signed int-64 to met VRL standards, so integer overflow happens when calculated hash is higher than signed int-64 max value. Depending on the use-case this might or mightn't be an issue.