### PR TITLE
chore: Drop `build-ci-docker-images` make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,10 +608,6 @@ compile-vrl-wasm: ## Compile VRL crates to WASM target
 
 ##@ Utility
 
-.PHONY: build-ci-docker-images
-build-ci-docker-images: ## Rebuilds all Docker images used in CI
-	@scripts/build-ci-docker-images.sh
-
 .PHONY: clean
 clean: environment-clean ## Clean everything
 	cargo clean


### PR DESCRIPTION
This just runs `scripts/build-ci-docker-images.sh` but that file no longer exists.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
