### PR TITLE
fix: (docs) Fix docker tag for distroless-libc image (In website documentation)

### DIFF
--- a/website/content/en/docs/setup/installation/platforms/docker.md
+++ b/website/content/en/docs/setup/installation/platforms/docker.md
@@ -20,6 +20,7 @@ Other available distributions (beyond `debian`):
 
 * `alpine`
 * `distroless-libc`
+* `distroless-static`
 {{< /success >}}
 
 ## Deployment

--- a/website/content/en/docs/setup/installation/platforms/docker.md
+++ b/website/content/en/docs/setup/installation/platforms/docker.md
@@ -19,7 +19,7 @@ docker pull timberio/vector:{{< version >}}-debian
 Other available distributions (beyond `debian`):
 
 * `alpine`
-* `distroless`
+* `distroless-libc`
 {{< /success >}}
 
 ## Deployment


### PR DESCRIPTION
Proof:
https://hub.docker.com/layers/timberio/vector/0.27.0-distroless-libc/images/sha256-7cc605c682ea9fc79e0f2732f6729b2cadec91d112f94b0699138c2d163a7a8c?context=explore