### PR TITLE
chore(deps): Update openssl-src crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5546,9 +5546,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.24.0+1.1.1s"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Resolves https://rustsec.org/advisories/RUSTSEC-2023-0009

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
