### PR TITLE
fix(distribution): Add missing check_proc function to install script

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -173,7 +173,7 @@ install_from_archive() {
     ensure mkdir -p "$_dir"
 
     printf "%s Downloading Vector via %s" "$_prompt" "$_url"
-    ensure downloader "$_url" "$_file"
+    ensure downloader "$_url" "$_file" "$_arch"
     printf " ✓\n"
 
     ensure mkdir -p "$prefix"

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -268,6 +268,14 @@ get_gnu_musl_glibc() {
   fi
 }
 
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
 get_bitness() {
     need_cmd head
     # Architecture detection without dependencies beyond coreutils.


### PR DESCRIPTION
Missed in #16398. Definitely could use some tests of this script on different platforms.

Fixes: #16472

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
