### PR TITLE
feat(vdev): Support `TEST_LOG` and add `--no-capture` flag to cargo nextest

### DIFF
--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -65,6 +65,7 @@ impl IntegrationTest {
             env_vars.insert(key, Some(value));
         }
 
+        env_vars.insert("TEST_LOG".to_string(), Some("info".into()));
         let mut args = self.config.args.clone().unwrap_or_default();
 
         args.push("--features".to_string());
@@ -84,6 +85,12 @@ impl IntegrationTest {
             args.push(filter.to_string());
         }
         args.extend(extra_args);
+
+        // Some arguments are not compatible with the --no-capture arg
+        if !args.contains(&"--test-threads".to_string()) {
+            args.push("--no-capture".to_string());
+        }
+
         self.runner
             .test(&env_vars, &self.config.runner.env, &args)?;
 


### PR DESCRIPTION
## Problem
There was previous support of printing out the info level logs from Vector on the integration tests, and now it is requested to bring that functionality into vdev integration tests

## Solution
This PR accomplishes the task by hardcoding the arguments in the test runner functions before they are ran.

## Testing
Added the `ci-condition: integration tests enable` for testing


## Related Issues
Closes #16367 

## Checklist
 - [x] Hardcode namely TEST_LOG into “info” env_vars and add TEST_LOG
 - [x] Wrap into option with Some(“info”.into())
 - [x] We unconditionally add the no-capture, similar to how we did test_filter or –features
 - [x] Add the ci-condition integration test
 - [x] Don’t forget to mention what issue should be closed
