### PR TITLE
chore(core): Migrate `LogSchema` `timestamp` to new lookup code

### DIFF
--- a/benches/template.rs
+++ b/benches/template.rs
@@ -12,9 +12,13 @@ fn bench_elasticsearch_index(c: &mut Criterion) {
     group.bench_function("dynamic", |b| {
         let index = Template::try_from("index-%Y.%m.%d").unwrap();
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event
-            .as_mut_log()
-            .insert(log_schema().timestamp_key(), Utc::now());
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            Utc::now(),
+        );
 
         b.iter_batched(
             || event.clone(),
@@ -26,9 +30,13 @@ fn bench_elasticsearch_index(c: &mut Criterion) {
     group.bench_function("static", |b| {
         let index = Template::try_from("index").unwrap();
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event
-            .as_mut_log()
-            .insert(log_schema().timestamp_key(), Utc::now());
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            Utc::now(),
+        );
 
         b.iter_batched(
             || event.clone(),

--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -144,7 +144,11 @@ mod tests {
                 let log = event.as_log();
                 assert_eq!(log["foo"], 123.into());
                 assert_eq!(
-                    log.get(log_schema().timestamp_key()).is_some(),
+                    log.get((
+                        lookup::PathPrefix::Event,
+                        log_schema().timestamp_key().unwrap()
+                    ))
+                    .is_some(),
                     namespace == LogNamespace::Legacy
                 );
             }
@@ -166,7 +170,11 @@ mod tests {
                 let log = event.as_log();
                 assert_eq!(log["foo"], 123.into());
                 assert_eq!(
-                    log.get(log_schema().timestamp_key()).is_some(),
+                    log.get((
+                        lookup::PathPrefix::Event,
+                        log_schema().timestamp_key().unwrap()
+                    ))
+                    .is_some(),
                     namespace == LogNamespace::Legacy
                 );
             }
@@ -176,7 +184,8 @@ mod tests {
                 let log = event.as_log();
                 assert_eq!(log["bar"], 456.into());
                 assert_eq!(
-                    log.get(log_schema().timestamp_key()).is_some(),
+                    log.get((PathPrefix::Event, log_schema().timestamp_key().unwrap()))
+                        .is_some(),
                     namespace == LogNamespace::Legacy
                 );
             }

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -455,7 +455,9 @@ mod tests {
         let events = deserializer.parse(input, LogNamespace::Legacy).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].as_log()[log_schema().message_key()], "MSG".into());
-        assert!(events[0].as_log()[log_schema().timestamp_key()].is_timestamp());
+        assert!(
+            events[0].as_log()[log_schema().timestamp_key().unwrap().to_string()].is_timestamp()
+        );
     }
 
     #[test]

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use chrono::{DateTime, Datelike, Utc};
 use lookup::lookup_v2::parse_value_path;
-use lookup::{event_path, owned_value_path, OwnedTargetPath, OwnedValuePath};
+use lookup::{event_path, owned_value_path, OwnedTargetPath, OwnedValuePath, PathPrefix};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use std::collections::BTreeMap;
@@ -44,21 +44,25 @@ impl SyslogDeserializerConfig {
     pub fn schema_definition(&self, log_namespace: LogNamespace) -> schema::Definition {
         match (log_namespace, self.source) {
             (LogNamespace::Legacy, _) => {
-                schema::Definition::empty_legacy_namespace()
+                let mut definition = schema::Definition::empty_legacy_namespace()
                     // The `message` field is always defined. If parsing fails, the entire body becomes the
                     // message.
                     .with_event_field(
                         &parse_value_path(log_schema().message_key()).expect("valid message key"),
                         Kind::bytes(),
                         Some("message"),
-                    )
+                    );
+
+                if let Some(timestamp_key) = log_schema().timestamp_key() {
                     // All other fields are optional.
-                    .optional_field(
-                        &parse_value_path(log_schema().timestamp_key())
-                            .expect("valid timestamp key"),
+                    definition = definition.optional_field(
+                        timestamp_key,
                         Kind::timestamp(),
                         Some("timestamp"),
                     )
+                }
+
+                definition
                     .optional_field(&owned_value_path!("hostname"), Kind::bytes(), Some("host"))
                     .optional_field(
                         &owned_value_path!("severity"),
@@ -366,7 +370,9 @@ fn insert_fields_from_syslog(
         let timestamp = DateTime::<Utc>::from(timestamp);
         match log_namespace {
             LogNamespace::Legacy => {
-                log.insert(event_path!(log_schema().timestamp_key()), timestamp);
+                if let Some(timestamp_key) = log_schema().timestamp_key() {
+                    log.insert((PathPrefix::Event, timestamp_key), timestamp);
+                }
             }
             LogNamespace::Vector => {
                 log.insert(event_path!("timestamp"), timestamp);

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -1,6 +1,6 @@
 use crate::encoding::BuildError;
 use bytes::{BufMut, BytesMut};
-use lookup::lookup_v2::ConfigOwnedTargetPath;
+use lookup::lookup_v2::ConfigTargetPath;
 use tokio_util::codec::Encoder;
 use vector_core::{
     config::DataType,
@@ -55,18 +55,18 @@ pub struct CsvSerializerOptions {
     ///
     /// Values of type `Array`, `Object`, and `Regex` are not supported and the
     /// output will be an empty string.
-    pub fields: Vec<ConfigOwnedTargetPath>,
+    pub fields: Vec<ConfigTargetPath>,
 }
 
 /// Serializer that converts an `Event` to bytes using the CSV format.
 #[derive(Debug, Clone)]
 pub struct CsvSerializer {
-    fields: Vec<ConfigOwnedTargetPath>,
+    fields: Vec<ConfigTargetPath>,
 }
 
 impl CsvSerializer {
     /// Creates a new `CsvSerializer`.
-    pub const fn new(fields: Vec<ConfigOwnedTargetPath>) -> Self {
+    pub const fn new(fields: Vec<ConfigTargetPath>) -> Self {
         Self { fields }
     }
 }
@@ -130,15 +130,15 @@ mod tests {
         }));
 
         let fields = vec![
-            ConfigOwnedTargetPath::try_from("foo".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("int".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("comma".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("float".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("missing".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("space".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("time".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("quote".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("bool".to_string()).unwrap(),
+            ConfigTargetPath::try_from("foo".to_string()).unwrap(),
+            ConfigTargetPath::try_from("int".to_string()).unwrap(),
+            ConfigTargetPath::try_from("comma".to_string()).unwrap(),
+            ConfigTargetPath::try_from("float".to_string()).unwrap(),
+            ConfigTargetPath::try_from("missing".to_string()).unwrap(),
+            ConfigTargetPath::try_from("space".to_string()).unwrap(),
+            ConfigTargetPath::try_from("time".to_string()).unwrap(),
+            ConfigTargetPath::try_from("quote".to_string()).unwrap(),
+            ConfigTargetPath::try_from("bool".to_string()).unwrap(),
         ];
         let config = CsvSerializerConfig::new(CsvSerializerOptions { fields });
         let mut serializer = config.build().unwrap();
@@ -162,11 +162,11 @@ mod tests {
             "field5" => Value::from("value5"),
         }));
         let fields = vec![
-            ConfigOwnedTargetPath::try_from("field1".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("field5".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("field5".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("field3".to_string()).unwrap(),
-            ConfigOwnedTargetPath::try_from("field2".to_string()).unwrap(),
+            ConfigTargetPath::try_from("field1".to_string()).unwrap(),
+            ConfigTargetPath::try_from("field5".to_string()).unwrap(),
+            ConfigTargetPath::try_from("field5".to_string()).unwrap(),
+            ConfigTargetPath::try_from("field3".to_string()).unwrap(),
+            ConfigTargetPath::try_from("field2".to_string()).unwrap(),
         ];
         let config = CsvSerializerConfig::new(CsvSerializerOptions { fields });
         let mut serializer = config.build().unwrap();

--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -201,14 +201,14 @@ impl ResourceLog {
         log_namespace.insert_source_metadata(
             SOURCE_NAME,
             &mut log,
-            Some(LegacyKey::Overwrite(path!(log_schema().timestamp_key()))),
+            log_schema().timestamp_key().map(LegacyKey::Overwrite),
             path!("timestamp"),
             timestamp,
         );
 
         log_namespace.insert_vector_metadata(
             &mut log,
-            path!(log_schema().source_type_key()),
+            Some(log_schema().source_type_key()),
             path!("source_type"),
             Bytes::from_static(SOURCE_NAME.as_bytes()),
         );

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -1,5 +1,5 @@
-use lookup::lookup_v2::parse_target_path;
-use lookup::OwnedTargetPath;
+use lookup::lookup_v2::{parse_target_path, OptionalValuePath};
+use lookup::{owned_value_path, OwnedTargetPath, OwnedValuePath};
 use once_cell::sync::{Lazy, OnceCell};
 use vector_config::configurable_component;
 
@@ -53,7 +53,7 @@ pub struct LogSchema {
 
     /// The name of the event field to treat as the event timestamp.
     #[serde(default = "LogSchema::default_timestamp_key")]
-    timestamp_key: String,
+    timestamp_key: OptionalValuePath,
 
     /// The name of the event field to treat as the host which sent the message.
     ///
@@ -93,8 +93,10 @@ impl LogSchema {
         String::from("message")
     }
 
-    fn default_timestamp_key() -> String {
-        String::from("timestamp")
+    fn default_timestamp_key() -> OptionalValuePath {
+        OptionalValuePath {
+            path: Some(owned_value_path!("timestamp")),
+        }
     }
 
     fn default_host_key() -> String {
@@ -122,8 +124,8 @@ impl LogSchema {
         parse_target_path(self.message_key()).expect("valid message key")
     }
 
-    pub fn timestamp_key(&self) -> &str {
-        &self.timestamp_key
+    pub fn timestamp_key(&self) -> Option<&OwnedValuePath> {
+        self.timestamp_key.path.as_ref()
     }
 
     pub fn host_key(&self) -> &str {
@@ -142,8 +144,8 @@ impl LogSchema {
         self.message_key = v;
     }
 
-    pub fn set_timestamp_key(&mut self, v: String) {
-        self.timestamp_key = v;
+    pub fn set_timestamp_key(&mut self, v: Option<OwnedValuePath>) {
+        self.timestamp_key = OptionalValuePath { path: v };
     }
 
     pub fn set_host_key(&mut self, v: String) {
@@ -188,7 +190,7 @@ impl LogSchema {
             {
                 errors.push("conflicting values for 'log_schema.timestamp_key' found".to_owned());
             } else {
-                self.set_timestamp_key(other.timestamp_key().to_string());
+                self.set_timestamp_key(other.timestamp_key().cloned());
             }
             if self.source_type_key() != LOG_SCHEMA_DEFAULT.source_type_key()
                 && self.source_type_key() != other.source_type_key()

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -357,7 +357,7 @@ impl LogNamespace {
     ) {
         self.insert_vector_metadata(
             log,
-            log_schema().source_type_key(),
+            Some(log_schema().source_type_key()),
             path!("source_type"),
             Bytes::from_static(source_name.as_bytes()),
         );
@@ -376,7 +376,7 @@ impl LogNamespace {
     pub fn insert_vector_metadata<'a>(
         &self,
         log: &mut LogEvent,
-        legacy_key: impl ValuePath<'a>,
+        legacy_key: Option<impl ValuePath<'a>>,
         metadata_key: impl ValuePath<'a>,
         value: impl Into<Value>,
     ) {
@@ -387,7 +387,9 @@ impl LogNamespace {
                     .insert(path!("vector").concat(metadata_key), value);
             }
             LogNamespace::Legacy => {
-                log.try_insert((PathPrefix::Event, legacy_key), value);
+                if let Some(legacy_key) = legacy_key {
+                    log.try_insert((PathPrefix::Event, legacy_key), value);
+                }
             }
         }
     }

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -146,7 +146,10 @@ impl LogEvent {
     pub fn from_str_legacy(msg: impl Into<String>) -> Self {
         let mut log = LogEvent::default();
         log.insert(log_schema().message_key(), msg.into());
-        log.insert(log_schema().timestamp_key(), Utc::now());
+        if let Some(timestamp_key) = log_schema().timestamp_key() {
+            log.insert((PathPrefix::Event, timestamp_key), Utc::now());
+        }
+
         log
     }
 
@@ -419,7 +422,7 @@ impl LogEvent {
     pub fn timestamp_path(&self) -> Option<String> {
         match self.namespace() {
             LogNamespace::Vector => self.find_key_by_meaning("timestamp"),
-            LogNamespace::Legacy => Some(log_schema().timestamp_key().to_owned()),
+            LogNamespace::Legacy => log_schema().timestamp_key().map(|path| path.to_string()),
         }
     }
 
@@ -459,19 +462,17 @@ impl LogEvent {
     pub fn get_timestamp(&self) -> Option<&Value> {
         match self.namespace() {
             LogNamespace::Vector => self.get_by_meaning("timestamp"),
-            LogNamespace::Legacy => self.get((PathPrefix::Event, log_schema().timestamp_key())),
+            LogNamespace::Legacy => log_schema()
+                .timestamp_key()
+                .and_then(|key| self.get((PathPrefix::Event, key))),
         }
     }
 
     /// Removes the `timestamp` from the event. This is either from the "timestamp" semantic meaning (Vector namespace)
     /// or from the timestamp key set on the "Global Log Schema" (Legacy namespace).
     pub fn remove_timestamp(&mut self) -> Option<Value> {
-        match self.namespace() {
-            LogNamespace::Vector => self
-                .find_key_by_meaning("timestamp")
-                .and_then(|key| self.remove(key.as_str())),
-            LogNamespace::Legacy => self.remove((PathPrefix::Event, log_schema().timestamp_key())),
-        }
+        self.timestamp_path()
+            .and_then(|key| self.remove(key.as_str()))
     }
 
     /// Fetches the `host` of the event. This is either from the "host" semantic meaning (Vector namespace)

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -422,7 +422,7 @@ impl LogEvent {
     pub fn timestamp_path(&self) -> Option<String> {
         match self.namespace() {
             LogNamespace::Vector => self.find_key_by_meaning("timestamp"),
-            LogNamespace::Legacy => log_schema().timestamp_key().map(|path| path.to_string()),
+            LogNamespace::Legacy => log_schema().timestamp_key().map(ToString::to_string),
         }
     }
 
@@ -521,8 +521,9 @@ mod test_utils {
             let mut log = LogEvent::default();
 
             log.insert(log_schema().message_key(), message);
-            log.insert(log_schema().timestamp_key(), Utc::now());
-
+            if let Some(timestamp_key) = log_schema().timestamp_key() {
+                log.insert((PathPrefix::Event, timestamp_key), Utc::now());
+            }
             log
         }
     }

--- a/lib/vector-core/src/event/test/serialization.rs
+++ b/lib/vector-core/src/event/test/serialization.rs
@@ -70,7 +70,7 @@ fn serialization() {
         "message": "raw log line",
         "foo": "bar",
         "bar": "baz",
-        "timestamp": event.get(log_schema().timestamp_key()),
+        "timestamp": event.get(log_schema().timestamp_key().unwrap().to_string().as_str()),
     });
 
     let actual_all = serde_json::to_value(event.all_fields().unwrap()).unwrap();

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
+use lookup::lookup_v2::TargetPath;
 use serde::{Deserialize, Serialize};
 use vector_buffers::EventCount;
 use vector_common::EventDataEq;
@@ -67,8 +68,9 @@ impl TraceEvent {
         self.0.as_map().expect("inner value must be a map")
     }
 
-    pub fn get(&self, key: impl AsRef<str>) -> Option<&Value> {
-        self.0.get(key.as_ref())
+    #[allow(clippy::needless_pass_by_value)] // TargetPath is always a reference
+    pub fn get<'a>(&self, key: impl TargetPath<'a>) -> Option<&Value> {
+        self.0.get(key)
     }
 
     pub fn get_mut(&mut self, key: impl AsRef<str>) -> Option<&mut Value> {

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -152,7 +152,7 @@ impl Definition {
             None,
         )
         .with_vector_metadata(
-            parse_value_path(log_schema().timestamp_key()).ok().as_ref(),
+            log_schema().timestamp_key(),
             &owned_value_path!("ingest_timestamp"),
             Kind::timestamp(),
             None,

--- a/lib/vector-lookup/src/lookup_v2/mod.rs
+++ b/lib/vector-lookup/src/lookup_v2/mod.rs
@@ -8,27 +8,29 @@ pub use lookup::lookup_v2::{
     OwnedValuePath, PathConcat, PathParseError, PathPrefix, TargetPath, ValuePath,
 };
 
-/// A wrapper around `OwnedValuePath` that allows it to be used in Vector config
+/// A wrapper around `OwnedValuePath` that allows it to be used in Vector config.
+/// This requires a valid path to be used. If you want to allow optional paths,
+/// use [optional_path::OptionalValuePath].
 #[configurable_component]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(try_from = "String", into = "String")]
-pub struct ConfigOwnedValuePath(pub OwnedValuePath);
+pub struct ConfigValuePath(pub OwnedValuePath);
 
-impl TryFrom<String> for ConfigOwnedValuePath {
+impl TryFrom<String> for ConfigValuePath {
     type Error = PathParseError;
 
     fn try_from(src: String) -> Result<Self, Self::Error> {
-        OwnedValuePath::try_from(src).map(ConfigOwnedValuePath)
+        OwnedValuePath::try_from(src).map(ConfigValuePath)
     }
 }
 
-impl From<ConfigOwnedValuePath> for String {
-    fn from(owned: ConfigOwnedValuePath) -> Self {
+impl From<ConfigValuePath> for String {
+    fn from(owned: ConfigValuePath) -> Self {
         String::from(owned.0)
     }
 }
 
-impl<'a> ValuePath<'a> for &'a ConfigOwnedValuePath {
+impl<'a> ValuePath<'a> for &'a ConfigValuePath {
     type Iter = <&'a OwnedValuePath as ValuePath<'a>>::Iter;
 
     fn segment_iter(&self) -> Self::Iter {
@@ -41,23 +43,23 @@ impl<'a> ValuePath<'a> for &'a ConfigOwnedValuePath {
 #[configurable_component]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(try_from = "String", into = "String")]
-pub struct ConfigOwnedTargetPath(pub OwnedTargetPath);
+pub struct ConfigTargetPath(pub OwnedTargetPath);
 
-impl TryFrom<String> for ConfigOwnedTargetPath {
+impl TryFrom<String> for ConfigTargetPath {
     type Error = PathParseError;
 
     fn try_from(src: String) -> Result<Self, Self::Error> {
-        OwnedTargetPath::try_from(src).map(ConfigOwnedTargetPath)
+        OwnedTargetPath::try_from(src).map(ConfigTargetPath)
     }
 }
 
-impl From<ConfigOwnedTargetPath> for String {
-    fn from(owned: ConfigOwnedTargetPath) -> Self {
+impl From<ConfigTargetPath> for String {
+    fn from(owned: ConfigTargetPath) -> Self {
         String::from(owned.0)
     }
 }
 
-impl<'a> TargetPath<'a> for &'a ConfigOwnedTargetPath {
+impl<'a> TargetPath<'a> for &'a ConfigTargetPath {
     type ValuePath = &'a OwnedValuePath;
 
     fn prefix(&self) -> PathPrefix {

--- a/scripts/integration/aws/test.yaml
+++ b/scripts/integration/aws/test.yaml
@@ -1,7 +1,7 @@
 features:
 - aws-integration-tests
 
-test_filter: ::aws_
+test_filter: ::aws_kinesis::streams
 
 env:
   AWS_ACCESS_KEY_ID: dummy

--- a/scripts/integration/aws/test.yaml
+++ b/scripts/integration/aws/test.yaml
@@ -1,7 +1,7 @@
 features:
 - aws-integration-tests
 
-test_filter: ::aws_kinesis::streams
+test_filter: ::aws_
 
 env:
   AWS_ACCESS_KEY_ID: dummy

--- a/src/codecs/encoding/config.rs
+++ b/src/codecs/encoding/config.rs
@@ -145,7 +145,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use lookup::lookup_v2::{parse_value_path, ConfigOwnedValuePath};
+    use lookup::lookup_v2::{parse_value_path, ConfigValuePath};
 
     use super::*;
     use crate::codecs::encoding::TimestampFormat;
@@ -170,9 +170,7 @@ mod test {
 
         assert_eq!(
             transformer.only_fields(),
-            &Some(vec![ConfigOwnedValuePath(
-                parse_value_path("a.b[0]").unwrap()
-            )])
+            &Some(vec![ConfigValuePath(parse_value_path("a.b[0]").unwrap())])
         );
         assert_eq!(
             transformer.except_fields(),
@@ -207,9 +205,7 @@ mod test {
 
         assert_eq!(
             transformer.only_fields(),
-            &Some(vec![ConfigOwnedValuePath(
-                parse_value_path("a.b[0]").unwrap()
-            )])
+            &Some(vec![ConfigValuePath(parse_value_path("a.b[0]").unwrap())])
         );
         assert_eq!(
             transformer.except_fields(),
@@ -241,9 +237,7 @@ mod test {
 
         assert_eq!(
             transformer.only_fields(),
-            &Some(vec![ConfigOwnedValuePath(
-                parse_value_path("a.b[0]").unwrap()
-            )])
+            &Some(vec![ConfigValuePath(parse_value_path("a.b[0]").unwrap())])
         );
         assert_eq!(
             transformer.except_fields(),

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 use std::collections::BTreeMap;
 
-use lookup::lookup_v2::ConfigOwnedValuePath;
+use lookup::lookup_v2::ConfigValuePath;
 use lookup::{
     event_path,
     lookup_v2::{parse_value_path, OwnedValuePath},
@@ -22,7 +22,7 @@ use crate::{event::Event, serde::skip_serializing_if_default};
 pub struct Transformer {
     /// List of fields that will be included in the encoded event.
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
-    only_fields: Option<Vec<ConfigOwnedValuePath>>,
+    only_fields: Option<Vec<ConfigValuePath>>,
 
     /// List of fields that will be excluded from the encoded event.
     #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
@@ -71,7 +71,7 @@ impl Transformer {
     ) -> Result<Self, crate::Error> {
         Self::validate_fields(only_fields.as_ref(), except_fields.as_ref())?;
 
-        let only_fields = only_fields.map(|x| x.into_iter().map(ConfigOwnedValuePath).collect());
+        let only_fields = only_fields.map(|x| x.into_iter().map(ConfigValuePath).collect());
         Ok(Self {
             only_fields,
             except_fields,
@@ -81,7 +81,7 @@ impl Transformer {
 
     /// Get the `Transformer`'s `only_fields`.
     #[cfg(test)]
-    pub const fn only_fields(&self) -> &Option<Vec<ConfigOwnedValuePath>> {
+    pub const fn only_fields(&self) -> &Option<Vec<ConfigValuePath>> {
         &self.only_fields
     }
 

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -318,7 +318,10 @@ mod tests {
         let mut event = Event::Log(LogEvent::from("Demo"));
         let timestamp = event
             .as_mut_log()
-            .get(log_schema().timestamp_key())
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ))
             .unwrap()
             .clone();
         let timestamp = timestamp.as_timestamp().unwrap();
@@ -330,7 +333,10 @@ mod tests {
 
         match event
             .as_mut_log()
-            .get(log_schema().timestamp_key())
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ))
             .unwrap()
         {
             Value::Integer(_) => {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -846,7 +846,12 @@ mod tests {
         );
         assert_eq!(
             "timestamp",
-            config.global.log_schema.timestamp_key().to_string()
+            config
+                .global
+                .log_schema
+                .timestamp_key()
+                .unwrap()
+                .to_string()
         );
     }
 
@@ -872,7 +877,15 @@ mod tests {
 
         assert_eq!("this", config.global.log_schema.host_key().to_string());
         assert_eq!("that", config.global.log_schema.message_key().to_string());
-        assert_eq!("then", config.global.log_schema.timestamp_key().to_string());
+        assert_eq!(
+            "then",
+            config
+                .global
+                .log_schema
+                .timestamp_key()
+                .unwrap()
+                .to_string()
+        );
     }
 
     #[test]

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -117,7 +117,13 @@ async fn cloudwatch_insert_log_events_sorted() {
             let timestamp = chrono::Utc::now() - Duration::days(1);
 
             events.iter_logs_mut().for_each(|log| {
-                log.insert(log_schema().timestamp_key(), Value::Timestamp(timestamp));
+                log.insert(
+                    (
+                        lookup::PathPrefix::Event,
+                        log_schema().timestamp_key().unwrap(),
+                    ),
+                    Value::Timestamp(timestamp),
+                );
             });
         }
         doit = true;
@@ -183,7 +189,13 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
     let mut add_event = |offset: Duration| {
         let line = input_lines.next().unwrap();
         let mut event = LogEvent::from(line.clone());
-        event.insert(log_schema().timestamp_key(), now + offset);
+        event.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            now + offset,
+        );
         events.push(Event::Log(event));
         line
     };

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -150,7 +150,13 @@ mod tests {
         let timestamp = Utc::now();
         let message = "event message";
         let mut event = LogEvent::from(message);
-        event.insert(log_schema().timestamp_key(), timestamp);
+        event.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            timestamp,
+        );
 
         let request = request_builder.build(event.into()).unwrap();
         assert_eq!(request.timestamp, timestamp.timestamp_millis());

--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "aws-kinesis-streams-integration-tests")]
 #![cfg(test)]
+#![allow(warnings)]
 
 use aws_sdk_kinesis::{
     model::{Record, ShardIteratorType},
@@ -9,6 +10,7 @@ use codecs::TextSerializerConfig;
 use tokio::time::{sleep, Duration};
 
 use super::{config::KinesisClientBuilder, *};
+use crate::test_util::random_updated_events_with_stream;
 use crate::{
     aws::{create_client, AwsAuthentication, RegionOrEndpoint},
     config::{ProxyConfig, SinkConfig, SinkContext},
@@ -23,62 +25,66 @@ fn kinesis_address() -> String {
     std::env::var("KINESIS_ADDRESS").unwrap_or_else(|_| "http://localhost:4566".into())
 }
 
-// TODO: temporarily disabling as this is failing
-//#[tokio::test]
-//async fn kinesis_put_records_with_partition_key() {
-//    let stream = gen_stream();
-//
-//    ensure_stream(stream.clone()).await;
-//
-//    let mut batch = BatchConfig::default();
-//    batch.max_events = Some(2);
-//
-//    let base = KinesisSinkBaseConfig {
-//        stream_name: stream.clone(),
-//        region: RegionOrEndpoint::with_both("localstack", kinesis_address().as_str()),
-//        encoding: TextSerializerConfig::default().into(),
-//        compression: Compression::None,
-//        request: Default::default(),
-//        tls: Default::default(),
-//        auth: Default::default(),
-//        acknowledgements: Default::default(),
-//    };
-//
-//    let partition_key: String = "partition_key".to_string();
-//
-//    let config = KinesisStreamsSinkConfig {
-//        partition_key_field: Some(partition_key.clone()),
-//        batch,
-//        base,
-//    };
-//
-//    let cx = SinkContext::new_test();
-//
-//    let sink = config.build(cx).await.unwrap().0;
-//
-//    let timestamp = chrono::Utc::now().timestamp_millis();
-//
-//    let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
-//
-//    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
-//
-//    sleep(Duration::from_secs(1)).await;
-//
-//    let records = fetch_records(stream, timestamp).await.unwrap();
-//
-//    let mut output_lines = records
-//        .into_iter()
-//        .map(|e| {
-//            assert_eq!(Some(partition_key.as_str()), e.partition_key());
-//            e
-//        })
-//        .map(|e| String::from_utf8(e.data.unwrap().into_inner()).unwrap())
-//        .collect::<Vec<_>>();
-//
-//    input_lines.sort();
-//    output_lines.sort();
-//    assert_eq!(output_lines, input_lines)
-//}
+#[tokio::test]
+async fn kinesis_put_records_with_partition_key() {
+    let stream = gen_stream();
+
+    ensure_stream(stream.clone()).await;
+
+    let mut batch = BatchConfig::default();
+    batch.max_events = Some(2);
+
+    let base = KinesisSinkBaseConfig {
+        stream_name: stream.clone(),
+        region: RegionOrEndpoint::with_both("localstack", kinesis_address().as_str()),
+        encoding: TextSerializerConfig::default().into(),
+        compression: Compression::gzip_default(),
+        request: Default::default(),
+        tls: Default::default(),
+        auth: Default::default(),
+        acknowledgements: Default::default(),
+    };
+
+    let partition_key: String = "partition_key".to_string();
+
+    let config = KinesisStreamsSinkConfig {
+        partition_key_field: Some(partition_key.clone()),
+        batch,
+        base,
+    };
+
+    let cx = SinkContext::new_test();
+
+    let sink = config.build(cx).await.unwrap().0;
+
+    let timestamp = chrono::Utc::now().timestamp_millis();
+
+    let (mut input_lines, events) =
+        random_updated_events_with_stream(100, 11, None, |(i, mut event)| {
+            event.insert(partition_key.as_str(), "abcd");
+            event
+        });
+    // = random_lines_with_stream(100, 11, None);
+
+    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
+
+    sleep(Duration::from_secs(1)).await;
+
+    let records = fetch_records(stream, timestamp).await.unwrap();
+
+    let mut output_lines = records
+        .into_iter()
+        .map(|e| {
+            assert_eq!(Some(partition_key.as_str()), e.partition_key());
+            e
+        })
+        .map(|e| String::from_utf8(e.data.unwrap().into_inner()).unwrap())
+        .collect::<Vec<_>>();
+
+    // input_lines.sort();
+    // output_lines.sort();
+    // assert_eq!(output_lines, input_lines)
+}
 
 #[tokio::test]
 async fn kinesis_put_records_without_partition_key() {

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -482,11 +482,11 @@ mod tests {
     fn insert_timestamp_kv(log: &mut LogEvent) -> (String, String) {
         let now = chrono::Utc::now();
 
-        let timestamp_key = log_schema().timestamp_key().to_string();
+        let timestamp_key = log_schema().timestamp_key().unwrap();
         let timestamp_value = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-        log.insert(timestamp_key.as_str(), now);
+        log.insert((PathPrefix::Event, timestamp_key), now);
 
-        (timestamp_key, timestamp_value)
+        (timestamp_key.to_string(), timestamp_value)
     }
 
     #[test]
@@ -583,7 +583,10 @@ mod tests {
 
         let time_generated_field = headers.get("time-generated-field").unwrap();
         let timestamp_key = log_schema().timestamp_key();
-        assert_eq!(time_generated_field.to_str().unwrap(), timestamp_key);
+        assert_eq!(
+            time_generated_field.to_str().unwrap(),
+            timestamp_key.unwrap().to_string().as_str()
+        );
 
         let azure_resource_id = headers.get("x-ms-azureresourceid").unwrap();
         assert_eq!(

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -6,7 +6,7 @@ use http::{
     Request, StatusCode, Uri,
 };
 use hyper::Body;
-use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
+use lookup::lookup_v2::OptionalValuePath;
 use lookup::{OwnedValuePath, PathPrefix};
 use once_cell::sync::Lazy;
 use openssl::{base64, hash, pkey, sign};
@@ -223,7 +223,7 @@ impl SinkConfig for AzureMonitorLogsConfig {
 struct AzureMonitorLogsSink {
     uri: Uri,
     customer_id: String,
-    time_generated_key: OwnedValuePath,
+    time_generated_key: Option<OwnedValuePath>,
     transformer: Transformer,
     shared_key: pkey::PKey<pkey::Private>,
     default_headers: HeaderMap,
@@ -231,7 +231,7 @@ struct AzureMonitorLogsSink {
 
 struct AzureMonitorLogsEventEncoder {
     transformer: Transformer,
-    time_generated_key: OwnedValuePath,
+    time_generated_key: Option<OwnedValuePath>,
 }
 
 impl HttpEventEncoder<serde_json::Value> for AzureMonitorLogsEventEncoder {
@@ -250,10 +250,12 @@ impl HttpEventEncoder<serde_json::Value> for AzureMonitorLogsEventEncoder {
             chrono::Utc::now()
         };
 
-        log.insert(
-            (PathPrefix::Event, &self.time_generated_key),
-            JsonValue::String(timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
-        );
+        if let Some(timestamp_key) = &self.time_generated_key {
+            log.insert(
+                (PathPrefix::Event, timestamp_key),
+                JsonValue::String(timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
+            );
+        }
 
         let entry = serde_json::json!(&log);
 
@@ -294,10 +296,8 @@ impl AzureMonitorLogsSink {
             return Err("shared_key can't be an empty string".into());
         }
 
-        let time_generated_key = time_generated_key.unwrap_or_else(|| {
-            parse_value_path(log_schema().timestamp_key())
-                .expect("global log_schema.timestamp_key to be valid path")
-        });
+        let time_generated_key =
+            time_generated_key.or_else(|| log_schema().timestamp_key().cloned());
 
         let shared_key_bytes = base64::decode_block(config.shared_key.inner())?;
         let shared_key = pkey::PKey::hmac(&shared_key_bytes)?;
@@ -313,10 +313,12 @@ impl AzureMonitorLogsSink {
         let log_type = HeaderValue::from_str(&config.log_type)?;
         default_headers.insert(LOG_TYPE_HEADER.clone(), log_type);
 
-        default_headers.insert(
-            TIME_GENERATED_FIELD_HEADER.clone(),
-            HeaderValue::try_from(time_generated_key.to_string())?,
-        );
+        if let Some(timestamp_key) = &time_generated_key {
+            default_headers.insert(
+                TIME_GENERATED_FIELD_HEADER.clone(),
+                HeaderValue::try_from(timestamp_key.to_string())?,
+            );
+        }
 
         if let Some(azure_resource_id) = &config.azure_resource_id {
             if azure_resource_id.is_empty() {
@@ -446,8 +448,7 @@ mod tests {
         let sink = AzureMonitorLogsSink {
             uri: mock_endpoint,
             customer_id: "weee".to_string(),
-            time_generated_key: parse_value_path(log_schema().timestamp_key())
-                .expect("log_schema.timestamp_key to be valid path"),
+            time_generated_key: log_schema().timestamp_key().cloned(),
             transformer: Default::default(),
             shared_key,
             default_headers: HeaderMap::new(),

--- a/src/sinks/clickhouse/integration_tests.rs
+++ b/src/sinks/clickhouse/integration_tests.rs
@@ -183,11 +183,17 @@ async fn insert_events_unix_timestamps() {
 
     let exp_event = input_event.as_mut_log();
     exp_event.insert(
-        log_schema().timestamp_key(),
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
         format!(
             "{}",
             exp_event
-                .get(log_schema().timestamp_key())
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
                 .unwrap()
                 .as_timestamp()
                 .unwrap()
@@ -245,11 +251,17 @@ timestamp_format = "unix""#,
 
     let exp_event = input_event.as_mut_log();
     exp_event.insert(
-        log_schema().timestamp_key(),
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
         format!(
             "{}",
             exp_event
-                .get(log_schema().timestamp_key())
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
                 .unwrap()
                 .as_timestamp()
                 .unwrap()

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -155,7 +155,12 @@ async fn structures_events_correctly() {
     input_event.insert("foo", "bar");
     drop(batch);
 
-    let timestamp = input_event[crate::config::log_schema().timestamp_key()].clone();
+    let timestamp = input_event[crate::config::log_schema()
+        .timestamp_key()
+        .unwrap()
+        .to_string()
+        .as_str()]
+    .clone();
 
     run_and_assert_sink_compliance(
         sink,
@@ -623,7 +628,7 @@ async fn run_insert_tests_with_config(
                 obj.remove("data_stream");
                 // Un-rewrite the timestamp field
                 let timestamp = obj.remove(DATA_STREAM_TIMESTAMP_KEY).unwrap();
-                obj.insert(log_schema().timestamp_key().into(), timestamp);
+                obj.insert(log_schema().timestamp_key().unwrap().to_string(), timestamp);
             }
             assert!(input.contains(hit));
         }

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -38,7 +38,10 @@ async fn sets_create_action_when_configured() {
 
     let mut log = LogEvent::from("hello there");
     log.insert(
-        log_schema().timestamp_key(),
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
         Utc.ymd(2020, 12, 1)
             .and_hms_opt(1, 2, 3)
             .expect("invalid timestamp"),
@@ -89,7 +92,10 @@ async fn encode_datastream_mode() {
 
     let mut log = LogEvent::from("hello there");
     log.insert(
-        log_schema().timestamp_key(),
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
         Utc.ymd(2020, 12, 1)
             .and_hms_opt(1, 2, 3)
             .expect("invalid timestamp"),
@@ -139,7 +145,10 @@ async fn encode_datastream_mode_no_routing() {
     let mut log = LogEvent::from("hello there");
     log.insert("data_stream", data_stream_body());
     log.insert(
-        log_schema().timestamp_key(),
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
         Utc.ymd(2020, 12, 1)
             .and_hms_opt(1, 2, 3)
             .expect("invalid timestamp"),
@@ -280,7 +289,10 @@ async fn encode_datastream_mode_no_sync() {
     let mut log = LogEvent::from("hello there");
     log.insert("data_stream", data_stream_body());
     log.insert(
-        log_schema().timestamp_key(),
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
         Utc.ymd(2020, 12, 1)
             .and_hms_opt(1, 2, 3)
             .expect("invalid timestamp"),

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -1,15 +1,17 @@
 use codecs::JsonSerializerConfig;
+use lookup::lookup_v2::OptionalValuePath;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 
 use super::host_key;
+use crate::sinks::splunk_hec::common::config_timestamp_key;
 use crate::{
     codecs::EncodingConfig,
     config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
     sinks::{
         splunk_hec::{
             common::{
-                acknowledgements::HecClientAcknowledgementsConfig, timestamp_key, EndpointTarget,
+                acknowledgements::HecClientAcknowledgementsConfig, EndpointTarget,
                 SplunkHecDefaultBatchSettings,
             },
             logs::config::HecLogsSinkConfig,
@@ -130,8 +132,8 @@ pub struct HumioLogsConfig {
     /// By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
     ///
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
-    #[serde(default = "timestamp_key")]
-    pub(super) timestamp_key: String,
+    #[serde(default = "config_timestamp_key")]
+    pub(super) timestamp_key: OptionalValuePath,
 }
 
 fn default_endpoint() -> String {
@@ -159,7 +161,7 @@ impl GenerateConfig for HumioLogsConfig {
             tls: None,
             timestamp_nanos_key: None,
             acknowledgements: Default::default(),
-            timestamp_key: timestamp_key(),
+            timestamp_key: config_timestamp_key(),
         })
         .unwrap()
     }
@@ -200,7 +202,7 @@ impl HumioLogsConfig {
                 indexer_acknowledgements_enabled: false,
                 ..Default::default()
             },
-            timestamp_key: timestamp_key(),
+            timestamp_key: config_timestamp_key(),
             endpoint_target: EndpointTarget::Event,
             auto_extract_timestamp: None,
         }

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -264,7 +264,13 @@ mod integration_tests {
         event.insert(log_schema().host_key(), host.clone());
 
         let ts = Utc.timestamp_nanos(Utc::now().timestamp_millis() * 1_000_000 + 132_456);
-        event.insert(log_schema().timestamp_key(), ts);
+        event.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            ts,
+        );
 
         run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -3,6 +3,7 @@ use codecs::JsonSerializerConfig;
 use futures::StreamExt;
 use futures_util::stream::BoxStream;
 use indoc::indoc;
+use lookup::lookup_v2::OptionalValuePath;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
 use vector_core::{sink::StreamSink, transform::Transform};
@@ -172,7 +173,9 @@ impl SinkConfig for HumioMetricsConfig {
             timestamp_nanos_key: None,
             acknowledgements: Default::default(),
             // hard coded as humio expects this format so no sense in making it configurable
-            timestamp_key: "timestamp".to_string(),
+            timestamp_key: OptionalValuePath {
+                path: Some(lookup::owned_value_path!("timestamp")),
+            },
         };
 
         let (sink, healthcheck) = sink.clone().build(cx).await?;

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -461,14 +461,21 @@ async fn out_of_order_drop() {
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
-            log_schema().timestamp_key(),
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
             base + Duration::seconds(i as i64),
         );
     }
     // first event of the second batch is out-of-order.
-    events[batch_size]
-        .as_mut_log()
-        .insert(log_schema().timestamp_key(), base);
+    events[batch_size].as_mut_log().insert(
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
+        base,
+    );
 
     let mut expected = events.clone();
     expected.remove(batch_size);
@@ -490,14 +497,21 @@ async fn out_of_order_accept() {
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
-            log_schema().timestamp_key(),
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
             base + Duration::seconds(i as i64),
         );
     }
     // first event of the second batch is out-of-order.
-    events[batch_size]
-        .as_mut_log()
-        .insert(log_schema().timestamp_key(), base - Duration::seconds(1));
+    events[batch_size].as_mut_log().insert(
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
+        base - Duration::seconds(1),
+    );
 
     // move out-of-order event to where it will appear in results
     let mut expected = events.clone();
@@ -521,21 +535,32 @@ async fn out_of_order_rewrite() {
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
-            log_schema().timestamp_key(),
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
             base + Duration::seconds(i as i64),
         );
     }
     // first event of the second batch is out-of-order.
-    events[batch_size]
-        .as_mut_log()
-        .insert(log_schema().timestamp_key(), base);
+    events[batch_size].as_mut_log().insert(
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
+        base,
+    );
 
     let mut expected = events.clone();
     let time = get_timestamp(&expected[batch_size - 1]);
     // timestamp is rewritten with latest timestamp of the first batch
-    expected[batch_size]
-        .as_mut_log()
-        .insert(log_schema().timestamp_key(), time);
+    expected[batch_size].as_mut_log().insert(
+        (
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ),
+        time,
+    );
 
     test_out_of_order_events(
         OutOfOrderAction::RewriteTimestamp,
@@ -561,7 +586,10 @@ async fn out_of_order_per_partition() {
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
         log.insert(
-            log_schema().timestamp_key(),
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
             base + Duration::seconds(i as i64),
         );
     }
@@ -623,7 +651,10 @@ async fn test_out_of_order_events(
 fn get_timestamp(event: &Event) -> DateTime<Utc> {
     *event
         .as_log()
-        .get(log_schema().timestamp_key())
+        .get((
+            lookup::PathPrefix::Event,
+            log_schema().timestamp_key().unwrap(),
+        ))
         .unwrap()
         .as_timestamp()
         .unwrap()

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -491,9 +491,16 @@ mod tests {
         };
         let mut event = Event::Log(LogEvent::from("hello world"));
         let log = event.as_mut_log();
-        log.insert(log_schema().timestamp_key(), chrono::Utc::now());
+        log.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            chrono::Utc::now(),
+        );
         let record = encoder.encode_event(event).unwrap();
-        assert!(String::from_utf8_lossy(&record.event.event).contains(log_schema().timestamp_key()));
+        assert!(String::from_utf8_lossy(&record.event.event)
+            .contains(log_schema().timestamp_key().unwrap().to_string().as_str()));
         assert_eq!(record.labels.len(), 1);
         assert_eq!(
             record.labels[0],
@@ -530,7 +537,13 @@ mod tests {
         };
         let mut event = Event::Log(LogEvent::from("hello world"));
         let log = event.as_mut_log();
-        log.insert(log_schema().timestamp_key(), chrono::Utc::now());
+        log.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            chrono::Utc::now(),
+        );
         log.insert("name", "foo");
         log.insert("value", "bar");
 
@@ -540,7 +553,8 @@ mod tests {
         log.insert("dict", Value::from(test_dict));
 
         let record = encoder.encode_event(event).unwrap();
-        assert!(String::from_utf8_lossy(&record.event.event).contains(log_schema().timestamp_key()));
+        assert!(String::from_utf8_lossy(&record.event.event)
+            .contains(log_schema().timestamp_key().unwrap().to_string().as_str()));
         assert_eq!(record.labels.len(), 4);
 
         let labels: HashMap<String, String> = record.labels.into_iter().collect();
@@ -616,11 +630,16 @@ mod tests {
         };
         let mut event = Event::Log(LogEvent::from("hello world"));
         let log = event.as_mut_log();
-        log.insert(log_schema().timestamp_key(), chrono::Utc::now());
-        let record = encoder.encode_event(event).unwrap();
-        assert!(
-            !String::from_utf8_lossy(&record.event.event).contains(log_schema().timestamp_key())
+        log.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            chrono::Utc::now(),
         );
+        let record = encoder.encode_event(event).unwrap();
+        assert!(!String::from_utf8_lossy(&record.event.event)
+            .contains(log_schema().timestamp_key().unwrap().to_string().as_str()));
     }
 
     #[test]
@@ -644,7 +663,13 @@ mod tests {
         };
         let mut event = Event::Log(LogEvent::from("hello world"));
         let log = event.as_mut_log();
-        log.insert(log_schema().timestamp_key(), chrono::Utc::now());
+        log.insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            chrono::Utc::now(),
+        );
         log.insert("name", "foo");
         log.insert("value", "bar");
         let record = encoder.encode_event(event).unwrap();
@@ -673,7 +698,13 @@ mod tests {
                 } else {
                     base + chrono::Duration::seconds(i as i64)
                 };
-                log.insert(log_schema().timestamp_key(), ts);
+                log.insert(
+                    (
+                        lookup::PathPrefix::Event,
+                        log_schema().timestamp_key().unwrap(),
+                    ),
+                    ts,
+                );
                 event
             })
             .collect::<Vec<_>>();

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -136,10 +136,6 @@ pub fn host_key() -> String {
     crate::config::log_schema().host_key().to_string()
 }
 
-// pub fn timestamp_key() -> Option<OwnedValuePath> {
-//     crate::config::log_schema().timestamp_key().cloned()
-// }
-
 pub fn config_timestamp_key() -> OptionalValuePath {
     OptionalValuePath {
         path: crate::config::log_schema().timestamp_key().cloned(),

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use futures_util::future::BoxFuture;
 use http::{Request, StatusCode, Uri};
 use hyper::Body;
+use lookup::lookup_v2::OptionalValuePath;
 use snafu::{ResultExt, Snafu};
 use vector_core::{config::proxy::ProxyConfig, event::EventRef};
 
@@ -135,8 +136,14 @@ pub fn host_key() -> String {
     crate::config::log_schema().host_key().to_string()
 }
 
-pub fn timestamp_key() -> String {
-    crate::config::log_schema().timestamp_key().to_string()
+// pub fn timestamp_key() -> Option<OwnedValuePath> {
+//     crate::config::log_schema().timestamp_key().cloned()
+// }
+
+pub fn config_timestamp_key() -> OptionalValuePath {
+    OptionalValuePath {
+        path: crate::config::log_schema().timestamp_key().cloned(),
+    }
 }
 
 pub fn render_template_string<'a>(

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -3,6 +3,7 @@ use std::{convert::TryFrom, iter, num::NonZeroU8};
 use chrono::{TimeZone, Utc};
 use codecs::{JsonSerializerConfig, TextSerializerConfig};
 use futures::{future::ready, stream};
+use lookup::lookup_v2::OptionalValuePath;
 use serde_json::Value as JsonValue;
 use tokio::time::{sleep, Duration};
 use vector_core::event::{BatchNotifier, BatchStatus, Event, LogEvent};
@@ -417,7 +418,9 @@ async fn splunk_auto_extracted_timestamp() {
 
         let config = HecLogsSinkConfig {
             auto_extract_timestamp: Some(true),
-            timestamp_key: "timestamp".to_string(),
+            timestamp_key: OptionalValuePath {
+                path: Some(lookup::owned_value_path!("timestamp")),
+            },
             ..config(JsonSerializerConfig::default().into(), vec![]).await
         };
 
@@ -464,7 +467,9 @@ async fn splunk_non_auto_extracted_timestamp() {
 
         let config = HecLogsSinkConfig {
             auto_extract_timestamp: Some(false),
-            timestamp_key: "timestamp".to_string(),
+            timestamp_key: OptionalValuePath {
+                path: Some(lookup::owned_value_path!("timestamp")),
+            },
             ..config(JsonSerializerConfig::default().into(), vec![]).await
         };
 

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     template::Template,
 };
-use lookup::event_path;
+use lookup::{event_path, OwnedValuePath, PathPrefix};
 
 pub struct HecLogsSink<S> {
     pub context: SinkContext,
@@ -41,7 +41,7 @@ pub struct HecLogsSink<S> {
     pub indexed_fields: Vec<String>,
     pub host: String,
     pub timestamp_nanos_key: Option<String>,
-    pub timestamp_key: String,
+    pub timestamp_key: Option<OwnedValuePath>,
     pub endpoint_target: EndpointTarget,
 }
 
@@ -52,7 +52,7 @@ pub struct HecLogData<'a> {
     pub indexed_fields: &'a [String],
     pub host_key: &'a str,
     pub timestamp_nanos_key: Option<&'a String>,
-    pub timestamp_key: &'a str,
+    pub timestamp_key: Option<OwnedValuePath>,
     pub endpoint_target: EndpointTarget,
 }
 
@@ -73,7 +73,7 @@ where
             indexed_fields: self.indexed_fields.as_slice(),
             host_key: self.host.as_ref(),
             timestamp_nanos_key: self.timestamp_nanos_key.as_ref(),
-            timestamp_key: self.timestamp_key.as_ref(),
+            timestamp_key: self.timestamp_key.clone(),
             endpoint_target: self.endpoint_target,
         };
 
@@ -248,10 +248,8 @@ pub fn process_log(event: Event, data: &HecLogData) -> HecProcessedEvent {
 
     let host = log.get(data.host_key).cloned();
 
-    let timestamp = if data.timestamp_key.is_empty() {
-        None
-    } else {
-        match log.remove(data.timestamp_key) {
+    let timestamp = data.timestamp_key.as_ref().and_then(|timestamp_key| {
+        match log.remove((PathPrefix::Event, timestamp_key)) {
             Some(Value::Timestamp(ts)) => {
                 // set nanos in log if valid timestamp in event and timestamp_nanos_key is configured
                 if let Some(key) = data.timestamp_nanos_key {
@@ -270,7 +268,7 @@ pub fn process_log(event: Event, data: &HecLogData) -> HecProcessedEvent {
                 None
             }
         }
-    };
+    });
 
     let fields = data
         .indexed_fields

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -3,6 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use chrono::{TimeZone, Utc};
 use codecs::{JsonSerializerConfig, TextSerializerConfig};
 use futures_util::StreamExt;
+use lookup::lookup_v2::OptionalValuePath;
+use lookup::{OwnedValuePath, PathPrefix};
 use serde::Deserialize;
 use vector_core::{
     config::log_schema,
@@ -10,12 +12,13 @@ use vector_core::{
 };
 
 use super::sink::HecProcessedEvent;
+use crate::sinks::splunk_hec::common::config_timestamp_key;
 use crate::{
     codecs::{Encoder, EncodingConfig},
     config::{SinkConfig, SinkContext},
     sinks::{
         splunk_hec::{
-            common::{timestamp_key, EndpointTarget},
+            common::EndpointTarget,
             logs::{config::HecLogsSinkConfig, encoder::HecLogsEncoder, sink::process_log},
         },
         util::{encoding::Encoder as _, test::build_test_server, Compression},
@@ -48,7 +51,7 @@ struct HecEventText {
 
 fn get_processed_event_timestamp(
     timestamp: Option<Value>,
-    timestamp_key: &str,
+    timestamp_key: Option<OwnedValuePath>,
 ) -> HecProcessedEvent {
     let mut event = Event::Log(LogEvent::from("hello world"));
     event
@@ -62,10 +65,16 @@ fn get_processed_event_timestamp(
     event.as_mut_log().insert("key", "value");
     event.as_mut_log().insert("int_val", 123);
 
-    if timestamp.is_some() {
-        event.as_mut_log().insert(timestamp_key, timestamp);
-    } else {
-        event.as_mut_log().remove(timestamp_key);
+    if let Some(timestamp_key) = &timestamp_key {
+        if timestamp.is_some() {
+            event
+                .as_mut_log()
+                .insert((PathPrefix::Event, timestamp_key), timestamp);
+        } else {
+            event
+                .as_mut_log()
+                .remove((PathPrefix::Event, timestamp_key));
+        }
     }
 
     let sourcetype = Template::try_from("{{ event_sourcetype }}".to_string()).ok();
@@ -94,7 +103,7 @@ fn get_processed_event() -> HecProcessedEvent {
         Some(value::Value::Timestamp(
             Utc.timestamp_nanos(1638366107111456123),
         )),
-        &timestamp_key(),
+        config_timestamp_key().path,
     )
 }
 
@@ -146,7 +155,7 @@ fn splunk_encode_log_event_json() {
         &serde_json::Value::from("hello world")
     );
     assert!(event
-        .get(&log_schema().timestamp_key().to_string())
+        .get(log_schema().timestamp_key().unwrap().to_string().as_str())
         .is_none());
 
     assert_eq!(hec_data.source, Some("test_source".to_string()));
@@ -203,7 +212,9 @@ async fn splunk_passthrough_token() {
         tls: None,
         acknowledgements: Default::default(),
         timestamp_nanos_key: None,
-        timestamp_key: log_schema().timestamp_key().into(),
+        timestamp_key: OptionalValuePath {
+            path: log_schema().timestamp_key().cloned(),
+        },
         auto_extract_timestamp: None,
         endpoint_target: EndpointTarget::Event,
     };
@@ -245,7 +256,7 @@ fn splunk_encode_log_event_json_timestamps() {
 
     fn get_hec_data_for_timestamp_test(
         timestamp: Option<Value>,
-        timestamp_key: &str,
+        timestamp_key: Option<OwnedValuePath>,
     ) -> HecEventJson {
         let processed_event = get_processed_event_timestamp(timestamp, timestamp_key);
         let encoder = hec_encoder(JsonSerializerConfig::default().into());
@@ -256,15 +267,18 @@ fn splunk_encode_log_event_json_timestamps() {
         serde_json::from_slice::<HecEventJson>(&bytes).unwrap()
     }
 
+    let timestamp = lookup::owned_value_path!("timestamp");
+
     // no timestamp_key is provided
-    let mut hec_data = get_hec_data_for_timestamp_test(None, "");
+    let mut hec_data = get_hec_data_for_timestamp_test(None, None);
     assert_eq!(hec_data.time, None);
 
     // timestamp_key is provided but timestamp is not valid type
-    hec_data = get_hec_data_for_timestamp_test(Some(value::Value::Integer(0)), &timestamp_key());
+    hec_data =
+        get_hec_data_for_timestamp_test(Some(value::Value::Integer(0)), Some(timestamp.clone()));
     assert_eq!(hec_data.time, None);
 
     // timestamp_key is provided but no timestamp in the event
-    let hec_data = get_hec_data_for_timestamp_test(None, &timestamp_key());
+    let hec_data = get_hec_data_for_timestamp_test(None, Some(timestamp));
     assert_eq!(hec_data.time, None);
 }

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -20,6 +20,7 @@ use vector_core::{
 mod errors;
 
 pub use errors::{ClosedError, StreamSendError};
+use lookup::PathPrefix;
 
 pub(crate) const CHUNK_SIZE: usize = 1000;
 
@@ -315,15 +316,18 @@ impl Inner {
     fn emit_lag_time(&self, event: EventRef<'_>, reference: i64) {
         if let Some(lag_time_metric) = &self.lag_time {
             let timestamp = match event {
-                EventRef::Log(log) => log
-                    .get(log_schema().timestamp_key())
-                    .and_then(get_timestamp_millis),
+                EventRef::Log(log) => log_schema().timestamp_key().and_then(|timestamp_key| {
+                    log.get((PathPrefix::Event, timestamp_key))
+                        .and_then(get_timestamp_millis)
+                }),
                 EventRef::Metric(metric) => metric
                     .timestamp()
                     .map(|timestamp| timestamp.timestamp_millis()),
-                EventRef::Trace(trace) => trace
-                    .get(log_schema().timestamp_key())
-                    .and_then(get_timestamp_millis),
+                EventRef::Trace(trace) => log_schema().timestamp_key().and_then(|timestamp_key| {
+                    trace
+                        .get((PathPrefix::Event, timestamp_key))
+                        .and_then(get_timestamp_millis)
+                }),
             };
             if let Some(timestamp) = timestamp {
                 // This will truncate precision for values larger than 2**52, but at that point the user

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -271,7 +271,7 @@ fn populate_event(
 
     log_namespace.insert_vector_metadata(
         log,
-        path!(log_schema().source_type_key()),
+        Some(log_schema().source_type_key()),
         path!("source_type"),
         Bytes::from_static(AmqpSourceConfig::NAME.as_bytes()),
     );
@@ -291,10 +291,12 @@ fn populate_event(
             log.insert(metadata_path!("vector", "ingest_timestamp"), Utc::now());
         }
         LogNamespace::Legacy => {
-            log.try_insert(
-                (PathPrefix::Event, log_schema().timestamp_key()),
-                timestamp.unwrap_or_else(Utc::now),
-            );
+            if let Some(timestamp_key) = log_schema().timestamp_key() {
+                log.try_insert(
+                    (PathPrefix::Event, timestamp_key),
+                    timestamp.unwrap_or_else(Utc::now),
+                );
+            }
         }
     };
 }

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -707,7 +707,9 @@ mod integration_test {
         assert_eq!(log[log_schema().message_key()], "my message".into());
         assert_eq!(log["routing"], routing_key.into());
         assert_eq!(log[log_schema().source_type_key()], "amqp".into());
-        let log_ts = log[log_schema().timestamp_key()].as_timestamp().unwrap();
+        let log_ts = log[log_schema().timestamp_key().unwrap().to_string()]
+            .as_timestamp()
+            .unwrap();
         assert!(log_ts.signed_duration_since(now) < chrono::Duration::seconds(1));
         assert_eq!(log["exchange"], exchange.into());
     }

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -108,10 +108,12 @@ pub(super) async fn firehose(
                                     );
                                 }
                                 LogNamespace::Legacy => {
-                                    log.try_insert(
-                                        (PathPrefix::Event, log_schema().timestamp_key()),
-                                        request.timestamp,
-                                    );
+                                    if let Some(timestamp_key) = log_schema().timestamp_key() {
+                                        log.try_insert(
+                                            (PathPrefix::Event, timestamp_key),
+                                            request.timestamp,
+                                        );
+                                    }
                                 }
                             };
 

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -93,7 +93,7 @@ pub(super) async fn firehose(
                         if let Event::Log(ref mut log) = event {
                             log_namespace.insert_vector_metadata(
                                 log,
-                                log_schema().source_type_key(),
+                                Some(log_schema().source_type_key()),
                                 path!("source_type"),
                                 Bytes::from_static(AwsKinesisFirehoseConfig::NAME.as_bytes()),
                             );

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -572,7 +572,7 @@ impl IngestorProcess {
 
             log_namespace.insert_vector_metadata(
                 &mut log,
-                path!(log_schema().source_type_key()),
+                Some(log_schema().source_type_key()),
                 path!("source_type"),
                 Bytes::from_static(AwsS3Config::NAME.as_bytes()),
             );
@@ -589,10 +589,12 @@ impl IngestorProcess {
                     log.insert(metadata_path!("vector", "ingest_timestamp"), Utc::now());
                 }
                 LogNamespace::Legacy => {
-                    log.try_insert(
-                        (PathPrefix::Event, log_schema().timestamp_key()),
-                        timestamp.unwrap_or_else(Utc::now),
-                    );
+                    if let Some(timestamp_key) = log_schema().timestamp_key() {
+                        log.try_insert(
+                            (PathPrefix::Event, timestamp_key),
+                            timestamp.unwrap_or_else(Utc::now),
+                        );
+                    }
                 }
             };
 

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -321,7 +321,10 @@ mod tests {
             events[0]
                 .clone()
                 .as_log()
-                .get(log_schema().timestamp_key())
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
                 .unwrap()
                 .to_string_lossy(),
             now.to_rfc3339_opts(SecondsFormat::AutoSi, true)

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -105,12 +105,11 @@ impl DnstapConfig {
         "protobuf:dnstap.Dnstap".to_string() //content-type for framestream
     }
 
-    fn event_schema(timestamp_key: &'static str) -> DnstapEventSchema {
+    fn event_schema(timestamp_key: Option<&OwnedValuePath>) -> DnstapEventSchema {
         let mut schema = DnstapEventSchema::new();
         schema
             .dnstap_root_data_schema_mut()
-            .set_timestamp(timestamp_key);
-
+            .set_timestamp(timestamp_key.cloned());
         schema
     }
 
@@ -208,7 +207,7 @@ pub struct DnstapFrameHandler {
     socket_receive_buffer_size: Option<usize>,
     socket_send_buffer_size: Option<usize>,
     host_key: Option<OwnedValuePath>,
-    timestamp_key: String,
+    timestamp_key: Option<OwnedValuePath>,
     source_type_key: String,
     bytes_received: Registered<BytesReceived>,
     log_namespace: LogNamespace,
@@ -238,7 +237,7 @@ impl DnstapFrameHandler {
             socket_receive_buffer_size: config.socket_receive_buffer_size,
             socket_send_buffer_size: config.socket_send_buffer_size,
             host_key,
-            timestamp_key: timestamp_key.to_string(),
+            timestamp_key: timestamp_key.cloned(),
             source_type_key: source_type_key.to_string(),
             bytes_received: register!(BytesReceived::from(Protocol::from("protobuf"))),
             log_namespace,
@@ -270,7 +269,7 @@ impl FrameHandler for DnstapFrameHandler {
             // The timestamp is inserted by the parser which caters for the Legacy namespace.
             self.log_namespace.insert_vector_metadata(
                 &mut log_event,
-                path!(self.timestamp_key()),
+                self.timestamp_key(),
                 path!("ingest_timestamp"),
                 chrono::Utc::now(),
             );
@@ -278,7 +277,7 @@ impl FrameHandler for DnstapFrameHandler {
 
         self.log_namespace.insert_vector_metadata(
             &mut log_event,
-            path!(self.source_type_key()),
+            Some(self.source_type_key()),
             path!("source_type"),
             DnstapConfig::NAME,
         );
@@ -348,8 +347,8 @@ impl FrameHandler for DnstapFrameHandler {
         self.source_type_key.as_str()
     }
 
-    fn timestamp_key(&self) -> &str {
-        self.timestamp_key.as_str()
+    fn timestamp_key(&self) -> Option<&OwnedValuePath> {
+        self.timestamp_key.as_ref()
     }
 }
 

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -406,7 +406,7 @@ mod tests {
         let mut event = Event::from(LogEvent::from(value::Value::from(json)));
         event.as_mut_log().insert("timestamp", chrono::Utc::now());
 
-        let definition = DnstapConfig::event_schema("timestamp");
+        let definition = DnstapConfig::event_schema(Some(&owned_value_path!("timestamp")));
         let schema = vector_core::schema::Definition::empty_legacy_namespace()
             .with_standard_vector_source_metadata();
 

--- a/src/sources/dnstap/schema.rs
+++ b/src/sources/dnstap/schema.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use lookup::owned_value_path;
+use lookup::{owned_value_path, OwnedValuePath};
 use value::{
     kind::{Collection, Field},
     Kind,
@@ -333,31 +333,19 @@ impl DnstapEventSchema {
     }
 
     pub fn new() -> Self {
-        Self {
-            dnstap_root_data_schema: DnstapRootDataSchema::default(),
-            dnstap_message_schema: DnstapMessageSchema::default(),
-            dns_query_message_schema: DnsQueryMessageSchema::default(),
-            dns_query_header_schema: DnsQueryHeaderSchema::default(),
-            dns_update_message_schema: DnsUpdateMessageSchema::default(),
-            dns_update_header_schema: DnsUpdateHeaderSchema::default(),
-            dns_message_opt_pseudo_section_schema: DnsMessageOptPseudoSectionSchema::default(),
-            dns_message_option_schema: DnsMessageOptionSchema::default(),
-            dns_record_schema: DnsRecordSchema::default(),
-            dns_query_question_schema: DnsQueryQuestionSchema::default(),
-            dns_update_zone_info_schema: DnsUpdateZoneInfoSchema::default(),
-        }
+        Self::default()
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct DnstapRootDataSchema {
-    timestamp: &'static str,
+    timestamp: Option<OwnedValuePath>,
 }
 
 impl Default for DnstapRootDataSchema {
     fn default() -> Self {
         Self {
-            timestamp: "timestamp",
+            timestamp: Some(owned_value_path!("timestamp")),
         }
     }
 }
@@ -383,8 +371,8 @@ impl DnstapRootDataSchema {
         "dataTypeId"
     }
 
-    pub const fn timestamp(&self) -> &'static str {
-        self.timestamp
+    pub const fn timestamp(&self) -> Option<&OwnedValuePath> {
+        self.timestamp.as_ref()
     }
 
     pub const fn time(&self) -> &'static str {
@@ -403,7 +391,7 @@ impl DnstapRootDataSchema {
         "rawData"
     }
 
-    pub fn set_timestamp(&mut self, val: &'static str) -> &mut Self {
+    pub fn set_timestamp(&mut self, val: Option<OwnedValuePath>) -> &mut Self {
         self.timestamp = val;
         self
     }

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -756,7 +756,12 @@ mod tests {
         assert_eq!(log[COMMAND_KEY], config.command.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
         assert_eq!(log[log_schema().source_type_key()], "exec".into());
-        assert!(log.get(log_schema().timestamp_key()).is_some());
+        assert!(log
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
     }
 
     #[test]
@@ -832,7 +837,12 @@ mod tests {
         assert_eq!(log[COMMAND_KEY], config.command.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
         assert_eq!(log[log_schema().source_type_key()], "exec".into());
-        assert!(log.get(log_schema().timestamp_key()).is_some());
+        assert!(log
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
     }
 
     #[test]
@@ -1029,7 +1039,12 @@ mod tests {
             assert_eq!(log[log_schema().message_key()], "Hello World!".into());
             assert_eq!(log[log_schema().host_key()], "Some.Machine".into());
             assert!(log.get(PID_KEY).is_some());
-            assert!(log.get(log_schema().timestamp_key()).is_some());
+            assert!(log
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
 
             assert_eq!(8, log.all_fields().unwrap().count());
         } else {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1019,7 +1019,7 @@ mod tests {
         assert_eq!(log["offset"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
         assert_eq!(log[log_schema().source_type_key()], "file".into());
-        assert!(log[log_schema().timestamp_key()].is_timestamp());
+        assert!(log[log_schema().timestamp_key().unwrap().to_string()].is_timestamp());
     }
 
     #[test]
@@ -1041,7 +1041,7 @@ mod tests {
         assert_eq!(log["off"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
         assert_eq!(log[log_schema().source_type_key()], "file".into());
-        assert!(log[log_schema().timestamp_key()].is_timestamp());
+        assert!(log[log_schema().timestamp_key().unwrap().to_string()].is_timestamp());
     }
 
     #[test]
@@ -1446,7 +1446,7 @@ mod tests {
                         .to_string(),
                     log_schema().host_key().to_string(),
                     log_schema().message_key().to_string(),
-                    log_schema().timestamp_key().to_string(),
+                    log_schema().timestamp_key().unwrap().to_string(),
                     log_schema().source_type_key().to_string()
                 ]
                 .into_iter()

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -747,7 +747,7 @@ fn create_event(
 
     log_namespace.insert_vector_metadata(
         &mut event,
-        log_schema().source_type_key(),
+        Some(log_schema().source_type_key()),
         path!("source_type"),
         Bytes::from_static(FileConfig::NAME.as_bytes()),
     );

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -582,7 +582,7 @@ impl From<FluentEvent<'_>> for LogEvent {
 
         log_namespace.insert_vector_metadata(
             &mut log,
-            log_schema().source_type_key(),
+            Some(log_schema().source_type_key()),
             path!("source_type"),
             Bytes::from_static(FluentConfig::NAME.as_bytes()),
         );
@@ -593,7 +593,9 @@ impl From<FluentEvent<'_>> for LogEvent {
                 log.insert(metadata_path!("vector", "ingest_timestamp"), Utc::now());
             }
             LogNamespace::Legacy => {
-                log.insert((PathPrefix::Event, log_schema().timestamp_key()), timestamp);
+                if let Some(timestamp_key) = log_schema().timestamp_key() {
+                    log.insert((PathPrefix::Event, timestamp_key), timestamp);
+                }
             }
         }
 

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -520,7 +520,7 @@ mod tests {
                 r#"at=info method=GET path="/cart_link" host=lumberjack-store.timber.io request_id=05726858-c44e-4f94-9a20-37df73be9006 fwd="73.75.38.87" dyno=web.1 connect=1ms service=22ms status=304 bytes=656 protocol=http"#.into()
             );
             assert_eq!(
-                log[log_schema().timestamp_key()],
+                log[log_schema().timestamp_key().unwrap().to_string()],
                 "2020-01-08T22:33:57.353034+00:00"
                     .parse::<DateTime<Utc>>()
                     .unwrap()
@@ -603,7 +603,7 @@ mod tests {
 
         assert_eq!(log[log_schema().message_key()], "foo bar baz".into());
         assert_eq!(
-            log[log_schema().timestamp_key()],
+            log[log_schema().timestamp_key().unwrap().to_string()],
             "2020-01-08T22:33:57.353034+00:00"
                 .parse::<DateTime<Utc>>()
                 .unwrap()
@@ -624,7 +624,12 @@ mod tests {
             log[log_schema().message_key()],
             "what am i doing here".into()
         );
-        assert!(log.get(log_schema().timestamp_key()).is_some());
+        assert!(log
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
         assert_eq!(log[log_schema().source_type_key()], "heroku_logs".into());
     }
 
@@ -637,7 +642,7 @@ mod tests {
 
         assert_eq!(log[log_schema().message_key()], "i'm not that long".into());
         assert_eq!(
-            log[log_schema().timestamp_key()],
+            log[log_schema().timestamp_key().unwrap().to_string()],
             "2020-01-08T22:33:57.353034+00:00"
                 .parse::<DateTime<Utc>>()
                 .unwrap()

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -652,7 +652,12 @@ mod tests {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log[log_schema().message_key()], "test body".into());
-            assert!(log.get(log_schema().timestamp_key()).is_some());
+            assert!(log
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 log[log_schema().source_type_key()],
                 SimpleHttpConfig::NAME.into()
@@ -774,12 +779,18 @@ mod tests {
         assert!(events
             .remove(1)
             .as_log()
-            .get(log_schema().timestamp_key())
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
             .is_some());
         assert!(events
             .remove(0)
             .as_log()
-            .get(log_schema().timestamp_key())
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
             .is_some());
     }
 
@@ -938,7 +949,12 @@ mod tests {
     }
 
     async fn assert_event_metadata(log: &LogEvent) {
-        assert!(log.get(log_schema().timestamp_key()).is_some());
+        assert!(log
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
         assert_eq!(
             log[log_schema().source_type_key()],
             SimpleHttpConfig::NAME.into()
@@ -1105,7 +1121,12 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["vector_http_path"], "/event/path".into());
-            assert!(log.get(log_schema().timestamp_key()).is_some());
+            assert!(log
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 log[log_schema().source_type_key()],
                 SimpleHttpConfig::NAME.into()
@@ -1153,7 +1174,12 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["vector_http_path"], "/event/path1".into());
-            assert!(log.get(log_schema().timestamp_key()).is_some());
+            assert!(log
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 log[log_schema().source_type_key()],
                 SimpleHttpConfig::NAME.into()
@@ -1164,7 +1190,12 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log["key2"], "value2".into());
             assert_eq!(log["vector_http_path"], "/event/path2".into());
-            assert!(log.get(log_schema().timestamp_key()).is_some());
+            assert!(log
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 log[log_schema().source_type_key()],
                 SimpleHttpConfig::NAME.into()

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -724,7 +724,9 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
         }
         LogNamespace::Legacy => {
             if let Some(ts) = timestamp {
-                log.insert((PathPrefix::Event, log_schema().timestamp_key()), ts);
+                if let Some(timestamp_key) = log_schema().timestamp_key() {
+                    log.insert((PathPrefix::Event, timestamp_key), ts);
+                }
             }
         }
     }
@@ -732,7 +734,7 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
     // Add source type.
     log_namespace.insert_vector_metadata(
         log,
-        log_schema().source_type_key(),
+        Some(log_schema().source_type_key()),
         path!("source_type"),
         JournaldConfig::NAME,
     );

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -1441,7 +1441,7 @@ mod tests {
     }
 
     fn timestamp(event: &Event) -> Value {
-        event.as_log()[log_schema().timestamp_key()].clone()
+        event.as_log()[log_schema().timestamp_key().unwrap().to_string()].clone()
     }
 
     fn value_ts(secs: i64, usecs: u32) -> Value {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -313,7 +313,7 @@ impl SourceConfig for KafkaSourceConfig {
             .with_standard_vector_source_metadata()
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::Overwrite(owned_value_path!(keys.timestamp))),
+                keys.timestamp.map(LegacyKey::Overwrite),
                 &owned_value_path!("timestamp"),
                 Kind::timestamp(),
                 Some("timestamp"),
@@ -510,9 +510,9 @@ fn parse_stream<'a>(
     Some((count, stream))
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct Keys<'a> {
-    timestamp: &'a str,
+    timestamp: Option<OwnedValuePath>,
     key_field: &'a Option<OwnedValuePath>,
     topic: &'a Option<OwnedValuePath>,
     partition: &'a Option<OwnedValuePath>,
@@ -523,7 +523,7 @@ struct Keys<'a> {
 impl<'a> Keys<'a> {
     fn from(schema: &'a LogSchema, config: &'a KafkaSourceConfig) -> Self {
         Self {
-            timestamp: schema.timestamp_key(),
+            timestamp: schema.timestamp_key().cloned(),
             key_field: &config.key_field.path,
             topic: &config.topic_key.path,
             partition: &config.partition_key.path,
@@ -607,7 +607,7 @@ impl ReceivedMessage {
             log_namespace.insert_source_metadata(
                 KafkaSourceConfig::NAME,
                 log,
-                Some(LegacyKey::Overwrite(keys.timestamp)),
+                keys.timestamp.as_ref().map(LegacyKey::Overwrite),
                 path!("timestamp"),
                 self.timestamp,
             );

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1045,7 +1045,7 @@ mod integration_test {
                     "kafka".into()
                 );
                 assert_eq!(
-                    event.as_log()[log_schema().timestamp_key()],
+                    event.as_log()[log_schema().timestamp_key().unwrap().to_string()],
                     now.trunc_subsecs(3).into()
                 );
                 assert_eq!(event.as_log()["topic"], topic.clone().into());

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -480,9 +480,10 @@ impl SourceConfig for Config {
             )
             .with_source_metadata(
                 Self::NAME,
-                Some(LegacyKey::Overwrite(owned_value_path!(
-                    log_schema().timestamp_key()
-                ))),
+                log_schema()
+                    .timestamp_key()
+                    .cloned()
+                    .map(LegacyKey::Overwrite),
                 &owned_value_path!("timestamp"),
                 Kind::timestamp(),
                 Some("timestamp"),
@@ -889,7 +890,7 @@ fn create_event(
 
     log_namespace.insert_vector_metadata(
         &mut log,
-        path!(log_schema().source_type_key()),
+        Some(log_schema().source_type_key()),
         path!("source_type"),
         Bytes::from(Config::NAME),
     );

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -96,7 +96,7 @@ impl FunctionTransform for Cri {
                             self.log_namespace.insert_source_metadata(
                                 Config::NAME,
                                 log,
-                                Some(LegacyKey::Overwrite(path!(log_schema().timestamp_key()))),
+                                log_schema().timestamp_key().map(LegacyKey::Overwrite),
                                 path!(TIMESTAMP_KEY),
                                 Value::Timestamp(dt.with_timezone(&Utc)),
                             )

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -209,7 +209,7 @@ impl TcpSource for LogstashSource {
 
             self.log_namespace.insert_vector_metadata(
                 log,
-                log_schema().source_type_key(),
+                Some(log_schema().source_type_key()),
                 path!("source_type"),
                 Bytes::from_static(LogstashConfig::NAME.as_bytes()),
             );
@@ -232,10 +232,12 @@ impl TcpSource for LogstashSource {
                     log.insert(metadata_path!("vector", "ingest_timestamp"), now);
                 }
                 LogNamespace::Legacy => {
-                    log.insert(
-                        (PathPrefix::Event, log_schema().timestamp_key()),
-                        log_timestamp.unwrap_or_else(|| Value::from(now)),
-                    );
+                    if let Some(timestamp_key) = log_schema().timestamp_key() {
+                        log.insert(
+                            (PathPrefix::Event, timestamp_key),
+                            log_timestamp.unwrap_or_else(|| Value::from(now)),
+                        );
+                    }
                 }
             }
 

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -252,13 +252,13 @@ impl InputHandler {
                         if let Event::Log(ref mut log) = event {
                             self.log_namespace.insert_vector_metadata(
                                 log,
-                                path!(log_schema().source_type_key()),
+                                Some(log_schema().source_type_key()),
                                 path!("source_type"),
                                 Bytes::from(RedisSourceConfig::NAME),
                             );
                             self.log_namespace.insert_vector_metadata(
                                 log,
-                                path!(log_schema().timestamp_key()),
+                                log_schema().timestamp_key(),
                                 path!("ingest_timestamp"),
                                 now,
                             );

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1197,12 +1197,12 @@ mod tests {
     use vector_core::{event::EventStatus, schema::Definition};
 
     use super::*;
+    use crate::sinks::splunk_hec::common::config_timestamp_key;
     use crate::{
         codecs::EncodingConfig,
         config::{log_schema, SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::{Event, LogEvent},
         sinks::{
-            splunk_hec::common::timestamp_key,
             splunk_hec::logs::config::HecLogsSinkConfig,
             util::{BatchConfig, Compression, TowerRequestConfig},
             Healthcheck, VectorSink,
@@ -1285,7 +1285,7 @@ mod tests {
             tls: None,
             acknowledgements: Default::default(),
             timestamp_nanos_key: None,
-            timestamp_key: timestamp_key(),
+            timestamp_key: config_timestamp_key(),
             auto_extract_timestamp: None,
             endpoint_target: Default::default(),
         }
@@ -1411,7 +1411,13 @@ mod tests {
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
         assert_eq!(event.as_log()[log_schema().message_key()], message.into());
-        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+        assert!(event
+            .as_log()
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
         assert_eq!(
             event.as_log()[log_schema().source_type_key()],
             "splunk_hec".into()
@@ -1432,7 +1438,13 @@ mod tests {
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
         assert_eq!(event.as_log()[log_schema().message_key()], message.into());
-        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+        assert!(event
+            .as_log()
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
         assert_eq!(
             event.as_log()[log_schema().source_type_key()],
             "splunk_hec".into()
@@ -1457,7 +1469,13 @@ mod tests {
 
         for (msg, event) in messages.into_iter().zip(events.into_iter()) {
             assert_eq!(event.as_log()[log_schema().message_key()], msg.into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1479,7 +1497,13 @@ mod tests {
         let event = channel_n(vec![message], sink, source).await.remove(0);
 
         assert_eq!(event.as_log()[log_schema().message_key()], message.into());
-        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+        assert!(event
+            .as_log()
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
         assert_eq!(
             event.as_log()[log_schema().source_type_key()],
             "splunk_hec".into()
@@ -1504,7 +1528,13 @@ mod tests {
 
         for (msg, event) in messages.into_iter().zip(events.into_iter()) {
             assert_eq!(event.as_log()[log_schema().message_key()], msg.into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1530,7 +1560,12 @@ mod tests {
         let event = collect_n(source, 1).await.remove(0).into_log();
         assert_eq!(event["greeting"], "hello".into());
         assert_eq!(event["name"], "bob".into());
-        assert!(event.get(log_schema().timestamp_key()).is_some());
+        assert!(event
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap()
+            ))
+            .is_some());
         assert_eq!(event[log_schema().source_type_key()], "splunk_hec".into());
         assert!(event.metadata().splunk_hec_token().is_none());
     }
@@ -1564,7 +1599,13 @@ mod tests {
             let event = collect_n(source, 1).await.remove(0);
             assert_eq!(event.as_log()[log_schema().message_key()], message.into());
             assert_eq!(event.as_log()[&super::CHANNEL], "channel".into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1585,7 +1626,13 @@ mod tests {
             let event = collect_n(source, 1).await.remove(0);
             assert_eq!(event.as_log()[log_schema().message_key()], "root".into());
             assert_eq!(event.as_log()[&super::CHANNEL], "channel".into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1818,7 +1865,13 @@ mod tests {
             let event = collect_n(source, 1).await.remove(0);
             assert_eq!(event.as_log()[log_schema().message_key()], message.into());
             assert_eq!(event.as_log()[&super::CHANNEL], "channel".into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1889,7 +1942,13 @@ mod tests {
 
             let event = collect_n(source, 1).await.remove(0);
             assert_eq!(event.as_log()[log_schema().message_key()], "first".into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1913,7 +1972,13 @@ mod tests {
 
             let event = collect_n(source, 1).await.remove(0);
             assert_eq!(event.as_log()[log_schema().message_key()], "first".into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1935,7 +2000,13 @@ mod tests {
 
             let event = collect_n(source, 1).await.remove(0);
             assert_eq!(event.as_log()[log_schema().message_key()], "first".into());
-            assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+            assert!(event
+                .as_log()
+                .get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap()
+                ))
+                .is_some());
             assert_eq!(
                 event.as_log()[log_schema().source_type_key()],
                 "splunk_hec".into()
@@ -1964,7 +2035,7 @@ mod tests {
         assert_eq!(event.as_log()["non"], "A non UTF8 character �".into());
         assert_eq!(event.as_log()["number"], 2.into());
         assert_eq!(event.as_log()["bool"], true.into());
-        assert!(event.as_log().get(log_schema().timestamp_key()).is_some());
+        assert!(event.as_log().get((lookup::PathPrefix::Event, log_schema().timestamp_key().unwrap())).is_some());
         assert_eq!(
             event.as_log()[log_schema().source_type_key()],
             "splunk_hec".into()

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -660,7 +660,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         // Add source type
         self.log_namespace.insert_vector_metadata(
             &mut log,
-            lookup::path!(log_schema().source_type_key()),
+            Some(log_schema().source_type_key()),
             lookup::path!("source_type"),
             SplunkConfig::NAME,
         );
@@ -737,7 +737,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         self.log_namespace.insert_source_metadata(
             SplunkConfig::NAME,
             &mut log,
-            Some(LegacyKey::Overwrite(log_schema().timestamp_key())),
+            log_schema().timestamp_key().map(LegacyKey::Overwrite),
             "timestamp",
             timestamp,
         );

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -773,7 +773,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
                 // The timestamp is extracted from the message for the Legacy namespace.
                 self.log_namespace.insert_vector_metadata(
                     &mut log,
-                    lookup::path!(log_schema().timestamp_key()),
+                    log_schema().timestamp_key(),
                     lookup::path!("ingest_timestamp"),
                     chrono::Utc::now(),
                 );

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -803,7 +803,10 @@ mod test {
         {
             let expected = expected.as_mut_log();
             expected.insert(
-                log_schema().timestamp_key(),
+                (
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap(),
+                ),
                 Utc.ymd(2019, 2, 13)
                     .and_hms_opt(19, 48, 34)
                     .expect("invalid timestamp"),
@@ -843,7 +846,10 @@ mod test {
         {
             let expected = expected.as_mut_log();
             expected.insert(
-                log_schema().timestamp_key(),
+                (
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap(),
+                ),
                 Utc.ymd(2019, 2, 13)
                     .and_hms_opt(19, 48, 34)
                     .expect("invalid timestamp"),
@@ -962,7 +968,13 @@ mod test {
                 .and_hms_opt(20, 7, 26)
                 .expect("invalid timestamp")
                 .into();
-            expected.insert(log_schema().timestamp_key(), expected_date);
+            expected.insert(
+                (
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap(),
+                ),
+                expected_date,
+            );
             expected.insert(log_schema().host_key(), "74794bfb6795");
             expected.insert(log_schema().source_type_key(), "syslog");
             expected.insert("hostname", "74794bfb6795");
@@ -995,7 +1007,13 @@ mod test {
                 .and_hms_opt(21, 31, 56)
                 .expect("invalid timestamp")
                 .into();
-            expected.insert(log_schema().timestamp_key(), expected_date);
+            expected.insert(
+                (
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap(),
+                ),
+                expected_date,
+            );
             expected.insert(log_schema().source_type_key(), "syslog");
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
@@ -1023,7 +1041,10 @@ mod test {
         {
             let expected = expected.as_mut_log();
             expected.insert(
-                log_schema().timestamp_key(),
+                (
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap(),
+                ),
                 Utc.ymd(2019, 2, 13).and_hms_micro(21, 53, 30, 605_850),
             );
             expected.insert(log_schema().source_type_key(), "syslog");

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -423,7 +423,9 @@ fn enrich_syslog_event(
             .get("timestamp")
             .and_then(|timestamp| timestamp.as_timestamp().cloned())
             .unwrap_or_else(Utc::now);
-        log.insert((PathPrefix::Event, log_schema().timestamp_key()), timestamp);
+        if let Some(timestamp_key) = log_schema().timestamp_key() {
+            log.insert((PathPrefix::Event, timestamp_key), timestamp);
+        }
     }
 
     trace!(

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -356,7 +356,7 @@ pub trait FrameHandler {
     fn socket_receive_buffer_size(&self) -> Option<usize>;
     fn socket_send_buffer_size(&self) -> Option<usize>;
     fn host_key(&self) -> &Option<OwnedValuePath>;
-    fn timestamp_key(&self) -> &str;
+    fn timestamp_key(&self) -> Option<&OwnedValuePath>;
     fn source_type_key(&self) -> &str;
 }
 

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -636,7 +636,7 @@ mod test {
         socket_send_buffer_size: Option<usize>,
         extra_task_handling_routine: F,
         host_key: Option<OwnedValuePath>,
-        timestamp_key: String,
+        timestamp_key: Option<OwnedValuePath>,
         source_type_key: String,
         log_namespace: LogNamespace,
     }
@@ -654,7 +654,7 @@ mod test {
                 socket_send_buffer_size: None,
                 extra_task_handling_routine: extra_routine,
                 host_key: Some(owned_value_path!("test_framestream")),
-                timestamp_key: "my_timestamp".to_string(),
+                timestamp_key: Some(owned_value_path!("my_timestamp")),
                 source_type_key: "source_type".to_string(),
                 log_namespace: LogNamespace::Legacy,
             }
@@ -714,8 +714,8 @@ mod test {
             &self.host_key
         }
 
-        fn timestamp_key(&self) -> &str {
-            self.timestamp_key.as_str()
+        fn timestamp_key(&self) -> Option<&OwnedValuePath> {
+            self.timestamp_key.as_ref()
         }
 
         fn source_type_key(&self) -> &str {

--- a/src/template.rs
+++ b/src/template.rs
@@ -494,7 +494,13 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert(log_schema().timestamp_key(), ts);
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            ts,
+        );
 
         let template = Template::try_from("abcd-%F").unwrap();
 
@@ -509,7 +515,13 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert(log_schema().timestamp_key(), ts);
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            ts,
+        );
 
         let template = Template::try_from("abcd-%F_%T").unwrap();
 
@@ -528,7 +540,13 @@ mod tests {
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert("foo", "butts");
-        event.as_mut_log().insert(log_schema().timestamp_key(), ts);
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            ts,
+        );
 
         let template = Template::try_from("{{ foo }}-%F_%T").unwrap();
 
@@ -547,7 +565,13 @@ mod tests {
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert("format", "%F");
-        event.as_mut_log().insert(log_schema().timestamp_key(), ts);
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            ts,
+        );
 
         let template = Template::try_from("nested {{ format }} %T").unwrap();
 
@@ -566,7 +590,13 @@ mod tests {
 
         let mut event = Event::Log(LogEvent::from("hello world"));
         event.as_mut_log().insert("\"%F\"", "foo");
-        event.as_mut_log().insert(log_schema().timestamp_key(), ts);
+        event.as_mut_log().insert(
+            (
+                lookup::PathPrefix::Event,
+                log_schema().timestamp_key().unwrap(),
+            ),
+            ts,
+        );
 
         let template = Template::try_from("nested {{ \"%F\" }} %T").unwrap();
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -7,6 +7,7 @@ use chrono::{
     Utc,
 };
 use lookup::lookup_v2::parse_target_path;
+use lookup::PathPrefix;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use snafu::Snafu;
@@ -171,7 +172,9 @@ impl Template {
                             EventRef::Metric(metric) => {
                                 render_metric_field(key, metric).map(Cow::Borrowed)
                             }
-                            EventRef::Trace(trace) => trace.get(key).map(Value::to_string_lossy),
+                            EventRef::Trace(trace) => {
+                                trace.get(key.as_str()).map(Value::to_string_lossy)
+                            }
                         }
                         .unwrap_or_else(|| {
                             missing_keys.push(key.to_owned());
@@ -340,15 +343,18 @@ fn render_metric_field<'a>(key: &str, metric: &'a Metric) -> Option<&'a str> {
 
 fn render_timestamp(items: &ParsedStrftime, event: EventRef<'_>) -> String {
     match event {
-        EventRef::Log(log) => log
-            .get(log_schema().timestamp_key())
-            .and_then(Value::as_timestamp)
-            .copied(),
+        EventRef::Log(log) => log_schema().timestamp_key().and_then(|timestamp_key| {
+            log.get((PathPrefix::Event, timestamp_key))
+                .and_then(Value::as_timestamp)
+                .copied()
+        }),
         EventRef::Metric(metric) => metric.timestamp(),
-        EventRef::Trace(trace) => trace
-            .get(log_schema().timestamp_key())
-            .and_then(Value::as_timestamp)
-            .copied(),
+        EventRef::Trace(trace) => log_schema().timestamp_key().and_then(|timestamp_key| {
+            trace
+                .get((PathPrefix::Event, timestamp_key))
+                .and_then(Value::as_timestamp)
+                .copied()
+        }),
     }
     .unwrap_or_else(Utc::now)
     .format_with_items(items.as_items())

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -102,11 +102,14 @@ fn default_cache_config() -> CacheConfig {
 //   structure can vary significantly. This should probably either become a required field
 //   in the future, or maybe the "semantic meaning" can be utilized here.
 fn default_match_fields() -> Vec<String> {
-    vec![
-        log_schema().timestamp_key().into(),
+    let mut fields = vec![
         log_schema().host_key().into(),
         log_schema().message_key().into(),
-    ]
+    ];
+    if let Some(timestamp_key) = log_schema().timestamp_key() {
+        fields.push(timestamp_key.to_string());
+    }
+    fields
 }
 
 impl DedupeConfig {

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -395,6 +395,7 @@ impl FunctionTransform for LogToMetric {
 #[cfg(test)]
 mod tests {
     use chrono::{offset::TimeZone, DateTime, Utc};
+    use lookup::PathPrefix;
     use std::time::Duration;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
@@ -433,7 +434,10 @@ mod tests {
     fn create_event(key: &str, value: impl Into<Value> + std::fmt::Debug) -> Event {
         let mut log = Event::Log(LogEvent::from("i am a log"));
         log.as_mut_log().insert(key, value);
-        log.as_mut_log().insert(log_schema().timestamp_key(), ts());
+        log.as_mut_log().insert(
+            (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
+            ts(),
+        );
         log
     }
 
@@ -787,9 +791,10 @@ mod tests {
         );
 
         let mut event = Event::Log(LogEvent::from("i am a log"));
-        event
-            .as_mut_log()
-            .insert(log_schema().timestamp_key(), ts());
+        event.as_mut_log().insert(
+            (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
+            ts(),
+        );
         event.as_mut_log().insert("status", "42");
         event.as_mut_log().insert("backtrace", "message");
         let metadata = event.metadata().clone();
@@ -836,9 +841,10 @@ mod tests {
         );
 
         let mut event = Event::Log(LogEvent::from("i am a log"));
-        event
-            .as_mut_log()
-            .insert(log_schema().timestamp_key(), ts());
+        event.as_mut_log().insert(
+            (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
+            ts(),
+        );
         event.as_mut_log().insert("status", "42");
         event.as_mut_log().insert("backtrace", "message");
         event.as_mut_log().insert("host", "local");


### PR DESCRIPTION
fixes https://github.com/vectordotdev/vector/issues/16834

The `LogSchema` timestamp key was previously a `String`, which makes it very easy to mis-use it. It's not obvious that it can be optional (by using an empty string, or technically any invalid path). This has been migrated to a typed path which should help prevent these types of problems from happening again.