### PR TITLE
enchancement(schemas): Validate only types when schema validation is true

### DIFF
--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -223,7 +223,7 @@ fn outputs(
             legacy_host_key,
             &owned_value_path!("host"),
             Kind::bytes(),
-            None,
+            Some("host"),
         )
         .with_standard_vector_source_metadata();
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -424,14 +424,12 @@ pub async fn build_pieces(
         let typetag = sink.inner.get_component_name();
         let input_type = sink.inner.input().data_type();
 
-        if config.schema.validation {
-            // At this point, we've validated that all transforms are valid, including any
-            // transform that mutates the schema provided by their sources. We can now validate the
-            // schema expectations of each individual sink.
-            if let Err(mut err) = schema::validate_sink_expectations(key, sink, config) {
-                errors.append(&mut err);
-            };
-        }
+        // At this point, we've validated that all transforms are valid, including any
+        // transform that mutates the schema provided by their sources. We can now validate the
+        // schema expectations of each individual sink.
+        if let Err(mut err) = schema::validate_sink_expectations(key, sink, config) {
+            errors.append(&mut err);
+        };
 
         let (tx, rx) = if let Some(buffer) = buffers.remove(key) {
             buffer

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -231,7 +231,7 @@ pub(super) fn validate_sink_expectations(
 
     // Validate each individual definition against the sink requirement.
     for definition in definitions {
-        if let Err(err) = requirement.validate(&definition) {
+        if let Err(err) = requirement.validate(&definition, config.schema.validation) {
             errors.append(
                 &mut err
                     .errors()


### PR DESCRIPTION
Closes #16534 

This updates the requirements validation so it always checks that the required meaning fields exist. Turning on schema validation will then further check that the types are correct.

This will do the validation regardless of whether log namespacing is switched on or not, which I'm not convinced is correct.