### PR TITLE
chore(external docs): Add note about trace events to concepts page

### DIFF
--- a/website/content/en/docs/about/concepts.md
+++ b/website/content/en/docs/about/concepts.md
@@ -26,8 +26,8 @@ A **metric** event represents a numerical operation performed on a time series. 
 
 ### Traces
 
-A **trace** event can be thought of as a special kind of log event. Currently Vector only supports trace events for the `datadog_agent` source, and the `datadog_traces` sink.
-Support for trace events in other components will be added on a case by case basis.
+A **trace** event can be thought of as a special kind of log event. As of this writing, the components that support trace events are: the `datadog_agent` source, the `datadog_traces` sink, and the `sample` and `remap` transforms.
+If you're interested in using traces with a Vector component that doesn't yet support them, please open an issue so we can have a better understanding of what components to prioritize adding trace support for."
 
 ## Components
 

--- a/website/content/en/docs/about/concepts.md
+++ b/website/content/en/docs/about/concepts.md
@@ -24,6 +24,11 @@ A **metric** event represents a numerical operation performed on a time series. 
 
 {{< jump "/docs/about/under-the-hood/architecture/data-model/metric" >}}
 
+### Traces
+
+A **trace** event can be thought of as a special kind of log event. Currently Vector only supports trace events for the `datadog_agent` source, and the `datadog_traces` sink.
+Support for trace events in other components will be added on a case by case basis.
+
 ## Components
 
 **Component** is the generic term for [sources], [transforms], and [sinks]. Components ingest, transform, and route events. You compose components to create [topologies].

--- a/website/content/en/docs/about/concepts.md
+++ b/website/content/en/docs/about/concepts.md
@@ -27,6 +27,7 @@ A **metric** event represents a numerical operation performed on a time series. 
 ### Traces
 
 A **trace** event can be thought of as a special kind of log event. As of this writing, the components that support trace events are: the `datadog_agent` source, the `datadog_traces` sink, and the `sample` and `remap` transforms.
+
 If you're interested in using traces with a Vector component that doesn't yet support them, please open an issue so we can have a better understanding of what components to prioritize adding trace support for."
 
 ## Components


### PR DESCRIPTION
User in discord support was asking about trace support in vector.
