### PR TITLE
chore(vdev): Fix guard for prepare_compose_volumes on unix

### DIFF
--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -172,11 +172,9 @@ impl Compose {
     }
 
     fn prepare(&self) -> Result<()> {
-        if cfg!(unix) {
-            unix::prepare_compose_volumes(&self.config, &self.test_dir)
-        } else {
-            Ok(())
-        }
+        #[cfg(unix)]
+        unix::prepare_compose_volumes(&self.config, &self.test_dir)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The call to `unix::prepare_compose_volumes` is compiled in for both unix and windows, but the code is only present when `cfg(unix)` so the guard caused a build failure on Windows. This changes it to a proper conditional code guard.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
