### PR TITLE
feat(file): optimize metrics in File source

### DIFF
--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -82,60 +82,89 @@ mod source {
     use std::{io::Error, path::Path, time::Duration};
 
     use file_source::FileSourceInternalEvents;
-    use metrics::counter;
+    use metrics::{counter, register_counter, Counter, SharedString};
 
     use super::{FileOpen, InternalEvent};
     use crate::emit;
-    use vector_common::internal_event::{error_stage, error_type};
+    use vector_common::internal_event::{
+        error_stage, error_type, ByteSize, InternalEventHandle, RegisterInternalEvent,
+    };
 
     #[derive(Debug)]
-    pub struct FileBytesReceived<'a> {
-        pub byte_size: usize,
-        pub file: &'a str,
+    pub struct FileBytesReceived {
+        pub file: SharedString,
     }
 
-    impl<'a> InternalEvent for FileBytesReceived<'a> {
-        fn emit(self) {
-            trace!(
-                message = "Bytes received.",
-                byte_size = %self.byte_size,
-                protocol = "file",
-                file = %self.file,
-            );
-            counter!(
-                "component_received_bytes_total", self.byte_size as u64,
-                "protocol" => "file",
-                "file" => self.file.to_owned()
-            );
+    impl RegisterInternalEvent for FileBytesReceived {
+        type Handle = FileBytesReceivedHandle;
+
+        fn register(self) -> Self::Handle {
+            FileBytesReceivedHandle {
+                received_bytes: register_counter!("component_received_bytes_total", "protocol" => "file", "file" => self.file.clone()),
+                file: self.file,
+            }
         }
     }
 
-    #[derive(Debug)]
-    pub struct FileEventsReceived<'a> {
-        pub count: usize,
-        pub file: &'a str,
-        pub byte_size: usize,
+    #[derive(Clone)]
+    pub struct FileBytesReceivedHandle {
+        received_bytes: Counter,
+        file: SharedString,
     }
 
-    impl InternalEvent for FileEventsReceived<'_> {
-        fn emit(self) {
+    impl InternalEventHandle for FileBytesReceivedHandle {
+        type Data = ByteSize;
+
+        fn emit(&self, data: Self::Data) {
+            self.received_bytes.increment(data.0 as u64);
+            trace!(message = "Bytes received.", byte_size = %data.0, protocol = "file", file = %self.file);
+        }
+    }
+
+    pub struct FileEventsReceivedData {
+        pub byte_size: usize,
+        pub count: u64,
+    }
+
+    #[derive(Debug)]
+    pub struct FileEventsReceived {
+        pub file: SharedString,
+    }
+
+    impl RegisterInternalEvent for FileEventsReceived {
+        type Handle = FileEventsReceivedHandle;
+
+        fn register(self) -> Self::Handle {
+            FileEventsReceivedHandle {
+                component_received_event_bytes_total: register_counter!("component_received_event_bytes_total", "file" => self.file.clone()),
+                component_received_events_total: register_counter!("component_received_events_total", "file" => self.file.clone()),
+                events_in_total: register_counter!("events_in_total", "file" => self.file.clone()),
+                file: self.file,
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct FileEventsReceivedHandle {
+        component_received_event_bytes_total: Counter,
+        component_received_events_total: Counter,
+        events_in_total: Counter,
+        file: SharedString,
+    }
+
+    impl InternalEventHandle for FileEventsReceivedHandle {
+        type Data = FileEventsReceivedData;
+
+        fn emit(&self, data: Self::Data) {
+            self.component_received_event_bytes_total
+                .increment(data.byte_size as u64);
+            self.component_received_events_total.increment(data.count);
+            self.events_in_total.increment(data.count);
             trace!(
                 message = "Events received.",
-                count = %self.count,
-                byte_size = %self.byte_size,
+                count = %data.count,
+                byte_size = %data.byte_size,
                 file = %self.file
-            );
-            counter!(
-                "events_in_total", self.count as u64,
-                "file" => self.file.to_owned(),
-            );
-            counter!(
-                "component_received_events_total", self.count as u64,
-                "file" => self.file.to_owned(),
-            );
-            counter!(
-                "component_received_event_bytes_total", self.byte_size as u64,
-                "file" => self.file.to_owned(),
             );
         }
     }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::{convert::TryInto, future, path::PathBuf, time::Duration};
 
 use bytes::Bytes;
@@ -14,16 +16,21 @@ use lookup::{
     lookup_v2::{parse_value_path, OptionalValuePath},
     owned_value_path, path, OwnedValuePath,
 };
+use metrics::SharedString;
 use regex::bytes::Regex;
 use snafu::{ResultExt, Snafu};
 use tokio::{sync::oneshot, task::spawn_blocking};
 use tracing::{Instrument, Span};
 use value::Kind;
 use vector_common::finalizer::OrderedFinalizer;
+use vector_common::internal_event::{ByteSize, InternalEventHandle};
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use super::util::{EncodingConfig, MultilineConfig};
+use crate::internal_events::{
+    FileBytesReceivedHandle, FileEventsReceivedData, FileEventsReceivedHandle,
+};
 use crate::{
     config::{
         log_schema, DataType, Output, SourceAcknowledgementsConfig, SourceConfig, SourceContext,
@@ -561,16 +568,26 @@ pub fn file_source(
 
         let mut encoding_decoder = encoding_charset.map(Decoder::new);
 
+        let mut file_id_to_metrics_mapping =
+            HashMap::<FileFingerprint, FileBytesReceivedHandle>::new();
+
         // sizing here is just a guess
         let (tx, rx) = futures::channel::mpsc::channel::<Vec<Line>>(2);
         let rx = rx
             .map(futures::stream::iter)
             .flatten()
             .map(move |mut line| {
-                emit!(FileBytesReceived {
-                    byte_size: line.text.len(),
-                    file: &line.filename,
-                });
+                let file_bytes_received_entry = file_id_to_metrics_mapping.entry(line.file_id);
+
+                let file_bytes_received_handle = match file_bytes_received_entry {
+                    Entry::Occupied(o) => o.into_mut(),
+                    Entry::Vacant(v) => v.insert(register!(FileBytesReceived {
+                        file: SharedString::from(line.filename.clone())
+                    })),
+                };
+
+                file_bytes_received_handle.emit(ByteSize(line.text.len()));
+
                 // transcode each line from the file's encoding charset to utf8
                 line.text = match encoding_decoder.as_mut() {
                     Some(d) => d.decode_to_utf8(line.text),
@@ -599,8 +616,24 @@ pub fn file_source(
 
         // Once file server ends this will run until it has finished processing remaining
         // logs in the queue.
+        let mut file_id_to_event_metrics_mapping =
+            HashMap::<FileFingerprint, FileEventsReceivedHandle>::new();
         let span = Span::current();
         let mut messages = messages.map(move |line| {
+            let file_events_received_entry = file_id_to_event_metrics_mapping.entry(line.file_id);
+
+            let file_events_received_handle = match file_events_received_entry {
+                Entry::Occupied(o) => o.into_mut(),
+                Entry::Vacant(v) => v.insert(register!(FileEventsReceived {
+                    file: SharedString::from(line.filename.clone())
+                })),
+            };
+
+            file_events_received_handle.emit(FileEventsReceivedData {
+                byte_size: line.text.len(),
+                count: 1,
+            });
+
             let mut event = create_event(
                 line.text,
                 line.start_offset,
@@ -718,12 +751,6 @@ fn create_event(
     meta: &EventMetadata,
     log_namespace: LogNamespace,
 ) -> LogEvent {
-    emit!(FileEventsReceived {
-        count: 1,
-        file,
-        byte_size: line.len(),
-    });
-
     let deserializer = BytesDeserializer::new();
     let mut event = deserializer.parse_single(line, log_namespace);
 


### PR DESCRIPTION
Related to the discussion https://github.com/vectordotdev/vector/discussions/15977

Here I reimplemented a few metrics in File source to the new `register!` pattern. This is done for achieving more performance in the File source scenario. According to my local benchmarks, these changes boost throughput up to 2.5x compared to the master branch.

The ugliest thing in this PR is a map for mapping files to the corresponding metric handle. If you have a better idea, that is easy to implement - that would be awesome.