### PR TITLE
chore(config): Replace `Serialize` with new `ToValue` trait in config schemas

### DIFF
--- a/lib/lookup/src/lookup_v2/optional_path.rs
+++ b/lib/lookup/src/lookup_v2/optional_path.rs
@@ -1,6 +1,7 @@
+use vector_config::configurable_component;
+
 use crate::lookup_v2::PathParseError;
 use crate::{OwnedTargetPath, OwnedValuePath};
-use vector_config::configurable_component;
 
 #[configurable_component]
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]

--- a/lib/vector-common/src/datetime.rs
+++ b/lib/vector-common/src/datetime.rs
@@ -3,13 +3,14 @@ use std::fmt::Debug;
 use chrono::{DateTime, Local, ParseError, TimeZone as _, Utc};
 use chrono_tz::Tz;
 use derivative::Derivative;
+use serde_json::Value;
 use vector_config::{
     schema::{
         apply_metadata, generate_const_string_schema, generate_one_of_schema,
         get_or_generate_schema,
     },
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 use vector_config_common::attributes::CustomAttribute;
 
@@ -129,5 +130,11 @@ impl Configurable for TimeZone {
         let tz_schema = get_or_generate_schema::<Tz>(gen, Some(tz_metadata))?;
 
         Ok(generate_one_of_schema(&[local_schema, tz_schema]))
+    }
+}
+
+impl ToValue for TimeZone {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("Could not convert time zone to JSON")
     }
 }

--- a/lib/vector-config/src/configurable.rs
+++ b/lib/vector-config/src/configurable.rs
@@ -1,3 +1,8 @@
+#![deny(missing_docs)]
+
+use schemars::{gen::SchemaGenerator, schema::SchemaObject};
+use serde_json::Value;
+
 use crate::{GenerateError, Metadata};
 
 /// A type that can be represented in a Vector configuration.
@@ -55,7 +60,12 @@ where
     ///
     /// If an error occurs while generating the schema, an error variant will be returned describing
     /// the issue.
-    fn generate_schema(
-        gen: &mut schemars::gen::SchemaGenerator,
-    ) -> Result<schemars::schema::SchemaObject, GenerateError>;
+    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>;
+}
+
+/// A type that can be converted directly to a `serde_json::Value`. This is used when translating
+/// the default value in a `Metadata` into a schema object.
+pub trait ToValue {
+    /// Convert this value into a `serde_json::Value`. Must not fail.
+    fn to_value(&self) -> Value;
 }

--- a/lib/vector-config/src/external/chrono.rs
+++ b/lib/vector-config/src/external/chrono.rs
@@ -1,12 +1,15 @@
+use chrono::{DateTime, TimeZone};
+use serde_json::Value;
+
 use crate::{
     schema::generate_string_schema,
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
-impl<TZ> Configurable for chrono::DateTime<TZ>
+impl<TZ> Configurable for DateTime<TZ>
 where
-    TZ: chrono::TimeZone,
+    TZ: TimeZone,
 {
     fn metadata() -> Metadata<Self> {
         let mut metadata = Metadata::default();
@@ -16,5 +19,15 @@ where
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
+    }
+}
+
+impl<TZ> ToValue for DateTime<TZ>
+where
+    Self: ToString,
+    TZ: TimeZone,
+{
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
     }
 }

--- a/lib/vector-config/src/external/encoding_rs.rs
+++ b/lib/vector-config/src/external/encoding_rs.rs
@@ -1,10 +1,13 @@
+use encoding_rs::Encoding;
+use serde_json::Value;
+
 use crate::{
     schema::generate_string_schema,
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
-impl Configurable for &'static encoding_rs::Encoding {
+impl Configurable for &'static Encoding {
     // TODO: At some point, we might want to override the metadata to define a validation pattern that only matches
     // valid character set encodings... but that would be a very large array of strings, and technically the Encoding
     // Standard is a living standard, so... :thinkies:
@@ -23,5 +26,11 @@ impl Configurable for &'static encoding_rs::Encoding {
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for &'static Encoding {
+    fn to_value(&self) -> Value {
+        Value::String(self.name().into())
     }
 }

