### PR TITLE
chore(config, docs): a bunch of fixes/additions to schema output

### DIFF
--- a/lib/codecs/src/decoding/framing/character_delimited.rs
+++ b/lib/codecs/src/decoding/framing/character_delimited.rs
@@ -35,16 +35,18 @@ pub struct CharacterDelimitedDecoderOptions {
     /// The character that delimits byte sequences.
     #[serde(with = "vector_core::serde::ascii_char")]
     pub delimiter: u8,
+
     /// The maximum length of the byte buffer.
     ///
     /// This length does *not* include the trailing delimiter.
     ///
     /// By default, there is no maximum length enforced. If events are malformed, this can lead to
-    /// additional resource usage as events continued to be buffered in memory, and can potentially
+    /// additional resource usage as events continue to be buffered in memory, and can potentially
     /// lead to memory exhaustion in extreme cases.
     ///
-    /// Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-    /// there is a risk of malformed data, such as if user-controlled data is consumed.
+    /// If there is a risk of processing malformed data, such as logs with user-controlled input,
+    /// consider setting the maximum length to a reasonably large value as a safety net. This will
+    /// ensure that processing is not truly unbounded.
     #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
     pub max_length: Option<usize>,
 }

--- a/lib/codecs/src/decoding/framing/character_delimited.rs
+++ b/lib/codecs/src/decoding/framing/character_delimited.rs
@@ -38,6 +38,13 @@ pub struct CharacterDelimitedDecoderOptions {
     /// The maximum length of the byte buffer.
     ///
     /// This length does *not* include the trailing delimiter.
+    ///
+    /// By default, there is no maximum length enforced. If events are malformed, this can lead to
+    /// additional resource usage as events continued to be buffered in memory, and can potentially
+    /// lead to memory exhaustion in extreme cases.
+    ///
+    /// Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+    /// there is a risk of malformed data, such as if user-controlled data is consumed.
     #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
     pub max_length: Option<usize>,
 }

--- a/lib/codecs/src/decoding/framing/newline_delimited.rs
+++ b/lib/codecs/src/decoding/framing/newline_delimited.rs
@@ -25,6 +25,13 @@ pub struct NewlineDelimitedDecoderOptions {
     /// The maximum length of the byte buffer.
     ///
     /// This length does *not* include the trailing delimiter.
+    ///
+    /// By default, there is no maximum length enforced. If events are malformed, this can lead to
+    /// additional resource usage as events continued to be buffered in memory, and can potentially
+    /// lead to memory exhaustion in extreme cases.
+    ///
+    /// Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+    /// there is a risk of malformed data, such as if user-controlled data is consumed.
     #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
     max_length: Option<usize>,
 }

