### PR TITLE
chore(config): Drop `const NAME` from `trait NamedComponent`

### DIFF
--- a/lib/vector-config-macros/src/component_name.rs
+++ b/lib/vector-config-macros/src/component_name.rs
@@ -90,8 +90,14 @@ pub fn derive_component_name_impl(input: TokenStream) -> TokenStream {
     // We have a single, valid component name, so let's actually spit out our derive.
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let derived = quote! {
+        impl #impl_generics #ident #ty_generics #where_clause {
+            pub(super) const NAME: &'static str = #component_name;
+        }
+
         impl #impl_generics ::vector_config::NamedComponent for #ident #ty_generics #where_clause {
-            const NAME: &'static str = #component_name;
+            fn get_component_name(&self) -> &'static str {
+                #component_name
+            }
         }
     };
     derived.into()

--- a/lib/vector-config/src/named.rs
+++ b/lib/vector-config/src/named.rs
@@ -3,10 +3,6 @@
 /// Users can derive this trait automatically by using the
 /// [`component_name`][vector-config::component_name] macro on their structs/enums.
 pub trait NamedComponent {
-    const NAME: &'static str;
-
     /// Gets the name of the component.
-    fn get_component_name(&self) -> &'static str {
-        Self::NAME
-    }
+    fn get_component_name(&self) -> &'static str;
 }

--- a/src/enrichment_tables/mod.rs
+++ b/src/enrichment_tables/mod.rs
@@ -27,10 +27,8 @@ pub enum EnrichmentTables {
     Geoip(geoip::GeoipConfig),
 }
 
