### PR TITLE
fix(observability): Fix tagging registered events in sources

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -270,7 +270,11 @@ pub async fn build_pieces(
             schema_definitions,
             schema: config.schema,
         };
-        let server = match source.inner.build(context).await {
+        let source = {
+            let _span = span.enter();
+            source.inner.build(context).await
+        };
+        let server = match source {
             Err(error) => {
                 errors.push(format!("Source \"{}\": {}", key, error));
                 continue;


### PR DESCRIPTION
Registered events have their tags/labels assigned when the event is registered rather than when the event is emitted. For most sources, this is during the source build stage. In order to set these tags properly, the builder needs to be run in the context of the same span that the component is normally run in. This span was being set up in the wrong place, and so all registered events that were set up in the build function weren't tagged properly. This commit fixes that span setup location.


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
