### PR TITLE
feat(signals): log received signals

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -131,10 +131,22 @@ pub fn os_signals() -> impl Stream<Item = SignalTo> {
     async_stream::stream! {
         loop {
             let signal = tokio::select! {
-                _ = sigint.recv() => SignalTo::Shutdown,
-                _ = sigterm.recv() => SignalTo::Shutdown,
-                _ = sigquit.recv() => SignalTo::Quit,
-                _ = sighup.recv() => SignalTo::ReloadFromDisk,
+                _ = sigint.recv() => {
+                    info!(message = "SIGINT signal received.");
+                    SignalTo::Shutdown
+                },
+                _ = sigterm.recv() => {
+                    info!(message = "SIGTERM signal received.");
+                    SignalTo::Shutdown
+                } ,
+                _ = sigquit.recv() => {
+                    info!(message = "SIGQUIT signal received.");
+                    SignalTo::Quit
+                },
+                _ = sighup.recv() => {
+                    info!(message = "SIGHUP signal received.");
+                    SignalTo::ReloadFromDisk
+                },
             };
             yield signal;
         }


### PR DESCRIPTION
Resolves https://github.com/vectordotdev/vector/issues/16781

@jszwedko there are some questions regarding the PR:
- do we want to log other received by Vector signals, even if they do nothing from the Vector perspective? For scenarios like "User sends a wrong signal to a Vector instance and does not understand why the config is not reloaded".
- is the `info` log level the right level for that? IMO, yes. 

Tested:
- local tests