### PR TITLE
docs(splunk_hec source): add info about endpoints

### DIFF
--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -5,6 +5,10 @@ components: sources: splunk_hec: {
 
 	title: "Splunk HTTP Event Collector (HEC)"
 
+	description: """
+		This source exposes three HTTP endpoints at a configurable address that jointly implement the [Splunk HEC API](https://docs.splunk.com/Documentation/Splunk/9.0.3/Data/UsetheHTTPEventCollector): `/services/collector/event`, `/services/collector/raw`, and `/services/collector/health`.
+		"""
+
 	classes: {
 		commonly_used: false
 		delivery:      "at_least_once"


### PR DESCRIPTION
Confusion around this source came up in Discord. A user incorrectly thought that the root HTTP path should be used for sending events. Reading the docs, that's a valid interpretation given that we don't mention the specific endpoints to use. This change mentions all three endpoints in the the description 😄 