### PR TITLE
feat(core): add metadata support to semantic meaning

### DIFF
--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use lookup::lookup_v2::parse_value_path;
-use lookup::LookupBuf;
+use lookup::OwnedTargetPath;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use value::Kind;
@@ -43,7 +43,7 @@ impl BytesDeserializerConfig {
             ),
             LogNamespace::Vector => {
                 schema::Definition::new_with_default_metadata(Kind::bytes(), [log_namespace])
-                    .with_meaning(LookupBuf::root(), "message")
+                    .with_meaning(OwnedTargetPath::event_root(), "message")
             }
         }
     }

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use chrono::{DateTime, Datelike, Utc};
 use lookup::lookup_v2::parse_value_path;
-use lookup::{event_path, owned_value_path, LookupBuf, OwnedValuePath};
+use lookup::{event_path, owned_value_path, OwnedTargetPath, OwnedValuePath};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use std::collections::BTreeMap;
@@ -112,7 +112,7 @@ impl SyslogDeserializerConfig {
             }
             (LogNamespace::Vector, Some(source)) => {
                 schema::Definition::new_with_default_metadata(Kind::bytes(), [log_namespace])
-                    .with_meaning(LookupBuf::root(), "message")
+                    .with_meaning(OwnedTargetPath::event_root(), "message")
                     .with_source_metadata(
                         source,
                         None,

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -1,3 +1,5 @@
+use lookup::lookup_v2::parse_target_path;
+use lookup::OwnedTargetPath;
 use once_cell::sync::{Lazy, OnceCell};
 use vector_config::configurable_component;
 
@@ -109,6 +111,15 @@ impl LogSchema {
 
     pub fn message_key(&self) -> &str {
         &self.message_key
+    }
+
+    /// Returns an `OwnedTargetPath` of the message key.
+    /// This parses the path and will panic if it is invalid.
+    ///
+    /// This should only be used where the result will either be cached,
+    /// or performance isn't critical, since this requires parsing / memory allocation.
+    pub fn owned_message_path(&self) -> OwnedTargetPath {
+        parse_target_path(self.message_key()).expect("valid message key")
     }
 
     pub fn timestamp_key(&self) -> &str {

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -268,7 +268,7 @@ impl LogEvent {
         self.metadata()
             .schema_definition()
             .meaning_path(meaning.as_ref())
-            .and_then(|path| self.inner.fields.get_by_path(path))
+            .and_then(|path| self.get(path))
     }
 
     // TODO(Jean): Once the event API uses `Lookup`, the allocation here can be removed.

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::config::{log_schema, LegacyKey, LogNamespace};
-use lookup::lookup_v2::parse_value_path;
-use lookup::{owned_value_path, LookupBuf, OwnedTargetPath, OwnedValuePath, PathPrefix};
+use lookup::lookup_v2::{parse_value_path, TargetPath};
+use lookup::{owned_value_path, OwnedTargetPath, OwnedValuePath, PathPrefix};
 use value::{kind::Collection, Kind};
 
 /// The definition of a schema.
@@ -40,8 +40,8 @@ pub struct Definition {
 /// sink builder, will return an error if the definition stores an "invalid" meaning pointer.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 enum MeaningPointer {
-    Valid(LookupBuf),
-    Invalid(BTreeSet<LookupBuf>),
+    Valid(OwnedTargetPath),
+    Invalid(BTreeSet<OwnedTargetPath>),
 }
 
 impl MeaningPointer {
@@ -64,20 +64,6 @@ impl MeaningPointer {
         };
 
         Self::Invalid(set)
-    }
-}
-
-#[cfg(test)]
-impl From<&str> for MeaningPointer {
-    fn from(v: &str) -> Self {
-        MeaningPointer::Valid(v.into())
-    }
-}
-
-#[cfg(test)]
-impl From<LookupBuf> for MeaningPointer {
-    fn from(v: LookupBuf) -> Self {
-        MeaningPointer::Valid(v)
     }
 }
 
@@ -300,8 +286,10 @@ impl Definition {
         self.event_kind.set_at_path(path, kind);
 
         if let Some(meaning) = meaning {
-            self.meaning
-                .insert(meaning, MeaningPointer::Valid(path.clone().into()));
+            self.meaning.insert(
+                meaning,
+                MeaningPointer::Valid(OwnedTargetPath::event(path.clone())),
+            );
         }
 
         self
@@ -372,17 +360,25 @@ impl Definition {
     ///
     /// This method panics if the provided path points to an unknown location in the collection.
     #[must_use]
-    pub fn with_meaning(mut self, path: impl Into<LookupBuf>, meaning: &str) -> Self {
-        let path = path.into();
-
+    pub fn with_meaning(mut self, target_path: OwnedTargetPath, meaning: &str) -> Self {
         // Ensure the path exists in the collection.
-        assert!(
-            self.event_kind.at_path(&path).contains_any_defined(),
-            "meaning must point to a valid path"
-        );
+        match target_path.prefix {
+            PathPrefix::Event => assert!(
+                self.event_kind
+                    .at_path(&target_path.path)
+                    .contains_any_defined(),
+                "meaning must point to a valid path"
+            ),
+            PathPrefix::Metadata => assert!(
+                self.metadata_kind
+                    .at_path(&target_path.path)
+                    .contains_any_defined(),
+                "meaning must point to a valid path"
+            ),
+        };
 
         self.meaning
-            .insert(meaning.to_owned(), MeaningPointer::Valid(path));
+            .insert(meaning.to_owned(), MeaningPointer::Valid(target_path));
         self
     }
 
@@ -419,22 +415,22 @@ impl Definition {
         self
     }
 
-    /// Returns a `Lookup` into an event, based on the provided `meaning`, if the meaning exists.
-    pub fn meaning_path(&self, meaning: &str) -> Option<&LookupBuf> {
+    /// Returns an `OwnedTargetPath` into an event, based on the provided `meaning`, if the meaning exists.
+    pub fn meaning_path(&self, meaning: &str) -> Option<&OwnedTargetPath> {
         match self.meaning.get(meaning) {
             Some(MeaningPointer::Valid(path)) => Some(path),
             None | Some(MeaningPointer::Invalid(_)) => None,
         }
     }
 
-    pub fn invalid_meaning(&self, meaning: &str) -> Option<&BTreeSet<LookupBuf>> {
+    pub fn invalid_meaning(&self, meaning: &str) -> Option<&BTreeSet<OwnedTargetPath>> {
         match &self.meaning.get(meaning) {
             Some(MeaningPointer::Invalid(paths)) => Some(paths),
             None | Some(MeaningPointer::Valid(_)) => None,
         }
     }
 
-    pub fn meanings(&self) -> impl Iterator<Item = (&String, &LookupBuf)> {
+    pub fn meanings(&self) -> impl Iterator<Item = (&String, &OwnedTargetPath)> {
         self.meaning
             .iter()
             .filter_map(|(id, pointer)| match pointer {
@@ -453,6 +449,14 @@ impl Definition {
 
     pub fn metadata_kind(&self) -> &Kind {
         &self.metadata_kind
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn kind_at<'a>(&self, target_path: impl TargetPath<'a>) -> Kind {
+        match target_path.prefix() {
+            PathPrefix::Event => self.event_kind.at_path(target_path.value_path()),
+            PathPrefix::Metadata => self.metadata_kind.at_path(target_path.value_path()),
+        }
     }
 }
 
@@ -519,6 +523,7 @@ mod test_utils {
 #[cfg(test)]
 mod tests {
     use crate::event::{Event, EventMetadata, LogEvent};
+    use lookup::lookup_v2::parse_target_path;
     use lookup::owned_value_path;
     use std::collections::{BTreeMap, HashMap};
     use value::Value;
@@ -636,7 +641,11 @@ mod tests {
                     want: Definition {
                         event_kind: Kind::object(BTreeMap::from([("foo".into(), Kind::boolean())])),
                         metadata_kind: Kind::object(Collection::empty()),
-                        meaning: [("foo_meaning".to_owned(), "foo".into())].into(),
+                        meaning: [(
+                            "foo_meaning".to_owned(),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
+                        )]
+                        .into(),
                         log_namespaces: BTreeSet::new(),
                     },
                 },
@@ -655,7 +664,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: [(
                             "foobar".to_owned(),
-                            LookupBuf::from_str(".foo.bar").unwrap().into(),
+                            MeaningPointer::Valid(parse_target_path(".foo.bar").unwrap()),
                         )]
                         .into(),
                         log_namespaces: BTreeSet::new(),
@@ -712,7 +721,11 @@ mod tests {
                             Kind::boolean().or_undefined(),
                         )])),
                         metadata_kind: Kind::object(Collection::empty()),
-                        meaning: [("foo_meaning".to_owned(), "foo".into())].into(),
+                        meaning: [(
+                            "foo_meaning".to_owned(),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
+                        )]
+                        .into(),
                         log_namespaces: BTreeSet::new(),
                     },
                 },
@@ -734,7 +747,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: [(
                             "foobar".to_owned(),
-                            LookupBuf::from_str(".foo.bar").unwrap().into(),
+                            MeaningPointer::Valid(parse_target_path(".foo.bar").unwrap()),
                         )]
                         .into(),
                         log_namespaces: BTreeSet::new(),
@@ -801,7 +814,10 @@ mod tests {
                             Kind::boolean().or_null(),
                         )]))),
                         metadata_kind: Kind::object(Collection::empty()),
-                        meaning: BTreeMap::from([("foo_meaning".to_owned(), "foo".into())]),
+                        meaning: BTreeMap::from([(
+                            "foo_meaning".to_owned(),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
+                        )]),
                         log_namespaces: BTreeSet::new(),
                     },
                     other: Definition {
@@ -810,7 +826,10 @@ mod tests {
                             Kind::boolean().or_null(),
                         )]))),
                         metadata_kind: Kind::object(Collection::empty()),
-                        meaning: BTreeMap::from([("foo_meaning".to_owned(), "foo".into())]),
+                        meaning: BTreeMap::from([(
+                            "foo_meaning".to_owned(),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
+                        )]),
                         log_namespaces: BTreeSet::new(),
                     },
                     want: Definition {
@@ -819,7 +838,10 @@ mod tests {
                             Kind::boolean().or_null(),
                         )]))),
                         metadata_kind: Kind::object(Collection::empty()),
