### PR TITLE
fix(amqp source, amqp sink): add openssl feature flag to lapin crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7895,6 +7895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a4b0a70bac0a58ca6a7659d1328e34ee462339c70b0fa49f72bad1f278910a"
 dependencies = [
  "cfg-if",
+ "openssl",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7895,7 +7895,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a4b0a70bac0a58ca6a7659d1328e34ee462339c70b0fa49f72bad1f278910a"
 dependencies = [
  "cfg-if",
- "openssl",
+ "native-tls",
+ "rustls-pemfile 1.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ goauth = { version = "0.13.1", optional = true }
 smpl_jwt = { version = "0.7.1", default-features = false, optional = true }
 
 # AMQP
-lapin = { version = "2.1.1", default-features = false, features = ["openssl"], optional = true }
+lapin = { version = "2.1.1", default-features = false, features = ["native-tls"], optional = true }
 
 # API
 async-graphql = { version = "5.0.6", default-features = false, optional = true, features = ["chrono"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ goauth = { version = "0.13.1", optional = true }
 smpl_jwt = { version = "0.7.1", default-features = false, optional = true }
 
 # AMQP
-lapin = { version = "2.1.1", default-features = false, optional = true }
+lapin = { version = "2.1.1", default-features = false, features = ["openssl"], optional = true }
 
 # API
 async-graphql = { version = "5.0.6", default-features = false, optional = true, features = ["chrono"] }


### PR DESCRIPTION
Closes #16504 

This adds the `openssl` feature to the `lapin` crate which allows the `amqp` components to work over tls with [CloudAMQP](https://www.cloudamqp.com/). Thanks @zamazan4ik for doing the investigation.

I am a little confused as to why this is necessary since the library should be using `native-tls` if no feature flag is specified, but I have tested it and this seems to be what is needed to make it work.