### PR TITLE
fix(aws service): Revert AWS-SDK updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,20 +602,19 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.53.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741327a7f70e6e639bdb5061964c66250460c70ad3f59c3fe2a3a64ac1484e33"
+checksum = "56a636c44c77fa18bdba56126a34d30cfe5538fe88f7d34988fa731fee143ddd"
 dependencies = [
- "aws-credential-types",
  "aws-http",
  "aws-sdk-sso",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "hex",
@@ -630,26 +629,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-credential-types"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f99dd587a46af58f8cf37773687ecec19d0373a5954942d7e0f405751fe2369"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types 0.53.1",
- "tokio",
- "tracing 0.1.37",
- "zeroize",
-]
-
-[[package]]
 name = "aws-endpoint"
-version = "0.53.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fdfc00c57d95e10bcf83d2331c4ae9ca460ca84dc983b2cdd692de87640389"
+checksum = "6ca8f374874f6459aaa88dc861d7f5d834ca1ff97668eae190e97266b5f6c3fb"
 dependencies = [
- "aws-smithy-http 0.53.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "http",
  "regex",
@@ -658,13 +644,12 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.53.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cdac70481d144bf7001c27884b95ee12c8f62e61db90320d59b673ae121cb8"
+checksum = "78d41e19e779b73463f5f0c21b3aacc995f4ba783ab13a7ae9f5dfb159a551b4"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-http 0.53.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -677,253 +662,240 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28d9292a854b545b03a1fa6d8fec512f7ffb58bc4df2f213b375a105d9e7706"
+checksum = "520b1ac14f0850d0d6a69136d15ba7702d41ee7f4014a5d2d1bf4a86e74f7a6b"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
- "aws-smithy-json",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-query",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85cce88c109db7f60cb51ee5d99abc05e454638281ec187954078c06386937d"
+checksum = "89415e55b57044a09a7eb0a885c2d0af1aa7f95b373e0e898f71a28d7e7d10f9"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-elasticsearch"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0572334dae37527f4cc47409b2084b7c9a74f88f7686359e6f5967a136749262"
+checksum = "e9f4cc10278701dbc0d386ddd8cddfda2695eae7103a54eae11b981f28779ff2"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tokio-stream",
  "tower",
- "url",
 ]
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb7a4fe8c486dba75bfe248eea441b7b1db615f5f048b9604882a116e4e1f99"
+checksum = "c68310f9d7860b4fe73c58e5cec4d7a310a658d1a983fdf176eb35149939896a"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tower",
- "url",
 ]
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d86beba79e9b24f13a6f3f2ff13ca2da332c3d60c44c2d2632bbacb87ee9ad2"
+checksum = "37766fdf50feab317b4f939b1c9ee58a2a1c51785974328ce84cff1eea7a1bb8"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae411cb03ea6df0d4c4340a0d3c15cab7b19715d091f76c5629f31acd6403f3"
+checksum = "a9f08665c8e03aca8cb092ef01e617436ebfa977fddc1240e1b062488ab5d48a"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-sigv4",
+ "aws-sigv4 0.51.0",
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-client",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
- "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-types 0.51.0",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "bytes-utils",
- "fastrand",
  "http",
  "http-body",
- "once_cell",
- "percent-encoding",
- "regex",
  "tokio-stream",
  "tower",
  "tracing 0.1.37",
- "url",
 ]
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe1f563e227905539d5d1514e93a4c4e096366e1325ab24646783a3d6fe2c45"
+checksum = "8b26bb3d12238492cb12bde0de8486679b007daada21fdb110913b32a2a38275"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
- "aws-smithy-json",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-query",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tokio-stream",
  "tower",
- "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d2fb56182ac693a19364cc0bde22d95aef9be3663bf9b906ffbd0ab0a7c7d1"
+checksum = "86dcb1cb71aa8763b327542ead410424515cff0cde5b753eedd2917e09c63734"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-json",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tokio-stream",
  "tower",
- "url",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70adf3e9518c8d6d14f1239f6af04c019ffd260ab791e17deb11f1bce6a9f76"
+checksum = "fdfcf584297c666f6b472d5368a78de3bc714b6e0a53d7fbf76c3e347c292ab1"
 dependencies = [
- "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
- "aws-smithy-json",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
  "aws-smithy-query",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "http",
- "regex",
  "tower",
- "tracing 0.1.37",
- "url",
 ]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.53.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22af7f6515f8b51dabef87df1d901c9734e4e367791c6d0e1082f9f31528120e"
+checksum = "12cbe7b2be9e185c1fbce27fc9c41c66b195b32d89aa099f98768d9544221308"
 dependencies = [
- "aws-credential-types",
- "aws-sigv4",
+ "aws-sigv4 0.51.0",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.53.1",
+ "aws-smithy-http 0.51.0",
  "aws-types",
  "http",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ff4cff8c4a101962d593ba94e72cd83891aecd423f0c6e3146bff6fb92c9e3"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.51.0",
+ "bytes 1.4.0",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "time",
  "tracing 0.1.37",
 ]
 
