### PR TITLE
feat(kinesis sinks): implement full retry of partial failures in firehose/streams

### DIFF
--- a/src/sinks/aws_kinesis/config.rs
+++ b/src/sinks/aws_kinesis/config.rs
@@ -58,6 +58,13 @@ pub struct KinesisSinkBaseConfig {
     #[serde(default)]
     pub auth: AwsAuthentication,
 
+    /// Whether or not to retry successful requests containing partial failures.
+    ///
+    /// Note: this will cause duplicates in firehose.
+    #[serde(default)]
+    #[configurable(metadata(docs::advanced))]
+    pub request_retry_partial: bool,
+
     #[configurable(derived)]
     #[serde(
         default,
@@ -83,6 +90,7 @@ pub async fn build_sink<C, R, RR, E, RT>(
     partition_key_field: Option<String>,
     batch_settings: BatcherSettings,
     client: C,
+    retry_logic: RT,
 ) -> crate::Result<VectorSink>
 where
     C: SendRecord + Clone + Send + Sync + 'static,
@@ -98,7 +106,7 @@ where
 
     let region = config.region.region();
     let service = ServiceBuilder::new()
-        .settings::<RT, BatchKinesisRequest<RR>>(request_limits, RT::default())
+        .settings::<RT, BatchKinesisRequest<RR>>(request_limits, retry_logic)
         .service(KinesisService::<C, R, E> {
             client,
             stream_name: config.stream_name.clone(),

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -193,7 +193,7 @@ impl RetryLogic for KinesisRetryLogic {
             let msg = format!("partial error count {}", response.failure_count);
             return RetryAction::Retry(msg.into());
         } else {
-            RetryAction::DontRetry("ok".into())
+            RetryAction::Successful
         }
     }
 }

--- a/src/sinks/aws_kinesis/firehose/record.rs
+++ b/src/sinks/aws_kinesis/firehose/record.rs
@@ -1,3 +1,5 @@
+use crate::sinks::aws_kinesis::KinesisResponse;
+use aws_sdk_firehose::output::PutRecordBatchOutput;
 use aws_sdk_firehose::types::{Blob, SdkError};
 use bytes::Bytes;
 use tracing::Instrument;
@@ -46,7 +48,13 @@ impl SendRecord for KinesisFirehoseClient {
     type T = KinesisRecord;
     type E = KinesisError;
 
-    async fn send(&self, records: Vec<Self::T>, stream_name: String) -> Option<SdkError<Self::E>> {
+    async fn send(
+        &self,
+        records: Vec<Self::T>,
+        stream_name: String,
+    ) -> Result<KinesisResponse, SdkError<Self::E>> {
+        let rec_count = records.len().clone();
+
         self.client
             .put_record_batch()
             .set_records(Some(records))
@@ -54,6 +62,10 @@ impl SendRecord for KinesisFirehoseClient {
             .send()
             .instrument(info_span!("request").or_current())
             .await
-            .err()
+            .map(|output: PutRecordBatchOutput| KinesisResponse {
+                count: rec_count,
+                failure_count: output.failed_put_count().unwrap_or(0) as usize,
+                events_byte_size: 0,
+            })
     }
 }

--- a/src/sinks/aws_kinesis/firehose/tests.rs
+++ b/src/sinks/aws_kinesis/firehose/tests.rs
@@ -33,6 +33,7 @@ async fn check_batch_size() {
         request: Default::default(),
         tls: None,
         auth: Default::default(),
+        request_retry_partial: false,
         acknowledgements: Default::default(),
     };
 
@@ -62,6 +63,7 @@ async fn check_batch_events() {
         request: Default::default(),
         tls: None,
         auth: Default::default(),
+        request_retry_partial: false,
         acknowledgements: Default::default(),
     };
 

--- a/src/sinks/aws_kinesis/record.rs
+++ b/src/sinks/aws_kinesis/record.rs
@@ -1,3 +1,4 @@
+use crate::sinks::aws_kinesis::KinesisResponse;
 use async_trait::async_trait;
 use aws_smithy_client::SdkError;
 use bytes::Bytes;
@@ -24,5 +25,9 @@ pub trait SendRecord {
     type E;
 
     /// Sends the records.
-    async fn send(&self, records: Vec<Self::T>, stream_name: String) -> Option<SdkError<Self::E>>;
+    async fn send(
+        &self,
+        records: Vec<Self::T>,
+        stream_name: String,
+    ) -> Result<KinesisResponse, SdkError<Self::E>>;
 }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -200,7 +200,7 @@ impl RetryLogic for KinesisRetryLogic {
             let msg = format!("partial error count {}", response.failure_count);
             return RetryAction::Retry(msg.into());
         } else {
-            RetryAction::DontRetry("ok".into())
+            RetryAction::Successful
         }
     }
 }

--- a/src/sinks/aws_kinesis/streams/record.rs
+++ b/src/sinks/aws_kinesis/streams/record.rs
@@ -1,3 +1,5 @@
+use crate::sinks::aws_kinesis::KinesisResponse;
+use aws_sdk_kinesis::output::PutRecordsOutput;
 use aws_sdk_kinesis::types::{Blob, SdkError};
 use bytes::Bytes;
 use tracing::Instrument;
@@ -62,7 +64,12 @@ impl SendRecord for KinesisStreamClient {
     type T = KinesisRecord;
     type E = KinesisError;
 
-    async fn send(&self, records: Vec<Self::T>, stream_name: String) -> Option<SdkError<Self::E>> {
+    async fn send(
+        &self,
+        records: Vec<Self::T>,
+        stream_name: String,
+    ) -> Result<KinesisResponse, SdkError<Self::E>> {
+        let rec_count = records.len().clone();
         self.client
             .put_records()
             .set_records(Some(records))
@@ -70,6 +77,10 @@ impl SendRecord for KinesisStreamClient {
             .send()
             .instrument(info_span!("request").or_current())
             .await
-            .err()
+            .map(|output: PutRecordsOutput| KinesisResponse {
+                count: rec_count,
+                failure_count: output.failed_record_count().unwrap_or(0) as usize,
+                events_byte_size: 0,
+            })
     }
 }


### PR DESCRIPTION
- Has configuration, but not per each of firehose/streams (probably should be per each, not just in base)
- It passes the failed count up for each of firehose/streams, then uses config to see if the request should be retried.
I have to test this, but looks okay. It's a little different than the ES implementation, but the change is fairly minimal.
Only wart is the way that the request size is "augmented" into the KinesisResponse after the call to `call`.

Hopefully looks alright - feel free to drop any feedback and I'll fix it up.
I think the config per each of streams/firehose is likely necessary to release this.

I reviewed/marked up the PR to help draw attention to these items and clarify.

--------- Further discussion/tickets -------

Handling of partial failures for firehose is open here: https://github.com/vectordotdev/vector/issues/359
Note that this issues is just the whole retry similar to what ES does (https://github.com/vectordotdev/vector/issues/140
)
I'd happily talk to someone about how I might improve this to handle only the partial failures (@decklyndubs on Discord - I'm in your server.) I have to look a little deeper but my fear in doing that is that a record gets indefinitely stuck and should be dropped, so in my mind there may need to be some separate retry policy in the sink. This design issue is broad and relates to multiple sinks such as ES that has partial failures.

Some other related tickets.
https://github.com/vectordotdev/vector/issues/7659
https://github.com/vectordotdev/vector/issues/9451
https://github.com/vectordotdev/vector/pull/9861
