### PR TITLE
chore(internal docs): `doc::label` meta for components, updated descriptions

### DIFF
--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -168,7 +168,7 @@ pub enum Sinks {
     #[configurable(metadata(docs::label = "AWS S3"))]
     AwsS3(aws_s3::S3SinkConfig),
 
-    /// Publish observability events to Simple Queue Service topics.
+    /// Publish observability events to AWS Simple Queue Service topics.
     #[cfg(feature = "sinks-aws_sqs")]
     #[configurable(metadata(docs::label = "AWS SQS"))]
     AwsSqs(aws_sqs::SqsSinkConfig),

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -193,7 +193,7 @@ pub enum Sinks {
     #[configurable(metadata(docs::label = "Blackhole"))]
     Blackhole(blackhole::BlackholeConfig),
 
-    /// Deliver log data to the ClickHouse database.
+    /// Deliver log data to a ClickHouse database.
     #[cfg(feature = "sinks-clickhouse")]
     #[configurable(metadata(docs::label = "ClickHouse"))]
     Clickhouse(clickhouse::ClickhouseConfig),

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -243,12 +243,12 @@ pub enum Sinks {
     #[configurable(metadata(docs::label = "GCP Chronicle Unstructured"))]
     GcpChronicleUnstructured(gcp::chronicle_unstructured::ChronicleUnstructuredConfig),
 
-    /// Deliver logs to GCP’s Cloud Operations suite.
+    /// Deliver logs to GCP's Cloud Operations suite.
     #[cfg(feature = "sinks-gcp")]
     #[configurable(metadata(docs::label = "GCP Operations (Stackdriver)"))]
     GcpStackdriverLogs(gcp::stackdriver_logs::StackdriverConfig),
 
-    /// Deliver metrics to GCP’s Cloud Monitoring system.
+    /// Deliver metrics to GCP's Cloud Monitoring system.
     #[cfg(feature = "sinks-gcp")]
     #[configurable(metadata(docs::label = "GCP Cloud Monitoring (Stackdriver)"))]
     GcpStackdriverMetrics(gcp::stackdriver_metrics::StackdriverConfig),
@@ -258,7 +258,7 @@ pub enum Sinks {
     #[configurable(metadata(docs::label = "GCP Cloud Storage"))]
     GcpCloudStorage(gcp::cloud_storage::GcsSinkConfig),
 
-    /// Publish observability events to GCP’s Pub/Sub messaging system.
+    /// Publish observability events to GCP's Pub/Sub messaging system.
     #[cfg(feature = "sinks-gcp")]
     #[configurable(metadata(docs::label = "GCP Pub/Sub"))]
     GcpPubsub(gcp::pubsub::PubsubConfig),
@@ -358,12 +358,12 @@ pub enum Sinks {
     #[configurable(metadata(docs::label = "Socket"))]
     Socket(socket::SocketSinkConfig),
 
-    /// Deliver log data to Splunk’s HTTP Event Collector.
+    /// Deliver log data to Splunk's HTTP Event Collector.
     #[cfg(feature = "sinks-splunk_hec")]
     #[configurable(metadata(docs::label = "Splunk HEC Logs"))]
     SplunkHecLogs(splunk_hec::logs::config::HecLogsSinkConfig),
 
-    /// Deliver metric data to Splunk’s HTTP Event Collector.
+    /// Deliver metric data to Splunk's HTTP Event Collector.
     #[cfg(feature = "sinks-splunk_hec")]
     #[configurable(metadata(docs::label = "Splunk HEC Metrics"))]
     SplunkHecMetrics(splunk_hec::metrics::config::HecMetricsSinkConfig),

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -323,7 +323,7 @@ pub enum Sinks {
     #[configurable(metadata(docs::label = "Papertrail"))]
     Papertrail(papertrail::PapertrailConfig),
 
-    /// Output metric events to a Prometheus exporter running on the host.
+    /// Expose metric events on a Prometheus compatible endpoint.
     #[cfg(feature = "sinks-prometheus")]
     #[configurable(metadata(docs::label = "Prometheus Exporter"))]
     PrometheusExporter(prometheus::exporter::PrometheusExporterConfig),

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -133,200 +133,249 @@ pub enum HealthcheckError {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[enum_dispatch(SinkConfig)]
 pub enum Sinks {
-    /// AMQP.
+    /// Send events to AMQP 0.9.1 compatible brokers like RabbitMQ.
     #[cfg(feature = "sinks-amqp")]
+    #[configurable(metadata(docs::label = "AMQP"))]
     Amqp(amqp::AmqpSinkConfig),
 
-    /// Apex Logs.
+    /// Deliver log events to Apex.
     #[cfg(feature = "sinks-apex")]
+    #[configurable(metadata(docs::label = "Apex"))]
     Apex(apex::ApexSinkConfig),
 
-    /// AWS CloudWatch Logs.
+    /// Publish log events to AWS CloudWatch Logs.
     #[cfg(feature = "sinks-aws_cloudwatch_logs")]
+    #[configurable(metadata(docs::label = "AWS CloudWatch Logs"))]
     AwsCloudwatchLogs(aws_cloudwatch_logs::CloudwatchLogsSinkConfig),
 
-    /// AWS CloudWatch Metrics.
+    /// Publish metric events to AWS CloudWatch Metrics.
     #[cfg(feature = "sinks-aws_cloudwatch_metrics")]
+    #[configurable(metadata(docs::label = "AWS CloudWatch Metrics"))]
     AwsCloudwatchMetrics(aws_cloudwatch_metrics::CloudWatchMetricsSinkConfig),
 
-    /// AWS Kinesis Firehose.
+    /// Publish logs to AWS Kinesis Data Firehose topics.
     #[cfg(feature = "sinks-aws_kinesis_firehose")]
+    #[configurable(metadata(docs::label = "AWS Kinesis Data Firehose Logs"))]
     AwsKinesisFirehose(aws_kinesis::firehose::KinesisFirehoseSinkConfig),
 
-    /// AWS Kinesis Streams.
+    /// Publish logs to AWS Kinesis Streams topics.
     #[cfg(feature = "sinks-aws_kinesis_streams")]
+    #[configurable(metadata(docs::label = "AWS Kinesis Streams Logs"))]
     AwsKinesisStreams(aws_kinesis::streams::KinesisStreamsSinkConfig),
 
-    /// AWS S3.
+    /// Store observability events in the AWS S3 object storage system.
     #[cfg(feature = "sinks-aws_s3")]
+    #[configurable(metadata(docs::label = "AWS S3"))]
     AwsS3(aws_s3::S3SinkConfig),
 
-    /// AWS SQS.
+    /// Publish observability events to Simple Queue Service topics.
     #[cfg(feature = "sinks-aws_sqs")]
+    #[configurable(metadata(docs::label = "AWS SQS"))]
     AwsSqs(aws_sqs::SqsSinkConfig),
 
-    /// Axiom.
+    /// Deliver log events to Axiom.
     #[cfg(feature = "sinks-axiom")]
+    #[configurable(metadata(docs::label = "Axiom"))]
     Axiom(axiom::AxiomConfig),
 
-    /// Azure Blob Storage.
+    /// Store your observability data in Azure Blob Storage.
     #[cfg(feature = "sinks-azure_blob")]
+    #[configurable(metadata(docs::label = "Azure Blob Storage"))]
     AzureBlob(azure_blob::AzureBlobSinkConfig),
 
-    /// Azure Monitor Logs.
+    /// Publish log events to the Azure Monitor Logs service.
     #[cfg(feature = "sinks-azure_monitor_logs")]
+    #[configurable(metadata(docs::label = "Azure Monitor Logs"))]
     AzureMonitorLogs(azure_monitor_logs::AzureMonitorLogsConfig),
 
-    /// Blackhole.
+    /// Send observability events nowhere, which can be useful for debugging purposes.
     #[cfg(feature = "sinks-blackhole")]
+    #[configurable(metadata(docs::label = "Blackhole"))]
     Blackhole(blackhole::BlackholeConfig),
 
-    /// ClickHouse.
+    /// Deliver log data to the ClickHouse database.
     #[cfg(feature = "sinks-clickhouse")]
+    #[configurable(metadata(docs::label = "ClickHouse"))]
     Clickhouse(clickhouse::ClickhouseConfig),
 
-    /// Console.
+    /// Display observability events in the console, which can be useful for debugging purposes.
     #[cfg(feature = "sinks-console")]
+    #[configurable(metadata(docs::label = "Console"))]
     Console(console::ConsoleSinkConfig),
 
-    /// Datadog Archives.
+    /// Send events to Datadog Archives.
     #[cfg(feature = "sinks-datadog_archives")]
+    #[configurable(metadata(docs::label = "Datadog Archives"))]
     DatadogArchives(datadog_archives::DatadogArchivesSinkConfig),
 
-    /// Datadog Events.
+    /// Publish observability events to the Datadog Events API.
     #[cfg(feature = "sinks-datadog_events")]
+    #[configurable(metadata(docs::label = "Datadog Events"))]
     DatadogEvents(datadog::events::DatadogEventsConfig),
 
-    /// Datadog Logs.
+    /// Publish log events to Datadog.
     #[cfg(feature = "sinks-datadog_logs")]
+    #[configurable(metadata(docs::label = "Datadog Logs"))]
     DatadogLogs(datadog::logs::DatadogLogsConfig),
 
-    /// Datadog Metrics.
+    /// Publish metric events to Datadog.
     #[cfg(feature = "sinks-datadog_metrics")]
+    #[configurable(metadata(docs::label = "Datadog Metrics"))]
     DatadogMetrics(datadog::metrics::DatadogMetricsConfig),
 
-    /// Datadog Traces.
+    /// Publish traces to Datadog.
     #[cfg(feature = "sinks-datadog_traces")]
+    #[configurable(metadata(docs::label = "Datadog Traces"))]
     DatadogTraces(datadog::traces::DatadogTracesConfig),
 
-    /// Elasticsearch.
+    /// Index observability events in Elasticsearch.
     #[cfg(feature = "sinks-elasticsearch")]
+    #[configurable(metadata(docs::label = "Elasticsearch"))]
     Elasticsearch(elasticsearch::ElasticsearchConfig),
 
-    /// File.
+    /// Output observability events into files.
     #[cfg(feature = "sinks-file")]
+    #[configurable(metadata(docs::label = "File"))]
     File(file::FileSinkConfig),
 
-    /// Google Chronicle (unstructured).
+    /// Store unstructured log events in Google Chronicle.
     #[cfg(feature = "sinks-gcp")]
+    #[configurable(metadata(docs::label = "GCP Chronicle Unstructured"))]
     GcpChronicleUnstructured(gcp::chronicle_unstructured::ChronicleUnstructuredConfig),
 
-    /// GCP Stackdriver Logs.
+    /// Deliver logs to GCP’s Cloud Operations suite.
     #[cfg(feature = "sinks-gcp")]
+    #[configurable(metadata(docs::label = "GCP Operations (Stackdriver)"))]
     GcpStackdriverLogs(gcp::stackdriver_logs::StackdriverConfig),
 
-    /// GCP Stackdriver Metrics.
+    /// Deliver metrics to GCP’s Cloud Monitoring system.
     #[cfg(feature = "sinks-gcp")]
+    #[configurable(metadata(docs::label = "GCP Cloud Monitoring (Stackdriver)"))]
     GcpStackdriverMetrics(gcp::stackdriver_metrics::StackdriverConfig),
 
-    /// GCP Cloud Storage.
+    /// Store observability events in GCP Cloud Storage.
     #[cfg(feature = "sinks-gcp")]
+    #[configurable(metadata(docs::label = "GCP Cloud Storage"))]
     GcpCloudStorage(gcp::cloud_storage::GcsSinkConfig),
 
-    /// GCP Pub/Sub.
+    /// Publish observability events to GCP’s Pub/Sub messaging system.
     #[cfg(feature = "sinks-gcp")]
+    #[configurable(metadata(docs::label = "GCP Pub/Sub"))]
     GcpPubsub(gcp::pubsub::PubsubConfig),
 
-    /// Honeycomb.
+    /// Deliver log events to Honeycomb.
     #[cfg(feature = "sinks-honeycomb")]
+    #[configurable(metadata(docs::label = "Honeycomb"))]
     Honeycomb(honeycomb::HoneycombConfig),
 
-    /// HTTP.
+    /// Deliver observability event data to an HTTP server.
     #[cfg(feature = "sinks-http")]
+    #[configurable(metadata(docs::label = "HTTP"))]
     Http(http::HttpSinkConfig),
 
-    /// Humio Logs.
+    /// Deliver log event data to Humio.
     #[cfg(feature = "sinks-humio")]
+    #[configurable(metadata(docs::label = "Humio Logs"))]
     HumioLogs(humio::logs::HumioLogsConfig),
 
-    /// Humio Metrics.
+    /// Deliver metric event data to Humio.
     #[cfg(feature = "sinks-humio")]
+    #[configurable(metadata(docs::label = "Humio Metrics"))]
     HumioMetrics(humio::metrics::HumioMetricsConfig),
 
-    /// InfluxDB Logs.
+    /// Deliver log event data to InfluxDB.
     #[cfg(any(feature = "sinks-influxdb", feature = "prometheus-integration-tests"))]
+    #[configurable(metadata(docs::label = "InfluxDB Logs"))]
     InfluxdbLogs(influxdb::logs::InfluxDbLogsConfig),
 
-    /// InfluxDB Metrics.
+    /// Deliver metric event data to InfluxDB.
     #[cfg(any(feature = "sinks-influxdb", feature = "prometheus-integration-tests"))]
+    #[configurable(metadata(docs::label = "InfluxDB Metrics"))]
     InfluxdbMetrics(influxdb::metrics::InfluxDbConfig),
 
-    /// Kafka.
+    /// Publish observability event data to Apache Kafka topics.
     #[cfg(feature = "sinks-kafka")]
+    #[configurable(metadata(docs::label = "Kafka"))]
     Kafka(kafka::KafkaSinkConfig),
 
-    /// LogDNA.
+    /// Deliver log event data to LogDNA.
     #[cfg(feature = "sinks-logdna")]
+    #[configurable(metadata(docs::label = "LogDNA"))]
     Logdna(logdna::LogdnaConfig),
 
-    /// Loki.
+    /// Deliver log event data to the Loki aggregation system.
     #[cfg(feature = "sinks-loki")]
+    #[configurable(metadata(docs::label = "Loki"))]
     Loki(loki::LokiConfig),
 
-    /// NATS.
+    /// Publish observability data to subjects on the NATS messaging system.
     #[cfg(feature = "sinks-nats")]
+    #[configurable(metadata(docs::label = "NATS"))]
     Nats(self::nats::NatsSinkConfig),
 
-    /// New Relic.
+    /// Deliver events to New Relic.
     #[cfg(feature = "sinks-new_relic")]
+    #[configurable(metadata(docs::label = "New Relic"))]
     NewRelic(new_relic::NewRelicConfig),
 
-    /// Papertrail.
+    /// Deliver log events to Papertrail from SolarWinds.
     #[cfg(feature = "sinks-papertrail")]
+    #[configurable(metadata(docs::label = "Papertrail"))]
     Papertrail(papertrail::PapertrailConfig),
 
-    /// Prometheus Exporter.
+    /// Output metric events to a Prometheus exporter running on the host.
     #[cfg(feature = "sinks-prometheus")]
+    #[configurable(metadata(docs::label = "Prometheus Exporter"))]
     PrometheusExporter(prometheus::exporter::PrometheusExporterConfig),
 
-    /// Prometheus Remote Write.
+    /// Deliver metric data to a Prometheus remote write endpoint.
     #[cfg(feature = "sinks-prometheus")]
+    #[configurable(metadata(docs::label = "Prometheus Remote Write"))]
     PrometheusRemoteWrite(prometheus::remote_write::RemoteWriteConfig),
 
-    /// Apache Pulsar.
+    /// Publish observability events to Apache Pulsar topics.
     #[cfg(feature = "sinks-pulsar")]
+    #[configurable(metadata(docs::label = "Pulsar"))]
     Pulsar(pulsar::PulsarSinkConfig),
 
-    /// Redis.
+    /// Publish observability data to Redis.
     #[cfg(feature = "sinks-redis")]
+    #[configurable(metadata(docs::label = "Redis"))]
     Redis(redis::RedisSinkConfig),
 
-    /// Sematext Logs.
+    /// Publish log events to Sematext.
     #[cfg(feature = "sinks-sematext")]
+    #[configurable(metadata(docs::label = "Sematext Logs"))]
     SematextLogs(sematext::logs::SematextLogsConfig),
 
-    /// Sematext Metrics.
+    /// Publish metric events to Sematext.
     #[cfg(feature = "sinks-sematext")]
+    #[configurable(metadata(docs::label = "Sematext Metrics"))]
     SematextMetrics(sematext::metrics::SematextMetricsConfig),
 
-    /// Socket.
+    /// Deliver logs to a remote socket endpoint.
     #[cfg(feature = "sinks-socket")]
+    #[configurable(metadata(docs::label = "Socket"))]
     Socket(socket::SocketSinkConfig),
 
-    /// Splunk HEC Logs.
+    /// Deliver log data to Splunk’s HTTP Event Collector.
     #[cfg(feature = "sinks-splunk_hec")]
+    #[configurable(metadata(docs::label = "Splunk HEC Logs"))]
     SplunkHecLogs(splunk_hec::logs::config::HecLogsSinkConfig),
 
-    /// Splunk HEC Metrics.
+    /// Deliver metric data to Splunk’s HTTP Event Collector.
     #[cfg(feature = "sinks-splunk_hec")]
+    #[configurable(metadata(docs::label = "Splunk HEC Metrics"))]
     SplunkHecMetrics(splunk_hec::metrics::config::HecMetricsSinkConfig),
 
-    /// StatsD.
+    /// Deliver metric data to a StatsD aggregator.
     #[cfg(feature = "sinks-statsd")]
+    #[configurable(metadata(docs::label = "Statsd"))]
     Statsd(statsd::StatsdSinkConfig),
 
     /// Test (adaptive concurrency).
     #[cfg(all(test, feature = "sources-demo_logs"))]
+    #[configurable(metadata(docs::label = ""))]
     TestArc(self::util::adaptive_concurrency::tests::TestConfig),
 
     /// Test (backpressure).
@@ -355,12 +404,14 @@ pub enum Sinks {
     /// Unit test stream.
     UnitTestStream(UnitTestStreamSinkConfig),
 
-    /// Vector.
+    /// Relay observability data to a Vector instance.
     #[cfg(feature = "sinks-vector")]
+    #[configurable(metadata(docs::label = "Vector"))]
     Vector(vector::VectorConfig),
 
-    /// Websocket.
+    /// Deliver observability event data to a websocket listener.
     #[cfg(feature = "sinks-websocket")]
+    #[configurable(metadata(docs::label = "Websocket"))]
     Websocket(websocket::WebSocketSinkConfig),
 }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -196,7 +196,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "Host metrics"))]
     HostMetrics(host_metrics::HostMetricsConfig),
 
-    /// Host a HTTP endpoint to receive logs.
+    /// Host an HTTP endpoint to receive logs.
     #[cfg(feature = "sources-http_server")]
     #[configurable(deprecated)]
     #[configurable(metadata(docs::label = "HTTP"))]
@@ -207,7 +207,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "HTTP Client"))]
     HttpClient(http_client::HttpClientConfig),
 
-    /// Host a HTTP endpoint to receive logs.
+    /// Host an HTTP endpoint to receive logs.
     #[cfg(feature = "sources-http_server")]
     #[configurable(metadata(docs::label = "HTTP Server"))]
     HttpServer(http_server::SimpleHttpConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -302,7 +302,7 @@ pub enum Sources {
     #[cfg(test)]
     TestTripwire(crate::test_util::mock::sources::TripwireSourceConfig),
 
-    /// Collect logs using the socket client.
+    /// Collect logs over a socket.
     #[cfg(feature = "sources-socket")]
     #[configurable(metadata(docs::label = "Socket"))]
     Socket(socket::SocketConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -181,12 +181,12 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "Fluent"))]
     Fluent(fluent::FluentConfig),
 
-    /// Fetch observability events from GCP’s Pub/Sub messaging system.
+    /// Fetch observability events from GCP's Pub/Sub messaging system.
     #[cfg(feature = "sources-gcp_pubsub")]
     #[configurable(metadata(docs::label = "GCP Pub/Sub"))]
     GcpPubsub(gcp_pubsub::PubsubConfig),
 
-    /// Collect logs from Heroku’s Logplex, the router responsible for receiving logs from your Heroku apps.
+    /// Collect logs from Heroku's Logplex, the router responsible for receiving logs from your Heroku apps.
     #[cfg(feature = "sources-heroku_logs")]
     #[configurable(metadata(docs::label = "Heroku Logplex"))]
     HerokuLogs(heroku_logs::LogplexConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -106,144 +106,181 @@ enum BuildError {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[enum_dispatch(SourceConfig)]
 pub enum Sources {
-    /// AMQP.
+    /// Collect events from AMQP 0.9.1 compatible brokers like RabbitMQ.
     #[cfg(feature = "sources-amqp")]
+    #[configurable(metadata(docs::label = "AMQP"))]
     Amqp(amqp::AmqpSourceConfig),
 
-    /// Apache HTTP Server (HTTPD) Metrics.
+    /// Collect metrics from Apache's HTTPD server.
     #[cfg(feature = "sources-apache_metrics")]
+    #[configurable(metadata(docs::label = "Apache Metrics"))]
     ApacheMetrics(apache_metrics::ApacheMetricsConfig),
 
-    /// AWS ECS Metrics.
+    /// Collect Docker container stats for tasks running in AWS ECS and AWS Fargate.
     #[cfg(feature = "sources-aws_ecs_metrics")]
+    #[configurable(metadata(docs::label = "AWS ECS Metrics"))]
     AwsEcsMetrics(aws_ecs_metrics::AwsEcsMetricsSourceConfig),
 
-    /// AWS Kinesis Firehose.
+    /// Collect logs from AWS Kinesis Firehose.
     #[cfg(feature = "sources-aws_kinesis_firehose")]
+    #[configurable(metadata(docs::label = "AWS Kinesis Firehose"))]
     AwsKinesisFirehose(aws_kinesis_firehose::AwsKinesisFirehoseConfig),
 
-    /// AWS S3.
+    /// Collect logs from AWS S3.
     #[cfg(feature = "sources-aws_s3")]
+    #[configurable(metadata(docs::label = "AWS S3"))]
     AwsS3(aws_s3::AwsS3Config),
 
-    /// AWS SQS.
+    /// Collect logs from AWS SQS.
     #[cfg(feature = "sources-aws_sqs")]
+    #[configurable(metadata(docs::label = "AWS SQS"))]
     AwsSqs(aws_sqs::AwsSqsConfig),
 
-    /// Datadog Agent.
+    /// Receive logs, metrics, and traces collected by a Datadog Agent.
     #[cfg(feature = "sources-datadog_agent")]
+    #[configurable(metadata(docs::label = "Datadog Agent"))]
     DatadogAgent(datadog_agent::DatadogAgentConfig),
 
-    /// Demo logs.
+    /// Generate fake log events, which can be useful for testing and demos.
     #[cfg(feature = "sources-demo_logs")]
+    #[configurable(metadata(docs::label = "Demo Logs"))]
     DemoLogs(demo_logs::DemoLogsConfig),
 
-    /// DNSTAP.
+    /// Collect DNS logs from a dnstap-compatible server.
     #[cfg(all(unix, feature = "sources-dnstap"))]
+    #[configurable(metadata(docs::label = "dnstap"))]
     Dnstap(dnstap::DnstapConfig),
 
-    /// Docker Logs.
+    /// Collect logs from Docker.
     #[cfg(feature = "sources-docker_logs")]
+    #[configurable(metadata(docs::label = "Docker Logs"))]
     DockerLogs(docker_logs::DockerLogsConfig),
 
-    /// EventStoreDB Metrics.
+    /// Receive metrics from collected by a EventStoreDB.
     #[cfg(feature = "sources-eventstoredb_metrics")]
+    #[configurable(metadata(docs::label = "EventStoreDB Metrics"))]
     EventstoredbMetrics(eventstoredb_metrics::EventStoreDbConfig),
 
-    /// Exec.
+    /// Collect output from a process running on the host.
     #[cfg(feature = "sources-exec")]
+    #[configurable(metadata(docs::label = "Exec"))]
     Exec(exec::ExecConfig),
 
-    /// File.
+    /// Collect logs from files.
     #[cfg(feature = "sources-file")]
+    #[configurable(metadata(docs::label = "File"))]
     File(file::FileConfig),
 
-    /// File descriptor.
+    /// Collect logs from a file descriptor.
     #[cfg(all(unix, feature = "sources-file-descriptor"))]
+    #[configurable(metadata(docs::label = "File Descriptor"))]
     FileDescriptor(file_descriptors::file_descriptor::FileDescriptorSourceConfig),
 
-    /// Fluent.
+    /// Collect logs from a Fluentd or Fluent Bit agent.
     #[cfg(feature = "sources-fluent")]
+    #[configurable(metadata(docs::label = "Fluent"))]
     Fluent(fluent::FluentConfig),
 
-    /// GCP Pub/Sub.
+    /// Fetch observability events from GCP’s Pub/Sub messaging system.
     #[cfg(feature = "sources-gcp_pubsub")]
+    #[configurable(metadata(docs::label = "GCP Pub/Sub"))]
     GcpPubsub(gcp_pubsub::PubsubConfig),
 
-    /// Heroku Logs.
+    /// Collect logs from Heroku’s Logplex, the router responsible for receiving logs
+    /// from your Heroku apps.
     #[cfg(feature = "sources-heroku_logs")]
+    #[configurable(metadata(docs::label = "Heroku Logplex"))]
     HerokuLogs(heroku_logs::LogplexConfig),
 
-    /// Host Metrics.
+    /// Collect metric data from the local system.
     #[cfg(feature = "sources-host_metrics")]
+    #[configurable(metadata(docs::label = "Host metrics"))]
     HostMetrics(host_metrics::HostMetricsConfig),
 
-    /// HTTP.
+    /// Receive logs emitted by an HTTP server.
     #[cfg(feature = "sources-http_server")]
+    #[configurable(deprecated)]
+    #[configurable(metadata(docs::label = "HTTP"))]
     Http(http_server::HttpConfig),
 
-    /// HTTP Client.
+    /// Pull observability data from an HTTP server at a configured interval.
     #[cfg(feature = "sources-http_client")]
+    #[configurable(metadata(docs::label = "HTTP Client"))]
     HttpClient(http_client::HttpClientConfig),
 
-    /// HTTP Server.
+    /// Receive logs emitted by an HTTP server.
     #[cfg(feature = "sources-http_server")]
+    #[configurable(metadata(docs::label = "HTTP Server"))]
     HttpServer(http_server::SimpleHttpConfig),
 
-    /// Internal Logs.
+    /// Expose all log and trace messages emitted by the running Vector instance.
     #[cfg(feature = "sources-internal_logs")]
+    #[configurable(metadata(docs::label = "Internal Logs"))]
     InternalLogs(internal_logs::InternalLogsConfig),
 
-    /// Internal Metrics.
+    /// Access to the metrics produced by Vector itself and process them in your Vector pipeline.
     #[cfg(feature = "sources-internal_metrics")]
+    #[configurable(metadata(docs::label = "Internal Metrics"))]
     InternalMetrics(internal_metrics::InternalMetricsConfig),
 
-    /// Journald.
+    /// Collect logs from JournalD.
     #[cfg(all(unix, feature = "sources-journald"))]
+    #[configurable(metadata(docs::label = "JournalD"))]
     Journald(journald::JournaldConfig),
 
-    /// Kafka.
+    /// Collect logs from Kafka.
     #[cfg(feature = "sources-kafka")]
+    #[configurable(metadata(docs::label = "Kafka"))]
     Kafka(kafka::KafkaSourceConfig),
 
-    /// Kubernetes Logs.
+    /// Collect logs from Kubernetes Nodes.
     #[cfg(feature = "sources-kubernetes_logs")]
+    #[configurable(metadata(docs::label = "Kubernetes Logs"))]
     KubernetesLogs(kubernetes_logs::Config),
 
-    /// Logstash.
+    /// Collect logs from a Logstash agent.
     #[cfg(all(feature = "sources-logstash"))]
+    #[configurable(metadata(docs::label = "Logstash"))]
     Logstash(logstash::LogstashConfig),
 
-    /// MongoDB Metrics.
+    /// Collect metrics from the MongoDB database.
     #[cfg(feature = "sources-mongodb_metrics")]
+    #[configurable(metadata(docs::label = "MongoDB Metrics"))]
     MongodbMetrics(mongodb_metrics::MongoDbMetricsConfig),
 
-    /// NATS.
+    /// Read observability data from subjects on the NATS messaging system.
     #[cfg(all(feature = "sources-nats"))]
+    #[configurable(metadata(docs::label = "NATS"))]
     Nats(nats::NatsSourceConfig),
 
-    /// NGINX Metrics.
+    /// Collect metrics from NGINX.
     #[cfg(feature = "sources-nginx_metrics")]
+    #[configurable(metadata(docs::label = "NGINX"))]
     NginxMetrics(nginx_metrics::NginxMetricsConfig),
 
-    /// OpenTelemetry.
+    /// Receive OTLP data through gRPC or HTTP.
     #[cfg(feature = "sources-opentelemetry")]
+    #[configurable(metadata(docs::label = "OpenTelemetry"))]
     Opentelemetry(opentelemetry::OpentelemetryConfig),
 
-    /// PostgreSQL Metrics.
+    /// Collect metrics from the PostgreSQL database.
     #[cfg(feature = "sources-postgresql_metrics")]
+    #[configurable(metadata(docs::label = "PostgreSQL Metrics"))]
     PostgresqlMetrics(postgresql_metrics::PostgresqlMetricsConfig),
 
-    /// Prometheus Scrape.
+    /// Collect metrics via the Prometheus client.
     #[cfg(feature = "sources-prometheus")]
+    #[configurable(metadata(docs::label = "Prometheus Scrape"))]
     PrometheusScrape(prometheus::PrometheusScrapeConfig),
 
-    /// Prometheus Remote Write.
+    /// Collect metrics from Prometheus.
     #[cfg(feature = "sources-prometheus")]
+    #[configurable(metadata(docs::label = "Prometheus Remote Write"))]
     PrometheusRemoteWrite(prometheus::PrometheusRemoteWriteConfig),
 
-    /// Redis.
+    /// Collect observability data from Redis.
     #[cfg(feature = "sources-redis")]
+    #[configurable(metadata(docs::label = "Redis"))]
     Redis(redis::RedisSourceConfig),
 
     /// Test (backpressure).
@@ -266,24 +303,29 @@ pub enum Sources {
     #[cfg(test)]
     TestTripwire(crate::test_util::mock::sources::TripwireSourceConfig),
 
-    /// Socket.
+    /// Collect logs using the socket client.
     #[cfg(feature = "sources-socket")]
+    #[configurable(metadata(docs::label = "Socket"))]
     Socket(socket::SocketConfig),
 
-    /// Splunk HEC.
+    /// Receive logs from Splunk.
     #[cfg(feature = "sources-splunk_hec")]
+    #[configurable(metadata(docs::label = "Splunk HEC"))]
     SplunkHec(splunk_hec::SplunkConfig),
 
-    /// StatsD.
+    /// Collect metrics emitted by the StatsD aggregator.
     #[cfg(feature = "sources-statsd")]
+    #[configurable(metadata(docs::label = "StatsD"))]
     Statsd(statsd::StatsdConfig),
 
-    /// Stdin.
+    /// Collect logs sent via stdin.
     #[cfg(feature = "sources-stdin")]
+    #[configurable(metadata(docs::label = "stdin"))]
     Stdin(file_descriptors::stdin::StdinConfig),
 
-    /// Syslog.
+    /// Collect logs sent via Syslog.
     #[cfg(feature = "sources-syslog")]
+    #[configurable(metadata(docs::label = "Syslog"))]
     Syslog(syslog::SyslogConfig),
 
     /// Unit test.
@@ -292,8 +334,9 @@ pub enum Sources {
     /// Unit test stream.
     UnitTestStream(UnitTestStreamSourceConfig),
 
-    /// Vector.
+    /// Collect observability data from a Vector instance.
     #[cfg(feature = "sources-vector")]
+    #[configurable(metadata(docs::label = "Vector"))]
     Vector(vector::VectorConfig),
 }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -232,7 +232,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "Kafka"))]
     Kafka(kafka::KafkaSourceConfig),
 
-    /// Collect logs from Kubernetes Nodes.
+    /// Collect Pod logs from Kubernetes Nodes.
     #[cfg(feature = "sources-kubernetes_logs")]
     #[configurable(metadata(docs::label = "Kubernetes Logs"))]
     KubernetesLogs(kubernetes_logs::Config),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -151,7 +151,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "dnstap"))]
     Dnstap(dnstap::DnstapConfig),
 