-                        meaning: BTreeMap::from([("foo_meaning".to_owned(), "foo".into())]),
+                        meaning: BTreeMap::from([(
+                            "foo_meaning".to_owned(),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
+                        )]),
                         log_namespaces: BTreeSet::new(),
                     },
                 },
@@ -931,7 +953,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: BTreeMap::from([(
                             "foo".into(),
-                            MeaningPointer::Valid("foo".into()),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
                         )]),
                         log_namespaces: BTreeSet::new(),
                     },
@@ -943,7 +965,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: BTreeMap::from([(
                             "foo".into(),
-                            MeaningPointer::Valid("bar".into()),
+                            MeaningPointer::Valid(parse_target_path("bar").unwrap()),
                         )]),
                         log_namespaces: BTreeSet::new(),
                     },
@@ -955,7 +977,10 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: BTreeMap::from([(
                             "foo".into(),
-                            MeaningPointer::Invalid(BTreeSet::from(["foo".into(), "bar".into()])),
+                            MeaningPointer::Invalid(BTreeSet::from([
+                                parse_target_path("foo").unwrap(),
+                                parse_target_path("bar").unwrap(),
+                            ])),
                         )]),
                         log_namespaces: BTreeSet::new(),
                     },
@@ -972,7 +997,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: BTreeMap::from([(
                             "foo".into(),
-                            MeaningPointer::Valid("foo".into()),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
                         )]),
                         log_namespaces: BTreeSet::new(),
                     },
