### PR TITLE
docs(axiom sink): Use autogenerated docs

### DIFF
--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -26,17 +26,24 @@ pub struct AxiomConfig {
     ///
     /// Only required if not using Axiom Cloud.
     #[configurable(validation(format = "uri"))]
+    #[configurable(metadata(docs::examples = "https://axiom.my-domain.com"))]
+    #[configurable(metadata(docs::examples = "${AXIOM_URL}"))]
     url: Option<String>,
 
     /// The Axiom organization ID.
     ///
     /// Only required when using personal tokens.
+    #[configurable(metadata(docs::examples = "${AXIOM_ORG_ID}"))]
+    #[configurable(metadata(docs::examples = "123abc"))]
     org_id: Option<String>,
 
     /// The Axiom API token.
+    #[configurable(metadata(docs::examples = "${AXIOM_TOKEN}"))]
+    #[configurable(metadata(docs::examples = "123abc"))]
     token: SensitiveString,
 
     /// The Axiom dataset to write to.
+    #[configurable(metadata(docs::examples = "vector.dev"))]
     dataset: String,
 
     #[configurable(derived)]

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -14,6 +14,7 @@ components: sinks: axiom: {
 
 	features: {
 		acknowledgements: true
+		auto_generated:   true
 		healthcheck: enabled: true
 		send: {
 			batch: {
@@ -64,48 +65,7 @@ components: sinks: axiom: {
 		notices: []
 	}
 
-	configuration: {
-		token: {
-			description: "Your Axiom token"
-			required:    true
-			warnings: []
-			type: string: {
-				examples: ["xxxx", "${AXIOM_TOKEN}"]
-				syntax: "literal"
-			}
-		}
-		dataset: {
-			description: "Your Axiom dataset"
-			required:    true
-			warnings: []
-			type: string: {
-				examples: ["vector.dev"]
-				syntax: "literal"
-			}
-		}
-		url: {
-			description: "Your Axiom URL (only required if not Axiom Cloud)"
-			common:      false
-			required:    false
-			warnings: []
-			type: string: {
-				examples: ["https://cloud.axiom.co", "${AXIOM_URL}"]
-				syntax:  "literal"
-				default: ""
-			}
-		}
-		org_id: {
-			description: "Your Axiom Org ID (only required for personal tokens)"
-			common:      false
-			required:    false
-			warnings: []
-			type: string: {
-				examples: ["xxxx", "${AXIOM_ORG_ID}"]
-				syntax:  "literal"
-				default: ""
-			}
-		}
-	}
+	configuration: base.components.sinks.axiom.configuration
 
 	input: {
 		logs: true

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -54,7 +54,7 @@ base: components: sinks: axiom: configuration: {
 	dataset: {
 		description: "The Axiom dataset to write to."
 		required:    true
-		type: string: {}
+		type: string: examples: ["vector.dev"]
 	}
 	org_id: {
 		description: """
@@ -63,7 +63,7 @@ base: components: sinks: axiom: configuration: {
 			Only required when using personal tokens.
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["${AXIOM_ORG_ID}", "123abc"]
 	}
 	request: {
 		description: "Outbound HTTP request settings."
@@ -307,7 +307,7 @@ base: components: sinks: axiom: configuration: {
 	token: {
 		description: "The Axiom API token."
 		required:    true
-		type: string: {}
+		type: string: examples: ["${AXIOM_TOKEN}", "123abc"]
 	}
 	url: {
 		description: """
@@ -316,6 +316,6 @@ base: components: sinks: axiom: configuration: {
 			Only required if not using Axiom Cloud.
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["https://axiom.my-domain.com", "${AXIOM_URL}"]
 	}
 }


### PR DESCRIPTION
Closes #16349

The docs drop both the `batch` and `encoding` options, but they weren't passed into the builder anyway - only using the defaults from `elasticsearch`
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
