### PR TITLE
chore(docs): increase logging verbosity for debugging spurious `generate-component-docs` failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,7 +369,7 @@ jobs:
         run: make check-markdown
       - name: Check Component Docs
         if: needs.changes.outputs.source == 'true' || needs.changes.outputs.component_docs == 'true'
-        run: make check-component-docs
+        run: LOG_LEVEL=debug make check-component-docs
   master-failure:
     name: master-failure
     if: failure() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
This is purely for testing and will not be merged.