### PR TITLE
chore: Remove awaiting-author label when PR is updated

### DIFF
--- a/.github/workflows/gardener_remove_waiting_author.yml
+++ b/.github/workflows/gardener_remove_waiting_author.yml
@@ -1,0 +1,14 @@
+name: Remove Awaiting Author Label
+
+on:
+  pull_request:
+    types: [synchronize, review_requested]
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "meta: awaiting-author"


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
