### PR TITLE
fix(pulsar sink): Rename batch size option

### DIFF
--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -95,7 +95,7 @@ pub struct BatchConfig {
     /// The maximum size of a batch, in events, before it is flushed.
     #[configurable(metadata(docs::type_unit = "events"))]
     #[configurable(metadata(docs::examples = 1000))]
-    pub batch_size: Option<u32>,
+    pub max_events: Option<u32>,
 }
 
 /// Authentication configuration.
@@ -333,7 +333,7 @@ impl PulsarSinkConfig {
         };
 
         if !is_healthcheck {
-            producer_options.batch_size = self.batch.batch_size;
+            producer_options.batch_size = self.batch.max_events;
         }
 
         if let SerializerConfig::Avro { avro } = self.encoding.config() {

--- a/src/sinks/pulsar.rs
+++ b/src/sinks/pulsar.rs
@@ -92,7 +92,7 @@ pub struct PulsarSinkConfig {
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct BatchConfig {
-    /// The maximum size of a batch, in events, before it is flushed.
+    /// The maximum size of a batch before it is flushed.
     #[configurable(metadata(docs::type_unit = "events"))]
     #[configurable(metadata(docs::examples = 1000))]
     pub max_events: Option<u32>,

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -86,7 +86,7 @@ base: components: sinks: pulsar: configuration: {
 	batch: {
 		description: "Event batching behavior."
 		required:    false
-		type: object: options: batch_size: {
+		type: object: options: max_events: {
 			description: "The maximum size of a batch, in events, before it is flushed."
 			required:    false
 			type: uint: {

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -87,7 +87,7 @@ base: components: sinks: pulsar: configuration: {
 		description: "Event batching behavior."
 		required:    false
 		type: object: options: max_events: {
-			description: "The maximum size of a batch, in events, before it is flushed."
+			description: "The maximum size of a batch before it is flushed."
 			required:    false
 			type: uint: {
 				examples: [1000]


### PR DESCRIPTION
To be consistent with other sink batch options.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
