### PR TITLE
chore(ci): Clean up runner containers and networks on stop

### DIFF
--- a/scripts/integration/amqp/compose.yaml
+++ b/scripts/integration/amqp/compose.yaml
@@ -9,4 +9,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/apex/compose.yaml
+++ b/scripts/integration/apex/compose.yaml
@@ -11,4 +11,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/aws/compose.yaml
+++ b/scripts/integration/aws/compose.yaml
@@ -18,4 +18,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/axiom/compose.yaml
+++ b/scripts/integration/axiom/compose.yaml
@@ -31,4 +31,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/azure/compose.yaml
+++ b/scripts/integration/azure/compose.yaml
@@ -10,4 +10,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/chronicle/compose.yaml
+++ b/scripts/integration/chronicle/compose.yaml
@@ -14,4 +14,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/clickhouse/compose.yaml
+++ b/scripts/integration/clickhouse/compose.yaml
@@ -7,4 +7,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/datadog-agent/compose.yaml
+++ b/scripts/integration/datadog-agent/compose.yaml
@@ -30,4 +30,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/datadog-traces/compose.yaml
+++ b/scripts/integration/datadog-traces/compose.yaml
@@ -33,4 +33,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/elasticsearch/compose.yaml
+++ b/scripts/integration/elasticsearch/compose.yaml
@@ -29,4 +29,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/eventstoredb/compose.yaml
+++ b/scripts/integration/eventstoredb/compose.yaml
@@ -10,4 +10,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/gcp/compose.yaml
+++ b/scripts/integration/gcp/compose.yaml
@@ -10,4 +10,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/http-client/compose.yaml
+++ b/scripts/integration/http-client/compose.yaml
@@ -33,4 +33,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/humio/compose.yaml
+++ b/scripts/integration/humio/compose.yaml
@@ -7,4 +7,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/influxdb/compose.yaml
+++ b/scripts/integration/influxdb/compose.yaml
@@ -23,4 +23,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/kafka/compose.yaml
+++ b/scripts/integration/kafka/compose.yaml
@@ -37,4 +37,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/logstash/compose.yaml
+++ b/scripts/integration/logstash/compose.yaml
@@ -16,4 +16,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/loki/compose.yaml
+++ b/scripts/integration/loki/compose.yaml
@@ -8,4 +8,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/mongodb/compose.yaml
+++ b/scripts/integration/mongodb/compose.yaml
@@ -34,4 +34,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/nats/compose.yaml
+++ b/scripts/integration/nats/compose.yaml
@@ -47,4 +47,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/nginx/compose.yaml
+++ b/scripts/integration/nginx/compose.yaml
@@ -17,4 +17,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/opentelemetry/compose.yaml
+++ b/scripts/integration/opentelemetry/compose.yaml
@@ -9,4 +9,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/postgres/compose.yaml
+++ b/scripts/integration/postgres/compose.yaml
@@ -15,4 +15,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/prometheus/compose.yaml
+++ b/scripts/integration/prometheus/compose.yaml
@@ -25,4 +25,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/pulsar/compose.yaml
+++ b/scripts/integration/pulsar/compose.yaml
@@ -10,4 +10,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/redis/compose.yaml
+++ b/scripts/integration/redis/compose.yaml
@@ -7,4 +7,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/shutdown/compose.yaml
+++ b/scripts/integration/shutdown/compose.yaml
@@ -29,10 +29,9 @@ services:
     - 9092:9092
     - 9093:9093
     volumes:
-    - ../../../tests/data/kafka.p12:/certs/kafka.p12:ro
+    - ../../../tests/data/ca/intermediate_server/private/kafka.p12:/certs/kafka.p12:ro
     - ../../../tests/data/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
 
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true

--- a/scripts/integration/splunk/compose.yaml
+++ b/scripts/integration/splunk/compose.yaml
@@ -17,4 +17,3 @@ services:
 networks:
   default:
     name: ${VECTOR_NETWORK}
-    external: true


### PR DESCRIPTION
This should cause integration test runners and the associated networks to be cleaned up after a test is run and stopped. However, it did fail CI integration tests last time I tried, so I'm taking another try at it.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