-    /// Collect logs from Docker.
+    /// Collect container logs from a Docker Daemon.
     #[cfg(feature = "sources-docker_logs")]
     #[configurable(metadata(docs::label = "Docker Logs"))]
     DockerLogs(docker_logs::DockerLogsConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -272,7 +272,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "Prometheus Scrape"))]
     PrometheusScrape(prometheus::PrometheusScrapeConfig),
 
-    /// Collect metrics from Prometheus.
+    /// Receive metric via the Prometheus Remote Write protocol.
     #[cfg(feature = "sources-prometheus")]
     #[configurable(metadata(docs::label = "Prometheus Remote Write"))]
     PrometheusRemoteWrite(prometheus::PrometheusRemoteWriteConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -196,7 +196,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "Host metrics"))]
     HostMetrics(host_metrics::HostMetricsConfig),
 
-    /// Receive logs emitted by an HTTP server.
+    /// Host a HTTP endpoint to receive logs.
     #[cfg(feature = "sources-http_server")]
     #[configurable(deprecated)]
     #[configurable(metadata(docs::label = "HTTP"))]
@@ -207,7 +207,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "HTTP Client"))]
     HttpClient(http_client::HttpClientConfig),
 
-    /// Receive logs emitted by an HTTP server.
+    /// Host a HTTP endpoint to receive logs.
     #[cfg(feature = "sources-http_server")]
     #[configurable(metadata(docs::label = "HTTP Server"))]
     HttpServer(http_server::SimpleHttpConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -212,7 +212,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "HTTP Server"))]
     HttpServer(http_server::SimpleHttpConfig),
 
