### PR TITLE
docs(pulsar sink): add example for producer_name

### DIFF
--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -57,6 +57,7 @@ pub struct PulsarSinkConfig {
     topic: String,
 
     /// The name of the producer. If not specified, the default name assigned by Pulsar will be used.
+    #[configurable(metadata(docs::examples = "producer-name"))]
     producer_name: Option<String>,
 
     #[configurable(derived)]

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -242,7 +242,7 @@ base: components: sinks: pulsar: configuration: {
 	producer_name: {
 		description: "The name of the producer. If not specified, the default name assigned by Pulsar will be used."
 		required:    false
-		type: string: {}
+		type: string: examples: ["producer-name"]
 	}
 	topic: {
 		description: "The Pulsar topic name to write events to."


### PR DESCRIPTION
Closes #16251

This sink was already ported over to the new Cue system a while back, but a contributor PR introduced the `producer_name` config option. This PR adds an example. 