### PR TITLE
docs(sinks): enable auto-generated proxy settings

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -870,9 +870,11 @@ components: {
 				description: """
 					Proxy configuration.
 
-					Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
-					proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
-					as well as set specific hosts that should not be proxied.
+					Configure to proxy traffic through an HTTP(S) proxy when making external requests.
+
+					Similar to common proxy configuration convention, users can set different proxies
+					to use based on the type of traffic being proxied, as well as set specific hosts that
+					should not be proxied.
 					"""
 				required:    false
 				type: object: options: {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -879,7 +879,7 @@ components: {
 				required: false
 				type: object: options: {
 					enabled: {
-						common: false
+						common:		 false
                         description: "Enables proxying support."
 						required:    false
 						type: bool: default: true
@@ -891,7 +891,7 @@ components: {
 
 							Must be a valid URI string.
 							"""
-						required:    false
+						required: false
 				        type: string: examples: ["http://foo.bar:3128"]
 					}
 					https: {
@@ -901,7 +901,7 @@ components: {
 
 							Must be a valid URI string.
 							"""
-						required:    false
+						required: false
 				        type: string: examples: ["http://foo.bar:3128"]
 					}
 					no_proxy: {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -866,7 +866,7 @@ components: {
 			}
 
 			_proxy: {
-				common:      false
+				common: false
 				description: """
 					Proxy configuration.
 
@@ -876,16 +876,16 @@ components: {
 					to use based on the type of traffic being proxied, as well as set specific hosts that
 					should not be proxied.
 					"""
-				required:    false
+				required: false
 				type: object: options: {
 					enabled: {
-						common:      false
+						common: false
                         description: "Enables proxying support."
 						required:    false
 						type: bool: default: true
 					}
 					http: {
-						common:      false
+						common: false
 						description: """
 							Proxy endpoint to use when proxying HTTP traffic.
 
@@ -895,7 +895,7 @@ components: {
 				        type: string: examples: ["http://foo.bar:3128"]
 					}
 					https: {
-						common:      false
+						common: false
 						description: """
 							Proxy endpoint to use when proxying HTTPS traffic.
 
@@ -905,7 +905,7 @@ components: {
 				        type: string: examples: ["http://foo.bar:3128"]
 					}
 					no_proxy: {
-						common:      false
+						common: false
 						description: """
 							A list of hosts to avoid proxying.
 
@@ -921,7 +921,7 @@ components: {
 
 							[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
 							"""
-						required:    false
+						required: false
 						type: array: {
 							default: []
 							items: type: string: {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -879,8 +879,8 @@ components: {
 				required: false
 				type: object: options: {
 					enabled: {
-						common:		 false
-                        description: "Enables proxying support."
+						common:      false
+						description: "Enables proxying support."
 						required:    false
 						type: bool: default: true
 					}
@@ -892,7 +892,7 @@ components: {
 							Must be a valid URI string.
 							"""
 						required: false
-				        type: string: examples: ["http://foo.bar:3128"]
+						type: string: examples: ["http://foo.bar:3128"]
 					}
 					https: {
 						common: false
@@ -902,7 +902,7 @@ components: {
 							Must be a valid URI string.
 							"""
 						required: false
-				        type: string: examples: ["http://foo.bar:3128"]
+						type: string: examples: ["http://foo.bar:3128"]
 					}
 					no_proxy: {
 						common: false

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -867,49 +867,61 @@ components: {
 
 			_proxy: {
 				common:      false
-				description: "Configures an HTTP(S) proxy for Vector to use. By default, the globally configured proxy is used."
+				description: """
+					Proxy configuration.
+
+					Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
+					proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
+					as well as set specific hosts that should not be proxied.
+					"""
 				required:    false
 				type: object: options: {
 					enabled: {
 						common:      false
-						description: "If false the proxy will be disabled."
+                        description: "Enables proxying support."
 						required:    false
 						type: bool: default: true
 					}
 					http: {
 						common:      false
-						description: "The URL to proxy HTTP requests through."
+						description: """
+							Proxy endpoint to use when proxying HTTP traffic.
+
+							Must be a valid URI string.
+							"""
 						required:    false
-						type: string: {
-							default: null
-							examples: ["http://foo.bar:3128"]
-						}
+				        type: string: examples: ["http://foo.bar:3128"]
 					}
 					https: {
 						common:      false
-						description: "The URL to proxy HTTPS requests through."
+						description: """
+							Proxy endpoint to use when proxying HTTPS traffic.
+
+							Must be a valid URI string.
+							"""
 						required:    false
-						type: string: {
-							default: null
-							examples: ["http://foo.bar:3128"]
-						}
+				        type: string: examples: ["http://foo.bar:3128"]
 					}
 					no_proxy: {
 						common:      false
 						description: """
-							A list of hosts to avoid proxying. Allowed patterns here include:
+							A list of hosts to avoid proxying.
 
-							Pattern | Example match
-							:-------|:-------------
-							Domain names | `example.com` matches requests to `example.com`
-							Wildcard domains | `.example.com` matches requests to `example.com` and its subdomains
-							IP addresses | `127.0.0.1` matches requests to 127.0.0.1
-							[CIDR](\(urls.cidr)) blocks | `192.168.0.0./16` matches requests to any IP addresses in this range
-							Splat | `*` matches all hosts
+							Multiple patterns are allowed:
+
+							| Pattern             | Example match                                                               |
+							| ------------------- | --------------------------------------------------------------------------- |
+							| Domain names        | `example.com` matches requests to `example.com`                     |
+							| Wildcard domains    | `.example.com` matches requests to `example.com` and its subdomains |
+							| IP addresses        | `127.0.0.1` matches requests to `127.0.0.1`                         |
+							| [CIDR][cidr] blocks | `192.168.0.0/16` matches requests to any IP addresses in this range     |
+							| Splat               | `*` matches all hosts                                                   |
+
+							[cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
 							"""
 						required:    false
 						type: array: {
-							default: null
+							default: []
 							items: type: string: {
 								examples: ["localhost", ".foo.bar", "*"]
 							}

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -164,7 +164,9 @@ base: components: sinks: configuration: {
 				required: false
 				type: array: {
 					default: []
-					items: type: string: {}
+					items: type: string: {
+						examples: ["localhost", ".foo.bar", "*"]
+                    }
 				}
 			}
 		}

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -116,9 +116,11 @@ base: components: sinks: configuration: {
 		description: """
 			Proxy configuration.
 
-			Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
-			proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
-			as well as set specific hosts that should not be proxied.
+			Configure to proxy traffic through an HTTP(S) proxy when making external requests.
+
+			Similar to common proxy configuration convention, users can set different proxies
+			to use based on the type of traffic being proxied, as well as set specific hosts that
+			should not be proxied.
 			"""
 		required: false
 		type: object: options: {

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -168,7 +168,7 @@ base: components: sinks: configuration: {
 					default: []
 					items: type: string: {
 						examples: ["localhost", ".foo.bar", "*"]
-                    }
+					}
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -24,6 +24,12 @@ components: sinks: [Name=string]: {
 			}
 		}
 
+		if features.send != _|_ && features.send.proxy != _|_ {
+			if features.send.proxy.enabled {
+				proxy: base.components.sinks.configuration.proxy
+			}
+		}
+
 		if !features.auto_generated {
 			if features.acknowledgements {
 				acknowledgements: {


### PR DESCRIPTION
The proxy from SourceContext was not being rendered in the auto generated docs

epic: https://github.com/vectordotdev/vector/issues/14999