### PR TITLE
chore: Revert "Regularize `vdev` integration test arguments to …

### DIFF
--- a/scripts/integration/amqp/test.yaml
+++ b/scripts/integration/amqp/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - amqp-integration-tests
-
-test_filter: '::amqp::'
+- --lib
+- '::amqp::'
 
 matrix:
   version: ['3.8']

--- a/scripts/integration/aws/test.yaml
+++ b/scripts/integration/aws/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - aws-integration-tests
-
-test_filter: ::aws_
+- --lib
+- ::aws_
 
 env:
   AWS_ACCESS_KEY_ID: dummy

--- a/scripts/integration/axiom/test.yaml
+++ b/scripts/integration/axiom/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - axiom-integration-tests
-
-test_filter: '::axiom::'
+- --lib
+- '::axiom::'
 
 runner:
   env:

--- a/scripts/integration/azure/test.yaml
+++ b/scripts/integration/azure/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - azure-integration-tests
-
-test_filter: ::azure_
+- --lib
+- ::azure_
 
 env:
   AZURE_ADDRESS: local-azure-blob

--- a/scripts/integration/chronicle/test.yaml
+++ b/scripts/integration/chronicle/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - chronicle-integration-tests
-
-test_filter: '::chronicle_unstructured::'
+- --lib
+- '::chronicle_unstructured::'
 
 env:
   CHRONICLE_ADDRESS: http://chronicle-emulator:3000

--- a/scripts/integration/clickhouse/test.yaml
+++ b/scripts/integration/clickhouse/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - clickhouse-integration-tests
-
-test_filter: '::clickhouse::'
+- --lib
+- '::clickhouse::'
 
 env:
   CLICKHOUSE_ADDRESS: http://clickhouse:8123

--- a/scripts/integration/databend/test.yaml
+++ b/scripts/integration/databend/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - databend-integration-tests
-
-test_filter: '::databend::'
+- --lib
+- '::databend::'
 
 runner:
   env:

--- a/scripts/integration/datadog-agent/test.yaml
+++ b/scripts/integration/datadog-agent/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - datadog-agent-integration-tests
-
-test_filter: 'sources::datadog_agent::integration_tests::'
+- --lib
+- 'sources::datadog_agent::integration_tests::'
 
 env:
   AGENT_ADDRESS: datadog-agent:8181

--- a/scripts/integration/datadog-logs/test.yaml
+++ b/scripts/integration/datadog-logs/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - datadog-logs-integration-tests
-
-test_filter: '::datadog::logs::'
+- --lib
+- '::datadog::logs::'
 
 runner:
   env:

--- a/scripts/integration/datadog-metrics/test.yaml
+++ b/scripts/integration/datadog-metrics/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - datadog-metrics-integration-tests
-
-test_filter: '::datadog::metrics::'
+- --lib
+- '::datadog::metrics::'
 
 runner:
   env:

--- a/scripts/integration/datadog-traces/test.yaml
+++ b/scripts/integration/datadog-traces/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - datadog-traces-integration-tests
-
-test_filter: '::datadog::traces::'
+- --lib
+- '::datadog::traces::'
 
 env:
   AGENT_PORT: '8082'

--- a/scripts/integration/dnstap/test.yaml
+++ b/scripts/integration/dnstap/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - dnstap-integration-tests
-
-test_filter: '::dnstap::'
+- --lib
+- '::dnstap::'
 
 runner:
   env:

--- a/scripts/integration/docker-logs/test.yaml
+++ b/scripts/integration/docker-logs/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - docker-logs-integration-tests
-
-test_filter: "::docker_logs::"
+- --lib
+- "::docker_logs::"
 
 runner:
   needs_docker_socket: true

--- a/scripts/integration/elasticsearch/test.yaml
+++ b/scripts/integration/elasticsearch/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - es-integration-tests
-
-test_filter: '::elasticsearch::integration_tests::'
+- --lib
+- '::elasticsearch::integration_tests::'
 
 env:
   AWS_ACCESS_KEY_ID: dummy

