### PR TITLE
docs: Build rust docs in netlify

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,2 +1,0 @@
-IgnoreDirs: 
-- "rustdocs"

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,2 @@
+IgnoreDirs: 
+- "rustdocs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,6 +379,7 @@ tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-ut
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
 default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise", "component-validation-runner"]
+docs = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "vrl-cli", "enterprise", "component-validation-runner"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise"]
 # Default features for *-pc-windows-msvc

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 base = "website"
 publish = "public"
+environment = { RUSTDOCFLAGS= "--cfg docsrs" }
 
 # Reinstate this when we figure out how to target this better
 #ignore = "./scripts/build-ignore.sh"

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -11,6 +11,15 @@ set -o errexit -o verbose
 readonly TMP_DIR="$(mktemp -d -t "protoc_XXXX")"
 trap 'rm -rf "${TMP_DIR?}"' EXIT
 
+# A parameter can be optionally passed to this script to specify an alternative
+# location to install protoc. Default is /usr/bin.
+readonly INSTALL_PATH=${1:-"/usr/bin"}
+
+if [[ -n $1 ]]
+then
+  mkdir -p ${INSTALL_PATH}
+fi
+
 get_platform() {
   local os
   os=$(uname)
@@ -54,5 +63,4 @@ install_protoc() {
   mv --force --verbose "${TMP_DIR}/bin/protoc" "${install_path}"
 }
 
-mkdir -p "${HOME}/protoc/"
-install_protoc "3.19.5" "${HOME}/protoc/protoc"
+install_protoc "3.19.5" "${INSTALL_PATH}/protoc"

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -54,6 +54,4 @@ install_protoc() {
   mv --force --verbose "${TMP_DIR}/bin/protoc" "${install_path}"
 }
 
-echo $PATH
-
-install_protoc "3.19.5" "/usr/bin/protoc"
+install_protoc "3.19.5" "${HOME}/protoc/protoc"

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -54,4 +54,5 @@ install_protoc() {
   mv --force --verbose "${TMP_DIR}/bin/protoc" "${install_path}"
 }
 
+mkdir -p "${HOME}/protoc/"
 install_protoc "3.19.5" "${HOME}/protoc/protoc"

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -54,4 +54,6 @@ install_protoc() {
   mv --force --verbose "${TMP_DIR}/bin/protoc" "${install_path}"
 }
 
+echo $PATH
+
 install_protoc "3.19.5" "/usr/bin/protoc"

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -17,7 +17,7 @@ readonly INSTALL_PATH=${1:-"/usr/bin"}
 
 if [[ -n $1 ]]
 then
-  mkdir -p ${INSTALL_PATH}
+  mkdir -p "${INSTALL_PATH}"
 fi
 
 get_platform() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
 #![deny(warnings)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wild_err_arm)]

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -3,6 +3,7 @@ public/
 resources/
 hugo_stats.json
 assets/jsconfig.json
+static/rustdocs/
 
 # JavaScript, Sass, CSS, etc.
 node_modules/

--- a/website/.htmltest.yml
+++ b/website/.htmltest.yml
@@ -4,4 +4,4 @@ CheckExternal: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
 IgnoreDirs:
-- "rustdocs"
+- ".*rustdocs.*"

--- a/website/.htmltest.yml
+++ b/website/.htmltest.yml
@@ -3,3 +3,5 @@ IgnoreDirectoryMissingTrailingSlash: true
 CheckExternal: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
+IgnoreDirs:
+- "rustdocs"

--- a/website/Makefile
+++ b/website/Makefile
@@ -4,6 +4,11 @@ clean:
 	rm -rf public resources data/docs.json
 
 setup:
+	apt-get update
+	apt-get install -y build-essential curl
+	curl https://sh.rustup.rs -sSf | bash -s -- -y
+	echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+	source $HOME/.bashrc
 	yarn
 
 # Build JSON from CUE sources
@@ -28,8 +33,12 @@ cue-vet:
 
 config-examples:
 	yarn config-examples
+	
+rust-docs:
+	cargo doc
+	mv ../target/doc/ static/rustdocs/
 
-structured-data: cue-build config-examples
+structured-data: cue-build config-examples rust-docs
 
 serve: clean setup structured-data
 	hugo server \

--- a/website/Makefile
+++ b/website/Makefile
@@ -30,6 +30,7 @@ config-examples:
 	yarn config-examples
 	
 rust-docs:
+	brew install cyrus-sasl
 	../scripts/environment/install-protoc.sh
 	PATH=${PATH}:~/protoc/ cargo doc
 	mv ../target/doc/ static/rustdocs/

--- a/website/Makefile
+++ b/website/Makefile
@@ -31,7 +31,7 @@ config-examples:
 	
 rust-docs:
 	../scripts/environment/install-protoc.sh
-	PATH=${PATH}:~/protoc/ cargo doc --no-default-features --features="docs"
+	PATH=${PATH}:~/protoc/ cargo doc --no-default-features --features="docs" --no-deps
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -31,7 +31,7 @@ config-examples:
 	
 rust-docs:
 	../scripts/environment/install-protoc.sh
-	PATH=${PATH}:~/protoc/ cargo doc --no-deps
+	PATH=${PATH}:~/protoc/ cargo doc --no-default-features --features="docs"
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -4,11 +4,6 @@ clean:
 	rm -rf public resources data/docs.json
 
 setup:
-	apt-get update
-	apt-get install -y build-essential curl
-	curl https://sh.rustup.rs -sSf | bash -s -- -y
-	echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
-	source $HOME/.bashrc
 	yarn
 
 # Build JSON from CUE sources

--- a/website/Makefile
+++ b/website/Makefile
@@ -30,8 +30,8 @@ config-examples:
 	yarn config-examples
 	
 rust-docs:
-	../scripts/environment/install-protoc.sh
-	PATH=${PATH}:~/protoc/ cargo doc --no-default-features --features="docs"
+	../scripts/environment/install-protoc.sh ${HOME}/protoc
+	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs"
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -31,7 +31,7 @@ config-examples:
 	
 rust-docs:
 	../scripts/environment/install-protoc.sh
-	PATH=$PATH:~/protoc/ cargo doc
+	PATH=${PATH}:~/protoc/ cargo doc
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -30,9 +30,8 @@ config-examples:
 	yarn config-examples
 	
 rust-docs:
-	brew install cyrus-sasl
 	../scripts/environment/install-protoc.sh
-	PATH=${PATH}:~/protoc/ cargo doc
+	PATH=${PATH}:~/protoc/ cargo doc --no-deps
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -30,6 +30,7 @@ config-examples:
 	yarn config-examples
 	
 rust-docs:
+	../script/environment/install-protoc.sh
 	cargo doc
 	mv ../target/doc/ static/rustdocs/
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -31,7 +31,7 @@ config-examples:
 	
 rust-docs:
 	../scripts/environment/install-protoc.sh
-	PATH=${PATH}:~/protoc/ cargo doc --no-default-features --features="docs" --no-deps
+	PATH=${PATH}:~/protoc/ cargo doc --no-default-features --features="docs"
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -31,7 +31,7 @@ config-examples:
 	
 rust-docs:
 	../scripts/environment/install-protoc.sh
-	cargo doc
+	PATH=$PATH:~/protoc/ cargo doc
 	mv ../target/doc/ static/rustdocs/
 
 structured-data: cue-build config-examples rust-docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -30,7 +30,7 @@ config-examples:
 	yarn config-examples
 	
 rust-docs:
-	../script/environment/install-protoc.sh
+	../scripts/environment/install-protoc.sh
 	cargo doc
 	mv ../target/doc/ static/rustdocs/
 


### PR DESCRIPTION
This will place the rust docs under https://vector.dev/rustdocs/vector/

You can preview [here](https://deploy-preview-16276--vector-project.netlify.app/rustdocs/vector/).

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
