### PR TITLE
chore(startup): Convert `Application::run` to an async fn

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,11 @@ fn main() {
         }
     }
 
-    let app = Application::prepare().unwrap_or_else(|code| {
+    let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
         std::process::exit(code);
     });
 
-    app.run();
+    runtime.block_on(app.run());
 }
 
 #[cfg(windows)]
@@ -49,10 +49,10 @@ pub fn main() {
     // interactive mode and then fallback to console mode.  See
     // https://docs.microsoft.com/en-us/dotnet/api/system.environment.userinteractive?redirectedfrom=MSDN&view=netcore-3.1#System_Environment_UserInteractive
     vector::vector_windows::run().unwrap_or_else(|_| {
-        let app = Application::prepare().unwrap_or_else(|code| {
+        let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
             std::process::exit(code);
         });
 
-        app.run();
+        runtime.block_on(app.run());
     });
 }


### PR DESCRIPTION
Effectively the entire function is run within an `async move` block, so just make the whole function async and `block_on` outside of it.

I strongly recommend turning off whitespace changes for reviewing this one. The entire `fn run` function is unindented one level.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
