### PR TITLE
docs(prometheus_remote_write sink): Use generated docs for configuration

### DIFF
--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -57,6 +57,9 @@ enum Errors {
 #[serde(deny_unknown_fields)]
 pub struct RemoteWriteConfig {
     /// The endpoint to send data to.
+    ///
+    /// The endpoint should include the scheme and the path to write to.
+    #[configurable(metadata(docs::examples = "https://localhost:8087/"))]
     pub endpoint: String,
 
     /// The default namespace for any metrics sent.
@@ -67,6 +70,7 @@ pub struct RemoteWriteConfig {
     /// It should follow the Prometheus [naming conventions][prom_naming_docs].
     ///
     /// [prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
+    #[configurable(metadata(docs::examples = "service"))]
     pub default_namespace: Option<String>,
 
     /// Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
@@ -95,6 +99,7 @@ pub struct RemoteWriteConfig {
     ///
     /// This may be used by Cortex or other remote services to identify the tenant making the request.
     #[serde(default)]
+    #[configurable(metadata(docs::examples = "my-domain"))]
     pub tenant_id: Option<Template>,
 
     #[configurable(derived)]

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -232,12 +232,16 @@ base: components: sinks: prometheus_remote_write: configuration: {
 			[prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["service"]
 	}
 	endpoint: {
-		description: "The endpoint to send data to."
-		required:    true
-		type: string: {}
+		description: """
+			The endpoint to send data to.
+
+			The endpoint should include the scheme and the path to write to.
+			"""
+		required: true
+		type: string: examples: ["https://localhost:8087/"]
 	}
 	quantiles: {
 		description: """
@@ -403,7 +407,10 @@ base: components: sinks: prometheus_remote_write: configuration: {
 			This may be used by Cortex or other remote services to identify the tenant making the request.
 			"""
 		required: false
-		type: string: syntax: "template"
+		type: string: {
+			examples: ["my-domain"]
+			syntax: "template"
+		}
 	}
 	tls: {
 		description: "TLS configuration."

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -13,6 +13,7 @@ components: sinks: prometheus_remote_write: {
 	}
 
 	features: {
+		auto_generated: true
 		acknowledgements: true
 		healthcheck: enabled: true
 		send: {
@@ -75,110 +76,7 @@ components: sinks: prometheus_remote_write: {
 		notices: []
 	}
 
-	configuration: {
-		endpoint: {
-			description: "The endpoint URL to send data to."
-			required:    true
-			warnings: []
-			type: string: {
-				examples: ["https://localhost:8087/"]
-			}
-		}
-		auth: {
-			common:      false
-			description: "Options for authentication."
-			required:    false
-			type: object: {
-				examples: []
-				options: components._aws.configuration.auth.type.object.options & {
-					password: {
-						description: "The basic authentication password."
-						required:    true
-						type: string: {
-							examples: ["${PROMETHEUS_PASSWORD}", "password"]
-						}
-					}
-					strategy: {
-						description: "The authentication strategy to use."
-						required:    true
-						type: string: {
-							enum: {
-								aws:   "Authentication strategy used for the [AWS managed Prometheus service](\(urls.aws_prometheus))."
-								basic: "The [basic authentication strategy](\(urls.basic_auth))."
-							}
-						}
-					}
-					user: {
-						description: "The basic authentication user name."
-						required:    true
-						type: string: {
-							examples: ["${PROMETHEUS_USERNAME}", "username"]
-						}
-					}
-				}
-			}
-		}
-		aws: {
-			common:      false
-			description: "Options for the AWS connections."
-			required:    false
-			type: object: {
-				examples: []
-				options: {
-					region: {
-						common:      true
-						description: "The [AWS region](\(urls.aws_regions)) of the target service. This defaults to the region named in the endpoint parameter, or the value of the `$AWS_REGION` or `$AWS_DEFAULT_REGION` environment variables if that cannot be determined, or \"us-east-1\"."
-						required:    false
-						type: string: {
-							default: null
-							examples: ["us-east-1"]
-						}
-					}
-				}
-			}
-		}
-		default_namespace: {
-			common:      true
-			description: """
-				Used as a namespace for metrics that don't have it.
-				A namespace will be prefixed to a metric's name.
-				It should follow Prometheus [naming conventions](\(urls.prometheus_metric_naming)).
-				"""
-			required:    false
-			type: string: {
-				default: null
-				examples: ["service"]
-			}
-		}
-		buckets: {
-			common:      false
-			description: "Default buckets to use for aggregating [distribution](\(urls.vector_metric)/#distribution) metrics into histograms."
-			required:    false
-			type: array: {
-				default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
-				items: type: float: examples: [0.005, 0.01]
-			}
-		}
-		quantiles: {
-			common:      false
-			description: "Quantiles to use for aggregating [distribution](\(urls.vector_metric)/#distribution) metrics into a summary."
-			required:    false
-			type: array: {
-				default: [0.5, 0.75, 0.9, 0.95, 0.99]
-				items: type: float: examples: [0.5, 0.75, 0.9, 0.95, 0.99]
-			}
-		}
-		tenant_id: {
-			common:      false
-			description: "If set, a header named `X-Scope-OrgID` will be added to outgoing requests with the text of this setting. This may be used by Cortex or other remote services to identify the tenant making the request."
-			required:    false
-			type: string: {
-				default: null
-				examples: ["my-domain"]
-				syntax: "template"
-			}
-		}
-	}
+	configuration: base.components.sinks.prometheus_remote_write.configuration
 
 	input: {
 		logs: false


### PR DESCRIPTION
Closes #16305 
Epic #14999 

This currently has the same issue as [this](https://github.com/vectordotdev/vector/pull/16323#issuecomment-1420627090).

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

