### PR TITLE
chore(config): fix schema generation handling of base vs override metadata

### DIFF
--- a/lib/vector-common/src/datetime.rs
+++ b/lib/vector-common/src/datetime.rs
@@ -126,7 +126,7 @@ impl Configurable for TimeZone {
 [tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"#,
         );
         tz_metadata.add_custom_attribute(CustomAttribute::kv("logical_name", "Named"));
-        let tz_schema = get_or_generate_schema::<Tz>(gen, tz_metadata)?;
+        let tz_schema = get_or_generate_schema::<Tz>(gen, Some(tz_metadata))?;
 
         Ok(generate_one_of_schema(&[local_schema, tz_schema]))
     }

--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -116,13 +116,7 @@ fn build_metadata_fn(container: &Container<'_>) -> proc_macro2::TokenStream {
 fn build_virtual_newtype_schema_fn(virtual_ty: Type) -> proc_macro2::TokenStream {
     quote! {
         fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
-            // Virtual newtypes always shuttle their schema's metadata/overridden metadata when generating the schema
-            // for the wrapped type, otherwise we wouldn't be able to effectively document them. This does mean we end
-            // up dropping any default value for _this_ schema's metadata, including overridden metadata, so the wrapped
-            // type must have a default value for itself if having a default value is required.
-            let metadata = <Self as ::vector_config::Configurable>::metadata().convert();
-
-            ::vector_config::schema::get_or_generate_schema::<#virtual_ty>(schema_gen, Some(metadata))
+            ::vector_config::schema::get_or_generate_schema::<#virtual_ty>(schema_gen, None)
         }
     }
 }
@@ -138,13 +132,9 @@ fn build_enum_generate_schema_fn(variants: &[Variant<'_>]) -> proc_macro2::Token
         fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             let mut subschemas = ::std::vec::Vec::new();
 
-            let enum_metadata = <Self as ::vector_config::Configurable>::metadata();
             #(#mapped_variants)*
 
-            let mut schema = ::vector_config::schema::generate_one_of_schema(&subschemas);
-            //::vector_config::schema::apply_metadata(&mut schema, enum_metadata);
-
-            Ok(schema)
+            Ok(::vector_config::schema::generate_one_of_schema(&subschemas))
         }
     }
 }
@@ -221,7 +211,6 @@ fn generate_named_struct_field(
             };
 
         quote! {
-            //println!("property '{}': subschema: {:?}", #field_key, subschema);
             if let Some(_) = properties.insert(#field_key.to_string(), subschema) {
                 panic!(#field_already_contained);
             }
@@ -232,10 +221,8 @@ fn generate_named_struct_field(
 
     quote! {
         {
-            //println!("property '{}': generating schema", #field_key);
             #field_schema
             #integrate_field
-            //println!("property '{}': generated schema", #field_key);
         }
     }
 }
@@ -294,8 +281,6 @@ fn build_named_struct_generate_schema_fn(
                 ::vector_config::schema::convert_to_flattened_schema(&mut schema, flattened_subschemas);
             }
 
-            //::vector_config::schema::apply_metadata(&mut schema, metadata);
-
             Ok(schema)
         }
     }
@@ -312,13 +297,9 @@ fn build_tuple_struct_generate_schema_fn(fields: &[Field<'_>]) -> proc_macro2::T
         fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             let mut subschemas = ::std::collections::Vec::new();
 
-            let metadata = <Self as ::vector_config::Configurable>::metadata();
             #(#mapped_fields)*
 
-            let mut schema = ::vector_config::schema::generate_tuple_schema(&subschemas);
-            //::vector_config::schema::apply_metadata(&mut schema, metadata);
-
-            Ok(schema)
+            Ok(::vector_config::schema::generate_tuple_schema(&subschemas))
         }
     }
 }
