### PR TITLE
docs(datadog_traces sink): use auto-generated config docs

### DIFF
--- a/src/common/datadog.rs
+++ b/src/common/datadog.rs
@@ -51,7 +51,10 @@ pub enum Region {
 /// This is a helper function for Datadog component configs using the deprecated `region` field.
 ///
 /// If `region` is not specified, we fallback to `site`.
-pub(crate) fn get_base_domain_region(site: &str, region: Option<Region>) -> &str {
+///
+/// TODO: This should be deleted when the deprecated `region` config option is fully removed,
+///       and the callers will replace the result of this function call with just `site`.
+pub(crate) const fn get_base_domain_region(site: &str, region: Option<Region>) -> &str {
     if let Some(region) = region {
         match region {
             Region::Eu => DD_EU_SITE,
@@ -62,21 +65,10 @@ pub(crate) fn get_base_domain_region(site: &str, region: Option<Region>) -> &str
     }
 }
 
-//    site.map(|s| s.as_str()).unwrap_or_else(|| match region {
-//site.map(|s| s.as_str()).unwrap_or_else(|| match region {
-//    Some(Region::Eu) => "datadoghq.eu",
-//    None | Some(Region::Us) => DD_US_SITE,
-//})
-//}
-
 /// Gets the base API endpoint to use for any calls to Datadog.
 ///
 /// If `endpoint` is not specified, we fallback to `site`.
-pub(crate) fn get_api_base_endpoint(
-    endpoint: Option<&String>,
-    site: &str,
-    //region: Option<Region>,
-) -> String {
+pub(crate) fn get_api_base_endpoint(endpoint: Option<&String>, site: &str) -> String {
     endpoint
         .cloned()
         .unwrap_or_else(|| format!("https://api.{}", site))

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use rand::Rng;
 use serde::Serialize;
 use tokio::{
-    sync::mpsc::{self},
+    sync::mpsc,
     time::{sleep, Duration},
 };
 use url::{ParseError, Url};
@@ -21,11 +21,11 @@ use super::{
     SourceOuter, TransformOuter,
 };
 use crate::{
-    common::datadog::{get_api_base_endpoint, Region},
+    common::datadog::{get_api_base_endpoint, get_base_domain_region, Region},
     conditions::AnyCondition,
     http::{HttpClient, HttpError},
     sinks::{
-        datadog::{logs::DatadogLogsConfig, metrics::DatadogMetricsConfig},
+        datadog::{default_site, logs::DatadogLogsConfig, metrics::DatadogMetricsConfig},
         util::{http::RequestConfig, retries::ExponentialBackoff},
     },
     sources::{
@@ -73,8 +73,8 @@ pub struct Options {
     /// The Datadog [site][dd_site] to send data to.
     ///
     /// [dd_site]: https://docs.datadoghq.com/getting_started/site
-    #[serde(default)]
-    site: Option<String>,
+    #[serde(default = "default_site")]
+    site: String,
 
     /// The Datadog region to send data to.
     ///
@@ -130,7 +130,7 @@ impl Default for Options {
         Self {
             enabled: default_enabled(),
             enable_logs_reporting: default_enable_logs_reporting(),
-            site: None,
+            site: default_site(),
             region: None,
             endpoint: None,
             api_key: None,
@@ -674,7 +674,7 @@ pub(crate) fn report_configuration(
         // Endpoint to report a config to Datadog OP.
         let endpoint = get_reporting_endpoint(
             opts.endpoint.as_ref(),
-            opts.site.as_ref(),
+            opts.site.as_str(),
             opts.region,
             &opts.configuration_key,
         );
@@ -711,13 +711,15 @@ pub(crate) fn report_configuration(
 /// Returns the full URL endpoint of where to POST a Datadog Vector configuration.
 fn get_reporting_endpoint(
     endpoint: Option<&String>,
-    site: Option<&String>,
+    site: &str,
     region: Option<Region>,
     configuration_key: &str,
 ) -> String {
+    let base = get_base_domain_region(site, region);
+
     format!(
         "{}{}/{}/versions",
-        get_api_base_endpoint(endpoint, site, region),
+        get_api_base_endpoint(endpoint, base),
         DATADOG_REPORTING_PATH_STUB,
         configuration_key
     )

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -78,12 +78,11 @@ impl GenerateConfig for DatadogEventsConfig {
 }
 
 impl DatadogEventsConfig {
-    fn get_base(&self) -> &str {
-        get_base_domain_region(self.site.as_str(), self.region)
-    }
-
     fn get_api_events_endpoint(&self) -> http::Uri {
-        let api_base_endpoint = get_api_base_endpoint(self.endpoint.as_ref(), self.get_base());
+        let api_base_endpoint = get_api_base_endpoint(
+            self.endpoint.as_ref(),
+            get_base_domain_region(self.site.as_str(), self.region),
+        );
 
         // We know this URI will be valid since we have just built it up ourselves.
         http::Uri::try_from(format!("{}/api/v1/events", api_base_endpoint)).expect("URI not valid")
@@ -96,7 +95,10 @@ impl DatadogEventsConfig {
     }
 
     fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
-        let validate_endpoint = get_api_validate_endpoint(self.endpoint.as_ref(), self.get_base())?;
+        let validate_endpoint = get_api_validate_endpoint(
+            self.endpoint.as_ref(),
+            get_base_domain_region(self.site.as_str(), self.region),
+        )?;
         Ok(healthcheck(
             client,
             validate_endpoint,

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -6,16 +6,17 @@ use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 
 use crate::{
-    common::datadog::{get_base_domain_region, DD_US_SITE},
+    common::datadog::{get_base_domain_region, Region},
     config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         datadog::{
+            default_site,
             events::{
                 service::{DatadogEventsResponse, DatadogEventsService},
                 sink::DatadogEventsSink,
             },
-            get_api_base_endpoint, get_api_validate_endpoint, healthcheck, Region,
+            get_api_base_endpoint, get_api_validate_endpoint, healthcheck,
         },
         util::{http::HttpStatusRetryLogic, ServiceBuilderExt, TowerRequestConfig},
         Healthcheck, VectorSink,
@@ -65,10 +66,6 @@ pub struct DatadogEventsConfig {
         skip_serializing_if = "crate::serde::skip_serializing_if_default"
     )]
     acknowledgements: AcknowledgementsConfig,
-}
-
-fn default_site() -> String {
-    DD_US_SITE.to_owned()
 }
 
 impl GenerateConfig for DatadogEventsConfig {

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -11,11 +11,14 @@ use vector_core::config::proxy::ProxyConfig;
 use super::{service::LogApiRetry, sink::LogSinkBuilder};
 use crate::{
     codecs::Transformer,
+    common::datadog::{get_base_domain_region, Region},
     config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     schema,
     sinks::{
-        datadog::{get_api_validate_endpoint, healthcheck, logs::service::LogApiService, Region},
+        datadog::{
+            default_site, get_api_validate_endpoint, healthcheck, logs::service::LogApiService,
+        },
         util::{
             http::RequestConfig, service::ServiceBuilderExt, BatchConfig, Compression,
             SinkBatchSettings,
@@ -63,7 +66,8 @@ pub struct DatadogLogsConfig {
     /// The Datadog [site][dd_site] to send logs to.
     ///
     /// [dd_site]: https://docs.datadoghq.com/getting_started/site
-    pub site: Option<String>,
+    #[serde(default = "default_site")]
+    pub site: String,
 
     /// The default Datadog [API key][api_key] to send logs with.
     ///
@@ -115,6 +119,10 @@ impl GenerateConfig for DatadogLogsConfig {
 }
 
 impl DatadogLogsConfig {
+    fn get_base(&self) -> &str {
+        get_base_domain_region(self.site.as_str(), self.region)
+    }
+
     // TODO: We should probably hoist this type of base URI generation so that all DD sinks can
     // utilize it, since it all follows the same pattern.
     fn get_uri(&self) -> http::Uri {
@@ -122,9 +130,10 @@ impl DatadogLogsConfig {
             .endpoint
             .clone()
             .or_else(|| {
-                self.site
-                    .as_ref()
-                    .map(|s| format!("https://http-intake.logs.{}/api/v2/logs", s))
+                Some(format!(
+                    "https://http-intake.logs.{}/api/v2/logs",
+                    self.site
+                ))
             })
             .unwrap_or_else(|| match self.region {
                 Some(Region::Eu) => "https://http-intake.logs.datadoghq.eu/api/v2/logs".to_string(),
@@ -170,8 +179,7 @@ impl DatadogLogsConfig {
     }
 
     pub fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
-        let validate_endpoint =
-            get_api_validate_endpoint(self.endpoint.as_ref(), self.site.as_ref(), self.region)?;
+        let validate_endpoint = get_api_validate_endpoint(self.endpoint.as_ref(), self.get_base())?;
         Ok(healthcheck(
             client,
             validate_endpoint,

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -119,10 +119,6 @@ impl GenerateConfig for DatadogLogsConfig {
 }
 
 impl DatadogLogsConfig {
-    fn get_base(&self) -> &str {
-        get_base_domain_region(self.site.as_str(), self.region)
-    }
-
     // TODO: We should probably hoist this type of base URI generation so that all DD sinks can
     // utilize it, since it all follows the same pattern.
     fn get_uri(&self) -> http::Uri {
@@ -179,7 +175,10 @@ impl DatadogLogsConfig {
     }
 
     pub fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
-        let validate_endpoint = get_api_validate_endpoint(self.endpoint.as_ref(), self.get_base())?;
+        let validate_endpoint = get_api_validate_endpoint(
+            self.endpoint.as_ref(),
+            get_base_domain_region(self.site.as_str(), self.region),
+        )?;
         Ok(healthcheck(
             client,
             validate_endpoint,

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -16,7 +16,7 @@ use crate::{
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
-        datadog::{get_api_validate_endpoint, healthcheck, default_site},
+        datadog::{default_site, get_api_validate_endpoint, healthcheck},
         util::{batch::BatchConfig, ServiceBuilderExt, SinkBatchSettings, TowerRequestConfig},
         Healthcheck, UriParseSnafu, VectorSink,
     },

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -166,10 +166,6 @@ impl SinkConfig for DatadogMetricsConfig {
 }
 
 impl DatadogMetricsConfig {
-    fn get_base(&self) -> &str {
-        get_base_domain_region(self.site.as_str(), self.region)
-    }
-
     /// Gets the base URI of the Datadog agent API.
     ///
     /// Per the Datadog agent convention, we should include a unique identifier as part of the
@@ -181,7 +177,11 @@ impl DatadogMetricsConfig {
     fn get_base_agent_endpoint(&self) -> String {
         self.endpoint.clone().unwrap_or_else(|| {
             let version = str::replace(crate::built_info::PKG_VERSION, ".", "-");
-            format!("https://{}-vector.agent.{}", version, self.get_base())
+            format!(
+                "https://{}-vector.agent.{}",
+                version,
+                get_base_domain_region(self.site.as_str(), self.region)
+            )
         })
     }
 
@@ -213,7 +213,10 @@ impl DatadogMetricsConfig {
     }
 
     fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
-        let validate_endpoint = get_api_validate_endpoint(self.endpoint.as_ref(), self.get_base())?;
+        let validate_endpoint = get_api_validate_endpoint(
+            self.endpoint.as_ref(),
+            get_base_domain_region(self.site.as_str(), self.region),
+        )?;
         Ok(healthcheck(
             client,
             validate_endpoint,

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::tls::{MaybeTlsSettings, TlsEnableableConfig};
 use crate::{
-    common::datadog::get_base_domain,
+    common::datadog::get_base_domain_region,
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
@@ -110,7 +110,7 @@ pub struct DatadogMetricsConfig {
     /// The Datadog [site][dd_site] to send metrics to.
     ///
     /// [dd_site]: https://docs.datadoghq.com/getting_started/site
-    pub site: Option<String>,
+    pub site: String,
 
     /// The default Datadog [API key][api_key] to send metrics with.
     ///
@@ -177,7 +177,7 @@ impl DatadogMetricsConfig {
             format!(
                 "https://{}-vector.agent.{}",
                 version,
-                get_base_domain(self.site.as_ref(), self.region)
+                get_base_domain_region(self.site.as_ref(), self.region)
             )
         })
     }

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -16,7 +16,7 @@ use crate::{
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
-        datadog::{get_api_validate_endpoint, healthcheck},
+        datadog::{get_api_validate_endpoint, healthcheck, default_site},
         util::{batch::BatchConfig, ServiceBuilderExt, SinkBatchSettings, TowerRequestConfig},
         Healthcheck, UriParseSnafu, VectorSink,
     },
@@ -113,6 +113,7 @@ pub struct DatadogMetricsConfig {
     /// The Datadog [site][dd_site] to send metrics to.
     ///
     /// [dd_site]: https://docs.datadoghq.com/getting_started/site
+    #[serde(default = "default_site")]
     pub site: String,
 
     /// The default Datadog [API key][api_key] to send metrics with.

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -3,7 +3,7 @@ use hyper::body::Body;
 use snafu::Snafu;
 
 use crate::{
-    common::datadog::{get_api_base_endpoint, Region},
+    common::datadog::{get_api_base_endpoint, DD_US_SITE},
     http::{HttpClient, HttpError},
     sinks::HealthcheckError,
 };
@@ -16,6 +16,10 @@ pub mod logs;
 pub mod metrics;
 #[cfg(feature = "sinks-datadog_traces")]
 pub mod traces;
+
+pub fn default_site() -> String {
+    DD_US_SITE.to_owned()
+}
 
 /// Gets the API endpoint for validating credentials.
 ///

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -19,14 +19,9 @@ pub mod traces;
 
 /// Gets the API endpoint for validating credentials.
 ///
-/// If `site` is not specified, we fallback to `region`, and if that is not specified, we fallback
-/// to the Datadog US domain.
-fn get_api_validate_endpoint(
-    endpoint: Option<&String>,
-    site: Option<&String>,
-    region: Option<Region>,
-) -> crate::Result<Uri> {
-    let base = get_api_base_endpoint(endpoint, site, region);
+/// If `endpoint` is not specified, we fallback to `site`.
+fn get_api_validate_endpoint(endpoint: Option<&String>, site: &str) -> crate::Result<Uri> {
+    let base = get_api_base_endpoint(endpoint, site);
     let validate = format!("{}{}", base, "/api/v1/validate");
     validate.parse::<Uri>().map_err(Into::into)
 }

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -62,6 +62,12 @@ impl SinkBatchSettings for DatadogTracesDefaultBatchSettings {
 #[serde(deny_unknown_fields)]
 pub struct DatadogTracesConfig {
     /// The endpoint to send traces to.
+    ///
+    /// This should include the protocol and host, and port.
+    ///
+    /// If set, overrides to `site` option.
+    #[configurable(metadata(docs::examples = "http://127.0.0.1:8080"))]
+    #[configurable(metadata(docs::examples = "http://example.com:12345"))]
     pub(crate) endpoint: Option<String>,
 
     /// The Datadog [site][dd_site] to send traces to.

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -15,12 +15,11 @@ use super::{
     service::TraceApiRetry,
 };
 use crate::{
-    common::datadog::DD_US_SITE,
     config::{GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
         datadog::{
-            get_api_validate_endpoint, healthcheck,
+            default_site, get_api_validate_endpoint, healthcheck,
             traces::{
                 request_builder::DatadogTracesRequestBuilder, service::TraceApiService,
                 sink::TracesSink,
@@ -114,10 +113,6 @@ pub struct DatadogTracesConfig {
     pub acknowledgements: AcknowledgementsConfig,
 }
 
-fn default_site() -> String {
-    DD_US_SITE.to_owned()
-}
-
 impl GenerateConfig for DatadogTracesConfig {
     fn generate_config() -> toml::Value {
         toml::from_str(indoc! {r#"
@@ -155,7 +150,7 @@ impl DatadogTracesConfig {
     fn get_base_uri(&self) -> String {
         self.endpoint
             .clone()
-            .unwrap_or_else(|| format!("https://trace.agent.{}", self.site.as_ref()))
+            .unwrap_or_else(|| format!("https://trace.agent.{}", self.site))
     }
 
     fn generate_traces_endpoint_configuration(
@@ -233,7 +228,7 @@ impl DatadogTracesConfig {
 
     pub fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
         let validate_endpoint =
-            get_api_validate_endpoint(self.endpoint.as_ref(), self.site.as_ref(), None)?;
+            get_api_validate_endpoint(self.endpoint.as_ref(), self.site.as_ref())?;
         Ok(healthcheck(
             client,
             validate_endpoint,

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -62,7 +62,8 @@ impl SinkBatchSettings for DatadogTracesDefaultBatchSettings {
 pub struct DatadogTracesConfig {
     /// The endpoint to send traces to.
     ///
-    /// This should include the protocol, host, and port.
+    /// The endpoint must contain an HTTP scheme, and may specify a
+    /// hostname or IP address and port.
     ///
     /// If set, overrides to `site` option.
     #[configurable(metadata(docs::examples = "http://127.0.0.1:8080"))]

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -65,7 +65,7 @@ pub struct DatadogTracesConfig {
     /// The endpoint must contain an HTTP scheme, and may specify a
     /// hostname or IP address and port.
     ///
-    /// If set, overrides to `site` option.
+    /// If set, overrides the `site` option.
     #[configurable(metadata(docs::examples = "http://127.0.0.1:8080"))]
     #[configurable(metadata(docs::examples = "http://example.com:12345"))]
     #[serde(default)]

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -207,7 +207,7 @@ base: components: sinks: datadog_events: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {}
+		type: string: default: "datadoghq.com"
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -298,7 +298,7 @@ base: components: sinks: datadog_logs: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {}
+		type: string: default: "datadoghq.com"
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -248,8 +248,8 @@ base: components: sinks: datadog_metrics: configuration: {
 
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
-		required: true
-		type: string: {}
+		required: false
+		type: string: default: "datadoghq.com"
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -248,7 +248,7 @@ base: components: sinks: datadog_metrics: configuration: {
 
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
-		required: false
+		required: true
 		type: string: {}
 	}
 	tls: {

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -96,9 +96,15 @@ base: components: sinks: datadog_traces: configuration: {
 		type: string: {}
 	}
 	endpoint: {
-		description: "The endpoint to send traces to."
-		required:    false
-		type: string: {}
+		description: """
+			The endpoint to send traces to.
+
+			This should include the protocol, host, and port.
+
+			If set, overrides to `site` option.
+			"""
+		required: false
+		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 	}
 	request: {
 		description: """
@@ -250,7 +256,7 @@ base: components: sinks: datadog_traces: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {}
+		type: string: default: "datadoghq.com"
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -88,12 +88,12 @@ base: components: sinks: datadog_traces: configuration: {
 			The default Datadog [API key][api_key] to send traces with.
 
 			If a trace has a Datadog [API key][api_key] set explicitly in its metadata, it will take
-			precedence over the default.
+			precedence over this setting.
 
 			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
 			"""
 		required: true
-		type: string: {}
+		type: string: examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 	}
 	endpoint: {
 		description: """
@@ -256,7 +256,10 @@ base: components: sinks: datadog_traces: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: default: "datadoghq.com"
+		type: string: {
+			default: "datadoghq.com"
+			examples: ["us3.datadoghq.com", "datadoghq.eu"]
+		}
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -102,7 +102,7 @@ base: components: sinks: datadog_traces: configuration: {
 			The endpoint must contain an HTTP scheme, and may specify a
 			hostname or IP address and port.
 
-			If set, overrides to `site` option.
+			If set, overrides the `site` option.
 			"""
 		required: false
 		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -99,7 +99,8 @@ base: components: sinks: datadog_traces: configuration: {
 		description: """
 			The endpoint to send traces to.
 
-			This should include the protocol, host, and port.
+			The endpoint must contain an HTTP scheme, and may specify a
+			hostname or IP address and port.
 
 			If set, overrides to `site` option.
 			"""

--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -7,6 +7,7 @@ components: sinks: datadog_traces: {
 
 	features: {
 		acknowledgements: true
+		auto_generated:   true
 		healthcheck: enabled: true
 		send: {
 			batch: {
@@ -64,11 +65,7 @@ components: sinks: datadog_traces: {
 		notices: []
 	}
 
-	configuration: {
-		default_api_key: sinks._datadog.configuration.default_api_key
-		endpoint:        sinks._datadog.configuration.endpoint
-		site:            sinks._datadog.configuration.site
-	}
+	configuration: base.components.sinks.datadog_traces.configuration
 
 	input: {
 		logs:    false


### PR DESCRIPTION
### Reviewer Notes:

- The changes to `site` , I had to do for each DD sink because they use shared code as you'll see in the PR. I didn't touch anything else in the configs for the other DD sinks so those will still get separate reviews.

- Consequently, my next PRs for the other DD sinks will be based off this one.



closes: https://github.com/vectordotdev/vector/issues/16224

epic: https://github.com/vectordotdev/vector/issues/14999