### PR TITLE
chore(deps): revert bump rustyline from 10.1.1 to 11.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fd-lock"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
+dependencies = [
+ "cfg-if",
+ "rustix 0.36.4",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "file-source"
 version = "0.1.0"
 dependencies = [
@@ -5153,6 +5164,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -7013,17 +7036,18 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "11.0.0"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+checksum = "c1e83c32c3f3c33b08496e0d1df9ea8c64d39adb8eb36a1ebb1440c690697aef"
 dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
+ "fd-lock",
  "libc",
  "log",
  "memchr",
- "nix 0.26.2",
+ "nix 0.25.1",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",

--- a/lib/vrl/cli/Cargo.toml
+++ b/lib/vrl/cli/Cargo.toml
@@ -17,7 +17,7 @@ indoc = "2.0.0"
 once_cell = { version = "1.17", optional = true }
 prettytable-rs = { version = "0.10", default-features = false, optional = true }
 regex = { version = "1", default-features = false, optional = true, features = ["perf"] }
-rustyline = { version = "11", default-features = false, optional = true }
+rustyline = { version = "10", default-features = false, optional = true }
 serde_json = "1"
 thiserror = "1"
 vector-common = { path = "../../vector-common", default-features = false }

--- a/lib/vrl/cli/src/repl.rs
+++ b/lib/vrl/cli/src/repl.rs
@@ -12,7 +12,6 @@ use rustyline::{
     error::ReadlineError,
     highlight::{Highlighter, MatchingBracketHighlighter},
     hint::{Hinter, HistoryHinter},
-    history::MemHistory,
     validate::{self, ValidationResult, Validator},
     Context, Editor, Helper,
 };
@@ -62,7 +61,7 @@ pub(crate) fn run(
     let mut state = TypeState::default();
 
     let mut rt = Runtime::new(state::Runtime::default());
-    let mut rl = Editor::<Repl, MemHistory>::new()?;
+    let mut rl = Editor::<Repl>::new()?;
     rl.set_helper(Some(Repl::new()));
 
     #[allow(clippy::print_stdout)]
@@ -84,7 +83,7 @@ pub(crate) fn run(
             // Capture "help docs <func_name>"
             Ok(line) if func_docs_regex.is_match(line) => show_func_docs(line, &func_docs_regex),
             Ok(line) => {
-                rl.add_history_entry(line)?;
+                rl.add_history_entry(line);
 
                 let command = match line {
                     "next" => {


### PR DESCRIPTION
Reverts vectordotdev/vector#16517

Seems to be causing build failures: https://github.com/nix-rust/nix/issues/1972