### PR TITLE
fix(aws service auth): Fix assume-role with access key, file-based auth profiles

### DIFF
--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use aws_config::{
     default_provider::credentials::DefaultCredentialsChain, imds, sts::AssumeRoleProviderBuilder,
 };
+use aws_config::profile::profile_file::{ProfileFileKind, ProfileFiles};
+use aws_config::profile::ProfileFileCredentialsProvider;
 use aws_types::{credentials::SharedCredentialsProvider, region::Region, Credentials};
 use serde_with::serde_as;
 use vector_common::sensitive_string::SensitiveString;
@@ -62,6 +64,21 @@ pub enum AwsAuthentication {
         /// The AWS secret access key.
         #[configurable(metadata(docs::examples = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"))]
         secret_access_key: SensitiveString,
+
+        /// The ARN of an [IAM role][iam_role] to assume.
+        ///
+        /// [iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+        #[configurable(metadata(docs::examples = "arn:aws:iam::123456789098:role/my_role"))]
+        assume_role: Option<String>,
+
+        /// The [AWS region][aws_region] to send STS requests to.
+        ///
+        /// If not set, this will default to the configured region
+        /// for the service itself.
+        ///
+        /// [aws_region]: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
+        #[configurable(metadata(docs::examples = "us-west-2"))]
+        region: Option<String>,
     },
 
     /// Authenticate using credentials stored in a file.
@@ -133,13 +150,37 @@ impl AwsAuthentication {
             Self::AccessKey {
                 access_key_id,
                 secret_access_key,
-            } => Ok(SharedCredentialsProvider::new(Credentials::from_keys(
-                access_key_id.inner(),
-                secret_access_key.inner(),
-                None,
-            ))),
-            AwsAuthentication::File { .. } => {
-                Err("Overriding the credentials file is not supported.".into())
+                assume_role,
+                region,
+            } => {
+                let provider = SharedCredentialsProvider::new(Credentials::from_keys(
+                    access_key_id.inner(),
+                    secret_access_key.inner(),
+                    None,
+                ));
+                if let Some(assume_role) = assume_role {
+                    let auth_region = region.clone().map(Region::new).unwrap_or(service_region);
+                    let provider = AssumeRoleProviderBuilder::new(assume_role)
+                        .region(auth_region)
+                        .build(provider);
+                    return Ok(SharedCredentialsProvider::new(provider))
+                }
+                Ok(provider)
+            },
+            AwsAuthentication::File {
+                credentials_file,
+                profile,
+            } => {
+                let profile_files = ProfileFiles::builder()
+                    .with_file(ProfileFileKind::Credentials, credentials_file)
+                    .build();
+                let mut builder = ProfileFileCredentialsProvider::builder()
+                    .profile_files(profile_files);
+                if let Some(profile) = profile {
+                    builder = builder.profile_name(profile);
+                }
+                let provider = builder.build();
+                Ok(SharedCredentialsProvider::new(provider))
             }
             AwsAuthentication::Role {
                 assume_role,
@@ -171,6 +212,8 @@ impl AwsAuthentication {
         AwsAuthentication::AccessKey {
             access_key_id: "dummy".to_string().into(),
             secret_access_key: "dummy".to_string().into(),
+            assume_role: None,
+            region: None,
         }
     }
 }
@@ -366,6 +409,32 @@ mod tests {
         .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::AccessKey { .. }));
+    }
+
+    #[test]
+    fn parsing_static_with_assume_role() {
+        let config = toml::from_str::<ComponentConfig>(
+            r#"
+            auth.access_key_id = "key"
+            auth.secret_access_key = "other"
+            auth.assume_role = "root"
+        "#,
+        )
+        .unwrap();
+
+        match config.auth {
+            AwsAuthentication::AccessKey {
+                access_key_id,
+                secret_access_key,
+                assume_role,
+                ..
+            } => {
+                assert_eq!(&access_key_id, &SensitiveString::from("key".to_string()));
+                assert_eq!(&secret_access_key, &SensitiveString::from("other".to_string()));
+                assert_eq!(&assume_role, &Some("root".to_string()));
+            },
+            _ => panic!()
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Fixes #9127. Original issue mentioned here is because of how serde is unmarshalling into the `AwsAuthentication` untagged enum.

Adds `assume-role` and `region` parameters to `AwsAuthentication::AccessKey`, copying the building of the necessary `AssumeRoleProvider` from `AwsAuthentication::Role`.

Separately also implements the `AwsAuthentication::File` variant, for specifying credentials in a given credentials profile file. Previously, although the `File` enum and requisite parameters existed, this variant was unimplemented.
