### PR TITLE
fix(ci): adjust file_to_blackhole Vector config

### DIFF
--- a/regression/cases/file_to_blackhole/vector/vector.toml
+++ b/regression/cases/file_to_blackhole/vector/vector.toml
@@ -20,7 +20,9 @@ type = "prometheus_exporter"
 inputs = ["internal_metrics"]
 address = "0.0.0.0:9090"
 
-[sinks.blackhole]
-type = "blackhole"
-print_interval_secs = 0
+[sinks.socket_sink]
+type = "socket"
 inputs = ["file"]
+mode = "tcp"
+address = "127.0.0.1:15400"
+encoding.codec = "json"


### PR DESCRIPTION
As part of the changes in PR #16468, I modified the `file_to_blackhole` regression experiment's Lading configuration to add a Lading blackhole based on similar changes in a dogfood repo for regression testing. However, as @spencergilbert suggested and @GeorgeHahn confirmed, the Lading blackhole is redundant because the Vector configuration for that experiment also uses a blackhole sink.

This commit modifies the `file_to_blackhole` regression experiment's Vector configuration so that the Vector sink is now a TCP socket instead of a blackhole, which is consistent with the Vector configuration in our regression testing dogfood repo.

Signed-off-by: Geoffrey M. Oxberry <geoffrey.oxberry@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
