### PR TITLE
chore(socket source): deprecate the `max_length` setting for `tcp` and `unix` modes

### DIFF
--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -119,12 +119,12 @@ impl SourceConfig for SocketConfig {
                 // decoding.default_stream_framing().
                 let framing = match (config.framing().clone(), config.max_length()) {
                     (Some(framing), Some(_)) => {
-                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Since a `framing` setting was provided, the `max_length` setting has no effect.");
+                        warn!(message = "DEPRECATION: The `max_length` setting is deprecated and will be removed in an upcoming release. Since a `framing` setting was provided, the `max_length` setting has no effect.");
                         framing
                     }
                     (Some(framing), None) => framing,
                     (None, Some(max_length)) => {
-                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Please configure the `max_length` from the `framing` setting instead.");
+                        warn!(message = "DEPRECATION: The `max_length` setting is deprecated and will be removed in an upcoming release. Please configure the `max_length` from the `framing` setting instead.");
                         NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into()
                     }
                     (None, None) => decoding.default_stream_framing(),
@@ -197,12 +197,12 @@ impl SourceConfig for SocketConfig {
                 // decoding.default_stream_framing().
                 let framing = match (config.framing.clone(), config.max_length) {
                     (Some(framing), Some(_)) => {
-                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Since a `framing` setting was provided, the `max_length` setting has no effect.");
+                        warn!(message = "DEPRECATION: The `max_length` setting is deprecated and will be removed in an upcoming release. Since a `framing` setting was provided, the `max_length` setting has no effect.");
                         framing
                     }
                     (Some(framing), None) => framing,
                     (None, Some(max_length)) => {
-                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Please configure the `max_length` from the `framing` setting instead.");
+                        warn!(message = "DEPRECATION: The `max_length` setting is deprecated and will be removed in an upcoming release. Please configure the `max_length` from the `framing` setting instead.");
                         NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into()
                     }
                     (None, None) => decoding.default_stream_framing(),

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -112,26 +112,22 @@ impl SourceConfig for SocketConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         match self.mode.clone() {
             Mode::Tcp(config) => {
-                let (framing, decoding) = match (config.framing(), config.max_length()) {
-                    (Some(_), Some(_)) => {
-                        return Err("Using `max_length` is deprecated and does not have any effect when framing is provided. Configure `max_length` on the framing config instead.".into());
+                let decoding = config.decoding().clone();
+                // TODO: in v0.30.0 , remove the `max_length` setting from
+                // the UnixConfig, and all of the below mess and replace
+                // it with the configured framing /
+                // decoding.default_stream_framing().
+                let framing = match (config.framing().clone(), config.max_length()) {
+                    (Some(framing), Some(_)) => {
+                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Since a `framing` setting was provided, the `max_length` setting has no effect.");
+                        framing
                     }
-                    (Some(framing), None) => {
-                        let decoding = config.decoding().clone();
-                        let framing = framing.clone();
-                        (framing, decoding)
-                    }
+                    (Some(framing), None) => framing,
                     (None, Some(max_length)) => {
-                        let decoding = config.decoding().clone();
-                        let framing =
-                            NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into();
-                        (framing, decoding)
+                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Please configure the `max_length` from the `framing` setting instead.");
+                        NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into()
                     }
-                    (None, None) => {
-                        let decoding = config.decoding().clone();
-                        let framing = decoding.default_stream_framing();
-                        (framing, decoding)
-                    }
+                    (None, None) => decoding.default_stream_framing(),
                 };
 
                 let log_namespace = cx.log_namespace(config.log_namespace);
@@ -193,25 +189,23 @@ impl SourceConfig for SocketConfig {
             }
             #[cfg(unix)]
             Mode::UnixStream(config) => {
-                let (framing, decoding) = match (config.framing.clone(), config.max_length) {
-                    (Some(_), Some(_)) => {
-                        return Err("Using `max_length` is deprecated and does not have any effect when framing is provided. Configure `max_length` on the framing config instead.".into());
+                let decoding = config.decoding.clone();
+
+                // TODO: in v0.30.0 , remove the `max_length` setting from
+                // the UnixConfig, and all of the below mess and replace
+                // it with the configured framing /
+                // decoding.default_stream_framing().
+                let framing = match (config.framing.clone(), config.max_length) {
+                    (Some(framing), Some(_)) => {
+                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Since a `framing` setting was provided, the `max_length` setting has no effect.");
+                        framing
                     }
-                    (Some(framing), None) => {
-                        let decoding = config.decoding.clone();
-                        (framing, decoding)
-                    }
+                    (Some(framing), None) => framing,
                     (None, Some(max_length)) => {
-                        let decoding = config.decoding.clone();
-                        let framing =
-                            NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into();
-                        (framing, decoding)
+                        warn!(message = "The `max_length` setting is deprecated and will be removed in an upcoming release. Please configure the `max_length` from the `framing` setting instead.");
+                        NewlineDelimitedDecoderConfig::new_with_max_length(max_length).into()
                     }
-                    (None, None) => {
-                        let decoding = config.decoding.clone();
-                        let framing = decoding.default_stream_framing();
-                        (framing, decoding)
-                    }
+                    (None, None) => decoding.default_stream_framing(),
                 };
 
                 let log_namespace = cx.log_namespace(config.log_namespace);

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -33,9 +33,7 @@ pub struct TcpConfig {
     /// The maximum buffer size of incoming messages.
     ///
     /// Messages larger than this are truncated.
-    // TODO: this option is noted as deprecated in the source build function in mod.rs , but
-    // behaviorally there are inconsistencies when adapting the from_address() function to use framing
-    // instead of max_length. Merits further investigation.
+    // TODO: communicated as deprecated in v0.29.0, can be removed in v0.30.0
     #[configurable(
         deprecated = "This option has been deprecated. Configure `max_length` on the framing config instead."
     )]

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -44,9 +44,7 @@ pub struct UnixConfig {
     /// The maximum buffer size of incoming messages.
     ///
     /// Messages larger than this are truncated.
-    // TODO: this option is noted as deprecated in the source build function in mod.rs , but
-    // behaviorally there are inconsistencies when adapting the new() function to use framing
-    // instead of max_length. Merits further investigation.
+    // TODO: communicated as deprecated in v0.29.0, can be removed in v0.30.0
     #[configurable(
         deprecated = "This option has been deprecated. Configure `max_length` on the framing config instead."
     )]

--- a/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-04-11-0-29-0-upgrade-guide.md
@@ -2,7 +2,7 @@
 date: "2023-04-11"
 title: "0.29 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.29.0"
-authors: ["stephenwakely"]
+authors: ["stephenwakely", "neuronull"]
 release: "0.29.0"
 hide_on_release_notes: false
 badges:
@@ -12,6 +12,7 @@ badges:
 Vector's 0.29.0 release includes **deprecations**:
 
 1. [The `logdna` sink has been renamed to `mezmo`](#mezmo_sink)
+2. [The `socket` source `tcp` and `unix` mode setting `max_length` has been deprecated](#socket-source-max-length)
 
 ## Upgrade guide
 
@@ -29,3 +30,10 @@ Please update your configurations accordingly.
 ```
 
 [mezmo]: https://www.mezmo.com/logdna
+
+#### The `socket` source `tcp` and `unix` mode setting `max_length` has been deprecated {#socket-source-max-length}
+
+The `socket` source modes `tcp` and `unix` have had a `max_length` setting which is meant to
+be replaced by the `max_length` setting within the `framing` setting.
+The `max_length` setting will be removed from these modes in a future release.
+Please replace any explicit usages of `max_length` with a `framing` setting in your configurations.


### PR DESCRIPTION
As part of postmortem to #16630

- Downgrading terminating vector to a warning, and ignoring the `max_length` if configured in combination with framing.

- Marked this as officially deprecated 