### PR TITLE
Revert "chore(ci): Fix the shutdown integration test to run in vdev (#16128)

### DIFF
--- a/scripts/integration/docker-compose.shutdown.yml
+++ b/scripts/integration/docker-compose.shutdown.yml
@@ -1,0 +1,67 @@
+version: "3"
+
+services:
+  zookeeper:
+    image: docker.io/wurstmeister/zookeeper
+    ports:
+      - 2181:2181
+  kafka:
+    image: docker.io/wurstmeister/kafka:2.13-2.6.0
+    depends_on:
+      - zookeeper
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENERS=PLAINTEXT://:9091,SSL://:9092,SASL_PLAINTEXT://:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9091,SSL://kafka:9092,SASL_PLAINTEXT://kafka:9093
+      - KAFKA_SSL_KEYSTORE_LOCATION=/certs/kafka.p12
+      - KAFKA_SSL_KEYSTORE_PASSWORD=NOPASS
+      - KAFKA_SSL_TRUSTSTORE_LOCATION=/certs/kafka.p12
+      - KAFKA_SSL_TRUSTSTORE_PASSWORD=NOPASS
+      - KAFKA_SSL_KEY_PASSWORD=NOPASS
+      - KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=none
+      - "KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+      - KAFKA_INTER_BROKER_LISTENER_NAME=SASL_PLAINTEXT
+      - KAFKA_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
+    ports:
+      - 9091:9091
+      - 9092:9092
+      - 9093:9093
+    volumes:
+      - ${PWD}/tests/data/kafka.p12:/certs/kafka.p12:ro
+      - ${PWD}/tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
+  runner:
+    build:
+      context: ${PWD}
+      dockerfile: scripts/integration/Dockerfile
+      args:
+        - RUST_VERSION=${RUST_VERSION}
+    working_dir: /code
+    command:
+      - "cargo"
+      - "nextest"
+      - "run"
+      - "--no-fail-fast"
+      - "--no-default-features"
+      - "--features"
+      - "shutdown-tests"
+      - "--test"
+      - "integration"
+      - "--test-threads"
+      - "4"
+    depends_on:
+      - kafka
+    environment:
+      - KAFKA_HOST=kafka
+    volumes:
+      - ${PWD}:/code
+      - target:/code/target
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
+
+volumes:
+  target: {}
+  cargogit: {}
+  cargoregistry: {}

--- a/scripts/integration/shutdown/test.yaml
+++ b/scripts/integration/shutdown/test.yaml
@@ -2,7 +2,7 @@ args:
 - --features
 - shutdown-tests
 - --test
-- shutdown
+- integration
 - --test-threads
 - '4'
 

--- a/scripts/integration/shutdown/test.yaml
+++ b/scripts/integration/shutdown/test.yaml
@@ -2,7 +2,7 @@ args:
 - --features
 - shutdown-tests
 - --test
-- integration
+- shutdown
 - --test-threads
 - '4'
 


### PR DESCRIPTION
The new test worked on my dev system and during the PR review, but has been failing in subsequent CI, so revert this to make `master` green again.

This reverts commit 1b27f7704b27768aa3bd92c9b86d5ecf4f3b6cd4.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
