### PR TITLE
fix(docs): fix rustdoc errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,11 +370,15 @@ jobs:
       - name: Check Component Docs
         if: needs.changes.outputs.source == 'true' || needs.changes.outputs.component_docs == 'true'
         run: make check-component-docs
+      - name: Check Rust Docs
+        if: needs.changes.outputs.source == 'true'
+        run: cd rust-doc && make docs
       - uses: actions/upload-artifact@v3
         with:
           name: "config-schema.json"
           path: "/tmp/vector-config-schema.json"
         if: success() || failure()
+
   master-failure:
     name: master-failure
     if: failure() && github.ref == 'refs/heads/master'

--- a/lib/vector-config-common/src/schema/gen.rs
+++ b/lib/vector-config-common/src/schema/gen.rs
@@ -42,6 +42,7 @@ impl SchemaSettings {
 
     /// Creates a `Visitor` from the given closure and appends it to the list of
     /// [visitors](SchemaSettings::visitors) for these `SchemaSettings`.
+    #[allow(rustdoc::private_intra_doc_links)]
     pub fn with_visitor<F, V>(mut self, visitor_fn: F) -> Self
     where
         F: FnOnce(&Self) -> V,
@@ -93,6 +94,7 @@ impl SchemaGenerator {
     ///
     /// The keys of the returned `Map` are the [schema names](JsonSchema::schema_name), and the
     /// values are the schemas themselves.
+    #[allow(rustdoc::broken_intra_doc_links)]
     pub fn definitions(&self) -> &Map<String, Schema> {
         &self.definitions
     }
@@ -102,6 +104,7 @@ impl SchemaGenerator {
     ///
     /// The keys of the returned `Map` are the [schema names](JsonSchema::schema_name), and the
     /// values are the schemas themselves.
+    #[allow(rustdoc::broken_intra_doc_links)]
     pub fn definitions_mut(&mut self) -> &mut Map<String, Schema> {
         &mut self.definitions
     }

--- a/lib/vector-config-common/src/schema/json_schema.rs
+++ b/lib/vector-config-common/src/schema/json_schema.rs
@@ -223,7 +223,7 @@ impl SchemaObject {
         self.reference.is_some()
     }
 
-    /// Returns `true` if `self` accepts values of the given type, according to the [`instance_type`] field.
+    /// Returns `true` if `self` accepts values of the given type, according to the [`Self::instance_type`] field.
     ///
     /// This is a basic check that always returns `true` if no `instance_type` is specified on the schema,
     /// and does not check any subschemas. Because of this, both `{}` and  `{"not": {}}` accept any type according

--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -1,4 +1,4 @@
-//! Functionality supporting both the [sources::amqp] source and `[sinks::amqp]` sink.
+//! Functionality supporting both the `[crate::sources::amqp] source and `[crate::sinks::amqp]` sink.
 use lapin::tcp::{OwnedIdentity, OwnedTLSConfig};
 use vector_config::configurable_component;
 

--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -1,4 +1,4 @@
-//! Functionality supporting both the `[crate::sources::amqp] source and `[crate::sinks::amqp]` sink.
+//! Functionality supporting both the `[crate::sources::amqp]` source and `[crate::sinks::amqp]` sink.
 use lapin::tcp::{OwnedIdentity, OwnedTLSConfig};
 use vector_config::configurable_component;
 

--- a/src/api/schema/events/notification.rs
+++ b/src/api/schema/events/notification.rs
@@ -85,7 +85,7 @@ impl Notification {
 /// directly nested into the union of [`super::OutputEventsPayload`].
 ///
 /// The GraphQL specification forbids such a nesting:
-/// http://spec.graphql.org/October2021/#sel-HAHdfFDABABkG3_I
+/// <http://spec.graphql.org/October2021/#sel-HAHdfFDABABkG3_I>
 #[derive(Debug, Clone)]
 pub struct EventNotification {
     pub notification: Notification,

--- a/src/api/schema/metrics/filter.rs
+++ b/src/api/schema/metrics/filter.rs
@@ -187,7 +187,7 @@ pub fn get_all_metrics(interval: i32) -> impl Stream<Item = Vec<Metric>> {
     }
 }
 
-/// Return Vec<Metric> based on a component id tag.
+/// Return [`Vec<Metric>`] based on a component id tag.
 pub fn by_component_key(component_key: &ComponentKey) -> Vec<Metric> {
     get_controller()
         .capture_metrics()

--- a/src/api/schema/metrics/host.rs
+++ b/src/api/schema/metrics/host.rs
@@ -326,7 +326,7 @@ impl HostMetrics {
     }
 }
 
-/// Filters a Vec<Metric> by name, returning the inner `value` or 0.00 if not found
+/// Filters a [`Vec<Metric>`] by name, returning the inner `value` or 0.00 if not found
 fn filter_host_metric(metrics: &[Metric], name: &str) -> f64 {
     metrics
         .iter()

--- a/src/api/schema/sort.rs
+++ b/src/api/schema/sort.rs
@@ -41,7 +41,7 @@ pub trait SortableByField<T: InputType> {
     fn sort(&self, rhs: &Self, field: &T) -> Ordering;
 }
 
-/// Performs an in-place sort against a slice of Sortable<T>, with the provided SortField<T>s
+/// Performs an in-place sort against a slice of `Sortable<T>`, with the provided [`SortField<T>`]s
 pub fn by_fields<T: InputType>(f: &mut [impl SortableByField<T>], sort_fields: &[SortField<T>]) {
     f.sort_by(|a, b| {
         sort_fields

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -90,7 +90,7 @@ pub enum AwsAuthentication {
     ///
     /// Additionally, the specific credential profile to use can be set.
     /// The file format must match the credentials file format outlined in
-    /// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html.
+    /// <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html>.
     File {
         /// Path to the credentials file.
         #[configurable(metadata(docs::examples = "/my/aws/credentials"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
 /// The current version of Vector in simplified format.
-/// <version-number>-nightly.
+/// `<version-number>-nightly`.
 pub fn vector_version() -> impl std::fmt::Display {
     #[cfg(feature = "nightly")]
     let pkg_version = format!("{}-nightly", built_info::PKG_VERSION);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
 /// The current version of Vector in simplified format.
-/// `<version-number>-nightly`.
+/// <version-number>-nightly.
 pub fn vector_version() -> impl std::fmt::Display {
     #[cfg(feature = "nightly")]
     let pkg_version = format!("{}-nightly", built_info::PKG_VERSION);

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -120,7 +120,7 @@ impl CloudwatchRequestBuilder {
 /// ByteSizeOf is being abused to represent the encoded size of a request for the Partitioned Batcher
 ///
 /// The maximum batch size is 1,048,576 bytes. This size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event.
-/// source: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
+/// source: <https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html>
 impl ByteSizeOf for CloudwatchRequest {
     fn size_of(&self) -> usize {
         self.message.len() + 26

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -91,7 +91,7 @@ impl Default for DatadogCommonConfig {
 
 impl DatadogCommonConfig {
     /// Returns a `Healthcheck` which is a future that will be used to ensure the
-    /// <site>/api/v1/validate endpoint is reachable.
+    /// `<site>/api/v1/validate` endpoint is reachable.
     fn build_healthcheck(
         &self,
         client: HttpClient,
@@ -108,7 +108,7 @@ impl DatadogCommonConfig {
     }
 }
 
-/// Makes a GET HTTP request to <site>/api/v1/validate using the provided client and API key.
+/// Makes a GET HTTP request to `<site>/api/v1/validate` using the provided client and API key.
 async fn build_healthcheck_future(
     client: HttpClient,
     validate_endpoint: Uri,

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -22,7 +22,7 @@ pub(in crate::sinks) enum Field {
     Float(f64),
     /// unsigned integer
     /// Influx can support 64 bit integers if compiled with a flag, see:
-    /// https://github.com/influxdata/influxdb/issues/7801#issuecomment-466801839
+    /// <https://github.com/influxdata/influxdb/issues/7801#issuecomment-466801839>
     UnsignedInt(u64),
     /// integer
     Int(i64),

--- a/src/sinks/util/statistic.rs
+++ b/src/sinks/util/statistic.rs
@@ -89,7 +89,7 @@ impl DistributionStatistic {
 /// it might be preferable to use a more common function, such as R-7.
 ///
 /// List of quantile functions:
-/// https://en.wikipedia.org/wiki/Quantile#Estimating_quantiles_from_a_sample
+/// <https://en.wikipedia.org/wiki/Quantile#Estimating_quantiles_from_a_sample>
 fn find_quantile(bins: &[Sample], p: f64) -> f64 {
     let count = bins.last().expect("bins is empty").rate;
     find_sample(bins, (p * count as f64).round() as u32)

--- a/src/sinks/webhdfs/mod.rs
+++ b/src/sinks/webhdfs/mod.rs
@@ -3,8 +3,8 @@
 //! This sink will send it's output to WEBHDFS.
 //!
 //! `webhdfs` is an OpenDal based services. This mod itself only provide
-//! config to build an [`OpenDalSink`]. All real implement are powered by
-//! [`OpenDalSink`].
+//! config to build an [`crate::sinks::opendal_common::OpenDalSink`]. All real implement are powered by
+//! [`crate::sinks::opendal_common::OpenDalSink`].
 
 mod config;
 pub use self::config::WebHdfsConfig;

--- a/src/sources/aws_ecs_metrics/parser.rs
+++ b/src/sources/aws_ecs_metrics/parser.rs
@@ -159,7 +159,7 @@ fn blkio_tags(item: &BlockIoStat, tags: &MetricTags) -> MetricTags {
     tags
 }
 
-/// reference https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt
+/// reference <https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt>
 fn blkio_metrics(
     blkio: &BlockIoStats,
     timestamp: DateTime<Utc>,

--- a/src/sources/aws_kinesis_firehose/models.rs
+++ b/src/sources/aws_kinesis_firehose/models.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Represents protocol v1.0 (the only protocol as of writing)
 ///
-/// https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html
+/// <https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html>
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FirehoseRequest {
@@ -28,7 +28,7 @@ pub struct EncodedFirehoseRecord {
 ///
 /// Represents protocol v1.0 (the only protocol as of writing)
 ///
-/// https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html
+/// <https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html>
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FirehoseResponse {

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -13,7 +13,7 @@ use vector_core::event::Value;
 ///
 /// Not yet handled are the handshake messages.
 ///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#event-modes
+/// <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#event-modes>
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub(super) enum FluentMessage {
@@ -38,7 +38,7 @@ pub(super) enum FluentMessage {
 
 /// Server options sent by client.
 ///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#option
+/// <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#option>
 #[derive(Default, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub(super) struct FluentMessageOptions {
@@ -49,7 +49,7 @@ pub(super) struct FluentMessageOptions {
 
 /// Fluent entry consisting of timestamp and record.
 ///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#forward-mode
+/// <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#forward-mode>
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct FluentEntry(pub(super) FluentTimestamp, pub(super) FluentRecord);
 
@@ -61,7 +61,7 @@ pub(super) type FluentTag = String;
 
 /// Custom decoder for Fluent's EventTime msgpack extension.
 ///
-/// https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format
+/// <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format>
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub(super) struct FluentEventTime(DateTime<Utc>);
 
@@ -172,10 +172,10 @@ impl From<FluentValue> for Value {
             ),
             rmpv::Value::Map(values) => {
                 // Per
-                // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes
+                // <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes>
                 // we should expect that keys are always stringy. Ultimately a
                 // lot hinges on what
-                // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#grammar
+                // <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#grammar>
                 // defines 'object' as.
                 //
                 // The current implementation will SILENTLY DROP non-stringy keys.

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -79,9 +79,9 @@ impl PathsProvider for K8sPathsProvider {
 /// the effective config hashsum, see the `extract_static_pod_config_hashsum`
 /// function that does this.
 ///
-/// See https://github.com/vectordotdev/vector/issues/6001
-/// See https://github.com/kubernetes/kubernetes/blob/ef3337a443b402756c9f0bfb1f844b1b45ce289d/pkg/kubelet/pod/pod_manager.go#L30-L44
-/// See https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/pod/mirror_client.go#L80-L81
+/// See <https://github.com/vectordotdev/vector/issues/6001>
+/// See <https://github.com/kubernetes/kubernetes/blob/ef3337a443b402756c9f0bfb1f844b1b45ce289d/pkg/kubelet/pod/pod_manager.go#L30-L44>
+/// See <https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/pkg/kubelet/pod/mirror_client.go#L80-L81>
 fn extract_pod_logs_directory(pod: &Pod) -> Option<PathBuf> {
     let metadata = &pod.metadata;
     let namespace = metadata.namespace.as_ref()?;

--- a/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/namespace_metadata_annotator.rs
@@ -63,7 +63,6 @@ impl NamespaceMetadataAnnotator {
 
 impl NamespaceMetadataAnnotator {
     /// Annotates an event with the information from the [`Namespace::metadata`].
-    /// The event has to have a [`POD_NAMESPACE`] field set.
     pub fn annotate(&self, event: &mut Event, pod_namespace: &str) -> Option<()> {
         let log = event.as_mut_log();
         let obj = ObjectRef::<Namespace>::new(pod_namespace);

--- a/src/sources/kubernetes_logs/node_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/node_metadata_annotator.rs
@@ -59,7 +59,6 @@ impl NodeMetadataAnnotator {
 
 impl NodeMetadataAnnotator {
     /// Annotates an event with the information from the [`Node::metadata`].
-    /// The event has to have a [`VECTOR_SELF_NODE_NAME`] field set.
     pub fn annotate(&self, event: &mut Event, node: &str) -> Option<()> {
         let log = event.as_mut_log();
         let obj = ObjectRef::<Node>::new(node);

--- a/src/sources/kubernetes_logs/path_helpers.rs
+++ b/src/sources/kubernetes_logs/path_helpers.rs
@@ -14,7 +14,7 @@ const LOG_PATH_DELIMITER: &str = "_";
 
 /// Builds absolute log directory path for a pod sandbox.
 ///
-/// Based on https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L178
+/// Based on <https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L178>
 pub(super) fn build_pod_logs_directory(
     pod_namespace: &str,
     pod_name: &str,
@@ -32,7 +32,7 @@ pub(super) fn build_pod_logs_directory(
 ///
 /// Assumes the input is a valid pod log file name.
 ///
-/// Inspired by https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L186
+/// Inspired by <https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L186>
 pub(super) fn parse_log_file_path(path: &str) -> Option<LogFileInfo<'_>> {
     let mut components = path.rsplit('/');
 

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -194,8 +194,6 @@ impl PodMetadataAnnotator {
 
 impl PodMetadataAnnotator {
     /// Annotates an event with the information from the [`Pod::metadata`].
-    /// The event has to be obtained from kubernetes log file, and have a
-    /// [`FILE_KEY`] field set with a file that the line came from.
     pub fn annotate<'a>(&self, event: &mut Event, file: &'a str) -> Option<LogFileInfo<'a>> {
         let log = event.as_mut_log();
         let file_info = parse_log_file_path(file)?;

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -166,7 +166,7 @@ impl SourceConfig for MongoDbMetricsConfig {
 
 impl MongoDbMetrics {
     /// Works only with Standalone connection-string. Collect metrics only from specified instance.
-    /// https://docs.mongodb.com/manual/reference/connection-string/#standard-connection-string-format
+    /// <https://docs.mongodb.com/manual/reference/connection-string/#standard-connection-string-format>
     async fn new(endpoint: &str, namespace: Option<String>) -> Result<MongoDbMetrics, BuildError> {
         let mut client_options = ClientOptions::parse(endpoint)
             .await
@@ -201,8 +201,8 @@ impl MongoDbMetrics {
             NodeType::Replset
         } else if msg.msg.map(|msg| msg == "isdbgrid").unwrap_or(false) {
             // Contains the value isdbgrid when isMaster returns from a mongos instance.
-            // https://docs.mongodb.com/manual/reference/command/isMaster/#isMaster.msg
-            // https://docs.mongodb.com/manual/core/sharded-cluster-query-router/#confirm-connection-to-mongos-instances
+            // <https://docs.mongodb.com/manual/reference/command/isMaster/#isMaster.msg>
+            // <https://docs.mongodb.com/manual/core/sharded-cluster-query-router/#confirm-connection-to-mongos-instances>
             NodeType::Mongos
         } else {
             NodeType::Mongod
@@ -270,7 +270,7 @@ impl MongoDbMetrics {
     }
 
     /// Collect metrics from `serverStatus` command.
-    /// https://docs.mongodb.com/manual/reference/command/serverStatus/
+    /// <https://docs.mongodb.com/manual/reference/command/serverStatus/>
     async fn collect_server_status(&self) -> Result<Vec<Metric>, CollectError> {
         self.print_version().await?;
 
@@ -1003,12 +1003,12 @@ fn document_size(doc: &Document) -> usize {
 }
 
 /// Remove credentials from endpoint.
-/// URI components: https://docs.mongodb.com/manual/reference/connection-string/#components
+/// URI components: <https://docs.mongodb.com/manual/reference/connection-string/#components>
 /// It's not possible to use [url::Url](https://docs.rs/url/2.1.1/url/struct.Url.html) because connection string can have multiple hosts.
-/// Would be nice to serialize [ClientOptions][https://docs.rs/mongodb/1.1.1/mongodb/options/struct.ClientOptions.html] to String, but it's not supported.
+/// Would be nice to serialize [ClientOptions](https://docs.rs/mongodb/1.1.1/mongodb/options/struct.ClientOptions.html) to String, but it's not supported.
 /// `endpoint` argument would not be required, but field `original_uri` in `ClientOptions` is private.
 /// `.unwrap()` in function is safe because endpoint was already verified by `ClientOptions`.
-/// Based on ClientOptions::parse_uri -- https://github.com/mongodb/mongo-rust-driver/blob/09e1193f93dcd850ebebb7fb82f6ab786fd85de1/src/client/options/mod.rs#L708
+/// Based on ClientOptions::parse_uri -- <https://github.com/mongodb/mongo-rust-driver/blob/09e1193f93dcd850ebebb7fb82f6ab786fd85de1/src/client/options/mod.rs#L708>
 fn sanitize_endpoint(endpoint: &str, options: &ClientOptions) -> String {
     let mut endpoint = endpoint.to_owned();
     if options.credential.is_some() {

--- a/src/sources/mongodb_metrics/types.rs
+++ b/src/sources/mongodb_metrics/types.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 pub enum NodeType {
     Mongod,  // MongoDB daemon
     Mongos,  // Mongo sharding server
-    Replset, // https://docs.mongodb.com/manual/reference/glossary/#term-replica-set
+    Replset, // <https://docs.mongodb.com/manual/reference/glossary/#term-replica-set>
 }
 
-/// https://docs.mongodb.com/manual/reference/command/isMaster/
+/// <https://docs.mongodb.com/manual/reference/command/isMaster/>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandIsMaster {
@@ -21,7 +21,7 @@ pub struct CommandIsMaster {
     pub hosts: Option<Vec<String>>,
 }
 
-/// https://docs.mongodb.com/manual/reference/command/buildInfo/
+/// <https://docs.mongodb.com/manual/reference/command/buildInfo/>
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandBuildInfo {
@@ -32,7 +32,7 @@ pub struct CommandBuildInfo {
     pub max_bson_object_size: i64,
 }
 
-/// https://docs.mongodb.com/manual/reference/command/serverStatus/
+/// <https://docs.mongodb.com/manual/reference/command/serverStatus/>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandServerStatus {
@@ -269,7 +269,7 @@ pub struct CommandServerStatusMetricsReplTtl {
     pub passes: i64,
 }
 
-/// https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/#latency-stats-document
+/// <https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/#latency-stats-document>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandServerStatusOpLatenciesStat {


### PR DESCRIPTION
A number of RustDoc errors have crept in. This fixes them. 

This also adds a CI job to test the rust doc.

One rust doc error has been left in for now to test this CI job.