@@ -984,7 +1009,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: BTreeMap::from([(
                             "foo".into(),
-                            MeaningPointer::Valid("foo".into()),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
                         )]),
                         log_namespaces: BTreeSet::new(),
                     },
@@ -996,7 +1021,7 @@ mod tests {
                         metadata_kind: Kind::object(Collection::empty()),
                         meaning: BTreeMap::from([(
                             "foo".into(),
-                            MeaningPointer::Valid("foo".into()),
+                            MeaningPointer::Valid(parse_target_path("foo").unwrap()),
                         )]),
                         log_namespaces: BTreeSet::new(),
                     },

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use lookup::LookupBuf;
+use lookup::OwnedTargetPath;
 use value::Kind;
 
 use super::Definition;
@@ -96,9 +96,9 @@ impl Requirement {
             });
 
             match maybe_meaning_path {
-                Some(path) => {
+                Some(target_path) => {
                     // Get the kind at the path for the given semantic meaning.
-                    let definition_kind = definition.event_kind().at_path(path);
+                    let definition_kind = definition.kind_at(target_path);
 
                     if req_meaning.kind.is_superset(&definition_kind).is_err() {
                         // The semantic meaning kind does not match the expected
@@ -174,7 +174,7 @@ pub enum ValidationError {
     /// A semantic meaning is pointing to multiple paths.
     MeaningDuplicate {
         identifier: &'static str,
-        paths: BTreeSet<LookupBuf>,
+        paths: BTreeSet<OwnedTargetPath>,
     },
 }
 
@@ -225,6 +225,7 @@ impl std::error::Error for ValidationError {}
 
 #[cfg(test)]
 mod tests {
+    use lookup::lookup_v2::parse_target_path;
     use lookup::owned_value_path;
     use std::collections::HashMap;
 
@@ -339,7 +340,10 @@ mod tests {
                         )),
                     errors: vec![ValidationError::MeaningDuplicate {
                         identifier: "foo",
-                        paths: BTreeSet::from(["foo".into(), "bar".into()]),
+                        paths: BTreeSet::from([
+                            parse_target_path("foo").unwrap(),
+                            parse_target_path("bar").unwrap(),
+                        ]),
                     }],
                 },
             ),

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -524,15 +524,24 @@ pub mod test {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
-                .with_metadata_field(&owned_value_path!("amqp", "timestamp"), Kind::timestamp())
-                .with_metadata_field(&owned_value_path!("amqp", "routing"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("amqp", "exchange"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("amqp", "offset"), Kind::integer());
+                .with_metadata_field(
+                    &owned_value_path!("amqp", "timestamp"),
+                    Kind::timestamp(),
+                    Some("timestamp"),
+                )
+                .with_metadata_field(&owned_value_path!("amqp", "routing"), Kind::bytes(), None)
+                .with_metadata_field(&owned_value_path!("amqp", "exchange"), Kind::bytes(), None)
+                .with_metadata_field(&owned_value_path!("amqp", "offset"), Kind::integer(), None);
 
         assert_eq!(definition, expected_definition);
     }

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -485,7 +485,7 @@ async fn handle_ack(status: BatchStatus, entry: FinalizerEntry) {
 
 #[cfg(test)]
 pub mod test {
-    use lookup::LookupBuf;
+    use lookup::OwnedTargetPath;
     use value::kind::Collection;
     use vector_core::schema::Definition;
 
@@ -523,7 +523,7 @@ pub mod test {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2087,12 +2087,12 @@ fn test_output_schema_definition_json_vector_namespace() {
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "ddsource"),
                 Kind::bytes(),
-                None
+                Some("source")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "ddtags"),
                 Kind::bytes(),
-                None
+                Some("tags")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "hostname"),
@@ -2102,12 +2102,12 @@ fn test_output_schema_definition_json_vector_namespace() {
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "service"),
                 Kind::bytes(),
-                None
+                Some("service")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "status"),
                 Kind::bytes(),
-                None
+                Some("severity")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "timestamp"),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2086,27 +2086,44 @@ fn test_output_schema_definition_json_vector_namespace() {
         Definition::new_with_default_metadata(Kind::json(), [LogNamespace::Vector])
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "ddsource"),
-                Kind::bytes()
+                Kind::bytes(),
+                None
             )
-            .with_metadata_field(&owned_value_path!("datadog_agent", "ddtags"), Kind::bytes())
+            .with_metadata_field(
+                &owned_value_path!("datadog_agent", "ddtags"),
+                Kind::bytes(),
+                None
+            )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "hostname"),
-                Kind::bytes()
+                Kind::bytes(),
+                Some("host")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "service"),
-                Kind::bytes()
+                Kind::bytes(),
+                None
             )
