### PR TITLE
chore(config): mark structs as `additionalProperties: false`

### DIFF
--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -1,11 +1,12 @@
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::Encoder;
+use vector_config::configurable_component;
 use vector_core::{config::DataType, event::Event, schema};
 
 use crate::MetricTagValues;
 
 /// Config used to build a `JsonSerializer`.
-#[crate::configurable_component]
+#[configurable_component]
 #[derive(Debug, Clone, Default)]
 pub struct JsonSerializerConfig {
     /// Controls how metric tag values are encoded.

--- a/lib/codecs/src/encoding/format/text.rs
+++ b/lib/codecs/src/encoding/format/text.rs
@@ -1,6 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::Encoder;
 use value::Kind;
+use vector_config::configurable_component;
 use vector_core::{
     config::{log_schema, DataType},
     event::Event,
@@ -10,7 +11,7 @@ use vector_core::{
 use crate::MetricTagValues;
 
 /// Config used to build a `TextSerializer`.
-#[crate::configurable_component]
+#[configurable_component]
 #[derive(Debug, Clone, Default)]
 pub struct TextSerializerConfig {
     /// Controls how metric tag values are encoded.

--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -259,11 +259,9 @@ fn build_named_struct_generate_schema_fn(
 
             let had_unflatted_properties = !properties.is_empty();
 
-            let additional_properties = None;
             let mut schema = ::vector_config::schema::generate_struct_schema(
                 properties,
                 required,
-                additional_properties,
             );
 
             // If we have any flattened subschemas, deal with them now.
@@ -656,8 +654,7 @@ fn generate_enum_struct_named_variant_schema(
 
             ::vector_config::schema::generate_struct_schema(
                 properties,
-                required,
-                None
+                required
             )
         }
     }
@@ -845,8 +842,7 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
 
                 ::vector_config::schema::generate_struct_schema(
                     wrapper_properties,
-                    wrapper_required,
-                    None
+                    wrapper_required
                 )
             }
         }
@@ -900,8 +896,7 @@ fn generate_single_field_struct_schema(
 
             ::vector_config::schema::generate_struct_schema(
                 wrapper_properties,
-                wrapper_required,
-                None
+                wrapper_required
             )
         }
     }

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -342,8 +342,9 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
         .typed_component()
         .map(|tc| tc.get_component_desc_registration(&input));
 
-    // Generate and apply all of the necessary derives.
+    // Generate and apply all of the necessary derives
     let mut derives = Punctuated::<Path, Comma>::new();
+
     derives.push(parse_quote_spanned! {input.ident.span()=>
         ::vector_config_macros::Configurable
     });

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -342,7 +342,7 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
         .typed_component()
         .map(|tc| tc.get_component_desc_registration(&input));
 
-    // Generate and apply all of the necessary derives
+    // Generate and apply all of the necessary derives.
     let mut derives = Punctuated::<Path, Comma>::new();
 
     derives.push(parse_quote_spanned! {input.ident.span()=>

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -277,7 +277,6 @@ where
 pub fn generate_struct_schema(
     properties: IndexMap<String, SchemaObject>,
     required: BTreeSet<String>,
-    additional_properties: Option<Box<Schema>>,
 ) -> SchemaObject {
     let properties = properties
         .into_iter()
@@ -288,7 +287,7 @@ pub fn generate_struct_schema(
         object: Some(Box::new(ObjectValidation {
             properties,
             required,
-            additional_properties,
+            additional_properties: Some(Box::new(Schema::Bool(false))),
             ..Default::default()
         })),
         ..Default::default()
@@ -479,7 +478,7 @@ pub fn generate_internal_tagged_variant_schema(
     let mut required = BTreeSet::new();
     required.insert(tag);
 
-    generate_struct_schema(properties, required, None)
+    generate_struct_schema(properties, required)
 }
 
 pub fn generate_root_schema<T>() -> Result<RootSchema, GenerateError>

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -325,8 +325,6 @@ impl Configurable for Duration {
         required.insert("secs".into());
         required.insert("nsecs".into());
 
-        Ok(crate::schema::generate_struct_schema(
-            properties, required, None,
-        ))
+        Ok(crate::schema::generate_struct_schema(properties, required))
     }
 }

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -887,7 +887,7 @@ def resolve_bare_schema(root_schema, schema)
       # If the object schema has `additionalProperties` set, we add an additional field
       # (`*`) which uses the specified schema for that field.
       additional_properties = schema['additionalProperties']
-      if !additional_properties.nil?
+      if !additional_properties.nil? && additional_properties != false
         @logger.debug "Handling additional properties."
 
         # Normally, we only get here if there's a hashmap field on a struct that can act as the

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -289,7 +289,7 @@ impl Configurable for Compression {
         );
         properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
 
-        let mut full_subschema = generate_struct_schema(properties, required, None);
+        let mut full_subschema = generate_struct_schema(properties, required);
         let mut full_metadata = Metadata::<()>::with_description("");
         full_metadata.add_custom_attribute(CustomAttribute::flag("docs::hidden"));
         apply_metadata(&mut full_subschema, full_metadata);


### PR DESCRIPTION
As part of the work to tighten up the generated configuration schema for Vector, this PR introduces a change to mark all struct schemas as `additionalProperties: false`, which indicates that any properties not specifically defined should not be ignored, and should rise to the level of a validation error.

Originally, this PR started out as a way to do that _and_ automatically apply `#[serde(deny_unknown_fields)]` where appropriate... but due to conflicts between `deny_unknown_fields` and `flatten`, I had to abandon that portion of the work.

In this respect, the configuration schema is more strict than what `serde`/Vector will accept when parsing a configuration.