-    /// Expose all log and trace messages emitted by the running Vector instance.
+    /// Expose all log messages emitted by the running Vector instance.
     #[cfg(feature = "sources-internal_logs")]
     #[configurable(metadata(docs::label = "Internal Logs"))]
     InternalLogs(internal_logs::InternalLogsConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -186,8 +186,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "GCP Pub/Sub"))]
     GcpPubsub(gcp_pubsub::PubsubConfig),
 
-    /// Collect logs from Heroku’s Logplex, the router responsible for receiving logs
-    /// from your Heroku apps.
+    /// Collect logs from Heroku’s Logplex, the router responsible for receiving logs from your Heroku apps.
     #[cfg(feature = "sources-heroku_logs")]
     #[configurable(metadata(docs::label = "Heroku Logplex"))]
     HerokuLogs(heroku_logs::LogplexConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -212,12 +212,12 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "HTTP Server"))]
     HttpServer(http_server::SimpleHttpConfig),
 
-    /// Expose all log messages emitted by the running Vector instance.
+    /// Expose internal log messages emitted by the running Vector instance.
     #[cfg(feature = "sources-internal_logs")]
     #[configurable(metadata(docs::label = "Internal Logs"))]
     InternalLogs(internal_logs::InternalLogsConfig),
 
