### PR TITLE
fix(http sink): provide a description to the compression field

### DIFF
--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -292,7 +292,8 @@ impl Configurable for Compression {
         properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
 
         let mut full_subschema = generate_struct_schema(properties, required, None);
-        let mut full_metadata = Metadata::with_description("");
+        let mut full_metadata =
+            Metadata::with_description("Compression algorithm and compression level.");
         full_metadata.add_custom_attribute(CustomAttribute::flag("docs::hidden"));
         apply_base_metadata(&mut full_subschema, full_metadata);
 


### PR DESCRIPTION
As required by https://datadoghq.atlassian.net/browse/OPB-655, the `Compression` field in for the `http` sink, when converted to JsonSchema, doesn't have a description for the second option which leads to a UI problem.
This PR just adds a description to that `oneOf` option.