### PR TITLE
docs(file sink): Use generated documentation

### DIFF
--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::time::{Duration, Instant};
 
 use async_compression::tokio::write::{GzipEncoder, ZstdEncoder};
@@ -12,6 +13,7 @@ use futures::{
     stream::{BoxStream, StreamExt},
     FutureExt,
 };
+use serde_with::serde_as;
 use tokio::{
     fs::{self, File},
     io::AsyncWriteExt,
@@ -33,22 +35,33 @@ use crate::{
     template::Template,
 };
 mod bytes_path;
-use std::convert::TryFrom;
 
 use bytes_path::BytesPath;
 
 /// Configuration for the `file` sink.
+#[serde_as]
 #[configurable_component(sink("file"))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FileSinkConfig {
     /// File name to write events to.
+    ///
+    /// Compression format extension must be explicit.
+    #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log"))]
+    #[configurable(metadata(
+        docs::examples = "/tmp/application-{{ application_id }}-%Y-%m-%d.log"
+    ))]
+    #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log.zst"))]
     pub path: Template,
 
-    /// The amount of time, in seconds, that a file can be idle and stay open.
+    /// The amount of time that a file can be idle and stay open.
     ///
     /// After not receiving any events in this amount of time, the file will be flushed and closed.
-    pub idle_timeout_secs: Option<u64>,
+    #[serde(default = "default_idle_timeout")]
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(rename = "idle_timeout_secs")]
+    #[configurable(metadata(docs::examples = 600))]
+    pub idle_timeout: Duration,
 
     #[serde(flatten)]
     pub encoding: EncodingConfigWithFraming,
@@ -73,7 +86,7 @@ impl GenerateConfig for FileSinkConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
             path: Template::try_from("/tmp/vector-%Y-%m-%d.log").unwrap(),
-            idle_timeout_secs: None,
+            idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
             compression: Default::default(),
             acknowledgements: Default::default(),
@@ -82,16 +95,25 @@ impl GenerateConfig for FileSinkConfig {
     }
 }
 
-/// Compression algorithm.
-// TODO: Why doesn't this already use `crate::sinks::util::Compression`? :thinkies:
+fn default_idle_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
+/// Compression configuration.
+// TODO: Why doesn't this already use `crate::sinks::util::Compression`
+// `crate::sinks::util::Compression` doesn't support zstd yet
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Compression {
-    /// Gzip compression.
+    /// [Gzip][gzip] compression.
+    ///
+    /// [gzip]: https://www.gzip.org/
     Gzip,
 
-    /// Zstandard compression.
+    /// [Zstandard][zstd] compression.
+    ///
+    /// [zstd]: https://facebook.github.io/zstd/
     Zstd,
 
     /// No compression.
@@ -193,7 +215,7 @@ impl FileSink {
             path: config.path.clone(),
             transformer,
             encoder,
-            idle_timeout: Duration::from_secs(config.idle_timeout_secs.unwrap_or(30)),
+            idle_timeout: config.idle_timeout,
             files: ExpiringHashMap::default(),
             compression: config.compression,
             events_sent: register!(EventsSent::from(Output(None))),
@@ -431,7 +453,7 @@ mod tests {
 
         let config = FileSinkConfig {
             path: template.clone().try_into().unwrap(),
-            idle_timeout_secs: None,
+            idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
             compression: Compression::None,
             acknowledgements: Default::default(),
@@ -453,7 +475,7 @@ mod tests {
 
         let config = FileSinkConfig {
             path: template.clone().try_into().unwrap(),
-            idle_timeout_secs: None,
+            idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
             compression: Compression::Gzip,
             acknowledgements: Default::default(),
@@ -475,7 +497,7 @@ mod tests {
 
         let config = FileSinkConfig {
             path: template.clone().try_into().unwrap(),
-            idle_timeout_secs: None,
+            idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
             compression: Compression::Zstd,
             acknowledgements: Default::default(),
@@ -502,7 +524,7 @@ mod tests {
 
         let config = FileSinkConfig {
             path: template.try_into().unwrap(),
-            idle_timeout_secs: None,
+            idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
             compression: Compression::None,
             acknowledgements: Default::default(),
@@ -579,7 +601,7 @@ mod tests {
 
         let config = FileSinkConfig {
             path: template.clone().try_into().unwrap(),
-            idle_timeout_secs: Some(1),
+            idle_timeout: Duration::from_secs(1),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
             compression: Compression::None,
             acknowledgements: Default::default(),

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -95,7 +95,7 @@ impl GenerateConfig for FileSinkConfig {
     }
 }
 
-fn default_idle_timeout() -> Duration {
+const fn default_idle_timeout() -> Duration {
     Duration::from_secs(30)
 }
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -44,7 +44,7 @@ use bytes_path::BytesPath;
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FileSinkConfig {
-    /// File name to write events to.
+    /// File path to write events to.
     ///
     /// Compression format extension must be explicit.
     #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log"))]

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -28,14 +28,22 @@ base: components: sinks: file: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression algorithm."
+		description: "Compression configuration."
 		required:    false
 		type: string: {
 			default: "none"
 			enum: {
-				gzip: "Gzip compression."
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://www.gzip.org/
+					"""
 				none: "No compression."
-				zstd: "Zstandard compression."
+				zstd: """
+					[Zstandard][zstd] compression.
+
+					[zstd]: https://facebook.github.io/zstd/
+					"""
 			}
 		}
 	}
@@ -187,16 +195,29 @@ base: components: sinks: file: configuration: {
 	}
 	idle_timeout_secs: {
 		description: """
-			The amount of time, in seconds, that a file can be idle and stay open.
+			The amount of time that a file can be idle and stay open.
 
 			After not receiving any events in this amount of time, the file will be flushed and closed.
 			"""
 		required: false
-		type: uint: {}
+		type: uint: {
+			default: 30
+			examples: [
+				600,
+			]
+			unit: "seconds"
+		}
 	}
 	path: {
-		description: "File name to write events to."
-		required:    true
-		type: string: syntax: "template"
+		description: """
+			File name to write events to.
+
+			Compression format extension must be explicit.
+			"""
+		required: true
+		type: string: {
+			examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log", "/tmp/vector-%Y-%m-%d.log.zst"]
+			syntax: "template"
+		}
 	}
 }

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -210,7 +210,7 @@ base: components: sinks: file: configuration: {
 	}
 	path: {
 		description: """
-			File name to write events to.
+			File path to write events to.
 
 			Compression format extension must be explicit.
 			"""

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -15,6 +15,7 @@ components: sinks: file: {
 
 	features: {
 		acknowledgements: true
+		auto_generated:   true
 		healthcheck: enabled: true
 		send: {
 			compression: {
@@ -42,25 +43,7 @@ components: sinks: file: {
 		notices: []
 	}
 
-	configuration: {
-		idle_timeout_secs: {
-			common:      false
-			description: "The amount of time a file can be idle  and stay open. After not receiving any events for this timeout, the file will be flushed and closed.\n"
-			required:    false
-			type: uint: {
-				default: 30
-				unit:    null
-			}
-		}
-		path: {
-			description: "File name to write events to. Compression format extension must be explicit."
-			required:    true
-			type: string: {
-				examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log"]
-				syntax: "template"
-			}
-		}
-	}
+	configuration: base.components.sinks.file.configuration
 
 	input: {
 		logs:    true


### PR DESCRIPTION
Closes #16345

* Updated the `idle_timeout` to actually be a duration and renamed internally
* Left a note for why it isn't using the shared util's compression struct
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
