### PR TITLE
chore: add `#[deny(missing_docs)]` to root

### DIFF
--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -1,3 +1,4 @@
+//! Functionality supporting both the [sources::amqp] source and `[sinks::amqp]` sink.
 use lapin::tcp::{OwnedIdentity, OwnedTLSConfig};
 use vector_config::configurable_component;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 mod handler;
 mod schema;
 mod server;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{collections::HashMap, num::NonZeroUsize, path::PathBuf, sync::Arc};
 
 use futures::StreamExt;

--- a/src/async_read.rs
+++ b/src/async_read.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     future::Future,
     pin::Pin,

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 pub mod auth;
 pub mod region;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, FromArgMatches, Parser};

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,1 +1,2 @@
+#![allow(missing_docs)]
 pub mod validation;

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use vector_config::configurable_component;
 
 use crate::event::Event;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Display, Formatter},

--- a/src/control_server.rs
+++ b/src/control_server.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     path::{Path, PathBuf},
     sync::Arc,

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
     task::{Context, Poll},

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{collections::HashMap, env, path::PathBuf};
 
 use bollard::{

--- a/src/encoding_transcode.rs
+++ b/src/encoding_transcode.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use bytes::{Bytes, BytesMut};
 use encoding_rs::{CoderResult, Encoding};
 

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -1,3 +1,4 @@
+//! Handles enrichment tables for `type = file`.
 use std::{
     collections::{BTreeMap, HashMap},
     fs,
@@ -247,6 +248,7 @@ impl EnrichmentTableConfig for FileConfig {
 
 impl_generate_config_from_default!(FileConfig);
 
+/// A struct that implements [enrichment::Table] to handle loading enricment data from a CSV file.
 #[derive(Clone)]
 pub struct File {
     config: FileConfig,
@@ -261,6 +263,7 @@ pub struct File {
 }
 
 impl File {
+    /// Creates a new [File] based on the provided config.
     pub fn new(
         config: FileConfig,
         last_modified: SystemTime,

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -1,6 +1,6 @@
 //! Handles enrichment tables for `type = geoip`.
-//! Enrichment data is loading from a MaxMind GeoIP database either
-//! [MaxMind GeoIP2][maxmind] or [GeoLite2 binary city database][geolite]
+//! Enrichment data is loaded from one of the MaxMind GeoIP databases,
+//! [MaxMind GeoIP2][maxmind] or [GeoLite2 binary city database][geolite].
 //!
 //! [maxmind]: https://dev.maxmind.com/geoip/geoip2/downloadable
 //! [geolite]: https://dev.maxmind.com/geoip/geoip2/geolite2/#Download_Access
@@ -99,7 +99,7 @@ impl EnrichmentTableConfig for GeoipConfig {
 }
 
 #[derive(Clone)]
-/// A struct that implements [enrichment::Table] to handle loading enricment data from a Geoip database.
+/// A struct that implements [enrichment::Table] to handle loading enrichment data from a GeoIP database.
 pub struct Geoip {
     config: GeoipConfig,
     dbreader: Arc<maxminddb::Reader<Vec<u8>>>,
@@ -108,7 +108,7 @@ pub struct Geoip {
 }
 
 impl Geoip {
-    /// Creates a new Geoup struct from the provided config.
+    /// Creates a new GeoIP struct from the provided config.
     pub fn new(config: GeoipConfig) -> crate::Result<Self> {
         let dbreader = Arc::new(Reader::open_readfile(config.path.clone())?);
         let dbkind = DatabaseKind::from(dbreader.metadata.database_type.as_str());

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -1,3 +1,9 @@
+//! Handles enrichment tables for `type = geoip`.
+//! Enrichment data is loading from a MaxMind GeoIP database either
+//! [MaxMind GeoIP2][maxmind] or [GeoLite2 binary city database][geolite]
+//!
+//! [maxmind]: https://dev.maxmind.com/geoip/geoip2/downloadable
+//! [geolite]: https://dev.maxmind.com/geoip/geoip2/geolite2/#Download_Access
 use std::{collections::BTreeMap, fs, net::IpAddr, sync::Arc, time::SystemTime};
 
 use enrichment::{Case, Condition, IndexHandle, Table};
@@ -14,6 +20,7 @@ use crate::config::{EnrichmentTableConfig, GenerateConfig};
 // products. If we encounter one of these two types, we look for ASN/ISP information;
 // otherwise we expect to be working with a City database.
 #[derive(Copy, Clone, Debug)]
+#[allow(missing_docs)]
 pub enum DatabaseKind {
     Asn,
     Isp,
@@ -92,6 +99,7 @@ impl EnrichmentTableConfig for GeoipConfig {
 }
 
 #[derive(Clone)]
+/// A struct that implements [enrichment::Table] to handle loading enricment data from a Geoip database.
 pub struct Geoip {
     config: GeoipConfig,
     dbreader: Arc<maxminddb::Reader<Vec<u8>>>,
@@ -100,6 +108,7 @@ pub struct Geoip {
 }
 
 impl Geoip {
+    /// Creates a new Geoup struct from the provided config.
     pub fn new(config: GeoipConfig) -> crate::Result<Self> {
         let dbreader = Arc::new(Reader::open_readfile(config.path.clone())?);
         let dbkind = DatabaseKind::from(dbreader.metadata.database_type.as_str());

--- a/src/enrichment_tables/mod.rs
+++ b/src/enrichment_tables/mod.rs
@@ -1,3 +1,4 @@
+//! Functionality to handle enrichment tables.
 pub use enrichment::{Condition, IndexHandle, Table};
 use enum_dispatch::enum_dispatch;
 use vector_config::{configurable_component, NamedComponent};

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     sync::{Arc, RwLock},
     time::Duration,

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     fs::{create_dir_all, File},
     io::Write,

--- a/src/generate_schema.rs
+++ b/src/generate_schema.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use vector_config::schema::generate_root_schema;
 
 use crate::config::ConfigBuilder;

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -1,3 +1,4 @@
+//! Emits a heartbeat internal metric.
 use std::time::{Duration, Instant};
 
 use tokio::time::interval;

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     fmt,
     task::{Context, Poll},

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 pub mod prelude;
 
 mod adaptive_concurrency;

--- a/src/internal_telemetry/mod.rs
+++ b/src/internal_telemetry/mod.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(feature = "allocation-tracing")]
 pub mod allocations;
 

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::path::{Path, PathBuf};
 
 use rdkafka::{consumer::ConsumerContext, ClientConfig, ClientContext, Statistics};

--- a/src/kubernetes/mod.rs
+++ b/src/kubernetes/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! This module contains helpers Kubernetes helpers as well as a
 //! `custom_reflector` which delays the removal of metadata allowing
 //! us to enrich events even after the resource is deleted from the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![deny(clippy::disallowed_methods)] // [nursery] mark some functions as verboten
 #![deny(clippy::missing_const_for_fn)] // [nursery] valuable to the optimizer, but may produce false positives
 
-//! This is the main entry point for Vector.
+//! The main library to support building Vector.
 
 #[macro_use]
 extern crate tracing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
 #![deny(warnings)]
+#![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
@@ -16,7 +17,9 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 #![deny(clippy::disallowed_methods)] // [nursery] mark some functions as verboten
 #![deny(clippy::missing_const_for_fn)] // [nursery] valuable to the optimizer,
-                                       // but may produce false positives
+// but may produce false positives
+
+//! This is the main entry point for Vector.
 
 #[macro_use]
 extern crate tracing;
@@ -123,6 +126,8 @@ pub use source_sender::SourceSender;
 pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
+/// The current version of Vector in simplified format.
+/// <version-number>-nightly.
 pub fn vector_version() -> impl std::fmt::Display {
     #[cfg(feature = "nightly")]
     let pkg_version = format!("{}-nightly", built_info::PKG_VERSION);
@@ -133,6 +138,7 @@ pub fn vector_version() -> impl std::fmt::Display {
     pkg_version
 }
 
+/// Returns a string containing full version information of the current build.
 pub fn get_version() -> String {
     let pkg_version = vector_version();
     let build_desc = built_info::VECTOR_BUILD_DESC;
@@ -153,15 +159,21 @@ pub fn get_version() -> String {
     format!("{} ({})", pkg_version, build_string)
 }
 
+/// Includes information about the current build.
 #[allow(warnings)]
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
+/// Returns the host name of the current system.
 pub fn get_hostname() -> std::io::Result<String> {
     Ok(hostname::get()?.to_string_lossy().into())
 }
 
+/// Spawn a task with the given name. The name is only used if
+/// built with [`tokio_unstable`][tokio_unstable].
+///
+/// [tokio_unstable]: https://docs.rs/tokio/latest/tokio/#unstable-features
 #[track_caller]
 pub(crate) fn spawn_named<T>(
     task: impl std::future::Future<Output = T> + Send + 'static,
@@ -177,6 +189,7 @@ where
     tokio::spawn(task)
 }
 
+/// Returns an estimate of the number of recommended threads that Vector should spawn.
 pub fn num_threads() -> usize {
     let count = match std::thread::available_parallelism() {
         Ok(count) => count,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@
 #![deny(clippy::clone_on_ref_ptr)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 #![deny(clippy::disallowed_methods)] // [nursery] mark some functions as verboten
-#![deny(clippy::missing_const_for_fn)] // [nursery] valuable to the optimizer,
-// but may produce false positives
+#![deny(clippy::missing_const_for_fn)] // [nursery] valuable to the optimizer, but may produce false positives
 
 //! This is the main entry point for Vector.
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use clap::Parser;
 use serde::Serialize;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use enum_dispatch::enum_dispatch;
 use vector_config::{configurable_component, NamedComponent};
 

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::collections::{HashMap, HashSet};
 
 use enum_dispatch::enum_dispatch;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     BytesDecoderConfig, BytesDeserializerConfig,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{ffi::OsString, path::PathBuf, time::Duration};
 
 use clap::Parser;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use tokio::sync::broadcast;
 use tokio_stream::{Stream, StreamExt};
 

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use enum_dispatch::enum_dispatch;
 use futures::future::BoxFuture;
 use snafu::Snafu;

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{collections::HashMap, fmt};
 
 use chrono::Utc;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use enum_dispatch::enum_dispatch;
 use snafu::Snafu;
 

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[cfg(any(feature = "sources-http_server"))]
 mod body_decoding;
 mod encoding_config;

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -1,3 +1,4 @@
+//! The `vector` source. See [VectorConfig].
 use std::net::SocketAddr;
 
 use chrono::Utc;
@@ -35,7 +36,7 @@ enum VectorConfigVersion {
 }
 
 #[derive(Debug, Clone)]
-pub struct Service {
+struct Service {
     pipeline: SourceSender,
     acknowledgements: bool,
     log_namespace: LogNamespace,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 /// Exponentially Weighted Moving Average
 #[derive(Clone, Copy, Debug)]
 pub struct Ewma {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,3 +1,4 @@
+//! Functionality for managing template fields used by Vector's sinks.
 use std::{borrow::Cow, convert::TryFrom, fmt, hash::Hash, path::PathBuf};
 
 use bytes::Bytes;
@@ -18,6 +19,8 @@ use crate::{
 
 static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\{\{(?P<key>[^\}]+)\}\}").unwrap());
 
+/// Errors raised whilst parsing a Template field.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, Eq, PartialEq, Snafu)]
 pub enum TemplateParseError {
     #[snafu(display("Invalid strftime item"))]
@@ -26,6 +29,8 @@ pub enum TemplateParseError {
     InvalidPathSyntax { path: String },
 }
 
+/// Errors raised whilst rendering a Template.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, Eq, PartialEq, Snafu)]
 pub enum TemplateRenderingError {
     #[snafu(display("Missing fields on event: {:?}", missing_keys))]
@@ -132,6 +137,7 @@ impl fmt::Display for Template {
 impl ConfigurableString for Template {}
 
 impl Template {
+    /// Renders the given template with data from the event.
     pub fn render<'a>(
         &self,
         event: impl Into<EventRef<'a>>,
@@ -139,6 +145,7 @@ impl Template {
         self.render_string(event.into()).map(Into::into)
     }
 
+    /// Renders the given template with data from the event.
     pub fn render_string<'a>(
         &self,
         event: impl Into<EventRef<'a>>,
@@ -181,6 +188,7 @@ impl Template {
         }
     }
 
+    /// Returns the names of the fields that are rendered in this template.
     pub fn get_fields(&self) -> Option<Vec<String>> {
         let parts: Vec<_> = self
             .parts
@@ -196,6 +204,7 @@ impl Template {
         (!parts.is_empty()).then_some(parts)
     }
 
+    /// Returns a reference to the template string.
     pub fn get_ref(&self) -> &str {
         &self.src
     }
@@ -205,6 +214,7 @@ impl Template {
         self.src.is_empty()
     }
 
+    /// A dynamic template string contains sections that depend on the input event or time.
     pub const fn is_dynamic(&self) -> bool {
         !self.is_static
     }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     collections::HashMap,
     convert::Infallible,

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Topology contains all topology based types.
 //!
 //! Topology is broken up into two main sections. The first

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{
     collections::HashMap,
     marker::PhantomData,

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[allow(unused_imports)]
 use std::collections::HashSet;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 pub use vector_common::conversion::{
     parse_check_conversion_map, parse_conversion_map, Conversion, Error,
 };

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use socket2::SockRef;
 use tokio::net::UdpSocket;
 

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::path::PathBuf;
 
 use clap::Parser;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{collections::HashMap, fmt, fs::remove_dir_all, path::PathBuf};
 
 use clap::Parser;

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::{ffi::OsString, time::Duration};
 
 use windows_service::{


### PR DESCRIPTION
This is ostensibly a fairly useless PR. It adds `#[deny(missing_docs)]` to the root of the project, and then for most of the submodules adds in  `#[allow(missing_docs)]`. It is the start of a process that will in time remove all the `alllow`s and replace them with useful docs.

I've added some comments to a small number of areas.

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>