--- a/scripts/integration/eventstoredb/test.yaml
+++ b/scripts/integration/eventstoredb/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - eventstoredb_metrics-integration-tests
-
-test_filter: '::eventstoredb_metrics::'
+- --lib
+- '::eventstoredb_metrics::'
 
 matrix:
   version: [latest]

--- a/scripts/integration/fluent/test.yaml
+++ b/scripts/integration/fluent/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - fluent-integration-tests
-
-test_filter: "::fluent::"
+- --lib
+- "::fluent::"
 
 runner:
   needs_docker_socket: true

--- a/scripts/integration/gcp/test.yaml
+++ b/scripts/integration/gcp/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - gcp-integration-tests
-
-test_filter: '::gcp::'
+- --lib
+- '::gcp::'
 
 env:
   EMULATOR_ADDRESS: http://gcloud-pubsub:8681

--- a/scripts/integration/http-client/test.yaml
+++ b/scripts/integration/http-client/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - http-client-integration-tests
-
-test_filter: 'sources::http_client::'
+- --lib
+- 'sources::http_client::'
 
 env:
   DUFS_ADDRESS: http://dufs:5000

--- a/scripts/integration/humio/test.yaml
+++ b/scripts/integration/humio/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - humio-integration-tests
-
-test_filter: '::humio::'
+- --lib
+- '::humio::'
 
 runner:
   env:

--- a/scripts/integration/influxdb/test.yaml
+++ b/scripts/integration/influxdb/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - influxdb-integration-tests
-
-test_filter: '::influxdb::'
+- --lib
+- '::influxdb::'
 
 env:
   INFLUXDB_V1_HTTPS_ADDRESS: https://influxdb-v1-tls:8086

--- a/scripts/integration/kafka/test.yaml
+++ b/scripts/integration/kafka/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - kafka-integration-tests
-
-test_filter: '::kafka::'
+- --lib
+- '::kafka::'
 
 env:
   KAFKA_HOST: kafka

--- a/scripts/integration/logstash/test.yaml
+++ b/scripts/integration/logstash/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - logstash-integration-tests
-
-test_filter: '::logstash::integration_tests::'
+- --lib
+- '::logstash::integration_tests::'
 
 env:
   HEARTBEAT_ADDRESS: 0.0.0.0:8080

--- a/scripts/integration/loki/test.yaml
+++ b/scripts/integration/loki/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - loki-integration-tests
-
-test_filter: '::loki::'
+- --lib
+- '::loki::'
 
 env:
   LOKI_ADDRESS: http://loki:3100

--- a/scripts/integration/mongodb/test.yaml
+++ b/scripts/integration/mongodb/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - mongodb_metrics-integration-tests
-
-test_filter: '::mongodb_metrics::'
+- --lib
+- '::mongodb_metrics::'
 
 env:
   PRIMARY_MONGODB_ADDRESS: mongodb://root:toor@mongodb-primary

--- a/scripts/integration/nats/test.yaml
+++ b/scripts/integration/nats/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - nats-integration-tests
-
-test_filter: '::nats::'
+- --lib
+- '::nats::'
 
 env:
   NATS_ADDRESS: nats://nats:4222

--- a/scripts/integration/nginx/test.yaml
+++ b/scripts/integration/nginx/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - nginx-integration-tests
-
-test_filter: '::nginx_metrics::'
+- --lib
+- '::nginx_metrics::'
 
 runner:
   env:

--- a/scripts/integration/opentelemetry/test.yaml
+++ b/scripts/integration/opentelemetry/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - opentelemetry-integration-tests
-
-test_filter: '::opentelemetry::'
+- --lib
+- '::opentelemetry::'
 
 runner:
   env:

--- a/scripts/integration/postgres/test.yaml
+++ b/scripts/integration/postgres/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - postgresql_metrics-integration-tests
-
-test_filter: ::postgres
+- --lib
+- ::postgres
 
 env:
   PG_HOST: postgres

--- a/scripts/integration/prometheus/test.yaml
+++ b/scripts/integration/prometheus/test.yaml
@@ -1,7 +1,8 @@
-test_filter: '::prometheus::remote_write::'
-
-features:
+args:
+- --features
 - prometheus-integration-tests
+- --lib
+- '::prometheus::remote_write::'
 
 env:
   REMOTE_WRITE_SOURCE_RECEIVE_ADDRESS: runner:9102

