### PR TITLE
chore(vdev): Drop the `display!` macro

### DIFF
--- a/vdev/src/commands/config/find.rs
+++ b/vdev/src/commands/config/find.rs
@@ -10,7 +10,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        display!("{}", config::path()?.display());
+        println!("{}", config::path()?.display());
 
         Ok(())
     }

--- a/vdev/src/commands/info.rs
+++ b/vdev/src/commands/info.rs
@@ -10,27 +10,27 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        display!("Container tool:  {:?}", *runner::CONTAINER_TOOL);
-        display!("Data path:       {:?}", platform::data_dir());
-        display!("Repository:      {:?}", app::path());
-        display!("Shell:           {:?}", *app::SHELL);
+        println!("Container tool:  {:?}", *runner::CONTAINER_TOOL);
+        println!("Data path:       {:?}", platform::data_dir());
+        println!("Repository:      {:?}", app::path());
+        println!("Shell:           {:?}", *app::SHELL);
 
-        display!("\nConfig:");
+        println!("\nConfig:");
         match config::path() {
             Ok(path) => {
-                display!("  Path:        {path:?}");
+                println!("  Path:        {path:?}");
                 match config::load() {
                     Ok(config) => {
-                        display!("  Repository:  {:?}", config.repo);
+                        println!("  Repository:  {:?}", config.repo);
                     }
-                    Err(error) => display!("  Could not load: {error}"),
+                    Err(error) => println!("  Could not load: {error}"),
                 }
             }
-            Err(error) => display!("  Path:  Not found: {error}"),
+            Err(error) => println!("  Path:  Not found: {error}"),
         }
 
-        display!("\nPlatform:");
-        display!("  Default target:  {}", platform::default_target());
+        println!("\nPlatform:");
+        println!("  Default target:  {}", platform::default_target());
         Ok(())
     }
 }

--- a/vdev/src/commands/integration/show.rs
+++ b/vdev/src/commands/integration/show.rs
@@ -31,7 +31,7 @@ impl Cli {
                 entries.sort();
 
                 for integration in &entries {
-                    display!("{integration}");
+                    println!("{integration}");
                 }
             }
             Some(integration) => {
@@ -39,15 +39,16 @@ impl Cli {
                 let envs_dir = state::envs_dir(&integration);
                 let active_envs = state::active_envs(&envs_dir)?;
 
-                display!("Test args: {}", config.args.join(" "));
+                println!("Test args: {}", config.args.join(" "));
 
-                display!("Environments:");
+                println!("Environments:");
                 for environment in config.environments().keys() {
-                    if active_envs.contains(environment) {
-                        display!("  {} (active)", environment);
+                    let active = if active_envs.contains(environment) {
+                        " (active)"
                     } else {
-                        display!("  {}", environment);
-                    }
+                        ""
+                    };
+                    println!("  {environment}{active}");
                 }
             }
         }

--- a/vdev/src/commands/meta/starship.rs
+++ b/vdev/src/commands/meta/starship.rs
@@ -33,7 +33,7 @@ impl Cli {
             }
         };
 
-        display!("vector{{ {} }}", contexts.join(", "));
+        println!("vector{{ {} }}", contexts.join(", "));
 
         Ok(())
     }

--- a/vdev/src/commands/status.rs
+++ b/vdev/src/commands/status.rs
@@ -10,8 +10,8 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        display!("Branch: {}", git::current_branch()?);
-        display!("Changed files: {}", git::changed_files()?.len());
+        println!("Branch: {}", git::current_branch()?);
+        println!("Changed files: {}", git::changed_files()?.len());
 
         Ok(())
     }

--- a/vdev/src/macros.rs
+++ b/vdev/src/macros.rs
@@ -1,4 +1,4 @@
-macro_rules! critical {
+macro_rules! fatal {
     ($($arg:tt)*) => {{
         use owo_colors::OwoColorize;
         eprintln!(
@@ -6,6 +6,7 @@ macro_rules! critical {
             format!($($arg)*)
                 .if_supports_color(owo_colors::Stream::Stderr, |text| text.bright_red())
         );
+        std::process::exit(1);
     }};
 }
 

--- a/vdev/src/macros.rs
+++ b/vdev/src/macros.rs
@@ -1,16 +1,3 @@
-macro_rules! display {
-    ($($arg:tt)*) => {{
-        use owo_colors::OwoColorize;
-        println!(
-            "{}",
-            format!($($arg)*)
-                // Simply bold rather than bright white for terminals with white backgrounds
-                .if_supports_color(owo_colors::Stream::Stdout, |text| text.bold())
-        );
-    }};
-}
-
-#[allow(unused_macros)]
 macro_rules! critical {
     ($($arg:tt)*) => {{
         use owo_colors::OwoColorize;

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -42,8 +42,7 @@ fn detect_container_tool() -> OsString {
             return OsString::from(String::from(tool));
         }
     }
-    critical!("No container tool could be detected.");
-    std::process::exit(1);
+    fatal!("No container tool could be detected.");
 }
 
 fn dockercmd<'a>(args: impl IntoIterator<Item = &'a str>) -> Command {


### PR DESCRIPTION
This macro causes all displayed output to be highlighted as bold text. If we
need bold text for some output, we can recreate this macro for the selected
uses but, otherwise, the default should be just plain text output.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
