### PR TITLE
chore(fix publish workflow): remove reference to non existent job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -475,7 +475,6 @@ jobs:
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages
-      - build-x86_64-unknown-linux-gnu-debug-tarball
       - build-x86_64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-gnu-packages
@@ -756,7 +755,6 @@ jobs:
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages
-      - build-x86_64-unknown-linux-gnu-debug-tarball
       - build-x86_64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-musl-packages
       - build-aarch64-unknown-linux-gnu-packages


### PR DESCRIPTION
introduced by https://github.com/vectordotdev/vector/pull/16307