### PR TITLE
chore(ci): Run workflows that have required checks on the merge queue

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,6 +21,8 @@ on:
       - "docs/**"
       - "rfcs/**"
       - "website/**"
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   cancel-previous:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test Suite
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - master


### PR DESCRIPTION
We can filter this down in the future to just the checks that are _actually_ required.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
