### PR TITLE
feat(axiom sink)!: Hardcode timestamp-field header to @timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9725,7 +9725,7 @@ dependencies = [
  "vrl",
  "vrl-core",
  "woothee",
- "zstd 0.12.2+zstd.1.5.2",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -4,10 +4,7 @@ use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 
 use crate::{
-    config::{
-        log_schema, AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig,
-        SinkContext,
-    },
+    config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
     sinks::{
         elasticsearch::{ElasticsearchApiVersion, ElasticsearchAuth, ElasticsearchConfig},
         util::{http::RequestConfig, Compression},
@@ -86,11 +83,7 @@ impl SinkConfig for AxiomConfig {
             "X-Axiom-Org-Id".to_string(),
             self.org_id.clone().unwrap_or_default(),
         );
-        let mut query = HashMap::with_capacity(1);
-        query.insert(
-            "timestamp-field".to_string(),
-            log_schema().timestamp_key().to_string(),
-        );
+        let query = HashMap::from([("timestamp-field".to_string(), "@timestamp".to_string())]);
 
         // Axiom has a custom high-performance database that can be ingested
         // into using our HTTP endpoints, including one compatible with the

--- a/website/content/en/highlights/2023-02-28-0-28-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-02-28-0-28-0-upgrade-guide.md
@@ -18,6 +18,7 @@ and **deprecations**:
 
 1. [The `redis` sink's `url` argument changed to `endpoint`](#redis-endpoint)
 2. [The `aws_s3` source's `strategy` option has been hidden](#aws_s3-strategy)
+3. [The `axiom` sink now hardcode the `timestamp-field` header](#axiom-header)
 
 and **potentially impactful changes**:
 
@@ -63,6 +64,12 @@ The `strategy` option has been hidden on the documentation for the `aws_s3` sour
 `sqs` is currently the only value for this option, and is currently the default. If
 additional strategies are added for this source, we will expose this option again.
 No changes need to be made by users of this source, it is a documentation only change.
+
+#### The `axiom` sink now hardcodes the `timestamp-field` header {#axiom-header}
+
+Previously this sink used the global `log_schema` to provide the value for this header, however the
+actual implementation always ensured an event's timestamp was stored at `@timestamp`. In this release
+we've hardcoded this header to match the underlying implementation.
 
 ### Potentially impactful changes
 


### PR DESCRIPTION
Closes #16493

The PR for `elasticsearch` actually implements the log namespace changes, this PR corrects the value as `elasticsearch` will always replace the `log_schema().timestamp_key()` with `@timestamp` for ES compatibility.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