-            .with_metadata_field(&owned_value_path!("datadog_agent", "status"), Kind::bytes())
+            .with_metadata_field(
+                &owned_value_path!("datadog_agent", "status"),
+                Kind::bytes(),
+                None
+            )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "timestamp"),
-                Kind::timestamp()
+                Kind::timestamp(),
+                Some("timestamp")
             )
             .with_metadata_field(
                 &owned_value_path!("vector", "ingest_timestamp"),
-                Kind::timestamp()
+                Kind::timestamp(),
+                None
             )
-            .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+            .with_metadata_field(
+                &owned_value_path!("vector", "source_type"),
+                Kind::bytes(),
+                None
+            )
     )
 }
 
@@ -2127,27 +2144,44 @@ fn test_output_schema_definition_bytes_vector_namespace() {
         Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "ddsource"),
-                Kind::bytes()
+                Kind::bytes(),
+                None
             )
-            .with_metadata_field(&owned_value_path!("datadog_agent", "ddtags"), Kind::bytes())
+            .with_metadata_field(
+                &owned_value_path!("datadog_agent", "ddtags"),
+                Kind::bytes(),
+                None
+            )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "hostname"),
-                Kind::bytes()
+                Kind::bytes(),
+                Some("host")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "service"),
-                Kind::bytes()
+                Kind::bytes(),
+                None
             )
-            .with_metadata_field(&owned_value_path!("datadog_agent", "status"), Kind::bytes())
+            .with_metadata_field(
+                &owned_value_path!("datadog_agent", "status"),
+                Kind::bytes(),
+                None
+            )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "timestamp"),
-                Kind::timestamp()
+                Kind::timestamp(),
+                Some("timestamp")
             )
             .with_metadata_field(
                 &owned_value_path!("vector", "ingest_timestamp"),
-                Kind::timestamp()
+                Kind::timestamp(),
+                None
             )
-            .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+            .with_metadata_field(
+                &owned_value_path!("vector", "source_type"),
+                Kind::bytes(),
+                None
+            )
             .with_meaning(OwnedTargetPath::event_root(), "message")
     )
 }

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2145,12 +2145,12 @@ fn test_output_schema_definition_bytes_vector_namespace() {
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "ddsource"),
                 Kind::bytes(),
-                None
+                Some("source")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "ddtags"),
                 Kind::bytes(),
-                None
+                Some("tags")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "hostname"),
@@ -2160,12 +2160,12 @@ fn test_output_schema_definition_bytes_vector_namespace() {
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "service"),
                 Kind::bytes(),
-                None
+                Some("service")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "status"),
                 Kind::bytes(),
-                None
+                Some("severity")
             )
             .with_metadata_field(
                 &owned_value_path!("datadog_agent", "timestamp"),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -14,8 +14,7 @@ use codecs::{
 use futures::{Stream, StreamExt};
 use http::HeaderMap;
 use indoc::indoc;
-use lookup::owned_value_path;
-use lookup::LookupBuf;
+use lookup::{owned_value_path, OwnedTargetPath};
 use ordered_float::NotNan;
 use prost::Message;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
@@ -2149,7 +2148,7 @@ fn test_output_schema_definition_bytes_vector_namespace() {
                 Kind::timestamp()
             )
             .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
-            .with_meaning(LookupBuf::root(), "message")
+            .with_meaning(OwnedTargetPath::event_root(), "message")
     )
 }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -801,7 +801,6 @@ mod tests {
     };
 
     use encoding_rs::UTF_16LE;
