### PR TITLE
chore(ci): Upload config schema as artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,6 +370,11 @@ jobs:
       - name: Check Component Docs
         if: needs.changes.outputs.source == 'true' || needs.changes.outputs.component_docs == 'true'
         run: make check-component-docs
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "config-schema.json"
+          path: "/tmp/vector-config-schema.json"
+        if: success() || failure()
   master-failure:
     name: master-failure
     if: failure() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Seems like this is generally useful, but, in particular, adding this to help determine why we are
seeing recent failures generating the docs from schemas in some PRs.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
