### PR TITLE
fix(component validation): fix two synchronization issues

### DIFF
--- a/src/components/validation/runner/config.rs
+++ b/src/components/validation/runner/config.rs
@@ -98,7 +98,7 @@ impl TopologyBuilder {
     /// topology itself. All controlled edges are built and spawned, and a channel sender/receiver
     /// is provided for them. Additionally, the telemetry collector is also spawned and a channel
     /// receiver for telemetry events is provided.
-    pub fn finalize(
+    pub async fn finalize(
         mut self,
         input_task_coordinator: &TaskCoordinator<Configuring>,
         output_task_coordinator: &TaskCoordinator<Configuring>,
@@ -114,8 +114,7 @@ impl TopologyBuilder {
         };
 
         let telemetry = Telemetry::attach_to_config(&mut self.config_builder);
-        let telemetry_collector =
-            telemetry.into_collector(telemetry_task_coordinator, output_task_coordinator);
+        let telemetry_collector = telemetry.into_collector(telemetry_task_coordinator).await;
 
         (self.config_builder, controlled_edges, telemetry_collector)
     }

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -211,7 +211,9 @@ impl Runner {
                     &input_task_coordinator,
                     &output_task_coordinator,
                     &telemetry_task_coordinator,
-                );
+                )
+                .await;
+
             debug!("Component topology configuration built and telemetry collector spawned.");
 
             // After that, we'll build the external resource necessary for this component, if any.
@@ -305,22 +307,10 @@ impl Runner {
             input_task_coordinator.shutdown().await;
             debug!("Input task(s) have been shutdown.");
 
-            // We sleep here to enable the internal_metrics source to scrape
-            // metrics. This process isn't governed by any of the task
-            // coordinators, so we need to wait for it to complete before
-            // shutting down the topology. This isn't a great solution since
-            // every other task has a task coordinator, but there isn't a way to
-            // hook into the source's internal logic to ensure it has processed
-            // the metrics that we'll want to validate.
-            //
-            // TODO(@davidhuie-dd)
-            tokio::time::sleep(Duration::from_millis(1000)).await;
-
             telemetry_task_coordinator.shutdown().await;
             debug!("Telemetry task(s) have been shutdown.");
 
             topology_task_coordinator.shutdown().await;
-
             debug!("Component topology task has been shutdown.");
 
             output_task_coordinator.shutdown().await;

--- a/src/components/validation/runner/telemetry.rs
+++ b/src/components/validation/runner/telemetry.rs
@@ -64,30 +64,70 @@ impl Telemetry {
         }
     }
 
-    pub fn into_collector(
+    pub async fn into_collector(
         self,
         telemetry_task_coordinator: &TaskCoordinator<Configuring>,
-        _output_task_coordinator: &TaskCoordinator<Configuring>,
     ) -> TelemetryCollector {
         let telemetry_started = telemetry_task_coordinator.track_started();
         let telemetry_completed = telemetry_task_coordinator.track_completed();
         let mut telemetry_shutdown_handle = telemetry_task_coordinator.register_for_shutdown();
 
-        spawn_grpc_server(self.listen_addr, self.service, telemetry_task_coordinator);
+        // We need a task coordinator for the gRPC server because it strictly
+        // needs to be shut down after the telemetry collector. This is because
+        // the server needs to be alive to process every last incoming event
+        // from the Vector sink that we're using to collect telemetry.
+        let grpc_task_coordinator = TaskCoordinator::new();
+        spawn_grpc_server(self.listen_addr, self.service, &grpc_task_coordinator);
+        let grpc_task_coordinator = grpc_task_coordinator.started().await;
+        debug!("All gRPC task(s) started.");
 
         let mut rx = self.rx;
         let driver_handle = tokio::spawn(async move {
             telemetry_started.mark_as_done();
 
             let mut telemetry_events = Vec::new();
-            loop {
+            'outer: loop {
                 select! {
                     _ = telemetry_shutdown_handle.wait() => {
-                        match rx.recv().await {
-                            None => break,
-                            Some(telemetry_event) => telemetry_events.push(telemetry_event),
+                        // After we receive the shutdown signal, we need to wait
+                        // for two event emissions from the internal_metrics
+                        // source. This is to ensure that we've received all the
+                        // events from the components that we're testing.
+                        //
+                        // We need exactly two because the internal_metrics
+                        // source does not emit component events until after the
+                        // component_received_events_total metric has been
+                        // emitted. Thus, two events ensure that all component
+                        // events have been emitted.
+
+                        debug!("telemetry: waiting for final internal_metrics events before shutting down");
+
+                        let mut events_seen = 0;
+                        let current_time = chrono::Utc::now();
+
+                        loop {
+                        match &rx.recv().await {
+                            None => break 'outer,
+                            Some(telemetry_event) => {
+                                    telemetry_events.push(telemetry_event.clone());
+
+                                    if let Event::Metric(metric) = telemetry_event {
+                                        if let Some(tags) = metric.tags() {
+                                            if metric.name() == "component_received_events_total" &&
+                                               tags.get("component_name") == Some(INTERNAL_LOGS_KEY) &&
+                                               metric.data().timestamp().unwrap() > &current_time {
+                                                debug!("telemetry: processed one component_received_events_total event");
+
+                                                events_seen += 1;
+                                                if events_seen == 2 {
+                                                    break 'outer;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        break
                     },
                     maybe_telemetry_event = rx.recv() => match maybe_telemetry_event {
                         None => break,
@@ -95,6 +135,9 @@ impl Telemetry {
                     },
                 }
             }
+
+            grpc_task_coordinator.shutdown().await;
+            debug!("gRPC task(s) have been shutdown.");
 
             telemetry_completed.mark_as_done();
 

--- a/src/components/validation/runner/telemetry.rs
+++ b/src/components/validation/runner/telemetry.rs
@@ -23,6 +23,9 @@ const INTERNAL_LOGS_KEY: &str = "_telemetry_logs";
 const INTERNAL_METRICS_KEY: &str = "_telemetry_metrics";
 const VECTOR_SINK_KEY: &str = "_telemetry_out";
 
+// The metrics event to monitor for before shutting down a telemetry collector.
+const INTERNAL_METRICS_SHUTDOWN_EVENT: &str = "component_received_events_total";
+
 /// Telemetry collector for a component under validation.
 pub struct Telemetry {
     listen_addr: GrpcAddress,
@@ -113,9 +116,9 @@ impl Telemetry {
 
                                     if let Event::Metric(metric) = telemetry_event {
                                         if let Some(tags) = metric.tags() {
-                                            if metric.name() == "component_received_events_total" &&
-                                               tags.get("component_name") == Some(INTERNAL_LOGS_KEY) &&
-                                               metric.data().timestamp().unwrap() > &current_time {
+                                            if metric.name() == INTERNAL_METRICS_SHUTDOWN_EVENT &&
+                                                tags.get("component_name") == Some(INTERNAL_LOGS_KEY) &&
+                                                metric.data().timestamp().unwrap() > &current_time {
                                                 debug!("telemetry: processed one component_received_events_total event");
 
                                                 events_seen += 1;


### PR DESCRIPTION
There are comments in the code explaining the two fixes in detail. In summary, there are two async processes that we didn't synchronize prior to this change: a gRPC server that's the ultimate destination of metrics of all validation telemetry, and the internal metrics source that's emitting telemetry. The first issue was fixed with an explicit task collector (a wait group). The second issue was fixed by waiting for evidence of two internal metrics event emissions. 