### PR TITLE
docs: Numerous fixes to make rustdocs compile.

### DIFF
--- a/lib/codecs/src/decoding/framing/octet_counting.rs
+++ b/lib/codecs/src/decoding/framing/octet_counting.rs
@@ -42,7 +42,7 @@ pub struct OctetCountingDecoderOptions {
 }
 
 /// Codec using the `Octet Counting` format as specified in
-/// https://tools.ietf.org/html/rfc6587#section-3.4.1.
+/// <https://tools.ietf.org/html/rfc6587#section-3.4.1>.
 #[derive(Clone, Debug)]
 pub struct OctetCountingDecoder {
     other: LinesCodec,

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -68,7 +68,7 @@ impl GelfSerializerConfig {
 }
 
 /// Serializer that converts an `Event` to bytes using the GELF format.
-/// Spec: https://docs.graylog.org/docs/gelf
+/// Spec: <https://docs.graylog.org/docs/gelf>
 #[derive(Debug, Clone)]
 pub struct GelfSerializer;
 

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -3,10 +3,10 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-/// GELF Message fields. Definitions from https://docs.graylog.org/docs/gelf
+/// GELF Message fields. Definitions from <https://docs.graylog.org/docs/gelf>.
 pub mod gelf_fields {
 
-    /// <not a field> The latest version of the GELF specification.
+    /// (not a field) The latest version of the GELF specification.
     pub const GELF_VERSION: &str = "1.1";
 
     /// (required) GELF spec version

--- a/lib/datadog/grok/src/parse_grok_rules.rs
+++ b/lib/datadog/grok/src/parse_grok_rules.rs
@@ -112,7 +112,7 @@ pub enum Error {
 ///
 /// Rules can reference aliases as %{alias_name}, aliases can reference each other themselves, cross-references or circular dependencies are not allowed and result in an error.
 /// Only one can match any given log. The first one that matches, from top to bottom, is the one that does the parsing.
-/// For further documentation and the full list of available matcher and filters check out https://docs.datadoghq.com/logs/processing/parsing
+/// For further documentation and the full list of available matcher and filters check out <https://docs.datadoghq.com/logs/processing/parsing>
 pub fn parse_grok_rules(
     patterns: &[String],
     aliases: BTreeMap<String, String>,

--- a/lib/value/src/kind/collection.rs
+++ b/lib/value/src/kind/collection.rs
@@ -192,7 +192,7 @@ impl<T: Ord + Clone> Collection<T> {
     /// For *known fields*:
     ///
     /// - If a field exists in both collections, their `Kind`s are merged, or the `other` fields
-    ///   are used (depending on the configured [`Strategy`](merge::Strategy)).
+    ///   are used (depending on the configured [`Strategy`](crate::kind::merge::Strategy)).
     ///
     /// - If a field exists in one but not the other, the field is merged with the "unknown"
     ///   of the other if it exists, or just the field is used otherwise.

--- a/lib/value/src/value.rs
+++ b/lib/value/src/value.rs
@@ -29,7 +29,7 @@ use std::{
 pub use crate::value::regex::ValueRegex;
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, SecondsFormat, Utc};
-pub use iter::IterItem;
+pub use iter::{IterItem, ValueIter};
 use lookup::lookup_v2::ValuePath;
 use ordered_float::NotNan;
 

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -22,8 +22,8 @@ pub trait IntoBuffer<T: Bufferable>: Send {
     /// in the middle of the channel without introducing an unnecessary hop, [`BufferSender`] and
     /// [`BufferReceiver`] can be configured to instrument all events flowing through directly.
     ///
-    /// When instrumentation is provided in this way, [`ByteSizeOf`] is used to calculate the size
-    /// of the event going both into and out of the buffer.
+    /// When instrumentation is provided in this way, [`vector_common::byte_size_of::ByteSizeOf`]
+    ///  is used to calculate the size of the event going both into and out of the buffer.
     fn provides_instrumentation(&self) -> bool {
         false
     }

--- a/lib/vector-config-macros/src/lib.rs
+++ b/lib/vector-config-macros/src/lib.rs
@@ -10,7 +10,7 @@ mod configurable_component;
 
 /// Designates a type as being part of a Vector configuration.
 ///
-/// This will automatically derive the [`Configurable`][vector_config::Configurable] trait for the given struct/enum, as
+/// This will automatically derive the [`Configurable`][vector-config::Configurable] trait for the given struct/enum, as
 /// well as ensuring that serialization/deserialization (via `serde`) is derived.
 ///
 /// ## Basics

--- a/lib/vector-config/src/named.rs
+++ b/lib/vector-config/src/named.rs
@@ -1,7 +1,7 @@
 /// A component with a well-known name.
 ///
 /// Users can derive this trait automatically by using the
-/// [`component_name`][vector_config::component_name] macro on their structs/enums.
+/// [`component_name`][vector-config::component_name] macro on their structs/enums.
 pub trait NamedComponent {
     const NAME: &'static str;
 

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -113,7 +113,7 @@ pub struct Output {
     ///
     /// For *sources*, a `None` schema is identical to a `Some(Definition::source_default())`.
     ///
-    /// For a *transform*, a schema [`Definition`] is required if `Datatype` is Log.
+    /// For a *transform*, a schema [`schema::Definition`] is required if `Datatype` is Log.
     pub log_schema_definition: Option<schema::Definition>,
 }
 

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -637,7 +637,7 @@ impl ByteSizeOf for Bucket {
 /// floating-point numbers and can represent higher-precision cut points, such as 0.9999, or the
 /// 99.99th percentile.
 ///
-/// [quantile_wikipedia]: https://en.wikipedia.org/wiki/Quantile
+/// [quantiles_wikipedia]: https://en.wikipedia.org/wiki/Quantile
 #[configurable_component]
 #[derive(Clone, Copy, Debug)]
 pub struct Quantile {

--- a/lib/vector-core/src/stream/partitioned_batcher.rs
+++ b/lib/vector-core/src/stream/partitioned_batcher.rs
@@ -236,7 +236,7 @@ impl BatcherSettings {
     }
 
     /// A batcher config using the `ByteSizeOf` trait to determine batch sizes.
-    /// The output is a Vec<T>
+    /// The output is a  `Vec<T>`.
     pub fn into_byte_size_config<T: ByteSizeOf>(
         self,
     ) -> BatchConfigParts<SizeLimit<ByteSizeOfItemSize>, Vec<T>> {
@@ -244,7 +244,7 @@ impl BatcherSettings {
     }
 
     /// A batcher config using the `ItemBatchSize` trait to determine batch sizes.
-    /// The output is a Vec<T>
+    /// The output is a `Vec<T>`.
     pub fn into_item_size_config<T, I>(self, item_size: I) -> BatchConfigParts<SizeLimit<I>, Vec<T>>
     where
         I: ItemBatchSize<T>,

--- a/lib/vrl/core/src/target.rs
+++ b/lib/vrl/core/src/target.rs
@@ -44,13 +44,13 @@ pub trait Target: std::fmt::Debug + SecretTarget {
 
     /// Get a value for a given path, or `None` if no value is found.
     ///
-    /// See [`Target::insert`] for more details.
+    /// See [`Target::target_insert`] for more details.
     fn target_get(&self, path: &OwnedTargetPath) -> Result<Option<&Value>, String>;
 
     /// Get a mutable reference to the value for a given path, or `None` if no
     /// value is found.
     ///
-    /// See [`Target::insert`] for more details.
+    /// See [`Target::target_insert`] for more details.
     fn target_get_mut(&mut self, path: &OwnedTargetPath) -> Result<Option<&mut Value>, String>;
 
     /// Remove the given path from the object.

--- a/src/api/schema/filter.rs
+++ b/src/api/schema/filter.rs
@@ -4,7 +4,7 @@ use async_graphql::{InputObject, InputType};
 
 use super::components::{source, ComponentKind};
 
-/// Takes an &Option<bool> and returns early if false
+/// Takes an `&Option<bool>` and returns early if false
 #[macro_export]
 macro_rules! filter_check {
     ($($match:expr),+) => {

--- a/src/kubernetes/reflector.rs
+++ b/src/kubernetes/reflector.rs
@@ -13,7 +13,7 @@ use tokio_util::time::DelayQueue;
 
 use super::meta_cache::{MetaCache, MetaDescribe};
 
-/// Handles events from a [`kube::runtime::watcher`] to delay the application of Deletion events.
+/// Handles events from a [`kube::runtime::watcher()`] to delay the application of Deletion events.
 pub async fn custom_reflector<K, W>(
     mut store: store::Writer<K>,
     mut meta_cache: MetaCache,

--- a/src/sinks/datadog/logs/mod.rs
+++ b/src/sinks/datadog/logs/mod.rs
@@ -1,7 +1,7 @@
-//! The Datadog Logs [`VectorSink`]
+//! The Datadog Logs [`vector_core::sink::VectorSink`]
 //!
-//! This module contains the [`VectorSink`] instance that is responsible for
-//! taking a stream of [`Event`] instances and getting them flung out to the
+//! This module contains the [`vector_core::sink::VectorSink`] instance that is responsible for
+//! taking a stream of [`vector_core::event::Event`] instances and getting them flung out to the
 //! Datadog Log API. The log API is relatively generous in terms of its
 //! constraints, except that:
 //!

--- a/src/sinks/datadog/traces/mod.rs
+++ b/src/sinks/datadog/traces/mod.rs
@@ -1,7 +1,7 @@
-//! The Datadog Traces [`VectorSink`]
+//! The Datadog Traces [`vector_core::sink::VectorSink`]
 //!
-//! This module contains the [`VectorSink`] instance responsible for taking
-//! a stream of [`Event`], partition them following the right directions and
+//! This module contains the [`vector_core::sink::VectorSink`] instance responsible for taking
+//! a stream of [`vector_core::event::Event`], partition them following the right directions and
 //! sending them to the Datadog Trace intake.
 //! This module use the same protocol as the official Datadog trace-agent to
 //! submit traces to the Datadog intake.

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -99,13 +99,19 @@ impl SinkBatchSettings for ChronicleUnstructuredDefaultBatchSettings {
 #[derive(Clone, Debug)]
 pub struct ChronicleUnstructuredConfig {
     /// The endpoint to send data to.
+    #[configurable(metadata(
+        docs::examples = "127.0.0.1:8080",
+        docs::examples = "example.com:12345"
+    ))]
     pub endpoint: Option<String>,
 
+    /// The GCP region to use.
     #[configurable(derived)]
     pub region: Option<Region>,
 
     /// The Unique identifier (UUID) corresponding to the Chronicle instance.
     #[configurable(validation(format = "uuid"))]
+    #[configurable(metadata(docs::examples = "c8c65bfa-5f2c-42d4-9189-64bb7b939f2c"))]
     pub customer_id: String,
 
     #[serde(flatten)]
@@ -131,6 +137,7 @@ pub struct ChronicleUnstructuredConfig {
     /// Chronicle will reject the entry with an error.
     ///
     /// [unstructured_log_types_doc]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers
+    #[configurable(metadata(docs::examples = "WINDOWS_DNS", docs::examples = "{{ log_type }}"))]
     pub log_type: Template,
 
     #[configurable(derived)]

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -1,5 +1,5 @@
 //! This sink sends data to Google Chronicles unstructured log entries endpoint.
-//! See https://cloud.google.com/chronicle/docs/reference/ingestion-api#unstructuredlogentries
+//! See <https://cloud.google.com/chronicle/docs/reference/ingestion-api#unstructuredlogentries>
 //! for more information.
 use bytes::{Bytes, BytesMut};
 use futures_util::{future::BoxFuture, task::Poll};

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -105,26 +105,26 @@ pub enum OutputFormat {
         lines: Vec<String>,
     },
 
-    /// Randomly generated logs in [Apache common][apache_common] format.
-    /// [apache_common]: https://httpd.apache.org/docs/current/logs.html#common
+    /// Randomly generated logs in
+    /// [Apache common](https://httpd.apache.org/docs/current/logs.html#common) format.
     ApacheCommon,
 
-    /// Randomly generated logs in [Apache error][apache_error] format.
-    /// [apache_error]: https://httpd.apache.org/docs/current/logs.html#errorlog
+    /// Randomly generated logs in
+    /// [Apache error](https://httpd.apache.org/docs/current/logs.html#errorlog) format.
     ApacheError,
 
-    /// Randomly generated logs in Syslog format ([RFC 5424][syslog_5424]).
-    /// [syslog_5424]: https://tools.ietf.org/html/rfc5424
+    /// Randomly generated logs in Syslog format
+    /// ([RFC 5424](https://tools.ietf.org/html/rfc5424)).
     #[serde(alias = "rfc5424")]
     Syslog,
 
-    /// Randomly generated logs in Syslog format ([RFC 3164][syslog_3164]).
-    /// [syslog_3164]: https://tools.ietf.org/html/rfc3164
+    /// Randomly generated logs in Syslog format
+    /// ([RFC 3164](https://tools.ietf.org/html/rfc3164)).
     #[serde(alias = "rfc3164")]
     BsdSyslog,
 
-    /// Randomly generated HTTP server logs in [JSON][json] format.
-    /// [json]: https://en.wikipedia.org/wiki/JSON
+    /// Randomly generated HTTP server logs in
+    /// [JSON](https://en.wikipedia.org/wiki/JSON) format.
     #[derivative(Default)]
     Json,
 }

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -55,7 +55,7 @@ pub struct MetricToLogConfig {
     ///
     /// When set to `single`, only the last non-bare value of tags will be displayed with the
     /// metric.  When set to `full`, all metric tags will be exposed as separate assignments as
-    /// described by [the `native_json` codec][vector_native_json].
+    /// described by [the `native_json` codec](https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue).
     #[serde(default)]
     pub metric_tag_values: MetricTagValues,
 }

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -84,7 +84,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 	customer_id: {
 		description: "The Unique identifier (UUID) corresponding to the Chronicle instance."
 		required:    true
-		type: string: {}
+		type: string: examples: ["c8c65bfa-5f2c-42d4-9189-64bb7b939f2c"]
 	}
 	encoding: {
 		description: "Configures how events are encoded into raw bytes."
@@ -205,7 +205,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 	endpoint: {
 		description: "The endpoint to send data to."
 		required:    false
-		type: string: {}
+		type: string: examples: ["127.0.0.1:8080", "example.com:12345"]
 	}
 	log_type: {
 		description: """
@@ -217,10 +217,13 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 			[unstructured_log_types_doc]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers
 			"""
 		required: true
-		type: string: syntax: "template"
+		type: string: {
+			examples: ["WINDOWS_DNS", "{{ log_type }}"]
+			syntax: "template"
+		}
 	}
 	region: {
-		description: "Google Chronicle regions."
+		description: "The GCP region to use."
 		required:    false
 		type: string: enum: {
 			asia: "APAC region."

--- a/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
@@ -13,6 +13,7 @@ components: sinks: gcp_chronicle_unstructured: {
 	}
 
 	features: {
+		auto_generated: true
 		acknowledgements: true
 		healthcheck: enabled: true
 		send: {
@@ -68,58 +69,7 @@ components: sinks: gcp_chronicle_unstructured: {
 		notices: []
 	}
 
-	configuration: {
-		api_key: configuration._gcp_api_key
-		credentials_path: {
-			category:    "Auth"
-			common:      true
-			description: "The filename for a Google Cloud service account credentials JSON file used to authenticate access to the Cloud Storage API. If this is unset, Vector checks the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for a filename.\n\nIf no filename is named, Vector will attempt to fetch an instance service account for the compute instance the program is running on. If Vector is not running on a GCE instance, you must define a credentials file as above."
-			required:    false
-			type: string: {
-				default: null
-				examples: ["/path/to/credentials.json"]
-			}
-		}
-		endpoint: {
-			common:        false
-			description:   "The endpoint to send data to."
-			relevant_when: "region is not set"
-			required:      false
-			type: string: {
-				default: null
-				examples: ["127.0.0.1:8080", "example.com:12345"]
-			}
-		}
-		region: {
-			common:        false
-			description:   "The region to send data to."
-			required:      false
-			relevant_when: "endpoint is not set"
-			type: string: {
-				default: null
-				enum: {
-					us:   "United States"
-					eu:   "Europe"
-					asia: "Asia"
-				}
-			}
-		}
-		customer_id: {
-			description: "The Unique identifier (UUID) corresponding to the Chronicle instance."
-			required:    true
-			type: string: {
-				examples: ["c8c65bfa-5f2c-42d4-9189-64bb7b939f2c"]
-			}
-		}
-		log_type: {
-			description: "Identifies the log entry. This must be one of the supported log types, otherwise Chronicle will reject the entry with an error."
-			required:    true
-			type: string: {
-				examples: ["WINDOWS_DNS", "{{ log_type }}"]
-				syntax: "template"
-			}
-		}
-	}
+	configuration: base.components.sinks.gcp_chronicle_unstructured.configuration
 
 	input: {
 		logs:    true


### PR DESCRIPTION
There were a number of errors when running  `cargo doc`, mostly relating to broken links. This fixes those errors so it now compiles.