### PR TITLE
fix(observability): Fix tagging more registered events in sources

### DIFF
--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -47,19 +47,16 @@ impl Builder {
     }
 
     pub fn add_output(&mut self, output: Output) -> LimitedReceiver<EventArray> {
+        let lag_time = self.lag_time.clone();
         match output.port {
             None => {
-                let (inner, rx) = Inner::new_with_buffer(
-                    self.buf_size,
-                    DEFAULT_OUTPUT.to_owned(),
-                    self.lag_time.clone(),
-                );
+                let (inner, rx) =
+                    Inner::new_with_buffer(self.buf_size, DEFAULT_OUTPUT.to_owned(), lag_time);
                 self.inner = Some(inner);
                 rx
             }
             Some(name) => {
-                let (inner, rx) =
-                    Inner::new_with_buffer(self.buf_size, name.clone(), self.lag_time.clone());
+                let (inner, rx) = Inner::new_with_buffer(self.buf_size, name.clone(), lag_time);
                 self.named_inners.insert(name, inner);
                 rx
             }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -175,16 +175,15 @@ pub async fn build_pieces(
             // maintained for compatibility
             component_name = %key.id(),
         );
+        let _entered_span = span.enter();
+
         let task_name = format!(
             ">> {} ({}, pump) >>",
             source.inner.get_component_name(),
             key.id()
         );
 
-        let mut builder = {
-            let _span = span.enter();
-            SourceSender::builder().with_buffer(*SOURCE_SENDER_BUFFER_SIZE)
-        };
+        let mut builder = SourceSender::builder().with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
         let mut pumps = Vec::new();
         let mut controls = HashMap::new();
         let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
@@ -270,10 +269,7 @@ pub async fn build_pieces(
             schema_definitions,
             schema: config.schema,
         };
-        let source = {
-            let _span = span.enter();
-            source.inner.build(context).await
-        };
+        let source = source.inner.build(context).await;
         let server = match source {
             Err(error) => {
                 errors.push(format!("Source \"{}\": {}", key, error));


### PR DESCRIPTION
Another event emitted by sources is registered when the source output is created by the `SourceSender` builder. This too was not being run with the span active. In order to fix this and catch any other events being registered without the span active, enter the span immediately after creating it while creating all of the other source bits. This coincidentally ends up simplifying out the other span entry points, as they are no longer needed.

This should finally close #16309
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
