### PR TITLE
docs(honeycomb sink): Use autogenerated docs

### DIFF
--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -24,9 +24,12 @@ pub struct HoneycombConfig {
     endpoint: String,
 
     /// The team key that will be used to authenticate against Honeycomb.
+    #[configurable(metadata(docs::examples = "${HONEYCOMB_API_KEY}"))]
+    #[configurable(metadata(docs::examples = "some-api-key"))]
     api_key: SensitiveString,
 
     /// The dataset to which logs are sent.
+    #[configurable(metadata(docs::examples = "my-honeycomb-dataset"))]
     // TODO: we probably want to make this a template
     // but this limits us in how we can do our healthcheck.
     dataset: String,

--- a/src/sinks/honeycomb.rs
+++ b/src/sinks/honeycomb.rs
@@ -20,6 +20,7 @@ use crate::{
 #[configurable_component(sink("honeycomb"))]
 #[derive(Clone, Debug)]
 pub struct HoneycombConfig {
+    // This endpoint is not user-configurable and only exists for testing purposes
     #[serde(skip, default = "default_endpoint")]
     endpoint: String,
 

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -30,7 +30,7 @@ base: components: sinks: honeycomb: configuration: {
 	api_key: {
 		description: "The team key that will be used to authenticate against Honeycomb."
 		required:    true
-		type: string: {}
+		type: string: examples: ["${HONEYCOMB_API_KEY}", "some-api-key"]
 	}
 	batch: {
 		description: "Event batching behavior."
@@ -67,7 +67,7 @@ base: components: sinks: honeycomb: configuration: {
 	dataset: {
 		description: "The dataset to which logs are sent."
 		required:    true
-		type: string: {}
+		type: string: examples: ["my-honeycomb-dataset"]
 	}
 	encoding: {
 		description: "Transformations to prepare an event for serialization."

--- a/website/cue/reference/components/sinks/honeycomb.cue
+++ b/website/cue/reference/components/sinks/honeycomb.cue
@@ -14,6 +14,7 @@ components: sinks: honeycomb: {
 
 	features: {
 		acknowledgements: true
+		auto_generated:   true
 		healthcheck: enabled: true
 		send: {
 			batch: {
@@ -57,22 +58,7 @@ components: sinks: honeycomb: {
 		notices: []
 	}
 
-	configuration: {
-		api_key: {
-			description: "The team key that will be used to authenticate against Honeycomb."
-			required:    true
-			type: string: {
-				examples: ["${HONEYCOMB_API_KEY}", "some-api-key"]
-			}
-		}
-		dataset: {
-			description: "The dataset that Vector will send logs to."
-			required:    true
-			type: string: {
-				examples: ["my-honeycomb-dataset"]
-			}
-		}
-	}
+	configuration: base.components.sinks.honeycomb.configuration
 
 	input: {
 		logs:    true


### PR DESCRIPTION
Closes #16346

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
