### PR TITLE
feat(datadog_archives sink): Use log namespacing and semantic meaning

### DIFF
--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -26,12 +26,13 @@ use rand::{thread_rng, Rng};
 use snafu::Snafu;
 use tower::ServiceBuilder;
 use uuid::Uuid;
+use value::Kind;
 use vector_common::request_metadata::RequestMetadata;
 use vector_config::{configurable_component, NamedComponent};
 use vector_core::{
-    config::{log_schema, AcknowledgementsConfig, LogSchema},
+    config::AcknowledgementsConfig,
     event::{Event, EventFinalizers, Finalizable},
-    ByteSizeOf,
+    schema, ByteSizeOf,
 };
 
 use crate::{
@@ -285,10 +286,7 @@ enum ConfigError {
 const KEY_TEMPLATE: &str = "/dt=%Y%m%d/hour=%H/";
 
 impl DatadogArchivesSinkConfig {
-    async fn build_sink(
-        &self,
-        cx: SinkContext,
-    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
+    async fn build_sink(&self, cx: SinkContext) -> crate::Result<(VectorSink, super::Healthcheck)> {
         match &self.service[..] {
             "aws_s3" => {
                 let s3_config = self.aws_s3.as_ref().expect("s3 config wasn't provided");
@@ -353,9 +351,9 @@ impl DatadogArchivesSinkConfig {
         &self,
         s3_options: &S3Options,
         service: S3Service,
-    ) -> std::result::Result<VectorSink, ConfigError> {
+    ) -> Result<VectorSink, ConfigError> {
         // we use lower default limits, because we send 100mb batches,
-        // thus no need of the higher number of outcoming requests
+        // thus no need of the higher number of outgoing requests
         let request_limits = self.request.unwrap_with(&Default::default());
         let service = ServiceBuilder::new()
             .settings(request_limits, S3RetryLogic)
@@ -494,7 +492,6 @@ struct DatadogArchivesEncoding {
     reserved_attributes: HashSet<&'static str>,
     id_rnd_bytes: [u8; 8],
     id_seq_number: AtomicU32,
-    log_schema: &'static LogSchema,
 }
 
 impl DatadogArchivesEncoding {
@@ -535,18 +532,18 @@ impl DatadogArchivesEncoding {
             reserved_attributes: RESERVED_ATTRIBUTES.iter().copied().collect(),
             id_rnd_bytes: thread_rng().gen::<[u8; 8]>(),
             id_seq_number: AtomicU32::new(0),
-            log_schema: log_schema(),
         }
     }
 }
 
 impl crate::sinks::util::encoding::Encoder<Vec<Event>> for DatadogArchivesEncoding {
     /// Applies the following transformations to align event's schema with DD:
-    /// - `_id` is generated in the sink(format described below);
-    /// - `date` is set from the Global Log Schema's `timestamp` mapping, or to the current time if missing;
-    /// - `message`,`host` are set from the corresponding Global Log Schema mappings;
+    /// - (required) `_id` is generated in the sink(format described below);
+    /// - (required) `date` is set from the `timestamp` meaning or Global Log Schema mapping, or to the current time if missing;
+    /// - `message`,`host` are set from the corresponding meanings or Global Log Schema mappings;
     /// - `source`, `service`, `status`, `tags` and other reserved attributes are left as is;
     /// - the rest of the fields is moved to `attributes`.
+    // TODO: All reserved attributes could have specific meanings, rather than specific paths
     fn encode_input(&self, mut input: Vec<Event>, writer: &mut dyn Write) -> io::Result<usize> {
         for event in input.iter_mut() {
             let log_event = event.as_mut_log();
@@ -554,18 +551,24 @@ impl crate::sinks::util::encoding::Encoder<Vec<Event>> for DatadogArchivesEncodi
             log_event.insert("_id", self.generate_log_id());
 
             let timestamp = log_event
-                .remove(self.log_schema.timestamp_key())
-                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().into());
+                .remove_timestamp()
+                .unwrap_or_else(|| Utc::now().timestamp_millis().into());
             log_event.insert(
                 "date",
                 timestamp
                     .as_timestamp()
                     .cloned()
-                    .unwrap_or_else(chrono::Utc::now)
+                    .unwrap_or_else(Utc::now)
                     .to_rfc3339_opts(SecondsFormat::Millis, true),
             );
-            log_event.rename_key(self.log_schema.message_key(), event_path!("message"));
-            log_event.rename_key(self.log_schema.host_key(), event_path!("host"));
+
+            if let Some(message_path) = log_event.message_path() {
+                log_event.rename_key(message_path.as_str(), event_path!("message"));
+            }
+
+            if let Some(host_path) = log_event.host_path() {
+                log_event.rename_key(host_path.as_str(), event_path!("host"));
+            }
 
             let mut attributes = BTreeMap::new();
 
@@ -863,16 +866,24 @@ impl NamedComponent for DatadogArchivesSinkConfig {
 
 #[async_trait::async_trait]
 impl SinkConfig for DatadogArchivesSinkConfig {
-    async fn build(
-        &self,
-        cx: SinkContext,
-    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, super::Healthcheck)> {
         let sink_and_healthcheck = self.build_sink(cx).await?;
         Ok(sink_and_healthcheck)
     }
 
     fn input(&self) -> Input {
-        Input::log()
+        let requirements = schema::Requirement::empty()
+            .optional_meaning("host", Kind::bytes())
+            .optional_meaning("message", Kind::bytes())
+            .optional_meaning("source", Kind::bytes())
+            .optional_meaning("service", Kind::bytes())
+            .optional_meaning("severity", Kind::bytes())
+            // TODO: A `timestamp` is required for rehydration, however today we generate a `Utc::now()`
+            // timestamp if it's not found in the event. We could require this meaning instead.
+            .optional_meaning("timestamp", Kind::timestamp())
+            .optional_meaning("trace_id", Kind::bytes());
+
+        Input::log().with_schema_requirement(requirements)
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {


### PR DESCRIPTION
Closes #16549

I left a few TODOs for possible changes we could make leveraging `meaning`s in the future, but opted to defer that work.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
