### PR TITLE
docs(splunk_hec sink): generate component docs for splunk sink

### DIFF
--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -35,7 +35,7 @@ use crate::{
 pub struct HecLogsSinkConfig {
     /// Default Splunk HEC token.
     ///
-    /// If an event has a token set in its metadata, it will prevail over the one set here.
+    /// If an event has a token set in its secrets (`splunk_hec_token`), it will prevail over the one set here.
     #[serde(alias = "token")]
     pub default_token: SensitiveString,
 

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -128,7 +128,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		description: """
 			Default Splunk HEC token.
 
-			If an event has a token set in its metadata, it will prevail over the one set here.
+			If an event has a token set in its secrets (`splunk_hec_token`), it will prevail over the one set here.
 			"""
 		required: true
 		type: string: {}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -128,7 +128,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		description: """
 			Default Splunk HEC token.
 
-			If an event has a token set in its secrets (`splunk_hec_token`), it will prevail over the one set here.
+			If an event has a token set in its metadata, it will prevail over the one set here.
 			"""
 		required: true
 		type: string: {}


### PR DESCRIPTION
A recent PR broke the check component docs check on master. This fixes it.