### PR TITLE
chore(vdev): Export all config matrix settings as CONFIG_{VAR}

### DIFF
--- a/scripts/integration/amqp/compose.yaml
+++ b/scripts/integration/amqp/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   rabbitmq:
-    image: docker.io/rabbitmq:${AMQP_VERSION}
+    image: docker.io/rabbitmq:${CONFIG_VERSION}
     ports:
     - 5672:5672
 

--- a/scripts/integration/apex/compose.yaml
+++ b/scripts/integration/apex/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mock-apex:
-    image: mcasper/mock-apex:${APEX_VERSION}
+    image: mcasper/mock-apex:${CONFIG_VERSION}
     environment:
     - MOCK_API_TOKEN=token
     ports:

--- a/scripts/integration/axiom/compose.yaml
+++ b/scripts/integration/axiom/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:${AXIOM_VERSION}
+    image: postgres:${CONFIG_POSTGRES}
     environment:
       POSTGRES_USER: axiom
       POSTGRES_PASSWORD: axiom

--- a/scripts/integration/axiom/test.yaml
+++ b/scripts/integration/axiom/test.yaml
@@ -9,4 +9,4 @@ runner:
     AXIOM_URL: http://axiom-core
 
 matrix:
-  version: [13-alpine]
+  postgres: [13-alpine]

--- a/scripts/integration/azure/compose.yaml
+++ b/scripts/integration/azure/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   local-azure-blob:
-    image: mcr.microsoft.com/azure-storage/azurite:${AZURE_VERSION}
+    image: mcr.microsoft.com/azure-storage/azurite:${CONFIG_VERSION}
     command: azurite --blobHost 0.0.0.0 --loose
     volumes:
     - /var/run:/var/run

--- a/scripts/integration/chronicle/compose.yaml
+++ b/scripts/integration/chronicle/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   chronicle-emulator:
-    image: docker.io/plork/chronicle-emulator:${CHRONICLE_VERSION}
+    image: docker.io/plork/chronicle-emulator:${CONFIG_VERSION}
     ports:
     - 3000:3000
     volumes:

--- a/scripts/integration/clickhouse/compose.yaml
+++ b/scripts/integration/clickhouse/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   clickhouse:
-    image: docker.io/yandex/clickhouse-server:${CLICKHOUSE_VERSION}
+    image: docker.io/yandex/clickhouse-server:${CONFIG_VERSION}
 
 networks:
   default:

--- a/scripts/integration/datadog-agent/compose.yaml
+++ b/scripts/integration/datadog-agent/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   datadog-agent:
-    image: docker.io/datadog/agent:${DATADOG_AGENT_VERSION}
+    image: docker.io/datadog/agent:${CONFIG_VERSION}
     environment:
     - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
     - DD_APM_ENABLED=false

--- a/scripts/integration/datadog-traces/compose.yaml
+++ b/scripts/integration/datadog-traces/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   datadog-trace-agent:
-    image: docker.io/datadog/agent:${DATADOG_TRACES_VERSION}
+    image: docker.io/datadog/agent:${CONFIG_VERSION}
     environment:
     - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
     - DD_APM_ENABLED=true
@@ -16,7 +16,7 @@ services:
     - DD_APM_MAX_CPU_PERCENT=0
     - DD_HOSTNAME=datadog-trace-agent
   datadog-trace-agent-to-vector:
-    image: docker.io/datadog/agent:${DATADOG_TRACES_VERSION}
+    image: docker.io/datadog/agent:${CONFIG_VERSION}
     environment:
     - DD_API_KEY=${TEST_DATADOG_API_KEY:?TEST_DATADOG_API_KEY required}
     - DD_APM_ENABLED=true

--- a/scripts/integration/elasticsearch/compose.yaml
+++ b/scripts/integration/elasticsearch/compose.yaml
@@ -6,12 +6,12 @@ services:
     environment:
     - SERVICES=elasticsearch:4571
   elasticsearch:
-    image: docker.io/elasticsearch:${ELASTICSEARCH_VERSION}
+    image: docker.io/elasticsearch:${CONFIG_VERSION}
     environment:
     - discovery.type=single-node
     - ES_JAVA_OPTS=-Xms400m -Xmx400m
   elasticsearch-secure:
