### PR TITLE
chore(ci): Fix gardener PR workflow

### DIFF
--- a/.github/workflows/gardener_open_pr.yml
+++ b/.github/workflows/gardener_open_pr.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add non-Vector PR to Gardener project board
+    runs-on: ubuntu-latest
     steps:
       - uses: tspascoal/get-user-teams-membership@v2
         id: checkVectorMember
@@ -15,7 +16,6 @@ jobs:
           username: ${{ github.actor }}
           team: 'Vector'
           GITHUB_TOKEN: ${{ secrets.GH_PROJECT_PAT }}
-        runs-on: ubuntu-latest
       - uses: actions/add-to-project@v0.4.0
         if: ${{ steps.checkVectorMember.outputs.isTeamMember == 'false' }}
         with:


### PR DESCRIPTION
The `runs-on` line was in the wrong place.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
