### PR TITLE
feat(vrl): add `ingress_upstreaminfo` log format to `parse_nginx_log`

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -385,6 +385,7 @@ Treq
 tzdata
 ubuntu
 Umeox
+upstreaminfo
 useragents
 usergroups
 userguide

--- a/lib/vrl/stdlib/benches/benches.rs
+++ b/lib/vrl/stdlib/benches/benches.rs
@@ -1727,6 +1727,33 @@ bench_function! {
         })),
     }
 
+    ingress_upstreaminfo {
+        args: func_args![
+            value: r#"0.0.0.0 - - [18/Mar/2023:15:00:00 +0000] "GET /some/path HTTP/2.0" 200 12312 "https://10.0.0.1/some/referer" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36" 462 0.050 [some-upstream-service-9000] [] 10.0.50.80:9000 19437 0.049 200 752178adb17130b291aefd8c386279e7"#,
+            format: "ingress_upstreaminfo",
+        ],
+        want: Ok(value!({
+            "remote_addr" => "0.0.0.0",
+            "timestamp" => Value::Timestamp(DateTime::parse_from_rfc3339("2023-03-18T15:00:00Z").unwrap().info()),
+            "request" => "GET /some/path HTTP/2.0",
+            "method" => "GET",
+            "path" => "/some/path",
+            "protocol" => "HTTP/2.0",
+            "status" => 200,
+            "body_bytes_size" => 12312,
+            "http_referer" => "https://10.0.0.1/some/referer",
+            "http_user_agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+            "request_length" => 462,
+            "request_time" => 0.050,
+            "proxy_upstream_name" => "some-upstream-service-9000",
+            "upstream_addr" => "10.0.50.80:9000",
+            "upstream_response_length" => 19437,
+            "upstream_response_time" => 0.049,
+            "upstream_status" => 200,
+            "req_id" => "752178adb17130b291aefd8c386279e7",
+        })),
+    }
+
     error {
         args: func_args![value: r#"2021/04/01 13:02:31 [error] 31#31: *1 open() "/usr/share/nginx/html/not-found" failed (2: No such file or directory), client: 172.17.0.1, server: localhost, request: "POST /not-found HTTP/1.1", host: "localhost:8081""#,
                          format: "error"

--- a/website/cue/reference/remap/functions/parse_nginx_log.cue
+++ b/website/cue/reference/remap/functions/parse_nginx_log.cue
@@ -3,7 +3,8 @@ package metadata
 remap: functions: parse_nginx_log: {
 	category:    "Parse"
 	description: """
-        Parses Nginx access and error log lines. Lines can be in [`combined`](\(urls.nginx_combined)), or [`error`](\(urls.nginx_error)) format.
+        Parses Nginx access and error log lines. Lines can be in [`combined`](\(urls.nginx_combined)),
+        [`ingress_upstreaminfo`(\(urls.nginx_ingress_upstreaminfo))] or [`error`](\(urls.nginx_error)) format.
         """
 	notices: [
 		"""
@@ -36,6 +37,7 @@ remap: functions: parse_nginx_log: {
 			required:    true
 			enum: {
 				"combined": "Nginx combined format"
+				"ingress_upstreaminfo": "Ingress-Nginx upstreaminfo format"
 				"error":    "Default Nginx error format"
 			}
 			type: ["string"]

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -372,6 +372,7 @@ urls: {
 	nginx:                                      "https://www.nginx.com/"
 	nginx_combined:                             "https://nginx.org/en/docs/http/ngx_http_log_module.html"
 	nginx_error:                                "https://github.com/nginx/nginx/blob/branches/stable-1.18/src/core/ngx_log.c#L102"
+	nginx_ingress_upstreaminfo:                 "https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/"
 	nginx_stub_status_module:                   "http://nginx.org/en/docs/http/ngx_http_stub_status_module.html"
 	nix:                                        "https://nixos.org/nix/"
 	nixos:                                      "https://nixos.org/"


### PR DESCRIPTION
Fixes vectordotdev/vrl#5


Also, what do you guys think on renaming parsed fields like they are named in Nginx docs [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/)?

I would stick with that nginx's internal fields naming "convention", it's so close to RFCs at least.

If you are agree with this, I would make another PR to rename fields in "combined" format too