### PR TITLE
docs: Build rust-doc.vector.dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,6 +379,8 @@ tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-ut
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
 default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise", "component-validation-runner"]
+# Default features for `cargo docs`. The same as `default` but without `rdkafka?/gssapi-vendored` which would require installing libsasl in our doc build environment.
+docs = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "vrl-cli", "enterprise", "component-validation-runner"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "vrl-cli", "enterprise"]
 # Default features for *-pc-windows-msvc

--- a/rust-doc/Makefile
+++ b/rust-doc/Makefile
@@ -1,0 +1,3 @@
+docs:
+	../scripts/environment/install-protoc.sh ${HOME}/protoc
+	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs"

--- a/rust-doc/netlify.toml
+++ b/rust-doc/netlify.toml
@@ -1,4 +1,3 @@
 [build]
 publish = "../target/doc/"
 command = "make docs"
-environment = { RUSTDOCFLAGS= "--cfg docsrs" }

--- a/rust-doc/netlify.toml
+++ b/rust-doc/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+publish = "../target/doc/"
+command = "make docs"
+environment = { RUSTDOCFLAGS= "--cfg docsrs" }

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -1,6 +1,15 @@
 #! /usr/bin/env bash
 set -o errexit -o verbose
 
+# A parameter can be optionally passed to this script to specify an alternative
+# location to install protoc. Default is /usr/bin.
+readonly INSTALL_PATH=${1:-"/usr/bin"}
+
+if [[ -n $1 ]]
+then
+  mkdir -p "${INSTALL_PATH}"
+fi
+
 # Protoc. No guard because we want to override Ubuntu's old version in
 # case it is already installed by a dependency.
 #
@@ -54,4 +63,4 @@ install_protoc() {
   mv --force --verbose "${TMP_DIR}/bin/protoc" "${install_path}"
 }
 
-install_protoc "3.19.5" "/usr/bin/protoc"
+install_protoc "3.19.5" "${INSTALL_PATH}/protoc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
 #![deny(warnings)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wild_err_arm)]


### PR DESCRIPTION
This builds the rust docs for Vector and sets them to `rust-doc.vector.dev`.

Preview is [here](https://deploy-preview-16386--vector-rust-doc.netlify.app/vector/). I'll update it to only build on master once this PR is ready to merge.


When I switch `RUSTDOCFLAGS="--cfg docsrs"`, I get this error, so have disabled for now:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> /home/stephenwakely/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-io-0.3.26/src/lib.rs:22:21
   |
22 | #![cfg_attr(docsrs, feature(doc_cfg))]
   |                     ^^^^^^^^^^^^^^^^

error: Compilation failed, aborting rustdoc
```



Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>

