### PR TITLE
fix(ci): Declare some Regression Detector experiments erratic

### DIFF
--- a/regression/cases/file_to_blackhole/experiment.yaml
+++ b/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,2 +1,2 @@
 optimization_goal: egress_throughput
-erratic: false
+erratic: true

--- a/regression/cases/syslog_regex_logs2metric_ddmetrics/experiment.yaml
+++ b/regression/cases/syslog_regex_logs2metric_ddmetrics/experiment.yaml
@@ -1,0 +1,2 @@
+optimization_goal: ingress_throughput
+erratic: true


### PR DESCRIPTION
In the days when this project used the 'soaks' we had a flag for declaring some experiments erratic, that is, when they fired we'd not ding a PR. The Regression Detector didn't expose an easy way to declare some experiments erratic and, for the most part, that worked alright. Lately we've been seeing what we call the 'wobble problem' which is vaguely co-incident to
https://github.com/DataDog/lading/pull/466 but not entirely explained by such. Capacity search made the problem more noticeable, we think.

Anyhow, this commit sets two experiments `syslog_regex_logs2metric_ddmetrics` and `file_to_blackhole` as 'erratic'. This has the same meaning as in the old days but is now exposed in a per-experiment configuration file.

REF SMP-333

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
