### PR TITLE
chore(internal docs): Mark advanced schema props

### DIFF
--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -14,6 +14,7 @@ pub struct RegionOrEndpoint {
 
     /// Custom endpoint for use with AWS-compatible services.
     #[configurable(metadata(docs::examples = "http://127.0.0.0:5000/path/to/service"))]
+    #[configurable(metadata(docs::advanced))]
     pub endpoint: Option<String>,
 }
 

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -46,6 +46,7 @@ pub struct KafkaAuthConfig {
     pub(crate) sasl: Option<KafkaSaslConfig>,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     pub(crate) tls: Option<TlsEnableableConfig>,
 }
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -77,6 +77,7 @@ pub struct GcsSinkConfig {
     ///
     /// [custom_metadata]: https://cloud.google.com/storage/docs/metadata#custom-metadata
     #[configurable(metadata(docs::additional_props_description = "A key/value pair."))]
+    #[configurable(metadata(docs::advanced))]
     metadata: Option<HashMap<String, String>>,
 
     /// A prefix to apply to all object keys.
@@ -91,6 +92,7 @@ pub struct GcsSinkConfig {
         docs::examples = "year=%Y/month=%m/day=%d/",
         docs::examples = "application_id={{ application_id }}/date=%F/"
     ))]
+    #[configurable(metadata(docs::advanced))]
     key_prefix: Option<String>,
 
     /// The timestamp format for the time component of the object key.
