### PR TITLE
chore(datadog sinks)!: extract default_api_key into shared config struct

### DIFF
--- a/regression/cases/enterprise_http_to_http/vector/vector.toml
+++ b/regression/cases/enterprise_http_to_http/vector/vector.toml
@@ -4,7 +4,7 @@ data_dir = "/var/lib/vector"
 ## Enterprise
 ##
 [enterprise]
-api_key = "${DD_API_KEY}"
+default_api_key = "${DD_API_KEY}"
 configuration_key = "${DD_CONFIGURATION_KEY}"
 endpoint = "http://localhost:8080"
 

--- a/regression/cases/enterprise_http_to_http/vector/vector.toml
+++ b/regression/cases/enterprise_http_to_http/vector/vector.toml
@@ -4,7 +4,7 @@ data_dir = "/var/lib/vector"
 ## Enterprise
 ##
 [enterprise]
-default_api_key = "${DD_API_KEY}"
+api_key = "${DD_API_KEY}"
 configuration_key = "${DD_CONFIGURATION_KEY}"
 endpoint = "http://localhost:8080"
 

--- a/regression/cases/syslog_regex_logs2metric_ddmetrics/vector/vector.toml
+++ b/regression/cases/syslog_regex_logs2metric_ddmetrics/vector/vector.toml
@@ -46,5 +46,5 @@ address = "0.0.0.0:9090"
 type = "datadog_metrics"
 inputs = ["log2metric"]
 endpoint = "http://localhost:8080"
