### PR TITLE
docs(syslog source): removed `unix` mode from docs

### DIFF
--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -60,7 +60,6 @@ base: components: sources: syslog: configuration: {
 		type: string: enum: {
 			tcp:  "Listen on TCP."
 			udp:  "Listen on UDP."
-			unix: "Listen on UDS. (Unix domain socket)"
 		}
 	}
 	path: {
@@ -69,7 +68,6 @@ base: components: sources: syslog: configuration: {
 
 			This should be an absolute path.
 			"""
-		relevant_when: "mode = \"unix\""
 		required:      true
 		type: string: examples: ["/path/to/socket"]
 	}
@@ -90,7 +88,6 @@ base: components: sources: syslog: configuration: {
 			Note that the file mode value can be specified in any numeric format supported by your configuration
 			language, but it is most intuitive to use an octal number.
 			"""
-		relevant_when: "mode = \"unix\""
 		required:      false
 		type: uint: {}
 	}


### PR DESCRIPTION
The syslog source doesn't seem to support the `unix` mode anymore, so I removed it from the docs. 
Although the `path` and `socket_file_mode` options seem to work just fine, maybe that is also worth looking into.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
