### PR TITLE
docs: replace headings with bold to fix table of contents rendering

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -646,7 +646,7 @@ _coercing_fields: """
 	2. The [time format specifiers](\(urls.chrono_time_formats)) from Rust's
 	   `chrono` library.
 
-	### Types
+	**Types**
 
 	* `bool`
 	* `string`
@@ -655,7 +655,7 @@ _coercing_fields: """
 	* `date`
 	* `timestamp` (see the table below for formats)
 
-	### Timestamp Formats
+	**Timestamp Formats**
 
 	Format | Description | Example
 	:------|:------------|:-------


### PR DESCRIPTION
The ToC for the global options reference is broken by some headings within the docs for a certain field. Replaces the headings with **bold** text.

<img width="1227" alt="Screen Shot 2023-03-02 at 10 41 19 AM" src="https://user-images.githubusercontent.com/2432634/222495078-a296b0e5-a1af-4ccc-b90e-18a501131beb.png">