-    image: docker.io/elasticsearch:${ELASTICSEARCH_VERSION}
+    image: docker.io/elasticsearch:${CONFIG_VERSION}
     environment:
     - discovery.type=single-node
     - xpack.security.enabled=true

--- a/scripts/integration/eventstoredb/compose.yaml
+++ b/scripts/integration/eventstoredb/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   eventstoredb:
-    image: docker.io/eventstore/eventstore:${EVENTSTOREDB_VERSION}
+    image: docker.io/eventstore/eventstore:${CONFIG_VERSION}
     command: --insecure --stats-period-sec=1
     volumes:
     - ../../../tests/data:/etc/vector:ro

--- a/scripts/integration/gcp/compose.yaml
+++ b/scripts/integration/gcp/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   gcloud-pubsub:
-    image: docker.io/messagebird/gcloud-pubsub-emulator:${GCP_VERSION}
+    image: docker.io/messagebird/gcloud-pubsub-emulator:${CONFIG_VERSION}
     environment:
     - PUBSUB_PROJECT1=testproject,topic1:subscription1
     - PUBSUB_PROJECT2=sourceproject,topic2:subscription2

--- a/scripts/integration/http-client/compose.yaml
+++ b/scripts/integration/http-client/compose.yaml
@@ -2,13 +2,13 @@ version: '3'
 
 services:
   dufs:
-    image: docker.io/sigoden/dufs:${HTTP_CLIENT_VERSION}
+    image: docker.io/sigoden/dufs:${CONFIG_VERSION}
     command:
     - /data
     volumes:
     - ../../../tests/data/http-client/serve:/data
   dufs-auth:
-    image: docker.io/sigoden/dufs:${HTTP_CLIENT_VERSION}
+    image: docker.io/sigoden/dufs:${CONFIG_VERSION}
     command:
     - -a
     - /@user:pass
@@ -18,7 +18,7 @@ services:
     volumes:
     - ../../../tests/data/http-client/serve:/data
   dufs-https:
-    image: docker.io/sigoden/dufs:${HTTP_CLIENT_VERSION}
+    image: docker.io/sigoden/dufs:${CONFIG_VERSION}
     command:
     - --tls-cert
     - /certs/ca.cert.pem

--- a/scripts/integration/humio/compose.yaml
+++ b/scripts/integration/humio/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   humio:
-    image: docker.io/humio/humio:${HUMIO_VERSION}
+    image: docker.io/humio/humio:${CONFIG_VERSION}
 
 networks:
   default:

--- a/scripts/integration/influxdb/compose.yaml
+++ b/scripts/integration/influxdb/compose.yaml
@@ -2,11 +2,11 @@ version: '3'
 
 services:
   influxdb-v1:
-    image: docker.io/influxdb:${INFLUXDB_VERSION}
+    image: docker.io/influxdb:${CONFIG_VERSION}
     environment:
     - INFLUXDB_REPORTING_DISABLED=true
   influxdb-v1-tls:
-    image: docker.io/influxdb:${INFLUXDB_VERSION}
+    image: docker.io/influxdb:${CONFIG_VERSION}
     environment:
     - INFLUXDB_REPORTING_DISABLED=true
     - INFLUXDB_HTTP_HTTPS_ENABLED=true

--- a/scripts/integration/kafka/compose.yaml
+++ b/scripts/integration/kafka/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   zookeeper:
-    image: docker.io/wurstmeister/zookeeper:${KAFKA_VERSION}
+    image: docker.io/wurstmeister/zookeeper:${CONFIG_VERSION}
     ports:
     - 2181:2181
   kafka:

--- a/scripts/integration/logstash/compose.yaml
+++ b/scripts/integration/logstash/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   beats-heartbeat:
-    image: docker.elastic.co/beats/heartbeat:${LOGSTASH_VERSION}
+    image: docker.elastic.co/beats/heartbeat:${CONFIG_VERSION}
     command: -environment=container -strict.perms=false
     volumes:
     - ../../../tests/data/logstash/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro

--- a/scripts/integration/loki/compose.yaml
+++ b/scripts/integration/loki/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   loki:
-    image: docker.io/grafana/loki:${LOKI_VERSION}
+    image: docker.io/grafana/loki:${CONFIG_VERSION}
     command: -config.file=/etc/loki/local-config.yaml -auth.enabled=true
 
 networks:

--- a/scripts/integration/mongodb/compose.yaml
+++ b/scripts/integration/mongodb/compose.yaml
@@ -2,14 +2,14 @@ version: '3'
 
 services:
   mongodb-primary:
-    image: docker.io/bitnami/mongodb:${MONGODB_VERSION}
+    image: docker.io/bitnami/mongodb:${CONFIG_VERSION}
     environment:
     - MONGODB_ADVERTISED_HOSTNAME=mongodb-primary
     - MONGODB_REPLICA_SET_MODE=primary
     - MONGODB_ROOT_PASSWORD=toor
     - MONGODB_REPLICA_SET_KEY=vector
   mongodb-secondary:
-    image: docker.io/bitnami/mongodb:${MONGODB_VERSION}
+    image: docker.io/bitnami/mongodb:${CONFIG_VERSION}
     depends_on:
     - mongodb-primary
     environment:
@@ -20,7 +20,7 @@ services:
     - MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD=toor
     - MONGODB_REPLICA_SET_KEY=vector
   mongodb-arbiter:
-    image: docker.io/bitnami/mongodb:${MONGODB_VERSION}
+    image: docker.io/bitnami/mongodb:${CONFIG_VERSION}
     depends_on:
     - mongodb-primary
     environment:

--- a/scripts/integration/nats/compose.yaml
+++ b/scripts/integration/nats/compose.yaml
@@ -2,42 +2,42 @@ version: '3'
 
 services:
   nats:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
   nats-userpass:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
     command:
     - --user
     - natsuser
     - --pass
     - natspass
   nats-token:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
     command:
     - --auth
     - secret
   nats-nkey:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
     command:
     - --config
     - /usr/share/nats/config/nats-nkey.conf
     volumes:
     - ../../../tests/data/nats:/usr/share/nats/config
   nats-tls:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
     command:
     - --config
     - /usr/share/nats/config/nats-tls.conf
     volumes:
     - ../../../tests/data/nats:/usr/share/nats/config
   nats-tls-client-cert:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
     command:
     - --config
     - /usr/share/nats/config/nats-tls-client-cert.conf
     volumes:
     - ../../../tests/data/nats:/usr/share/nats/config
   nats-jwt:
-    image: docker.io/library/nats:${NATS_VERSION}
+    image: docker.io/library/nats:${CONFIG_VERSION}
     command:
     - --config
     - /usr/share/nats/config/nats-jwt.conf

--- a/scripts/integration/nginx/compose.yaml
+++ b/scripts/integration/nginx/compose.yaml
@@ -9,13 +9,13 @@ services:
     - default
     - proxy
   nginx:
-    image: docker.io/nginx:${NGINX_VERSION}
+    image: docker.io/nginx:${CONFIG_VERSION}
     volumes:
     - ../../../tests/data/nginx/:/etc/nginx:ro
     networks:
     - default
   nginx-proxy:
-    image: docker.io/nginx:${NGINX_VERSION}
+    image: docker.io/nginx:${CONFIG_VERSION}
     volumes:
     - ../../../tests/data/nginx/:/etc/nginx:ro
     networks:

--- a/scripts/integration/opentelemetry/compose.yaml
+++ b/scripts/integration/opentelemetry/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opentelemetry-collector:
-    image: docker.io/otel/opentelemetry-collector-contrib:${OPENTELEMETRY_VERSION}
+    image: docker.io/otel/opentelemetry-collector-contrib:${CONFIG_VERSION}
     volumes:
     - ../../../tests/data/opentelemetry/config.yaml:/etc/otelcol-contrib/config.yaml
 

--- a/scripts/integration/postgres/compose.yaml
+++ b/scripts/integration/postgres/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION}
+    image: docker.io/postgres:${CONFIG_VERSION}
     command: /postgres-init.sh
     environment:
     - POSTGRES_USER=vector