--- a/lib/vector-config/src/external/indexmap.rs
+++ b/lib/vector-config/src/external/indexmap.rs
@@ -1,16 +1,17 @@
-use serde::Serialize;
+use indexmap::{IndexMap, IndexSet};
+use serde_json::Value;
 
 use crate::{
     schema::{assert_string_schema_for_map, generate_map_schema, generate_set_schema},
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
     str::ConfigurableString,
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
-impl<K, V> Configurable for indexmap::IndexMap<K, V>
+impl<K, V> Configurable for IndexMap<K, V>
 where
-    K: ConfigurableString + Serialize + std::hash::Hash + Eq,
-    V: Configurable + Serialize,
+    K: ConfigurableString + ToValue + std::hash::Hash + Eq,
+    V: Configurable + ToValue,
 {
     fn is_optional() -> bool {
         // A hashmap with required fields would be... an object.  So if you want that, make a struct
@@ -35,9 +36,23 @@ where
     }
 }
 
-impl<V> Configurable for indexmap::IndexSet<V>
+impl<K, V> ToValue for IndexMap<K, V>
 where
-    V: Configurable + Serialize + std::hash::Hash + Eq,
+    K: ToString,
+    V: ToValue,
+{
+    fn to_value(&self) -> Value {
+        Value::Object(
+            self.iter()
+                .map(|(k, v)| (k.to_string(), v.to_value()))
+                .collect(),
+        )
+    }
+}
+
+impl<V> Configurable for IndexSet<V>
+where
+    V: Configurable + ToValue + std::hash::Hash + Eq,
 {
     fn metadata() -> Metadata<Self> {
         Metadata::with_transparent(true)
@@ -50,5 +65,11 @@ where
 
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
+    }
+}
+
+impl<V: ToValue> ToValue for IndexSet<V> {
+    fn to_value(&self) -> Value {
+        Value::Array(self.iter().map(ToValue::to_value).collect())
     }
 }

--- a/lib/vector-config/src/external/no_proxy.rs
+++ b/lib/vector-config/src/external/no_proxy.rs
@@ -1,7 +1,9 @@
+use serde_json::Value;
+
 use crate::{
     schema::generate_array_schema,
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
 impl Configurable for no_proxy::NoProxy {
@@ -15,5 +17,11 @@ impl Configurable for no_proxy::NoProxy {
         // `NoProxy` (de)serializes itself as a vector of strings, without any constraints on the string value itself, so
         // we just... do that.
         generate_array_schema::<String>(gen)
+    }
+}
+
+impl ToValue for no_proxy::NoProxy {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("Could not convert no-proxy list to JSON")
     }
 }

--- a/lib/vector-config/src/external/toml.rs
+++ b/lib/vector-config/src/external/toml.rs
@@ -1,6 +1,8 @@
+use serde_json::Value;
+
 use crate::{
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError,
+    Configurable, GenerateError, ToValue,
 };
 
 impl Configurable for toml::Value {
@@ -8,5 +10,11 @@ impl Configurable for toml::Value {
         // `toml::Value` can be anything that it is possible to represent in TOML, and equivalently, is anything it's
         // possible to represent in JSON, so... a default schema indicates that.
         Ok(SchemaObject::default())
+    }
+}
+
+impl ToValue for toml::Value {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("Could not convert TOML value to JSON")
     }
 }

