### PR TITLE
[Single-Machine-Performance] Increase Regression Detector replicates

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -38,7 +38,7 @@ jobs:
         id: experimental-meta
         run: |
           export WARMUP_SECONDS="45"
-          export REPLICAS="10"
+          export REPLICAS="20"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
           export SMP_CRATE_VERSION="0.7.1"


### PR DESCRIPTION
This commit doubles the number of Regression Detector replicates. We are working on a method to elide replicate runs automatically for experiments that have sufficient data but we want a higher maximum number of replicates. In the meanwhile, we believe that increasing the total number of replicates should address some of the 'wobble' we're seeing in some experiments here, that is, phantom dings.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