@@ -933,9 +905,7 @@ version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee0d796882321e91ca7b991ab6193864e04b605be3a6c18adb9134a90d5a860"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-http 0.53.1",
- "bytes 1.4.0",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -950,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9900be224962d65a626072d8777f847ae5406c07547f0dc14c60048978c4b"
+checksum = "7b3442b4c5d3fc39891a2e5e625735fba6b24694887d49c6518460fde98247a9"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -962,12 +932,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e9e4d3c2296bcec2c03f9f769ac9b2424d972c2fe7afc0b59235447ac3a5c3"
+checksum = "cc227e36e346f45298288359f37123e1a92628d1cec6b11b5eb335553278bd9e"
 dependencies = [
- "aws-smithy-http 0.53.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-types 0.51.0",
  "bytes 1.4.0",
  "crc32c",
  "crc32fast",
@@ -983,14 +953,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710ca0f8dacddda5fbcaf5c3cd9d02da7913fd463a2ee9555b617bf168bedacb"
+checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.53.1",
- "aws-smithy-http-tower 0.53.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-types 0.51.0",
  "bytes 1.4.0",
  "fastrand",
  "http",
@@ -1005,13 +975,34 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1ff11ee22de3581114b60d4ae8e700638dacb5b5bbe6769726e251e6c3f20a"
+checksum = "d7ea0df7161ce65b5c8ca6eb709a1a907376fa18226976e41c748ce02ccccf24"
 dependencies = [
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "bytes 1.4.0",
  "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types 0.51.0",
+ "bytes 1.4.0",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -1020,7 +1011,6 @@ version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29dcab29afbea7726f5c10c7be0c38666d7eb07db551580b3b26ed7cfb5d1935"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-types 0.53.1",
  "bytes 1.4.0",
  "bytes-utils",
@@ -1057,12 +1047,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5856d2f1063c0f726a85f32dcd2a9f5a1d994eb27b156abccafc7260f3f471d"
+checksum = "20c96d7bd35e7cf96aca1134b2f81b1b59ffe493f7c6539c051791cbbf7a42d3"
 dependencies = [
- "aws-smithy-http 0.53.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
  "bytes 1.4.0",
  "http",
  "http-body",
@@ -1089,21 +1078,33 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb33659b68480495b5f906b946c8642928440118b1d7e26a25a067303ca01a5"
+checksum = "d8324ba98c8a94187723cc16c37aefa09504646ee65c3d2c3af495bab5ea701b"
 dependencies = [
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4b21ee0e30ff046e87c7b7e017b99d445b42a81fe52c6e5139b23b795a98ae"
+checksum = "83834ed2ff69ea6f6657baf205267dc2c0abe940703503a3e5d60ce23be3d306"
 dependencies = [
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
+dependencies = [
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time",
 ]
 
 [[package]]
@@ -1134,27 +1135,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.53.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d27bfaa164aa94aac721726a83aa78abe708a275e88a573e103b4961c5f0ede"
+checksum = "246e9f83dd1fdf5d347fa30ae4ad30a9d1d42ce4cd74a93d94afa874646f94cd"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.53.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f00f4b0cdd345686e6389f3343a3020f93232d20040802b87673ddc2d02956"
+checksum = "05701d32da168b44f7ee63147781aed8723e792cc131cb9b18363b5393f17f70"
 dependencies = [
- "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-http 0.51.0",
+ "aws-smithy-types 0.51.0",
  "http",
  "rustc_version 0.4.0",
  "tracing 0.1.37",
+ "zeroize",
 ]
 
 [[package]]
@@ -4086,9 +4087,9 @@ checksum = "a898e4b7951673fce96614ce5751d13c40fc5674bc2d759288e46c3ab62598b3"
 
 [[package]]
 name = "inherent"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb659d59c4af6c9dc568b13db431174ab5fa961aa53f5aad7f42fb710c06bc46"
+checksum = "a036328c11e86e024522cb1e9b78ba9df3e316995e004e98854a18e4a326d2e1"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
@@ -5432,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "onig"
@@ -9071,7 +9072,6 @@ dependencies = [
  "async-trait",
  "atty",
  "aws-config",
- "aws-credential-types",
  "aws-sdk-cloudwatch",
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-elasticsearch",
@@ -9079,12 +9079,12 @@ dependencies = [
  "aws-sdk-kinesis",
  "aws-sdk-s3",
  "aws-sdk-sqs",
- "aws-sigv4",
+ "aws-sigv4 0.53.0",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.53.1",
+ "aws-smithy-http 0.51.0",
  "aws-smithy-http-tower 0.54.1",
- "aws-smithy-types 0.53.1",
+ "aws-smithy-types 0.51.0",
  "aws-types",
  "axum",
  "azure_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "9c6368f9ae5c6ec403ca910327ae0c9437b0a85255b6950c90d497e6177f6e5e"
 dependencies = [
  "proc-macro-hack",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -260,17 +260,6 @@ name = "ascii_utils"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
-
-[[package]]
-name = "assert-json-diff"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
-dependencies = [
- "extend",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "assert-json-diff"
@@ -420,7 +409,7 @@ dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "thiserror",
 ]
 
@@ -540,7 +529,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -562,7 +551,7 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -579,7 +568,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -613,9 +602,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3d1e2a1f1ab3ac6c4b884e37413eaa03eb9d901e4fc68ee8f5c1d49721680e"
+checksum = "741327a7f70e6e639bdb5061964c66250460c70ad3f59c3fe2a3a64ac1484e33"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -623,10 +612,10 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "hex",
@@ -642,12 +631,12 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0696a0523a39a19087747e4dafda0362dc867531e3d72a3f195564c84e5e08"
+checksum = "5f99dd587a46af58f8cf37773687ecec19d0373a5954942d7e0f405751fe2369"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "tokio",
  "tracing 0.1.37",
  "zeroize",
@@ -655,12 +644,12 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4f935ab6a1919fbfd6102a80c4fccd9ff5f47f94ba154074afe1051903261"
+checksum = "13fdfc00c57d95e10bcf83d2331c4ae9ca460ca84dc983b2cdd692de87640389"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "http",
  "regex",
@@ -669,13 +658,13 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82976ca4e426ee9ca3ffcf919d9b2c8d14d0cd80d43cc02173737a8f07f28d4d"
+checksum = "74cdac70481d144bf7001c27884b95ee12c8f62e61db90320d59b673ae121cb8"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -688,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca35aa6f343ca08847b0f1bbebf2cf8518e2d0e6db7409e410001113536d98cd"
+checksum = "d28d9292a854b545b03a1fa6d8fec512f7ffb58bc4df2f213b375a105d9e7706"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -698,11 +687,11 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -714,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f8dbe7e86cb0c5999cb5911e052ec1e6e3f4abbbcb1333a63538b4aecdaa9b"
+checksum = "d85cce88c109db7f60cb51ee5d99abc05e454638281ec187954078c06386937d"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -724,10 +713,10 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -738,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-elasticsearch"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26b30b456954c76df16bcc07b53c76416add85b5f17764e6051b8289572f7af"
+checksum = "0572334dae37527f4cc47409b2084b7c9a74f88f7686359e6f5967a136749262"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -748,23 +737,24 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "http",
  "regex",
  "tokio-stream",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f8c3898ce8ad0ae8c81c340fdd30f0b12785ffbce242d3d9854e5196f81113"
+checksum = "cdb7a4fe8c486dba75bfe248eea441b7b1db615f5f048b9604882a116e4e1f99"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -772,22 +762,23 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "http",
  "regex",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85f773996e276281696482efe866719d12e962041bb75f326f8375fb8ac574d"
+checksum = "0d86beba79e9b24f13a6f3f2ff13ca2da332c3d60c44c2d2632bbacb87ee9ad2"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -795,10 +786,10 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -809,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1533be023eeac69668eb718b1c48af7bd5e26305ed770553d2877ab1f7507b68"
+checksum = "5ae411cb03ea6df0d4c4340a0d3c15cab7b19715d091f76c5629f31acd6403f3"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -822,10 +813,10 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-client",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -844,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2afbc1dfbf260945ad1cc19a1d2109f588663b053ffd828faacb29b02c9260"
+checksum = "ffe1f563e227905539d5d1514e93a4c4e096366e1325ab24646783a3d6fe2c45"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -854,11 +845,11 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -866,13 +857,14 @@ dependencies = [
  "regex",
  "tokio-stream",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0119bacf0c42f587506769390983223ba834e605f049babe514b2bd646dbb2"
+checksum = "d5d2fb56182ac693a19364cc0bde22d95aef9be3663bf9b906ffbd0ab0a7c7d1"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -880,23 +872,24 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "bytes 1.4.0",
  "http",
  "regex",
  "tokio-stream",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270b6a33969ebfcb193512fbd5e8ee5306888ad6c6d5d775cdbfb2d50d94de26"
+checksum = "a70adf3e9518c8d6d14f1239f6af04c019ffd260ab791e17deb11f1bce6a9f76"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -904,11 +897,11 @@ dependencies = [
  "aws-sig-auth",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
  "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -916,18 +909,19 @@ dependencies = [
  "regex",
  "tower",
  "tracing 0.1.37",
+ "url",
 ]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660a02a98ab1af83bd8d714afbab2d502ba9b18c49e7e4cddd6bf8837ff778cb"
+checksum = "22af7f6515f8b51dabef87df1d901c9734e4e367791c6d0e1082f9f31528120e"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.53.1",
  "aws-types",
  "http",
  "tracing 0.1.37",
@@ -935,12 +929,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdaf11005b7444e6cd66f600d09861a3aeb6eb89a0f003c7c9820dbab2d15297"
+checksum = "eee0d796882321e91ca7b991ab6193864e04b605be3a6c18adb9134a90d5a860"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.53.1",
  "bytes 1.4.0",
  "form_urlencoded",
  "hex",
@@ -956,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.54.4"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c712a28a4f2f2139759235c08bf98aca99d4fdf1b13c78c5f95613df0a5db9"
+checksum = "d8b9900be224962d65a626072d8777f847ae5406c07547f0dc14c60048978c4b"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -968,12 +962,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.54.2"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596e886b87ac17cb182b01af6452f45ec27c49a199cfc1f2fb81136ace4141af"
+checksum = "85e9e4d3c2296bcec2c03f9f769ac9b2424d972c2fe7afc0b59235447ac3a5c3"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-types 0.53.1",
  "bytes 1.4.0",
  "crc32c",
  "crc32fast",
@@ -989,25 +983,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.54.4"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104ca17f56cde00a10207169697dfe9c6810db339d52fb352707e64875b30a44"
+checksum = "710ca0f8dacddda5fbcaf5c3cd9d02da7913fd463a2ee9555b617bf168bedacb"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-protocol-test",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.53.1",
+ "aws-smithy-types 0.53.1",
  "bytes 1.4.0",
  "fastrand",
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
- "lazy_static",
  "pin-project-lite",
- "serde",
  "tokio",
  "tower",
  "tracing 0.1.37",
@@ -1015,23 +1005,43 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.54.4"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac250d8c0e42af0097a6837ffc5a6fb9f8ba4107bb53124c047c91bc2a58878f"
+checksum = "8d1ff11ee22de3581114b60d4ae8e700638dacb5b5bbe6769726e251e6c3f20a"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "bytes 1.4.0",
  "crc32fast",
 ]
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.54.4"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873f316f1833add0d3aa54ed1b0cd252ddd88c792a0cf839886400099971e844"
+checksum = "29dcab29afbea7726f5c10c7be0c38666d7eb07db551580b3b26ed7cfb5d1935"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
+ "bytes 1.4.0",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd86f48d7e36fb24ee922d04d79c8353e01724b1c38757ed92593179223aa7"
+dependencies = [
+ "aws-smithy-types 0.54.1",
  "bytes 1.4.0",
  "bytes-utils",
  "futures-core",
@@ -1047,12 +1057,28 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.54.4"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38231d3f5dac9ac7976f44e12803add1385119ffca9e5f050d8e980733d164"
+checksum = "f5856d2f1063c0f726a85f32dcd2a9f5a1d994eb27b156abccafc7260f3f471d"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-types 0.53.1",
+ "bytes 1.4.0",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8972d1b4ae3aba1a10e7106fed53a5a36bc8ef86170a84f6ddd33d36fac12ad"
+dependencies = [
+ "aws-smithy-http 0.54.1",
+ "aws-smithy-types 0.54.1",
  "bytes 1.4.0",
  "http",
  "http-body",
@@ -1063,43 +1089,41 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.54.2"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33123c0a5c876eede87c170c93cfc49ab8fd5619e3f0a1acae6047ba3f43c8c9"
+checksum = "dfb33659b68480495b5f906b946c8642928440118b1d7e26a25a067303ca01a5"
 dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-protocol-test"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d1c9bcb35ce11055ec128dab2c66a7ed47e2dfff99883e32c21a1ab6d6bee6"
-dependencies = [
- "assert-json-diff 1.1.0",
- "http",
- "pretty_assertions",
- "regex",
- "roxmltree 0.14.1",
- "serde_json",
- "thiserror",
+ "aws-smithy-types 0.53.1",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.54.2"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ab0ca83b86080618294164cbfb333e4bbce9f13b4c5993afa58043a96cd077"
+checksum = "9c4b21ee0e30ff046e87c7b7e017b99d445b42a81fe52c6e5139b23b795a98ae"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.53.1",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.54.4"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8161232eda10290f5136610a1eb9de56aceaccd70c963a26a260af20ac24794f"
+checksum = "2013465a070decdeb3e85ceb3370ae85ba05f56f914abfd89858d7281c4f12c3"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7e499c4b15bab8eb6b234df31833cc83a1bdaa691ba72d5d81efc109d9d705"
 dependencies = [
  "base64-simd",
  "itoa",
@@ -1110,24 +1134,24 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.54.2"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57927651cde61bf181874694ea19b1c59f2bcb6e2efba4adaef222d570ec8d"
+checksum = "6d27bfaa164aa94aac721726a83aa78abe708a275e88a573e103b4961c5f0ede"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.54.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f15b34253b68cde08e39b0627cc6101bcca64351229484b4743392c035d057"
+checksum = "61f00f4b0cdd345686e6389f3343a3020f93232d20040802b87673ddc2d02956"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-types 0.53.1",
  "http",
  "rustc_version 0.4.0",
  "tracing 0.1.37",
@@ -1305,12 +1329,11 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64-simd"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
 dependencies = [
- "outref",
- "vsimd",
+ "simd-abstraction",
 ]
 
 [[package]]
@@ -1362,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9e32d7420c85055e8107e5b2463c4eeefeaac18b52359fe9f9c08a18f342b2"
 dependencies = [
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1483,7 +1506,7 @@ dependencies = [
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2 1.0.51",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1494,7 +1517,7 @@ checksum = "61820b4c5693eafb998b1e67485423c923db4a75f72585c247bdee32bad81e7b"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1505,7 +1528,7 @@ checksum = "c76cdbfa13def20d1f8af3ae7b3c6771f06352a74221d8851262ac384c122b8e"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1574,7 +1597,7 @@ checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1659,7 +1682,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1888,7 +1911,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2344,7 +2367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2399,7 +2422,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "scratch",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2416,7 +2439,7 @@ checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2450,7 +2473,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "strsim 0.10.0",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2464,7 +2487,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "strsim 0.10.0",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2475,7 +2498,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2486,7 +2509,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2608,7 +2631,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2619,7 +2642,7 @@ checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2632,7 +2655,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustc_version 0.4.0",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2854,7 +2877,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2866,7 +2889,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2878,7 +2901,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2898,7 +2921,7 @@ checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2949,7 +2972,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustversion",
- "syn 1.0.109",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -3013,18 +3036,6 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
-
-[[package]]
-name = "extend"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "fakedata"
@@ -3128,7 +3139,7 @@ checksum = "e4c81935e123ab0741c4c4f0d9b8377e5fb21d3de7e062fa4b1263b1fbcba1ea"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3297,7 +3308,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3380,7 +3391,7 @@ checksum = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3482,7 +3493,7 @@ dependencies = [
  "quote 1.0.23",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3493,7 +3504,7 @@ checksum = "d52fc9cde811f44b15ec0692b31e56a3067f6f431c5ace712f286e47c1dacc98"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2 1.0.51",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4081,7 +4092,7 @@ checksum = "cb659d59c4af6c9dc568b13db431174ab5fa961aa53f5aad7f42fb710c06bc46"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4859,7 +4870,7 @@ checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5363,7 +5374,7 @@ dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5506,7 +5517,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5600,19 +5611,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "outref"
-version = "0.5.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "overload"
@@ -5742,7 +5744,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5836,7 +5838,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6025,18 +6027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
-dependencies = [
- "ctor",
- "diff",
- "output_vt100",
- "yansi",
-]
-
-[[package]]
 name = "prettydiff"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6054,7 +6044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2 1.0.51",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6100,7 +6090,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -6220,7 +6210,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn 1.0.107",
  "tempfile",
  "which",
 ]
@@ -6235,7 +6225,7 @@ dependencies = [
  "itertools",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6264,7 +6254,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6359,7 +6349,7 @@ checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6753,7 +6743,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -6805,15 +6795,6 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "retain_mut",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
-dependencies = [
- "xmlparser",
 ]
 
 [[package]]
@@ -7234,7 +7215,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7245,7 +7226,7 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7297,7 +7278,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7356,7 +7337,7 @@ dependencies = [
  "darling 0.13.4",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7368,7 +7349,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7520,6 +7501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "simd-abstraction"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
+dependencies = [
+ "outref",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7630,7 +7620,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7761,7 +7751,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7780,7 +7770,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "rustversion",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7812,9 +7802,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
@@ -7835,7 +7825,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "unicode-xid 0.2.4",
 ]
 
@@ -7963,7 +7953,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7975,7 +7965,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "test-case-core",
 ]
 
@@ -8023,7 +8013,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8169,7 +8159,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8382,7 +8372,7 @@ dependencies = [
  "proc-macro2 1.0.51",
  "prost-build",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8504,7 +8494,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8631,7 +8621,7 @@ checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8799,7 +8789,7 @@ checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8829,7 +8819,7 @@ checksum = "8f9568611f0de5e83e0993b85c54679cd0afd659adcfcb0233f16280b980492e"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -9092,9 +9082,9 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-types",
+ "aws-smithy-http 0.53.1",
+ "aws-smithy-http-tower 0.54.1",
+ "aws-smithy-types 0.53.1",
  "aws-types",
  "axum",
  "azure_core",
@@ -9392,7 +9382,7 @@ dependencies = [
  "quote 1.0.23",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -9405,7 +9395,7 @@ dependencies = [
  "quote 1.0.23",
  "serde",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 1.0.107",
  "vector-config",
  "vector-config-common",
 ]
@@ -9663,7 +9653,7 @@ dependencies = [
  "quoted_printable",
  "rand 0.8.5",
  "regex",
- "roxmltree 0.18.0",
+ "roxmltree",
  "rust_decimal",
  "seahash",
  "serde",
@@ -9724,12 +9714,6 @@ dependencies = [
  "vrl-stdlib",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -9857,7 +9841,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -9891,7 +9875,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10167,7 +10151,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12316b50eb725e22b2f6b9c4cbede5b7b89984274d113a7440c86e5c3fc6f99b"
 dependencies = [
- "assert-json-diff 2.0.2",
+ "assert-json-diff",
  "async-trait",
  "base64 0.13.1",
  "deadpool",
@@ -10215,12 +10199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
 name = "zerocopy"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10238,7 +10216,7 @@ checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -10258,7 +10236,7 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
- "syn 1.0.109",
+ "syn 1.0.107",
  "synstructure",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,22 +169,22 @@ metrics = "0.20.1"
 metrics-tracing-context = { version = "0.12.0", default-features = false }
 
 # AWS - Official SDK
-aws-sdk-s3 = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-sqs = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatch = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatchlogs = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-elasticsearch = {version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-firehose = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-kinesis = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-types = { version = "0.54.1", default-features = false, optional = true }
-aws-sigv4 = { version = "0.54.1", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "0.54.1", default-features = false, features = ["native-tls"], optional = true }
-aws-credential-types = { version = "0.54.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-smithy-async = { version = "0.54.4", default-features = false, optional = true }
-aws-smithy-client = { version = "0.54.4", default-features = false, features = ["client-hyper"], optional = true}
-aws-smithy-http = { version = "0.54.1", default-features = false, features = ["event-stream"], optional = true }
-aws-smithy-http-tower = { version = "0.54.4", default-features = false, optional = true }
-aws-smithy-types = { version = "0.54.1", default-features = false, optional = true }
+aws-sdk-s3 = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-sqs = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatch = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatchlogs = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-elasticsearch = {version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-firehose = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-kinesis = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
+aws-types = { version = "0.53.0", default-features = false, optional = true }
+aws-sigv4 = { version = "0.53.0", default-features = false, features = ["sign-http"], optional = true }
+aws-config = { version = "0.53.0", default-features = false, features = ["native-tls"], optional = true }
+aws-credential-types = { version = "0.53.0", default-features = false, features = ["hardcoded-credentials"], optional = true }
+aws-smithy-async = { version = "0.53.1", default-features = false, optional = true }
+aws-smithy-client = { version = "0.53.1", default-features = false, features = ["client-hyper"], optional = true}
+aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream"], optional = true }
+aws-smithy-http-tower = { version = "0.54.1", default-features = false, optional = true }
+aws-smithy-types = { version = "0.53.1", default-features = false, optional = true }
 
 # Azure
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "b4544d4920fa3064eb921340054cd9cc130b7664", default-features = false, features = ["enable_reqwest"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,22 +169,21 @@ metrics = "0.20.1"
 metrics-tracing-context = { version = "0.12.0", default-features = false }
 
 # AWS - Official SDK
-aws-sdk-s3 = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-sqs = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatch = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatchlogs = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-elasticsearch = {version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-firehose = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-kinesis = { version = "0.23.0", default-features = false, features = ["native-tls"], optional = true }
-aws-types = { version = "0.53.0", default-features = false, optional = true }
+aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-sqs = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatch = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatchlogs = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-elasticsearch = {version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-firehose = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
+aws-types = { version = "0.51.0", default-features = false, features = ["hardcoded-credentials"], optional = true }
 aws-sigv4 = { version = "0.53.0", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "0.53.0", default-features = false, features = ["native-tls"], optional = true }
-aws-credential-types = { version = "0.53.0", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-smithy-async = { version = "0.53.1", default-features = false, optional = true }
-aws-smithy-client = { version = "0.53.1", default-features = false, features = ["client-hyper"], optional = true}
-aws-smithy-http = { version = "0.53.1", default-features = false, features = ["event-stream"], optional = true }
+aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"], optional = true }
+aws-smithy-async = { version = "0.51.0", default-features = false, optional = true }
+aws-smithy-client = { version = "0.51.0", default-features = false, features = ["client-hyper"], optional = true}
+aws-smithy-http = { version = "0.51.0", default-features = false, features = ["event-stream"], optional = true }
 aws-smithy-http-tower = { version = "0.54.1", default-features = false, optional = true }
-aws-smithy-types = { version = "0.53.1", default-features = false, optional = true }
+aws-smithy-types = { version = "0.51.0", default-features = false, optional = true }
 
 # Azure
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "b4544d4920fa3064eb921340054cd9cc130b7664", default-features = false, features = ["enable_reqwest"], optional = true }
@@ -443,7 +442,6 @@ api-client = [
 
 aws-core = [
   "aws-config",
-  "dep:aws-credential-types",
   "dep:aws-sigv4",
   "dep:aws-types",
   "dep:aws-smithy-async",

--- a/scripts/integration/aws/compose.yaml
+++ b/scripts/integration/aws/compose.yaml
@@ -7,7 +7,6 @@ services:
     image: docker.io/localstack/localstack-full:0.11.6
     environment:
     - SERVICES=kinesis,s3,cloudwatch,elasticsearch,es,firehose,sqs
-    - DEBUG=1
   mock-watchlogs:
     image: docker.io/luciofranco/mockwatchlogs:latest
   mock-ecs:

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 use aws_config::{
     default_provider::credentials::DefaultCredentialsChain, imds, sts::AssumeRoleProviderBuilder,
 };
-use aws_credential_types::provider::SharedCredentialsProvider;
-use aws_credential_types::Credentials;
-use aws_types::region::Region;
+use aws_types::{credentials::SharedCredentialsProvider, region::Region, Credentials};
 use serde_with::serde_as;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -3,11 +3,9 @@ use std::time::Duration;
 use aws_config::{
     default_provider::credentials::DefaultCredentialsChain, imds, sts::AssumeRoleProviderBuilder,
 };
-use aws_credential_types::{
-    cache::CredentialsCache, provider::SharedCredentialsProvider, Credentials,
-};
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_credential_types::Credentials;
 use aws_types::region::Region;
-
 use serde_with::serde_as;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
@@ -129,27 +127,6 @@ pub enum AwsAuthentication {
 }
 
 impl AwsAuthentication {
-    pub async fn credentials_cache(&self) -> crate::Result<CredentialsCache> {
-        match self {
-            AwsAuthentication::Role {
-                load_timeout_secs, ..
-            }
-            | AwsAuthentication::Default {
-                load_timeout_secs, ..
-            } => {
-                let credentials_cache = CredentialsCache::lazy_builder()
-                    .load_timeout(
-                        load_timeout_secs
-                            .map(Duration::from_secs)
-                            .unwrap_or(DEFAULT_LOAD_TIMEOUT),
-                    )
-                    .into_credentials_cache();
-
-                Ok(credentials_cache)
-            }
-            _ => Ok(CredentialsCache::lazy()),
-        }
-    }
     pub async fn credentials_provider(
         &self,
         service_region: Region,
@@ -168,19 +145,25 @@ impl AwsAuthentication {
             }
             AwsAuthentication::Role {
                 assume_role,
+                load_timeout_secs,
                 imds,
                 region,
-                ..
             } => {
                 let auth_region = region.clone().map(Region::new).unwrap_or(service_region);
                 let provider = AssumeRoleProviderBuilder::new(assume_role)
                     .region(auth_region.clone())
-                    .build(default_credentials_provider(auth_region, *imds).await?);
+                    .build(
+                        default_credentials_provider(auth_region, *load_timeout_secs, *imds)
+                            .await?,
+                    );
 
                 Ok(SharedCredentialsProvider::new(provider))
             }
-            AwsAuthentication::Default { imds, .. } => Ok(SharedCredentialsProvider::new(
-                default_credentials_provider(service_region, *imds).await?,
+            AwsAuthentication::Default {
+                load_timeout_secs,
+                imds,
+            } => Ok(SharedCredentialsProvider::new(
+                default_credentials_provider(service_region, *load_timeout_secs, *imds).await?,
             )),
         }
     }
@@ -196,6 +179,7 @@ impl AwsAuthentication {
 
 async fn default_credentials_provider(
     region: Region,
+    load_timeout_secs: Option<u64>,
     imds: ImdsAuthentication,
 ) -> crate::Result<SharedCredentialsProvider> {
     let client = imds::Client::builder()
@@ -205,13 +189,16 @@ async fn default_credentials_provider(
         .build()
         .await?;
 
-    let credentials_provider = DefaultCredentialsChain::builder()
+    let chain = DefaultCredentialsChain::builder()
         .region(region)
         .imds_client(client)
-        .build()
-        .await;
+        .load_timeout(
+            load_timeout_secs
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_LOAD_TIMEOUT),
+        );
 
-    Ok(SharedCredentialsProvider::new(credentials_provider))
+    Ok(SharedCredentialsProvider::new(chain.build().await))
 }
 
 #[cfg(test)]

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -2,7 +2,6 @@
 pub mod auth;
 pub mod region;
 
-use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -12,23 +11,22 @@ use std::time::{Duration, SystemTime};
 
 pub use auth::{AwsAuthentication, ImdsAuthentication};
 use aws_config::meta::region::ProvideRegion;
-use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
 use aws_sigv4::http_request::{SignableRequest, SigningSettings};
 use aws_sigv4::SigningParams;
 use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
 use aws_smithy_client::bounds::SmithyMiddleware;
 use aws_smithy_client::erase::{DynConnector, DynMiddleware};
 use aws_smithy_client::{Builder, SdkError};
-use aws_smithy_http::body::{BoxBody, SdkBody};
+use aws_smithy_http::callback::BodyCallback;
+use aws_smithy_http::endpoint::Endpoint;
+use aws_smithy_http::event_stream::BoxError;
 use aws_smithy_http::operation::{Request, Response};
 use aws_smithy_types::retry::RetryConfig;
+use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
 use aws_types::region::Region;
 use aws_types::SdkConfig;
 use bytes::Bytes;
-use http::HeaderMap;
-use http_body::Body;
 use once_cell::sync::OnceCell;
-use pin_project::pin_project;
 use regex::RegexSet;
 pub use region::RegionOrEndpoint;
 use tower::{Layer, Service, ServiceBuilder};
@@ -44,46 +42,39 @@ pub fn is_retriable_error<T>(error: &SdkError<T>) -> bool {
     match error {
         SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => true,
         SdkError::ConstructionFailure(_) => false,
-        SdkError::ResponseError(err) => check_response(err.raw()),
-        SdkError::ServiceError(err) => check_response(err.raw()),
-        _ => {
-            warn!("AWS returned an unhandled error, retrying request.");
-            true
+        SdkError::ResponseError { err: _, raw } | SdkError::ServiceError { err: _, raw } => {
+            // This header is a direct indication that we should retry the request. Eventually it'd
+            // be nice to actually schedule the retry after the given delay, but for now we just
+            // check that it contains a positive value.
+            let retry_header = raw.http().headers().get("x-amz-retry-after").is_some();
+
+            // Certain 400-level responses will contain an error code indicating that the request
+            // should be retried. Since we don't retry 400-level responses by default, we'll look
+            // for these specifically before falling back to more general heuristics. Because AWS
+            // services use a mix of XML and JSON response bodies and the AWS SDK doesn't give us
+            // a parsed representation, we resort to a simple string match.
+            //
+            // S3: RequestTimeout
+            // SQS: RequestExpired, ThrottlingException
+            // ECS: RequestExpired, ThrottlingException
+            // Kinesis: RequestExpired, ThrottlingException
+            // Cloudwatch: RequestExpired, ThrottlingException
+            //
+            // Now just look for those when it's a client_error
+            let re = RETRIABLE_CODES.get_or_init(|| {
+                RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException"])
+                    .expect("invalid regex")
+            });
+
+            let status = raw.http().status();
+            let response_body = String::from_utf8_lossy(raw.http().body().bytes().unwrap_or(&[]));
+
+            retry_header
+                || status.is_server_error()
+                || status == http::StatusCode::TOO_MANY_REQUESTS
+                || (status.is_client_error() && re.is_match(response_body.as_ref()))
         }
     }
-}
-
-fn check_response(res: &Response) -> bool {
-    // This header is a direct indication that we should retry the request. Eventually it'd
-    // be nice to actually schedule the retry after the given delay, but for now we just
-    // check that it contains a positive value.
-    let retry_header = res.http().headers().get("x-amz-retry-after").is_some();
-
-    // Certain 400-level responses will contain an error code indicating that the request
-    // should be retried. Since we don't retry 400-level responses by default, we'll look
-    // for these specifically before falling back to more general heuristics. Because AWS
-    // services use a mix of XML and JSON response bodies and the AWS SDK doesn't give us
-    // a parsed representation, we resort to a simple string match.
-    //
-    // S3: RequestTimeout
-    // SQS: RequestExpired, ThrottlingException
-    // ECS: RequestExpired, ThrottlingException
-    // Kinesis: RequestExpired, ThrottlingException
-    // Cloudwatch: RequestExpired, ThrottlingException
-    //
-    // Now just look for those when it's a client_error
-    let re = RETRIABLE_CODES.get_or_init(|| {
-        RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException"])
-            .expect("invalid regex")
-    });
-
-    let status = res.http().status();
-    let response_body = String::from_utf8_lossy(res.http().body().bytes().unwrap_or(&[]));
-
-    retry_header
-        || status.is_server_error()
-        || status == http::StatusCode::TOO_MANY_REQUESTS
-        || (status.is_client_error() && re.is_match(response_body.as_ref()))
 }
 
 pub trait ClientBuilder {
@@ -144,7 +135,7 @@ pub async fn resolve_region(region: Option<Region>) -> crate::Result<Region> {
 pub async fn create_client<T: ClientBuilder>(
     auth: &AwsAuthentication,
     region: Option<Region>,
-    endpoint: Option<String>,
+    endpoint: Option<Endpoint>,
     proxy: &ProxyConfig,
     tls_options: &Option<TlsConfig>,
     is_sink: bool,
@@ -162,7 +153,7 @@ pub async fn create_client<T: ClientBuilder>(
         .retry_config(retry_config.clone());
 
     if let Some(endpoint_override) = endpoint {
-        config_builder = config_builder.endpoint_url(endpoint_override);
+        config_builder = config_builder.endpoint_resolver(endpoint_override);
     }
 
     let config = config_builder.build();
@@ -255,31 +246,16 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request) -> Self::Future {
+    fn call(&mut self, mut req: Request) -> Self::Future {
         // Attach a body callback that will capture the bytes sent by interrogating the body chunks that get read as it
         // sends the request out over the wire. We'll read the shared atomic counter, which will contain the number of
         // bytes "read", aka the bytes it actually sent, if and only if we get back a successful response.
+        let maybe_bytes_sent = self.enabled.then(|| {
+            let (callback, shared_bytes_sent) = BodyCaptureCallback::new();
+            req.http_mut().body_mut().with_callback(Box::new(callback));
 
-        let (req, maybe_bytes_sent) = if self.enabled {
-            let shared_bytes_sent = Arc::new(AtomicUsize::new(0));
-            let (request, properties) = req.into_parts();
-            let (parts, body) = request.into_parts();
-
-            let body = {
-                let shared_bytes_sent = Arc::clone(&shared_bytes_sent);
-
-                body.map(move |body| {
-                    let body = MeasuredBody::new(body, Arc::clone(&shared_bytes_sent));
-                    SdkBody::from_dyn(BoxBody::new(body))
-                })
-            };
-
-            let req = Request::from_parts(http::Request::from_parts(parts, body), properties);
-
-            (req, Some(shared_bytes_sent))
-        } else {
-            (req, None)
-        };
+            shared_bytes_sent
+        });
 
         let region = self.region.clone();
         let fut = self.inner.call(req);
@@ -308,49 +284,69 @@ where
     }
 }
 
-#[pin_project]
-struct MeasuredBody {
-    #[pin]
-    inner: SdkBody,
+struct BodyCaptureCallback {
+    bytes_sent: usize,
     shared_bytes_sent: Arc<AtomicUsize>,
 }
 
-impl MeasuredBody {
-    fn new(body: SdkBody, shared_bytes_sent: Arc<AtomicUsize>) -> Self {
-        Self {
-            inner: body,
+impl BodyCaptureCallback {
+    fn new() -> (Self, Arc<AtomicUsize>) {
+        let shared_bytes_sent = Arc::new(AtomicUsize::new(0));
+
+        (
+            Self {
+                bytes_sent: 0,
+                shared_bytes_sent: Arc::clone(&shared_bytes_sent),
+            },
             shared_bytes_sent,
-        }
+        )
     }
 }
 
-impl Body for MeasuredBody {
-    type Data = Bytes;
-    type Error = Box<dyn Error + Send + Sync>;
-
-    fn poll_data(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        let this = self.project();
-
-        match this.inner.poll_data(cx) {
-            Poll::Ready(Some(Ok(data))) => {
-                this.shared_bytes_sent
-                    .fetch_add(data.len(), Ordering::Release);
-
-                Poll::Ready(Some(Ok(data)))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
-            Poll::Pending => Poll::Pending,
-        }
+impl BodyCallback for BodyCaptureCallback {
+    fn update(&mut self, bytes: &[u8]) -> Result<(), BoxError> {
+        // This gets called every time a chunk is read from the request body, which includes both static chunks and
+        // streaming bodies. Just add the chunk's length to our running tally.
+        self.bytes_sent += bytes.len();
+        Ok(())
     }
 
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
-        Poll::Ready(Ok(None))
+    fn trailers(&self) -> Result<Option<headers::HeaderMap<headers::HeaderValue>>, BoxError> {
+        Ok(None)
+    }
+
+    fn make_new(&self) -> Box<dyn BodyCallback> {
+        // We technically don't use retries within the AWS side of the API clients, but we have to satisfy this trait
+        // method, because `aws_smithy_http` uses the retry layer from `tower`, which clones the request regardless
+        // before it even executes the first attempt... so there's no reason not to make it technically correct.
+        Box::new(Self {
+            bytes_sent: 0,
+            shared_bytes_sent: Arc::clone(&self.shared_bytes_sent),
+        })
+    }
+}
+
+impl Drop for BodyCaptureCallback {
+    fn drop(&mut self) {
+        // This is where we actually emit. We specifically emit here, and not in `trailers`, because despite the
+        // documentation that `trailers` is called after all chunks of the body are successfully read, `hyper` won't
+        // continue polling a body if it knows it's gotten all the available bytes i.e. it doesn't necessarily drive it
+        // until `poll_data` returns `None`. This means the only consistent place to know that the body is "done" is
+        // when it's dropped.
+        //
+        // We update our shared atomic counter with the total bytes sent that we accumulated, and it will read the
+        // atomic if the response indicates that the request was successful. Since we know the body will go out-of-scope
+        // before a response can possibly be generated, we know the atomic will in turn be updated before it is read.
+        //
+        // This design also copes with the fact that, technically, `aws_smithy_client` supports retries and could clone
+        // this callback for each copy of the request... which it already does at least once per request since the retry
+        // middleware has to clone the request before trying it. As requests are retried sequentially, only after the
+        // previous attempt failed, we know that we'll end up in a "last write wins" scenario, so this is still sound.
+        //
+        // In the future, we may track every single byte sent in order to generate "raw bytes over the wire, regardless
+        // of status" metrics, but right now, this is purely "how many bytes have we sent as part of _successful_
+        // sends?"
+        self.shared_bytes_sent
+            .store(self.bytes_sent, Ordering::Release);
     }
 }

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -47,7 +47,7 @@ pub fn is_retriable_error<T>(error: &SdkError<T>) -> bool {
         SdkError::ResponseError(err) => check_response(err.raw()),
         SdkError::ServiceError(err) => check_response(err.raw()),
         _ => {
-            warn!("AWS returned unknown error, retrying request.");
+            warn!("AWS returned an unhandled error, retrying request.");
             true
         }
     }
@@ -157,7 +157,6 @@ pub async fn create_client<T: ClientBuilder>(
 
     // Build the configuration first.
     let mut config_builder = SdkConfig::builder()
-        .credentials_cache(auth.credentials_cache().await?)
         .credentials_provider(auth.credentials_provider(region.clone()).await?)
         .region(region.clone())
         .retry_config(retry_config.clone());
@@ -339,6 +338,7 @@ impl Body for MeasuredBody {
             Poll::Ready(Some(Ok(data))) => {
                 this.shared_bytes_sent
                     .fetch_add(data.len(), Ordering::Release);
+
                 Poll::Ready(Some(Ok(data)))
             }
             Poll::Ready(None) => Poll::Ready(None),

--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -1,4 +1,8 @@
+use std::str::FromStr;
+
+use aws_smithy_http::endpoint::Endpoint;
 use aws_types::region::Region;
+use http::Uri;
 use vector_config::configurable_component;
 
 /// Configuration of the region/endpoint to use when interacting with an AWS service.
@@ -33,9 +37,9 @@ impl RegionOrEndpoint {
         }
     }
 
-    pub fn endpoint(&self) -> crate::Result<Option<String>> {
-        let endpoint = self.endpoint.clone();
-        Ok(endpoint)
+    pub fn endpoint(&self) -> crate::Result<Option<Endpoint>> {
+        let uri = self.endpoint.as_deref().map(Uri::from_str).transpose()?;
+        Ok(uri.map(Endpoint::immutable))
     }
 
     pub fn region(&self) -> Option<Region> {

--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -33,8 +33,9 @@ impl RegionOrEndpoint {
         }
     }
 
-    pub fn endpoint(&self) -> Option<String> {
-        self.endpoint.clone()
+    pub fn endpoint(&self) -> crate::Result<Option<String>> {
+        let endpoint = self.endpoint.clone();
+        Ok(endpoint)
     }
 
     pub fn region(&self) -> Option<Region> {

--- a/src/common/s3.rs
+++ b/src/common/s3.rs
@@ -12,10 +12,6 @@ impl ClientBuilder for S3ClientBuilder {
     }
 
     fn build(client: aws_smithy_client::Client, config: &aws_types::SdkConfig) -> Self::Client {
-        let config = aws_sdk_s3::config::Builder::from(config)
-            .force_path_style(true)
-            .build();
-
-        aws_sdk_s3::client::Client::with_config(client, config)
+        aws_sdk_s3::client::Client::with_config(client, config.into())
     }
 }

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -136,7 +136,7 @@ impl CloudwatchLogsSinkConfig {
         create_client::<CloudwatchLogsClientBuilder>(
             &self.auth,
             self.region.region(),
-            self.region.endpoint(),
+            self.region.endpoint()?,
             proxy,
             &self.tls,
             true,

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
-
 use chrono::Duration;
 use codecs::TextSerializerConfig;
 use futures::{stream, StreamExt};

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -1,9 +1,12 @@
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
+use aws_sdk_cloudwatchlogs::{Endpoint, Region};
 use chrono::Duration;
 use codecs::TextSerializerConfig;
 use futures::{stream, StreamExt};
+use http::Uri;
 use similar_asserts::assert_eq;
 
 use super::*;
@@ -445,9 +448,11 @@ async fn cloudwatch_healthcheck() {
 
 async fn create_client_test() -> CloudwatchLogsClient {
     let auth = AwsAuthentication::test_auth();
-    let region = Some(aws_types::region::Region::new("localstack"));
+    let region = Some(Region::new("localstack"));
     let watchlogs_address = watchlogs_address();
-    let endpoint = Some(watchlogs_address);
+    let endpoint = Some(Endpoint::immutable(
+        Uri::from_str(&watchlogs_address).unwrap(),
+    ));
     let proxy = ProxyConfig::default();
 
     create_client::<CloudwatchLogsClientBuilder>(&auth, region, endpoint, &proxy, &None, true)

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -14,9 +14,8 @@ use aws_sdk_cloudwatchlogs::model::InputLogEvent;
 use aws_sdk_cloudwatchlogs::output::{DescribeLogStreamsOutput, PutLogEventsOutput};
 use aws_sdk_cloudwatchlogs::types::SdkError;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
+use aws_smithy_http::operation::{Operation, Request};
 use futures::{future::BoxFuture, FutureExt};
-use http::header::HeaderName;
-use http::HeaderValue;
 use indexmap::IndexMap;
 use tokio::sync::oneshot;
 
@@ -228,9 +227,11 @@ impl Client {
         let group_name = self.group_name.clone();
         let stream_name = self.stream_name.clone();
         let headers = self.headers.clone();
-
         Box::pin(async move {
-            let mut op = PutLogEvents::builder()
+            // #12760 this is a relatively convoluted way of changing the headers of a request
+            // about to be sent. https://github.com/awslabs/aws-sdk-rust/issues/537 should
+            // eventually make this better.
+            let op = PutLogEvents::builder()
                 .set_log_events(Some(log_events))
                 .set_sequence_token(sequence_token)
                 .log_group_name(group_name)
@@ -241,18 +242,24 @@ impl Client {
                 .await
                 .map_err(SdkError::construction_failure)?;
 
+            let (req, parts) = op.into_request_response();
+            let (mut body, props) = req.into_parts();
             for (header, value) in headers.iter() {
                 let owned_header = header.clone();
                 let owned_value = value.clone();
-                op.request_mut().headers_mut().insert(
-                    HeaderName::from_bytes(owned_header.as_bytes())
+                body.headers_mut().insert(
+                    http::header::HeaderName::from_bytes(owned_header.as_bytes())
                         .map_err(SdkError::construction_failure)?,
-                    HeaderValue::from_str(owned_value.as_str())
+                    http::HeaderValue::from_str(owned_value.as_str())
                         .map_err(SdkError::construction_failure)?,
                 );
             }
-
-            client.call(op).await
+            client
+                .call(Operation::from_parts(
+                    Request::from_parts(body, props),
+                    parts,
+                ))
+                .await
         })
     }
 

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -101,9 +101,9 @@ impl Future for CloudwatchFuture {
                     let response = match ready!(fut.poll_unpin(cx)) {
                         Ok(response) => response,
                         Err(err) => {
-                            if let SdkError::ServiceError(inner) = &err {
+                            if let SdkError::ServiceError { err, raw: _ } = &err {
                                 if let DescribeLogStreamsErrorKind::ResourceNotFoundException(_) =
-                                    inner.err().kind
+                                    err.kind
                                 {
                                     if self.create_missing_group {
                                         info!("Log group provided does not exist; creating a new one.");
@@ -148,8 +148,8 @@ impl Future for CloudwatchFuture {
                         Ok(_) => {}
                         Err(err) => {
                             let resource_already_exists = match &err {
-                                SdkError::ServiceError(inner) => matches!(
-                                    inner.err().kind,
+                                SdkError::ServiceError { err, raw: _ } => matches!(
+                                    err.kind,
                                     CreateLogGroupErrorKind::ResourceAlreadyExistsException(_)
                                 ),
                                 _ => false,
@@ -173,8 +173,8 @@ impl Future for CloudwatchFuture {
                         Ok(_) => {}
                         Err(err) => {
                             let resource_already_exists = match &err {
-                                SdkError::ServiceError(inner) => matches!(
-                                    inner.err().kind,
+                                SdkError::ServiceError { err, raw: _ } => matches!(
+                                    err.kind,
                                     CreateLogStreamErrorKind::ResourceAlreadyExistsException(_)
                                 ),
                                 _ => false,
@@ -237,10 +237,10 @@ impl Client {
                 .log_group_name(group_name)
                 .log_stream_name(stream_name)
                 .build()
-                .map_err(SdkError::construction_failure)?
+                .map_err(|err| SdkError::ConstructionFailure(err.into()))?
                 .make_operation(cw_client.conf())
                 .await
-                .map_err(SdkError::construction_failure)?;
+                .map_err(|err| SdkError::ConstructionFailure(err.into()))?;
 
             let (req, parts) = op.into_request_response();
             let (mut body, props) = req.into_parts();
@@ -249,9 +249,9 @@ impl Client {
                 let owned_value = value.clone();
                 body.headers_mut().insert(
                     http::header::HeaderName::from_bytes(owned_header.as_bytes())
-                        .map_err(SdkError::construction_failure)?,
+                        .map_err(|err| SdkError::ConstructionFailure(err.into()))?,
                     http::HeaderValue::from_str(owned_value.as_str())
-                        .map_err(SdkError::construction_failure)?,
+                        .map_err(|err| SdkError::ConstructionFailure(err.into()))?,
                 );
             }
             client

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -36,8 +36,7 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
             CloudwatchError::Put(err) => {
-                if let SdkError::ServiceError(inner) = err {
-                    let err = inner.err();
+                if let SdkError::ServiceError { err, raw: _ } = err {
                     if let PutLogEventsErrorKind::ServiceUnavailableException(_) = err.kind {
                         return true;
                     }
@@ -45,8 +44,7 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
                 is_retriable_error(err)
             }
             CloudwatchError::Describe(err) => {
-                if let SdkError::ServiceError(inner) = err {
-                    let err = inner.err();
+                if let SdkError::ServiceError { err, raw: _ } = err {
                     if let DescribeLogStreamsErrorKind::ServiceUnavailableException(_) = err.kind {
                         return true;
                     }
@@ -54,8 +52,7 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
                 is_retriable_error(err)
             }
             CloudwatchError::CreateStream(err) => {
-                if let SdkError::ServiceError(inner) = err {
-                    let err = inner.err();
+                if let SdkError::ServiceError { err, raw: _ } = err {
                     if let CreateLogStreamErrorKind::ServiceUnavailableException(_) = err.kind {
                         return true;
                     }
@@ -69,7 +66,7 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
 
 #[cfg(test)]
 mod test {
-    use aws_sdk_cloudwatchlogs::error::PutLogEventsError;
+    use aws_sdk_cloudwatchlogs::error::{PutLogEventsError, PutLogEventsErrorKind};
     use aws_sdk_cloudwatchlogs::types::SdkError;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_http::operation::Response;
@@ -92,10 +89,13 @@ mod test {
         *http_response.status_mut() = http::StatusCode::BAD_REQUEST;
         let raw = Response::new(http_response);
 
-        let err = CloudwatchError::Put(SdkError::service_error(
-            PutLogEventsError::unhandled(meta_err),
+        let err = CloudwatchError::Put(SdkError::ServiceError {
+            err: PutLogEventsError::new(
+                PutLogEventsErrorKind::Unhandled(Box::new(meta_err.clone())),
+                meta_err,
+            ),
             raw,
-        ));
+        });
         assert!(retry_logic.is_retriable_error(&err));
     }
 }

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -32,7 +32,6 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
     type Error = CloudwatchError;
     type Response = T;
 
-    // TODO this match may not be necessary given the logic in `is_retriable_error()`
     #[allow(clippy::cognitive_complexity)] // long, but just a hair over our limit
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {

--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -168,7 +168,7 @@ impl CloudWatchMetricsSinkConfig {
         create_client::<CloudwatchMetricsClientBuilder>(
             &self.auth,
             region,
-            self.region.endpoint(),
+            self.region.endpoint()?,
             proxy,
             &self.tls,
             true,

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -108,7 +108,7 @@ impl KinesisFirehoseSinkConfig {
         create_client::<KinesisFirehoseClientBuilder>(
             &self.base.auth,
             self.base.region.region(),
-            self.base.region.endpoint(),
+            self.base.region.endpoint()?,
             proxy,
             &self.base.tls,
             true,

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -174,8 +174,8 @@ impl RetryLogic for KinesisRetryLogic {
     type Response = KinesisResponse;
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        if let SdkError::ServiceError(inner) = error {
-            if let PutRecordBatchErrorKind::ServiceUnavailableException(_) = inner.err().kind {
+        if let SdkError::ServiceError { err, raw: _ } = error {
+            if let PutRecordBatchErrorKind::ServiceUnavailableException(_) = err.kind {
                 return true;
             }
         }

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -137,7 +137,7 @@ async fn firehose_client() -> aws_sdk_firehose::Client {
     create_client::<KinesisFirehoseClientBuilder>(
         &auth,
         region_endpoint.region(),
-        region_endpoint.endpoint(),
+        region_endpoint.endpoint().unwrap(),
         &proxy,
         &None,
         true,
@@ -148,6 +148,7 @@ async fn firehose_client() -> aws_sdk_firehose::Client {
 
 /// creates ES domain with the given name and returns the ARN
 async fn ensure_elasticsearch_domain(domain_name: String) -> String {
+    let endpoint = test_region_endpoint().endpoint().unwrap().unwrap();
     let client = EsClient::from_conf(
         aws_sdk_elasticsearch::config::Builder::new()
             .credentials_provider(
@@ -156,7 +157,7 @@ async fn ensure_elasticsearch_domain(domain_name: String) -> String {
                     .await
                     .unwrap(),
             )
-            .endpoint_url(test_region_endpoint().endpoint().unwrap())
+            .endpoint_url(endpoint)
             .region(test_region_endpoint().region())
             .build(),
     );

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -148,7 +148,6 @@ async fn firehose_client() -> aws_sdk_firehose::Client {
 
 /// creates ES domain with the given name and returns the ARN
 async fn ensure_elasticsearch_domain(domain_name: String) -> String {
-    let endpoint = test_region_endpoint().endpoint().unwrap().unwrap();
     let client = EsClient::from_conf(
         aws_sdk_elasticsearch::config::Builder::new()
             .credentials_provider(
@@ -157,7 +156,7 @@ async fn ensure_elasticsearch_domain(domain_name: String) -> String {
                     .await
                     .unwrap(),
             )
-            .endpoint_url(endpoint)
+            .endpoint_resolver(test_region_endpoint().endpoint().unwrap().unwrap())
             .region(test_region_endpoint().region())
             .build(),
     );

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -181,9 +181,8 @@ impl RetryLogic for KinesisRetryLogic {
     type Response = KinesisResponse;
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        if let SdkError::ServiceError(inner) = error {
-            if let PutRecordsErrorKind::ProvisionedThroughputExceededException(_) = inner.err().kind
-            {
+        if let SdkError::ServiceError { err, raw: _ } = error {
+            if let PutRecordsErrorKind::ProvisionedThroughputExceededException(_) = err.kind {
                 return true;
             }
         }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -115,7 +115,7 @@ impl KinesisStreamsSinkConfig {
         create_client::<KinesisClientBuilder>(
             &self.base.auth,
             self.base.region.region(),
-            self.base.region.endpoint(),
+            self.base.region.endpoint()?,
             proxy,
             &self.base.tls,
             true,

--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -174,7 +174,7 @@ async fn client() -> aws_sdk_kinesis::Client {
     create_client::<KinesisClientBuilder>(
         &auth,
         region.region(),
-        region.endpoint(),
+        region.endpoint().unwrap(),
         &proxy,
         &None,
         true,

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -369,7 +369,7 @@ async fn client() -> S3Client {
     create_client::<S3ClientBuilder>(
         &auth,
         region.region(),
-        region.endpoint(),
+        region.endpoint().unwrap(),
         &proxy,
         &tls_options,
         true,

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -426,7 +426,7 @@ async fn create_bucket(bucket: &str, object_lock_enabled: bool) {
     {
         Ok(_) => {}
         Err(err) => match err {
-            SdkError::ServiceError(inner) => match &inner.err().kind {
+            SdkError::ServiceError { err, raw: _ } => match err.kind {
                 CreateBucketErrorKind::BucketAlreadyOwnedByYou(_) => {}
                 err => panic!("Failed to create bucket: {:?}", err),
             },

--- a/src/sinks/aws_sqs/config.rs
+++ b/src/sinks/aws_sqs/config.rs
@@ -149,7 +149,7 @@ impl SqsSinkConfig {
         create_client::<SqsClientBuilder>(
             &self.auth,
             self.region.region(),
-            self.region.endpoint(),
+            self.region.endpoint()?,
             proxy,
             &self.tls,
             true,

--- a/src/sinks/aws_sqs/integration_tests.rs
+++ b/src/sinks/aws_sqs/integration_tests.rs
@@ -1,9 +1,11 @@
 #![cfg(all(test, feature = "aws-sqs-integration-tests"))]
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
-use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient};
+use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient, Endpoint, Region};
 use codecs::TextSerializerConfig;
+use http::Uri;
 use tokio::time::{sleep, Duration};
 
 use super::{config::SqsSinkConfig, sink::SqsSink};
@@ -29,8 +31,8 @@ async fn create_test_client() -> SqsClient {
     let proxy = ProxyConfig::default();
     create_client::<SqsClientBuilder>(
         &auth,
-        Some(aws_types::region::Region::new("localstack")),
-        Some(endpoint),
+        Some(Region::new("localstack")),
+        Some(Endpoint::immutable(Uri::from_str(&endpoint).unwrap())),
         &proxy,
         &None,
         true,

--- a/src/sinks/aws_sqs/integration_tests.rs
+++ b/src/sinks/aws_sqs/integration_tests.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient, Region};
+use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient};
 use codecs::TextSerializerConfig;
 use tokio::time::{sleep, Duration};
 
@@ -29,7 +29,7 @@ async fn create_test_client() -> SqsClient {
     let proxy = ProxyConfig::default();
     create_client::<SqsClientBuilder>(
         &auth,
-        Some(Region::new("localstack")),
+        Some(aws_types::region::Region::new("localstack")),
         Some(endpoint),
         &proxy,
         &None,

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use bytes::{Buf, Bytes};
 use http::{Response, StatusCode, Uri};

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use bytes::Bytes;
 use futures::future::BoxFuture;

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::task;
 
-use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, stream, FutureExt, SinkExt};

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -299,7 +299,9 @@ impl From<S3CannedAcl> for ObjectCannedAcl {
             S3CannedAcl::AuthenticatedRead => ObjectCannedAcl::AuthenticatedRead,
             S3CannedAcl::BucketOwnerRead => ObjectCannedAcl::BucketOwnerRead,
             S3CannedAcl::BucketOwnerFullControl => ObjectCannedAcl::BucketOwnerFullControl,
-            S3CannedAcl::LogDeliveryWrite => ObjectCannedAcl::from("log-delivery-write"),
+            S3CannedAcl::LogDeliveryWrite => {
+                ObjectCannedAcl::Unknown("log-delivery-write".to_string())
+            }
         }
     }
 }
@@ -338,7 +340,7 @@ pub fn build_healthcheck(bucket: String, client: S3Client) -> crate::Result<Heal
         match req {
             Ok(_) => Ok(()),
             Err(error) => Err(match error {
-                SdkError::ServiceError(inner) => match inner.raw().http().status() {
+                SdkError::ServiceError { err: _, raw } => match raw.http().status() {
                     StatusCode::FORBIDDEN => HealthcheckError::InvalidCredentials.into(),
                     StatusCode::NOT_FOUND => HealthcheckError::UnknownBucket { bucket }.into(),
                     status => HealthcheckError::UnknownStatus { status }.into(),

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -338,7 +338,7 @@ pub fn build_healthcheck(bucket: String, client: S3Client) -> crate::Result<Heal
         match req {
             Ok(_) => Ok(()),
             Err(error) => Err(match error {
-                SdkError::ServiceError(inner) => match inner.into_raw().http().status() {
+                SdkError::ServiceError(inner) => match inner.raw().http().status() {
                     StatusCode::FORBIDDEN => HealthcheckError::InvalidCredentials.into(),
                     StatusCode::NOT_FOUND => HealthcheckError::UnknownBucket { bucket }.into(),
                     status => HealthcheckError::UnknownStatus { status }.into(),
@@ -357,7 +357,7 @@ pub async fn create_service(
     proxy: &ProxyConfig,
     tls_options: &Option<TlsConfig>,
 ) -> crate::Result<S3Service> {
-    let endpoint = region.endpoint();
+    let endpoint = region.endpoint()?;
     let region = region.region();
     let client =
         create_client::<S3ClientBuilder>(auth, region.clone(), endpoint, proxy, tls_options, true)

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -203,7 +203,10 @@ impl AwsS3Config {
             .region()
             .ok_or(CreateSqsIngestorError::RegionMissing)?;
 
-        let endpoint = self.region.endpoint();
+        let endpoint = self
+            .region
+            .endpoint()
+            .map_err(|_| CreateSqsIngestorError::InvalidEndpoint)?;
 
         let s3_client = create_client::<S3ClientBuilder>(
             &self.auth,
@@ -890,7 +893,7 @@ mod integration_tests {
         create_client::<S3ClientBuilder>(
             &auth,
             region_endpoint.region(),
-            region_endpoint.endpoint(),
+            region_endpoint.endpoint().unwrap(),
             &proxy_config,
             &None,
             false,
@@ -909,7 +912,7 @@ mod integration_tests {
         create_client::<SqsClientBuilder>(
             &auth,
             region_endpoint.region(),
-            region_endpoint.endpoint(),
+            region_endpoint.endpoint().unwrap(),
             &proxy_config,
             &None,
             false,

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -156,7 +156,7 @@ impl AwsSqsConfig {
         create_client::<SqsClientBuilder>(
             &self.auth,
             self.region.region(),
-            self.region.endpoint(),
+            self.region.endpoint()?,
             &cx.proxy,
             &self.tls,
             false,

--- a/src/sources/aws_sqs/integration_tests.rs
+++ b/src/sources/aws_sqs/integration_tests.rs
@@ -50,6 +50,7 @@ async fn send_test_events(count: u32, queue_url: &str, client: &aws_sdk_sqs::Cli
 }
 
 async fn get_sqs_client() -> aws_sdk_sqs::Client {
+    let endpoint = sqs_address().clone();
     let config = aws_sdk_sqs::config::Builder::new()
         .credentials_provider(
             AwsAuthentication::test_auth()
@@ -57,7 +58,7 @@ async fn get_sqs_client() -> aws_sdk_sqs::Client {
                 .await
                 .unwrap(),
         )
-        .endpoint_url(sqs_address())
+        .endpoint_url(endpoint)
         .region(Some(Region::new("us-east-1")))
         .build();
 

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -110,7 +110,7 @@ impl SqsSource {
             .visibility_timeout(self.visibility_timeout_secs as i32)
             // I think this should be a known attribute
             // https://github.com/awslabs/aws-sdk-rust/issues/411
-            .attribute_names(QueueAttributeName::from("SentTimestamp"))
+            .attribute_names(QueueAttributeName::Unknown(String::from("SentTimestamp")))
             .send()
             .await;
 


### PR DESCRIPTION
- Revert "chore(deps): upgrade AWS crates to v0.54.1 (#16443)"
- Revert "chore(deps): Update aws-sdks to 0.23 and aws supporting crates to 0.53 (#16365)"

Closes #16629

Nathan and I tracked this down to a (possible) bug in the SDK, pending resolution/information upstream reverting the changes to the last known-good version we have.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
