### PR TITLE
chore(ci): Revert Fix the logstash integration test to run through vdev

### DIFF
--- a/scripts/integration/docker-compose.logstash.yml
+++ b/scripts/integration/docker-compose.logstash.yml
@@ -1,0 +1,62 @@
+version: "3"
+
+services:
+  beats-heartbeat:
+    image: docker.elastic.co/beats/heartbeat:7.12.1
+    networks:
+      - backend
+    # adding `-strict.perms=false to the default cmd as otherwise heartbeat was
+    # complaining about the file permissions when running in CI
+    # https://www.elastic.co/guide/en/beats/libbeat/5.3/config-file-permissions.html
+    command: -environment=container -strict.perms=false
+    volumes:
+      - ${PWD}/tests/data/logstash/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:7.13.1
+    networks:
+      - backend
+    volumes:
+      - /dev/null:/usr/share/logstash/pipeline/logstash.yml
+      - ${PWD}/tests/data/host.docker.internal.crt:/tmp/logstash.crt
+      - ${PWD}/tests/data/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+
+  runner:
+    build:
+      context: ${PWD}
+      dockerfile: scripts/integration/Dockerfile
+      args:
+        - RUST_VERSION=${RUST_VERSION}
+    working_dir: /code
+    hostname: runner
+    networks:
+      - backend
+    command:
+      - "cargo"
+      - "nextest"
+      - "run"
+      - "--no-fail-fast"
+      - "--no-default-features"
+      - "--features"
+      - "logstash-integration-tests"
+      - "--lib"
+      - "::logstash::integration_tests::"
+    environment:
+      - HEARTBEAT_ADDRESS=0.0.0.0:8080
+      - LOGSTASH_ADDRESS=0.0.0.0:8081
+    depends_on:
+      - beats-heartbeat
+      - logstash
+    volumes:
+      - ${PWD}:/code
+      - target:/code/target
+      - cargogit:/usr/local/cargo/git
+      - cargoregistry:/usr/local/cargo/registry
+
+networks:
+  backend: {}
+
+volumes:
+  target: {}
+  cargogit: {}
+  cargoregistry: {}