-    use lookup::LookupBuf;
     use similar_asserts::assert_eq;
     use tempfile::tempdir;
     use tokio::time::{sleep, timeout, Duration};
@@ -950,7 +949,7 @@ mod tests {
         assert_eq!(
             definition,
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
@@ -2184,6 +2183,7 @@ mod tests {
         Unfinalized, // Acknowledgement handling but no finalization
         Acks,        // Full acknowledgements and proper finalization
     }
+    use lookup::OwnedTargetPath;
     use AckingMode::*;
 
     async fn run_file_source(

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -950,17 +950,23 @@ mod tests {
             definition,
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
-                    Kind::timestamp()
+                    Kind::timestamp(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("file", "host"),
-                    Kind::bytes().or_undefined()
+                    Kind::bytes().or_undefined(),
+                    Some("host")
                 )
-                .with_metadata_field(&owned_value_path!("file", "offset"), Kind::integer())
-                .with_metadata_field(&owned_value_path!("file", "path"), Kind::bytes())
+                .with_metadata_field(&owned_value_path!("file", "offset"), Kind::integer(), None)
+                .with_metadata_field(&owned_value_path!("file", "path"), Kind::bytes(), None)
         )
     }
 

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -622,7 +622,7 @@ impl From<FluentEvent<'_>> for LogEvent {
 mod tests {
     use bytes::BytesMut;
     use chrono::{DateTime, Utc};
-    use lookup::LookupBuf;
+    use lookup::OwnedTargetPath;
     use rmp_serde::Serializer;
     use serde::Serialize;
     use std::collections::BTreeMap;
@@ -963,7 +963,7 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(&owned_value_path!("fluent", "tag"), Kind::bytes())
                 .with_metadata_field(&owned_value_path!("fluent", "timestamp"), Kind::timestamp())

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -964,21 +964,36 @@ mod tests {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("fluent", "tag"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("fluent", "timestamp"), Kind::timestamp())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_metadata_field(&owned_value_path!("fluent", "tag"), Kind::bytes(), None)
+                .with_metadata_field(
+                    &owned_value_path!("fluent", "timestamp"),
+                    Kind::timestamp(),
+                    Some("timestamp"),
+                )
                 .with_metadata_field(
                     &owned_value_path!("fluent", "record"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
-                .with_metadata_field(&owned_value_path!("fluent", "host"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("fluent", "host"),
+                    Kind::bytes(),
+                    Some("host"),
+                )
                 .with_metadata_field(
                     &owned_value_path!("fluent", "tls_client_metadata"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -735,7 +735,7 @@ impl Future for Task {
 
 #[cfg(test)]
 mod tests {
-    use lookup::LookupBuf;
+    use lookup::OwnedTargetPath;
     use vector_core::schema::Definition;
 
     use super::*;
@@ -759,7 +759,7 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -760,22 +760,30 @@ mod tests {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("gcp_pubsub", "timestamp"),
                     Kind::timestamp().or_undefined(),
+                    Some("timestamp"),
                 )
                 .with_metadata_field(
                     &owned_value_path!("gcp_pubsub", "attributes"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("gcp_pubsub", "message_id"),
                     Kind::bytes(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition);

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -395,7 +395,7 @@ mod tests {
 
     use chrono::{DateTime, Utc};
     use futures::Stream;
-    use lookup::{owned_value_path, LookupBuf};
+    use lookup::{owned_value_path, OwnedTargetPath};
     use similar_asserts::assert_eq;
     use value::{kind::Collection, Kind};
     use vector_config::NamedComponent;
@@ -656,7 +656,7 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -657,30 +657,40 @@ mod tests {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogplexConfig::NAME, "timestamp"),
                     Kind::timestamp().or_undefined(),
+                    Some("timestamp"),
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogplexConfig::NAME, "host"),
                     Kind::bytes(),
+                    Some("host"),
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogplexConfig::NAME, "app_name"),
                     Kind::bytes(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogplexConfig::NAME, "proc_id"),
                     Kind::bytes(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogplexConfig::NAME, "query_parameters"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -461,7 +461,7 @@ impl HttpSource for SimpleHttpSource {
 
 #[cfg(test)]
 mod tests {
-    use lookup::{event_path, owned_value_path, LookupBuf};
+    use lookup::{event_path, owned_value_path, OwnedTargetPath};
     use std::str::FromStr;
     use std::{collections::BTreeMap, io::Write, net::SocketAddr};
     use value::kind::Collection;
@@ -1294,7 +1294,7 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!(SimpleHttpConfig::NAME, "path"),

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -1295,22 +1295,30 @@ mod tests {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!(SimpleHttpConfig::NAME, "path"),
                     Kind::bytes(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(SimpleHttpConfig::NAME, "headers"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(SimpleHttpConfig::NAME, "query_parameters"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -198,7 +198,7 @@ async fn run(
 #[cfg(test)]
 mod tests {
     use futures::Stream;
-    use lookup::LookupBuf;
+    use lookup::OwnedTargetPath;
     use tokio::time::{sleep, Duration};
     use value::kind::Collection;
     use vector_core::event::Value;
@@ -342,7 +342,7 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!(InternalLogsConfig::NAME, "pid"),

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -343,18 +343,25 @@ mod tests {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!(InternalLogsConfig::NAME, "pid"),
                     Kind::integer(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(InternalLogsConfig::NAME, "host"),
                     Kind::bytes().or_undefined(),
+                    Some("host"),
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -1469,22 +1469,30 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes().or_null(), [LogNamespace::Vector])
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(JournaldConfig::NAME, "metadata"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(JournaldConfig::NAME, "timestamp"),
                     Kind::timestamp().or_undefined(),
+                    Some("timestamp"),
                 )
                 .with_metadata_field(
                     &owned_value_path!(JournaldConfig::NAME, "host"),
                     Kind::bytes().or_undefined(),
+                    Some("host"),
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -729,7 +729,7 @@ impl ConsumerContext for CustomContext {
 
 #[cfg(test)]
 mod test {
-    use lookup::LookupBuf;
+    use lookup::OwnedTargetPath;
     use vector_core::schema::Definition;
 
     use super::*;
@@ -782,7 +782,7 @@ mod test {
         assert_eq!(
             definition,
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("kafka", "timestamp"), Kind::timestamp())
                 .with_metadata_field(&owned_value_path!("kafka", "message_key"), Kind::bytes())
                 .with_metadata_field(&owned_value_path!("kafka", "topic"), Kind::bytes())

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -783,20 +783,38 @@ mod test {
             definition,
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("kafka", "timestamp"), Kind::timestamp())
-                .with_metadata_field(&owned_value_path!("kafka", "message_key"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("kafka", "topic"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("kafka", "partition"), Kind::bytes())
-                .with_metadata_field(&owned_value_path!("kafka", "offset"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("kafka", "timestamp"),
+                    Kind::timestamp(),
+                    Some("timestamp")
+                )
+                .with_metadata_field(
+                    &owned_value_path!("kafka", "message_key"),
+                    Kind::bytes(),
+                    None
+                )
+                .with_metadata_field(&owned_value_path!("kafka", "topic"), Kind::bytes(), None)
+                .with_metadata_field(
+                    &owned_value_path!("kafka", "partition"),
+                    Kind::bytes(),
+                    None
+                )
+                .with_metadata_field(&owned_value_path!("kafka", "offset"), Kind::bytes(), None)
                 .with_metadata_field(
                     &owned_value_path!("kafka", "headers"),
-                    Kind::object(Collection::empty().with_unknown(Kind::bytes()))
+                    Kind::object(Collection::empty().with_unknown(Kind::bytes())),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
-                    Kind::timestamp()
+                    Kind::timestamp(),
+                    None
                 )
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None
+                )
         )
     }
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -1169,75 +1169,100 @@ mod tests {
         assert_eq!(
             definition,
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_metadata_field(&owned_value_path!("kubernetes_logs", "file"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("kubernetes_logs", "file"),
+                    Kind::bytes(),
+                    None
+                )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "container_id"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "container_image"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "container_name"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "namespace_labels"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "node_labels"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_annotations"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_ip"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_ips"),
                     Kind::array(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_labels"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_name"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_namespace"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_node_name"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_owner"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "pod_uid"),
                     Kind::bytes().or_undefined(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "stream"),
-                    Kind::bytes()
+                    Kind::bytes(),
+                    None
                 )
                 .with_metadata_field(
                     &owned_value_path!("kubernetes_logs", "timestamp"),
-                    Kind::timestamp()
+                    Kind::timestamp(),
+                    Some("timestamp")
                 )
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
-                    Kind::timestamp()
+                    Kind::timestamp(),
+                    None
                 )
                 .with_meaning(OwnedTargetPath::event_root(), "message")
         )

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -1014,7 +1014,7 @@ fn prepare_label_selector(selector: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use lookup::{owned_value_path, LookupBuf};
+    use lookup::{owned_value_path, OwnedTargetPath};
     use similar_asserts::assert_eq;
     use value::{kind::Collection, Kind};
     use vector_core::{config::LogNamespace, schema::Definition};
@@ -1239,7 +1239,7 @@ mod tests {
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp()
                 )
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
         )
     }
 

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -676,7 +676,7 @@ impl From<LogstashEventFrame> for SmallVec<[Event; 1]> {
 #[cfg(test)]
 mod test {
     use bytes::BufMut;
-    use lookup::LookupBuf;
+    use lookup::OwnedTargetPath;
     use rand::{thread_rng, Rng};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use value::kind::Collection;
@@ -795,7 +795,7 @@ mod test {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -796,22 +796,30 @@ mod test {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogstashConfig::NAME, "timestamp"),
                     Kind::timestamp().or_undefined(),
+                    Some("timestamp"),
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogstashConfig::NAME, "host"),
                     Kind::bytes(),
+                    Some("host"),
                 )
                 .with_metadata_field(
                     &owned_value_path!(LogstashConfig::NAME, "tls_client_metadata"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -267,7 +267,7 @@ async fn create_subscription(
 mod tests {
     #![allow(clippy::print_stdout)] //tests
 
-    use lookup::{owned_value_path, LookupBuf};
+    use lookup::{owned_value_path, OwnedTargetPath};
     use value::{kind::Collection, Kind};
     use vector_core::schema::Definition;
 
@@ -293,7 +293,7 @@ mod tests {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -294,12 +294,17 @@ mod tests {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
-                .with_metadata_field(&owned_value_path!("nats", "subject"), Kind::bytes());
+                .with_metadata_field(&owned_value_path!("nats", "subject"), Kind::bytes(), None);
 
         assert_eq!(definition, expected_definition);
     }

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -11,7 +11,7 @@ mod status;
 use std::net::SocketAddr;
 
 use futures::{future::join, FutureExt, TryFutureExt};
-use lookup::{owned_value_path, LookupBuf};
+use lookup::{owned_value_path, OwnedTargetPath};
 use opentelemetry_proto::convert::{
     ATTRIBUTES_KEY, DROPPED_ATTRIBUTES_COUNT_KEY, FLAGS_KEY, OBSERVED_TIMESTAMP_KEY, RESOURCE_KEY,
     SEVERITY_NUMBER_KEY, SEVERITY_TEXT_KEY, SPAN_ID_KEY, TRACE_ID_KEY,
@@ -246,9 +246,11 @@ impl SourceConfig for OpentelemetryConfig {
             .with_standard_vector_source_metadata();
 
         let schema_definition = match log_namespace {
-            LogNamespace::Vector => schema_definition.with_meaning(LookupBuf::root(), "message"),
+            LogNamespace::Vector => {
+                schema_definition.with_meaning(OwnedTargetPath::event_root(), "message")
+            }
             LogNamespace::Legacy => {
-                schema_definition.with_meaning(log_schema().message_key(), "message")
+                schema_definition.with_meaning(log_schema().owned_message_path(), "message")
             }
         };
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2380,18 +2380,40 @@ mod tests {
             Kind::object(Collection::empty()).or_bytes(),
             [LogNamespace::Vector],
         )
-        .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+        .with_metadata_field(
+            &owned_value_path!("vector", "source_type"),
+            Kind::bytes(),
+            None,
+        )
         .with_metadata_field(
             &owned_value_path!("vector", "ingest_timestamp"),
             Kind::timestamp(),
+            None,
         )
-        .with_metadata_field(&owned_value_path!("splunk_hec", "host"), Kind::bytes())
-        .with_metadata_field(&owned_value_path!("splunk_hec", "index"), Kind::bytes())
-        .with_metadata_field(&owned_value_path!("splunk_hec", "source"), Kind::bytes())
-        .with_metadata_field(&owned_value_path!("splunk_hec", "channel"), Kind::bytes())
+        .with_metadata_field(
+            &owned_value_path!("splunk_hec", "host"),
+            Kind::bytes(),
+            Some("host"),
+        )
+        .with_metadata_field(
+            &owned_value_path!("splunk_hec", "index"),
+            Kind::bytes(),
+            None,
+        )
+        .with_metadata_field(
+            &owned_value_path!("splunk_hec", "source"),
+            Kind::bytes(),
+            None,
+        )
+        .with_metadata_field(
+            &owned_value_path!("splunk_hec", "channel"),
+            Kind::bytes(),
+            None,
+        )
         .with_metadata_field(
             &owned_value_path!("splunk_hec", "sourcetype"),
             Kind::bytes(),
+            None,
         );
 
         assert_eq!(definition, expected_definition);

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -433,7 +433,7 @@ fn enrich_syslog_event(
 
 #[cfg(test)]
 mod test {
-    use lookup::{event_path, owned_value_path, LookupBuf};
+    use lookup::{event_path, owned_value_path, OwnedTargetPath};
     use std::{
         collections::{BTreeMap, HashMap},
         fmt,
@@ -499,7 +499,7 @@ mod test {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
-                .with_meaning(LookupBuf::root(), "message")
+                .with_meaning(OwnedTargetPath::event_root(), "message")
                 .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -523,7 +523,7 @@ mod test {
                 .with_metadata_field(
                     &owned_value_path!("syslog", "severity"),
                     Kind::bytes().or_undefined(),
-                    None,
+                    Some("severity"),
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "facility"),

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -500,49 +500,67 @@ mod test {
         let expected_definition =
             Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
                 .with_meaning(OwnedTargetPath::event_root(), "message")
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 )
-                .with_metadata_field(&owned_value_path!("syslog", "timestamp"), Kind::timestamp())
+                .with_metadata_field(
+                    &owned_value_path!("syslog", "timestamp"),
+                    Kind::timestamp(),
+                    Some("timestamp"),
+                )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "hostname"),
                     Kind::bytes().or_undefined(),
+                    Some("host"),
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "severity"),
                     Kind::bytes().or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "facility"),
                     Kind::bytes().or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "version"),
                     Kind::integer().or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "appname"),
                     Kind::bytes().or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "msgid"),
                     Kind::bytes().or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "procid"),
                     Kind::integer().or_bytes().or_undefined(),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "structured_data"),
                     Kind::object(Collection::from_unknown(Kind::object(
                         Collection::from_unknown(Kind::bytes()),
                     ))),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "tls_client_metadata"),
                     Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition);

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -234,10 +234,15 @@ mod test {
 
         let expected_definition =
             Definition::new_with_default_metadata(Kind::any(), [LogNamespace::Vector])
-                .with_metadata_field(&owned_value_path!("vector", "source_type"), Kind::bytes())
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    Some("source_type"),
+                )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),
                     Kind::timestamp(),
+                    None,
                 );
 
         assert_eq!(definition, expected_definition)

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -237,7 +237,7 @@ mod test {
                 .with_metadata_field(
                     &owned_value_path!("vector", "source_type"),
                     Kind::bytes(),
-                    Some("source_type"),
+                    None,
                 )
                 .with_metadata_field(
                     &owned_value_path!("vector", "ingest_timestamp"),

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -338,6 +338,7 @@ mod tests {
     use std::collections::HashMap;
 
     use indexmap::IndexMap;
+    use lookup::lookup_v2::parse_target_path;
     use lookup::owned_value_path;
     use similar_asserts::assert_eq;
     use value::Kind;
@@ -450,7 +451,7 @@ mod tests {
                             Kind::integer().or_bytes().or_timestamp(),
                             Some("foo bar"),
                         )
-                        .with_meaning("foo", "baz qux"),
+                        .with_meaning(parse_target_path("foo").unwrap(), "baz qux"),
                 },
             ),
         ]) {

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -205,6 +205,7 @@ impl TransformConfig for MetricToLogConfig {
                 schema_definition = schema_definition.with_metadata_field(
                     &owned_value_path!("vector"),
                     Kind::object(Collection::empty()),
+                    None,
                 );
             }
             LogNamespace::Legacy => {

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -8,7 +8,7 @@ use std::{
 
 use codecs::MetricTagValues;
 use lookup::lookup_v2::{parse_value_path, ValuePath};
-use lookup::{metadata_path, owned_value_path, path, PathPrefix};
+use lookup::{metadata_path, owned_value_path, path, OwnedTargetPath, PathPrefix};
 use snafu::{ResultExt, Snafu};
 use value::Kind;
 use vector_common::TimeZone;
@@ -227,6 +227,7 @@ impl TransformConfig for RemapConfig {
                 input_definition.clone(),
             )
             .map(|(program, _, _, external_context)| {
+                // Apply any semantic meanings set in the VRL program
                 let meaning = external_context
                     .get_custom::<MeaningList>()
                     .cloned()
@@ -240,7 +241,8 @@ impl TransformConfig for RemapConfig {
                     input_definition.log_namespaces().clone(),
                 );
                 for (id, path) in meaning {
-                    new_type_def = new_type_def.with_meaning(path, &id);
+                    // currently only event paths are supported
+                    new_type_def = new_type_def.with_meaning(OwnedTargetPath::event(path), &id);
                 }
                 new_type_def
             })

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -286,11 +286,11 @@ impl TransformConfig for RemapConfig {
             dropped_definition = dropped_definition.merge(
                 input_definition
                     .clone()
-                    .with_metadata_field(&owned_value_path!("reason"), Kind::bytes())
-                    .with_metadata_field(&owned_value_path!("message"), Kind::bytes())
-                    .with_metadata_field(&owned_value_path!("component_id"), Kind::bytes())
-                    .with_metadata_field(&owned_value_path!("component_type"), Kind::bytes())
-                    .with_metadata_field(&owned_value_path!("component_kind"), Kind::bytes()),
+                    .with_metadata_field(&owned_value_path!("reason"), Kind::bytes(), None)
+                    .with_metadata_field(&owned_value_path!("message"), Kind::bytes(), None)
+                    .with_metadata_field(&owned_value_path!("component_id"), Kind::bytes(), None)
+                    .with_metadata_field(&owned_value_path!("component_type"), Kind::bytes(), None)
+                    .with_metadata_field(&owned_value_path!("component_kind"), Kind::bytes(), None),
             );
         }
 


### PR DESCRIPTION
This updates all the legacy paths (`LookupBuf`) used in semantic meaning to the new paths (`OwnedTargetPath`), which also allows semantic meaning to point to metadata.

Since the `with_metadata_field` helper function didn't allow setting a meaning, this required touching many different files. These changes were contained in the [update component definitions](https://github.com/vectordotdev/vector/pull/16455/commits/c91b5797bb148664c6c53e5715abc3f9c0a392e4) commit if you want to review those separately. The main changes are in the first commit, [add metadata support to semantic meaning](https://github.com/vectordotdev/vector/pull/16455/commits/2f60e67741e31c533e64b890e7a4087aaa29c7fa)
