### PR TITLE
chore(kafka): revert make consumer group instance id configurable

### DIFF
--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -94,10 +94,6 @@ pub struct KafkaSourceConfig {
     #[configurable(metadata(docs::examples = "consumer-group-name"))]
     group_id: String,
 
-    /// Override dynamic membership and broker assignment behavior with static membership, using a group instance (member) id.
-    #[configurable(metadata(docs::examples = "kafka-streams-instance-1"))]
-    group_instance_id: Option<String>,
-
     /// If offsets for consumer group do not exist, set them using this strategy.
     ///
     /// See the [librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for the `auto.offset.reset` option for further clarification.
@@ -702,10 +698,6 @@ fn create_consumer(config: &KafkaSourceConfig) -> crate::Result<StreamConsumer<C
         for (key, value) in librdkafka_options {
             client_config.set(key.as_str(), value.as_str());
         }
-    }
-
-    if let Some(group_instance_id) = &config.group_instance_id {
-        client_config.set("group.instance.id", group_instance_id);
     }
 
     let consumer = client_config

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -209,11 +209,6 @@ base: components: sources: kafka: configuration: {
 		required:    true
 		type: string: examples: ["consumer-group-name"]
 	}
-	group_instance_id: {
-		description: "Override dynamic membership and broker assignment behavior with static membership, using a group instance (member) id."
-		required:    false
-		type: string: examples: ["kafka-streams-instance-1"]
-	}
 	headers_key: {
 		description: """
 			Overrides the name of the log field used to add the headers to each event.


### PR DESCRIPTION
Circling back to the PR this is reverting, I realized I was incorrect that Vector is already setting the `group.instance.id` option per my suggested test:

I think one test could be: is Vector setting the librdkafka option explicitly and do we want it to be configurable. In this case, the answer seems to be yes which means we should add a top-level option for it.

It doesn't look like Vector is currently setting that option. Given that, I don't think we actually need this new option but can just let users configure it via `librdkafka_options."group.instance.id" =  ....`

This reverts commit f90ca9e3e82b7577608b0c82a5feffb3f96d5f4c.
