### PR TITLE
docs(kafka sink): autogen docs

### DIFF
--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -32,6 +32,7 @@ mod integration_test {
             util::{BatchConfig, NoDefaultsBatchSettings},
             VectorSink,
         },
+        template::Template,
         test_util::{
             components::{assert_sink_compliance, SINK_TAGS},
             random_lines_with_stream, random_string, wait_for,
@@ -55,14 +56,14 @@ mod integration_test {
 
         let config = KafkaSinkConfig {
             bootstrap_servers: kafka_address(9091),
-            topic: topic.clone(),
+            topic: Template::try_from(topic.clone()).unwrap(),
             key_field: None,
             encoding: TextSerializerConfig::default().into(),
             batch: BatchConfig::default(),
             compression: KafkaCompression::None,
             auth: KafkaAuthConfig::default(),
-            socket_timeout_ms: 60000,
-            message_timeout_ms: 300000,
+            socket_timeout_ms: Duration::from_millis(60000),
+            message_timeout_ms: Duration::from_millis(300000),
             librdkafka_options: HashMap::new(),
             headers_key: None,
             acknowledgements: Default::default(),
@@ -107,7 +108,7 @@ mod integration_test {
         let topic = format!("test-{}", random_string(10));
         let config = KafkaSinkConfig {
             bootstrap_servers: kafka_address(9091),
-            topic: format!("{}-%Y%m%d", topic),
+            topic: Template::try_from(format!("{}-%Y%m%d", topic)).unwrap(),
             compression: KafkaCompression::None,
             encoding: TextSerializerConfig::default().into(),
             key_field: None,
@@ -115,8 +116,8 @@ mod integration_test {
                 sasl: None,
                 tls: None,
             },
-            socket_timeout_ms: 60000,
-            message_timeout_ms: 300000,
+            socket_timeout_ms: Duration::from_millis(60000),
+            message_timeout_ms: Duration::from_millis(300000),
             batch,
             librdkafka_options,
             headers_key: None,
@@ -241,14 +242,14 @@ mod integration_test {
         let kafka_auth = KafkaAuthConfig { sasl, tls };
         let config = KafkaSinkConfig {
             bootstrap_servers: server.clone(),
-            topic: format!("{}-%Y%m%d", topic),
+            topic: Template::try_from(format!("{}-%Y%m%d", topic)).unwrap(),
             key_field: None,
             encoding: TextSerializerConfig::default().into(),
             batch: BatchConfig::default(),
             compression,
             auth: kafka_auth.clone(),
-            socket_timeout_ms: 60000,
-            message_timeout_ms: 300000,
+            socket_timeout_ms: Duration::from_millis(60000),
+            message_timeout_ms: Duration::from_millis(300000),
             librdkafka_options: HashMap::new(),
             headers_key: Some(headers_key.clone()),
             acknowledgements: Default::default(),

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -58,12 +58,15 @@ base: components: sinks: kafka: configuration: {
 	}
 	bootstrap_servers: {
 		description: """
-			A comma-separated list of the initial Kafka brokers to connect to.
+			A comma-separated list of Kafka bootstrap servers.
 
-			Each value must be in the form of `<host>` or `<host>:<port>`, and separated by a comma.
+			These are the servers in a Kafka cluster that a client should use to "bootstrap" its
+			connection to the cluster, allowing discovering all other hosts in the cluster.
+
+			Must be in the form of `host:port`, and comma-separated.
 			"""
 		required: true
-		type: string: {}
+		type: string: examples: ["10.14.22.123:9092,10.14.23.332:9092"]
 	}
 	compression: {
 		description: "Supported compression types for Kafka."
@@ -208,12 +211,14 @@ base: components: sinks: kafka: configuration: {
 		description: """
 			The log field name or tags key to use for the topic key.
 
-			If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent.
+			If the field does not exist in the log or in tags, a blank value will be used. If
+			unspecified, the key is not sent.
 
-			Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key.
+			Kafka uses a hash of the key to choose the partition or uses round-robin if the record has
+			no key.
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["user_id"]
 	}
 	librdkafka_options: {
 		description: """
@@ -224,16 +229,27 @@ base: components: sinks: kafka: configuration: {
 			[config_props_docs]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 			"""
 		required: false
-		type: object: options: "*": {
-			description: "A librdkafka configuration option."
-			required:    true
-			type: string: {}
+		type: object: {
+			examples: [{
+				"client.id":                "${ENV_VAR}"
+				"fetch.error.backoff.ms":   "1000"
+				"socket.send.buffer.bytes": "100"
+			}]
+			options: "*": {
+				description: "A librdkafka configuration option."
+				required:    true
+				type: string: {}
+			}
 		}
 	}
 	message_timeout_ms: {
 		description: "Local message timeout, in milliseconds."
 		required:    false
-		type: uint: default: 300000
+		type: uint: {
+			default: 300000
+			examples: [150000, 450000]
+			unit: "milliseconds"
+		}
 	}
 	sasl: {
 		description: "Configuration for SASL authentication when interacting with Kafka."
@@ -274,7 +290,11 @@ base: components: sinks: kafka: configuration: {
 	socket_timeout_ms: {
 		description: "Default timeout, in milliseconds, for network requests."
 		required:    false
-		type: uint: default: 60000
+		type: uint: {
+			default: 60000
+			examples: [30000, 60000]
+			unit: "milliseconds"
+		}
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -205,7 +205,7 @@ base: components: sinks: kafka: configuration: {
 			If omitted, no headers will be written.
 			"""
 		required: false
-		type: string: {}
+		type: string: examples: ["headers"]
 	}
 	key_field: {
 		description: """
@@ -394,6 +394,9 @@ base: components: sinks: kafka: configuration: {
 	topic: {
 		description: "The Kafka topic name to write events to."
 		required:    true
-		type: string: syntax: "template"
+		type: string: {
+			examples: ["topic-1234", "logs-{{unit}}-%Y-%m-%d"]
+			syntax: "template"
+		}
 	}
 }

--- a/website/cue/reference/components/sinks/kafka.cue
+++ b/website/cue/reference/components/sinks/kafka.cue
@@ -13,6 +13,7 @@ components: sinks: kafka: {
 	}
 
 	features: {
+		auto_generated:   true
 		acknowledgements: true
 		healthcheck: enabled: true
 		send: {
@@ -50,90 +51,7 @@ components: sinks: kafka: {
 
 	support: components._kafka.support
 
-	configuration: {
-		bootstrap_servers: components._kafka.configuration.bootstrap_servers
-		key_field: {
-			common:      true
-			description: "The log field name or tags key to use for the topic key. If the field does not exist in the log or in tags, a blank value will be used. If unspecified, the key is not sent. Kafka uses a hash of the key to choose the partition or uses round-robin if the record has no key."
-			required:    false
-			type: string: {
-				default: null
-				examples: ["user_id"]
-			}
-		}
-		librdkafka_options: components._kafka.configuration.librdkafka_options
-		message_timeout_ms: {
-			common:      false
-			description: "Local message timeout."
-			required:    false
-			type: uint: {
-				default: 300000
-				examples: [150000, 450000]
-				unit: null
-			}
-		}
-		sasl: {
-			common:      false
-			description: "Options for SASL/SCRAM authentication support."
-			required:    false
-			type: object: {
-				examples: []
-				options: {
-					enabled: {
-						common:      true
-						description: "Enable SASL/SCRAM authentication to the remote. (Not supported on Windows at this time.)"
-						required:    false
-						type: bool: default: null
-					}
-					mechanism: {
-						common:      true
-						description: "The Kafka SASL/SCRAM mechanisms."
-						required:    false
-						type: string: {
-							default: null
-							examples: ["SCRAM-SHA-256", "SCRAM-SHA-512"]
-						}
-					}
-					password: {
-						common:      true
-						description: "The Kafka SASL/SCRAM authentication password."
-						required:    false
-						type: string: {
-							default: null
-							examples: ["password"]
-						}
-					}
-					username: {
-						common:      true
-						description: "The Kafka SASL/SCRAM authentication username."
-						required:    false
-						type: string: {
-							default: null
-							examples: ["username"]
-						}
-					}
-				}
-			}
-		}
-		socket_timeout_ms: components._kafka.configuration.socket_timeout_ms
-		topic: {
-			description: "The Kafka topic name to write events to."
-			required:    true
-			type: string: {
-				examples: ["topic-1234", "logs-{{unit}}-%Y-%m-%d"]
-				syntax: "template"
-			}
-		}
-		headers_key: {
-			common:      false
-			description: "The log field name to use for the Kafka headers. If omitted, no headers will be written."
-			required:    false
-			type: string: {
-				default: null
-				examples: ["headers"]
-			}
-		}
-	}
+	configuration: base.components.sinks.kafka.configuration
 
 	input: {
 		logs: true


### PR DESCRIPTION
Closes #16023

A few minor changes you might notice:
- I turned the `topic` var into a `Template` 
- brought in some docs & examples from the Kafka *source*, since they were slightly better in places