@@ -110,6 +112,7 @@ pub struct GcsSinkConfig {
     ///
     /// [chrono_strftime_specifiers]: https://docs.rs/chrono/latest/chrono/format/strftime/index.html#specifiers
     #[serde(default = "default_time_format")]
+    #[configurable(metadata(docs::advanced))]
     filename_time_format: String,
 
     /// Whether or not to append a UUID v4 token to the end of the object key.
@@ -121,11 +124,13 @@ pub struct GcsSinkConfig {
     /// This ensures there are no name collisions, and can be useful in high-volume workloads where
     /// object keys must be unique.
     #[serde(default = "crate::serde::default_true")]
+    #[configurable(metadata(docs::advanced))]
     filename_append_uuid: bool,
 
     /// The filename extension to use in the object key.
     ///
     /// If not specified, the extension will be determined by the compression scheme used.
+    #[configurable(metadata(docs::advanced))]
     filename_extension: Option<String>,
 
     #[serde(flatten)]

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -38,6 +38,7 @@ pub struct KafkaSinkConfig {
     /// If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent.
     ///
     /// Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key.
+    #[configurable(metadata(docs::advanced))]
     pub key_field: Option<String>,
 
     #[configurable(derived)]
@@ -45,10 +46,12 @@ pub struct KafkaSinkConfig {
 
     // These batching options will **not** override librdkafka_options values.
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     #[serde(default)]
     pub batch: BatchConfig<NoDefaultsBatchSettings>,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     #[serde(default)]
     pub compression: KafkaCompression,
 
@@ -58,10 +61,12 @@ pub struct KafkaSinkConfig {
 
     /// Default timeout, in milliseconds, for network requests.
     #[serde(default = "default_socket_timeout_ms")]
+    #[configurable(metadata(docs::advanced))]
     pub socket_timeout_ms: u64,
 
     /// Local message timeout, in milliseconds.
     #[serde(default = "default_message_timeout_ms")]
+    #[configurable(metadata(docs::advanced))]
     pub message_timeout_ms: u64,
 
     /// A map of advanced options to pass directly to the underlying `librdkafka` client.
@@ -70,6 +75,7 @@ pub struct KafkaSinkConfig {
     ///
     /// [config_props_docs]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
     #[serde(default)]
+    #[configurable(metadata(docs::advanced))]
     #[configurable(metadata(
         docs::additional_props_description = "A librdkafka configuration option."
     ))]
@@ -78,6 +84,7 @@ pub struct KafkaSinkConfig {
     /// The log field name to use for the Kafka headers.
     ///
     /// If omitted, no headers will be written.
+    #[configurable(metadata(docs::advanced))]
     #[serde(alias = "headers_field")] // accidentally released as `headers_field` in 0.18
     pub headers_key: Option<String>,
 

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -74,6 +74,7 @@ pub struct PrometheusExporterConfig {
     ///
     /// [prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
     #[serde(alias = "namespace")]
+    #[configurable(metadata(docs::advanced))]
     pub default_namespace: Option<String>,
 
     /// The address to expose for scraping.
@@ -93,12 +94,14 @@ pub struct PrometheusExporterConfig {
     ///
     /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_histogram_buckets")]
+    #[configurable(metadata(docs::advanced))]
     pub buckets: Vec<f64>,
 
     /// Quantiles to use for aggregating [distribution][dist_metric_docs] metrics into a summary.
     ///
     /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_summary_quantiles")]
+    #[configurable(metadata(docs::advanced))]
     pub quantiles: Vec<f64>,
 
     /// Whether or not to render [distributions][dist_metric_docs] as an [aggregated histogram][prom_agg_hist_docs] or  [aggregated summary][prom_agg_summ_docs].
@@ -111,6 +114,7 @@ pub struct PrometheusExporterConfig {
     /// [prom_agg_hist_docs]: https://prometheus.io/docs/concepts/metric_types/#histogram
     /// [prom_agg_summ_docs]: https://prometheus.io/docs/concepts/metric_types/#summary
     #[serde(default = "default_distributions_as_summaries")]
+    #[configurable(metadata(docs::advanced))]
     pub distributions_as_summaries: bool,
 
     /// The interval, in seconds, on which metrics are flushed.
@@ -121,6 +125,7 @@ pub struct PrometheusExporterConfig {
     /// Be sure to configure this value higher than your client’s scrape interval.
     #[serde(default = "default_flush_period_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::advanced))]
     pub flush_period_secs: Duration,
 
     /// Suppresses timestamps on the Prometheus output.
@@ -129,6 +134,7 @@ pub struct PrometheusExporterConfig {
     /// far in the past for Prometheus to allow them, such as when aggregating metrics over long
     /// time periods, or when replaying old metrics from a disk buffer.
     #[serde(default)]
+    #[configurable(metadata(docs::advanced))]
     pub suppress_timestamp: bool,
 
     #[configurable(derived)]

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -71,18 +71,21 @@ pub struct RemoteWriteConfig {
     ///
     /// [prom_naming_docs]: https://prometheus.io/docs/practices/naming/#metric-names
     #[configurable(metadata(docs::examples = "service"))]
+    #[configurable(metadata(docs::advanced))]
     pub default_namespace: Option<String>,
 
     /// Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
     ///
     /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_histogram_buckets")]
+    #[configurable(metadata(docs::advanced))]
     pub buckets: Vec<f64>,
 
     /// Quantiles to use for aggregating [distribution][dist_metric_docs] metrics into a summary.
     ///
     /// [dist_metric_docs]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/#distribution
     #[serde(default = "super::default_summary_quantiles")]
+    #[configurable(metadata(docs::advanced))]
     pub quantiles: Vec<f64>,
 
     #[configurable(derived)]
@@ -100,6 +103,7 @@ pub struct RemoteWriteConfig {
     /// This may be used by Cortex or other remote services to identify the tenant making the request.
     #[serde(default)]
     #[configurable(metadata(docs::examples = "my-domain"))]
+    #[configurable(metadata(docs::advanced))]
     pub tenant_id: Option<Template>,
 
     #[configurable(derived)]
@@ -109,6 +113,7 @@ pub struct RemoteWriteConfig {
     pub auth: Option<PrometheusRemoteWriteAuth>,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     pub aws: Option<RegionOrEndpoint>,
 
     #[configurable(derived)]

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -76,6 +76,7 @@ pub struct AwsS3Config {
     compression: Compression,
 
     /// The strategy to use to consume objects from S3.
+    #[configurable(metadata(docs::hidden))]
     strategy: Strategy,
 
     /// Configuration options for SQS.

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -75,9 +75,11 @@ pub struct KafkaSourceConfig {
     /// The Kafka topics names to read events from.
     ///
     /// Regular expression syntax is supported if the topic begins with `^`.
-    #[configurable(metadata(docs::examples = "^(prefix1|prefix2)-.+"))]
-    #[configurable(metadata(docs::examples = "topic-1"))]
-    #[configurable(metadata(docs::examples = "topic-2"))]
+    #[configurable(metadata(
+        docs::examples = "^(prefix1|prefix2)-.+",
+        docs::examples = "topic-1",
+        docs::examples = "topic-2"
+    ))]
     topics: Vec<String>,
 
     /// The consumer group name to be used to consume events from Kafka.
@@ -97,30 +99,29 @@ pub struct KafkaSourceConfig {
 
     /// The Kafka session timeout.
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
-    #[configurable(metadata(docs::examples = 5000))]
-    #[configurable(metadata(docs::examples = 10000))]
+    #[configurable(metadata(docs::examples = 5000, docs::examples = 10000))]
+    #[configurable(metadata(docs::advanced))]
     #[serde(default = "default_session_timeout_ms")]
     session_timeout_ms: Duration,
 
     /// Timeout for network requests.
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
-    #[configurable(metadata(docs::examples = 30000))]
-    #[configurable(metadata(docs::examples = 60000))]
+    #[configurable(metadata(docs::examples = 30000, docs::examples = 60000))]
+    #[configurable(metadata(docs::advanced))]
     #[serde(default = "default_socket_timeout_ms")]
     socket_timeout_ms: Duration,
 
     /// Maximum time the broker may wait to fill the response.
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
-    #[configurable(metadata(docs::examples = 50))]
-    #[configurable(metadata(docs::examples = 100))]
+    #[configurable(metadata(docs::examples = 50, docs::examples = 100))]
+    #[configurable(metadata(docs::advanced))]
     #[serde(default = "default_fetch_wait_max_ms")]
     fetch_wait_max_ms: Duration,
 
     /// The frequency that the consumer offsets are committed (written) to offset storage.
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
     #[serde(default = "default_commit_interval_ms")]
-    #[configurable(metadata(docs::examples = 5000))]
-    #[configurable(metadata(docs::examples = 10000))]
+    #[configurable(metadata(docs::examples = 5000, docs::examples = 10000))]
     commit_interval_ms: Duration,
 
     /// Overrides the name of the log field used to add the message key to each event.
@@ -172,6 +173,7 @@ pub struct KafkaSourceConfig {
     ///
     /// See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for details.
     #[configurable(metadata(docs::examples = "example_librdkafka_options()"))]
+    #[configurable(metadata(docs::advanced))]
     #[configurable(metadata(
         docs::additional_props_description = "A librdkafka configuration option."
     ))]
@@ -181,6 +183,7 @@ pub struct KafkaSourceConfig {
     auth: kafka::KafkaAuthConfig,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     framing: FramingConfig,

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -43,6 +43,7 @@ pub struct LogstashConfig {
     address: SocketListenAddr,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     keepalive: Option<TcpKeepaliveConfig>,
 
     #[configurable(derived)]
@@ -53,10 +54,12 @@ pub struct LogstashConfig {
     /// This generally should not need to be changed.
     #[configurable(metadata(docs::type_unit = "bytes"))]
     #[configurable(metadata(docs::examples = 65536))]
+    #[configurable(metadata(docs::advanced))]
     receive_buffer_bytes: Option<usize>,
 
     /// The maximum number of TCP connections that will be allowed at any given time.
     #[configurable(metadata(docs::type_unit = "connections"))]
+    #[configurable(metadata(docs::advanced))]
     connection_limit: Option<u32>,
 
     #[configurable(derived)]

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -36,6 +36,7 @@ pub struct PrometheusRemoteWriteConfig {
     tls: Option<TlsEnableableConfig>,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     auth: Option<HttpSourceAuthConfig>,
 
     #[configurable(derived)]

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -59,11 +59,13 @@ pub struct PrometheusScrapeConfig {
     /// The tag name added to each event representing the scraped instance's host:port.
     ///
     /// The tag value will be the host/port of the scraped instance.
+    #[configurable(metadata(docs::advanced))]
     instance_tag: Option<String>,
 
     /// The tag name added to each event representing the scraped instance's endpoint.
     ///
     /// The tag value will be the endpoint of the scraped instance.
+    #[configurable(metadata(docs::advanced))]
     endpoint_tag: Option<String>,
 
     /// Controls how tag conflicts are handled if the scraped source has tags to be added.
@@ -73,6 +75,7 @@ pub struct PrometheusScrapeConfig {
     ///
     /// This matches Prometheus’ `honor_labels` configuration.
     #[serde(default = "crate::serde::default_false")]
+    #[configurable(metadata(docs::advanced))]
     honor_labels: bool,
 
     /// Custom parameters for the scrape request query string.
@@ -89,6 +92,7 @@ pub struct PrometheusScrapeConfig {
     tls: Option<TlsConfig>,
 
     #[configurable(derived)]
+    #[configurable(metadata(docs::advanced))]
     auth: Option<Auth>,
 }
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -61,7 +61,7 @@ pub struct RemapConfig {
     /// Required if `source` is missing.
     ///
     /// [vrl]: https://vector.dev/docs/reference/vrl
-    #[configurable(metadata(docs::examples = "./my/program.vrl",))]
+    #[configurable(metadata(docs::examples = "./my/program.vrl"))]
     pub file: Option<PathBuf>,
 
     /// When set to `single`, metric tag values will be exposed as single strings, the
@@ -82,6 +82,7 @@ pub struct RemapConfig {
     /// [global_timezone]: https://vector.dev/docs/reference/configuration//global-options#timezone
     /// [tz_database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     #[serde(default)]
+    #[configurable(metadata(docs::advanced))]
     pub timezone: Option<TimeZone>,
 
     /// Drops any event that encounters an error during processing.


### PR DESCRIPTION
(Apologies for the codeowner spam!)

Small PR to mark a few fields with `docs::advanced` meta for internal schema generation.

## To test

```bash
cargo run -- generate-schema
```

... and manually verify that transform descriptions in the returned JSON are expanded.

Signed-off-by: Lee Benson <lee@leebenson.com>