### PR TITLE
fix(docs): correct proxy doc comments

### DIFF
--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -39,9 +39,11 @@ impl NoProxyInterceptor {
 
 /// Proxy configuration.
 ///
-/// Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
-/// proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
-/// as well as set specific hosts that should not be proxied.
+/// Configure to proxy traffic through an HTTP(S) proxy when making external requests.
+///
+/// Similar to common proxy configuration convention, users can set different proxies
+/// to use based on the type of traffic being proxied, as well as set specific hosts that
+/// should not be proxied.
 #[configurable_component]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -86,6 +88,9 @@ pub struct ProxyConfig {
         default,
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
+    #[configurable(metadata(docs::examples = "localhost"))]
+    #[configurable(metadata(docs::examples = ".foo.bar"))]
+    #[configurable(metadata(docs::examples = "*"))]
     pub no_proxy: NoProxy,
 }
 

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -166,9 +166,7 @@ base: components: sinks: configuration: {
 				required: false
 				type: array: {
 					default: []
-					items: type: string: {
-						examples: ["localhost", ".foo.bar", "*"]
-					}
+					items: type: string: examples: ["localhost", ".foo.bar", "*"]
 				}
 			}
 		}

--- a/website/cue/reference/components/base/sources.cue
+++ b/website/cue/reference/components/base/sources.cue
@@ -4,9 +4,11 @@ base: components: sources: configuration: proxy: {
 	description: """
 		Proxy configuration.
 
-		Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
-		proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
-		as well as set specific hosts that should not be proxied.
+		Configure to proxy traffic through an HTTP(S) proxy when making external requests.
+
+		Similar to common proxy configuration convention, users can set different proxies
+		to use based on the type of traffic being proxied, as well as set specific hosts that
+		should not be proxied.
 		"""
 	required: false
 	type: object: options: {
@@ -52,7 +54,7 @@ base: components: sources: configuration: proxy: {
 			required: false
 			type: array: {
 				default: []
-				items: type: string: {}
+				items: type: string: examples: ["localhost", ".foo.bar", "*"]
 			}
 		}
 	}

--- a/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
@@ -23,9 +23,11 @@ base: components: transforms: aws_ec2_metadata: configuration: {
 		description: """
 			Proxy configuration.
 
-			Configure to proxy traffic through an HTTP(S) proxy when making external requests. Similar to common
-			proxy configuration convention, users can set different proxies to use based on the type of traffic being proxied,
-			as well as set specific hosts that should not be proxied.
+			Configure to proxy traffic through an HTTP(S) proxy when making external requests.
+
+			Similar to common proxy configuration convention, users can set different proxies
+			to use based on the type of traffic being proxied, as well as set specific hosts that
+			should not be proxied.
 			"""
 		required: false
 		type: object: options: {
@@ -71,7 +73,7 @@ base: components: transforms: aws_ec2_metadata: configuration: {
 				required: false
 				type: array: {
 					default: []
-					items: type: string: {}
+					items: type: string: examples: ["localhost", ".foo.bar", "*"]
 				}
 			}
 		}


### PR DESCRIPTION
Fixes an issue in component docs on master.

locally, `make check-docs` and `make check-component-docs` pass