### PR TITLE
chore(config): Convert top-level transforms enum to typetag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9403,7 +9403,6 @@ dependencies = [
  "serde_with 2.2.0",
  "snafu",
  "toml 0.7.2",
- "typetag",
  "url",
  "vector-config-common",
  "vector-config-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9403,6 +9403,7 @@ dependencies = [
  "serde_with 2.2.0",
  "snafu",
  "toml 0.7.2",
+ "typetag",
  "url",
  "vector-config-common",
  "vector-config-macros",
@@ -9426,6 +9427,7 @@ name = "vector-config-macros"
 version = "0.1.0"
 dependencies = [
  "darling 0.13.4",
+ "itertools",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "serde",

--- a/lib/vector-config-macros/Cargo.toml
+++ b/lib/vector-config-macros/Cargo.toml
@@ -9,6 +9,7 @@ proc-macro = true
 
 [dependencies]
 darling = { version = "0.13", default-features = false, features = ["suggestions"] }
+itertools = { version = "0.10.5", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
 serde_derive_internals = "0.26"

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_with = { version = "2.2.0", default-features = false, features = ["std"] }
 snafu = { version = "0.7.4", default-features = false }
 toml = { version = "0.7.2", default-features = false }
-typetag = { version = "0.2.5", default-features = false }
 url = { version = "2.3.1", default-features = false, features = ["serde"] }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_with = { version = "2.2.0", default-features = false, features = ["std"] }
 snafu = { version = "0.7.4", default-features = false }
 toml = { version = "0.7.2", default-features = false }
+typetag = { version = "0.2.5", default-features = false }
 url = { version = "2.3.1", default-features = false, features = ["serde"] }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }

--- a/lib/vector-config/src/component/description.rs
+++ b/lib/vector-config/src/component/description.rs
@@ -1,9 +1,12 @@
-use std::marker::PhantomData;
+use std::{cell::RefCell, marker::PhantomData};
 
 use snafu::Snafu;
 use toml::Value;
+use vector_config_common::attributes::CustomAttribute;
 
 use super::{ComponentMarker, GenerateConfig};
+use crate::schema::{SchemaGenerator, SchemaObject};
+use crate::{schema, Configurable, ConfigurableRef, GenerateError, Metadata};
 
 #[derive(Debug, Snafu, Clone, PartialEq, Eq)]
 pub enum ExampleError {
@@ -17,7 +20,11 @@ pub enum ExampleError {
 /// Description of a component.
 pub struct ComponentDescription<T: ComponentMarker + Sized> {
     component_name: &'static str,
+    description: &'static str,
+    label: &'static str,
+    logical_name: &'static str,
     example_value: fn() -> Option<Value>,
+    config: ConfigurableRef,
     _component_type: PhantomData<T>,
 }
 
@@ -33,11 +40,21 @@ where
     /// type `T` and the component name. As such, if `T` is `SourceComponent`, and the name is
     /// `stdin`, you would say that the component is a "source called `stdin`".
     ///
-    /// The type parameter `C` must be the component's configuration type that implements `GenerateConfig`.
-    pub const fn new<C: GenerateConfig>(component_name: &'static str) -> Self {
+    /// The type parameter `C` must be the component's configuration type that implements
+    /// `Configurable` and `GenerateConfig`.
+    pub const fn new<C: GenerateConfig + Configurable + 'static>(
+        component_name: &'static str,
+        label: &'static str,
+        logical_name: &'static str,
+        description: &'static str,
+    ) -> Self {
         ComponentDescription {
             component_name,
+            description,
+            label,
+            logical_name,
             example_value: || Some(C::generate_config()),
+            config: ConfigurableRef::new::<C>(),
             _component_type: PhantomData,
         }
     }
@@ -66,5 +83,48 @@ where
         }
         types.sort_unstable();
         types
+    }
+
+    /// Generate a schema object covering all the descriptions of this type.
+    pub fn generate_schemas(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        let mut descriptions: Vec<_> = inventory::iter::<Self>.into_iter().collect();
+        descriptions.sort_unstable_by_key(|desc| desc.component_name);
+        let subschemas: Vec<SchemaObject> = descriptions
+            .into_iter()
+            .map(|description| description.generate_schema(gen))
+            .collect::<Result<_, _>>()?;
+        Ok(schema::generate_one_of_schema(&subschemas))
+    }
+
+    /// Generate a schema object for this description.
+    fn generate_schema(
+        &self,
+        gen: &RefCell<SchemaGenerator>,
+    ) -> Result<SchemaObject, GenerateError> {
+        let tag_schema = schema::generate_internal_tagged_variant_schema("type".to_string(), {
+            let mut tag_subschema =
+                schema::generate_const_string_schema(self.component_name.to_string());
+            let mut variant_tag_metadata = Metadata::default();
+            variant_tag_metadata.set_description(self.description);
+            schema::apply_base_metadata(&mut tag_subschema, variant_tag_metadata);
+            tag_subschema
+        });
+        let flattened_subschemas = vec![tag_schema];
+
+        let mut field_metadata = Metadata::default();
+        field_metadata.set_transparent();
+        let mut subschema =
+            schema::get_or_generate_schema(&self.config, gen, Some(field_metadata))?;
+
+        schema::convert_to_flattened_schema(&mut subschema, flattened_subschemas);
+
+        let mut variant_metadata = Metadata::default();
+        variant_metadata.set_description(self.description);
+        variant_metadata.add_custom_attribute(CustomAttribute::kv("docs::label", self.label));
+        variant_metadata
+            .add_custom_attribute(CustomAttribute::kv("logical_name", self.logical_name));
+        schema::apply_base_metadata(&mut subschema, variant_metadata);
+
+        Ok(subschema)
     }
 }

--- a/lib/vector-config/src/component/description.rs
+++ b/lib/vector-config/src/component/description.rs
@@ -101,14 +101,13 @@ where
         &self,
         gen: &RefCell<SchemaGenerator>,
     ) -> Result<SchemaObject, GenerateError> {
-        let tag_schema = schema::generate_internal_tagged_variant_schema("type".to_string(), {
-            let mut tag_subschema =
-                schema::generate_const_string_schema(self.component_name.to_string());
-            let mut variant_tag_metadata = Metadata::default();
-            variant_tag_metadata.set_description(self.description);
-            schema::apply_base_metadata(&mut tag_subschema, variant_tag_metadata);
-            tag_subschema
-        });
+        let mut tag_subschema =
+            schema::generate_const_string_schema(self.component_name.to_string());
+        let variant_tag_metadata = Metadata::with_description(self.description);
+        schema::apply_base_metadata(&mut tag_subschema, variant_tag_metadata);
+
+        let tag_schema =
+            schema::generate_internal_tagged_variant_schema("type".to_string(), tag_subschema);
         let flattened_subschemas = vec![tag_schema];
 
         let mut field_metadata = Metadata::default();

--- a/lib/vector-config/src/configurable.rs
+++ b/lib/vector-config/src/configurable.rs
@@ -17,15 +17,15 @@ use crate::{
 /// `Configurable` provides the machinery to allow describing and encoding the shape of a type, recursively, so that by
 /// instrumenting all transitive types of the configuration, the schema can be discovered by generating the schema from
 /// some root type.
-pub trait Configurable
-where
-    Self: Sized,
-{
+pub trait Configurable {
     /// Gets the referenceable name of this value, if any.
     ///
     /// When specified, this implies the value is both complex and standardized, and should be
     /// reused within any generated schema it is present in.
-    fn referenceable_name() -> Option<&'static str> {
+    fn referenceable_name() -> Option<&'static str>
+    where
+        Self: Sized,
+    {
         None
     }
 
@@ -38,12 +38,18 @@ where
     /// Maps, by definition, are inherently free-form, and thus inherently optional. Thus, this
     /// method should likely not be overridden except for implementing `Configurable` for map
     /// types. If you're using it for something else, you are expected to know what you're doing.
-    fn is_optional() -> bool {
+    fn is_optional() -> bool
+    where
+        Self: Sized,
+    {
         false
     }
 
     /// Gets the metadata for this value.
-    fn metadata() -> Metadata {
+    fn metadata() -> Metadata
+    where
+        Self: Sized,
+    {
         Metadata::default()
     }
 
@@ -54,7 +60,10 @@ where
     /// numeric types, there is a limited amount of validation that can occur within the
     /// `Configurable` derive macro, and additional validation must happen at runtime when the
     /// `Configurable` trait is being used, which this method allows for.
-    fn validate_metadata(_metadata: &Metadata) -> Result<(), GenerateError> {
+    fn validate_metadata(_metadata: &Metadata) -> Result<(), GenerateError>
+    where
+        Self: Sized,
+    {
         Ok(())
     }
 
@@ -64,12 +73,14 @@ where
     ///
     /// If an error occurs while generating the schema, an error variant will be returned describing
     /// the issue.
-    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError>;
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError>
+    where
+        Self: Sized;
 
     /// Create a new configurable reference table.
     fn as_configurable_ref() -> ConfigurableRef
     where
-        Self: 'static,
+        Self: Sized + 'static,
     {
         ConfigurableRef::new::<Self>()
     }
@@ -98,7 +109,7 @@ pub struct ConfigurableRef {
 
 impl ConfigurableRef {
     /// Create a new configurable reference table.
-    pub const fn new<T: Configurable + ?Sized + 'static>() -> Self {
+    pub const fn new<T: Configurable + 'static>() -> Self {
         Self {
             type_name: std::any::type_name::<T>,
             referenceable_name: T::referenceable_name,

--- a/src/api/schema/components/mod.rs
+++ b/src/api/schema/components/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         filter::{self, filter_items},
         relay, sort,
     },
-    config::{ComponentKey, Config, TransformConfig},
+    config::{ComponentKey, Config},
     filter_check,
 };
 use crate::{config::SourceConfig, topology::schema::merged_definition};

--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -6,7 +6,7 @@ mod test_case;
 pub mod util;
 mod validators;
 
-use crate::{sinks::Sinks, sources::Sources, transforms::Transforms};
+use crate::{config::BoxedTransform, sinks::Sinks, sources::Sources};
 
 pub use self::resources::*;
 #[cfg(feature = "component-validation-runner")]
@@ -43,7 +43,7 @@ pub enum ComponentConfiguration {
     Source(Sources),
 
     /// A transform component.
-    Transform(Transforms),
+    Transform(BoxedTransform),
 
     /// A sink component.
     Sink(Sinks),
@@ -78,7 +78,7 @@ impl ValidationConfiguration {
     }
 
     /// Creates a new `ValidationConfiguration` for a transform.
-    pub fn from_transform<C: Into<Transforms>>(component_name: &'static str, config: C) -> Self {
+    pub fn from_transform(component_name: &'static str, config: impl Into<BoxedTransform>) -> Self {
         Self {
             component_name,
             component_type: ComponentType::Source,

--- a/src/components/validation/runner/config.rs
+++ b/src/components/validation/runner/config.rs
@@ -4,11 +4,10 @@ use crate::{
         util::GrpcAddress,
         ComponentConfiguration, ComponentType, ValidationConfiguration,
     },
-    config::ConfigBuilder,
+    config::{BoxedTransform, ConfigBuilder},
     sinks::{vector::VectorConfig as VectorSinkConfig, Sinks},
     sources::{vector::VectorConfig as VectorSourceConfig, Sources},
     test_util::next_addr,
-    transforms::Transforms,
 };
 
 use super::{
@@ -57,7 +56,7 @@ impl TopologyBuilder {
         }
     }
 
-    fn from_transform(transform: Transforms) -> Self {
+    fn from_transform(transform: BoxedTransform) -> Self {
         let (input_edge, input_source) = build_input_edge();
         let (output_edge, output_sink) = build_output_edge();
 

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -10,7 +10,7 @@ use vector_core::config::GlobalOptions;
 
 use crate::{
     enrichment_tables::EnrichmentTables, providers::Providers, secrets::SecretBackends,
-    sinks::Sinks, sources::Sources, transforms::Transforms,
+    sinks::Sinks, sources::Sources,
 };
 
 #[cfg(feature = "api")]
@@ -18,8 +18,8 @@ use super::api;
 #[cfg(feature = "enterprise")]
 use super::enterprise;
 use super::{
-    compiler, schema, ComponentKey, Config, EnrichmentTableOuter, HealthcheckOptions, SinkOuter,
-    SourceOuter, TestDefinition, TransformOuter,
+    compiler, schema, BoxedTransform, ComponentKey, Config, EnrichmentTableOuter,
+    HealthcheckOptions, SinkOuter, SourceOuter, TestDefinition, TransformOuter,
 };
 
 /// A complete Vector configuration.
@@ -275,11 +275,11 @@ impl ConfigBuilder {
 
     // For some feature sets, no transforms are compiled, which leads to no callers using this
     // method, and in turn, annoying errors about unused variables.
-    pub fn add_transform<K: Into<String>, T: Into<Transforms>>(
+    pub fn add_transform(
         &mut self,
-        key: K,
+        key: impl Into<String>,
         inputs: &[&str],
-        transform: T,
+        transform: impl Into<BoxedTransform>,
     ) {
         let inputs = inputs
             .iter()

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -2,7 +2,7 @@ use indexmap::IndexSet;
 
 use super::{
     builder::ConfigBuilder, graph::Graph, id::Inputs, schema, validation, Config, OutputId,
-    SourceConfig, TransformConfig,
+    SourceConfig,
 };
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::{
     schema, ComponentKey, DataType, Output, OutputId, SinkConfig, SinkOuter, SourceConfig,
-    SourceOuter, TransformConfig, TransformOuter,
+    SourceOuter, TransformOuter,
 };
 
 #[derive(Debug, Clone)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,7 +53,7 @@ pub use provider::ProviderConfig;
 pub use secret::SecretBackend;
 pub use sink::{SinkConfig, SinkContext, SinkHealthcheckOptions, SinkOuter};
 pub use source::{SourceConfig, SourceContext, SourceOuter};
-pub use transform::{TransformConfig, TransformContext, TransformOuter};
+pub use transform::{BoxedTransform, TransformConfig, TransformContext, TransformOuter};
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
 pub use vector_core::config::{log_schema, proxy::ProxyConfig, LogSchema};

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -1,20 +1,50 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
+use dyn_clone::DynClone;
 use enum_dispatch::enum_dispatch;
 use serde::Serialize;
-use vector_config::{configurable_component, Configurable, NamedComponent};
-use vector_core::config::LogNamespace;
+use vector_config::{
+    configurable_component,
+    schema::{SchemaGenerator, SchemaObject},
+    Configurable, GenerateError, Metadata, NamedComponent,
+};
+use vector_config_common::attributes::CustomAttribute;
 use vector_core::{
-    config::{GlobalOptions, Input, Output},
+    config::{GlobalOptions, Input, LogNamespace, Output},
     schema,
     transform::Transform,
 };
 
-use crate::transforms::Transforms;
-
 use super::schema::Options as SchemaOptions;
 use super::{id::Inputs, ComponentKey};
+
+pub type BoxedTransform = Box<dyn TransformConfig>;
+
+impl Configurable for BoxedTransform {
+    fn referenceable_name() -> Option<&'static str> {
+        Some("vector::transforms::Transforms")
+    }
+
+    fn metadata() -> Metadata {
+        let mut metadata = Metadata::default();
+        metadata.set_description("Configurable transforms in Vector.");
+        metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "internal"));
+        metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tag_field", "type"));
+        metadata
+    }
+
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        vector_config::component::TransformDescription::generate_schemas(gen)
+    }
+}
+
+impl<T: TransformConfig + 'static> From<T> for BoxedTransform {
+    fn from(that: T) -> Self {
+        Box::new(that)
+    }
+}
 
 /// Fully resolved transform component.
 #[configurable_component]
@@ -29,7 +59,7 @@ where
 
     #[configurable(metadata(docs::hidden))]
     #[serde(flatten)]
-    pub inner: Transforms,
+    pub inner: BoxedTransform,
 }
 
 impl<T> TransformOuter<T>
@@ -39,12 +69,11 @@ where
     pub(crate) fn new<I, IT>(inputs: I, inner: IT) -> Self
     where
         I: IntoIterator<Item = T>,
-        IT: Into<Transforms>,
+        IT: Into<BoxedTransform>,
     {
-        TransformOuter {
-            inputs: Inputs::from_iter(inputs),
-            inner: inner.into(),
-        }
+        let inputs = Inputs::from_iter(inputs);
+        let inner = inner.into();
+        TransformOuter { inputs, inner }
     }
 
     pub(super) fn map_inputs<U>(self, f: impl Fn(&T) -> U) -> TransformOuter<U>
@@ -142,7 +171,8 @@ impl TransformContext {
 /// Generalized interface for describing and building transform components.
 #[async_trait]
 #[enum_dispatch]
-pub trait TransformConfig: NamedComponent + core::fmt::Debug + Send + Sync {
+#[typetag::serde(tag = "type")]
+pub trait TransformConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync {
     /// Builds the transform with the given context.
     ///
     /// If the transform is built successfully, `Ok(...)` is returned containing the transform.
@@ -203,3 +233,5 @@ pub trait TransformConfig: NamedComponent + core::fmt::Debug + Send + Sync {
         true
     }
 }
+
+dyn_clone::clone_trait_object!(TransformConfig);

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use dyn_clone::DynClone;
-use enum_dispatch::enum_dispatch;
 use serde::Serialize;
 use vector_config::{
     configurable_component,
@@ -170,7 +169,6 @@ impl TransformContext {
 
 /// Generalized interface for describing and building transform components.
 #[async_trait]
-#[enum_dispatch]
 #[typetag::serde(tag = "type")]
 pub trait TransformConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync {
     /// Builds the transform with the given context.

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -22,7 +22,7 @@ pub use self::unit_test_components::{
     UnitTestSinkCheck, UnitTestSinkConfig, UnitTestSinkResult, UnitTestSourceConfig,
     UnitTestStreamSinkConfig, UnitTestStreamSourceConfig,
 };
-use super::{compiler::expand_globs, graph::Graph, OutputId, TransformConfig};
+use super::{compiler::expand_globs, graph::Graph, OutputId};
 use crate::{
     conditions::Condition,
     config::{

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -6,9 +6,7 @@ use indexmap::IndexMap;
 use std::{collections::HashMap, path::PathBuf};
 use vector_core::internal_event::DEFAULT_OUTPUT;
 
-use super::{
-    builder::ConfigBuilder, ComponentKey, Config, OutputId, Resource, SourceConfig, TransformConfig,
-};
+use super::{builder::ConfigBuilder, ComponentKey, Config, OutputId, Resource, SourceConfig};
 
 /// Check that provide + topology config aren't present in the same builder, which is an error.
 pub fn check_provider(config: &ConfigBuilder) -> Result<(), Vec<String>> {

--- a/src/test_util/mock/transforms/basic.rs
+++ b/src/test_util/mock/transforms/basic.rs
@@ -17,7 +17,7 @@ use vector_core::{
 use crate::config::{TransformConfig, TransformContext};
 
 /// Configuration for the `test_basic` transform.
-#[configurable_component(transform("test_basic"))]
+#[configurable_component(transform("test_basic", "Test (basic)"))]
 #[derive(Clone, Debug, Default)]
 pub struct BasicTransformConfig {
     /// Suffix to add to the message of any log event.
@@ -36,6 +36,7 @@ impl BasicTransformConfig {
 }
 
 #[async_trait]
+#[typetag::serde(name = "test_basic")]
 impl TransformConfig for BasicTransformConfig {
     async fn build(&self, _globals: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::function(BasicTransform {

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -16,7 +16,7 @@ use crate::config::{GenerateConfig, TransformConfig, TransformContext};
 use super::TransformType;
 
 /// Configuration for the `test_noop` transform.
-#[configurable_component(transform("test_noop"))]
+#[configurable_component(transform("test_noop", "Test (no-op)"))]
 #[derive(Clone, Debug)]
 pub struct NoopTransformConfig {
     #[configurable(derived)]
@@ -33,6 +33,7 @@ impl GenerateConfig for NoopTransformConfig {
 }
 
 #[async_trait]
+#[typetag::serde(name = "test_noop")]
 impl TransformConfig for NoopTransformConfig {
     fn input(&self) -> Input {
         Input::all()

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -42,8 +42,8 @@ use super::{
 use crate::{
     config::{
         ComponentKey, DataType, EnrichmentTableConfig, Input, Inputs, Output, OutputId,
-        ProxyConfig, SinkConfig, SinkContext, SourceConfig, SourceContext, TransformConfig,
-        TransformContext, TransformOuter,
+        ProxyConfig, SinkConfig, SinkContext, SourceConfig, SourceContext, TransformContext,
+        TransformOuter,
     },
     event::{EventArray, EventContainer},
     internal_events::EventsReceived,

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -4,10 +4,7 @@ use value::Kind;
 pub(super) use crate::schema::Definition;
 
 use crate::{
-    config::{
-        ComponentKey, Config, Output, OutputId, SinkConfig, SinkOuter, SourceConfig,
-        TransformConfig,
-    },
+    config::{ComponentKey, Config, Output, OutputId, SinkConfig, SinkOuter, SourceConfig},
     topology,
 };
 

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Configuration for the `aggregate` transform.
-#[configurable_component(transform("aggregate"))]
+#[configurable_component(transform("aggregate", "Aggregate metrics passing through a topology."))]
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AggregateConfig {
@@ -36,6 +36,7 @@ const fn default_interval_ms() -> u64 {
 impl_generate_config_from_default!(AggregateConfig);
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "aggregate")]
 impl TransformConfig for AggregateConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
         Aggregate::new(self).map(Transform::event_task)

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -76,7 +76,10 @@ static TOKEN_HEADER: Lazy<Bytes> = Lazy::new(|| Bytes::from("X-aws-ec2-metadata-
 
 /// Configuration for the `aws_ec2_metadata` transform.
 #[serde_as]
-#[configurable_component(transform("aws_ec2_metadata"))]
+#[configurable_component(transform(
+    "aws_ec2_metadata",
+    "Parse metadata emitted by AWS EC2 instances."
+))]
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default)]
 pub struct Ec2Metadata {
@@ -189,6 +192,7 @@ struct Keys {
 impl_generate_config_from_default!(Ec2Metadata);
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "aws_ec2_metadata")]
 impl TransformConfig for Ec2Metadata {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         let state = Arc::new(ArcSwap::new(Arc::new(vec![])));

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -68,7 +68,7 @@ pub struct CacheConfig {
 }
 
 /// Configuration for the `dedupe` transform.
-#[configurable_component(transform("dedupe"))]
+#[configurable_component(transform("dedupe", "Deduplicate logs passing through a topology."))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DedupeConfig {
@@ -139,6 +139,7 @@ impl GenerateConfig for DedupeConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "dedupe")]
 impl TransformConfig for DedupeConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::event_task(Dedupe::new(self.clone())))

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Configuration for the `filter` transform.
-#[configurable_component(transform("filter"))]
+#[configurable_component(transform("filter", "Filter events based on a set of conditions."))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FilterConfig {
@@ -36,6 +36,7 @@ impl GenerateConfig for FilterConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "filter")]
 impl TransformConfig for FilterConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::function(Filter::new(

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Configuration for the `log_to_metric` transform.
-#[configurable_component(transform("log_to_metric"))]
+#[configurable_component(transform("log_to_metric", "Convert log events to metric events."))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct LogToMetricConfig {
@@ -144,6 +144,7 @@ impl GenerateConfig for LogToMetricConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "log_to_metric")]
 impl TransformConfig for LogToMetricConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::function(LogToMetric::new(self.clone())))

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -62,7 +62,10 @@ pub struct LuaConfigV2 {
 }
 
 /// Configuration for the `lua` transform.
-#[configurable_component(transform("lua"))]
+#[configurable_component(transform(
+    "lua",
+    "Modify event data using the Lua programming language."
+))]
 #[derive(Clone, Debug)]
 #[serde(untagged)]
 pub enum LuaConfig {
@@ -84,6 +87,7 @@ impl GenerateConfig for LuaConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "lua")]
 impl TransformConfig for LuaConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
         match self {

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// Configuration for the `metric_to_log` transform.
-#[configurable_component(transform("metric_to_log"))]
+#[configurable_component(transform("metric_to_log", "Convert metric events to log events."))]
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct MetricToLogConfig {
@@ -75,6 +75,7 @@ impl GenerateConfig for MetricToLogConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "metric_to_log")]
 impl TransformConfig for MetricToLogConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::function(MetricToLog::new(

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -2,7 +2,6 @@
 #[allow(unused_imports)]
 use std::collections::HashSet;
 
-use enum_dispatch::enum_dispatch;
 use snafu::Snafu;
 
 #[cfg(feature = "transforms-aggregate")]
@@ -31,17 +30,10 @@ pub mod tag_cardinality_limit;
 #[cfg(feature = "transforms-throttle")]
 pub mod throttle;
 
-use vector_config::{configurable_component, NamedComponent};
 pub use vector_core::transform::{
     FunctionTransform, OutputBuffer, SyncTransform, TaskTransform, Transform, TransformOutputs,
     TransformOutputsBuf,
 };
-use vector_core::{
-    config::{Input, LogNamespace, Output},
-    schema,
-};
-
-use crate::config::{TransformConfig, TransformContext};
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -52,124 +44,6 @@ enum BuildError {
     InvalidSubstring { name: String },
 }
 
-/// Configurable transforms in Vector.
-#[configurable_component]
-#[derive(Clone, Debug)]
-#[serde(tag = "type", rename_all = "snake_case")]
-#[enum_dispatch(TransformConfig)]
-pub enum Transforms {
-    /// Aggregate metrics passing through a topology.
-    #[cfg(feature = "transforms-aggregate")]
-    #[configurable(metadata(docs::label = "Aggregate"))]
-    Aggregate(aggregate::AggregateConfig),
-
-    /// Parse metadata emitted by AWS EC2 instances.
-    #[cfg(feature = "transforms-aws_ec2_metadata")]
-    #[configurable(metadata(docs::label = "AWS EC2 Metadata"))]
-    AwsEc2Metadata(aws_ec2_metadata::Ec2Metadata),
-
-    /// Deduplicate logs passing through a topology.
-    #[cfg(feature = "transforms-dedupe")]
-    #[configurable(metadata(docs::label = "Dedupe"))]
-    Dedupe(dedupe::DedupeConfig),
-
-    /// Filter events based on a set of conditions.
-    #[cfg(feature = "transforms-filter")]
-    #[configurable(metadata(docs::label = "Filter"))]
-    Filter(filter::FilterConfig),
-
-    /// Convert log events to metric events.
-    #[configurable(metadata(docs::label = "Log To Metric"))]
-    LogToMetric(log_to_metric::LogToMetricConfig),
-
-    /// Modify event data using the Lua programming language.
-    #[cfg(feature = "transforms-lua")]
-    #[configurable(metadata(docs::label = "Lua"))]
-    Lua(lua::LuaConfig),
-
-    /// Convert metric events to log events.
-    #[cfg(feature = "transforms-metric_to_log")]
-    #[configurable(metadata(docs::label = "Metric To Log"))]
-    MetricToLog(metric_to_log::MetricToLogConfig),
-
-    /// Collapse multiple log events into a single event based on a set of conditions and merge strategies.
-    #[cfg(feature = "transforms-reduce")]
-    #[configurable(metadata(docs::label = "Reduce"))]
-    Reduce(reduce::ReduceConfig),
-
-    /// Modify your observability data as it passes through your topology using Vector Remap Language (VRL).
-    #[cfg(feature = "transforms-remap")]
-    #[configurable(metadata(docs::label = "Remap"))]
-    Remap(remap::RemapConfig),
-
-    /// Split a stream of events into multiple sub-streams based on user-supplied conditions.
-    #[cfg(feature = "transforms-route")]
-    #[configurable(metadata(docs::label = "Route"))]
-    Route(route::RouteConfig),
-
-    /// Sample events from an event stream based on supplied criteria and at a configurable rate.
-    #[cfg(feature = "transforms-sample")]
-    #[configurable(metadata(docs::label = "Sample"))]
-    Sample(sample::SampleConfig),
-
-    /// Limit the cardinality of tags on metrics events as a safeguard against cardinality explosion.
-    #[cfg(feature = "transforms-tag_cardinality_limit")]
-    #[configurable(metadata(docs::label = "Tag Cardinality Limit"))]
-    TagCardinalityLimit(tag_cardinality_limit::TagCardinalityLimitConfig),
-
-    /// Test (basic).
-    #[cfg(test)]
-    TestBasic(crate::test_util::mock::transforms::BasicTransformConfig),
-
-    /// Test (noop).
-    #[cfg(test)]
-    TestNoop(crate::test_util::mock::transforms::NoopTransformConfig),
-
-    /// Rate limit logs passing through a topology.
-    #[cfg(feature = "transforms-throttle")]
-    #[configurable(metadata(docs::label = "Throttle"))]
-    Throttle(throttle::ThrottleConfig),
-}
-
-// TODO: Use `enum_dispatch` here.
-impl NamedComponent for Transforms {
-    fn get_component_name(&self) -> &'static str {
-        match self {
-            #[cfg(feature = "transforms-aggregate")]
-            Transforms::Aggregate(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-aws_ec2_metadata")]
-            Transforms::AwsEc2Metadata(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-dedupe")]
-            Transforms::Dedupe(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-filter")]
-            Transforms::Filter(config) => config.get_component_name(),
-            Transforms::LogToMetric(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-lua")]
-            Transforms::Lua(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-metric_to_log")]
-            Transforms::MetricToLog(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-reduce")]
-            Transforms::Reduce(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-remap")]
-            Transforms::Remap(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-route")]
-            Transforms::Route(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-sample")]
-            Transforms::Sample(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-tag_cardinality_limit")]
-            Transforms::TagCardinalityLimit(config) => config.get_component_name(),
-            #[cfg(test)]
-            Transforms::TestBasic(config) => config.get_component_name(),
-            #[cfg(test)]
-            Transforms::TestNoop(config) => config.get_component_name(),
-            #[cfg(feature = "transforms-throttle")]
-            Transforms::Throttle(config) => config.get_component_name(),
-            #[allow(unreachable_patterns)]
-            _ => unimplemented!(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use futures::Stream;
@@ -178,11 +52,10 @@ mod test {
     use tokio_util::sync::PollSender;
     use vector_core::transform::FunctionTransform;
 
-    use super::Transforms;
     use crate::{
         config::{
             unit_test::{UnitTestStreamSinkConfig, UnitTestStreamSourceConfig},
-            ConfigBuilder,
+            ConfigBuilder, TransformConfig,
         },
         event::Event,
         test_util::start_topology,
@@ -209,7 +82,7 @@ mod test {
     }
 
     #[allow(dead_code)]
-    pub async fn create_topology<T: Into<Transforms>>(
+    pub async fn create_topology<T: TransformConfig + 'static>(
         events: impl Stream<Item = Event> + Send + 'static,
         transform_config: T,
     ) -> (RunningTopology, mpsc::Receiver<Event>) {

--- a/src/transforms/reduce/mod.rs
+++ b/src/transforms/reduce/mod.rs
@@ -33,7 +33,10 @@ use vector_core::config::LogNamespace;
 
 /// Configuration for the `reduce` transform.
 #[serde_as]
-#[configurable_component(transform("reduce"))]
+#[configurable_component(transform(
+    "reduce",
+    "Collapse multiple log events into a single event based on a set of conditions and merge strategies.",
+))]
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default)]
 #[serde(deny_unknown_fields)]
@@ -111,6 +114,7 @@ const fn default_flush_period_ms() -> Duration {
 impl_generate_config_from_default!(ReduceConfig);
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "reduce")]
 impl TransformConfig for ReduceConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         Reduce::new(self, &context.enrichment_tables).map(Transform::event_task)

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -38,7 +38,10 @@ use crate::{
 const DROPPED: &str = "dropped";
 
 /// Configuration for the `remap` transform.
-#[configurable_component(transform("remap"))]
+#[configurable_component(transform(
+    "remap",
+    "Modify your observability data as it passes through your topology using Vector Remap Language (VRL)."
+))]
 #[derive(Clone, Debug, Derivative)]
 #[serde(deny_unknown_fields)]
 #[derivative(Default)]
@@ -193,6 +196,7 @@ impl RemapConfig {
 impl_generate_config_from_default!(RemapConfig);
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "remap")]
 impl TransformConfig for RemapConfig {
     async fn build(&self, context: &TransformContext) -> Result<Transform> {
         let (transform, warnings) = match self.runtime {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -51,7 +51,10 @@ impl SyncTransform for Route {
 }
 
 /// Configuration for the `route` transform.
-#[configurable_component(transform("route"))]
+#[configurable_component(transform(
+    "route",
+    "Split a stream of events into multiple sub-streams based on user-supplied conditions."
+))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RouteConfig {
@@ -77,6 +80,7 @@ impl GenerateConfig for RouteConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "route")]
 impl TransformConfig for RouteConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         let route = Route::new(self, context)?;

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 
 /// Configuration for the `sample` transform.
-#[configurable_component(transform("sample"))]
+#[configurable_component(transform(
+    "sample",
+    "Sample events from an event stream based on supplied criteria and at a configurable rate."
+))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SampleConfig {
@@ -46,6 +49,7 @@ impl GenerateConfig for SampleConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "sample")]
 impl TransformConfig for SampleConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::function(Sample::new(

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -6,7 +6,10 @@ use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 
 /// Configuration for the `tag_cardinality_limit` transform.
-#[configurable_component(transform("tag_cardinality_limit"))]
+#[configurable_component(transform(
+    "tag_cardinality_limit",
+    "Limit the cardinality of tags on metrics events as a safeguard against cardinality explosion."
+))]
 #[derive(Clone, Debug)]
 pub struct TagCardinalityLimitConfig {
     /// How many distinct values to accept for any given key.
@@ -93,6 +96,7 @@ impl GenerateConfig for TagCardinalityLimitConfig {
 }
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "tag_cardinality_limit")]
 impl TransformConfig for TagCardinalityLimitConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
         Ok(Transform::event_task(TagCardinalityLimit::new(

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -20,7 +20,7 @@ use crate::{
 
 /// Configuration for the `throttle` transform.
 #[serde_as]
-#[configurable_component(transform("throttle"))]
+#[configurable_component(transform("throttle", "Rate limit logs passing through a topology."))]
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ThrottleConfig {
@@ -49,6 +49,7 @@ pub struct ThrottleConfig {
 impl_generate_config_from_default!(ThrottleConfig);
 
 #[async_trait::async_trait]
+#[typetag::serde(name = "throttle")]
 impl TransformConfig for ThrottleConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
         Throttle::new(self, context, clock::MonotonicClock).map(Transform::event_task)


### PR DESCRIPTION
This replaces the top-level `enum Transforms` into a boxed transform type. Serialization and deserialization are handled by `typetag`, and the `configurable_component` macro is enhanced to build out the necessary table entries to generate the schema bits dynamically from all of the components that are compiled into the current configuration.

Note that this same approach is now possible for both the sources and sinks as well. This focuses on the transforms as the smallest step to prove it out for the other component types. Making it work for either sources or sinks should be able to be scoped down to just the actual sources and sinks and not need to touch support code like this does.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
