### PR TITLE
chore(vrl): Remove `Default` impl from owned paths

### DIFF
--- a/lib/vector-lookup/src/lookup_v2/mod.rs
+++ b/lib/vector-lookup/src/lookup_v2/mod.rs
@@ -10,7 +10,7 @@ pub use lookup::lookup_v2::{
 
 /// A wrapper around `OwnedValuePath` that allows it to be used in Vector config
 #[configurable_component]
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(try_from = "String", into = "String")]
 pub struct ConfigOwnedValuePath(pub OwnedValuePath);
 

--- a/lib/vrl/lookup/src/lookup_v2/owned.rs
+++ b/lib/vrl/lookup/src/lookup_v2/owned.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
 /// A lookup path.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct OwnedValuePath {
     pub segments: Vec<OwnedSegment>,


### PR DESCRIPTION
paths don't really have a reasonable default, and it's not required so it was removed