### PR TITLE
fix(core): Fix `LogEvent::source_type_path`

### DIFF
--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -439,10 +439,10 @@ impl LogEvent {
     /// or from the `source_type` key set on the "Global Log Schema" (Legacy namespace).
     // TODO: This can eventually return a `&TargetOwnedPath` once Semantic meaning and the
     //   "Global Log Schema" are updated to the new path lookup code
-    pub fn source_type_path(&self) -> Option<String> {
+    pub fn source_type_path(&self) -> &'static str {
         match self.namespace() {
-            LogNamespace::Vector => self.find_key_by_meaning("source_type"),
-            LogNamespace::Legacy => Some(log_schema().source_type_key().to_owned()),
+            LogNamespace::Vector => "%vector.source_type",
+            LogNamespace::Legacy => log_schema().source_type_key(),
         }
     }
 

--- a/src/sinks/datadog/events/sink.rs
+++ b/src/sinks/datadog/events/sink.rs
@@ -75,8 +75,7 @@ async fn ensure_required_fields(event: Event) -> Option<Event> {
     }
 
     if !log.contains("source_type_name") {
-        let source_type_path = log.source_type_path();
-        log.rename_key(source_type_path, "source_type_name")
+        log.rename_key(log.source_type_path(), "source_type_name")
     }
 
     Some(Event::from(log))

--- a/src/sinks/datadog/events/sink.rs
+++ b/src/sinks/datadog/events/sink.rs
@@ -75,9 +75,8 @@ async fn ensure_required_fields(event: Event) -> Option<Event> {
     }
 
     if !log.contains("source_type_name") {
-        if let Some(source_type_path) = log.source_type_path() {
-            log.rename_key(source_type_path.as_str(), "source_type_name");
-        }
+        let source_type_path = log.source_type_path();
+        log.rename_key(source_type_path, "source_type_name")
     }
 
     Some(Event::from(log))


### PR DESCRIPTION
`source_type` should point to a static metadata location (when using Log Namespacing), and not depend on semantic meaning