### PR TITLE
docs: remove scrollbars from component tag on website

### DIFF
--- a/website/layouts/_default/component-card.html
+++ b/website/layouts/_default/component-card.html
@@ -12,7 +12,7 @@
         {{ partial "badge.html" (dict "word" $kind "color" "indigo") }}
       </span>
 
-      <div class="mt-3.5 overflow-x-auto">
+      <div class="mt-3.5 overflow-x-visible">
         <span class="text-xs font-mono bg-gray-100 text-dark dark:bg-gray-600 dark:text-gray-200 py-1 px-2 rounded font-bold">
           {{ $componentTag }}
         </span>


### PR DESCRIPTION
Something that has annoyed me for a long time. The component tag at <https://vector.dev/components/> shows redundant scrollbars next to it. 

![image](https://user-images.githubusercontent.com/192679/216995495-08d413f7-cb60-4ee0-ba31-ba774fe4f111.png)

This PR removes them.

![image](https://user-images.githubusercontent.com/192679/216996944-4e35d8a7-2266-46cd-881f-9e60cb07901a.png)

Tested on chrome, firefox and vivaldi on Linux.


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