--- a/scripts/integration/prometheus/compose.yaml
+++ b/scripts/integration/prometheus/compose.yaml
@@ -2,11 +2,11 @@ version: '3'
 
 services:
   influxdb-v1:
-    image: docker.io/influxdb:1.8
+    image: docker.io/influxdb:${CONFIG_INFLUXDB}
     environment:
     - INFLUXDB_REPORTING_DISABLED=true
   influxdb-v1-tls:
-    image: docker.io/influxdb:1.8
+    image: docker.io/influxdb:${CONFIG_INFLUXDB}
     environment:
     - INFLUXDB_REPORTING_DISABLED=true
     - INFLUXDB_HTTP_HTTPS_ENABLED=true
@@ -17,7 +17,7 @@ services:
     volumes:
     - ../../../tests/data/ca:/etc/ssl:ro
   prometheus:
-    image: docker.io/prom/prometheus:${PROMETHEUS_VERSION:-v2.33.4}
+    image: docker.io/prom/prometheus:${CONFIG_PROMETHEUS}
     command: --config.file=/etc/vector/prometheus.yaml
     volumes:
     - ../../../tests/data:/etc/vector:ro

--- a/scripts/integration/prometheus/test.yaml
+++ b/scripts/integration/prometheus/test.yaml
@@ -8,4 +8,5 @@ env:
   REMOTE_WRITE_SOURCE_RECEIVE_ADDRESS: runner:9102
 
 matrix:
-  version: [v2.33.4]
+  prometheus: ['v2.33.4']
+  influxdb: ['1.8']

--- a/scripts/integration/pulsar/compose.yaml
+++ b/scripts/integration/pulsar/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   pulsar:
-    image: docker.io/apachepulsar/pulsar:${PULSAR_VERSION}
+    image: docker.io/apachepulsar/pulsar:${CONFIG_VERSION}
     command: bin/pulsar standalone
     ports:
     - 6650:6650

--- a/scripts/integration/redis/compose.yaml
+++ b/scripts/integration/redis/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   redis:
-    image: docker.io/redis:${REDIS_VERSION}
+    image: docker.io/redis:${CONFIG_VERSION}
 
 networks:
   default:

--- a/scripts/integration/shutdown/compose.yaml
+++ b/scripts/integration/shutdown/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   zookeeper:
-    image: docker.io/wurstmeister/zookeeper:${SHUTDOWN_VERSION}
+    image: docker.io/wurstmeister/zookeeper:${CONFIG_VERSION}
     ports:
     - 2181:2181
   kafka:

--- a/scripts/integration/splunk/compose.yaml
+++ b/scripts/integration/splunk/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   splunk-hec:
-    image: docker.io/splunk/splunk:${SPLUNK_VERSION}
+    image: docker.io/splunk/splunk:${CONFIG_VERSION}
     environment:
     - SPLUNK_START_ARGS=--accept-license
     - SPLUNK_PASSWORD=password

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -409,7 +409,7 @@ async fn splunk_auto_extracted_timestamp() {
     // The auto_extract_timestamp setting only works on version 8 and above of splunk.
     // If the splunk version is set to 7, we ignore this test.
     // This environment variable is set by the integration test docker-compose file.
-    if std::env::var("SPLUNK_VERSION")
+    if std::env::var("CONFIG_VERSION")
         .map(|version| !version.starts_with("7."))
         .unwrap_or(true)
     {
@@ -456,7 +456,7 @@ async fn splunk_non_auto_extracted_timestamp() {
     // The auto_extract_timestamp setting only works on version 8 and above of splunk.
     // If the splunk version is set to 7, we ignore this test.
     // This environment variable is set by the integration test docker-compose file.
-    if std::env::var("SPLUNK_VERSION")
+    if std::env::var("CONFIG_VERSION")
         .map(|version| !version.starts_with("7."))
         .unwrap_or(true)
     {


### PR DESCRIPTION
This allows for having separate versions show up in the compose files, for example with the prometheus integration test where we pull down both a prometheus and influxdb image with separate versions.

One of the bits I had written up last week, didn't actually end up needing for the actual tests, but is worth moving forward since we have it.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
