### PR TITLE
chore(website): Add a links to footer for to the /releases and /downloads pages

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -137,14 +137,19 @@ url = "/download"
 weight = 4
 
 [[languages.en.menus.navbar]]
+name = "Releases"
+url = "/releases"
+weight = 5
+
+[[languages.en.menus.navbar]]
 name = "Blog"
 url = "/blog"
-weight = 5
+weight = 6
 
 [[languages.en.menus.navbar]]
 name = "Support"
 url = "https://www.datadoghq.com/product/observability-pipelines"
-weight = 6
+weight = 7
 
 # Footer menu
 [[languages.en.menus.footer]]

--- a/website/config.toml
+++ b/website/config.toml
@@ -137,19 +137,14 @@ url = "/download"
 weight = 4
 
 [[languages.en.menus.navbar]]
-name = "Releases"
-url = "/releases"
-weight = 5
-
-[[languages.en.menus.navbar]]
 name = "Blog"
 url = "/blog"
-weight = 6
+weight = 5
 
 [[languages.en.menus.navbar]]
 name = "Support"
 url = "https://www.datadoghq.com/product/observability-pipelines"
-weight = 7
+weight = 6
 
 # Footer menu
 [[languages.en.menus.footer]]
@@ -258,6 +253,18 @@ name = "Chat"
 url = "https://chat.vector.dev"
 parent = "community"
 weight = 3
+
+[[languages.en.menus.footer]]
+name = "Download"
+url = "/download"
+identifier = "download"
+weight = 5
+
+[[languages.en.menus.footer]]
+name = "Releases"
+url = "/releases"
+weight = 1
+parent = "download"
 
 # Extra links under the "Meta" section in the docs
 [[languages.en.menus.meta]]

--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     {{ site.Title }} site footer
   </h2>
   <div class="max-w-7xl mx-auto py-10 px-6 lg:px-8 lg:py-16">
-    <div class="pb-8 grid grid-cols-2 md:grid-cols-4 gap-10">
+    <div class="pb-8 grid grid-cols-2 md:grid-cols-5 gap-10">
       {{ range $menu }}
       <div>
         <h3 class="dark:text-gray-400 text-gray-700 font-semibold tracking-wider uppercase">

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -6,9 +6,13 @@
 {{ $version := .File.BaseFileName }}
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
+
 {{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "deprecation" "deprecations"}}
 <div class="max-w-3xl md:max-w-5xl px-6 lg:px-8 mx-auto">
   <div class="my-16">
+    <div class="mb-4 md:mb-6">
+      {{ partial "breadcrumb.html" . }}
+    </div>
     <div class="pb-8 md:pb-10 lg:pb-12">
       {{ partial "hero.html" . }}
     </div>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -6,7 +6,6 @@
 {{ $version := .File.BaseFileName }}
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
-
 {{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "deprecation" "deprecations"}}
 <div class="max-w-3xl md:max-w-5xl px-6 lg:px-8 mx-auto">
   <div class="my-16">


### PR DESCRIPTION
Closes: https://github.com/vectordotdev/vector/issues/16438

Seems to be working fine

<img width="798" alt="Screenshot 2023-02-14 at 3 38 18 PM" src="https://user-images.githubusercontent.com/9162534/218879263-8c6c9c3f-bdd0-402c-a1cc-2a1e53a92362.png">
