### PR TITLE
enhancement(vdev): Add support for adding features to `run` command

### DIFF
--- a/vdev/src/commands/features.rs
+++ b/vdev/src/commands/features.rs
@@ -14,8 +14,9 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let features = features::load_and_extract(&self.config)?;
-        println!("{features}");
+        for feature in features::load_and_extract(&self.config)? {
+            println!("{feature}");
+        }
         Ok(())
     }
 }

--- a/vdev/src/commands/run.rs
+++ b/vdev/src/commands/run.rs
@@ -17,6 +17,10 @@ pub struct Cli {
     #[arg(long)]
     release: bool,
 
+    /// Name an additional feature to add to the build
+    #[arg(short = 'F', long)]
+    feature: Vec<String>,
+
     /// Path to configuration file
     config: PathBuf,
 
@@ -30,7 +34,9 @@ impl Cli {
             bail!("Can only set one of `--debug` and `--release`");
         }
 
-        let features = features::load_and_extract(&self.config)?;
+        let mut features = features::load_and_extract(&self.config)?;
+        features.extend(self.feature);
+        let features = features.join(",");
         let mut command = Command::new("cargo");
         command.args(["run", "--no-default-features", "--features", &features]);
         if self.release {

--- a/vdev/src/features.rs
+++ b/vdev/src/features.rs
@@ -61,7 +61,7 @@ struct Component {
     r#type: String,
 }
 
-pub fn load_and_extract(filename: &Path) -> Result<String> {
+pub fn load_and_extract(filename: &Path) -> Result<Vec<String>> {
     let config =
         fs::read_to_string(filename).with_context(|| format!("failed to read {filename:?}"))?;
 
@@ -81,7 +81,7 @@ pub fn load_and_extract(filename: &Path) -> Result<String> {
     Ok(from_config(config))
 }
 
-pub fn from_config(config: VectorConfig) -> String {
+pub fn from_config(config: VectorConfig) -> Vec<String> {
     let mut features = FeatureSet::default();
     add_option(&mut features, "api", &config.api);
     add_option(&mut features, "enterprise", &config.enterprise);
@@ -104,7 +104,7 @@ pub fn from_config(config: VectorConfig) -> String {
     // not be emitted as they don't actually have a feature flag because we always compile them.
     features.remove("transforms-log_to_metric");
 
-    features.into_iter().collect::<Vec<_>>().join(",")
+    features.into_iter().collect()
 }
 
 fn add_option<T>(features: &mut FeatureSet, name: &str, field: &Option<T>) {


### PR DESCRIPTION
When running a config, it may be useful to add features not necessarily present in the config file for ancillary uses. For example, if the config contains an `api` block, it would be useful to add the `api-client` feature to enable running the `top` subcommand without recompiling. This change adds a `--feature` flag to the `run` subcommand for this purpose.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
