### PR TITLE
docs: Remove strategy link from s3 source page

### DIFF
--- a/website/content/en/highlights/2023-02-28-0-28-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-02-28-0-28-0-upgrade-guide.md
@@ -17,6 +17,7 @@ Vector's 0.28.0 release includes **breaking changes**:
 and **deprecations**:
 
 1. [The `redis` sink's `url` argument changed to `endpoint`](#redis-endpoint)
+2. [The `aws_s3` source's `strategy` option has been hidden](#aws_s3-strategy)
 
 and **potentially impactful changes**:
 
@@ -55,6 +56,13 @@ syntax to use to migrate.
 To maintain consistent naming with other Vector sinks, the `url` option in the
 `redis` sink has been renamed to `endpoint`. `url` will still work, but has
 been deprecated and will be removed in due course.
+
+#### The `aws_s3` source's `strategy` option has been hidden {#aws_s3-strategy}
+
+The `strategy` option has been hidden on the documentation for the `aws_s3` source.
+`sqs` is currently the only value for this option, and is currently the default. If
+additional strategies are added for this source, we will expose this option again.
+No changes need to be made by users of this source, it is a documentation only change.
 
 ### Potentially impactful changes
 

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -152,11 +152,10 @@ components: sources: aws_s3: components._aws & {
 			policies: [
 				{
 					_action:       "ReceiveMessage"
-					required_when: "[`strategy`](#strategy) is set to `sqs`"
 				},
 				{
 					_action:       "DeleteMessage"
-					required_when: "[`strategy`](#strategy) is set to `sqs` and [`delete_message`](#sqs.delete_message) is set to `true`"
+					required_when: "[`delete_message`](#sqs.delete_message) is set to `true`"
 				},
 			]
 		},

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -151,7 +151,7 @@ components: sources: aws_s3: components._aws & {
 
 			policies: [
 				{
-					_action:       "ReceiveMessage"
+					_action: "ReceiveMessage"
 				},
 				{
 					_action:       "DeleteMessage"


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