-api_key = "DEADBEEF"
+default_api_key = "DEADBEEF"
 default_namespace = "vector"

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -484,9 +484,9 @@ fn setup_logs_reporting(
         dd_common: DatadogCommonConfig {
             endpoint: datadog.endpoint.clone(),
             site: datadog.site.clone(),
+            default_api_key: api_key.into(),
             ..Default::default()
         },
-        default_api_key: api_key.into(),
         region: datadog.region,
         request: RequestConfig {
             headers: IndexMap::from([(
@@ -592,9 +592,9 @@ fn setup_metrics_reporting(
         dd_common: DatadogCommonConfig {
             endpoint: datadog.endpoint.clone(),
             site: datadog.site.clone(),
+            default_api_key: api_key.into(),
             ..Default::default()
         },
-        default_api_key: api_key.into(),
         region: datadog.region,
         ..Default::default()
     };

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -3,7 +3,6 @@ use std::{convert::TryFrom, sync::Arc};
 use indoc::indoc;
 use tower::ServiceBuilder;
 use value::Kind;
-use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 
@@ -53,19 +52,6 @@ impl SinkBatchSettings for DatadogLogsDefaultBatchSettings {
 pub struct DatadogLogsConfig {
     #[serde(flatten)]
     pub dd_common: DatadogCommonConfig,
-
-    /// The default Datadog [API key][api_key] to use in authentication of HTTP requests.
-    ///
-    /// If an event has a Datadog [API key][api_key] set explicitly in its metadata, it will take
-    /// precedence over this setting.
-    ///
-    /// [api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
-    // TODO `api_key` is a deprecated name for this setting and should be removed in v0.29.0
-    // After which, this entire setting should be migrated to the `DatadogCommonConfig` struct.
-    #[serde(alias = "api_key")]
-    #[configurable(metadata(docs::examples = "${DATADOG_API_KEY_ENV_VAR}"))]
-    #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
-    pub default_api_key: SensitiveString,
 
     /// The Datadog region to send logs to.
     #[configurable(deprecated = "This option has been deprecated, use the `site` option instead.")]
@@ -129,7 +115,7 @@ impl DatadogLogsConfig {
     }
 
     pub fn build_processor(&self, client: HttpClient) -> crate::Result<VectorSink> {
-        let default_api_key: Arc<str> = Arc::from(self.default_api_key.inner());
+        let default_api_key: Arc<str> = Arc::from(self.dd_common.default_api_key.inner());
         let request_limits = self.request.tower.unwrap_with(&Default::default());
 
         // We forcefully cap the provided batch configuration to the size/log line limits imposed by
@@ -178,11 +164,9 @@ impl SinkConfig for DatadogLogsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = self.create_client(&cx.proxy)?;
 
-        let healthcheck = self.dd_common.build_healthcheck(
-            client.clone(),
-            self.default_api_key.clone().into(),
-            self.region.as_ref(),
-        )?;
+        let healthcheck = self
+            .dd_common
+            .build_healthcheck(client.clone(), self.region.as_ref())?;
 
         let sink = self.build_processor(client)?;
 

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -1,7 +1,6 @@
 use http::Uri;
 use snafu::ResultExt;
 use tower::ServiceBuilder;
-use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 use vector_core::config::proxy::ProxyConfig;
 
@@ -94,19 +93,6 @@ pub struct DatadogMetricsConfig {
     #[serde(flatten)]
     pub dd_common: DatadogCommonConfig,
 
-    /// The default Datadog [API key][api_key] to use in authentication of HTTP requests.
-    ///
-    /// If an event has a Datadog [API key][api_key] set explicitly in its metadata, it will take
-    /// precedence over this setting.
-    ///
-    /// [api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
-    // TODO `api_key` is a deprecated name for this setting and should be removed in v0.29.0
-    // After which, this entire setting should be migrated to the `DatadogCommonConfig` struct.
-    #[serde(alias = "api_key")]
-    #[configurable(metadata(docs::examples = "${DATADOG_API_KEY_ENV_VAR}"))]
-    #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
-    pub default_api_key: SensitiveString,
-
     /// Sets the default namespace for any metrics sent.
     ///
     /// This namespace is only used if a metric has no existing namespace. When a namespace is
@@ -135,11 +121,9 @@ impl_generate_config_from_default!(DatadogMetricsConfig);
 impl SinkConfig for DatadogMetricsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = self.build_client(&cx.proxy)?;
-        let healthcheck = self.dd_common.build_healthcheck(
-            client.clone(),
-            self.default_api_key.clone().into(),
-            self.region.as_ref(),
-        )?;
+        let healthcheck = self
+            .dd_common
+            .build_healthcheck(client.clone(), self.region.as_ref())?;
         let sink = self.build_sink(client)?;
 
         Ok((sink, healthcheck))
@@ -215,7 +199,7 @@ impl DatadogMetricsConfig {
             .settings(request_limits, DatadogMetricsRetryLogic)
             .service(DatadogMetricsService::new(
                 client,
-                self.default_api_key.inner(),
+                self.dd_common.default_api_key.inner(),
             ));
 
         let request_builder = DatadogMetricsRequestBuilder::new(

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -2,6 +2,7 @@ use futures_util::FutureExt;
 use http::{Request, StatusCode, Uri};
 use hyper::body::Body;
 use snafu::Snafu;
+use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 use vector_core::{config::AcknowledgementsConfig, tls::TlsEnableableConfig};
 
@@ -29,8 +30,6 @@ pub(crate) fn default_site() -> String {
 
 /// Shared configuration for Datadog sinks.
 /// Contains the maximum set of common settings that applies to all DD sink components.
-// TODO: The `default_api_key` option should be included in this struct once the `api_key`
-// (a deprecated alias to default_api_key` is fully eradicated, which is targeted for v0.29.0.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -55,6 +54,16 @@ pub struct DatadogCommonConfig {
     #[serde(default = "default_site")]
     pub site: String,
 
+    /// The default Datadog [API key][api_key] to use in authentication of HTTP requests.
+    ///
+    /// If an event has a Datadog [API key][api_key] set explicitly in its metadata, it will take
+    /// precedence over this setting.
+    ///
+    /// [api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
+    #[configurable(metadata(docs::examples = "${DATADOG_API_KEY_ENV_VAR}"))]
+    #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
+    pub default_api_key: SensitiveString,
+
     #[configurable(derived)]
     #[serde(default)]
     pub tls: Option<TlsEnableableConfig>,
@@ -73,6 +82,7 @@ impl Default for DatadogCommonConfig {
         Self {
             endpoint: None,
             site: default_site(),
+            default_api_key: SensitiveString::default(),
             tls: None,
             acknowledgements: AcknowledgementsConfig::default(),
         }
@@ -85,13 +95,14 @@ impl DatadogCommonConfig {
     fn build_healthcheck(
         &self,
         client: HttpClient,
-        api_key: String,
         region: Option<&Region>,
     ) -> crate::Result<Healthcheck> {
         let validate_endpoint = get_api_validate_endpoint(
             self.endpoint.as_ref(),
             get_base_domain_region(self.site.as_str(), region),
         )?;
+
+        let api_key: String = self.default_api_key.clone().into();
 
         Ok(build_healthcheck_future(client, validate_endpoint, api_key).boxed())
     }

--- a/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
@@ -2,18 +2,38 @@
 date: "2023-04-11"
 title: "0.29 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.29.0"
-authors: ["stephenwakely"]
+authors: ["stephenwakely", "neuronull"]
 release: "0.29.0"
 hide_on_release_notes: false
 badges:
   type: breaking change
 ---
 
+Vector's 0.29.0 release includes **breaking changes**:
+
+1. [Removal of the `datadog_logs` and `datadog_metrics` sinks' `api_key` setting](#dd-sinks-api-key)
+
 Vector's 0.29.0 release includes **deprecations**:
 
 1. [The `logdna` sink has been renamed to `mezmo`](#mezmo_sink)
 
+We cover them below to help you upgrade quickly:
+
 ## Upgrade guide
+
+### Breaking changes
+
+#### Removal of the `datadog_logs` and `datadog_metrics` sinks' `api_key` setting {#dd-sinks-api-key}
+
+The `api_key` option has been hidden on the documentation for the `datadog_logs`
+and `datadog_metrics` sinks for a few releases now, with the documented name for
+that setting being `default_api_key`.
+
+In `v0.28.0`, the `api_key` was communicated as deprecated and as part of the
+deprecation policy, is fully removed in this release.
+
+Any usages of `api_key` setting in these sinks will no longer work and they
+will need to be instead defined as `default_api_key`.
 
 ### Deprecation notices
 


### PR DESCRIPTION
Addresses the TODO introduced by https://github.com/vectordotdev/vector/pull/16280

(now that the serde alias is compatible with flatten.)

Additionally, removes the deprecated `api_key` alias.

