### PR TITLE
fix(socket source): remove default_max_length default

### DIFF
--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -40,7 +40,6 @@ pub struct TcpConfig {
         deprecated = "This option has been deprecated. Configure `max_length` on the framing config instead."
     )]
     #[configurable(metadata(docs::type_unit = "bytes"))]
-    #[serde(default = "default_max_length")]
     max_length: Option<usize>,
 
     /// The timeout before a connection is forcefully closed during shutdown.

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -50,7 +50,6 @@ pub struct UnixConfig {
     #[configurable(
         deprecated = "This option has been deprecated. Configure `max_length` on the framing config instead."
     )]
-    #[serde(default = "default_max_length")]
     #[configurable(metadata(docs::type_unit = "bytes"))]
     pub max_length: Option<usize>,
 

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -189,10 +189,7 @@ base: components: sources: socket: configuration: {
 			Messages larger than this are truncated.
 			"""
 		required: false
-		type: uint: {
-			default: 102400
-			unit:    "bytes"
-		}
+		type: uint: unit: "bytes"
 	}
 	mode: {
 		description: "The type of socket to use."


### PR DESCRIPTION
Closes #16630 

A recent change added a default to the `max_length` config setting on the tcp socket source. Unfortunately if you have framing and `max_length` set it results in an [error](https://github.com/vectordotdev/vector/blob/master/src/sources/socket/mod.rs#L115-L116).

This removes the default for `max_length` so if it is unspecified the value remains `None`.