### PR TITLE
chore(ci): Fix gardener PR workflow

### DIFF
--- a/.github/workflows/gardener_open_pr.yml
+++ b/.github/workflows/gardener_open_pr.yml
@@ -1,13 +1,15 @@
 # Add new pull requests to Gardener project board for triage
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+      - reopened
 
 jobs:
   add-to-project:
     name: Add non-Vector PR to Gardener project board
+    runs-on: ubuntu-latest
     steps:
       - uses: tspascoal/get-user-teams-membership@v2
         id: checkVectorMember
@@ -15,7 +17,6 @@ jobs:
           username: ${{ github.actor }}
           team: 'Vector'
           GITHUB_TOKEN: ${{ secrets.GH_PROJECT_PAT }}
-        runs-on: ubuntu-latest
       - uses: actions/add-to-project@v0.4.0
         if: ${{ steps.checkVectorMember.outputs.isTeamMember == 'false' }}
         with:


### PR DESCRIPTION
Needs to run on base branch to have access to secrets.

Also fixes runs-on placement and runs the workflow on re-opened PRs.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
