### PR TITLE
fix(gcp_stackdriver_metrics)!: fixes invalid format for gcp metrics (#14890)

### DIFF
--- a/src/sinks/gcp/mod.rs
+++ b/src/sinks/gcp/mod.rs
@@ -25,7 +25,6 @@ pub struct GcpTypedResource {
     pub r#type: String,
 
     /// Type-specific labels.
-    #[serde(flatten)]
     #[configurable(metadata(docs::additional_props_description = "A type-specific label."))]
     pub labels: std::collections::HashMap<String, String>,
 }


### PR DESCRIPTION
Confirmed with manual testing, this does fix compatibility with gcp monitoring. I can push metrics.  But there is a side effect.  Because this struct is used both for configuration and for calling the gcp API, it changes the structure of the configuration.  You need to move the resource labels to a "labels" attribute, like this:

```
[sinks.my_sink_id]
type = "gcp_stackdriver_metrics"
inputs = [ "my-source-or-transform-id" ]
credentials_path = "/path/to/credentials.json"
project_id = "vector-123456"

[sinks.my_sink_id.resource]
type = "global"
labels = {projectId = "vector-123456", instanceId = "Twilight", zone = "us-central1-a"}
```

Not sure if that is ok...this sink was totally broken I think, so I guess no one is using it.

I see in the v0.22.0 highlights, it seems this flattening of the labels was intentional.  
https://github.com/vectordotdev/vector/blob/master/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md?plain=1#L31

The alternative, to keep the flattened labels in the config, would be to use a different struct for config vs serialization?  