### PR TITLE
Revert "chore(config): mark structs as `additionalProperties: false`"

### DIFF
--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -1,12 +1,11 @@
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::Encoder;
-use vector_config::configurable_component;
 use vector_core::{config::DataType, event::Event, schema};
 
 use crate::MetricTagValues;
 
 /// Config used to build a `JsonSerializer`.
-#[configurable_component]
+#[crate::configurable_component]
 #[derive(Debug, Clone, Default)]
 pub struct JsonSerializerConfig {
     /// Controls how metric tag values are encoded.

--- a/lib/codecs/src/encoding/format/text.rs
+++ b/lib/codecs/src/encoding/format/text.rs
@@ -1,7 +1,6 @@
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::Encoder;
 use value::Kind;
-use vector_config::configurable_component;
 use vector_core::{
     config::{log_schema, DataType},
     event::Event,
@@ -11,7 +10,7 @@ use vector_core::{
 use crate::MetricTagValues;
 
 /// Config used to build a `TextSerializer`.
-#[configurable_component]
+#[crate::configurable_component]
 #[derive(Debug, Clone, Default)]
 pub struct TextSerializerConfig {
     /// Controls how metric tag values are encoded.

--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -273,9 +273,11 @@ fn build_named_struct_generate_schema_fn(
 
             let had_unflatted_properties = !properties.is_empty();
 
+            let additional_properties = None;
             let mut schema = ::vector_config::schema::generate_struct_schema(
                 properties,
                 required,
+                additional_properties,
             );
 
             // If we have any flattened subschemas, deal with them now.
@@ -668,7 +670,8 @@ fn generate_enum_struct_named_variant_schema(
 
             ::vector_config::schema::generate_struct_schema(
                 properties,
-                required
+                required,
+                None
             )
         }
     }
@@ -856,7 +859,8 @@ fn generate_enum_variant_schema(variant: &Variant<'_>) -> proc_macro2::TokenStre
 
                 ::vector_config::schema::generate_struct_schema(
                     wrapper_properties,
-                    wrapper_required
+                    wrapper_required,
+                    None
                 )
             }
         }
@@ -910,7 +914,8 @@ fn generate_single_field_struct_schema(
 
             ::vector_config::schema::generate_struct_schema(
                 wrapper_properties,
-                wrapper_required
+                wrapper_required,
+                None
             )
         }
     }

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -344,7 +344,6 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
 
     // Generate and apply all of the necessary derives.
     let mut derives = Punctuated::<Path, Comma>::new();
-
     derives.push(parse_quote_spanned! {input.ident.span()=>
         ::vector_config_macros::Configurable
     });

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -274,6 +274,7 @@ where
 pub fn generate_struct_schema(
     properties: IndexMap<String, SchemaObject>,
     required: BTreeSet<String>,
+    additional_properties: Option<Box<Schema>>,
 ) -> SchemaObject {
     let properties = properties
         .into_iter()
@@ -284,7 +285,7 @@ pub fn generate_struct_schema(
         object: Some(Box::new(ObjectValidation {
             properties,
             required,
-            additional_properties: Some(Box::new(Schema::Bool(false))),
+            additional_properties,
             ..Default::default()
         })),
         ..Default::default()
@@ -475,7 +476,7 @@ pub fn generate_internal_tagged_variant_schema(
     let mut required = BTreeSet::new();
     required.insert(tag);
 
-    generate_struct_schema(properties, required)
+    generate_struct_schema(properties, required, None)
 }
 
 pub fn generate_root_schema<T>() -> Result<RootSchema, GenerateError>

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -424,7 +424,9 @@ impl Configurable for Duration {
         required.insert("secs".into());
         required.insert("nsecs".into());
 
-        Ok(crate::schema::generate_struct_schema(properties, required))
+        Ok(crate::schema::generate_struct_schema(
+            properties, required, None,
+        ))
     }
 }
 

--- a/scripts/generate-component-docs.rb
+++ b/scripts/generate-component-docs.rb
@@ -887,7 +887,7 @@ def resolve_bare_schema(root_schema, schema)
       # If the object schema has `additionalProperties` set, we add an additional field
       # (`*`) which uses the specified schema for that field.
       additional_properties = schema['additionalProperties']
-      if !additional_properties.nil? && additional_properties != false
+      if !additional_properties.nil?
         @logger.debug "Handling additional properties."
 
         # Normally, we only get here if there's a hashmap field on a struct that can act as the

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -290,7 +290,7 @@ impl Configurable for Compression {
         );
         properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
 
-        let mut full_subschema = generate_struct_schema(properties, required);
+        let mut full_subschema = generate_struct_schema(properties, required, None);
         let mut full_metadata = Metadata::<()>::with_description("");
         full_metadata.add_custom_attribute(CustomAttribute::flag("docs::hidden"));
         apply_metadata(&mut full_subschema, full_metadata);


### PR DESCRIPTION
Reverts vectordotdev/vector#16464

We ran into some issues with `additionalProperties: false`; putting up as a ~draft~ PR to test this locally.