### PR TITLE
chore(startup): Break up application config setup more

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -60,6 +60,130 @@ pub struct Application {
     pub config: ApplicationConfig,
 }
 
+impl ApplicationConfig {
+    pub async fn prepare_from_opts(opts: &Opts) -> Result<Self, ExitCode> {
+        let color = opts.root.color.use_color();
+
+        let json = match &opts.root.log_format {
+            LogFormat::Text => false,
+            LogFormat::Json => true,
+        };
+
+        let level = get_log_levels(opts.log_level());
+
+        let config_paths = opts.root.config_paths_with_formats();
+        let watch_config = opts.root.watch_config;
+        let require_healthy = opts.root.require_healthy;
+
+        trace::init(color, json, &level, opts.root.internal_log_rate_limit);
+        info!(
+            message = "Internal log rate limit configured.",
+            internal_log_rate_secs = opts.root.internal_log_rate_limit
+        );
+        // Signal handler for OS and provider messages.
+        let (mut signal_handler, signal_rx) = signal::SignalHandler::new();
+        signal_handler.forever(signal::os_signals());
+
+        if let Some(s) = &opts.sub_command {
+            let code = match s {
+                SubCommand::Generate(g) => generate::cmd(g),
+                SubCommand::GenerateSchema => generate_schema::cmd(),
+                SubCommand::Graph(g) => graph::cmd(g),
+                SubCommand::Config(c) => config::cmd(c),
+                SubCommand::List(l) => list::cmd(l),
+                SubCommand::Test(t) => unit_test::cmd(t, &mut signal_handler).await,
+                #[cfg(windows)]
+                SubCommand::Service(s) => service::cmd(s),
+                #[cfg(feature = "api-client")]
+                SubCommand::Top(t) => top::cmd(t).await,
+                #[cfg(feature = "api-client")]
+                SubCommand::Tap(t) => tap::cmd(t, signal_rx).await,
+
+                SubCommand::Validate(v) => validate::validate(v, color).await,
+                #[cfg(feature = "vrl-cli")]
+                SubCommand::Vrl(s) => vrl_cli::cmd::cmd(s),
+            };
+
+            return Err(code);
+        };
+
+        info!(message = "Log level is enabled.", level = ?level);
+
+        let config_paths = config::process_paths(&config_paths).ok_or(exitcode::CONFIG)?;
+
+        if watch_config {
+            // Start listening for config changes immediately.
+            config::watcher::spawn_thread(config_paths.iter().map(Into::into), None).map_err(
+                |error| {
+                    error!(message = "Unable to start config watcher.", %error);
+                    exitcode::CONFIG
+                },
+            )?;
+        }
+
+        info!(
+            message = "Loading configs.",
+            paths = ?config_paths.iter().map(<&PathBuf>::from).collect::<Vec<_>>()
+        );
+
+        #[cfg(not(feature = "enterprise-tests"))]
+        config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;
+
+        let mut config =
+            config::load_from_paths_with_provider_and_secrets(&config_paths, &mut signal_handler)
+                .await
+                .map_err(handle_config_errors)?;
+
+        if !config.healthchecks.enabled {
+            info!("Health checks are disabled.");
+        }
+        config.healthchecks.set_require_healthy(require_healthy);
+
+        #[cfg(feature = "enterprise")]
+        // Enable enterprise features, if applicable.
+        let enterprise = match EnterpriseMetadata::try_from(&config) {
+            Ok(metadata) => {
+                let enterprise = EnterpriseReporter::new();
+
+                attach_enterprise_components(&mut config, &metadata);
+                enterprise.send(report_configuration(config_paths.clone(), metadata));
+
+                Some(enterprise)
+            }
+            Err(EnterpriseError::MissingApiKey) => {
+                error!("Enterprise configuration incomplete: missing API key.");
+                return Err(exitcode::CONFIG);
+            }
+            Err(_) => None,
+        };
+
+        let diff = config::ConfigDiff::initial(&config);
+        let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+            .await
+            .ok_or(exitcode::CONFIG)?;
+
+        #[cfg(feature = "api")]
+        let api = config.api;
+
+        let result = topology::start_validated(config, diff, pieces).await;
+        let (topology, (graceful_crash_sender, graceful_crash_receiver)) =
+            result.ok_or(exitcode::CONFIG)?;
+
+        Ok(Self {
+            config_paths,
+            topology,
+            graceful_crash_sender,
+            graceful_crash_receiver,
+            #[cfg(feature = "api")]
+            api,
+            #[cfg(feature = "enterprise")]
+            enterprise,
+            signal_handler,
+            signal_rx,
+        })
+    }
+}
+
 impl Application {
     pub fn prepare() -> Result<(Runtime, Self), ExitCode> {
         let opts = Opts::get_matches().map_err(|error| {
@@ -74,135 +198,11 @@ impl Application {
     pub fn prepare_from_opts(opts: Opts) -> Result<(Runtime, Self), ExitCode> {
         openssl_probe::init_ssl_cert_env_vars();
 
-        let level = get_log_levels(opts.log_level());
-
-        let color = opts.root.color.use_color();
-
-        let json = match &opts.root.log_format {
-            LogFormat::Text => false,
-            LogFormat::Json => true,
-        };
-
         #[cfg(not(feature = "enterprise-tests"))]
         metrics::init_global().expect("metrics initialization failed");
 
         let runtime = build_runtime(opts.root.threads, "vector-worker")?;
-
-        let config = {
-            let config_paths = opts.root.config_paths_with_formats();
-            let watch_config = opts.root.watch_config;
-            let require_healthy = opts.root.require_healthy;
-
-            runtime.block_on(async move {
-                trace::init(color, json, &level, opts.root.internal_log_rate_limit);
-                info!(
-                    message = "Internal log rate limit configured.",
-                    internal_log_rate_secs = opts.root.internal_log_rate_limit
-                );
-                // Signal handler for OS and provider messages.
-                let (mut signal_handler, signal_rx) = signal::SignalHandler::new();
-                signal_handler.forever(signal::os_signals());
-
-                if let Some(s) = opts.sub_command {
-                    let code = match s {
-                        SubCommand::Generate(g) => generate::cmd(&g),
-                        SubCommand::GenerateSchema => generate_schema::cmd(),
-                        SubCommand::Graph(g) => graph::cmd(&g),
-                        SubCommand::Config(c) => config::cmd(&c),
-                        SubCommand::List(l) => list::cmd(&l),
-                        SubCommand::Test(t) => unit_test::cmd(&t, &mut signal_handler).await,
-                        #[cfg(windows)]
-                        SubCommand::Service(s) => service::cmd(&s),
-                        #[cfg(feature = "api-client")]
-                        SubCommand::Top(t) => top::cmd(&t).await,
-                        #[cfg(feature = "api-client")]
-                        SubCommand::Tap(t) => tap::cmd(&t, signal_rx).await,
-
-                        SubCommand::Validate(v) => validate::validate(&v, color).await,
-                        #[cfg(feature = "vrl-cli")]
-                        SubCommand::Vrl(s) => vrl_cli::cmd::cmd(&s),
-                    };
-
-                    return Err(code);
-                };
-
-                info!(message = "Log level is enabled.", level = ?level);
-
-                let config_paths = config::process_paths(&config_paths).ok_or(exitcode::CONFIG)?;
-
-                if watch_config {
-                    // Start listening for config changes immediately.
-                    config::watcher::spawn_thread(config_paths.iter().map(Into::into), None)
-                        .map_err(|error| {
-                            error!(message = "Unable to start config watcher.", %error);
-                            exitcode::CONFIG
-                        })?;
-                }
-
-                info!(
-                    message = "Loading configs.",
-                    paths = ?config_paths.iter().map(<&PathBuf>::from).collect::<Vec<_>>()
-                );
-
-                #[cfg(not(feature = "enterprise-tests"))]
-                config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;
-
-                let mut config = config::load_from_paths_with_provider_and_secrets(
-                    &config_paths,
-                    &mut signal_handler,
-                )
-                .await
-                .map_err(handle_config_errors)?;
-
-                if !config.healthchecks.enabled {
-                    info!("Health checks are disabled.");
-                }
-                config.healthchecks.set_require_healthy(require_healthy);
-
-                #[cfg(feature = "enterprise")]
-                // Enable enterprise features, if applicable.
-                let enterprise = match EnterpriseMetadata::try_from(&config) {
-                    Ok(metadata) => {
-                        let enterprise = EnterpriseReporter::new();
-
-                        attach_enterprise_components(&mut config, &metadata);
-                        enterprise.send(report_configuration(config_paths.clone(), metadata));
-
-                        Some(enterprise)
-                    }
-                    Err(EnterpriseError::MissingApiKey) => {
-                        error!("Enterprise configuration incomplete: missing API key.");
-                        return Err(exitcode::CONFIG);
-                    }
-                    Err(_) => None,
-                };
-
-                let diff = config::ConfigDiff::initial(&config);
-                let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
-                    .await
-                    .ok_or(exitcode::CONFIG)?;
-
-                #[cfg(feature = "api")]
-                let api = config.api;
-
-                let result = topology::start_validated(config, diff, pieces).await;
-                let (topology, (graceful_crash_sender, graceful_crash_receiver)) =
-                    result.ok_or(exitcode::CONFIG)?;
-
-                Ok(ApplicationConfig {
-                    config_paths,
-                    topology,
-                    graceful_crash_sender,
-                    graceful_crash_receiver,
-                    #[cfg(feature = "api")]
-                    api,
-                    #[cfg(feature = "enterprise")]
-                    enterprise,
-                    signal_handler,
-                    signal_rx,
-                })
-            })
-        }?;
+        let config = runtime.block_on(ApplicationConfig::prepare_from_opts(&opts))?;
 
         Ok((
             runtime,

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,8 +22,6 @@ use crate::config::enterprise::{
 use crate::control_server::ControlServer;
 #[cfg(not(feature = "enterprise-tests"))]
 use crate::metrics;
-#[cfg(windows)]
-use crate::service;
 #[cfg(feature = "api")]
 use crate::{api, internal_events::ApiStarted};
 use crate::{

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,8 +28,9 @@ use crate::service;
 use crate::{api, internal_events::ApiStarted};
 use crate::{
     cli::{handle_config_errors, LogFormat, Opts, RootOpts},
-    config, heartbeat,
-    signal::{self, SignalTo},
+    config::{self, Config, ConfigPath},
+    heartbeat,
+    signal::{self, SignalHandler, SignalTo},
     topology::{self, ReloadOutcome, RunningTopology, TopologyController},
     trace,
 };
@@ -67,19 +68,17 @@ impl ApplicationConfig {
             LogFormat::Json => true,
         };
 
-        let level = get_log_levels(opts.log_level());
-
         let config_paths = opts.root.config_paths_with_formats();
-        let watch_config = opts.root.watch_config;
-        let require_healthy = opts.root.require_healthy;
 
+        let level = get_log_levels(opts.log_level());
         trace::init(color, json, &level, opts.root.internal_log_rate_limit);
+
         info!(
             message = "Internal log rate limit configured.",
             internal_log_rate_secs = opts.root.internal_log_rate_limit
         );
         // Signal handler for OS and provider messages.
-        let (mut signal_handler, signal_rx) = signal::SignalHandler::new();
+        let (mut signal_handler, signal_rx) = SignalHandler::new();
         signal_handler.forever(signal::os_signals());
 
         if let Some(sub_command) = &opts.sub_command {
@@ -90,36 +89,16 @@ impl ApplicationConfig {
 
         info!(message = "Log level is enabled.", level = ?level);
 
-        let config_paths = config::process_paths(&config_paths).ok_or(exitcode::CONFIG)?;
+        let config = load_configs(
+            &config_paths,
+            opts.root.watch_config,
+            opts.root.require_healthy,
+            &mut signal_handler,
+        )
+        .await?;
 
-        if watch_config {
-            // Start listening for config changes immediately.
-            config::watcher::spawn_thread(config_paths.iter().map(Into::into), None).map_err(
-                |error| {
-                    error!(message = "Unable to start config watcher.", %error);
-                    exitcode::CONFIG
-                },
-            )?;
-        }
-
-        info!(
-            message = "Loading configs.",
-            paths = ?config_paths.iter().map(<&PathBuf>::from).collect::<Vec<_>>()
-        );
-
-        #[cfg(not(feature = "enterprise-tests"))]
-        config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;
-
-        let mut config =
-            config::load_from_paths_with_provider_and_secrets(&config_paths, &mut signal_handler)
-                .await
-                .map_err(handle_config_errors)?;
-
-        if !config.healthchecks.enabled {
-            info!("Health checks are disabled.");
-        }
-        config.healthchecks.set_require_healthy(require_healthy);
-
+        #[cfg(feature = "enterprise")]
+        let mut config = config;
         #[cfg(feature = "enterprise")]
         // Enable enterprise features, if applicable.
         let enterprise = match EnterpriseMetadata::try_from(&config) {
@@ -445,4 +424,43 @@ pub fn build_runtime(threads: Option<usize>, thread_name: &str) -> Result<Runtim
     }
 
     Ok(rt_builder.build().expect("Unable to create async runtime"))
+}
+
+pub async fn load_configs(
+    config_paths: &[ConfigPath],
+    watch_config: bool,
+    require_healthy: Option<bool>,
+    signal_handler: &mut SignalHandler,
+) -> Result<Config, ExitCode> {
+    let config_paths = config::process_paths(config_paths).ok_or(exitcode::CONFIG)?;
+
+    if watch_config {
+        // Start listening for config changes immediately.
+        config::watcher::spawn_thread(config_paths.iter().map(Into::into), None).map_err(
+            |error| {
+                error!(message = "Unable to start config watcher.", %error);
+                exitcode::CONFIG
+            },
+        )?;
+    }
+
+    info!(
+        message = "Loading configs.",
+        paths = ?config_paths.iter().map(<&PathBuf>::from).collect::<Vec<_>>()
+    );
+
+    #[cfg(not(feature = "enterprise-tests"))]
+    config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;
+
+    let mut config =
+        config::load_from_paths_with_provider_and_secrets(&config_paths, signal_handler)
+            .await
+            .map_err(handle_config_errors)?;
+
+    if !config.healthchecks.enabled {
+        info!("Health checks are disabled.");
+    }
+    config.healthchecks.set_require_healthy(require_healthy);
+
+    Ok(config)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ use crate::tap;
 #[cfg(feature = "api-client")]
 use crate::top;
 use crate::{config, generate, get_version, graph, list, unit_test, validate};
+use crate::{generate_schema, signal};
 
 #[derive(Parser, Debug)]
 #[command(rename_all = "kebab-case")]
@@ -238,6 +239,34 @@ pub enum SubCommand {
     /// Vector Remap Language CLI
     #[cfg(feature = "vrl-cli")]
     Vrl(vrl_cli::Opts),
+}
+
+impl SubCommand {
+    pub async fn execute(
+        &self,
+        signal_handler: &mut signal::SignalHandler,
+        #[allow(unused_variables)] signal_rx: signal::SignalRx,
+        color: bool,
+    ) -> exitcode::ExitCode {
+        match self {
+            Self::Generate(g) => generate::cmd(g),
+            Self::GenerateSchema => generate_schema::cmd(),
+            Self::Graph(g) => graph::cmd(g),
+            Self::Config(c) => config::cmd(c),
+            Self::List(l) => list::cmd(l),
+            Self::Test(t) => unit_test::cmd(t, signal_handler).await,
+            #[cfg(windows)]
+            Self::Service(s) => service::cmd(s),
+            #[cfg(feature = "api-client")]
+            Self::Top(t) => top::cmd(t).await,
+            #[cfg(feature = "api-client")]
+            Self::Tap(t) => tap::cmd(t, signal_rx).await,
+
+            Self::Validate(v) => validate::validate(v, color).await,
+            #[cfg(feature = "vrl-cli")]
+            Self::Vrl(s) => vrl_cli::cmd::cmd(s),
+        }
+    }
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,19 +249,18 @@ impl SubCommand {
         color: bool,
     ) -> exitcode::ExitCode {
         match self {
+            Self::Config(c) => config::cmd(c),
             Self::Generate(g) => generate::cmd(g),
             Self::GenerateSchema => generate_schema::cmd(),
             Self::Graph(g) => graph::cmd(g),
-            Self::Config(c) => config::cmd(c),
             Self::List(l) => list::cmd(l),
-            Self::Test(t) => unit_test::cmd(t, signal_handler).await,
             #[cfg(windows)]
             Self::Service(s) => service::cmd(s),
             #[cfg(feature = "api-client")]
-            Self::Top(t) => top::cmd(t).await,
-            #[cfg(feature = "api-client")]
             Self::Tap(t) => tap::cmd(t, signal_rx).await,
-
+            Self::Test(t) => unit_test::cmd(t, signal_handler).await,
+            #[cfg(feature = "api-client")]
+            Self::Top(t) => top::cmd(t).await,
             Self::Validate(v) => validate::validate(v, color).await,
             #[cfg(feature = "vrl-cli")]
             Self::Vrl(s) => vrl_cli::cmd::cmd(s),


### PR DESCRIPTION
Breaking out more functionality from the big application methods. Pretty much all just code reorgs.

Again, probably best to view it with "hide whitespace changes" enabled.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
