### PR TITLE
fix(test_util): drop no-op track_caller annotations

### DIFF
--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -242,7 +242,6 @@ impl ComponentTester {
 }
 
 /// Runs and returns a future and asserts that the provided test specification passes.
-#[track_caller]
 pub async fn assert_source<T>(
     tests: &Lazy<ComponentTests>,
     tags: &[&str],
@@ -258,13 +257,11 @@ pub async fn assert_source<T>(
 }
 
 /// Convenience wrapper for running source tests.
-#[track_caller]
 pub async fn assert_source_compliance<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     assert_source(&SOURCE_TESTS, tags, f).await
 }
 
 /// Runs source tests with timeout and asserts happy path compliance.
-#[track_caller]
 pub async fn run_and_assert_source_compliance<SC>(
     source: SC,
     timeout: Duration,
@@ -277,7 +274,6 @@ where
 }
 
 /// Runs source tests with an event count limit and asserts happy path compliance.
-#[track_caller]
 pub async fn run_and_assert_source_compliance_n<SC>(
     source: SC,
     event_count: usize,
@@ -291,7 +287,6 @@ where
 }
 
 /// Runs and returns a future and asserts that the provided test specification passes.
-#[track_caller]
 pub async fn assert_source_error<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -303,7 +298,6 @@ pub async fn assert_source_error<T>(tags: &[&str], f: impl Future<Output = T>) -
 }
 
 /// Runs source tests with timeout and asserts error path compliance.
-#[track_caller]
 pub async fn run_and_assert_source_error<SC>(
     source: SC,
     timeout: Duration,
@@ -337,7 +331,6 @@ where
     run_and_assert_source_advanced(source, setup, timeout, event_count, &SOURCE_TESTS, tags).await
 }
 
-#[track_caller]
 pub async fn run_and_assert_source_advanced<SC>(
     source: SC,
     setup: impl FnOnce(&mut SourceContext),
@@ -406,7 +399,6 @@ where
     .await
 }
 
-#[track_caller]
 pub async fn assert_transform_compliance<T>(f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -418,7 +410,6 @@ pub async fn assert_transform_compliance<T>(f: impl Future<Output = T>) -> T {
 }
 
 /// Convenience wrapper for running sink tests
-#[track_caller]
 pub async fn assert_sink_compliance<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -429,7 +420,6 @@ pub async fn assert_sink_compliance<T>(tags: &[&str], f: impl Future<Output = T>
     result
 }
 
-#[track_caller]
 pub async fn run_and_assert_sink_compliance<S, I>(sink: VectorSink, events: S, tags: &[&str])
 where
     S: Stream<Item = I> + Send,
@@ -442,7 +432,6 @@ where
     .await;
 }
 
-#[track_caller]
 pub async fn assert_nonsending_sink_compliance<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -453,7 +442,6 @@ pub async fn assert_nonsending_sink_compliance<T>(tags: &[&str], f: impl Future<
     result
 }
 
-#[track_caller]
 pub async fn run_and_assert_nonsending_sink_compliance<S, I>(
     sink: VectorSink,
     events: S,
@@ -470,7 +458,6 @@ pub async fn run_and_assert_nonsending_sink_compliance<S, I>(
 }
 
 /// Convenience wrapper for running sink error tests
-#[track_caller]
 pub async fn assert_sink_error<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -481,7 +468,6 @@ pub async fn assert_sink_error<T>(tags: &[&str], f: impl Future<Output = T>) -> 
     result
 }
 
-#[track_caller]
 pub async fn run_and_assert_sink_error<S, I>(sink: VectorSink, events: S, tags: &[&str])
 where
     S: Stream<Item = I> + Send,


### PR DESCRIPTION
These track_caller annotations are considered no-ops in async functions. These annotations were causing warnings and local tests to fail in certain cases.
