### PR TITLE
chore(config): Move the `SchemaGenerator` into a `RefCell`

### DIFF
--- a/lib/vector-common/src/datetime.rs
+++ b/lib/vector-common/src/datetime.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{cell::RefCell, fmt::Debug};
 
 use chrono::{DateTime, Local, ParseError, TimeZone as _, Utc};
 use chrono_tz::Tz;
@@ -114,7 +114,7 @@ impl Configurable for TimeZone {
         metadata
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         let mut local_schema = generate_const_string_schema("local".to_string());
         let mut local_metadata = Metadata::with_description("System local timezone.");
         local_metadata.add_custom_attribute(CustomAttribute::kv("logical_name", "Local"));

--- a/lib/vector-config-macros/src/configurable.rs
+++ b/lib/vector-config-macros/src/configurable.rs
@@ -129,7 +129,7 @@ fn build_to_value_fn(_container: &Container<'_>) -> proc_macro2::TokenStream {
 
 fn build_virtual_newtype_schema_fn(virtual_ty: Type) -> proc_macro2::TokenStream {
     quote! {
-        fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
+        fn generate_schema(schema_gen: &::std::cell::RefCell<::vector_config::schemars::gen::SchemaGenerator>) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             ::vector_config::schema::get_or_generate_schema::<#virtual_ty>(schema_gen, None)
         }
     }
@@ -143,7 +143,7 @@ fn build_enum_generate_schema_fn(variants: &[Variant<'_>]) -> proc_macro2::Token
         .map(generate_enum_variant_schema);
 
     quote! {
-        fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
+        fn generate_schema(schema_gen: &::std::cell::RefCell<::vector_config::schemars::gen::SchemaGenerator>) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             let mut subschemas = ::std::vec::Vec::new();
 
             #(#mapped_variants)*
@@ -264,7 +264,7 @@ fn build_named_struct_generate_schema_fn(
         .map(|field| generate_named_struct_field(container, field));
 
     quote! {
-        fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
+        fn generate_schema(schema_gen: &::std::cell::RefCell<::vector_config::schemars::gen::SchemaGenerator>) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             let mut properties = ::vector_config::indexmap::IndexMap::new();
             let mut required = ::std::collections::BTreeSet::new();
             let mut flattened_subschemas = ::std::vec::Vec::new();
@@ -309,7 +309,7 @@ fn build_tuple_struct_generate_schema_fn(fields: &[Field<'_>]) -> proc_macro2::T
         .map(generate_tuple_struct_field);
 
     quote! {
-        fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
+        fn generate_schema(schema_gen: &::std::cell::RefCell<::vector_config::schemars::gen::SchemaGenerator>) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             let mut subschemas = ::std::collections::Vec::new();
 
             #(#mapped_fields)*
@@ -335,7 +335,7 @@ fn build_newtype_struct_generate_schema_fn(fields: &[Field<'_>]) -> proc_macro2:
     let field_schema = mapped_fields.remove(0);
 
     quote! {
-        fn generate_schema(schema_gen: &mut ::vector_config::schemars::gen::SchemaGenerator) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
+        fn generate_schema(schema_gen: &::std::cell::RefCell<::vector_config::schemars::gen::SchemaGenerator>) -> std::result::Result<::vector_config::schemars::schema::SchemaObject, ::vector_config::GenerateError> {
             #field_schema
 
             Ok(subschema)

--- a/lib/vector-config/src/configurable.rs
+++ b/lib/vector-config/src/configurable.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
 
+use std::cell::RefCell;
+
 use schemars::{gen::SchemaGenerator, schema::SchemaObject};
 use serde_json::Value;
 
@@ -60,7 +62,7 @@ where
     ///
     /// If an error occurs while generating the schema, an error variant will be returned describing
     /// the issue.
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>;
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError>;
 }
 
 /// A type that can be converted directly to a `serde_json::Value`. This is used when translating

--- a/lib/vector-config/src/external/chrono.rs
+++ b/lib/vector-config/src/external/chrono.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use chrono::{DateTime, TimeZone};
 use serde_json::Value;
 
@@ -17,7 +19,7 @@ where
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }

--- a/lib/vector-config/src/external/encoding_rs.rs
+++ b/lib/vector-config/src/external/encoding_rs.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use encoding_rs::Encoding;
 use serde_json::Value;
 
@@ -24,7 +26,7 @@ impl Configurable for &'static Encoding {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }

--- a/lib/vector-config/src/external/indexmap.rs
+++ b/lib/vector-config/src/external/indexmap.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use indexmap::{IndexMap, IndexSet};
 use serde_json::Value;
 
@@ -28,7 +30,7 @@ where
         V::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // Make sure our key type is _truly_ a string schema.
         assert_string_schema_for_map::<K, Self>(gen)?;
 
@@ -63,7 +65,7 @@ where
         V::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
     }
 }

--- a/lib/vector-config/src/external/no_proxy.rs
+++ b/lib/vector-config/src/external/no_proxy.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use serde_json::Value;
 
 use crate::{
@@ -13,7 +15,7 @@ impl Configurable for no_proxy::NoProxy {
         Metadata::with_transparent(true)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // `NoProxy` (de)serializes itself as a vector of strings, without any constraints on the string value itself, so
         // we just... do that.
         generate_array_schema::<String>(gen)

--- a/lib/vector-config/src/external/serde_with.rs
+++ b/lib/vector-config/src/external/serde_with.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use vector_config_common::attributes::CustomAttribute;
 
 use crate::{
@@ -36,7 +38,7 @@ where
         T::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // Forward to the underlying `T`.
         //
         // We have to convert from `Metadata` to `Metadata` which erases the default value,
@@ -65,7 +67,7 @@ impl Configurable for serde_with::DurationSeconds<u64, serde_with::formats::Stri
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // This boils down to a number schema, but we just need to shuttle around the metadata so
         // that we can call the relevant schema generation function.
         Ok(generate_number_schema::<u64>())
@@ -91,7 +93,7 @@ impl Configurable for serde_with::DurationSeconds<f64, serde_with::formats::Stri
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // This boils down to a number schema, but we just need to shuttle around the metadata so
         // that we can call the relevant schema generation function.
         Ok(generate_number_schema::<f64>())
@@ -116,7 +118,7 @@ impl Configurable for serde_with::DurationMilliSeconds<u64, serde_with::formats:
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // This boils down to a number schema, but we just need to shuttle around the metadata so
         // that we can call the relevant schema generation function.
         Ok(generate_number_schema::<u64>())

--- a/lib/vector-config/src/external/toml.rs
+++ b/lib/vector-config/src/external/toml.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use serde_json::Value;
 
 use crate::{
@@ -6,7 +8,7 @@ use crate::{
 };
 
 impl Configurable for toml::Value {
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // `toml::Value` can be anything that it is possible to represent in TOML, and equivalently, is anything it's
         // possible to represent in JSON, so... a default schema indicates that.
         Ok(SchemaObject::default())

--- a/lib/vector-config/src/external/tz.rs
+++ b/lib/vector-config/src/external/tz.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use serde_json::Value;
 
 use crate::{
@@ -13,7 +15,7 @@ impl Configurable for chrono_tz::Tz {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }

--- a/lib/vector-config/src/external/url.rs
+++ b/lib/vector-config/src/external/url.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use serde_json::Value;
 use vector_config_common::validation::{Format, Validation};
 
@@ -15,7 +17,7 @@ impl Configurable for url::Url {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }

--- a/lib/vector-config/src/schema.rs
+++ b/lib/vector-config/src/schema.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, mem};
+use std::{cell::RefCell, collections::BTreeSet, mem};
 
 use indexmap::IndexMap;
 use schemars::{
@@ -219,7 +219,9 @@ where
     schema
 }
 
-pub fn generate_array_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
+pub fn generate_array_schema<T>(
+    gen: &RefCell<SchemaGenerator>,
+) -> Result<SchemaObject, GenerateError>
 where
     T: Configurable + ToValue,
 {
@@ -236,7 +238,7 @@ where
     })
 }
 
-pub fn generate_set_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
+pub fn generate_set_schema<T>(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError>
 where
     T: Configurable + ToValue,
 {
@@ -254,7 +256,7 @@ where
     })
 }
 
-pub fn generate_map_schema<V>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
+pub fn generate_map_schema<V>(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError>
 where
     V: Configurable + ToValue,
 {
@@ -292,7 +294,9 @@ pub fn generate_struct_schema(
     }
 }
 
-pub fn generate_optional_schema<T>(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError>
+pub fn generate_optional_schema<T>(
+    gen: &RefCell<SchemaGenerator>,
+) -> Result<SchemaObject, GenerateError>
 where
     T: Configurable + ToValue,
 {
@@ -486,9 +490,10 @@ where
     // Set env variable to enable generating all schemas, including platform-specific ones.
     std::env::set_var("VECTOR_GENERATE_SCHEMA", "true");
 
-    let mut schema_gen = SchemaSettings::draft2019_09().into_generator();
+    let schema_gen = RefCell::new(SchemaSettings::draft2019_09().into_generator());
 
-    let schema = get_or_generate_schema::<T>(&mut schema_gen, Some(T::metadata()))?;
+    let schema = get_or_generate_schema::<T>(&schema_gen, Some(T::metadata()))?;
+    let mut schema_gen = schema_gen.into_inner();
     Ok(RootSchema {
         meta_schema: None,
         schema,
@@ -497,7 +502,7 @@ where
 }
 
 pub fn get_or_generate_schema<T>(
-    gen: &mut SchemaGenerator,
+    gen: &RefCell<SchemaGenerator>,
     overrides: Option<Metadata>,
 ) -> Result<SchemaObject, GenerateError>
 where
@@ -508,13 +513,14 @@ where
         // list, and if it exists, create a schema reference to it. Otherwise, generate it and
         // backfill it in the schema generator.
         Some(name) => {
-            if !gen.definitions().contains_key(name) {
+            if !gen.borrow().definitions().contains_key(name) {
                 // In order to avoid infinite recursion, we copy the approach that `schemars` takes and
                 // insert a dummy boolean schema before actually generating the real schema, and then
                 // replace it afterwards. If any recursion occurs, a schema reference will be handed
                 // back, which means we don't have to worry about the dummy schema needing to be updated
                 // after the fact.
-                gen.definitions_mut()
+                gen.borrow_mut()
+                    .definitions_mut()
                     .insert(name.to_string(), Schema::Bool(false));
 
                 // We generate the schema for `T` with its own default metadata, and not the
@@ -528,7 +534,8 @@ where
                 // for all usages of `T` that didn't override the default themselves.
                 let schema = generate_baseline_schema::<T>(gen, T::metadata())?;
 
-                gen.definitions_mut()
+                gen.borrow_mut()
+                    .definitions_mut()
                     .insert(name.to_string(), Schema::Object(schema));
             }
 
@@ -575,7 +582,7 @@ where
 }
 
 pub fn generate_baseline_schema<T>(
-    gen: &mut SchemaGenerator,
+    gen: &RefCell<SchemaGenerator>,
     metadata: Metadata,
 ) -> Result<SchemaObject, GenerateError>
 where
@@ -588,8 +595,12 @@ where
     Ok(schema)
 }
 
-fn get_schema_ref<S: AsRef<str>>(gen: &mut SchemaGenerator, name: S) -> SchemaObject {
-    let ref_path = format!("{}{}", gen.settings().definitions_path, name.as_ref());
+fn get_schema_ref<S: AsRef<str>>(gen: &RefCell<SchemaGenerator>, name: S) -> SchemaObject {
+    let ref_path = format!(
+        "{}{}",
+        gen.borrow().settings().definitions_path,
+        name.as_ref()
+    );
     SchemaObject::new_ref(ref_path)
 }
 
@@ -604,7 +615,9 @@ fn get_schema_ref<S: AsRef<str>>(gen: &mut SchemaGenerator, name: S) -> SchemaOb
 ///
 /// If the schema is not a valid, string-like schema, an error variant will be returned describing
 /// the issue.
-pub fn assert_string_schema_for_map<K, M>(gen: &mut SchemaGenerator) -> Result<(), GenerateError>
+pub fn assert_string_schema_for_map<K, M>(
+    gen: &RefCell<SchemaGenerator>,
+) -> Result<(), GenerateError>
 where
     K: ConfigurableString + ToValue,
 {
@@ -618,6 +631,7 @@ where
 
     // Get a reference to the underlying schema if we're dealing with a reference, or just use what
     // we have if it's the actual definition.
+    let gen = gen.borrow();
     let underlying_schema = if wrapped_schema.is_ref() {
         gen.dereference(&wrapped_schema)
     } else {

--- a/lib/vector-config/src/ser.rs
+++ b/lib/vector-config/src/ser.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::marker::PhantomData;
+use std::{cell::RefCell, marker::PhantomData};
 
 use serde::{Serialize, Serializer};
 
@@ -91,7 +91,7 @@ where
         H::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // Forward to the underlying `H`.
         H::generate_schema(gen)
     }

--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     hash::Hash,
     net::SocketAddr,
@@ -28,7 +29,7 @@ use crate::{
 
 // Unit type.
 impl Configurable for () {
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // Using a unit type in a configuration-related type is never actually valid.
         Err(GenerateError::InvalidType)
     }
@@ -66,7 +67,7 @@ where
         T::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         generate_optional_schema::<T>(gen)
     }
 }
@@ -85,7 +86,7 @@ impl Configurable for bool {
         Metadata::with_transparent(true)
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_bool_schema())
     }
 }
@@ -102,7 +103,7 @@ impl Configurable for String {
         Metadata::with_transparent(true)
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }
@@ -123,7 +124,7 @@ impl Configurable for char {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }
@@ -151,7 +152,9 @@ macro_rules! impl_configurable_numeric {
                 $crate::__ensure_numeric_validation_bounds::<Self>(metadata)
             }
 
-            fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+            fn generate_schema(
+                _: &RefCell<SchemaGenerator>,
+            ) -> Result<SchemaObject, GenerateError> {
                 Ok(generate_number_schema::<Self>())
             }
         }
@@ -201,7 +204,7 @@ where
         T::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         generate_array_schema::<T>(gen)
     }
 }
@@ -232,7 +235,7 @@ where
         V::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // Make sure our key type is _truly_ a string schema.
         assert_string_schema_for_map::<K, Self>(gen)?;
 
@@ -267,7 +270,7 @@ where
         V::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
     }
 }
@@ -298,7 +301,7 @@ where
         V::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // Make sure our key type is _truly_ a string schema.
         assert_string_schema_for_map::<K, Self>(gen)?;
 
@@ -333,7 +336,7 @@ where
         V::validate_metadata(&converted)
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         generate_set_schema::<V>(gen)
     }
 }
@@ -359,7 +362,7 @@ impl Configurable for SocketAddr {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         // TODO: We don't need anything other than a string schema to (de)serialize a `SocketAddr`,
         // but we eventually should have validation since the format for the possible permutations
         // is well-known and can be easily codified.
@@ -392,7 +395,7 @@ impl Configurable for PathBuf {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         Ok(generate_string_schema())
     }
 }
@@ -415,7 +418,7 @@ impl Configurable for Duration {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         let mut properties = IndexMap::default();
         properties.insert("secs".into(), generate_number_schema::<u64>());
         properties.insert("nsecs".into(), generate_number_schema::<u32>());

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fmt};
+use std::{cell::RefCell, collections::BTreeSet, fmt};
 
 use indexmap::IndexMap;
 use serde::{de, ser};
@@ -221,7 +221,7 @@ impl Configurable for Compression {
         metadata
     }
 
-    fn generate_schema(gen: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         const ALGORITHM_NAME: &str = "algorithm";
         const LEVEL_NAME: &str = "level";
         const LOGICAL_NAME: &str = "logical_name";
@@ -431,7 +431,7 @@ impl Configurable for CompressionLevel {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         let string_consts = ["none", "fast", "best", "default"]
             .iter()
             .map(|s| serde_json::Value::from(*s));

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -1,6 +1,7 @@
+use std::{cell::RefCell, fmt};
+
 use serde::Serializer;
 use serde_json::Value;
-use std::fmt;
 use vector_config::{
     schema::{
         apply_metadata, generate_const_string_schema, generate_number_schema,
@@ -137,7 +138,7 @@ impl Configurable for Concurrency {
         metadata
     }
 
-    fn generate_schema(_: &mut SchemaGenerator) -> Result<SchemaObject, GenerateError> {
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
         let mut none_schema = generate_const_string_schema("none".to_string());
         let mut none_metadata = Metadata::with_title("A fixed concurrency of 1.");
         none_metadata.set_description("Only one request can be outstanding at any given time.");


### PR DESCRIPTION
Due to a [bug](https://github.com/rust-lang/rust/issues/57349#issuecomment-1266769993) in the implementation of const functions, we cannot create references to functions that have `mut` references in the parameter lists. Since the `generate-schema` function currently takes such a reference, this wraps the value in a `RefCell` and handles mutability within `get_or_generate_schema`, which is the only location that requires it.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
