### PR TITLE
fix(elasticsearch): Fix panic in parsing `BulkConfig.index` by making `BulkConfig` non-optional.

### DIFF
--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -77,10 +77,10 @@ async fn firehose_put_records() {
             imds: ImdsAuthentication::default(),
         })),
         endpoints: vec![elasticsearch_address()],
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: Template::try_from(stream.clone()).expect("unable to parse Template"),
             ..Default::default()
-        }),
+        },
         aws: Some(region),
         ..Default::default()
     };

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -163,9 +163,13 @@ pub struct ElasticsearchConfig {
     #[serde(rename = "distribution")]
     pub endpoint_health: Option<HealthConfig>,
 
-    #[serde(alias = "normal", default = "default_bulk")]
+    // TODO: `bulk` and `data_stream` are each only relevant if the `mode` is set to their
+    // corresponding mode. An improvement to look into would be to extract the `BulkConfig` and
+    // `DataStreamConfig` into the `mode` enum variants. Doing so would remove them from the root
+    // of the config here and thus any post serde config parsing manual error prone logic.
+    #[serde(alias = "normal", default)]
     #[configurable(derived)]
-    pub bulk: Option<BulkConfig>,
+    pub bulk: BulkConfig,
 
     #[serde(default)]
     #[configurable(derived)]
@@ -192,10 +196,6 @@ fn query_examples() -> HashMap<String, String> {
     HashMap::<_, _>::from_iter([("X-Powered-By".to_owned(), "Vector".to_owned())].into_iter())
 }
 
-fn default_bulk() -> Option<BulkConfig> {
-    Some(BulkConfig::default())
-}
-
 impl Default for ElasticsearchConfig {
     fn default() -> Self {
         Self {
@@ -217,7 +217,7 @@ impl Default for ElasticsearchConfig {
             aws: None,
             tls: None,
             endpoint_health: None,
-            bulk: Some(BulkConfig::default()), // the default mode is Bulk
+            bulk: BulkConfig::default(), // the default mode is Bulk
             data_stream: None,
             metrics: None,
             acknowledgements: Default::default(),
@@ -226,23 +226,11 @@ impl Default for ElasticsearchConfig {
 }
 
 impl ElasticsearchConfig {
-    pub fn bulk_action(&self) -> Option<Template> {
-        self.bulk
-            .as_ref()
-            .map(|bulk_config| bulk_config.action.clone())
-    }
-
-    pub fn index(&self) -> Option<Template> {
-        self.bulk
-            .as_ref()
-            .map(|bulk_config| bulk_config.index.clone())
-    }
-
     pub fn common_mode(&self) -> crate::Result<ElasticsearchCommonMode> {
         match self.mode {
             ElasticsearchMode::Bulk => Ok(ElasticsearchCommonMode::Bulk {
-                index: self.index().ok_or("index should not be undefined")?,
-                action: self.bulk_action(),
+                index: self.bulk.index.clone(),
+                action: self.bulk.action.clone(),
             }),
             ElasticsearchMode::DataStream => Ok(ElasticsearchCommonMode::DataStream(
                 self.data_stream.clone().unwrap_or_default(),
@@ -253,7 +241,7 @@ impl ElasticsearchConfig {
 
 /// Elasticsearch bulk mode configuration.
 #[configurable_component]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct BulkConfig {
     /// Action to use when making requests to the [Elasticsearch Bulk API][es_bulk].
@@ -625,6 +613,7 @@ mod tests {
         "#,
         )
         .unwrap();
-        assert_eq!(config.bulk, Some(BulkConfig::default()));
+        assert_eq!(config.mode, ElasticsearchMode::Bulk);
+        assert_eq!(config.bulk, BulkConfig::default());
     }
 }

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -163,7 +163,7 @@ pub struct ElasticsearchConfig {
     #[serde(rename = "distribution")]
     pub endpoint_health: Option<HealthConfig>,
 
-    #[serde(alias = "normal", default)]
+    #[serde(alias = "normal", default = "default_bulk")]
     #[configurable(derived)]
     pub bulk: Option<BulkConfig>,
 
@@ -190,6 +190,10 @@ fn default_doc_type() -> String {
 
 fn query_examples() -> HashMap<String, String> {
     HashMap::<_, _>::from_iter([("X-Powered-By".to_owned(), "Vector".to_owned())].into_iter())
+}
+
+fn default_bulk() -> Option<BulkConfig> {
+    Some(BulkConfig::default())
 }
 
 impl Default for ElasticsearchConfig {
@@ -611,5 +615,16 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.api_version, ElasticsearchApiVersion::Auto);
+    }
+
+    #[test]
+    fn parse_default_bulk() {
+        let config = toml::from_str::<ElasticsearchConfig>(
+            r#"
+            endpoints = [""]
+        "#,
+        )
+        .unwrap();
+        assert_eq!(config.bulk, Some(BulkConfig::default()));
     }
 }

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -237,7 +237,7 @@ impl ElasticsearchConfig {
     pub fn common_mode(&self) -> crate::Result<ElasticsearchCommonMode> {
         match self.mode {
             ElasticsearchMode::Bulk => Ok(ElasticsearchCommonMode::Bulk {
-                index: self.index().expect("index should not be undefined"),
+                index: self.index().ok_or("index should not be undefined")?,
                 action: self.bulk_action(),
             }),
             ElasticsearchMode::DataStream => Ok(ElasticsearchCommonMode::DataStream(

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -111,10 +111,10 @@ async fn ensure_pipeline_in_params() {
 
     let config = ElasticsearchConfig {
         endpoints: vec![http_server()],
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index,
             ..Default::default()
-        }),
+        },
         pipeline: Some(pipeline.clone()),
         batch: batch_settings(),
         ..Default::default()
@@ -131,10 +131,10 @@ async fn structures_events_correctly() {
     let index = gen_index();
     let config = ElasticsearchConfig {
         endpoints: vec![http_server()],
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: index.clone(),
             ..Default::default()
-        }),
+        },
         doc_type: "log_lines".to_string(),
         id_key: Some("my_id".into()),
         compression: Compression::None,
@@ -422,10 +422,10 @@ async fn insert_events_in_data_stream() {
     let cfg = ElasticsearchConfig {
         endpoints: vec![http_server()],
         mode: ElasticsearchMode::DataStream,
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: Template::try_from(stream_index.clone()).expect("unable to parse template"),
             ..Default::default()
-        }),
+        },
         batch: batch_settings(),
         ..Default::default()
     };
@@ -464,10 +464,10 @@ async fn distributed_insert_events() {
         batch: batch_settings(),
         ..Default::default()
     };
-    config.bulk = Some(BulkConfig {
+    config.bulk = BulkConfig {
         index: gen_index(),
         ..Default::default()
-    });
+    };
     run_insert_tests_with_multiple_endpoints(&config).await;
 }
 
@@ -495,10 +495,10 @@ async fn distributed_insert_events_failover() {
         batch: batch_settings(),
         ..Default::default()
     };
-    config.bulk = Some(BulkConfig {
+    config.bulk = BulkConfig {
         index: gen_index(),
         ..Default::default()
-    });
+    };
     run_insert_tests_with_multiple_endpoints(&config).await;
 }
 
@@ -507,10 +507,10 @@ async fn run_insert_tests(
     break_events: bool,
     status: BatchStatus,
 ) {
-    config.bulk = Some(BulkConfig {
+    config.bulk = BulkConfig {
         index: gen_index(),
         ..Default::default()
-    });
+    };
     run_insert_tests_with_config(&config, break_events, status).await;
 }
 
@@ -543,7 +543,7 @@ async fn run_insert_tests_with_config(
             "{}",
             Utc::now().format(".ds-logs-generic-default-%Y.%m.%d-000001")
         ),
-        ElasticsearchMode::Bulk => config.bulk.as_ref().unwrap().index.to_string(),
+        ElasticsearchMode::Bulk => config.bulk.index.to_string(),
     };
     let base_url = common.base_url.clone();
 
@@ -641,7 +641,7 @@ async fn run_insert_tests_with_multiple_endpoints(config: &ElasticsearchConfig) 
             "{}",
             Utc::now().format(".ds-logs-generic-default-%Y.%m.%d-000001")
         ),
-        ElasticsearchMode::Bulk => config.bulk.as_ref().unwrap().index.to_string(),
+        ElasticsearchMode::Bulk => config.bulk.index.to_string(),
     };
 
     let (sink, healthcheck) = config

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -26,10 +26,10 @@ async fn sets_create_action_when_configured() {
     use crate::config::log_schema;
 
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             action: parse_template("{{ action }}te"),
             index: parse_template("vector"),
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
@@ -76,10 +76,10 @@ async fn encode_datastream_mode() {
     use crate::config::log_schema;
 
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: parse_template("vector"),
             ..Default::default()
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         mode: ElasticsearchMode::DataStream,
         api_version: ElasticsearchApiVersion::V6,
@@ -120,10 +120,10 @@ async fn encode_datastream_mode_no_routing() {
     use crate::config::log_schema;
 
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: parse_template("vector"),
             ..Default::default()
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         mode: ElasticsearchMode::DataStream,
         data_stream: Some(DataStreamConfig {
@@ -164,10 +164,10 @@ async fn encode_datastream_mode_no_routing() {
 #[tokio::test]
 async fn handle_metrics() {
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             action: parse_template("create"),
             index: parse_template("vector"),
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         api_version: ElasticsearchApiVersion::V6,
         ..Default::default()
@@ -206,10 +206,10 @@ async fn handle_metrics() {
 #[tokio::test]
 async fn decode_bulk_action_error() {
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             action: parse_template("{{ action }}"),
             index: parse_template("vector"),
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         api_version: ElasticsearchApiVersion::V7,
         ..Default::default()
@@ -223,13 +223,25 @@ async fn decode_bulk_action_error() {
     assert!(action.is_none());
 }
 
+/// validates that the configuration parsing for ElasticsearchCommon succeeds when BulkConfig is
+/// not explicitly set in the configuration (using defaults).
+#[tokio::test]
+async fn default_bulk_settings() {
+    let config = ElasticsearchConfig {
+        endpoints: vec![String::from("https://example.com")],
+        api_version: ElasticsearchApiVersion::V7,
+        ..Default::default()
+    };
+    assert!(ElasticsearchCommon::parse_single(&config).await.is_ok());
+}
+
 #[tokio::test]
 async fn decode_bulk_action() {
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             action: parse_template("create"),
             index: parse_template("vector"),
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         api_version: ElasticsearchApiVersion::V7,
         ..Default::default()
@@ -248,10 +260,10 @@ async fn encode_datastream_mode_no_sync() {
     use crate::config::log_schema;
 
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: parse_template("vector"),
             ..Default::default()
-        }),
+        },
         endpoints: vec![String::from("https://example.com")],
         mode: ElasticsearchMode::DataStream,
         data_stream: Some(DataStreamConfig {
@@ -294,10 +306,10 @@ async fn encode_datastream_mode_no_sync() {
 #[tokio::test]
 async fn allows_using_except_fields() {
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: parse_template("{{ idx }}"),
             ..Default::default()
-        }),
+        },
         encoding: Transformer::new(
             None,
             Some(vec!["idx".to_string(), "timestamp".to_string()]),
@@ -334,10 +346,10 @@ async fn allows_using_except_fields() {
 #[tokio::test]
 async fn allows_using_only_fields() {
     let config = ElasticsearchConfig {
-        bulk: Some(BulkConfig {
+        bulk: BulkConfig {
             index: parse_template("{{ idx }}"),
             ..Default::default()
-        }),
+        },
         encoding: Transformer::new(Some(vec![owned_value_path!("foo")]), None, None).unwrap(),
         endpoints: vec![String::from("https://example.com")],
         api_version: ElasticsearchApiVersion::V6,

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -93,11 +93,11 @@ impl SinkConfig for SematextLogsConfig {
             doc_type: "\
                 logs"
                 .to_string(),
-            bulk: Some(BulkConfig {
+            bulk: BulkConfig {
                 index: Template::try_from(self.token.inner())
                     .expect("unable to parse token as Template"),
                 ..Default::default()
-            }),
+            },
             batch: self.batch,
             request: RequestConfig {
                 tower: self.request,


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/16719