### PR TITLE
fix(ci): temporarily disable new aws integration test that is failing

### DIFF
--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -23,61 +23,62 @@ fn kinesis_address() -> String {
     std::env::var("KINESIS_ADDRESS").unwrap_or_else(|_| "http://localhost:4566".into())
 }
 
-#[tokio::test]
-async fn kinesis_put_records_with_partition_key() {
-    let stream = gen_stream();
-
-    ensure_stream(stream.clone()).await;
-
-    let mut batch = BatchConfig::default();
-    batch.max_events = Some(2);
-
-    let base = KinesisSinkBaseConfig {
-        stream_name: stream.clone(),
-        region: RegionOrEndpoint::with_both("localstack", kinesis_address().as_str()),
-        encoding: TextSerializerConfig::default().into(),
-        compression: Compression::None,
-        request: Default::default(),
-        tls: Default::default(),
-        auth: Default::default(),
-        acknowledgements: Default::default(),
-    };
-
-    let partition_key: String = "partition_key".to_string();
-
-    let config = KinesisStreamsSinkConfig {
-        partition_key_field: Some(partition_key.clone()),
-        batch,
-        base,
-    };
-
-    let cx = SinkContext::new_test();
-
-    let sink = config.build(cx).await.unwrap().0;
-
-    let timestamp = chrono::Utc::now().timestamp_millis();
-
-    let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
-
-    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
-
-    sleep(Duration::from_secs(1)).await;
-
-    let records = fetch_records(stream, timestamp).await.unwrap();
-
-    let mut output_lines = records
-        .into_iter()
-        .map(|e| {
-            assert_eq!(Some(partition_key.as_str()), e.partition_key());
-            e
-        })
-        .map(|e| String::from_utf8(e.data.unwrap().into_inner()).unwrap())
-        .collect::<Vec<_>>();
-
-    input_lines.sort();
-    output_lines.sort();
-    assert_eq!(output_lines, input_lines)
-}
+// TODO: temporarily disabling as this is failing
+//#[tokio::test]
+//async fn kinesis_put_records_with_partition_key() {
+//    let stream = gen_stream();
+//
+//    ensure_stream(stream.clone()).await;
+//
+//    let mut batch = BatchConfig::default();
+//    batch.max_events = Some(2);
+//
+//    let base = KinesisSinkBaseConfig {
+//        stream_name: stream.clone(),
+//        region: RegionOrEndpoint::with_both("localstack", kinesis_address().as_str()),
+//        encoding: TextSerializerConfig::default().into(),
+//        compression: Compression::None,
+//        request: Default::default(),
+//        tls: Default::default(),
+//        auth: Default::default(),
+//        acknowledgements: Default::default(),
+//    };
+//
+//    let partition_key: String = "partition_key".to_string();
+//
+//    let config = KinesisStreamsSinkConfig {
+//        partition_key_field: Some(partition_key.clone()),
+//        batch,
+//        base,
+//    };
+//
+//    let cx = SinkContext::new_test();
+//
+//    let sink = config.build(cx).await.unwrap().0;
+//
+//    let timestamp = chrono::Utc::now().timestamp_millis();
+//
+//    let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
+//
+//    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
+//
+//    sleep(Duration::from_secs(1)).await;
+//
+//    let records = fetch_records(stream, timestamp).await.unwrap();
+//
+//    let mut output_lines = records
+//        .into_iter()
+//        .map(|e| {
+//            assert_eq!(Some(partition_key.as_str()), e.partition_key());
+//            e
+//        })
+//        .map(|e| String::from_utf8(e.data.unwrap().into_inner()).unwrap())
+//        .collect::<Vec<_>>();
+//
+//    input_lines.sort();
+//    output_lines.sort();
+//    assert_eq!(output_lines, input_lines)
+//}
 
 #[tokio::test]
 async fn kinesis_put_records_without_partition_key() {


### PR DESCRIPTION
We merged https://github.com/vectordotdev/vector/pull/16286

, without running integration tests there. Seems that new int test is not ready.

Timing out on master:

https://github.com/vectordotdev/vector/actions/runs/4129227074/jobs/7134930917

I also tried on my EC2 instance and saw the same behavior.

Commenting that out to unblock master while we sort it out.

Not reverting the commit because the commit also included a fix for a bug.

Ran the int test locally with this change:

```
$ cargo vdev int test aws
        PASS [  59.148s] vector sinks::aws_kinesis::streams::integration_tests::kinesis_put_records_without_partition_key
```
