### PR TITLE
fix(s3-source): ensure batch status is updated

### DIFF
--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -614,6 +614,10 @@ impl IngestorProcess {
         // so we explicitly drop it so that we can again utilize `read_error` below.
         drop(stream);
 
+        // The BatchNotifier is cloned for each LogEvent in the batch stream, but the last
+        // reference must be dropped before the status of the batch is sent to the channel.
+        drop(batch);
+
         if let Some(error) = read_error {
             Err(ProcessingError::ReadObject {
                 source: error,


### PR DESCRIPTION
Previously, with acknowledgments enabled on a sink the S3 source would get into a state where it was waiting for a message on a `BatchNotifier` channel that would never be sent. This is because the notifier itself was being cloned for each event in the batch, but the final reference was not dropped prior to awaiting the channel.

Fixes #16741

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