--- a/vdev/src/testing/config.rs
+++ b/vdev/src/testing/config.rs
@@ -26,29 +26,11 @@ impl RustToolchainConfig {
         let repo_path = app::path();
         let config_file: PathBuf = [repo_path, "rust-toolchain.toml"].iter().collect();
         let contents = fs::read_to_string(&config_file)
-            .with_context(|| format!("failed to read {config_file:?}"))?;
+            .with_context(|| format!("failed to read {}", config_file.display()))?;
         let config: RustToolchainRootConfig = toml::from_str(&contents)
-            .with_context(|| format!("failed to parse {config_file:?}"))?;
+            .with_context(|| format!("failed to parse {}", config_file.display()))?;
 
         Ok(config.toolchain)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ComposeConfig {
-    pub services: BTreeMap<String, ComposeService>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ComposeService {
-    pub volumes: Option<Vec<String>>,
-}
-
-impl ComposeConfig {
-    pub fn parse(path: &Path) -> Result<Self> {
-        let contents =
-            fs::read_to_string(path).with_context(|| format!("failed to read {path:?}"))?;
-        serde_yaml::from_str(&contents).with_context(|| format!("failed to parse {path:?}"))
     }
 }
 

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -1,21 +1,14 @@
-use std::fs::{self, Permissions};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt as _;
 use std::{collections::BTreeMap, path::Path, path::PathBuf, process::Command};
 
 use anyhow::{bail, Context, Result};
 
-use super::config::{ComposeConfig, Environment, IntegrationTestConfig, RustToolchainConfig};
+use super::config::{Environment, IntegrationTestConfig, RustToolchainConfig};
 use super::runner::{
     ContainerTestRunner as _, IntegrationTestRunner, TestRunner as _, CONTAINER_TOOL,
 };
 use super::state::EnvsDir;
 use crate::app::{self, CommandExt as _};
-use crate::util;
-
-/// Unix permissions mask to allow everybody to read a file
-#[cfg(unix)]
-const ALL_READ: u32 = 0o444;
+use crate::util::exists;
 
 const NETWORK_ENV_VAR: &str = "VECTOR_NETWORK";
 
@@ -29,7 +22,7 @@ fn old_integration_path(integration: &str) -> PathBuf {
 
 pub fn old_exists(integration: &str) -> Result<bool> {
     let path = old_integration_path(integration);
-    util::exists(path)
+    exists(path)
 }
 
 /// Temporary runner setup for old-style integration tests
@@ -80,7 +73,6 @@ pub struct IntegrationTest {
     config: IntegrationTestConfig,
     envs_dir: EnvsDir,
     runner: IntegrationTestRunner,
-    compose_path: PathBuf,
 }
 
 impl IntegrationTest {
@@ -90,10 +82,6 @@ impl IntegrationTest {
         let (test_dir, config) = IntegrationTestConfig::load(&integration)?;
         let envs_dir = EnvsDir::new(&integration);
         let runner = IntegrationTestRunner::new(integration.clone())?;
-        let compose_path: PathBuf = [&test_dir, Path::new("compose.yaml")].iter().collect();
-        let compose_path = dunce::canonicalize(&compose_path).with_context(|| {
-            format!("Could not canonicalize docker compose path {compose_path:?}")
-        })?;
 
         Ok(Self {
             integration,
@@ -102,7 +90,6 @@ impl IntegrationTest {
             config,
             envs_dir,
             runner,
-            compose_path,
         })
     }
 
@@ -135,7 +122,6 @@ impl IntegrationTest {
             bail!("environment is already up");
         }
 
-        self.prepare_compose()?;
         self.run_compose("Starting", &["up", "--detach"], cmd_config)?;
 
         self.envs_dir.save(&self.environment, cmd_config)
@@ -157,46 +143,17 @@ impl IntegrationTest {
         Ok(())
     }
 
-    #[allow(clippy::dbg_macro)]
-    // Fix up potential issues before starting a compose container
-    fn prepare_compose(&self) -> Result<()> {
-        #[cfg(unix)]
-        {
-            let compose_config = ComposeConfig::parse(Path::new(&self.compose_path))?;
-            for service in compose_config.services.values() {
-                // Make sure all volume files are world readable
-                if let Some(volumes) = &service.volumes {
-                    for volume in volumes {
-                        let source = volume
-                            .split_once(':')
-                            .expect("Invalid volume in compose file")
-                            .0;
-                        let path: PathBuf = [&self.test_dir, Path::new(source)].iter().collect();
-                        if path.is_file() {
-                            let perms = path
-                                .metadata()
-                                .with_context(|| format!("Could not get permissions on {path:?}"))?
-                                .permissions();
-                            let new_perms = Permissions::from_mode(perms.mode() | ALL_READ);
-                            if new_perms != perms {
-                                fs::set_permissions(&path, new_perms).with_context(|| {
-                                    format!("Could not set permissions on {path:?}")
-                                })?;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
     fn run_compose(&self, action: &str, args: &[&'static str], config: &Environment) -> Result<()> {
+        let compose_path: PathBuf = [&self.test_dir, Path::new("compose.yaml")].iter().collect();
+        let compose_file = dunce::canonicalize(compose_path)
+            .context("Could not canonicalize docker compose path")?
+            .display()
+            .to_string();
+
         let mut command = CONTAINER_TOOL.clone();
         command.push("-compose");
         let mut command = Command::new(command);
-        let compose_arg = self.compose_path.display().to_string();
-        command.args(["--file", &compose_arg]);
+        command.args(["--file", &compose_file]);
         command.args(args);
 
         command.current_dir(&self.test_dir);

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -14,7 +14,6 @@ const TARGET_PATH: &str = "/home/target";
 const VOLUME_TARGET: &str = "vector_target";
 const VOLUME_CARGO_GIT: &str = "vector_cargo_git";
 const VOLUME_CARGO_REGISTRY: &str = "vector_cargo_registry";
-const RUNNER_HOSTNAME: &str = "runner";
 const TEST_COMMAND: &[&str] = &[
     "cargo",
     "nextest",
@@ -211,8 +210,6 @@ pub trait ContainerTestRunner: TestRunner {
             &self.container_name(),
             "--network",
             &self.network_name(),
-            "--hostname",
-            RUNNER_HOSTNAME,
             "--workdir",
             MOUNT_PATH,
             "--volume",


### PR DESCRIPTION
Reverts vectordotdev/vector#16168

Temporarily reverting as this introduces some dead code on Windows which causes the nightly build to fail.

It looks like the PR workflows only warn on the dead code, but the release workflows consider it an error. Separately I think we should have the PR workflows consider it an error too.