### PR TITLE
chore(vdev): Allow only a single running integration test environment

### DIFF
--- a/vdev/src/commands/integration/start.rs
+++ b/vdev/src/commands/integration/start.rs
@@ -1,21 +1,29 @@
 use anyhow::Result;
 use clap::Args;
 
-use crate::testing::integration::IntegrationTest;
+use crate::testing::{config::IntegrationTestConfig, integration::IntegrationTest};
 
 /// Start an environment
 #[derive(Args, Debug)]
 #[command()]
 pub struct Cli {
-    /// The desired integration
+    /// The integration name
     integration: String,
 
-    /// The desired environment
-    environment: String,
+    /// The desired environment name to start. If omitted, the first environment name is used.
+    environment: Option<String>,
 }
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        IntegrationTest::new(self.integration, self.environment)?.start()
+        let environment = if let Some(environment) = self.environment {
+            environment
+        } else {
+            let (_test_dir, config) = IntegrationTestConfig::load(&self.integration)?;
+            let envs = config.environments();
+            let env = envs.keys().next().expect("Integration has no environments");
+            env.clone()
+        };
+        IntegrationTest::new(self.integration, environment)?.start()
     }
 }

--- a/vdev/src/commands/integration/stop.rs
+++ b/vdev/src/commands/integration/stop.rs
@@ -4,41 +4,26 @@ use clap::Args;
 use crate::testing::integration::{self, IntegrationTest, OldIntegrationTest};
 use crate::testing::state::EnvsDir;
 
-/// Stop an environment
+/// Stop an integration test environment
 #[derive(Args, Debug)]
 #[command()]
 pub struct Cli {
-    /// The desired integration
+    /// The integration name to stop
     integration: String,
-
-    /// The desired environment. If not present, all running environments are stopped.
-    environment: Option<String>,
-
-    /// Use the currently defined configuration if the environment is not up
-    #[arg(short, long)]
-    force: bool,
 }
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
         // Temporary hack to run old-style integration tests
-        if self.environment.is_none() && integration::old_exists(&self.integration)? {
+        if integration::old_exists(&self.integration)? {
             let integration = OldIntegrationTest::new(&self.integration);
             return integration.stop();
         }
 
-        if let Some(environment) = self.environment {
-            IntegrationTest::new(self.integration, environment)?.stop(self.force)
+        if let Some(active) = EnvsDir::new(&self.integration).active()? {
+            IntegrationTest::new(self.integration, active)?.stop()
         } else {
-            let envs = EnvsDir::new(&self.integration).list_active()?;
-            if envs.is_empty() {
-                println!("No environments for {:?} are active.", self.integration);
-            } else {
-                for environment in envs {
-                    IntegrationTest::new(self.integration.clone(), environment)?
-                        .stop(self.force)?;
-                }
-            }
+            println!("No environment for {:?} is active.", self.integration);
             Ok(())
         }
     }


### PR DESCRIPTION
Some of the integration test configs (notably splunk) are reused to run the same environment with different image versions. While it would be convenient to allow testing against multiple environments at the same time, there are some unresolved conflicts that make that currently impossible, most notably volume management. As this use case is more of an interesting use case than a requirement, we are going to reduce the complexity by allowing only starting one environment at a time.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
