### PR TITLE
chore(external docs): Add clarifying example for GCP Storage key_prefix usage

### DIFF
--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -319,6 +319,15 @@ components: sinks: aws_s3: components._aws & {
 				You can control the resulting name via the [`key_prefix`](#key_prefix),
 				[`filename_time_format`](#filename_time_format), and
 				[`filename_append_uuid`](#filename_append_uuid) options.
+
+				For example, to store objects at the root S3 folder, without a timestamp or UUID use
+				these configuration options:
+
+				```text
+				key_prefix = "{{ my_file_name }}"
+				filename_time_format = ""
+				filename_append_uuid = false
+				```
 				"""
 		}
 

--- a/website/cue/reference/components/sinks/azure_blob.cue
+++ b/website/cue/reference/components/sinks/azure_blob.cue
@@ -111,6 +111,15 @@ components: sinks: azure_blob: {
 
 				You can control the resulting name via the [`blob_prefix`](#blob_prefix),
 				[`blob_time_format`](#blob_time_format), and [`blob_append_uuid`](#blob_append_uuid) options.
+
+				For example, to store objects at the root Azure storage folder, without a timestamp or UUID use
+				these configuration options:
+
+				```text
+				blob_prefix = "{{ my_file_name }}"
+				blob_time_format = ""
+				blob_append_uuid = false
+				```
 				"""
 		}
 	}

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -129,6 +129,15 @@ components: sinks: gcp_cloud_storage: {
 				You can control the resulting name via the [`key_prefix`](#key_prefix),
 				[`filename_time_format`](#filename_time_format),
 				and [`filename_append_uuid`](#filename_append_uuid) options.
+
+				For example, to store objects at the root GCS folder, without a timestamp or UUID use
+				these configuration options:
+
+				```text
+				key_prefix = "{{ my_file_name }}"
+				filename_time_format = ""
+				filename_append_uuid = false
+				```
 				"""
 		}
 


### PR DESCRIPTION
Based on a discord support discussion where the combination of these options was not clear.
