### PR TITLE
chore(vdev): Refactor test runners

### DIFF
--- a/vdev/src/commands/integration/test.rs
+++ b/vdev/src/commands/integration/test.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Args;
 
-use crate::testing::runner::{ContainerTestRunnerBase, IntegrationTestRunner};
+use crate::testing::runner::{ContainerTestRunner, IntegrationTestRunner};
 use crate::testing::{config::IntegrationTestConfig, integration::IntegrationTest, state::EnvsDir};
 
 /// Execute integration tests

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use std::collections::BTreeMap;
 
 use crate::platform;
-use crate::testing::{config::RustToolchainConfig, runner::get_agent_test_runner};
+use crate::testing::runner::get_agent_test_runner;
 
 /// Execute tests
 #[derive(Args, Debug)]
@@ -35,8 +35,7 @@ fn parse_env(env: Vec<String>) -> BTreeMap<String, String> {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let toolchain_config = RustToolchainConfig::parse()?;
-        let runner = get_agent_test_runner(self.container, toolchain_config.channel);
+        let runner = get_agent_test_runner(self.container)?;
 
         let mut args = vec!["--workspace".to_string()];
         if let Some(extra_args) = &self.args {

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, path::Path, path::PathBuf, process::Command};
 use anyhow::{bail, Context, Result};
 
 use super::runner::{
-    ContainerTestRunnerBase as _, IntegrationTestRunner, TestRunner as _, CONTAINER_TOOL,
+    ContainerTestRunner as _, IntegrationTestRunner, TestRunner as _, CONTAINER_TOOL,
     NETWORK_ENV_VAR,
 };
 use super::{config::Environment, config::IntegrationTestConfig, state::EnvsDir};

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -64,9 +64,9 @@ pub enum RunnerState {
 
 pub fn get_agent_test_runner(container: bool) -> Result<Box<dyn TestRunner>> {
     if container {
-        Ok(Box::new(DockerTestRunner::new()))
+        Ok(Box::new(DockerTestRunner))
     } else {
-        Ok(Box::new(LocalTestRunner::new()))
+        Ok(Box::new(LocalTestRunner))
     }
 }
 
@@ -291,13 +291,7 @@ impl ContainerTestRunner for IntegrationTestRunner {
     }
 }
 
-pub struct DockerTestRunner {}
-
-impl DockerTestRunner {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
+pub struct DockerTestRunner;
 
 impl TestRunner for DockerTestRunner {
     fn test(&self, env_vars: &BTreeMap<String, String>, args: &[String]) -> Result<()> {
@@ -332,13 +326,7 @@ impl ContainerTestRunner for DockerTestRunner {
     }
 }
 
-pub struct LocalTestRunner {}
-
-impl LocalTestRunner {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
+pub struct LocalTestRunner;
 
 impl TestRunner for LocalTestRunner {
     fn test(&self, env_vars: &BTreeMap<String, String>, args: &[String]) -> Result<()> {

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -62,11 +62,11 @@ pub enum RunnerState {
     Unknown,
 }
 
-pub fn get_agent_test_runner(container: bool, rust_version: String) -> Box<dyn TestRunner> {
+pub fn get_agent_test_runner(container: bool) -> Result<Box<dyn TestRunner>> {
     if container {
-        Box::new(DockerTestRunner::new(rust_version))
+        Ok(Box::new(DockerTestRunner::new()?))
     } else {
-        Box::new(LocalTestRunner::new())
+        Ok(Box::new(LocalTestRunner::new()))
     }
 }
 
@@ -300,8 +300,9 @@ pub struct DockerTestRunner {
 }
 
 impl DockerTestRunner {
-    pub fn new(rust_version: String) -> Self {
-        Self { rust_version }
+    pub fn new() -> Result<Self> {
+        let rust_version = RustToolchainConfig::parse()?.channel;
+        Ok(Self { rust_version })
     }
 }
 


### PR DESCRIPTION
This just simplifies some of the code within the test runner hierarchy, reducing some duplication.

I came across this while working on fixing the broken integration tests and thought I could break it out for quick review.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