-// We can't use `enum_dispatch` here because it doesn't support associated constants.
+// TODO: Use `enum_dispatch` here.
 impl NamedComponent for EnrichmentTables {
-    const NAME: &'static str = "_invalid_usage";
-
     fn get_component_name(&self) -> &'static str {
         match self {
             Self::File(config) => config.get_component_name(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -21,10 +21,8 @@ pub enum Providers {
     Http(http::HttpConfig),
 }
 
-// We can't use `enum_dispatch` here because it doesn't support associated constants.
+// TODO: Use `enum_dispatch` here.
 impl NamedComponent for Providers {
-    const NAME: &'static str = "_invalid_usage";
-
     fn get_component_name(&self) -> &'static str {
         match self {
             Self::Http(config) => config.get_component_name(),

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -23,10 +23,8 @@ pub enum SecretBackends {
     Test(test::TestBackend),
 }
 
-// We can't use `enum_dispatch` here because it doesn't support associated constants.
+// TODO: Use `enum_dispatch` here.
 impl NamedComponent for SecretBackends {
-    const NAME: &'static str = "_invalid_usage";
-
     fn get_component_name(&self) -> &'static str {
         match self {
             Self::Exec(config) => config.get_component_name(),

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -856,7 +856,9 @@ impl RequestBuilder<(String, Vec<Event>)> for DatadogAzureRequestBuilder {
 //
 // TODO: When the sink is fully supported and we expose it for use/within the docs, remove this.
 impl NamedComponent for DatadogArchivesSinkConfig {
-    const NAME: &'static str = "datadog_archives";
+    fn get_component_name(&self) -> &'static str {
+        "datadog_archives"
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -11,7 +11,7 @@ use http::{
 use hyper::Body;
 use indexmap::IndexMap;
 use tokio_util::codec::Encoder as _;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 
 use crate::{
     codecs::{Encoder, EncodingConfigWithFraming, SinkType, Transformer},

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -410,8 +410,6 @@ pub enum Sinks {
 }
 
 impl NamedComponent for Sinks {
-    const NAME: &'static str = "_invalid_usage";
-
     fn get_component_name(&self) -> &'static str {
         match self {
             #[cfg(feature = "sinks-amqp")]

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -29,7 +29,7 @@ use vector_common::{
     finalizer::UnorderedFinalizer,
     internal_event::{CountByteSize, EventsReceived, InternalEventHandle as _},
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{log_schema, LegacyKey, LogNamespace, SourceAcknowledgementsConfig},
     event::Event,

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -15,7 +15,6 @@ use vector_common::{
         ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Registered,
     },
 };
-use vector_config::NamedComponent;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     event::BatchNotifier,

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -6,7 +6,7 @@ use lookup::owned_value_path;
 use tracing::Span;
 use value::Kind;
 use vector_common::sensitive_string::SensitiveString;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 use warp::Filter;
 

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -8,7 +8,7 @@ use lookup::owned_value_path;
 use snafu::Snafu;
 use tokio_util::io::StreamReader;
 use value::{kind::Collection, Kind};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{DataType, LegacyKey, LogNamespace};
 
 use super::util::MultilineConfig;
@@ -419,7 +419,6 @@ mod integration_tests {
     use lookup::path;
     use similar_asserts::assert_eq;
     use value::Value;
-    use vector_config::NamedComponent;
 
     use super::{sqs, AwsS3Config, Compression, Strategy};
     use crate::{

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -23,7 +23,7 @@ use tracing::Instrument;
 use vector_common::internal_event::{
     ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol, Registered,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 
 use crate::{
     config::{SourceAcknowledgementsConfig, SourceContext},

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use lookup::owned_value_path;
 use value::Kind;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use crate::aws::create_client;

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -222,7 +222,6 @@ mod tests {
     use crate::codecs::DecodingConfig;
     use chrono::SecondsFormat;
     use lookup::path;
-    use vector_config::NamedComponent;
 
     use super::*;
     use crate::config::{log_schema, SourceConfig};

--- a/src/sources/datadog_agent/logs.rs
+++ b/src/sources/datadog_agent/logs.rs
@@ -7,7 +7,6 @@ use http::StatusCode;
 use lookup::path;
 use tokio_util::codec::Decoder;
 use vector_common::internal_event::{CountByteSize, InternalEventHandle as _};
-use vector_config::NamedComponent;
 use vector_core::{config::LegacyKey, EstimatedJsonEncodedSizeOf};
 use warp::{filters::BoxedFilter, path as warp_path, path::FullPath, reply::Response, Filter};
 

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -32,7 +32,7 @@ use snafu::Snafu;
 use tracing::Span;
 use value::Kind;
 use vector_common::internal_event::{EventsReceived, Registered};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 use vector_core::event::{BatchNotifier, BatchStatus};
 use warp::{filters::BoxedFilter, reject::Rejection, reply::Response, Filter, Reply};

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -14,7 +14,7 @@ use tokio_util::codec::FramedRead;
 use vector_common::internal_event::{
     ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{config::LogNamespace, EstimatedJsonEncodedSizeOf};
 
 use crate::{

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -7,7 +7,7 @@ use value::{kind::Collection, Kind};
 use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 
 use super::util::framestream::{build_framestream_unix_source, FrameHandler};
 use crate::{

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -25,7 +25,7 @@ use value::{kind::Collection, Kind};
 use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use super::util::MultilineConfig;

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -22,7 +22,7 @@ use tokio_stream::wrappers::IntervalStream;
 use tokio_util::codec::FramedRead;
 use value::Kind;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{config::LegacyKey, EstimatedJsonEncodedSizeOf};
 
 use crate::{

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -18,7 +18,7 @@ use tokio::{sync::oneshot, task::spawn_blocking};
 use tracing::{Instrument, Span};
 use value::Kind;
 use vector_common::finalizer::OrderedFinalizer;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use super::util::{EncodingConfig, MultilineConfig};

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -4,7 +4,7 @@ use super::{outputs, FileDescriptorConfig};
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use indoc::indoc;
 use lookup::lookup_v2::OptionalValuePath;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
 use crate::{

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -85,7 +85,7 @@ pub trait FileDescriptorConfig: NamedComponent {
             out,
             shutdown,
             host_key,
-            Self::NAME,
+            self.get_component_name(),
             hostname,
             log_namespace,
         )))

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use lookup::lookup_v2::OptionalValuePath;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
 use crate::{

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -15,7 +15,7 @@ use smallvec::{smallvec, SmallVec};
 use tokio_util::codec::Decoder;
 use value::kind::Collection;
 use value::{Kind, Value};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 use vector_core::schema::Definition;
 

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -25,7 +25,7 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, EventsReceived, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_common::{byte_size_of::ByteSizeOf, finalizer::UnorderedFinalizer};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use crate::{

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -17,7 +17,7 @@ use tokio_util::codec::Decoder as _;
 use value::{kind::Collection, Kind};
 use warp::http::{HeaderMap, StatusCode};
 
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     schema::Definition,
@@ -398,7 +398,6 @@ mod tests {
     use lookup::{owned_value_path, OwnedTargetPath};
     use similar_asserts::assert_eq;
     use value::{kind::Collection, Kind};
-    use vector_config::NamedComponent;
     use vector_core::{
         config::LogNamespace,
         event::{Event, EventStatus, Value},

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -31,7 +31,7 @@ use codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     StreamDecodingError,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{log_schema, LogNamespace, Output},
     event::Event,

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -16,7 +16,6 @@ use crate::{
     SourceSender,
 };
 use codecs::decoding::DeserializerConfig;
-use vector_config::NamedComponent;
 use vector_core::config::log_schema;
 
 use super::{

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -12,7 +12,7 @@ use http::{StatusCode, Uri};
 use lookup::{lookup_v2::OptionalValuePath, owned_value_path, path};
 use tokio_util::codec::Decoder as _;
 use value::{kind::Collection, Kind};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{DataType, LegacyKey, LogNamespace},
     schema::Definition,
@@ -466,7 +466,6 @@ mod tests {
     use std::{collections::BTreeMap, io::Write, net::SocketAddr};
     use value::kind::Collection;
     use value::Kind;
-    use vector_config::NamedComponent;
     use vector_core::config::LogNamespace;
     use vector_core::event::LogEvent;
     use vector_core::schema::Definition;

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -4,7 +4,7 @@ use futures::{stream, StreamExt};
 use lookup::lookup_v2::OptionalValuePath;
 use lookup::{owned_value_path, path, OwnedValuePath};
 use value::Kind;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::log_schema;
 use vector_core::{
     config::{LegacyKey, LogNamespace},

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -35,7 +35,7 @@ use vector_common::{
         ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol, Registered,
     },
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     schema::Definition,

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -26,7 +26,7 @@ use tokio_util::codec::FramedRead;
 
 use value::{kind::Collection, Kind};
 use vector_common::finalizer::OrderedFinalizer;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     EstimatedJsonEncodedSizeOf,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -35,7 +35,7 @@ use vector_common::{
     internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol},
     TimeZone,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::LegacyKey, config::LogNamespace, transform::TaskTransform, EstimatedJsonEncodedSizeOf,
 };

--- a/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
@@ -6,7 +6,7 @@ use k8s_openapi::{api::core::v1::Namespace, apimachinery::pkg::apis::meta::v1::O
 use kube::runtime::reflector::{store::Store, ObjectRef};
 use lookup::lookup_v2::OptionalTargetPath;
 use lookup::{lookup_v2::ValuePath, owned_value_path, path, OwnedTargetPath};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use crate::event::{Event, LogEvent};

--- a/src/sources/kubernetes_logs/node_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/node_metadata_annotator.rs
@@ -7,7 +7,7 @@ use k8s_openapi::{api::core::v1::Node, apimachinery::pkg::apis::meta::v1::Object
 use kube::runtime::reflector::{store::Store, ObjectRef};
 use lookup::lookup_v2::OptionalTargetPath;
 use lookup::{lookup_v2::ValuePath, owned_value_path, path, OwnedTargetPath};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use super::Config;

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use lookup::path;
 use vector_common::conversion;
-use vector_config::NamedComponent;
 use vector_core::config::{log_schema, LegacyKey, LogNamespace};
 
 use crate::{

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, Utc};
 use lookup::path;
 use serde_json::Value as JsonValue;
 use snafu::{OptionExt, ResultExt, Snafu};
-use vector_config::NamedComponent;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use crate::{

--- a/src/sources/kubernetes_logs/parser/test_util.rs
+++ b/src/sources/kubernetes_logs/parser/test_util.rs
@@ -4,7 +4,6 @@ use similar_asserts::assert_eq;
 use chrono::{DateTime, Utc};
 use lookup::{event_path, metadata_path};
 use value::Value;
-use vector_config::NamedComponent;
 use vector_core::{config::LogNamespace, event};
 
 use crate::{

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -11,7 +11,7 @@ use lookup::{
     lookup_v2::{OptionalTargetPath, ValuePath},
     owned_value_path, path, OwnedTargetPath,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use super::{

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -16,7 +16,7 @@ use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Decoder;
 use value::kind::Collection;
 use value::Kind;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     schema::Definition,

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -340,10 +340,8 @@ pub enum Sources {
     Vector(vector::VectorConfig),
 }
 
-// We can't use `enum_dispatch` here because it doesn't support associated constants.
+// TODO: Use `enum_dispatch` here
 impl NamedComponent for Sources {
-    const NAME: &'static str = "_invalid_usage";
-
     fn get_component_name(&self) -> &'static str {
         match self {
             #[cfg(feature = "sources-amqp")]

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -8,7 +8,7 @@ use value::Kind;
 use vector_common::internal_event::{
     ByteSize, BytesReceived, CountByteSize, EventsReceived, InternalEventHandle as _, Protocol,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     EstimatedJsonEncodedSizeOf,

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -20,7 +20,7 @@ use opentelemetry_proto::convert::{
 use opentelemetry_proto::proto::collector::logs::v1::logs_service_server::LogsServiceServer;
 use value::{kind::Collection, Kind};
 use vector_common::internal_event::{BytesReceived, EventsReceived, Protocol};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{log_schema, LegacyKey, LogNamespace},
     schema::Definition,

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -11,7 +11,6 @@ use opentelemetry_proto::proto::{
 use similar_asserts::assert_eq;
 use std::collections::BTreeMap;
 use tonic::Request;
-use vector_config::NamedComponent;
 use vector_core::config::LogNamespace;
 
 use crate::{

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -12,7 +12,7 @@ use value::Kind;
 use vector_common::internal_event::{
     ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol, Registered,
 };
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     EstimatedJsonEncodedSizeOf,

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -6,7 +6,7 @@ mod unix;
 use codecs::{decoding::DeserializerConfig, NewlineDelimitedDecoderConfig};
 use lookup::{lookup_v2::OptionalValuePath, owned_value_path};
 use value::{kind::Collection, Kind};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{log_schema, LegacyKey, LogNamespace};
 
 #[cfg(unix)]
@@ -364,7 +364,6 @@ mod test {
         time::{timeout, Duration, Instant},
     };
     use vector_common::btreemap;
-    use vector_config::NamedComponent;
     use vector_core::event::EventContainer;
     #[cfg(unix)]
     use {

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -5,7 +5,7 @@ use codecs::decoding::{DeserializerConfig, FramingConfig};
 use lookup::{lookup_v2::OptionalValuePath, owned_value_path, path};
 use serde_with::serde_as;
 use smallvec::SmallVec;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use crate::{

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -9,7 +9,7 @@ use listenfd::ListenFd;
 use lookup::{lookup_v2::OptionalValuePath, owned_value_path, path};
 use tokio_util::codec::FramedRead;
 use vector_common::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     EstimatedJsonEncodedSizeOf,

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use lookup::{lookup_v2::OptionalValuePath, path};
 use vector_common::shutdown::ShutdownSignal;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 use crate::{

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -18,7 +18,7 @@ use tracing::Span;
 use value::{kind::Collection, Kind};
 use vector_common::internal_event::{CountByteSize, InternalEventHandle as _, Registered};
 use vector_common::sensitive_string::SensitiveString;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::{LegacyKey, LogNamespace},
     event::BatchNotifier,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -14,7 +14,7 @@ use serde_with::serde_as;
 use smallvec::{smallvec, SmallVec};
 use tokio_util::udp::UdpFramed;
 use vector_common::internal_event::{CountByteSize, InternalEventHandle as _, Registered};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::EstimatedJsonEncodedSizeOf;
 
 use self::parser::ParseError;

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -16,7 +16,7 @@ use lookup::{
 };
 use smallvec::SmallVec;
 use tokio_util::udp::UdpFramed;
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 
 #[cfg(unix)]

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -6,7 +6,7 @@ use codecs::NativeDeserializerConfig;
 use futures::TryFutureExt;
 use tonic::{Request, Response, Status};
 use vector_common::internal_event::{CountByteSize, InternalEventHandle as _};
-use vector_config::{configurable_component, NamedComponent};
+use vector_config::configurable_component;
 use vector_core::{
     config::LogNamespace,
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event},

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -131,10 +131,8 @@ pub enum Transforms {
     Throttle(throttle::ThrottleConfig),
 }
 
-// We can't use `enum_dispatch` here because it doesn't support associated constants.
+// TODO: Use `enum_dispatch` here.
 impl NamedComponent for Transforms {
-    const NAME: &'static str = "_invalid_usage";
-
     fn get_component_name(&self) -> &'static str {
         match self {
             #[cfg(feature = "transforms-aggregate")]


### PR DESCRIPTION
This trait will need to be object safe for component registration work, so associated data types are out. The constant is instead moved to an additional implementation block for the concrete type.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
