### PR TITLE
docs(aws_kinesis_streams sink): Use generated documentation

### DIFF
--- a/src/sinks/aws_kinesis/config.rs
+++ b/src/sinks/aws_kinesis/config.rs
@@ -33,9 +33,11 @@ pub struct KinesisSinkBaseConfig {
     /// The [stream name][stream_name] of the target Kinesis Firehose delivery stream.
     ///
     /// [stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
+    #[configurable(metadata(docs::examples = "my-stream"))]
     pub stream_name: String,
 
     #[serde(flatten)]
+    #[configurable(derived)]
     pub region: RegionOrEndpoint,
 
     #[configurable(derived)]

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -75,6 +75,7 @@ pub struct KinesisStreamsSinkConfig {
     /// The log field used as the Kinesis record’s partition key value.
     ///
     /// If not specified, a unique partition key will be generated for each Kinesis record.
+    #[configurable(metadata(docs::examples = "user_id"))]
     pub partition_key_field: Option<String>,
 
     #[configurable(derived)]

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -14,6 +14,7 @@ components: sinks: aws_kinesis_streams: components._aws & {
 
 	features: {
 		acknowledgements: true
+		auto_generated:   true
 		healthcheck: enabled: true
 		send: {
 			batch: {
@@ -72,23 +73,8 @@ components: sinks: aws_kinesis_streams: components._aws & {
 		warnings: []
 	}
 
-	configuration: {
-		partition_key_field: {
-			common:      true
-			description: "The log field used as the Kinesis record's partition key value."
-			required:    false
-			type: string: {
-				default: null
-				examples: ["user_id"]
-			}
-		}
-		stream_name: {
-			description: "The [stream name](\(urls.aws_cloudwatch_logs_stream_name)) of the target Kinesis Logs stream."
-			required:    true
-			type: string: {
-				examples: ["my-stream"]
-			}
-		}
+	configuration: base.components.sinks.aws_kinesis_streams.configuration & {
+		_aws_include: false
 	}
 
 	input: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -456,7 +456,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 			"""
 		required: true
-		type: string: {}
+		type: string: examples: ["my-stream"]
 	}
 	tls: {
 		description: "TLS configuration."

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -304,7 +304,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 			If not specified, a unique partition key will be generated for each Kinesis record.
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["user_id"]
 	}
 	region: {
 		description: """
@@ -465,7 +465,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 			[stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
 			"""
 		required: true
-		type: string: {}
+		type: string: examples: ["my-stream"]
 	}
 	tls: {
 		description: "TLS configuration."


### PR DESCRIPTION
Closes #16342

Copies the same changes from the firehose PR for the base config

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
