### PR TITLE
chore(ci): test file_to_blackhole egress throughput

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -41,8 +41,8 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.6.5"
-          export LADING_VERSION="0.11.3"
+          export SMP_CRATE_VERSION="0.7.0"
+          export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"
           echo "replicas: ${REPLICAS}"

--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -41,7 +41,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.7.0"
+          export SMP_CRATE_VERSION="0.7.1"
           export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"

--- a/regression/cases/file_to_blackhole/experiment.yaml
+++ b/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,0 +1,2 @@
+optimization_goal: egress_throughput
+erratic: false

--- a/regression/cases/file_to_blackhole/lading/lading.yaml
+++ b/regression/cases/file_to_blackhole/lading/lading.yaml
@@ -8,3 +8,7 @@ generator:
       bytes_per_second: "100Mb"
       maximum_bytes_per_file: "100Mb"
       maximum_prebuild_cache_size_bytes: "400Mb"
+
+blackhole:
+  - tcp:
+      binding_addr: "127.0.0.1:15400"


### PR DESCRIPTION
As part of updating the regression testing backend, this commit changes the optimization goal for the `file_to_blackhole` experiment to egress throughput from ingress throughput (the default).

This commit also modifies the Lading configuration for this experiment so that it writes a file to a TCP blackhole.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