--- a/scripts/integration/pulsar/test.yaml
+++ b/scripts/integration/pulsar/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - pulsar-integration-tests
-
-test_filter: '::pulsar::'
+- --lib
+- '::pulsar::'
 
 env:
   PULSAR_ADDRESS: pulsar://pulsar:6650

--- a/scripts/integration/redis/test.yaml
+++ b/scripts/integration/redis/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - redis-integration-tests
-
-test_filter: "::redis::"
+- --lib
+- '::redis::'
 
 env:
   REDIS_URL: redis://redis:6379/0

--- a/scripts/integration/shutdown/test.yaml
+++ b/scripts/integration/shutdown/test.yaml
@@ -1,11 +1,10 @@
 args:
+- --features
+- shutdown-tests
+- --test
+- integration
 - --test-threads
 - '4'
-
-features:
-- shutdown-tests
-
-test: "integration"
 
 env:
   KAFKA_HOST: kafka

--- a/scripts/integration/splunk/test.yaml
+++ b/scripts/integration/splunk/test.yaml
@@ -1,7 +1,8 @@
-features:
+args:
+- --features
 - splunk-integration-tests
-
-test_filter: '::splunk_hec::'
+- --lib
+- '::splunk_hec::'
 
 env:
   SPLUNK_API_ADDRESS: https://splunk-hec:8089

--- a/vdev/src/commands/integration/show.rs
+++ b/vdev/src/commands/integration/show.rs
@@ -38,12 +38,7 @@ impl Cli {
                 let envs_dir = state::EnvsDir::new(&integration);
                 let active_env = envs_dir.active()?;
 
-                if let Some(args) = &config.args {
-                    println!("Test args: {}", args.join(" "));
-                } else {
-                    println!("Test args: N/A");
-                }
-
+                println!("Test args: {}", config.args.join(" "));
 
                 println!("Environment:");
                 print_env("  ", &config.env);

--- a/vdev/src/testing/config.rs
+++ b/vdev/src/testing/config.rs
@@ -62,7 +62,7 @@ impl ComposeConfig {
 #[serde(deny_unknown_fields)]
 pub struct IntegrationTestConfig {
     /// The list of arguments to add to the command line for the test runner
-    pub args: Option<Vec<String>>,
+    pub args: Vec<String>,
     /// The set of environment variables to set in both the services and the runner. Variables with
     /// no value are treated as "passthrough" -- they must be set by the caller of `vdev` and are
     /// passed into the containers.
@@ -73,12 +73,6 @@ pub struct IntegrationTestConfig {
     /// Configuration specific to the compose services.
     #[serde(default)]
     pub runner: IntegrationRunnerConfig,
-
-    pub features: Vec<String>,
-
-    pub test: Option<String>,
-
-    pub test_filter: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -64,20 +64,7 @@ impl IntegrationTest {
         for (key, value) in config_env(&self.env_config) {
             env_vars.insert(key, Some(value));
         }
-
-        let mut args = self.config.args.clone().unwrap_or_default();
-
-        args.push("--features".to_string());
-        args.push(self.config.features.join(","));
-
-        // If the test field is not present then use the --lib flag
-        match self.config.test {
-            Some(ref test_arg) => {
-                args.push("--test".to_string());
-                args.push(test_arg.to_string());
-            }
-            None => args.push("--lib".to_string()),
-        }
+        let mut args = self.config.args.clone();
         args.extend(extra_args);
         self.runner
             .test(&env_vars, &self.config.runner.env, &args)?;


### PR DESCRIPTION
This reverts commit c305b05a600e442dd54ae174d16066c255e2fa58.

That commit resulted in the Prometheus integration tests failing with the error:

```
--- TRY 4 STDERR:        vector sinks::prometheus::exporter::integration_tests::prometheus_metrics ---
thread 'sinks::prometheus::exporter::integration_tests::prometheus_metrics' panicked at 'Could not fetch query: CallRequest { source: hyper::Error(Connect, Custom { kind: Other, error: ConnectError("tcp connect error", Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" }) }) }', src/sinks/prometheus/exporter.rs:1394:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
