### PR TITLE
chore(vdev): Clean up integration compose handling

### DIFF
--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -127,8 +127,8 @@ impl IntegrationTest {
             let mut command = CONTAINER_TOOL.clone();
             command.push("-compose");
             let mut command = Command::new(command);
-            let compose_arg = compose_path.display().to_string();
-            command.args(["--file", &compose_arg]);
+            command.arg("--file");
+            command.arg(compose_path);
             command.args(args);
 
             command.current_dir(&self.test_dir);

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -295,7 +295,7 @@ where
     }
 }
 
-pub struct IntegrationTestRunner {
+pub(super) struct IntegrationTestRunner {
     integration: String,
     needs_docker_socket: bool,
     network: Option<String>,
@@ -303,12 +303,11 @@ pub struct IntegrationTestRunner {
 }
 
 impl IntegrationTestRunner {
-    pub fn new(
+    pub(super) fn new(
         integration: String,
         config: &IntegrationRunnerConfig,
-        needs_network: bool,
+        network: Option<String>,
     ) -> Result<Self> {
-        let network = needs_network.then(|| format!("vector-integration-tests-{integration}"));
         Ok(Self {
             integration,
             needs_docker_socket: config.needs_docker_socket,

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -83,7 +83,7 @@ pub trait ContainerTestRunner: TestRunner {
 
     fn image_name(&self) -> String;
 
-    fn network_name(&self) -> Option<String>;
+    fn network_name(&self) -> Option<&str>;
 
     fn needs_docker_socket(&self) -> bool;
 
@@ -213,8 +213,7 @@ pub trait ContainerTestRunner: TestRunner {
     }
 
     fn create(&self) -> Result<()> {
-        let network_name = self.network_name();
-        let network_name = network_name.as_deref().unwrap_or("host");
+        let network_name = self.network_name().unwrap_or("host");
 
         let docker_socket = format!("{}:/var/run/docker.sock", DOCKER_SOCKET.display());
         let docker_args = self
@@ -299,7 +298,7 @@ where
 pub struct IntegrationTestRunner {
     integration: String,
     needs_docker_socket: bool,
-    needs_network: bool,
+    network: Option<String>,
     volumes: Vec<String>,
 }
 
@@ -309,10 +308,11 @@ impl IntegrationTestRunner {
         config: &IntegrationRunnerConfig,
         needs_network: bool,
     ) -> Result<Self> {
+        let network = needs_network.then(|| format!("vector-integration-tests-{integration}"));
         Ok(Self {
             integration,
             needs_docker_socket: config.needs_docker_socket,
-            needs_network,
+            network,
             volumes: config
                 .volumes
                 .iter()
@@ -322,7 +322,7 @@ impl IntegrationTestRunner {
     }
 
     pub(super) fn ensure_network(&self) -> Result<()> {
-        if let Some(network_name) = self.network_name() {
+        if let Some(network_name) = &self.network {
             let mut command = dockercmd(["network", "ls", "--format", "{{.Name}}"]);
 
             if command
@@ -333,7 +333,7 @@ impl IntegrationTestRunner {
                 return Ok(());
             }
 
-            dockercmd(["network", "create", &network_name]).wait("Creating network")
+            dockercmd(["network", "create", network_name]).wait("Creating network")
         } else {
             Ok(())
         }
@@ -341,9 +341,8 @@ impl IntegrationTestRunner {
 }
 
 impl ContainerTestRunner for IntegrationTestRunner {
-    fn network_name(&self) -> Option<String> {
-        self.needs_network
-            .then(|| format!("vector-integration-tests-{}", self.integration))
+    fn network_name(&self) -> Option<&str> {
+        self.network.as_deref()
     }
 
     fn container_name(&self) -> String {
@@ -370,7 +369,7 @@ impl ContainerTestRunner for IntegrationTestRunner {
 pub struct DockerTestRunner;
 
 impl ContainerTestRunner for DockerTestRunner {
-    fn network_name(&self) -> Option<String> {
+    fn network_name(&self) -> Option<&str> {
         None
     }
 


### PR DESCRIPTION
More pure tech debt I wrote up last week and put aside as not strictly needed. This addresses another TODO item. In the current code base, handling running docker-compose is sprinkled throughout the overall integration test runner. This PR mostly just refactors that out into its own type to simplify the overall logic.

I think we could also get away with dropping the state files that indicate which integration test has been started already, as we should be able to get that information out of `docker ps` etc. As it stands now there are some known issues with, for example, rebooting while an integration test is setup causing the inability to start it again, etc.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
