### PR TITLE
chore(config, docs): start marking certain shared config types as advanced

### DIFF
--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -39,6 +39,7 @@ pub const TEST_PEM_CLIENT_KEY_PATH: &str =
 
 /// Configures the TLS options for incoming/outgoing connections.
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Debug, Default)]
 pub struct TlsEnableableConfig {
     /// Whether or not to require TLS for incoming/outgoing connections.
@@ -80,6 +81,7 @@ pub struct TlsSourceConfig {
 
 /// TLS configuration.
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TlsConfig {

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -91,6 +91,7 @@ pub struct Unmerged;
 // defaults, since that is satisfied here.
 #[serde_as]
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct BatchConfig<D: SinkBatchSettings + Clone, S = Unmerged>
 where

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -216,6 +216,7 @@ impl Configurable for Compression {
         metadata.set_title("Compression configuration.");
         metadata.set_description("All compression algorithms use the default compression level unless otherwise specified.");
         metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
+        metadata.add_custom_attribute(CustomAttribute::flag("docs::advanced"));
         metadata
     }
 

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -87,6 +87,7 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
 /// Various settings can be configured, such as concurrency and rate limits, timeouts, etc.
 #[serde_as]
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Copy, Debug)]
 pub struct TowerRequestConfig {
     #[configurable(derived)]

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -96,6 +96,7 @@ const fn access_keys_example() -> [&'static str; 2] {
 
 /// Compression scheme for records in a Firehose message.
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Copy, Debug, Derivative, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[derivative(Default)]

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -25,6 +25,7 @@ pub mod sqs;
 
 /// Compression scheme for objects retrieved from S3.
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Copy, Debug, Derivative, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[derivative(Default)]


### PR DESCRIPTION
Part of #16222.

This PR addresses the most common shared configuration types which drive the common `batch`, `compression`, `request`, and `tls` sections in most sinks, and in some sources.

This is a purely schema-based change, annotating these types as being advanced. It doesn't yet affect the auto-generated documentation as the documentation generation script doesn't pay attention to the attribute yet.