### PR TITLE
fix(ci): Update `smp` to 0.7.2 from 0.7.1

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -41,7 +41,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.7.1"
+          export SMP_CRATE_VERSION="0.7.2"
           export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"


### PR DESCRIPTION
This commit updates Single Machine Performance's `smp` tool to 0.7.2. This release includes a fix of undesirable behavior when our compute cluster is saturated, in which `smp` might allow analysis on a run that only has partial results.

REF SMP-333

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