--- a/lib/vector-config/src/external/tz.rs
+++ b/lib/vector-config/src/external/tz.rs
@@ -1,7 +1,9 @@
+use serde_json::Value;
+
 use crate::{
     schema::generate_string_schema,
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
 impl Configurable for chrono_tz::Tz {
@@ -13,5 +15,11 @@ impl Configurable for chrono_tz::Tz {
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for chrono_tz::Tz {
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
     }
 }

--- a/lib/vector-config/src/external/url.rs
+++ b/lib/vector-config/src/external/url.rs
@@ -1,9 +1,10 @@
+use serde_json::Value;
 use vector_config_common::validation::{Format, Validation};
 
 use crate::{
     schema::generate_string_schema,
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
 impl Configurable for url::Url {
@@ -16,5 +17,11 @@ impl Configurable for url::Url {
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for url::Url {
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
     }
 }

--- a/lib/vector-config/src/lib.rs
+++ b/lib/vector-config/src/lib.rs
@@ -133,10 +133,11 @@ pub mod indexmap {
 pub mod schemars {
     pub use schemars::*;
 }
+pub use serde_json;
 
 pub mod component;
 mod configurable;
-pub use self::configurable::Configurable;
+pub use self::configurable::{Configurable, ToValue};
 mod errors;
 pub use self::errors::{BoundDirection, GenerateError};
 mod external;

--- a/lib/vector-config/src/metadata.rs
+++ b/lib/vector-config/src/metadata.rs
@@ -2,8 +2,6 @@ use std::fmt;
 
 use vector_config_common::{attributes::CustomAttribute, validation};
 
-use crate::Configurable;
-
 /// The metadata associated with a given type or field.
 #[derive(Clone)]
 pub struct Metadata<T> {
@@ -73,23 +71,6 @@ impl<T> Metadata<T> {
 
     pub fn consume_default_value(&mut self) -> Option<T> {
         self.default_value.take()
-    }
-
-    pub fn map_default_value<F, U>(self, f: F) -> Metadata<U>
-    where
-        F: FnOnce(T) -> U,
-        U: Configurable,
-    {
-        Metadata {
-            title: self.title,
-            description: self.description,
-            default_value: self.default_value.map(f),
-            custom_attributes: self.custom_attributes,
-            deprecated: self.deprecated,
-            deprecated_message: self.deprecated_message,
-            transparent: self.transparent,
-            validations: self.validations,
-        }
     }
 
     pub fn deprecated(&self) -> bool {

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -8,12 +8,11 @@ use schemars::{
         SchemaObject, SingleOrVec, SubschemaValidation,
     },
 };
-use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::{
     num::ConfigurableNumber, Configurable, ConfigurableString, CustomAttribute, GenerateError,
-    Metadata,
+    Metadata, ToValue,
 };
 
 /// Applies metadata to the given schema.
@@ -22,7 +21,7 @@ use crate::{
 /// patterns, etc), as well as actual arbitrary key/value data.
 pub fn apply_metadata<T>(schema: &mut SchemaObject, metadata: Metadata<T>)
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     let base_metadata = T::metadata();
 
@@ -58,9 +57,7 @@ where
     }
 
     // If a default value was given, serialize it.
-    let schema_default = metadata
-        .default_value()
-        .map(|v| serde_json::to_value(v).expect("default value should never fail to serialize"));
+    let schema_default = metadata.default_value().map(ToValue::to_value);
 
     // Take the existing schema metadata, if any, or create a default version of it, and then apply
     // all of our newly-calculated values to it.
@@ -224,7 +221,7 @@ where
 
 pub fn generate_array_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     // Generate the actual schema for the element type `T`.
     let element_schema = get_or_generate_schema::<T>(gen, None)?;
@@ -241,7 +238,7 @@ where
 
 pub fn generate_set_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     // Generate the actual schema for the element type `T`.
     let element_schema = get_or_generate_schema::<T>(gen, None)?;
@@ -259,7 +256,7 @@ where
 
 pub fn generate_map_schema<V>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
 where
-    V: Configurable + Serialize,
+    V: Configurable + ToValue,
 {
     // Generate the actual schema for the element type `V`.
     let element_schema = get_or_generate_schema::<V>(gen, None)?;
@@ -297,7 +294,7 @@ pub fn generate_struct_schema(
 
 pub fn generate_optional_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     // Optional schemas are generally very simple in practice, but because of how we memoize schema
     // generation and use references to schema definitions, we have to handle quite a few cases
@@ -484,7 +481,7 @@ pub fn generate_internal_tagged_variant_schema(
 
 pub fn generate_root_schema<T>() -> Result<RootSchema, GenerateError>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     // Set env variable to enable generating all schemas, including platform-specific ones.
     std::env::set_var("VECTOR_GENERATE_SCHEMA", "true");
@@ -504,7 +501,7 @@ pub fn get_or_generate_schema<T>(
     overrides: Option<Metadata<T>>,
 ) -> Result<SchemaObject, GenerateError>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     let (mut schema, metadata) = match T::referenceable_name() {
         // When `T` has a referenceable name, try looking it up in the schema generator's definition
@@ -582,7 +579,7 @@ pub fn generate_baseline_schema<T>(
     metadata: Metadata<T>,
 ) -> Result<SchemaObject, GenerateError>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     // Generate the schema and apply its metadata.
     let mut schema = T::generate_schema(gen)?;
@@ -609,7 +606,7 @@ fn get_schema_ref<S: AsRef<str>>(gen: &mut SchemaGenerator, name: S) -> SchemaOb
 /// the issue.
 pub fn assert_string_schema_for_map<K, M>(gen: &mut SchemaGenerator) -> Result<(), GenerateError>
 where
-    K: ConfigurableString + Serialize,
+    K: ConfigurableString + ToValue,
 {
     // We need to force the schema to be treated as transparent so that when the schema generation
     // finalizes the schema, we don't throw an error due to a lack of title/description.

--- a/lib/vector-config/src/ser.rs
+++ b/lib/vector-config/src/ser.rs
@@ -1,10 +1,11 @@
+use serde_json::Value;
 use std::marker::PhantomData;
 
 use serde::{Serialize, Serializer};
 
 use crate::{
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
 /// Delegated serialization.
@@ -93,5 +94,15 @@ where
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         // Forward to the underlying `H`.
         H::generate_schema(gen)
+    }
+}
+
+impl<I, H> ToValue for Delegated<I, H>
+where
+    H: Configurable,
+    Delegated<I, H>: Serialize,
+{
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).unwrap()
     }
 }

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    hash::Hash,
     net::SocketAddr,
     num::{
         NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU16, NonZeroU32, NonZeroU64,
@@ -11,7 +12,7 @@ use std::{
 
 use indexmap::IndexMap;
 use schemars::{gen::SchemaGenerator, schema::SchemaObject};
-use serde::Serialize;
+use serde_json::{Number, Value};
 use vector_config_common::{attributes::CustomAttribute, validation::Validation};
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::{
         generate_string_schema,
     },
     str::ConfigurableString,
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 
 // Unit type.
@@ -33,10 +34,16 @@ impl Configurable for () {
     }
 }
 
+impl ToValue for () {
+    fn to_value(&self) -> Value {
+        Value::Null
+    }
+}
+
 // Null and boolean.
 impl<T> Configurable for Option<T>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     fn referenceable_name() -> Option<&'static str> {
         match T::referenceable_name() {
@@ -64,6 +71,15 @@ where
     }
 }
 
+impl<T: ToValue> ToValue for Option<T> {
+    fn to_value(&self) -> Value {
+        match self {
+            None => Value::Null,
+            Some(inner) => inner.to_value(),
+        }
+    }
+}
+
 impl Configurable for bool {
     fn metadata() -> Metadata<Self> {
         Metadata::with_transparent(true)
@@ -71,6 +87,12 @@ impl Configurable for bool {
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_bool_schema())
+    }
+}
+
+impl ToValue for bool {
+    fn to_value(&self) -> Value {
+        Value::Bool(*self)
     }
 }
 
@@ -82,6 +104,12 @@ impl Configurable for String {
 
     fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for String {
+    fn to_value(&self) -> Value {
+        Value::String(self.clone())
     }
 }
 
@@ -100,59 +128,69 @@ impl Configurable for char {
     }
 }
 
-// Numbers.
-macro_rules! impl_configurable_numeric {
-	($($ty:ty),+) => {
-		$(
-			impl Configurable for $ty {
-                fn metadata() -> Metadata<Self> {
-                    let mut metadata = Metadata::with_transparent(true);
-                    let numeric_type = <Self as ConfigurableNumber>::class();
-                    metadata.add_custom_attribute(CustomAttribute::kv("docs::numeric_type", numeric_type));
-
-                    metadata
-                }
-
-                fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
-                    $crate::__ensure_numeric_validation_bounds::<Self>(metadata)
-                }
-
-				fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
-					Ok(generate_number_schema::<Self>())
-				}
-			}
-		)+
-	};
+impl ToValue for char {
+    fn to_value(&self) -> Value {
+        Value::String(format!("{self}"))
+    }
 }
 
-impl_configurable_numeric!(
-    u8,
-    u16,
-    u32,
-    u64,
-    usize,
-    i8,
-    i16,
-    i32,
-    i64,
-    isize,
-    f32,
-    f64,
-    NonZeroU8,
-    NonZeroU16,
-    NonZeroU32,
-    NonZeroU64,
-    NonZeroI8,
-    NonZeroI16,
-    NonZeroI32,
-    NonZeroI64,
-    NonZeroUsize
-);
+// Numbers.
+macro_rules! impl_configurable_numeric {
+    ($ty:ty => $into:expr) => {
+        impl Configurable for $ty {
+            fn metadata() -> Metadata<Self> {
+                let mut metadata = Metadata::with_transparent(true);
+                let numeric_type = <Self as ConfigurableNumber>::class();
+                metadata
+                    .add_custom_attribute(CustomAttribute::kv("docs::numeric_type", numeric_type));
+
+                metadata
+            }
+
+            fn validate_metadata(metadata: &Metadata<Self>) -> Result<(), GenerateError> {
+                $crate::__ensure_numeric_validation_bounds::<Self>(metadata)
+            }
+
+            fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+                Ok(generate_number_schema::<Self>())
+            }
+        }
+
+        impl ToValue for $ty {
+            fn to_value(&self) -> Value {
+                let into = $into;
+                Value::Number(into(*self))
+            }
+        }
+    };
+}
+
+impl_configurable_numeric!(u8 => Into::into);
+impl_configurable_numeric!(u16 => Into::into);
+impl_configurable_numeric!(u32 => Into::into);
+impl_configurable_numeric!(u64 => Into::into);
+impl_configurable_numeric!(usize => Into::into);
+impl_configurable_numeric!(i8 => Into::into);
+impl_configurable_numeric!(i16 => Into::into);
+impl_configurable_numeric!(i32 => Into::into);
+impl_configurable_numeric!(i64 => Into::into);
+impl_configurable_numeric!(isize => Into::into);
+impl_configurable_numeric!(f32 => |v| Number::from_f64(v as f64).expect("Could not convert number to JSON"));
+impl_configurable_numeric!(f64 => |v| Number::from_f64(v).expect("Could not convert number to JSON"));
+impl_configurable_numeric!(NonZeroU8 => |v: NonZeroU8| v.get().into());
+impl_configurable_numeric!(NonZeroU16 => |v: NonZeroU16| v.get().into());
+impl_configurable_numeric!(NonZeroU32 => |v: NonZeroU32| v.get().into());
+impl_configurable_numeric!(NonZeroU64 => |v: NonZeroU64| v.get().into());
+impl_configurable_numeric!(NonZeroI8 => |v: NonZeroI8| v.get().into());
+impl_configurable_numeric!(NonZeroI16 => |v: NonZeroI16| v.get().into());
+impl_configurable_numeric!(NonZeroI32 => |v: NonZeroI32| v.get().into());
+impl_configurable_numeric!(NonZeroI64 => |v: NonZeroI64| v.get().into());
+impl_configurable_numeric!(NonZeroUsize => |v: NonZeroUsize| v.get().into());
 
 // Arrays and maps.
 impl<T> Configurable for Vec<T>
 where
-    T: Configurable + Serialize,
+    T: Configurable + ToValue,
 {
     fn metadata() -> Metadata<Self> {
         T::metadata().convert()
@@ -168,10 +206,16 @@ where
     }
 }
 
+impl<T: ToValue> ToValue for Vec<T> {
+    fn to_value(&self) -> Value {
+        Value::Array(self.iter().map(ToValue::to_value).collect())
+    }
+}
+
 impl<K, V> Configurable for BTreeMap<K, V>
 where
-    K: ConfigurableString + Serialize + Ord,
-    V: Configurable + Serialize,
+    K: ConfigurableString + Ord + ToValue,
+    V: Configurable + ToValue,
 {
     fn is_optional() -> bool {
         // A map with required fields would be... an object.  So if you want that, make a struct
@@ -193,12 +237,26 @@ where
         assert_string_schema_for_map::<K, Self>(gen)?;
 
         generate_map_schema::<V>(gen)
+    }
+}
+
+impl<K, V> ToValue for BTreeMap<K, V>
+where
+    K: ToString,
+    V: ToValue,
+{
+    fn to_value(&self) -> Value {
+        Value::Object(
+            self.iter()
+                .map(|(k, v)| (k.to_string(), v.to_value()))
+                .collect(),
+        )
     }
 }
 
 impl<V> Configurable for BTreeSet<V>
 where
-    V: Configurable + Serialize + Eq + std::hash::Hash,
+    V: Configurable + ToValue + Eq + Hash,
 {
     fn metadata() -> Metadata<Self> {
         Metadata::with_transparent(true)
@@ -214,10 +272,16 @@ where
     }
 }
 
+impl<V: ToValue> ToValue for BTreeSet<V> {
+    fn to_value(&self) -> Value {
+        Value::Array(self.iter().map(ToValue::to_value).collect())
+    }
+}
+
 impl<K, V> Configurable for HashMap<K, V>
 where
-    K: ConfigurableString + Serialize + std::hash::Hash + Eq,
-    V: Configurable + Serialize,
+    K: ConfigurableString + ToValue + Hash + Eq,
+    V: Configurable + ToValue,
 {
     fn is_optional() -> bool {
         // A map with required fields would be... an object.  So if you want that, make a struct
@@ -242,9 +306,23 @@ where
     }
 }
 
+impl<K, V> ToValue for HashMap<K, V>
+where
+    K: ToString,
+    V: ToValue,
+{
+    fn to_value(&self) -> Value {
+        Value::Object(
+            self.iter()
+                .map(|(k, v)| (k.to_string(), v.to_value()))
+                .collect(),
+        )
+    }
+}
+
 impl<V> Configurable for HashSet<V>
 where
-    V: Configurable + Serialize + Eq + std::hash::Hash,
+    V: Configurable + ToValue + Eq + Hash,
 {
     fn metadata() -> Metadata<Self> {
         Metadata::with_transparent(true)
@@ -257,6 +335,15 @@ where
 
     fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
+    }
+}
+
+impl<V> ToValue for HashSet<V>
+where
+    V: ToValue,
+{
+    fn to_value(&self) -> Value {
+        Value::Array(self.iter().map(ToValue::to_value).collect())
     }
 }
 
@@ -277,6 +364,12 @@ impl Configurable for SocketAddr {
         // but we eventually should have validation since the format for the possible permutations
         // is well-known and can be easily codified.
         Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for SocketAddr {
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
     }
 }
 
@@ -304,6 +397,12 @@ impl Configurable for PathBuf {
     }
 }
 
+impl ToValue for PathBuf {
+    fn to_value(&self) -> Value {
+        Value::String(self.display().to_string())
+    }
+}
+
 // The use of `Duration` is deprecated and will be removed in a future version
 impl Configurable for Duration {
     fn referenceable_name() -> Option<&'static str> {
@@ -328,5 +427,11 @@ impl Configurable for Duration {
         Ok(crate::schema::generate_struct_schema(
             properties, required, None,
         ))
+    }
+}
+
+impl ToValue for Duration {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("Could not convert duration to JSON")
     }
 }

--- a/lib/vector-config/src/str.rs
+++ b/lib/vector-config/src/str.rs
@@ -7,6 +7,6 @@ use crate::Configurable;
 ///
 /// If this trait is implemented for a type that is not string-like, things will probably break.
 /// Don't implement this for things that are not string-like.
-pub trait ConfigurableString: Configurable {}
+pub trait ConfigurableString: Configurable + ToString {}
 
 impl ConfigurableString for String {}

--- a/lib/vector-config/tests/integration/configurable_string.rs
+++ b/lib/vector-config/tests/integration/configurable_string.rs
@@ -10,6 +10,12 @@ pub struct FakeString(u64);
 
 impl ConfigurableString for FakeString {}
 
+impl ToString for FakeString {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
 #[test]
 #[should_panic]
 fn non_string_key_schema_stdlib_hashmap() {

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -37,6 +37,12 @@ pub struct Template {
 
 impl ConfigurableString for Template {}
 
+impl ToString for Template {
+    fn to_string(&self) -> String {
+        self.src.clone()
+    }
+}
+
 impl TryFrom<String> for Template {
     type Error = String;
 

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -2,13 +2,14 @@ use std::{collections::BTreeSet, fmt};
 
 use indexmap::IndexMap;
 use serde::{de, ser};
+use serde_json::Value;
 use vector_config::{
     schema::{
         apply_metadata, generate_const_string_schema, generate_enum_schema, generate_one_of_schema,
         generate_struct_schema, get_or_generate_schema,
     },
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 use vector_config_common::attributes::CustomAttribute;
 
@@ -302,6 +303,12 @@ impl Configurable for Compression {
     }
 }
 
+impl ToValue for Compression {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("Could not convert compression settings to JSON")
+    }
+}
+
 /// Compression level.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CompressionLevel(flate2::Compression);
@@ -433,6 +440,13 @@ impl Configurable for CompressionLevel {
 
         let valid_values = string_consts.chain(level_consts).collect();
         Ok(generate_enum_schema(valid_values))
+    }
+}
+
+impl ToValue for CompressionLevel {
+    fn to_value(&self) -> Value {
+        // FIXME
+        serde_json::to_value(self).expect("Could not convert compression level to JSON")
     }
 }
 

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -1,4 +1,5 @@
 use serde::Serializer;
+use serde_json::Value;
 use std::fmt;
 use vector_config::{
     schema::{
@@ -6,7 +7,7 @@ use vector_config::{
         generate_one_of_schema,
     },
     schemars::{gen::SchemaGenerator, schema::SchemaObject},
-    Configurable, GenerateError, Metadata,
+    Configurable, GenerateError, Metadata, ToValue,
 };
 use vector_config_common::attributes::CustomAttribute;
 
@@ -165,6 +166,12 @@ impl Configurable for Concurrency {
             adaptive_schema,
             fixed_schema,
         ]))
+    }
+}
+
+impl ToValue for Concurrency {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("Could not convert concurrency to JSON")
     }
 }
 


### PR DESCRIPTION
The `Serialize` trait is only used by the configurable system in order to
translate default values into `serde_json::Value`. Since the `Serialize` trait
is not object safe, this causes complications for making the other traits object
safe in preparation for moving to an inventory-style system for registering
components.

This change introduces an object-safe `ToValue` trait that is used to express a
direct conversion from values into a `serde_json::Value`. Where possible, this
is implemented directly, however the fallback of `serde_json::to_value` is used
for types where this is difficult.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
