### PR TITLE
chore(vdev): Drop backwards compat hack for old integrations

### DIFF
--- a/vdev/src/commands/integration/stop.rs
+++ b/vdev/src/commands/integration/stop.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use clap::Args;
 
-use crate::testing::integration::{self, IntegrationTest, OldIntegrationTest};
-use crate::testing::state::EnvsDir;
+use crate::testing::{integration::IntegrationTest, state::EnvsDir};
 
 /// Stop an integration test environment
 #[derive(Args, Debug)]
@@ -14,12 +13,6 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        // Temporary hack to run old-style integration tests
-        if integration::old_exists(&self.integration)? {
-            let integration = OldIntegrationTest::new(&self.integration);
-            return integration.stop();
-        }
-
         if let Some(active) = EnvsDir::new(&self.integration).active()? {
             IntegrationTest::new(self.integration, active)?.stop()
         } else {

--- a/vdev/src/commands/integration/test.rs
+++ b/vdev/src/commands/integration/test.rs
@@ -1,8 +1,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::testing::integration::{self, IntegrationTest, OldIntegrationTest};
-use crate::testing::{config::IntegrationTestConfig, state::EnvsDir};
+use crate::testing::{config::IntegrationTestConfig, integration::IntegrationTest, state::EnvsDir};
 
 /// Execute integration tests
 ///
@@ -27,13 +26,6 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        // Temporary hack to run old-style integration tests
-        if self.environment.is_none() && integration::old_exists(&self.integration)? {
-            let integration = OldIntegrationTest::new(&self.integration);
-            integration.build()?;
-            return integration.test();
-        }
-
         let (_test_dir, config) = IntegrationTestConfig::load(&self.integration)?;
         let envs = config.environments();
 

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -2,69 +2,14 @@ use std::{path::Path, path::PathBuf, process::Command};
 
 use anyhow::{bail, Context, Result};
 
-use super::config::{Environment, IntegrationTestConfig, RustToolchainConfig};
+use super::config::{Environment, IntegrationTestConfig};
 use super::runner::{
     ContainerTestRunner as _, IntegrationTestRunner, TestRunner as _, CONTAINER_TOOL, DOCKER_SOCKET,
 };
 use super::state::EnvsDir;
-use crate::app::{self, CommandExt as _};
-use crate::util;
+use crate::app::CommandExt as _;
 
 const NETWORK_ENV_VAR: &str = "VECTOR_NETWORK";
-
-#[allow(clippy::dbg_macro)]
-fn old_integration_path(integration: &str) -> PathBuf {
-    let filename = format!("docker-compose.{integration}.yml");
-    [app::path(), "scripts", "integration", &filename]
-        .into_iter()
-        .collect()
-}
-
-pub fn old_exists(integration: &str) -> Result<bool> {
-    let path = old_integration_path(integration);
-    util::exists(path)
-}
-
-/// Temporary runner setup for old-style integration tests
-pub struct OldIntegrationTest {
-    compose_path: PathBuf,
-}
-
-impl OldIntegrationTest {
-    pub fn new(integration: &str) -> Self {
-        let compose_path = old_integration_path(integration);
-        Self { compose_path }
-    }
-
-    pub fn build(&self) -> Result<()> {
-        self.compose(&["build"])
-    }
-
-    pub fn test(&self) -> Result<()> {
-        self.compose(&["run", "--rm", "runner"])
-    }
-
-    pub fn stop(&self) -> Result<()> {
-        self.compose(&["rm", "--force", "--stop", "-v"])
-    }
-
-    fn compose(&self, args: &[&'static str]) -> Result<()> {
-        let mut command = CONTAINER_TOOL.clone();
-        command.push("-compose");
-        let mut command = Command::new(command);
-        command.arg("--file");
-        command.arg(&self.compose_path);
-        command.args(args);
-        command.current_dir(app::path());
-
-        let rust_version = RustToolchainConfig::parse()
-            .expect("Could not parse `rust-toolchain.toml`")
-            .channel;
-        command.env("RUST_VERSION", rust_version);
-
-        command.check_run()
-    }
-}
 
 pub struct IntegrationTest {
     integration: String,


### PR DESCRIPTION
The compatibility hack was introduced in #16124 as we were starting to run tests through vdev but didn't want to deal with fixing all of them at once. The last test has been fixed, so this path is no longer needed.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
