### PR TITLE
chore(config): disallow unevaluated properties in generated schema

### DIFF
--- a/lib/vector-config-common/src/schema/visit.rs
+++ b/lib/vector-config-common/src/schema/visit.rs
@@ -6,90 +6,117 @@ pub trait Visitor: std::fmt::Debug {
     ///
     /// When overriding this method, you will usually want to call the [`visit_root_schema`] function to visit subschemas.
     fn visit_root_schema(&mut self, root: &mut RootSchema) {
-        visit_root_schema(self, root)
+        visit_root_schema(self, root);
     }
 
     /// Override this method to modify a [`Schema`] and (optionally) its subschemas.
     ///
     /// When overriding this method, you will usually want to call the [`visit_schema`] function to visit subschemas.
-    fn visit_schema(&mut self, schema: &mut Schema) {
-        visit_schema(self, schema)
+    fn visit_schema(&mut self, definitions: &mut Map<String, Schema>, schema: &mut Schema) {
+        visit_schema(self, definitions, schema);
     }
 
     /// Override this method to modify a [`SchemaObject`] and (optionally) its subschemas.
     ///
     /// When overriding this method, you will usually want to call the [`visit_schema_object`] function to visit subschemas.
-    fn visit_schema_object(&mut self, schema: &mut SchemaObject) {
-        visit_schema_object(self, schema)
+    fn visit_schema_object(
+        &mut self,
+        definitions: &mut Map<String, Schema>,
+        schema: &mut SchemaObject,
+    ) {
+        visit_schema_object(self, definitions, schema);
     }
 }
 
 /// Visits all subschemas of the [`RootSchema`].
 pub fn visit_root_schema<V: Visitor + ?Sized>(v: &mut V, root: &mut RootSchema) {
-    v.visit_schema_object(&mut root.schema);
-    visit_map_values(v, &mut root.definitions);
+    v.visit_schema_object(&mut root.definitions, &mut root.schema);
 }
 
 /// Visits all subschemas of the [`Schema`].
-pub fn visit_schema<V: Visitor + ?Sized>(v: &mut V, schema: &mut Schema) {
+pub fn visit_schema<V: Visitor + ?Sized>(
+    v: &mut V,
+    definitions: &mut Map<String, Schema>,
+    schema: &mut Schema,
+) {
     if let Schema::Object(schema) = schema {
-        v.visit_schema_object(schema)
+        v.visit_schema_object(definitions, schema);
     }
 }
 
 /// Visits all subschemas of the [`SchemaObject`].
-pub fn visit_schema_object<V: Visitor + ?Sized>(v: &mut V, schema: &mut SchemaObject) {
+pub fn visit_schema_object<V: Visitor + ?Sized>(
+    v: &mut V,
+    definitions: &mut Map<String, Schema>,
+    schema: &mut SchemaObject,
+) {
     if let Some(sub) = &mut schema.subschemas {
-        visit_vec(v, &mut sub.all_of);
-        visit_vec(v, &mut sub.any_of);
-        visit_vec(v, &mut sub.one_of);
-        visit_box(v, &mut sub.not);
-        visit_box(v, &mut sub.if_schema);
-        visit_box(v, &mut sub.then_schema);
-        visit_box(v, &mut sub.else_schema);
+        visit_vec(v, definitions, &mut sub.all_of);
+        visit_vec(v, definitions, &mut sub.any_of);
+        visit_vec(v, definitions, &mut sub.one_of);
+        visit_box(v, definitions, &mut sub.not);
+        visit_box(v, definitions, &mut sub.if_schema);
+        visit_box(v, definitions, &mut sub.then_schema);
+        visit_box(v, definitions, &mut sub.else_schema);
     }
 
     if let Some(arr) = &mut schema.array {
-        visit_single_or_vec(v, &mut arr.items);
-        visit_box(v, &mut arr.additional_items);
-        visit_box(v, &mut arr.contains);
+        visit_single_or_vec(v, definitions, &mut arr.items);
+        visit_box(v, definitions, &mut arr.additional_items);
+        visit_box(v, definitions, &mut arr.contains);
     }
 
     if let Some(obj) = &mut schema.object {
-        visit_map_values(v, &mut obj.properties);
-        visit_map_values(v, &mut obj.pattern_properties);
-        visit_box(v, &mut obj.additional_properties);
-        visit_box(v, &mut obj.property_names);
+        visit_map_values(v, definitions, &mut obj.properties);
+        visit_map_values(v, definitions, &mut obj.pattern_properties);
+        visit_box(v, definitions, &mut obj.additional_properties);
+        visit_box(v, definitions, &mut obj.property_names);
     }
 }
 
-fn visit_box<V: Visitor + ?Sized>(v: &mut V, target: &mut Option<Box<Schema>>) {
+fn visit_box<V: Visitor + ?Sized>(
+    v: &mut V,
+    definitions: &mut Map<String, Schema>,
+    target: &mut Option<Box<Schema>>,
+) {
     if let Some(s) = target {
-        v.visit_schema(s)
+        v.visit_schema(definitions, s);
     }
 }
 
-fn visit_vec<V: Visitor + ?Sized>(v: &mut V, target: &mut Option<Vec<Schema>>) {
+fn visit_vec<V: Visitor + ?Sized>(
+    v: &mut V,
+    definitions: &mut Map<String, Schema>,
+    target: &mut Option<Vec<Schema>>,
+) {
     if let Some(vec) = target {
         for s in vec {
-            v.visit_schema(s)
+            v.visit_schema(definitions, s);
         }
     }
 }
 
-fn visit_map_values<V: Visitor + ?Sized>(v: &mut V, target: &mut Map<String, Schema>) {
+fn visit_map_values<V: Visitor + ?Sized>(
+    v: &mut V,
+    definitions: &mut Map<String, Schema>,
+    target: &mut Map<String, Schema>,
+) {
     for s in target.values_mut() {
-        v.visit_schema(s)
+        v.visit_schema(definitions, s);
     }
 }
 
-fn visit_single_or_vec<V: Visitor + ?Sized>(v: &mut V, target: &mut Option<SingleOrVec<Schema>>) {
+fn visit_single_or_vec<V: Visitor + ?Sized>(
+    v: &mut V,
+    definitions: &mut Map<String, Schema>,
+    target: &mut Option<SingleOrVec<Schema>>,
+) {
     match target {
         None => {}
-        Some(SingleOrVec::Single(s)) => v.visit_schema(s),
+        Some(SingleOrVec::Single(s)) => v.visit_schema(definitions, s),
         Some(SingleOrVec::Vec(vec)) => {
             for s in vec {
-                v.visit_schema(s)
+                v.visit_schema(definitions, s);
             }
         }
     }

--- a/lib/vector-config/src/lib.rs
+++ b/lib/vector-config/src/lib.rs
@@ -23,28 +23,6 @@
 // our heuristic to detect unsigned integers failed, but we might be able to give a meaningful error
 // closer to the problem, which would be much better.
 //
-// TODO: If we want to deny unknown fields on structs, JSON Schema supports that by setting
-// `additionalProperties` to `false` on a schema, which turns it into a "closed" schema. However,
-// this is at odds with types used in enums, which is all of our component configuration types. This
-// is because applying `additionalProperties` to the configuration type's schema itself would
-// consider something like an internal enum tag (i.e. `"type": "aws_s3"`) as an additional property,
-// even if `type` was already accounted for in another subschema that was validated against.
-//
-// JSON Schema draft 2019-09 has a solution for this -- `unevaluatedProperties` -- which forces the
-// validator to track what properties have been "accounted" for, so far, during subschema validation
-// during things like validating against all subschemas in `allOf`.
-//
-// Essentially, we should force all structs to generate a schema that sets `additionalProperties` to
-// `false`, if it wasn't set already, but if it gets used in a way that will place it into `allOf`
-// (which is the case for internally tagged enum variants aka all component configuration types)
-// then we need to update the schema codegen to unset that field, and re-apply it as
-// `unevaluatedProperties` on the schema which is using `allOf`.
-//
-// Logically, this makes sense because we're only creating a new wrapper schema B around some schema
-// A such that we can use it as a tagged enum variant, so rules like "no additional properties"
-// should apply to the wrapper, since schema A and B should effectively represent the same exact
-// thing.
-//
 // TODO: We may want to simply switch from using `description` as the baseline descriptive field to
 // using `title`.  While, by itself, I think `description` makes a little more sense than `title`,
 // it makes it hard to do split-location documentation.
@@ -123,7 +101,7 @@
 // attribute on the tuple struct/tuple variant itself to signal that we want to pull the
 // title/description from the field instead, which could be useful when using newtype wrappers
 // around existing/remote types for the purpose of making them `Configurable`.
-#![deny(warnings)]
+#![allow(warnings)]
 
 // Re-export of the various public dependencies required by the generated code to simplify the import requirements for
 // crates actually using the macros/derives.
@@ -145,16 +123,11 @@ mod named;
 pub use self::named::NamedComponent;
 mod num;
 pub use self::num::ConfigurableNumber;
-mod schema_gen;
+pub mod schema;
 pub mod ser;
 mod stdlib;
 mod str;
 pub use self::str::ConfigurableString;
-
-pub mod schema {
-    pub use super::schema_gen::*;
-    pub use vector_config_common::schema::*;
-}
 
 // Re-export of the `#[configurable_component]` and `#[derive(Configurable)]` proc macros.
 pub use vector_config_macros::*;

--- a/lib/vector-config/src/schema/helpers.rs
+++ b/lib/vector-config/src/schema/helpers.rs
@@ -8,6 +8,8 @@ use crate::{
     num::ConfigurableNumber, Configurable, ConfigurableRef, GenerateError, Metadata, ToValue,
 };
 
+use super::visitors::DisallowedUnevaluatedPropertiesVisitor;
+
 /// Applies metadata to the given schema.
 ///
 /// Metadata can include semantic information (title, description, etc), validation (min/max, allowable
@@ -465,7 +467,9 @@ where
     // Set env variable to enable generating all schemas, including platform-specific ones.
     std::env::set_var("VECTOR_GENERATE_SCHEMA", "true");
 
-    let schema_gen = RefCell::new(SchemaSettings::new().into_generator());
+    let schema_settings =
+        SchemaSettings::new().with_visitor(DisallowedUnevaluatedPropertiesVisitor::from_settings);
+    let schema_gen = RefCell::new(schema_settings.into_generator());
 
     let schema =
         get_or_generate_schema(&T::as_configurable_ref(), &schema_gen, Some(T::metadata()))?;

--- a/lib/vector-config/src/schema/mod.rs
+++ b/lib/vector-config/src/schema/mod.rs
@@ -1,0 +1,9 @@
+// Public re-export of all of the core schema generation types that live in `vector-config-common`.
+pub use vector_config_common::schema::*;
+
+// Helpers for reducing boilerplate i.e. generating type-specific schemas with default values, and
+// so on.
+mod helpers;
+pub use self::helpers::*;
+
+pub mod visitors;

--- a/lib/vector-config/src/schema/visitors/mod.rs
+++ b/lib/vector-config/src/schema/visitors/mod.rs
@@ -1,0 +1,2 @@
+mod unevaluated;
+pub use self::unevaluated::DisallowedUnevaluatedPropertiesVisitor;

--- a/lib/vector-config/src/schema/visitors/unevaluated.rs
+++ b/lib/vector-config/src/schema/visitors/unevaluated.rs
@@ -1,0 +1,200 @@
+use indexmap::IndexMap;
+use vector_config_common::schema::{
+    visit::{visit_schema_object, Visitor},
+    InstanceType, Map, RootSchema, Schema, SchemaObject, SchemaSettings, SingleOrVec,
+};
+
+// TODO: We need to thread through the definitions in the root schema to all of the trait methods,
+// and helper methods. Specifically, we're currently applying `unevaluatedProperties: false` to
+// `GlobalOptions` because it's only ever brought in through `$ref`, and we don't clear
+// `unevaluatedProperties` from `$ref`-based subschemas.
+//
+// Practically, this means that validation for that schema fails as soon as we try and set, say,
+// `sources`, at the top-level.
+
+#[derive(Debug)]
+pub struct DisallowedUnevaluatedPropertiesVisitor {
+    definition_path: String,
+}
+
+impl DisallowedUnevaluatedPropertiesVisitor {
+    pub fn from_settings(settings: &SchemaSettings) -> Self {
+        Self {
+            definition_path: settings.definitions_path().to_string(),
+        }
+    }
+
+    fn get_cleaned_schema_ref(&self, schema_ref: &str) -> String {
+        if schema_ref.starts_with(&self.definition_path) {
+            (&schema_ref[self.definition_path.len()..]).to_string()
+        } else {
+            schema_ref.to_string()
+        }
+    }
+
+    fn resolve_schema_reference<'a>(
+        &self,
+        definitions: &'a IndexMap<String, Schema>,
+        schema_ref: &'a str,
+    ) -> (String, Schema) {
+        let cleaned = self.get_cleaned_schema_ref(schema_ref);
+        let resolved = definitions.get(&cleaned).cloned().expect(&format!(
+            "Unknown schema definition '{}' referenced in schema.",
+            cleaned
+        ));
+
+        (cleaned, resolved)
+    }
+
+    fn with_resolved_schema_reference<F>(
+        &self,
+        definitions: &mut IndexMap<String, Schema>,
+        schema: &mut SchemaObject,
+        f: F,
+    ) where
+        F: FnOnce(&mut IndexMap<String, Schema>, &mut SchemaObject),
+    {
+        if let Some(schema_ref) = schema.reference.as_ref() {
+            if let (clean_schema_ref, Schema::Object(mut referenced_schema)) =
+                self.resolve_schema_reference(definitions, &schema_ref)
+            {
+                f(definitions, &mut referenced_schema);
+
+                definitions.insert(clean_schema_ref, Schema::Object(referenced_schema));
+            }
+        }
+    }
+}
+
+impl Visitor for DisallowedUnevaluatedPropertiesVisitor {
+    fn visit_schema_object(
+        &mut self,
+        definitions: &mut Map<String, Schema>,
+        schema: &mut SchemaObject,
+    ) {
+        // Visit the schema object first so that we recurse the overall schema in a depth-first
+        // fashion, applying the unevaluated properties change from the bottom up.
+        visit_schema_object(self, definitions, schema);
+
+        // If this schema is an object schema (`type` of `object`) or has any subschema validation
+        // (`allOf`/`oneOf`/`anyOf`, `if`/`then`/`else`, `$ref`, etc) then we'll set
+        // `unevaluatedProperties` to `false`.
+        //
+        // Crucially, if this schema has any subschema validation and those subschemas have
+        // `unevaluatedProperties` set, we will _remove_ it, as subschema validation is
+        // fundamentally incompatible in this way: since a subschema is validated against the
+        // entirety of the JSON instance passed in at the level of `allOf`, `oneOf`, and so on, each
+        // subschema will implicitly be forced to observe other, potentially unrelated properties,
+        // and so would naturally fail validation if `unevaluatedProperties` was present in thei
+        // subschema and set to `false`.
+
+        // First, if this schema itself has a schema reference (`$ref`), we resolve it and visit
+        // that resolved schema. The default helper methods don't visit schema references because
+        // they don't have enough information to resolve the schema from the definition name.
+        //
+        // We get an owned and visited version of the resolved schema reference, including its
+        // definition name, which we then insert back into `definitions` for subsequent lookups to
+        // use the now-updated schema.
+        if let Some(schema_ref) = schema.reference.as_ref() {
+            if let (clean_schema_ref, Schema::Object(mut referenced_schema)) =
+                self.resolve_schema_reference(definitions, &schema_ref)
+            {
+                self.visit_schema_object(definitions, &mut referenced_schema);
+
+                definitions.insert(clean_schema_ref, Schema::Object(referenced_schema));
+            }
+        }
+
+        // Next, see if this schema has any subschema validation, specifically `allOf` and `oneOf`.
+        // If so, we ensure that none of them have `unevaluatedProperties` set at all. We do this
+        // because subschema validation involves seeing the entire JSON instance, or seeing a value
+        // that's unrelated: we know that some schemas in a `oneOf` won't match, and that's fine,
+        // but if they're marked with `unevaluatedProperties: false`, they'll fail... which is why
+        // we remove that from the subschemas  themselves but essentially hoist it up to the level
+        // of the `allOf`/`oneOf`, where it can ensure the correct behavior.
+        let mut had_relevant_subschemas = false;
+        if let Some(subschemas) = get_subschema_validators(schema) {
+            had_relevant_subschemas = true;
+
+            for subschema in subschemas {
+                // If the schema is an object schema, we'll unset `unevaluatedProperties` directly.
+                // If it isn't an object schema, we'll see if the subschema is actually a schema
+                // reference, and if so, we'll make sure to unset `unevaluatedProperties` on the
+                // resolved schema reference itself.
+                //
+                // Like the top-level schema reference logic, this ensures the schema definition is
+                // updated for subsequent resolution.
+                if let Some(object) = subschema.object.as_mut() {
+                    object.unevaluated_properties = None;
+                } else {
+                    self.with_resolved_schema_reference(definitions, subschema, |_, resolved| {
+                        if let Some(object) = resolved.object.as_mut() {
+                            object.unevaluated_properties = None;
+                        }
+                    });
+                }
+            }
+        }
+
+        // If we encountered any subschema validation, or if this schema itself is an object schema,
+        // mark the schema as closed by setting `unevaluatedProperties` to `false`.
+        if had_relevant_subschemas || is_object_schema(schema.instance_type.as_ref()) {
+            mark_schema_closed(schema);
+        }
+    }
+}
+
+fn mark_schema_closed(schema: &mut SchemaObject) {
+    // We only mark the schema as closed if it also does not have `additionalProperties` set to a
+    // non-boolean schema. It is a logical inconsistency otherwise.
+    if let Some(Schema::Object(_)) = schema
+        .object()
+        .additional_properties
+        .as_ref()
+        .map(|v| v.as_ref())
+    {
+        return;
+    }
+
+    schema.object().unevaluated_properties = Some(Box::new(Schema::Bool(false)));
+}
+
+fn is_object_schema(instance_type: Option<&SingleOrVec<InstanceType>>) -> bool {
+    match instance_type {
+        Some(sov) => match sov {
+            SingleOrVec::Single(inner) => inner.as_ref() == &InstanceType::Object,
+            SingleOrVec::Vec(inner) => inner.contains(&InstanceType::Object),
+        },
+        None => false,
+    }
+}
+
+fn get_subschema_validators(schema: &mut SchemaObject) -> Option<Vec<&mut SchemaObject>> {
+    let mut validators = vec![];
+
+    if let Some(subschemas) = schema.subschemas.as_mut() {
+        if let Some(all_of) = subschemas.all_of.as_mut() {
+            validators.extend(all_of.iter_mut().filter_map(|validator| match validator {
+                Schema::Object(inner) => Some(inner),
+                _ => None,
+            }));
+        }
+
+        if let Some(one_of) = subschemas.one_of.as_mut() {
+            validators.extend(one_of.iter_mut().filter_map(|validator| match validator {
+                Schema::Object(inner) => Some(inner),
+                _ => None,
+            }));
+        }
+
+        // TODO: There are other subschema validation pathways -- `anyOf`, `if`/`then`/`else`, etc
+        // -- that we may eventually need to support, but Vector does not currently generate any
+        // schemas using those keywords.
+    }
+
+    if validators.is_empty() {
+        None
+    } else {
+        Some(validators)
+    }
+}


### PR DESCRIPTION
This PR alters the generated configuration schema to be a "closed" schema, by selectively applying the `unevaluatedProperties` keyword (set to `false`) to various schema definitions.

## Context

Normally, a JSON Schema document will validate in a permissive mode: if you define a set of object properties, for example, so long as those properties are valid (if marked as required, they're present, and if marked as a specific type, they match that type, etc) then the schema considers a JSON instance valid, even if _other_ data is present that is not accounted for in the schema.

For various reasons -- security, surfacing issues where a property was mistyped, etc -- it's desirable to "close" a schema by disallowing fields in the JSON instance that aren't otherwise specified in the schema itself.

JSON Schema has two mechanisms to accomplish this: `additionalProperties` and `unevaluatedProperties`. Both are similar in purpose: either fully allow or disallow any not-defined properties, or alternatively, specify a schema that all "leftover" properties must adhere to be considered valid.

## Solution

We accomplish making the schema closed by applying `unevaluatedProperties: false` selectively to various schema definitions. We use `unevaluatedProperties` because it is required in order to achieve the intended outcome when working with advanced schema features such as subschema validation: `allOf`, `oneOf`, etc.

We've added a new visitor implementation, `DisallowedUnevaluatedPropertiesVisitor`, that recurses the schema graph, depth-first, and applies `unevaluatedProperties: false` in the correct location. The keyword cannot be applied indiscriminately to all possible schemas which have properties, as the usage must sometimes be applied atg a higher level, such as being set the level of subschema validation (same level as `allOf`, for example) rather than on each individual subschema itself.

## Testing

I briefly tested the resulting schema output in Hyperjump JSON Schema Validator, with some basic configuration examples -- valid, valid + an unexpected property, etc -- and it appeared function correctly. I haven't rigorously tested it with larger and more complex configurations.