### PR TITLE
docs(journald source): Override default description for timestamp

### DIFF
--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -65,7 +65,9 @@ components: sources: journald: {
 						examples: ["journald"]
 					}
 				}
-				timestamp: fields._current_timestamp
+				timestamp: fields._current_timestamp & {
+					description: "The time at which the event appeared in the journal."
+				}
 				"*": {
 					common:      false
 					description: "Any Journald field"


### PR DESCRIPTION
Closes #16653
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
