### PR TITLE
fix(observability): fix improper expect during allocation group ID registration

### DIFF
--- a/src/internal_telemetry/allocations/mod.rs
+++ b/src/internal_telemetry/allocations/mod.rs
@@ -191,22 +191,22 @@ pub fn acquire_allocation_group_id(
     component_type: String,
     component_kind: String,
 ) -> AllocationGroupId {
-    let group_id =
-        AllocationGroupId::register().expect("failed to register allocation group token");
-    let idx = group_id.as_raw();
-    match GROUP_INFO.get(idx as usize) {
-        Some(mutex) => {
-            let mut writer = mutex.lock().unwrap();
+    if let Some(group_id) = AllocationGroupId::register() {
+        if let Some(group_lock) = GROUP_INFO.get(group_id.as_raw() as usize) {
+            let mut writer = group_lock.lock().unwrap();
             *writer = GroupInfo {
                 component_id,
                 component_kind,
                 component_type,
             };
-            group_id
-        }
-        None => {
-            info!("Maximum number of registrable allocation group IDs reached ({}). Allocations for component '{}' will be attributed to the root allocation group.", NUM_GROUPS, component_id);
-            AllocationGroupId::ROOT
+
+            return group_id;
         }
     }
+
+    // TODO: Technically, `NUM_GROUPS` is lower (128) than the upper bound for the
+    // `AllocationGroupId::register` call itself (253), so we can hardcode `NUM_GROUPS` here knowing
+    // it's the lower of the two values and will trigger first.. but this may not always be true.
+    info!("Maximum number of registrable allocation group IDs reached ({}). Allocations for component '{}' will be attributed to the root allocation group.", NUM_GROUPS, component_id);
+    AllocationGroupId::ROOT
 }


### PR DESCRIPTION
This PR fixes #16028, which outlines an issue where the code for registering an allocation group improperly calls `expect` on the initial registration call which will trigger after trying to allocate more than 254 groups IDs.

Internally, `AllocationGroupId` uses `NonZeroU8` for the ID storage, with one of the values reserved for the root allocation group, leaving 254 possible registrable group IDs. While the code for storing the group information properly limited itself once it went out of bounds, deferring to returning the root allocation group.... the initial registration just panics a little while later. Not great.

We've simply chained the logic now so that both stages have to "pass" -- get back a non-`None` group ID, and have it be within the range of `NUM_GROUPS` -- before it returns that group ID, or it just falls through to returning the root allocation group. 