### PR TITLE
fix(sinks): Sinks webhdfs is not built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,9 +5571,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendal"
-version = "0.29.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ae5735ee4517b68e4fe034c12790e0ac694a8977d1e2aea1b128926c8e8737"
+checksum = "b3f51ae9f36eabb51da3a10c491feb406ecf2c65faf1edb0b580f9a1acb0f1e8"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev =
 azure_storage_blobs = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "b4544d4920fa3064eb921340054cd9cc130b7664", default-features = false, optional = true }
 
 # OpenDAL
-opendal = {version = "0.29.1", default-features = false, features = ["native-tls"], optional = true}
+opendal = {version = "0.30", default-features = false, features = ["native-tls"], optional = true}
 
 # Tower
 tower = { version = "0.4.13", default-features = false, features = ["buffer", "limit", "retry", "timeout", "util", "balance", "discover"] }
@@ -644,6 +644,7 @@ sinks-logs = [
   "sinks-splunk_hec",
   "sinks-vector",
   "sinks-websocket",
+  "sinks-webhdfs",
 ]
 sinks-metrics = [
   "sinks-aws_cloudwatch_metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -643,8 +643,8 @@ sinks-logs = [
   "sinks-socket",
   "sinks-splunk_hec",
   "sinks-vector",
-  "sinks-websocket",
   "sinks-webhdfs",
+  "sinks-websocket",
 ]
 sinks-metrics = [
   "sinks-aws_cloudwatch_metrics",

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -270,7 +270,7 @@ pub enum Sinks {
     /// WebHDFS.
     #[cfg(feature = "sinks-webhdfs")]
     #[configurable(metadata(docs::label = "WebHDFS"))]
-    WebHdfs(webhdfs::WebHdfsConfig),
+    Webhdfs(webhdfs::WebHdfsConfig),
 
     /// Deliver log events to Honeycomb.
     #[cfg(feature = "sinks-honeycomb")]
@@ -485,7 +485,7 @@ impl NamedComponent for Sinks {
             #[cfg(feature = "sinks-gcp")]
             Self::GcpPubsub(config) => config.get_component_name(),
             #[cfg(feature = "sinks-webhdfs")]
-            Self::WebHdfs(config) => config.get_component_name(),
+            Self::Webhdfs(config) => config.get_component_name(),
             #[cfg(feature = "sinks-honeycomb")]
             Self::Honeycomb(config) => config.get_component_name(),
             #[cfg(feature = "sinks-http")]

--- a/src/sinks/opendal_common.rs
+++ b/src/sinks/opendal_common.rs
@@ -272,8 +272,7 @@ impl Service<OpenDalRequest> for OpenDalService {
 
         Box::pin(async move {
             let result = op
-                .object(&request.metadata.partition_key)
-                .write(request.payload)
+                .write(&request.metadata.partition_key, request.payload)
                 .in_current_span()
                 .await;
             result.map(|_| OpenDalResponse {

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -157,7 +157,7 @@ impl WebHdfsConfig {
         builder.root(&self.root);
         builder.endpoint(&self.endpoint);
 
-        let op = Operator::create(builder)?
+        let op = Operator::new(builder)?
             .layer(LoggingLayer::default())
             .finish();
         Ok(op)


### PR DESCRIPTION
This pull request addresses the issue of webhdfs sinks not being built.

Additionally, it updates OpenDAL to its latest version. For more information on the latest version, please refer to the following changelog: https://docs.rs/opendal/0.30.2/opendal/docs/changelog/index.html.

Close: https://github.com/vectordotdev/vector/pull/16779 