### PR TITLE
chore(datadog sinks)!: extract `default_api_key` into shared config struct

### DIFF
--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -484,9 +484,9 @@ fn setup_logs_reporting(
         dd_common: DatadogCommonConfig {
             endpoint: datadog.endpoint.clone(),
             site: datadog.site.clone(),
+            default_api_key: api_key.into(),
             ..Default::default()
         },
-        default_api_key: api_key.into(),
         region: datadog.region,
         request: RequestConfig {
             headers: IndexMap::from([(
@@ -592,9 +592,9 @@ fn setup_metrics_reporting(
         dd_common: DatadogCommonConfig {
             endpoint: datadog.endpoint.clone(),
             site: datadog.site.clone(),
+            default_api_key: api_key.into(),
             ..Default::default()
         },
-        default_api_key: api_key.into(),
         region: datadog.region,
         ..Default::default()
     };

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -3,7 +3,6 @@ use std::{convert::TryFrom, sync::Arc};
 use indoc::indoc;
 use tower::ServiceBuilder;
 use value::Kind;
-use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 
@@ -53,19 +52,6 @@ impl SinkBatchSettings for DatadogLogsDefaultBatchSettings {
 pub struct DatadogLogsConfig {
     #[serde(flatten)]
     pub dd_common: DatadogCommonConfig,
-
-    /// The default Datadog [API key][api_key] to use in authentication of HTTP requests.
-    ///
-    /// If an event has a Datadog [API key][api_key] set explicitly in its metadata, it will take
-    /// precedence over this setting.
-    ///
-    /// [api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
-    // TODO `api_key` is a deprecated name for this setting and should be removed in v0.29.0
-    // After which, this entire setting should be migrated to the `DatadogCommonConfig` struct.
-    #[serde(alias = "api_key")]
-    #[configurable(metadata(docs::examples = "${DATADOG_API_KEY_ENV_VAR}"))]
-    #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
-    pub default_api_key: SensitiveString,
 
     /// The Datadog region to send logs to.
     #[configurable(deprecated = "This option has been deprecated, use the `site` option instead.")]
@@ -129,7 +115,7 @@ impl DatadogLogsConfig {
     }
 
     pub fn build_processor(&self, client: HttpClient) -> crate::Result<VectorSink> {
-        let default_api_key: Arc<str> = Arc::from(self.default_api_key.inner());
+        let default_api_key: Arc<str> = Arc::from(self.dd_common.default_api_key.inner());
         let request_limits = self.request.tower.unwrap_with(&Default::default());
 
         // We forcefully cap the provided batch configuration to the size/log line limits imposed by
@@ -178,11 +164,9 @@ impl SinkConfig for DatadogLogsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = self.create_client(&cx.proxy)?;
 
-        let healthcheck = self.dd_common.build_healthcheck(
-            client.clone(),
-            self.default_api_key.clone().into(),
-            self.region.as_ref(),
-        )?;
+        let healthcheck = self
+            .dd_common
+            .build_healthcheck(client.clone(), self.region.as_ref())?;
 
         let sink = self.build_processor(client)?;
 

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -1,7 +1,6 @@
 use http::Uri;
 use snafu::ResultExt;
 use tower::ServiceBuilder;
-use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 
@@ -94,19 +93,6 @@ pub struct DatadogMetricsConfig {
     #[serde(flatten)]
     pub dd_common: DatadogCommonConfig,
 
-    /// The default Datadog [API key][api_key] to use in authentication of HTTP requests.
-    ///
-    /// If an event has a Datadog [API key][api_key] set explicitly in its metadata, it will take
-    /// precedence over this setting.
-    ///
-    /// [api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
-    // TODO `api_key` is a deprecated name for this setting and should be removed in v0.29.0
-    // After which, this entire setting should be migrated to the `DatadogCommonConfig` struct.
-    #[serde(alias = "api_key")]
-    #[configurable(metadata(docs::examples = "${DATADOG_API_KEY_ENV_VAR}"))]
-    #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
-    pub default_api_key: SensitiveString,
-
     /// Sets the default namespace for any metrics sent.
     ///
     /// This namespace is only used if a metric has no existing namespace. When a namespace is
@@ -135,11 +121,9 @@ impl_generate_config_from_default!(DatadogMetricsConfig);
 impl SinkConfig for DatadogMetricsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = self.build_client(&cx.proxy)?;
-        let healthcheck = self.dd_common.build_healthcheck(
-            client.clone(),
-            self.default_api_key.clone().into(),
-            self.region.as_ref(),
-        )?;
+        let healthcheck = self
+            .dd_common
+            .build_healthcheck(client.clone(), self.region.as_ref())?;
         let sink = self.build_sink(client)?;
 
         Ok((sink, healthcheck))
@@ -215,7 +199,7 @@ impl DatadogMetricsConfig {
             .settings(request_limits, DatadogMetricsRetryLogic)
             .service(DatadogMetricsService::new(
                 client,
-                self.default_api_key.inner(),
+                self.dd_common.default_api_key.inner(),
             ));
 
         let request_builder = DatadogMetricsRequestBuilder::new(

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -30,8 +30,6 @@ pub(crate) fn default_site() -> String {
 
 /// Shared configuration for Datadog sinks.
 /// Contains the maximum set of common settings that applies to all DD sink components.
-// TODO: The `default_api_key` option should be included in this struct once the `api_key`
-// (a deprecated alias to default_api_key` is fully eradicated, which is targeted for v0.29.0.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -60,8 +60,6 @@ pub struct DatadogCommonConfig {
     /// precedence over this setting.
     ///
     /// [api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
-    // TODO: `api_key` is a deprecated name for this setting and should be removed in v0.29.0
-    #[serde(alias = "api_key")]
     #[configurable(metadata(docs::examples = "${DATADOG_API_KEY_ENV_VAR}"))]
     #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
     pub default_api_key: SensitiveString,

--- a/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
@@ -28,5 +28,5 @@ that setting being `default_api_key`.
 In `v0.28.0`, the `api_key` was communicated as deprecated and as part of the
 deprecation policy, is fully removed in this release.
 
-Any usages of `api_key` setting in these sinks will no longer work and they 
+Any usages of `api_key` setting in these sinks will no longer work and they
 will need to be re-labeled as `default_api_key`.

--- a/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
@@ -1,0 +1,31 @@
+---
+date: "2023-04-11"
+title: "0.29 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.29.0"
+authors: ["neuronull"]
+release: "0.29.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.29.0 release includes **deprecations**:
+
+1. [The `datadog` sink has been renamed to `mezmo`](#mezmo_sink)
+
+## Upgrade guide
+
+### Deprecation notices
+
+#### The `logdna` sink has been renamed to `mezmo` {#mezmo_sink}
+
+Following LogDNA's [re-branding][mezmo] to Mezmo, the `logdna` sink has been renamed
+to `mezmo`. The old name `logdna` has been deprecated and will be removed in a future release.
+Please update your configurations accordingly.
+
+```diff
+-type = "logdna"
++type = "mezmo"
+```
+
+[mezmo]: https://www.mezmo.com/logdna

--- a/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
@@ -9,23 +9,24 @@ badges:
   type: breaking change
 ---
 
-Vector's 0.29.0 release includes **deprecations**:
+Vector's 0.29.0 release includes **breaking changes**:
 
-1. [The `datadog` sink has been renamed to `mezmo`](#mezmo_sink)
+1. [Removal of the `datadog_logs` and `datadog_metrics` sinks' `api_key` setting](#dd-sinks-api-key)
+
+We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
 
-### Deprecation notices
+### Breaking changes
 
-#### The `logdna` sink has been renamed to `mezmo` {#mezmo_sink}
+#### Removal of the `datadog_logs` and `datadog_metrics` sinks' `api_key` setting {#dd-sinks-api-key}
 
-Following LogDNA's [re-branding][mezmo] to Mezmo, the `logdna` sink has been renamed
-to `mezmo`. The old name `logdna` has been deprecated and will be removed in a future release.
-Please update your configurations accordingly.
+The `api_key` option has been hidden on the documentation for the `datadog_logs`
+and `datadog_metrics` sinks for a few releases now, with the documented name for
+that setting being `default_api_key`.
 
-```diff
--type = "logdna"
-+type = "mezmo"
-```
+In `v0.28.0`, the `api_key` was communicated as deprecated and as part of the
+deprecation policy, is fully removed in this release.
 
-[mezmo]: https://www.mezmo.com/logdna
+Any usages of `api_key` setting in these sinks will no longer work and they 
+will need to be re-labeled as `default_api_key`.


### PR DESCRIPTION
Addresses the TODO indroduced by https://github.com/vectordotdev/vector/pull/16280

, now that the serde alias is compatible with flatten.