### PR TITLE
chore(config): Store default value in a box

### DIFF
--- a/lib/vector-config-macros/src/ast/container.rs
+++ b/lib/vector-config-macros/src/ast/container.rs
@@ -236,7 +236,7 @@ impl<'a> Container<'a> {
 
                 let original = input;
                 let name = serde.attrs.name().deserialize_name();
-                let default_value = get_serde_default_value(serde.attrs.default());
+                let default_value = get_serde_default_value(&serde.ident, serde.attrs.default());
 
                 let container = Container {
                     original,

--- a/lib/vector-config-macros/src/ast/field.rs
+++ b/lib/vector-config-macros/src/ast/field.rs
@@ -33,7 +33,7 @@ impl<'a> Field<'a> {
         let original = serde.original;
 
         let name = serde.attrs.name().deserialize_name();
-        let default_value = get_serde_default_value(serde.attrs.default());
+        let default_value = get_serde_default_value(&serde.ty, serde.attrs.default());
 
         Attributes::from_attributes(&original.attrs)
             .and_then(|attrs| {

--- a/lib/vector-config/src/metadata.rs
+++ b/lib/vector-config/src/metadata.rs
@@ -2,11 +2,13 @@ use std::fmt;
 
 use vector_config_common::{attributes::CustomAttribute, validation};
 
+use crate::ToValue;
+
 /// The metadata associated with a given type or field.
 pub struct Metadata<T> {
     title: Option<&'static str>,
     description: Option<&'static str>,
-    default_value: Option<T>,
+    default_value: Option<Box<dyn ToValue>>,
     custom_attributes: Vec<CustomAttribute>,
     deprecated: bool,
     deprecated_message: Option<&'static str>,
@@ -54,12 +56,12 @@ impl<T> Metadata<T> {
         self.description = None;
     }
 
-    pub fn default_value(&self) -> Option<&T> {
-        self.default_value.as_ref()
+    pub fn default_value(&self) -> Option<&dyn ToValue> {
+        self.default_value.as_deref()
     }
 
-    pub fn set_default_value(&mut self, default_value: T) {
-        self.default_value = Some(default_value);
+    pub fn set_default_value(&mut self, default_value: impl ToValue + 'static) {
+        self.default_value = Some(Box::new(default_value));
     }
 
     pub fn deprecated(&self) -> bool {

--- a/lib/vector-config/src/metadata.rs
+++ b/lib/vector-config/src/metadata.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use vector_config_common::{attributes::CustomAttribute, validation};
 
 /// The metadata associated with a given type or field.
-#[derive(Clone)]
 pub struct Metadata<T> {
     title: Option<&'static str>,
     description: Option<&'static str>,

--- a/lib/vector-config/src/metadata.rs
+++ b/lib/vector-config/src/metadata.rs
@@ -13,6 +13,7 @@ pub struct Metadata<T> {
     deprecated_message: Option<&'static str>,
     transparent: bool,
     validations: Vec<validation::Validation>,
+    _dummy: std::marker::PhantomData<T>,
 }
 
 impl<T> Metadata<T> {
@@ -122,6 +123,7 @@ impl<T> Metadata<T> {
             deprecated_message: other.deprecated_message.or(self.deprecated_message),
             transparent: other.transparent,
             validations: self.validations,
+            _dummy: Default::default(),
         }
     }
 
@@ -138,6 +140,7 @@ impl<T> Metadata<T> {
             deprecated_message: self.deprecated_message,
             transparent: self.transparent,
             validations: self.validations.clone(),
+            _dummy: Default::default(),
         }
     }
 }
@@ -153,6 +156,7 @@ impl<T> Default for Metadata<T> {
             deprecated_message: None,
             transparent: false,
             validations: Vec::new(),
+            _dummy: Default::default(),
         }
     }
 }

--- a/lib/vector-config/src/metadata.rs
+++ b/lib/vector-config/src/metadata.rs
@@ -58,19 +58,8 @@ impl<T> Metadata<T> {
         self.default_value.as_ref()
     }
 
-    pub fn with_default_value(default: T) -> Self {
-        Self {
-            default_value: Some(default),
-            ..Default::default()
-        }
-    }
-
     pub fn set_default_value(&mut self, default_value: T) {
         self.default_value = Some(default_value);
-    }
-
-    pub fn consume_default_value(&mut self) -> Option<T> {
-        self.default_value.take()
     }
 
     pub fn deprecated(&self) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -335,7 +335,7 @@ impl Display for Resource {
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct TestDefinition<T = OutputId> {
+pub struct TestDefinition<T: 'static = OutputId> {
     /// The name of the unit test.
     pub name: String,
 

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -263,7 +263,7 @@ impl Configurable for Compression {
             gzip_string_subschema,
             zlib_string_subschema,
         ]);
-        apply_metadata(&mut all_string_oneof_subschema, string_metadata.clone());
+        apply_metadata(&mut all_string_oneof_subschema, string_metadata);
 
         // Next we'll create a full schema for the given algorithms.
         //


### PR DESCRIPTION
Another baby step towards making configuration schemas object safe. This stores the default value for the config metadata in a box instead of a concrete type. The type bounds on the metadata remain for now, as I'm trying to make this minimal behavior-preserving change before tackling the generic bounds. As far as I can tell from `vector generate-schema`, the resulting data is identical.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
