### PR TITLE
fix(panic): fix panic under low resources

### DIFF
--- a/src/sources/util/net/tcp/request_limiter.rs
+++ b/src/sources/util/net/tcp/request_limiter.rs
@@ -57,7 +57,10 @@ impl RequestLimiterData {
 
     pub fn target_requests_in_flight(&self) -> usize {
         let target = (self.event_limit_target as f64) / self.average_request_size.average();
-        (target as usize).clamp(MINIMUM_PERMITS, self.max_requests)
+        #[allow(clippy::manual_clamp)]
+        (target as usize)
+            .max(MINIMUM_PERMITS)
+            .min(self.max_requests)
     }
 
     pub fn increase_permits(&mut self) {


### PR DESCRIPTION
Should resolve https://github.com/vectordotdev/vector/issues/16273

`clamp` call panics under certain situations, the `max`/`min` pair - does not (as it was written before `clamp` introduction in b56193e6769ea01cf375f90c7da57f540f609d6c (Rust 1.66 upgrade)).