### PR TITLE
chore(startup): Break up application config setup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ use crate::metrics;
 #[cfg(feature = "api")]
 use crate::{api, internal_events::ApiStarted};
 use crate::{
-    cli::{handle_config_errors, Color, LogFormat, Opts},
+    cli::{handle_config_errors, LogFormat, Opts},
     config::{self, Config, ConfigPath},
     heartbeat,
     signal::{SignalHandler, SignalPair, SignalTo},
@@ -125,16 +125,16 @@ impl Application {
     pub fn prepare_from_opts(opts: Opts) -> Result<(Runtime, Self), ExitCode> {
         init_global();
 
+        let color = opts.root.color.use_color();
+
         init_logging(
-            opts.root.color,
+            color,
             opts.root.log_format,
             opts.log_level(),
             opts.root.internal_log_rate_limit,
         );
 
         let runtime = build_runtime(opts.root.threads, "vector-worker")?;
-
-        let color = opts.root.color.use_color();
 
         // Signal handler for OS and provider messages.
         let mut signals = SignalPair::default();
@@ -475,14 +475,14 @@ fn build_enterprise(
     }
 }
 
-pub fn init_logging(color: Color, format: LogFormat, log_level: &str, rate: u64) {
+pub fn init_logging(color: bool, format: LogFormat, log_level: &str, rate: u64) {
     let level = get_log_levels(log_level);
     let json = match format {
         LogFormat::Text => false,
         LogFormat::Json => true,
     };
 
-    trace::init(color.use_color(), json, &level, rate);
+    trace::init(color, json, &level, rate);
     debug!(
         message = "Internal log rate limit configured.",
         internal_log_rate_secs = rate,

--- a/src/app.rs
+++ b/src/app.rs
@@ -124,10 +124,7 @@ impl Application {
     }
 
     pub fn prepare_from_opts(opts: Opts) -> Result<(Runtime, Self), ExitCode> {
-        openssl_probe::init_ssl_cert_env_vars();
-
-        #[cfg(not(feature = "enterprise-tests"))]
-        metrics::init_global().expect("metrics initialization failed");
+        init_global();
 
         init_logging(
             opts.root.color,
@@ -349,6 +346,13 @@ async fn sources_finished(mutex: Arc<Mutex<TopologyController>>) {
             continue;
         }
     }
+}
+
+pub fn init_global() {
+    openssl_probe::init_ssl_cert_env_vars();
+
+    #[cfg(not(feature = "enterprise-tests"))]
+    metrics::init_global().expect("metrics initialization failed");
 }
 
 fn get_log_levels(default: &str) -> String {

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,7 +77,6 @@ impl ApplicationConfig {
         );
         // Signal handler for OS and provider messages.
         let (mut signal_handler, signal_rx) = SignalHandler::new();
-        signal_handler.forever(signal::os_signals());
 
         if let Some(sub_command) = &opts.sub_command {
             return Err(sub_command

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,7 +137,7 @@ impl Application {
         let runtime = build_runtime(opts.root.threads, "vector-worker")?;
 
         // Signal handler for OS and provider messages.
-        let mut signals = SignalPair::default();
+        let mut signals = runtime.block_on(SignalPair::new());
 
         if let Some(sub_command) = &opts.sub_command {
             return Err(runtime.block_on(sub_command.execute(signals, color)));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -247,8 +247,7 @@ pub enum SubCommand {
 impl SubCommand {
     pub async fn execute(
         &self,
-        signal_handler: &mut signal::SignalHandler,
-        #[allow(unused_variables)] signal_rx: signal::SignalRx,
+        mut signals: signal::SignalPair,
         color: bool,
     ) -> exitcode::ExitCode {
         match self {
@@ -260,8 +259,8 @@ impl SubCommand {
             #[cfg(windows)]
             Self::Service(s) => service::cmd(s),
             #[cfg(feature = "api-client")]
-            Self::Tap(t) => tap::cmd(t, signal_rx).await,
-            Self::Test(t) => unit_test::cmd(t, signal_handler).await,
+            Self::Tap(t) => tap::cmd(t, signals.receiver).await,
+            Self::Test(t) => unit_test::cmd(t, &mut signals.handler).await,
             #[cfg(feature = "api-client")]
             Self::Top(t) => top::cmd(t).await,
             Self::Validate(v) => validate::validate(v, color).await,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, FromArgMatches, Parser};
-use once_cell::sync::Lazy;
 
 #[cfg(windows)]
 use crate::service;
@@ -12,8 +11,6 @@ use crate::tap;
 use crate::top;
 use crate::{config, generate, get_version, graph, list, unit_test, validate};
 use crate::{generate_schema, signal};
-
-static ISATTY: Lazy<bool> = Lazy::new(|| atty::is(atty::Stream::Stdout));
 
 #[derive(Parser, Debug)]
 #[command(rename_all = "kebab-case")]
@@ -281,7 +278,7 @@ impl Color {
     pub fn use_color(&self) -> bool {
         match self {
             #[cfg(unix)]
-            Color::Auto => *ISATTY,
+            Color::Auto => atty::is(atty::Stream::Stdout),
             #[cfg(windows)]
             Color::Auto => false, // ANSI colors are not supported by cmd.exe
             Color::Always => true,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, FromArgMatches, Parser};
+use once_cell::sync::Lazy;
 
 #[cfg(windows)]
 use crate::service;
@@ -11,6 +12,8 @@ use crate::tap;
 use crate::top;
 use crate::{config, generate, get_version, graph, list, unit_test, validate};
 use crate::{generate_schema, signal};
+
+static ISATTY: Lazy<bool> = Lazy::new(|| atty::is(atty::Stream::Stdout));
 
 #[derive(Parser, Debug)]
 #[command(rename_all = "kebab-case")]
@@ -268,7 +271,7 @@ impl SubCommand {
     }
 }
 
-#[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Color {
     Auto,
     Always,
@@ -279,7 +282,7 @@ impl Color {
     pub fn use_color(&self) -> bool {
         match self {
             #[cfg(unix)]
-            Color::Auto => atty::is(atty::Stream::Stdout),
+            Color::Auto => *ISATTY,
             #[cfg(windows)]
             Color::Auto => false, // ANSI colors are not supported by cmd.exe
             Color::Always => true,
@@ -288,7 +291,7 @@ impl Color {
     }
 }
 
-#[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LogFormat {
     Text,
     Json,

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -39,6 +39,7 @@ impl SignalHandler {
             shutdown_txs: vec![],
         };
 
+        handler.forever(os_signals());
         (handler, rx)
     }
 
@@ -54,7 +55,7 @@ impl SignalHandler {
 
     /// Takes a stream who's elements are convertible to `SignalTo`, and spawns a permanent
     /// task for transmitting to the receiver.
-    pub fn forever<T, S>(&mut self, stream: S)
+    fn forever<T, S>(&self, stream: S)
     where
         T: Into<SignalTo> + Send + Sync,
         S: Stream<Item = T> + 'static + Send,
@@ -120,7 +121,7 @@ impl SignalHandler {
 
 /// Signals from OS/user.
 #[cfg(unix)]
-pub fn os_signals() -> impl Stream<Item = SignalTo> {
+fn os_signals() -> impl Stream<Item = SignalTo> {
     use tokio::signal::unix::{signal, SignalKind};
 
     let mut sigint = signal(SignalKind::interrupt()).expect("Signal handlers should not panic.");
@@ -143,7 +144,7 @@ pub fn os_signals() -> impl Stream<Item = SignalTo> {
 
 /// Signals from OS/user.
 #[cfg(windows)]
-pub(crate) fn os_signals() -> impl Stream<Item = SignalTo> {
+fn os_signals() -> impl Stream<Item = SignalTo> {
     use futures::future::FutureExt;
 
     async_stream::stream! {

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -368,7 +368,7 @@ pub fn run() -> Result<()> {
 fn run_service(_arguments: Vec<OsString>) -> Result<()> {
     match Application::prepare() {
         Ok((runtime, app)) => {
-            let signal_tx = app.config.signal_handler.clone_tx();
+            let signal_tx = app.signals.handler.clone_tx();
             let event_handler = move |control_event| -> ServiceControlHandlerResult {
                 match control_event {
                     // Notifies a service to report its current status information to the service


### PR DESCRIPTION
This is probably the last major change to the application setup stage, mostly focused on `ApplicationConfig`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
