### PR TITLE
chore(dev): Adding ux-team as CODEOWNERS for docs/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+docs/ @vectordotdev/ux-team
 lib/file-source/ @spencergilbert @vectordotdev/integrations-team
 lib/k8s-e2e-tests/ @spencergilbert @vectordotdev/integrations-team
 lib/k8s-test-framework/ @spencergilbert @vectordotdev/integrations-team


### PR DESCRIPTION
Since this includes specifications and processes.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
