### PR TITLE
chore(config): apply the field-level defaults to all ARC settings

### DIFF
--- a/src/sinks/util/adaptive_concurrency/mod.rs
+++ b/src/sinks/util/adaptive_concurrency/mod.rs
@@ -47,6 +47,7 @@ pub struct AdaptiveConcurrencySettings {
     /// the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
     /// unusually high response variability.
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
+    #[serde(default = "default_ewma_alpha")]
     pub(super) ewma_alpha: f64,
 
     /// Scale of RTT deviations which are not considered anomalous.
@@ -58,6 +59,7 @@ pub struct AdaptiveConcurrencySettings {
     /// can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
     /// an appropriate range.  Larger values cause the algorithm to ignore larger increases in the RTT.
     #[configurable(validation(range(min = 0.0)))]
+    #[serde(default = "default_rtt_deviation_scale")]
     pub(super) rtt_deviation_scale: f64,
 }
 


### PR DESCRIPTION
In #16150, a change was made to remove `#[serde(default)]` from `AdaptiveConcurrencySettings`. This is standard practice now due to how it affects the resulting configuration schema output, where we instead prefer to set the defaults on a per-field basis.

However, only one of the struct fields was changed to properly set the default, while the other two were not. This resulted in a change to the schema that made the two unchanged fields appear to be required, when they are in fact not.
