### PR TITLE
feat(elasticsearch): add AWS OpenSearch Serverless support

### DIFF
--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -182,6 +182,10 @@ pub struct ElasticsearchConfig {
     )]
     #[configurable(derived)]
     pub acknowledgements: AcknowledgementsConfig,
+
+    /// If `true`, enables AWS OpenSearch Serverless mode.
+    #[serde(default)]
+    pub aws_opensearch_serverless: bool,
 }
 
 fn default_doc_type() -> String {
@@ -217,6 +221,7 @@ impl Default for ElasticsearchConfig {
             data_stream: None,
             metrics: None,
             acknowledgements: Default::default(),
+            aws_opensearch_serverless: false,
         }
     }
 }

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -91,6 +91,7 @@ pub struct HttpRequestBuilder {
     pub http_request_config: RequestConfig,
     pub http_auth: Option<Auth>,
     pub credentials_provider: Option<SharedCredentialsProvider>,
+    pub aws_opensearch_serverless: bool,
 }
 
 impl HttpRequestBuilder {
@@ -103,6 +104,7 @@ impl HttpRequestBuilder {
             region: common.region.clone(),
             compression: config.compression,
             credentials_provider: common.aws_auth.clone(),
+            aws_opensearch_serverless: common.aws_opensearch_serverless,
         }
     }
 
@@ -135,7 +137,13 @@ impl HttpRequestBuilder {
             .expect("Invalid http request value used");
 
         if let Some(credentials_provider) = &self.credentials_provider {
-            sign_request(&mut request, credentials_provider, &self.region).await?;
+            sign_request(
+                &mut request,
+                credentials_provider,
+                &self.region,
+                self.aws_opensearch_serverless,
+            )
+            .await?;
         }
 
         Ok(request)

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -188,6 +188,11 @@ base: components: sinks: elasticsearch: configuration: {
 			}
 		}
 	}
+	aws_opensearch_serverless: {
+		description: "If `true`, enables AWS OpenSearch Serverless mode."
+		required:    false
+		type: bool: default: false
+	}
 	batch: {
 		description: "Event batching behavior."
 		required:    false


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/16252

- add `aws_opensearch_serverless` config
- update documentation

Tested:
- No
