### PR TITLE
docs(internal docs): fix cue fmt command

### DIFF
--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -61,7 +61,7 @@ properly formatted. To run CUE's autoformatting, first [install cue](https://cue
 then run this command from the `vector` root:
 
 ```bash
-cue fmt ./docs/**/*.cue
+cue fmt ./website/**/*.cue
 ```
 
 If that rewrites any files, make sure to commit your changes or else you'll see


### PR DESCRIPTION
The `cue fmt` command references the `docs/` directory that is not used for docs written in cue (anymore). Those docs reside in the `website/` directory. Update the command to match.