### PR TITLE
fix(http sink): restore POST as the correct default method

### DIFF
--- a/src/sinks/http.rs
+++ b/src/sinks/http.rs
@@ -41,7 +41,7 @@ pub struct HttpSinkConfig {
     pub uri: UriSerde,
 
     /// The HTTP method to use when making the request.
-    #[serde(default = "default_http_method")]
+    #[serde(default)]
     pub method: HttpMethod,
 
     #[configurable(derived)]
@@ -110,13 +110,13 @@ pub struct HttpSinkConfig {
 #[derivative(Default)]
 pub enum HttpMethod {
     /// GET.
-    #[derivative(Default)]
     Get,
 
     /// HEAD.
     Head,
 
     /// POST.
+    #[derivative(Default)]
     Post,
 
     /// PUT.
@@ -148,10 +148,6 @@ impl From<HttpMethod> for Method {
             HttpMethod::Trace => Self::TRACE,
         }
     }
-}
-
-const fn default_http_method() -> HttpMethod {
-    HttpMethod::Get
 }
 
 impl GenerateConfig for HttpSinkConfig {
@@ -647,7 +643,6 @@ mod tests {
         user = "waldo"
         password = "hunter2"
     "#,
-            "post",
             |parts| {
                 assert_eq!(Method::POST, parts.method);
                 assert_eq!("/frames", parts.uri.path());
@@ -664,12 +659,12 @@ mod tests {
     async fn http_happy_path_put() {
         run_sink(
             r#"
+        method = "put"
         [auth]
         strategy = "basic"
         user = "waldo"
         password = "hunter2"
     "#,
-            "put",
             |parts| {
                 assert_eq!(Method::PUT, parts.method);
                 assert_eq!("/frames", parts.uri.path());
@@ -690,7 +685,6 @@ mod tests {
         foo = "bar"
         baz = "quux"
     "#,
-            "post",
             |parts| {
                 assert_eq!(Method::POST, parts.method);
                 assert_eq!("/frames", parts.uri.path());
@@ -712,7 +706,7 @@ mod tests {
         components::assert_sink_compliance(&HTTP_SINK_TAGS, async {
             let num_lines = 10;
 
-            let (in_addr, sink) = build_sink("", "post").await;
+            let (in_addr, sink) = build_sink("").await;
 
             let (batch, mut receiver) = BatchNotifier::new_with_receiver();
             let (input_lines, events) = random_lines_with_stream(100, num_lines, Some(batch));
@@ -749,7 +743,7 @@ mod tests {
             const NUM_LINES: usize = 1000;
             const NUM_FAILURES: usize = 2;
 
-            let (in_addr, sink) = build_sink("", "post").await;
+            let (in_addr, sink) = build_sink("").await;
 
             let counter = Arc::new(atomic::AtomicUsize::new(0));
             let in_counter = Arc::clone(&counter);
@@ -796,7 +790,7 @@ mod tests {
         components::assert_sink_error(&COMPONENT_ERROR_TAGS, async {
             let num_lines = 1000;
 
-            let (in_addr, sink) = build_sink("", "post").await;
+            let (in_addr, sink) = build_sink("").await;
 
             let (rx, trigger, server) = build_test_server_status(in_addr, StatusCode::FORBIDDEN);
 
@@ -957,14 +951,10 @@ mod tests {
         .await
     }
 
-    async fn run_sink(
-        extra_config: &str,
-        method: &str,
-        assert_parts: impl Fn(http::request::Parts),
-    ) {
+    async fn run_sink(extra_config: &str, assert_parts: impl Fn(http::request::Parts)) {
         let num_lines = 1000;
 
-        let (in_addr, sink) = build_sink(extra_config, method).await;
+        let (in_addr, sink) = build_sink(extra_config).await;
 
         let (rx, trigger, server) = build_test_server(in_addr);
         tokio::spawn(server);
@@ -982,10 +972,7 @@ mod tests {
         assert_eq!(input_lines, output_lines);
     }
 
-    async fn build_sink(
-        extra_config: &str,
-        method: &str,
-    ) -> (std::net::SocketAddr, crate::sinks::VectorSink) {
+    async fn build_sink(extra_config: &str) -> (std::net::SocketAddr, crate::sinks::VectorSink) {
         let in_addr = next_addr();
 
         let config = format!(
@@ -994,12 +981,10 @@ mod tests {
                 compression = "gzip"
                 framing.method = "newline_delimited"
                 encoding.codec = "json"
-                method = "{method}"
                 {extras}
             "#,
             addr = in_addr,
             extras = extra_config,
-            method = method
         );
         let config: HttpSinkConfig = toml::from_str(&config).unwrap();
 

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -290,7 +290,7 @@ base: components: sinks: http: configuration: {
 		description: "The HTTP method to use when making the request."
 		required:    false
 		type: string: {
-			default: "get"
+			default: "post"
 			enum: {
 				delete:  "DELETE."
 				get:     "GET."


### PR DESCRIPTION
fixes: #16740

The default method was incorrectly changed to `GET` (from `POST`), in https://github.com/vectordotdev/vector/pull/16204

The code comment (and the actual #[derivative(Default)] code) is what led me to make that incorrect change.
Not sure what I was thinking.

I tracked down the history here for context:

- initially the HttpMethod enum only supported POST and PUT, and POST was set a the derivative(Default).
- then later the other http methods were added (by a separate contributor), but the derivative(Default) was not repositioned to continue to be on POST, instead it was above GET.
- then later a third unique contributor added doc comments over the enum and it's variant, re-iterating that GET was the default.
- also in play- the derivative(Default) was never actually applied, instead we were taking POST as the default explicitly in the build request function, which is why when the default was changed from POST to GET, it didn't trigger any test failures.

This was part of the config schema docs gen work and between this regression and another recent one, it is clear that you can't necessarily trust the external docs (well, before config schema auto generated docs) , nor can you necessarily trust the code as the source of truth.