### PR TITLE
feat(component spec validation tests): validate component_errors_total source metric

### DIFF
--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -17,7 +17,11 @@ pub enum TestEvent {
     ///
     /// For transforms and sinks, generally, the only way to cause an error is if the event itself
     /// is malformed in some way, which can be achieved without this test event variant.
-    Modified { modified: bool, event: EventData },
+    Modified {
+        modified: bool,
+        event: EventData,
+        expected_errors: u32,
+    },
 }
 
 impl TestEvent {

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -114,8 +114,10 @@ fn spawn_input_http_server(
 
                     buffer.into_response()
                 } else {
-                    // No outstanding events to send, so just provide an empty response.
-                    StatusCode::NO_CONTENT.into_response()
+                    // We'll send an empty 200 in the response since some
+                    // sources throw errors for anything other than a valid
+                    // response.
+                    StatusCode::OK.into_response()
                 }
             }
         });

--- a/src/components/validation/validators/component_spec/mod.rs
+++ b/src/components/validation/validators/component_spec/mod.rs
@@ -126,11 +126,24 @@ fn validate_telemetry(
     }
 }
 
-fn filter_events_by_metric_and_component<'a>(
+fn filter_events_by_metric_and_component_with_errors<'a>(
     telemetry_events: &'a [Event],
-    metric: SourceMetrics,
+    metric: &SourceMetrics,
     component_name: &'a str,
 ) -> Result<Vec<&'a Metric>, Vec<String>> {
+    let metrics = filter_events_by_metric_and_component(telemetry_events, metric, component_name);
+    if metrics.is_empty() {
+        return Err(vec![format!("{}: no metrics were emitted.", metric)]);
+    }
+
+    Ok(metrics)
+}
+
+fn filter_events_by_metric_and_component<'a>(
+    telemetry_events: &'a [Event],
+    metric: &SourceMetrics,
+    component_name: &'a str,
+) -> Vec<&'a Metric> {
     let metrics: Vec<&Metric> = telemetry_events
         .iter()
         .flat_map(|e| {
@@ -155,9 +168,5 @@ fn filter_events_by_metric_and_component<'a>(
 
     debug!("{}: {} metrics found.", metric.to_string(), metrics.len(),);
 
-    if metrics.is_empty() {
-        return Err(vec![format!("{}: no metrics were emitted.", metric)]);
-    }
-
-    Ok(metrics)
+    metrics
 }

--- a/tests/validation/components/sources/http_client.yaml
+++ b/tests/validation/components/sources/http_client.yaml
@@ -11,3 +11,4 @@
     - simple message 2
     - modified: true
       event: simple message with the wrong encoding
+      expected_errors: 1

--- a/tests/validation/components/sources/http_server.yaml
+++ b/tests/validation/components/sources/http_server.yaml
@@ -11,3 +11,4 @@
     - simple message 2
     - modified: true
       event: simple message with the wrong encoding
+      expected_errors: 1


### PR DESCRIPTION
Closes #16841

I check for a lower bound on component_errors_total instead of a specific number. The test harness can throw errors in certain situations. One example is when the http_client source tries to check for new metrics, but the origin server of the metrics was recently shutdown (this happens as the test harness is destructed). We don't have a lot of options here because we can't control the number of times sources pull in metrics, just the schedule. 