### PR TITLE
docs: Setup a redirect from `rust-doc.vector.dev/` to `rust-doc.vector.dev/vector`

### DIFF
--- a/rust-doc/netlify.toml
+++ b/rust-doc/netlify.toml
@@ -1,3 +1,9 @@
 [build]
 publish = "../target/doc/"
 command = "make docs"
+
+[[redirects]]
+from = "/"
+to = "/vector"
+status = 301
+force = false


### PR DESCRIPTION
This sets up a redirect rule from <https://rust-doc.vector.dev/> to go to <https://rust-doc.vector.dev/vector>. This avoids getting a 404 on when visiting the root.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>