@@ -340,10 +321,7 @@ fn build_newtype_struct_generate_schema_fn(fields: &[Field<'_>]) -> proc_macro2:
 
     quote! {
         fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
-            let metadata = <Self as ::vector_config::Configurable>::metadata();
-
             #field_schema
-            //::vector_config::schema::apply_metadata(&mut subschema, metadata);
 
             Ok(subschema)
         }
@@ -390,45 +368,6 @@ fn generate_field_metadata(meta_ident: &Ident, field: &Field<'_>) -> proc_macro2
     let field_ty = field.ty();
     let field_schema_ty = get_field_schema_ty(field);
 
-    // Our rules around how we generate this metadata are slightly complex, but here it goes:
-    //
-    // - All `Configurable` types define their own metadata, which at a minimum is their
-    //   description. It can optionally include things like validation rules, and custom attributes,
-    //   of which we use to better document types for downstream consumption. An example would be
-    //   specifying the integer type (signed vs unsigned vs floating point) as JSON Schema does not
-    //   differentiate between the three.
-    // - Building on that, there are types like `bool` or `u64` (scalars, essentially) where having
-    //   a description for the `Configurable` implementation on `bool` or `u64` makes no sense,
-    //   because the type name is self-describing. These types set the "transparent" flag in their
-    //   metadata to indicate that they intentionally have no description and that it's fine to not
-    //   emit a description in the schema for this type.
-    // - Scalars are also not "referenceable" which means their schema is used inline, not pointed
-    //   to by a schema reference.
-    // - All other types, whether they have a derive-based or hand-written implementation of
-    //   `Configurable` should have a referenceable name.
-    // - When using a referenceable type for a named field (struct or enum variant), it can be
-    //   annotated with a derive helper attribute called `derived`, which informs the codegen that
-    //   the title/description for that field should come from the field type's schema itself.
-    //
-    // Now that we've laid out the rules and invariants, let's talk about this code below.
-    //
-    // For non-referenceable types, their schema -- and thus their metadata -- will be used inline
-    // as the schema for the field, so we want to simply _merge_ our field's metadata into the field
-    // type's metadata.
-    //
-    // For referenceable types, their schema will be referred to by an identifier, and the
-    // definition attached to that identifier will carry the field type's metadata. Any metadata
-    // specified on the field itself should live solely on the field's schema (which can exist
-    // alongside the schema reference) and vice versa.
-    /*let spanned_metadata = quote_spanned! {field.span()=>
-        if <#field_schema_ty as ::vector_config::Configurable>::referenceable_name().is_none() {
-            <#field_schema_ty as ::vector_config::Configurable>::metadata()
-        } else {
-            ::vector_config::Metadata::default()
-        }
-    };*/
-    let spanned_metadata = quote! { ::vector_config::Metadata::<#field_schema_ty>::default() };
-
     let maybe_title = get_metadata_title(meta_ident, field.title());
     let maybe_description = get_metadata_description(meta_ident, field.description());
     let maybe_clear_title_description = field
@@ -458,7 +397,7 @@ fn generate_field_metadata(meta_ident: &Ident, field: &Field<'_>) -> proc_macro2
     let maybe_custom_attributes = get_metadata_custom_attributes(meta_ident, field.metadata());
 
     quote! {
-        let mut #meta_ident = #spanned_metadata;
+        let mut #meta_ident = ::vector_config::Metadata::<#field_schema_ty>::default();
         #maybe_clear_title_description
         #maybe_title
         #maybe_description

--- a/lib/vector-config/src/external/indexmap.rs
+++ b/lib/vector-config/src/external/indexmap.rs
@@ -19,7 +19,7 @@ where
     }
 
     fn metadata() -> Metadata<Self> {
-        V::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
@@ -40,7 +40,7 @@ where
     V: Configurable + Serialize + std::hash::Hash + Eq,
 {
     fn metadata() -> Metadata<Self> {
-        V::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {

--- a/lib/vector-config/src/external/indexmap.rs
+++ b/lib/vector-config/src/external/indexmap.rs
@@ -4,7 +4,7 @@ use crate::{
     schema::{assert_string_schema_for_map, generate_map_schema, generate_set_schema},
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
     str::ConfigurableString,
-    Configurable, GenerateError,
+    Configurable, GenerateError, Metadata,
 };
 
 impl<K, V> Configurable for indexmap::IndexMap<K, V>
@@ -16,6 +16,15 @@ where
         // A hashmap with required fields would be... an object.  So if you want that, make a struct
         // instead, not a hashmap.
         true
+    }
+
+    fn metadata() -> Metadata<Self> {
+        V::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<V>();
+        V::validate_metadata(&converted)
     }
 
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
@@ -30,6 +39,15 @@ impl<V> Configurable for indexmap::IndexSet<V>
 where
     V: Configurable + Serialize + std::hash::Hash + Eq,
 {
+    fn metadata() -> Metadata<Self> {
+        V::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<V>();
+        V::validate_metadata(&converted)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
     }

--- a/lib/vector-config/src/external/no_proxy.rs
+++ b/lib/vector-config/src/external/no_proxy.rs
@@ -1,10 +1,16 @@
 use crate::{
     schema::generate_array_schema,
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError,
+    Configurable, GenerateError, Metadata,
 };
 
 impl Configurable for no_proxy::NoProxy {
+    fn metadata() -> Metadata<Self> {
+        // Any schema that maps to a scalar type needs to be marked as transparent... and since we
+        // generate a schema equivalent to a string, we need to mark ourselves as transparent, too.
+        Metadata::with_transparent(true)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         // `NoProxy` (de)serializes itself as a vector of strings, without any constraints on the string value itself, so
         // we just... do that.

--- a/lib/vector-config/src/metadata.rs
+++ b/lib/vector-config/src/metadata.rs
@@ -108,6 +108,13 @@ impl<T> Metadata<T> {
         self.deprecated_message = Some(message);
     }
 
+    pub fn with_transparent(transparent: bool) -> Self {
+        Self {
+            transparent,
+            ..Default::default()
+        }
+    }
+
     pub fn transparent(&self) -> bool {
         self.transparent
     }

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -33,12 +33,17 @@ where
     // met:
     // - the field is marked transparent
     // - `T` is referenceable and _does_ have a description
-    let has_referenceable_description =
-        T::referenceable_name().is_some() && T::metadata().description().is_some();
-    let schema_title = metadata.title().map(|s| s.to_string());
-    let schema_description = metadata.description().map(|s| s.to_string());
-    if schema_description.is_none() && !metadata.transparent() && !has_referenceable_description {
-        panic!("no description provided for `{}`; all `Configurable` types must define a description or be provided one when used within another `Configurable` type", std::any::type_name::<T>());
+    let base_metadata = T::metadata();
+    let referenceable_name = T::referenceable_name();
+
+    let has_referenceable_description = referenceable_name.is_some() && base_metadata.description().is_some();
+    let is_transparent = base_metadata.transparent() || metadata.transparent();
+
+    let schema_title = metadata.title().or(base_metadata.title()).map(|s| s.to_string());
+    let schema_description = metadata.description().or(base_metadata.description()).map(|s| s.to_string());
+    if schema_description.is_none() && !is_transparent && !has_referenceable_description {
+        let type_name = std::any::type_name::<T>();
+        panic!("no description provided for `{}`; all `Configurable` types must define a description or be provided one when used within another `Configurable` type", type_name);
     }
 
     // Set the default value for this schema, if any.
@@ -46,67 +51,80 @@ where
         .default_value()
         .map(|v| serde_json::to_value(v).expect("default value should never fail to serialize"));
 
-    let schema_metadata = schemars::schema::Metadata {
+    let mut schema_metadata = schema.metadata.take().unwrap_or_default();
+    schema_metadata.title = schema_title.or(schema_metadata.title);
+    schema_metadata.description = schema_description.or(schema_metadata.description);
+    schema_metadata.default = schema_default.or(schema_metadata.default);
+    schema_metadata.deprecated = metadata.deprecated();
+    /*let schema_metadata = schemars::schema::Metadata {
         title: schema_title,
         description: schema_description,
         default: schema_default,
         deprecated: metadata.deprecated(),
         ..Default::default()
-    };
+    };*/
 
     // Set any custom attributes as extensions on the schema. If an attribute is declared multiple
     // times, we turn the value into an array and merge them together. We _do_ not that, however, if
     // the original value is a flag, or the value being added to an existing key is a flag, as
     // having a flag declared multiple times, or mixing a flag with a KV pair, doesn't make sense.
-    let mut custom_map = Map::new();
+    let map_entries_len = {
+        let custom_map = schema.extensions
+            .entry("_metadata".to_string())
+            .or_insert_with(|| Value::Object(Map::new()))
+            .as_object_mut()
+            .expect("metadata extension must always be a map");
 
-    if let Some(message) = metadata.deprecated_message() {
-        custom_map.insert(
-            "deprecated_message".to_string(),
-            serde_json::Value::String(message.to_string()),
-        );
-    }
+        if let Some(message) = metadata.deprecated_message() {
+            custom_map.insert(
+                "deprecated_message".to_string(),
+                serde_json::Value::String(message.to_string()),
+            );
+        }
 
-    for attribute in metadata.custom_attributes() {
-        match attribute {
-            CustomAttribute::Flag(key) => {
-                match custom_map.insert(key.to_string(), Value::Bool(true)) {
-                    // Overriding a flag is fine, because flags are only ever "enabled", so there's
-                    // no harm to enabling it... again. Likewise, if there was no existing value,
-                    // it's fine.
-                    Some(Value::Bool(_)) | None => {},
-                    // Any other value being present means we're clashing with a different metadata
-                    // attribute, which is not good, so we have to bail out.
-                    _ => panic!("Tried to set metadata flag '{}' but already existed in schema metadata for `{}`.", key, std::any::type_name::<T>()),
+        for attribute in metadata.custom_attributes() {
+            match attribute {
+                CustomAttribute::Flag(key) => {
+                    match custom_map.insert(key.to_string(), Value::Bool(true)) {
+                        // Overriding a flag is fine, because flags are only ever "enabled", so there's
+                        // no harm to enabling it... again. Likewise, if there was no existing value,
+                        // it's fine.
+                        Some(Value::Bool(_)) | None => {},
+                        // Any other value being present means we're clashing with a different metadata
+                        // attribute, which is not good, so we have to bail out.
+                        _ => panic!("Tried to set metadata flag '{}' but already existed in schema metadata for `{}`.", key, std::any::type_name::<T>()),
+                    }
+                }
+                CustomAttribute::KeyValue { key, value } => {
+                    custom_map.entry(key.to_string())
+                        .and_modify(|existing_value| match existing_value {
+                            // We already have a flag entry for this key, which we cannot turn into an
+                            // array, so we panic in this particular case to signify the weirdness.
+                            Value::Bool(_) => {
+                                panic!("Tried to overwrite metadata flag '{}' but already existed in schema metadata for `{}` as a flag.", key, std::any::type_name::<T>());
+                            },
+                            // The entry is already a multi-value KV pair, so just append the value.
+                            Value::Array(items) => {
+                                items.push(value.clone());
+                            },
+                            // The entry is not already a multi-value KV pair, so turn it into one.
+                            _ => {
+                                let taken_existing_value = std::mem::replace(existing_value, Value::Null);
+                                *existing_value = Value::Array(vec![taken_existing_value, value.clone()]);
+                            },
+                        })
+                        .or_insert(value.clone());
                 }
             }
-            CustomAttribute::KeyValue { key, value } => {
-                custom_map.entry(key.to_string())
-                    .and_modify(|existing_value| match existing_value {
-                        // We already have a flag entry for this key, which we cannot turn into an
-                        // array, so we panic in this particular case to signify the weirdness.
-                        Value::Bool(_) => {
-                            panic!("Tried to overwrite metadata flag '{}' but already existed in schema metadata for `{}` as a flag.", key, std::any::type_name::<T>());
-                        },
-                        // The entry is already a multi-value KV pair, so just append the value.
-                        Value::Array(items) => {
-                            items.push(value.clone());
-                        },
-                        // The entry is not already a multi-value KV pair, so turn it into one.
-                        _ => {
-                            let taken_existing_value = std::mem::replace(existing_value, Value::Null);
-                            *existing_value = Value::Array(vec![taken_existing_value, value.clone()]);
-                        },
-                    })
-                    .or_insert(value.clone());
-            }
         }
-    }
 
-    if !custom_map.is_empty() {
-        schema
-            .extensions
-            .insert("_metadata".to_string(), Value::Object(custom_map));
+        custom_map.len()
+    };
+
+    // If the schema had no existing metadata, and we didn't add any of our own, then remove the
+    // metadata extension property entirely, as it would only add noise to the schema output.
+    if map_entries_len == 0 {
+        schema.extensions.remove("_metadata");
     }
 
     // Now apply any relevant validations.
@@ -114,7 +132,8 @@ where
         validation.apply(schema);
     }
 
-    schema.metadata = Some(Box::new(schema_metadata));
+    //schema.metadata = Some(Box::new(schema_metadata));
+    schema.metadata = Some(schema_metadata);
 }
 
 pub fn convert_to_flattened_schema(primary: &mut SchemaObject, mut subschemas: Vec<SchemaObject>) {
@@ -196,17 +215,8 @@ pub fn generate_array_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObjec
 where
     T: Configurable + Serialize,
 {
-    // We set `T` to be "transparent", which means that during schema finalization, we will relax
-    // the rules we enforce, such as needing a description, knowing that they'll be enforced on the
-    // field that is specifying this array schema, since carrying that description forward to `T`
-    // would not make sense: if it's a schema reference, the definition will have a description, and
-    // otherwise, if it's a primitive like a string... then the field description itself will
-    // already inherently describe it.
-    let mut metadata = Metadata::<T>::default();
-    metadata.set_transparent();
-
     // Generate the actual schema for the element type `T`.
-    let element_schema = get_or_generate_schema::<T>(gen, metadata)?;
+    let element_schema = get_or_generate_schema::<T>(gen, None)?;
 
     Ok(SchemaObject {
         instance_type: Some(InstanceType::Array.into()),
@@ -222,17 +232,8 @@ pub fn generate_set_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject,
 where
     T: Configurable + Serialize,
 {
-    // We set `T` to be "transparent", which means that during schema finalization, we will relax
-    // the rules we enforce, such as needing a description, knowing that they'll be enforced on the
-    // field that is specifying this set schema, since carrying that description forward to `T`
-    // would not make sense: if it's a schema reference, the definition will have a description, and
-    // otherwise, if it's a primitive like a string... then the field description itself will
-    // already inherently describe it.
-    let mut metadata = Metadata::<T>::default();
-    metadata.set_transparent();
-
     // Generate the actual schema for the element type `T`.
-    let element_schema = get_or_generate_schema::<T>(gen, metadata)?;
+    let element_schema = get_or_generate_schema::<T>(gen, None)?;
 
     Ok(SchemaObject {
         instance_type: Some(InstanceType::Array.into()),
@@ -249,17 +250,8 @@ pub fn generate_map_schema<V>(gen: &mut SchemaGenerator) -> Result<SchemaObject,
 where
     V: Configurable + Serialize,
 {
-    // We set `V` to be "transparent", which means that during schema finalization, we will relax
-    // the rules we enforce, such as needing a description, knowing that they'll be enforced on the
-    // field that is specifying this map schema, since carrying that description forward to `V`
-    // would not make sense: if it's a schema reference, the definition will have a description, and
-    // otherwise, if it's a primitive like a string... then the field description itself will
-    // already inherently describe it.
-    let mut metadata = Metadata::<V>::default();
-    metadata.set_transparent();
-
     // Generate the actual schema for the element type `V`.
-    let element_schema = get_or_generate_schema::<V>(gen, metadata)?;
+    let element_schema = get_or_generate_schema::<V>(gen, None)?;
 
     Ok(SchemaObject {
         instance_type: Some(InstanceType::Object.into()),
@@ -292,27 +284,77 @@ pub fn generate_struct_schema(
     }
 }
 
-pub fn make_schema_optional(schema: &mut SchemaObject) -> Result<(), GenerateError> {
-    // We do a little dance here to add an additional instance type of "null" to the schema to
-    // signal it can be "X or null", achieving the functional behavior of "this is optional".
+pub fn generate_optional_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
+where
+    T: Configurable + Serialize,
+{
+    //println!("optional schema for {}", std::any::type_name::<T>());
+
+    // Optional schemas are generally very simple in practice, but because of how we memoize schema
+    // generation and use references to schema definitions, we have to handle quite a few cases
+    // here.
+    //
+    // Specifically, for the `T` in `Option<T>`, we might be dealing with:
+    // - a scalar type, where we're going to emit a schema that has `"type": ["string","null"]`, or
+    //   something to that effect, where we can simply add the `"`null"` instance type and be done
+    // - we may have a referenceable type (i.e. `struct FooBar`) and then we need to generate the
+    //   schema for that referenceable type and either:
+    //   - append a "null" schema as a `oneOf`/`anyOf` if the generated schema for the referenceable
+    //     type already uses that mechanism
+    //   - create our own `oneOf` schema to map between either the "null" schema or the real schema
+
+    // Generate the inner schema for `T` We'll add some override metadata, too, so that we can mark
+    // this resulting schema as "optional". This is only consequential to documentation generation
+    // so that some of the more complex code for parsing enum schemas can correctly differentiate a
+    // `oneOf` schema that represents a Rust enum versus one that simply represents our "null or X"
+    // wrapped schema.
+    let mut overrides = Metadata::default();
+    overrides.add_custom_attribute(CustomAttribute::flag("docs::optional"));
+    let mut schema = get_or_generate_schema::<T>(gen, Some(overrides))?;
+
+    // Take the metadata and extensions of the original schema.
+    //
+    // We'll apply these back to `schema` at the end, which will either place them back where they
+    // came from (if we don't have to wrap the original schema) or will apply them to the new
+    // wrapped schema.
+    let original_metadata = schema.metadata.take();
+    let original_extensions = std::mem::replace(&mut schema.extensions, IndexMap::default());
+
+    //println!("original extensions: {:?}", original_extensions);
+
+    // Figure out if the schema is a referenceable schema or a scalar schema.
     match schema.instance_type.as_mut() {
-        // If the schema has no instance type, this would generally imply an issue. The one
-        // exception to this rule is if the schema represents a composite schema, or in other words,
-        // does all validation via a set of subschemas.
+        // If the schema has no instance types, this implies it's a non-scalar schema: it references
+        // another schema, or it's a composite schema/does subschema validation (`$ref`, `oneOf`,
+        // `anyOf`, etc).
         //
-        // If we're dealing with one-of or any-of, we insert a subschema that allows for `null`. If
-        // we're dealing with all-of, we wrap the existing all-of subschemas in a new schema object,
-        // and then change this schema to be a one-of, with two subschemas: a null subschema, and
-        // the wrapped all-of subschemas.
-        //
-        // Anything else like if/then/else... we can't reasonably encode optionality in such a
-        // schema, and we have to bail.
+        // Figure out which it is, and either modify the schema or generate a new schema accordingly.
         None => match schema.subschemas.as_mut() {
-            None => return Err(GenerateError::InvalidOptionalSchema),
+            None => {
+                // If we don't have a scalar schema, or a schema that uses subschema validation,
+                // then we simply create a new schema that uses `oneOf` to allow mapping to either
+                // the existing schema _or_ a null schema.
+                //
+                // This should handle all cases of "normal" referenceable schema types.
+                let wrapped_schema = SchemaObject {
+                    subschemas: Some(Box::new(SubschemaValidation {
+                        one_of: Some(vec![
+                            Schema::Object(generate_null_schema()),
+                            Schema::Object(std::mem::replace(&mut schema, SchemaObject::default())),
+                        ]),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                };
+
+                schema = wrapped_schema;
+            }
             Some(subschemas) => {
                 if let Some(any_of) = subschemas.any_of.as_mut() {
+                    // A null schema is just another possible variant, so we add it directly.
                     any_of.push(Schema::Object(generate_null_schema()));
                 } else if let Some(one_of) = subschemas.one_of.as_mut() {
+                    // A null schema is just another possible variant, so we add it directly.
                     one_of.push(Schema::Object(generate_null_schema()));
                 } else if subschemas.all_of.is_some() {
                     // If we're dealing with an all-of schema, we have to build a new one-of schema
@@ -350,7 +392,13 @@ pub fn make_schema_optional(schema: &mut SchemaObject) -> Result<(), GenerateErr
         },
     }
 
-    Ok(())
+    // Stick the metadata and extensions back on `schema`.
+    schema.metadata = original_metadata;
+    schema.extensions = original_extensions;
+
+    //println!("schema after re-adding original extensions: {:?}", schema.extensions);
+
+    Ok(schema)
 }
 
 pub fn generate_one_of_schema(subschemas: &[SchemaObject]) -> SchemaObject {
@@ -438,7 +486,7 @@ where
 
     let mut schema_gen = SchemaSettings::draft2019_09().into_generator();
 
-    let schema = get_or_generate_schema::<T>(&mut schema_gen, T::metadata())?;
+    let schema = get_or_generate_schema::<T>(&mut schema_gen, Some(T::metadata()))?;
     Ok(RootSchema {
         meta_schema: None,
         schema,
@@ -448,20 +496,21 @@ where
 
 pub fn get_or_generate_schema<T>(
     gen: &mut SchemaGenerator,
-    overrides: Metadata<T>,
+    overrides: Option<Metadata<T>>,
 ) -> Result<SchemaObject, GenerateError>
 where
     T: Configurable + Serialize,
 {
-    // Ensure the given override metadata is valid for `T`.
-    T::validate_metadata(&overrides)?;
+    //let schema_type = std::any::type_name::<T>();
+    //println!("generating schema for {}", schema_type);
 
-    let mut schema = match T::referenceable_name() {
+    let (mut schema, metadata) = match T::referenceable_name() {
         // When `T` has a referenceable name, try looking it up in the schema generator's definition
         // list, and if it exists, create a schema reference to it. Otherwise, generate it and
         // backfill it in the schema generator.
         Some(name) => {
             if !gen.definitions().contains_key(name) {
+                //println!("schema is referenceable but not yet defined in schema gen");
                 // In order to avoid infinite recursion, we copy the approach that `schemars` takes and
                 // insert a dummy boolean schema before actually generating the real schema, and then
                 // replace it afterwards. If any recursion occurs, a schema reference will be handed
@@ -485,19 +534,58 @@ where
                     .insert(name.to_string(), Schema::Object(schema));
             }
 
-            get_schema_ref(gen, name)
+            (get_schema_ref(gen, name), None)
         }
         // Always generate the schema directly if `T` is not referenceable.
-        None => T::generate_schema(gen)?,
+        None => (T::generate_schema(gen)?, Some(T::metadata())),
     };
 
-    // Apply the overrides metadata to the resulting schema before handing it back.
+    // Figure out what metadata we should apply to the resulting schema.
     //
-    // Additionally, following on the comments above about default vs override metadata when
-    // generating the schema for `T`, we apply the override metadata here because this is where we
-    // would actually be setting the title/description for a field itself, etc, so even if `T` has a
-    // title/description, we can specify a more contextual title/description at the point of use.
-    apply_metadata(&mut schema, overrides);
+    // If `T` was referenceable, we use its implicit metadata when generating the
+    // "baseline" schema, because a referenceable type should always be self-contained. We then
+    // apply the override metadata, if it exists, to the schema we got back. This allows us to
+    // override titles, descriptions, and add additional attributes, and so on.
+    //
+    // If `T` was not referenceable, we only generate its schema without trying to apply any
+    // metadata. We do that because applying schema metadata enforces logic like "can't be without a
+    // description". The implicit metadata for `T` may lack that.
+    if let Some(overrides) = overrides.as_ref() {
+        T::validate_metadata(&overrides)?;
+    }
+
+    let maybe_metadata = match metadata {
+        // If we generated the schema for a referenceable type, we won't need to merge its implicit
+        // metadata into the schema we're returning _here_, so just use the override metadata if
+        // it was given.
+        None => {
+            //println!("  using override metadata as no base metadata present");
+            overrides
+        }
+
+        // If we didn't generate the schema for a referenceable type, we'll be holding its implicit
+        // metadata here, which we need to merge the override metadata into if it was given. If
+        // there was no override metadata, then we just use the base by itself.
+        Some(base) => match overrides {
+            None => {
+                //println!("  using base metadata as no override metadata present");
+                Some(base)
+            }
+            Some(overrides) => {
+                //println!("  using merge base/override metadata");
+                //println!("  base: {:?}", base);
+                //println!("  override: {:?}", overrides);
+                Some(base.merge(overrides))
+            }
+        },
+    };
+
+    if let Some(metadata) = maybe_metadata {
+        //println!("  maybe metadata: {:?}", metadata);
+        apply_metadata(&mut schema, metadata);
+    }
+
+    //println!("generated schema for {}: {:?}", schema_type, schema);
 
     Ok(schema)
 }
@@ -541,7 +629,7 @@ where
     let mut key_metadata = Metadata::<K>::default();
     key_metadata.set_transparent();
 
-    let key_schema = get_or_generate_schema::<K>(gen, key_metadata)?;
+    let key_schema = get_or_generate_schema::<K>(gen, None)?;
     let wrapped_schema = Schema::Object(key_schema);
 
     // Get a reference to the underlying schema if we're dealing with a reference, or just use what

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -144,7 +144,6 @@ where
         validation.apply(schema);
     }
 
-    //schema.metadata = Some(Box::new(schema_metadata));
     schema.metadata = Some(schema_metadata);
 }
 

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -50,14 +50,6 @@ where
     }
 
     fn metadata() -> Metadata<Self> {
-        // We clone the default metadata of the wrapped type because otherwise this "level" of the schema would
-        // effective sever the link between things like the description of `T` itself and what we show for a field of
-        // type `Option<T>`.
-        //
-        // Said another way, this allows callers to use `#[configurable(derived)]` on a field of `Option<T>` so long as
-        // `T` has a description, and both the optional field and the schema for `T` will get the description... but the
-        // description for the optional field can still be overridden independently, etc.
-        //T::metadata().convert()
         Metadata::with_transparent(true)
     }
 
@@ -68,12 +60,7 @@ where
     }
 
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
-        let result = generate_optional_schema::<T>(gen);
-
-        //println!("schema gen result for Option<{}>: {:?}", std::any::type_name::<T>(), result);
-        //println!("");
-
-        result
+        generate_optional_schema::<T>(gen)
     }
 }
 
@@ -193,7 +180,7 @@ where
     }
 
     fn metadata() -> Metadata<Self> {
-        V::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
@@ -214,7 +201,7 @@ where
     V: Configurable + Serialize + Eq + std::hash::Hash,
 {
     fn metadata() -> Metadata<Self> {
-        V::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
@@ -239,7 +226,7 @@ where
     }
 
     fn metadata() -> Metadata<Self> {
-        V::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
@@ -260,7 +247,7 @@ where
     V: Configurable + Serialize + Eq + std::hash::Hash,
 {
     fn metadata() -> Metadata<Self> {
-        V::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -17,9 +17,9 @@ use vector_config_common::{attributes::CustomAttribute, validation::Validation};
 use crate::{
     num::ConfigurableNumber,
     schema::{
-        assert_string_schema_for_map, generate_array_schema, generate_baseline_schema,
-        generate_bool_schema, generate_map_schema, generate_number_schema, generate_set_schema,
-        generate_string_schema, make_schema_optional,
+        assert_string_schema_for_map, generate_array_schema, generate_bool_schema,
+        generate_map_schema, generate_number_schema, generate_optional_schema, generate_set_schema,
+        generate_string_schema,
     },
     str::ConfigurableString,
     Configurable, GenerateError, Metadata,
@@ -57,7 +57,8 @@ where
         // Said another way, this allows callers to use `#[configurable(derived)]` on a field of `Option<T>` so long as
         // `T` has a description, and both the optional field and the schema for `T` will get the description... but the
         // description for the optional field can still be overridden independently, etc.
-        T::metadata().convert()
+        //T::metadata().convert()
+        Metadata::with_transparent(true)
     }
 
     fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
@@ -67,29 +68,20 @@ where
     }
 
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
-        // Instead of the normal approach of using `get_or_generate_schema`, we manually generate
-        // the schema here. We do this because if `T` isn't a referenceable schema, we'd be
-        // generating the schema directly anyways (i.e. we wouldn't memoize it and return a schema
-        // reference) and if it _is_ a referenceable schema, we need to generate it directly so that
-        // when someone calls `get_or_generate_schema::<Option<T>>`, they get back a schema for `T`
-        // that allows for `null`.
-        //
-        // If we just used `get_or_generate_schema::<T>`, it would generate and memoize the schema
-        // for `T`, and we wouldn't be able to add the optionality (via allowing `null`) to it...
-        // and from testing, it seems like JSON Schema validators don't observe setting `type` on a
-        // schema reference, and we want to avoid composite schemas here if we can because they're
-        // annoying to utilize for non-validation purposes (i.e. configuration documentation).
-        let mut inner_metadata = T::metadata();
-        inner_metadata.set_transparent();
+        let result = generate_optional_schema::<T>(gen);
 
-        let mut inner_schema = generate_baseline_schema(gen, inner_metadata)?;
-        make_schema_optional(&mut inner_schema)?;
+        //println!("schema gen result for Option<{}>: {:?}", std::any::type_name::<T>(), result);
+        //println!("");
 
-        Ok(inner_schema)
+        result
     }
 }
 
 impl Configurable for bool {
+    fn metadata() -> Metadata<Self> {
+        Metadata::with_transparent(true)
+    }
+
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_bool_schema())
     }
@@ -97,6 +89,10 @@ impl Configurable for bool {
 
 // Strings.
 impl Configurable for String {
+    fn metadata() -> Metadata<Self> {
+        Metadata::with_transparent(true)
+    }
+
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
@@ -104,7 +100,7 @@ impl Configurable for String {
 
 impl Configurable for char {
     fn metadata() -> Metadata<Self> {
-        let mut metadata = Metadata::default();
+        let mut metadata = Metadata::with_transparent(true);
         metadata.add_validation(Validation::Length {
             minimum: Some(1),
             maximum: Some(1),
@@ -123,7 +119,7 @@ macro_rules! impl_configurable_numeric {
 		$(
 			impl Configurable for $ty {
                 fn metadata() -> Metadata<Self> {
-                    let mut metadata = Metadata::default();
+                    let mut metadata = Metadata::with_transparent(true);
                     let numeric_type = <Self as ConfigurableNumber>::class();
                     metadata.add_custom_attribute(CustomAttribute::kv("docs::numeric_type", numeric_type));
 
@@ -171,6 +167,15 @@ impl<T> Configurable for Vec<T>
 where
     T: Configurable + Serialize,
 {
+    fn metadata() -> Metadata<Self> {
+        T::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<T>();
+        T::validate_metadata(&converted)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         generate_array_schema::<T>(gen)
     }
@@ -187,6 +192,15 @@ where
         true
     }
 
+    fn metadata() -> Metadata<Self> {
+        V::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<V>();
+        V::validate_metadata(&converted)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         // Make sure our key type is _truly_ a string schema.
         assert_string_schema_for_map::<K, Self>(gen)?;
@@ -199,6 +213,15 @@ impl<V> Configurable for BTreeSet<V>
 where
     V: Configurable + Serialize + Eq + std::hash::Hash,
 {
+    fn metadata() -> Metadata<Self> {
+        V::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<V>();
+        V::validate_metadata(&converted)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
     }
@@ -215,6 +238,15 @@ where
         true
     }
 
+    fn metadata() -> Metadata<Self> {
+        V::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<V>();
+        V::validate_metadata(&converted)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         // Make sure our key type is _truly_ a string schema.
         assert_string_schema_for_map::<K, Self>(gen)?;
@@ -227,6 +259,15 @@ impl<V> Configurable for HashSet<V>
 where
     V: Configurable + Serialize + Eq + std::hash::Hash,
 {
+    fn metadata() -> Metadata<Self> {
+        V::metadata().convert()
+    }
+
+    fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+        let converted = metadata.convert::<V>();
+        V::validate_metadata(&converted)
+    }
+
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
     }

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use serde::{de, Deserialize, Deserializer};
 use serde_with::serde_as;
 use vector_config::{
     component::GenerateConfig, configurable_component, schema::generate_root_schema,
@@ -153,31 +152,72 @@ pub struct TlsConfig {
 }
 
 /// A listening address that can optionally support being passed in by systemd.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[configurable_component]
-#[serde(untagged)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(try_from = "String", into = "String")]
+#[configurable(metadata(docs::examples = "0.0.0.0:9000"))]
+#[configurable(metadata(docs::examples = "systemd"))]
+#[configurable(metadata(docs::examples = "systemd#3"))]
 pub enum SocketListenAddr {
-    /// A literal socket address.
+    /// An IPv4/IPv6 address and port.
     SocketAddr(SocketAddr),
 
-    /// A file descriptor identifier passed by systemd.
-    #[serde(deserialize_with = "parse_systemd_fd")]
+    /// A file descriptor identifier that is given from, and managed by, the socket activation feature of `systemd`.
     SystemdFd(usize),
 }
 
-fn parse_systemd_fd<'de, D>(des: D) -> Result<usize, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: &'de str = Deserialize::deserialize(des)?;
-    match s {
-        "systemd" => Ok(0),
-        s if s.starts_with("systemd#") => s[8..]
-            .parse::<usize>()
-            .map_err(de::Error::custom)?
-            .checked_sub(1)
-            .ok_or_else(|| de::Error::custom("systemd indices start from 1, found 0")),
-        _ => Err(de::Error::custom("must start with \"systemd\"")),
+impl From<SocketAddr> for SocketListenAddr {
+    fn from(addr: SocketAddr) -> Self {
+        Self::SocketAddr(addr)
+    }
+}
+
+impl From<usize> for SocketListenAddr {
+    fn from(fd: usize) -> Self {
+        Self::SystemdFd(fd)
+    }
+}
+
+impl TryFrom<String> for SocketListenAddr {
+    type Error = String;
+
+    fn try_from(input: String) -> Result<Self, Self::Error> {
+        // first attempt to parse the string into a SocketAddr directly
+        match input.parse::<SocketAddr>() {
+            Ok(socket_addr) => Ok(socket_addr.into()),
+
+            // then attempt to parse a systemd file descriptor
+            Err(_) => {
+                let fd: usize = match input.as_str() {
+                    "systemd" => Ok(0),
+                    s if s.starts_with("systemd#") => s[8..]
+                        .parse::<usize>()
+                        .map_err(|_| "failed to parse usize".to_string())?
+                        .checked_sub(1)
+                        .ok_or_else(|| "systemd indices start at 1".to_string()),
+
+                    // otherwise fail
+                    _ => Err("unable to parse".to_string()),
+                }?;
+
+                Ok(fd.into())
+            }
+        }
+    }
+}
+
+impl From<SocketListenAddr> for String {
+    fn from(addr: SocketListenAddr) -> String {
+        match addr {
+            SocketListenAddr::SocketAddr(addr) => addr.to_string(),
+            SocketListenAddr::SystemdFd(fd) => {
+                if fd == 0 {
+                    "systemd".to_owned()
+                } else {
+                    format!("systemd#{}", fd)
+                }
+            }
+        }
     }
 }
 

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use indexmap::IndexMap;
 use serde::{de, Deserialize, Deserializer};
 use serde_with::serde_as;
 use vector_config::{
@@ -310,6 +311,9 @@ pub struct AdvancedSinkConfig {
 
     /// The tags to apply to each event.
     tags: HashMap<String, TagConfig>,
+
+    /// The headers to apply to each event.
+    headers: HashMap<String, Vec<String>>,
 }
 
 /// Specification of the value of a created tag.
@@ -336,6 +340,7 @@ impl GenerateConfig for AdvancedSinkConfig {
             tls: None,
             partition_key: default_partition_key(),
             tags: HashMap::new(),
+            headers: HashMap::new(),
         })
         .unwrap()
     }
@@ -469,6 +474,9 @@ pub enum SinkConfig {
 pub struct GlobalOptions {
     /// The data directory where Vector will store state.
     data_dir: Option<String>,
+
+    /// A map of additional tags for metrics.
+    tags: Option<IndexMap<String, String>>,
 }
 
 /// The overall configuration for Vector.

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -982,10 +982,10 @@ def resolve_enum_schema(root_schema, schema)
     .reject { |subschema| get_schema_metadata(subschema, 'docs::hidden') }
   subschema_count = subschemas.count
 
-  # If we only have one subschema after filtering, check to see if it's an `allOf` or `oneOf`
-  # schema and `is_optional` is true.
+  # If we only have one subschema after filtering, check to see if it's an `allOf` or `oneOf` schema
+  # and `is_optional` is true.
   #
-  # If it's an `allOf` subschema, then that means we originall had an `allOf` schema that we had to
+  # If it's an `allOf` subschema, then that means we originally had an `allOf` schema that we had to
   # make optional, thus converting it to a `oneOf` with subschemas in the shape of `[null, allOf]`.
   # In this case, we'll just remove the `oneOf` and move the `allOf` subschema up, as if it this
   # schema was a `allOf` one all along.

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -976,25 +976,43 @@ end
 def resolve_enum_schema(root_schema, schema)
   # Filter out all subschemas which are purely null schemas used for indicating optionality, as well
   # as any subschemas that are marked as being hidden.
+  is_optional = get_schema_metadata(schema, 'docs::optional')
   subschemas = schema['oneOf']
     .reject { |subschema| subschema['type'] == 'null' }
     .reject { |subschema| get_schema_metadata(subschema, 'docs::hidden') }
   subschema_count = subschemas.count
 
-  # If we only have one subschema after filtering, check to see if it's an `allOf` schema. If so, we
-  # unwrap it such that we end up with a copy of `schema` that looks like it was an `allOf` schema
-  # all along. We do this to properly resolve `allOf` schemas that were wrapped as `oneOf` w/ a null
-  # schema in order to establish optionality.
-  if subschema_count == 1 && get_json_schema_type(subschemas[0]) == 'all-of'
-    @logger.debug "Detected optional all-of schema, unwrapping all-of schema to resolve..."
+  # If we only have one subschema after filtering, check to see if it's an `allOf` or `oneOf`
+  # schema and `is_optional` is true.
+  #
+  # If it's an `allOf` subschema, then that means we originall had an `allOf` schema that we had to
+  # make optional, thus converting it to a `oneOf` with subschemas in the shape of `[null, allOf]`.
+  # In this case, we'll just remove the `oneOf` and move the `allOf` subschema up, as if it this
+  # schema was a `allOf` one all along.
+  #
+  # If so, we unwrap it such that we end up with a copy of `schema` that looks like it was an
+  # `allOf` schema all along. We do this to properly resolve `allOf` schemas that were wrapped as
+  # `oneOf` w/ a null schema in order to establish optionality.
+  if is_optional && subschema_count == 1
+    if get_json_schema_type(subschemas[0]) == 'all-of'
+      @logger.debug "Detected optional all-of schema, unwrapping all-of schema to resolve..."
 
-    # Copy the current schema and drop `oneOf` and set `allOf`, which will get us the correct
-    # unwrapped structure.
-    unwrapped_schema = deep_copy(schema)
-    unwrapped_schema.delete('oneOf')
-    unwrapped_schema['allOf'] = deep_copy(subschemas[0]['allOf'])
+      # Copy the current schema and drop `oneOf` and set `allOf` with the subschema, which will get us the correct
+      # unwrapped structure.
+      unwrapped_schema = deep_copy(schema)
+      unwrapped_schema.delete('oneOf')
+      unwrapped_schema['allOf'] = deep_copy(subschemas[0]['allOf'])
 
-    return { '_resolved' => resolve_schema(root_schema, unwrapped_schema) }
+      return { '_resolved' => resolve_schema(root_schema, unwrapped_schema) }
+    else
+      # For all other subschema types, we copy the current schema, drop the `oneOf`, and merge the
+      # subschema into it. This essentially unnests the schema.
+      unwrapped_schema = deep_copy(schema)
+      unwrapped_schema.delete('oneOf')
+      unwrapped_schema = schema_aware_nested_merge(unwrapped_schema, subschemas[0])
+
+      return { '_resolved' => resolve_schema(root_schema, unwrapped_schema) }
+    end
   end
 
   # Collect all of the tagging mode information upfront.

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -277,10 +277,7 @@ impl Configurable for Compression {
         // generation, where we need to be able to generate the right enum key/value pair for the
         // `none` algorithm as part of the overall set of enum values declared for the `algorithm`
         // field in the "full" schema version.
-        let mut compression_level_metadata = Metadata::default();
-        compression_level_metadata.set_transparent();
-        let compression_level_schema =
-            get_or_generate_schema::<CompressionLevel>(gen, compression_level_metadata)?;
+        let compression_level_schema = get_or_generate_schema::<CompressionLevel>(gen, None)?;
 
         let mut required = BTreeSet::new();
         required.insert(ALGORITHM_NAME.to_string());

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -124,7 +124,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 		required:    false
 		type: array: {
 			default: [0.5, 0.75, 0.9, 0.95, 0.99]
-			items: type: number: {}
+			items: type: float: {}
 		}
 	}
 	request: {

--- a/website/cue/reference/components/sinks/base/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_exporter.cue
@@ -92,7 +92,7 @@ base: components: sinks: prometheus_exporter: configuration: {
 		required: false
 		type: array: {
 			default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
-			items: type: number: {}
+			items: type: float: {}
 		}
 	}
 	default_namespace: {
@@ -148,7 +148,7 @@ base: components: sinks: prometheus_exporter: configuration: {
 		required: false
 		type: array: {
 			default: [0.5, 0.75, 0.9, 0.95, 0.99]
-			items: type: number: {}
+			items: type: float: {}
 		}
 	}
 	suppress_timestamp: {

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -217,7 +217,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 		required: false
 		type: array: {
 			default: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
-			items: type: number: {}
+			items: type: float: {}
 		}
 	}
 	default_namespace: {
@@ -248,7 +248,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 		required: false
 		type: array: {
 			default: [0.5, 0.75, 0.9, 0.95, 0.99]
-			items: type: number: {}
+			items: type: float: {}
 		}
 	}
 	request: {


### PR DESCRIPTION
# Context

## Schema metadata

In general, `Configurable` accomplishes most of its goals by providing a concept of schema "metadata". While we can trivially examine the raw structure of a Rust type -- what are its fields, what is the type of those fields, etc -- it's harder to divine intent and usage characteristics purely from the syntactical structure. We need a mechanism to annotate types and fields to better describe their purpose and usage.

This is the primary reason that `vector_config::Metadata` exists. We use it to hold the title/description of a schema element (struct, enum, struct/enum field, etc), as well as validation annotations, and custom attributes, such as free-form key/value pairs.

## How schema metadata is defined

We use schema metadata in two main "modes": base and override.

The base metadata for a type implementing `Configurable` is exposed via `Configurable::metadata`. Base metadata generally includes things that are intrinsic to the type, such as its own description, or declaring the underlying numeric type (`docs::numeric_type`) for `u64` to be `uint`, since JSON Schema has no existing mechanism to say anything other than `number` (floating-point number) or `integer` (whole integer, but maybe signed, maybe unsigned).

Override metadata is generated at the callsite. For example, a struct field like the follow will have its own override metadata that includes the description of the field, as well as an additional custom attribute for declaring an example usage of the field:

```rust
#[configurable_component]
pub struct Foo {
  // Listen address.
  #[configurable(metadata(docs::examples = "localhost:1234"))]
  listen_addr: String,
}
```

## Merging base and override schema metadata

At some point during the schema generation process, we need to meld both the base and override metadata for all `Configurable` types, and their fields, and so on. This is where things sometimes get tricky, and indeed, is the thrust of this PR in terms of fixing and cleaning up the logic around how such merging happens.

Prior to this PR, the way that we handled metadata was.... very clunky. In general, we have a slew of implementations of `Configurable` for standard library types, and common 3rd-party crate types. For some of these types, we were haphazardly declaring their metadata, either by setting it as a one-off to fix a bug, or using part or all of the metadata of a wrapped type, such as the `T` in `Option<T>`.

As schema generation is somewhat involved, and recursive in nature, this lead to scenarios where we might apply the base metadata to the field itself, resulting in duplicate custom attributes, or we might incorrectly overwrite the base metadata with the override metadata, instead of merging, leading to common metadata (such as the aforementioned `docs::numeric_type` custom attribute) being dropped in the process. We also had areas where some implementations of `Configurable::generate_schema` would apply their own base metadata to the schema before returning it, even though higher-level methods like `get_or_generate_schema` would additionally apply metadata to the schema.

# Solution

This PR reworks the logic and flow of how we apply base and override metadata.

Essentially, within the core method we use for getting the generated schema for a given type `T` -- `vector_config::schema::get_or_generate_schema` -- we've changed up the logic to ensure that only the base metadata is applied to the schema for `T`. In some cases, a reference to the schema may be handed back -- if the definition can be shared -- or the complete inline schema might be returned itself. If override metadata is defined, it is applied in such a way that it actually _merges_ with the base metadata, rather than overwriting it. We've also gone through implementations of `Configurable::generate_schema` to ensure that they're not applying their own metadata, leaving that logic to the higher-level helper methods like `get_or_generate_schema`.

A lot of the other changes are essentially in support of that:

- many of the standard library/3rd-party crate types have had their `Configurable::metadata` impl adjusted to avoid forwarding any metadata from the underlying type that it shouldn't be
- we're correctly emitting optional schemas for fields that are `Option<T>` where `T` was a shared type
- we added a new metadata attribute, `docs::optional`, to optional schemas to allow for simpler logic around discerning if a `oneOf` schema was actually a `Option<EnumTypeHere>` or just a `Option<T>` (which we now generate a `oneOf` schema of `[<null schema>, <schema for T>]` for)
- changes to `generate-component-docs.rb` to take advantage of `docs::optional`

# Result

The grand outcome of all of this work is that we now properly mark a few configuration fields in the machine-generated Cue output as `float` instead of `number`. 😂