### PR TITLE
chore(vdev): Add new `info` command to show overall vdev setup

### DIFF
--- a/vdev/src/app.rs
+++ b/vdev/src/app.rs
@@ -20,7 +20,7 @@ const DEFAULT_SHELL: &str = "/bin/sh";
 
 // Extract the shell from the environment variable `$SHELL` and substitute the above default value
 // if it isn't set.
-static SHELL: Lazy<OsString> =
+pub static SHELL: Lazy<OsString> =
     Lazy::new(|| (env::var_os("SHELL").unwrap_or_else(|| DEFAULT_SHELL.into())));
 
 static VERBOSITY: OnceCell<LevelFilter> = OnceCell::new();

--- a/vdev/src/commands/info.rs
+++ b/vdev/src/commands/info.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use clap::Args;
+
+use crate::{app, config, platform, testing::runner};
+
+/// Show `vdev` command configuration
+#[derive(Args, Debug)]
+#[command()]
+pub struct Cli {}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        display!("Container tool:  {:?}", *runner::CONTAINER_TOOL);
+        display!("Data path:       {:?}", platform::data_dir());
+        display!("Repository:      {:?}", app::path());
+        display!("Shell:           {:?}", *app::SHELL);
+
+        display!("\nConfig:");
+        match config::path() {
+            Ok(path) => {
+                display!("  Path:        {path:?}");
+                match config::load() {
+                    Ok(config) => {
+                        display!("  Repository:  {:?}", config.repo);
+                    }
+                    Err(error) => display!("  Could not load: {error}"),
+                }
+            }
+            Err(error) => display!("  Path:  Not found: {error}"),
+        }
+
+        display!("\nPlatform:");
+        display!("  Default target:  {}", platform::default_target());
+        Ok(())
+    }
+}

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -78,6 +78,7 @@ cli_commands! {
     mod features,
     mod fmt,
     mod generate,
+    mod info,
     mod integration,
     mod meta,
     mod package,

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -26,7 +26,7 @@ const TEST_COMMAND: &[&str] = &[
 const UPSTREAM_IMAGE: &str =
     "docker.io/timberio/vector-dev:sha-3eadc96742a33754a5859203b58249f6a806972a";
 
-static CONTAINER_TOOL: Lazy<OsString> =
+pub static CONTAINER_TOOL: Lazy<OsString> =
     Lazy::new(|| env::var_os("CONTAINER_TOOL").unwrap_or_else(detect_container_tool));
 
 fn detect_container_tool() -> OsString {


### PR DESCRIPTION
This shows some useful info about the setup of the `vdev` command, much like running `docker info`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