-    /// Access to the metrics produced by Vector itself and process them in your Vector pipeline.
+    /// Expose internal metrics emitted by the running Vector instance.
     #[cfg(feature = "sources-internal_metrics")]
     #[configurable(metadata(docs::label = "Internal Metrics"))]
     InternalMetrics(internal_metrics::InternalMetricsConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -267,7 +267,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "PostgreSQL Metrics"))]
     PostgresqlMetrics(postgresql_metrics::PostgresqlMetricsConfig),
 
-    /// Collect metrics via the Prometheus client.
+    /// Collect metrics from Prometheus exporters.
     #[cfg(feature = "sources-prometheus")]
     #[configurable(metadata(docs::label = "Prometheus Scrape"))]
     PrometheusScrape(prometheus::PrometheusScrapeConfig),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -227,7 +227,7 @@ pub enum Sources {
     #[configurable(metadata(docs::label = "JournalD"))]
     Journald(journald::JournaldConfig),
 
-    /// Collect logs from Kafka.
+    /// Collect logs from Apache Kafka.
     #[cfg(feature = "sources-kafka")]
     #[configurable(metadata(docs::label = "Kafka"))]
     Kafka(kafka::KafkaSourceConfig),

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -59,49 +59,61 @@ enum BuildError {
 pub enum Transforms {
     /// Aggregate metrics passing through a topology.
     #[cfg(feature = "transforms-aggregate")]
+    #[configurable(metadata(docs::label = "Aggregate"))]
     Aggregate(aggregate::AggregateConfig),
 
     /// Parse metadata emitted by AWS EC2 instances.
     #[cfg(feature = "transforms-aws_ec2_metadata")]
+    #[configurable(metadata(docs::label = "AWS EC2 Metadata"))]
     AwsEc2Metadata(aws_ec2_metadata::Ec2Metadata),
 
     /// Deduplicate logs passing through a topology.
     #[cfg(feature = "transforms-dedupe")]
+    #[configurable(metadata(docs::label = "Dedupe"))]
     Dedupe(dedupe::DedupeConfig),
 
     /// Filter events based on a set of conditions.
     #[cfg(feature = "transforms-filter")]
+    #[configurable(metadata(docs::label = "Filter"))]
     Filter(filter::FilterConfig),
 
     /// Convert log events to metric events.
+    #[configurable(metadata(docs::label = "Log To Metric"))]
     LogToMetric(log_to_metric::LogToMetricConfig),
 
     /// Modify event data using the Lua programming language.
     #[cfg(feature = "transforms-lua")]
+    #[configurable(metadata(docs::label = "Lua"))]
     Lua(lua::LuaConfig),
 
     /// Convert metric events to log events.
     #[cfg(feature = "transforms-metric_to_log")]
+    #[configurable(metadata(docs::label = "Metric To Log"))]
     MetricToLog(metric_to_log::MetricToLogConfig),
 
     /// Collapse multiple log events into a single event based on a set of conditions and merge strategies.
     #[cfg(feature = "transforms-reduce")]
+    #[configurable(metadata(docs::label = "Reduce"))]
     Reduce(reduce::ReduceConfig),
 
     /// Modify your observability data as it passes through your topology using Vector Remap Language (VRL).
     #[cfg(feature = "transforms-remap")]
+    #[configurable(metadata(docs::label = "Remap"))]
     Remap(remap::RemapConfig),
 
     /// Split a stream of events into multiple sub-streams based on user-supplied conditions.
     #[cfg(feature = "transforms-route")]
+    #[configurable(metadata(docs::label = "Route"))]
     Route(route::RouteConfig),
 
     /// Sample events from an event stream based on supplied criteria and at a configurable rate.
     #[cfg(feature = "transforms-sample")]
+    #[configurable(metadata(docs::label = "Sample"))]
     Sample(sample::SampleConfig),
 
     /// Limit the cardinality of tags on metrics events as a safeguard against cardinality explosion.
     #[cfg(feature = "transforms-tag_cardinality_limit")]
+    #[configurable(metadata(docs::label = "Tag Cardinality Limit"))]
     TagCardinalityLimit(tag_cardinality_limit::TagCardinalityLimitConfig),
 
     /// Test (basic).
@@ -114,6 +126,7 @@ pub enum Transforms {
 
     /// Rate limit logs passing through a topology.
     #[cfg(feature = "transforms-throttle")]
+    #[configurable(metadata(docs::label = "Throttle"))]
     Throttle(throttle::ThrottleConfig),
 }
 


### PR DESCRIPTION
This PR adds new `docs::label` meta to each component and updates descriptions to match  labels used in Cue data (for the most part).

The purpose is to disambiguate names from descriptions and give components standard meta in generated schema.

I've taken some liberties with grammar in places, preferring Title Cased names where appropriate and attempting to match brand or product names as they're commonly represented. Feel free to suggest additional changes as necessary. Both names and descriptions will be used in public UI.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