--- a/lib/codecs/src/decoding/framing/newline_delimited.rs
+++ b/lib/codecs/src/decoding/framing/newline_delimited.rs
@@ -27,11 +27,12 @@ pub struct NewlineDelimitedDecoderOptions {
     /// This length does *not* include the trailing delimiter.
     ///
     /// By default, there is no maximum length enforced. If events are malformed, this can lead to
-    /// additional resource usage as events continued to be buffered in memory, and can potentially
+    /// additional resource usage as events continue to be buffered in memory, and can potentially
     /// lead to memory exhaustion in extreme cases.
     ///
-    /// Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-    /// there is a risk of malformed data, such as if user-controlled data is consumed.
+    /// If there is a risk of processing malformed data, such as logs with user-controlled input,
+    /// consider setting the maximum length to a reasonably large value as a safety net. This will
+    /// ensure that processing is not truly unbounded.
     #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
     max_length: Option<usize>,
 }

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -203,12 +203,16 @@ pub enum BufferType {
     /// be lost if Vector is restarted forcefully or crashes.
     ///
     /// Data is synchronized to disk every 500ms.
-    #[configurable(title = "Events are buffered on disk. (version 2)")]
+    #[configurable(title = "Events are buffered on disk.")]
     #[serde(rename = "disk")]
     DiskV2 {
         /// The maximum size of the buffer on disk.
         ///
         /// Must be at least ~256 megabytes (268435488 bytes).
+        #[configurable(
+            validation(range(min = 268435488)),
+            metadata(docs::type_unit = "bytes")
+        )]
         max_size: NonZeroU64,
 
         #[configurable(derived)]

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -35,7 +35,6 @@ pub(crate) enum DataDirError {
 // function!
 #[configurable_component]
 #[derive(Clone, Debug, Default, PartialEq)]
-#[serde(default)]
 pub struct GlobalOptions {
     /// The directory used for persisting Vector state data.
     ///

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -49,7 +49,10 @@ pub struct GlobalOptions {
     ///
     /// This is used if a component does not have its own specific log schema. All events use a log
     /// schema, whether or not the default is used, to assign event fields on incoming events.
-    #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
     pub log_schema: LogSchema,
 
     /// The name of the timezone to apply to timestamp conversions that do not contain an explicit timezone.
@@ -58,11 +61,17 @@ pub struct GlobalOptions {
     /// local time.
     ///
     /// [tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
     pub timezone: Option<TimeZone>,
 
     #[configurable(derived)]
-    #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
     pub proxy: ProxyConfig,
 
     /// Controls how acknowledgements are handled for all sinks by default.
@@ -87,7 +96,10 @@ pub struct GlobalOptions {
     /// captured, but not so long that they continue to build up indefinitely, as this will consume
     /// a small amount of memory for each metric.
     #[configurable(deprecated)]
-    #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
     pub expire_metrics: Option<Duration>,
 
     /// The amount of time, in seconds, that internal metrics will persist after having not been
@@ -98,7 +110,10 @@ pub struct GlobalOptions {
     /// setting this to a value that ensures that metrics live long enough to be emitted and
     /// captured, but not so long that they continue to build up indefinitely, as this will consume
     /// a small amount of memory for each metric.
-    #[serde(skip_serializing_if = "crate::serde::skip_serializing_if_default")]
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+    )]
     pub expire_metrics_secs: Option<f64>,
 }
 

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -45,6 +45,7 @@ impl NoProxyInterceptor {
 /// to use based on the type of traffic being proxied, as well as set specific hosts that
 /// should not be proxied.
 #[configurable_component]
+#[configurable(metadata(docs::advanced))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ProxyConfig {

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -19,7 +19,7 @@ pub struct VrlConfig {
     /// The VRL boolean expression.
     pub(crate) source: String,
 
-    #[configurable(derived)]
+    #[configurable(derived, metadata(docs::hidden))]
     #[serde(default)]
     pub(crate) runtime: VrlRuntime,
 }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -54,11 +54,9 @@ pub struct ConfigBuilder {
     pub enrichment_tables: IndexMap<ComponentKey, EnrichmentTableOuter>,
 
     /// All configured sources.
-    #[serde(default)]
     pub sources: IndexMap<ComponentKey, SourceOuter>,
 
     /// All configured sinks.
-    #[serde(default)]
     pub sinks: IndexMap<ComponentKey, SinkOuter<String>>,
 
     /// All configured transforms.

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -54,9 +54,11 @@ pub struct ConfigBuilder {
     pub enrichment_tables: IndexMap<ComponentKey, EnrichmentTableOuter>,
 
     /// All configured sources.
+    #[serde(default)]
     pub sources: IndexMap<ComponentKey, SourceOuter>,
 
     /// All configured sinks.
+    #[serde(default)]
     pub sinks: IndexMap<ComponentKey, SinkOuter<String>>,
 
     /// All configured transforms.

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -124,7 +124,7 @@ pub struct RemapConfig {
     #[serde(default = "crate::serde::default_false")]
     pub reroute_dropped: bool,
 
-    #[configurable(derived)]
+    #[configurable(derived, metadata(docs::hidden))]
     #[serde(default)]
     pub runtime: VrlRuntime,
 }

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -26,7 +26,7 @@ base: components: sinks: configuration: {
 					"""
 				relevant_when: "type = \"disk\""
 				required:      true
-				type: uint: {}
+				type: uint: unit: "bytes"
 			}
 			type: {
 				description: "The type of buffer to use."
@@ -35,7 +35,7 @@ base: components: sinks: configuration: {
 					default: "memory"
 					enum: {
 						disk: """
-														Events are buffered on disk. (version 2)
+														Events are buffered on disk.
 
 														This is less performant, but more durable. Data that has been synchronized to disk will not
 														be lost if Vector is restarted forcefully or crashes.

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -125,6 +125,13 @@ base: components: sources: amqp: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -158,6 +165,13 @@ base: components: sources: amqp: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -127,11 +127,12 @@ base: components: sources: amqp: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -167,11 +168,12 @@ base: components: sources: amqp: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -125,11 +125,12 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -165,11 +166,12 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -123,6 +123,13 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -156,6 +163,13 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -215,6 +215,13 @@ base: components: sources: aws_sqs: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -248,6 +255,13 @@ base: components: sources: aws_sqs: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -217,11 +217,12 @@ base: components: sources: aws_sqs: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -257,11 +258,12 @@ base: components: sources: aws_sqs: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -122,11 +122,12 @@ base: components: sources: datadog_agent: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -162,11 +163,12 @@ base: components: sources: datadog_agent: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -120,6 +120,13 @@ base: components: sources: datadog_agent: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -153,6 +160,13 @@ base: components: sources: datadog_agent: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -118,11 +118,12 @@ base: components: sources: demo_logs: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -158,11 +159,12 @@ base: components: sources: demo_logs: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -116,6 +116,13 @@ base: components: sources: demo_logs: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -149,6 +156,13 @@ base: components: sources: demo_logs: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -80,6 +80,13 @@ base: components: sources: exec: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -110,6 +117,13 @@ base: components: sources: exec: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -82,11 +82,12 @@ base: components: sources: exec: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -119,11 +120,12 @@ base: components: sources: exec: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -82,6 +82,13 @@ base: components: sources: file_descriptor: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -112,6 +119,13 @@ base: components: sources: file_descriptor: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -84,11 +84,12 @@ base: components: sources: file_descriptor: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -121,11 +122,12 @@ base: components: sources: file_descriptor: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -157,11 +157,12 @@ base: components: sources: gcp_pubsub: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -197,11 +198,12 @@ base: components: sources: gcp_pubsub: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -155,6 +155,13 @@ base: components: sources: gcp_pubsub: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -188,6 +195,13 @@ base: components: sources: gcp_pubsub: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -117,6 +117,13 @@ base: components: sources: heroku_logs: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -150,6 +157,13 @@ base: components: sources: heroku_logs: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -119,11 +119,12 @@ base: components: sources: heroku_logs: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -159,11 +160,12 @@ base: components: sources: heroku_logs: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -134,11 +134,12 @@ base: components: sources: http: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -171,11 +172,12 @@ base: components: sources: http: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -132,6 +132,13 @@ base: components: sources: http: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -162,6 +169,13 @@ base: components: sources: http: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -120,6 +120,13 @@ base: components: sources: http_client: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -153,6 +160,13 @@ base: components: sources: http_client: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -122,11 +122,12 @@ base: components: sources: http_client: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -162,11 +163,12 @@ base: components: sources: http_client: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -134,11 +134,12 @@ base: components: sources: http_server: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -171,11 +172,12 @@ base: components: sources: http_server: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -132,6 +132,13 @@ base: components: sources: http_server: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -162,6 +169,13 @@ base: components: sources: http_server: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -140,11 +140,12 @@ base: components: sources: kafka: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -180,11 +181,12 @@ base: components: sources: kafka: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -138,6 +138,13 @@ base: components: sources: kafka: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -171,6 +178,13 @@ base: components: sources: kafka: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -174,11 +174,12 @@ base: components: sources: nats: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -214,11 +215,12 @@ base: components: sources: nats: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -172,6 +172,13 @@ base: components: sources: nats: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -205,6 +212,13 @@ base: components: sources: nats: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -90,6 +90,13 @@ base: components: sources: redis: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -123,6 +130,13 @@ base: components: sources: redis: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -92,11 +92,12 @@ base: components: sources: redis: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -132,11 +133,12 @@ base: components: sources: redis: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -94,11 +94,12 @@ base: components: sources: socket: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -131,11 +132,12 @@ base: components: sources: socket: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -92,6 +92,13 @@ base: components: sources: socket: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -122,6 +129,13 @@ base: components: sources: socket: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -77,11 +77,12 @@ base: components: sources: stdin: configuration: {
 																This length does *not* include the trailing delimiter.
 
 																By default, there is no maximum length enforced. If events are malformed, this can lead to
-																additional resource usage as events continued to be buffered in memory, and can potentially
+																additional resource usage as events continue to be buffered in memory, and can potentially
 																lead to memory exhaustion in extreme cases.
 
-																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-																there is a risk of malformed data, such as if user-controlled data is consumed.
+																If there is a risk of processing malformed data, such as logs with user-controlled input,
+																consider setting the maximum length to a reasonably large value as a safety net. This will
+																ensure that processing is not truly unbounded.
 																"""
 						required: false
 						type: uint: {}
@@ -114,11 +115,12 @@ base: components: sources: stdin: configuration: {
 						This length does *not* include the trailing delimiter.
 
 						By default, there is no maximum length enforced. If events are malformed, this can lead to
-						additional resource usage as events continued to be buffered in memory, and can potentially
+						additional resource usage as events continue to be buffered in memory, and can potentially
 						lead to memory exhaustion in extreme cases.
 
-						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
-						there is a risk of malformed data, such as if user-controlled data is consumed.
+						If there is a risk of processing malformed data, such as logs with user-controlled input,
+						consider setting the maximum length to a reasonably large value as a safety net. This will
+						ensure that processing is not truly unbounded.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -75,6 +75,13 @@ base: components: sources: stdin: configuration: {
 																The maximum length of the byte buffer.
 
 																This length does *not* include the trailing delimiter.
+
+																By default, there is no maximum length enforced. If events are malformed, this can lead to
+																additional resource usage as events continued to be buffered in memory, and can potentially
+																lead to memory exhaustion in extreme cases.
+
+																Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+																there is a risk of malformed data, such as if user-controlled data is consumed.
 																"""
 						required: false
 						type: uint: {}
@@ -105,6 +112,13 @@ base: components: sources: stdin: configuration: {
 						The maximum length of the byte buffer.
 
 						This length does *not* include the trailing delimiter.
+
+						By default, there is no maximum length enforced. If events are malformed, this can lead to
+						additional resource usage as events continued to be buffered in memory, and can potentially
+						lead to memory exhaustion in extreme cases.
+
+						Consider setting this to a reasonable value, based on the expected maximum buffer length, if
+						there is a risk of malformed data, such as if user-controlled data is consumed.
 						"""
 					required: false
 					type: uint: {}

--- a/website/cue/reference/components/transforms/base/remap.cue
+++ b/website/cue/reference/components/transforms/base/remap.cue
@@ -85,18 +85,6 @@ base: components: transforms: remap: configuration: {
 		required: false
 		type: bool: default: false
 	}
-	runtime: {
-		description: "Available VRL runtimes."
-		required:    false
-		type: string: {
-			default: "ast"
-			enum: ast: """
-				Tree-walking runtime.
-
-				This is the only, and default, runtime.
-				"""
-		}
-	}
 	source: {
 		description: """
 			The [Vector Remap Language][vrl] (VRL) program to execute for each event.


### PR DESCRIPTION
This PR is a grab bag of a bunch of tweaks/cleanup work for the generated configuration schema / schema-based documentation:

- updated description for `max_length` configuration setting of the character/newline-delimited framers to indicate that the default value is, practically, unlimited, and that care should be taken, yadda yadda
- tweaks to the buffer configuration stuff, namely specifying the minimum disk buffer size as a validator attribute, and specifying the type unit of "bytes"
- a small tweak to `GlobalOptions` to not use `#[serde(default)]` at the type level, which drops some extraneous (and incorrect) default values from the generated schema [1]
- marking `ProxyConfig` as advanced
- hiding the `runtime` configuration setting from both the `remap` transform and the generic VRL condition settings (i.e. specifying a condition in the `filter` transforms) as there's only one valid value, which is the default, and so showing it is pointless