### PR TITLE
refactor(deps): looser prost version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,8 +211,8 @@ rmp-serde = { version = "1.1.1", default-features = false, optional = true }
 rmpv = { version = "1.0.0", default-features = false, features = ["with-serde"], optional = true }
 
 # Prost
-prost = { version = "0.11.8", default-features = false, features = ["std"] }
-prost-types = { version = "0.11.8", default-features = false, optional = true }
+prost = { version = "0.11", default-features = false, features = ["std"] }
+prost-types = { version = "0.11", default-features = false, optional = true }
 
 # GCP
 goauth = { version = "0.13.1", optional = true }
@@ -346,7 +346,7 @@ atty = { version = "0.2.14", default-features = false }
 nix = { version = "0.26.2", default-features = false, features = ["socket", "signal"] }
 
 [build-dependencies]
-prost-build = { version = "0.11.8", default-features = false, optional = true }
+prost-build = { version = "0.11", default-features = false, optional = true }
 tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"], optional = true }
 openssl-src = { version = "111", default-features = false, features = ["force-engine"] }
 

--- a/lib/opentelemetry-proto/Cargo.toml
+++ b/lib/opentelemetry-proto/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [build-dependencies]
-prost-build = { version = "0.11.8", default-features = false}
+prost-build = { version = "0.11", default-features = false}
 tonic-build = { version = "0.8", default-features = false, features = ["prost", "transport"] }
 
 [dependencies]
@@ -15,7 +15,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 lookup = { package = "vector-lookup", path = "../vector-lookup", default-features = false }
 ordered-float = { version = "3.4.0", default-features = false }
-prost = { version = "0.11.8", default-features = false, features = ["std"] }
+prost = { version = "0.11", default-features = false, features = ["std"] }
 tonic = { version = "0.8", default-features = false, features = ["codegen", "gzip", "prost", "tls", "tls-roots", "transport"] }
 value = { path = "../vrl/value"}
 vector-core = { path = "../vector-core", default-features = false }

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -12,11 +12,11 @@ license = "MPL-2.0"
 indexmap = "~1.9.2"
 nom = "7.1.3"
 num_enum = "0.5.11"
-prost = "0.11.8"
-prost-types = "0.11.8"
+prost = "0.11"
+prost-types = "0.11"
 snafu = { version = "0.7" }
 vector-common = { path = "../vector-common", features = ["btreemap"] }
 value = { path = "../vrl/value", features = ["json"] }
 
 [build-dependencies]
-prost-build = "0.11.8"
+prost-build = "0.11"

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -35,8 +35,8 @@ ordered-float = { version = "3.4.0", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 pin-project = { version = "1.0.12", default-features = false }
 proptest = { version = "1.1", optional = true }
-prost-types = { version = "0.11.8", default-features = false }
-prost = { version = "0.11.8", default-features = false, features = ["std"] }
+prost-types = { version = "0.11", default-features = false }
+prost = { version = "0.11", default-features = false, features = ["std"] }
 quanta = { version = "0.10.1", default-features = false }
 regex = { version = "1.7.1", default-features = false, features = ["std", "perf"] }
 ryu = { version = "1", default-features = false }
@@ -77,7 +77,7 @@ security-framework = "2.8.2"
 schannel = "0.1.21"
 
 [build-dependencies]
-prost-build = "0.11.8"
+prost-build = "0.11"
 
 [dev-dependencies]
 base64 = "0.21.0"


### PR DESCRIPTION
Here at Greptime, we are working on a vector sink that writes data into [GreptimeDB](https://github.com/greptimeteam/greptimedb). One of issues that blocked us was that GreptimeDB's client depends on arrow-flight which has a pinned version of [prost-build](https://github.com/apache/arrow-rs/blob/master/arrow-flight/Cargo.tomlL71). Anytime when vector's prost-build version requirement is ahead of arrow-flight, it results in a version conflict at cargo, like:

```
error: failed to select a version for `prost-build`.
    ... required by package `arrow-flight v33.0.0`
    ... which satisfies dependency `arrow-flight = "^33.0"` of package `api v0.1.0 (https://github.com/GreptimeTeam/greptimedb.git?rev=bd98a26ccaa24e3d26681a1054d2d21972755bd3#bd98a26c)`
    ... which satisfies git dependency `api` (locked to 0.1.0) of package `client v0.1.0 (https://github.com/GreptimeTeam/greptimedb.git?rev=bd98a26ccaa24e3d26681a1054d2d21972755bd3#bd98a26c)`
    ... which satisfies git dependency `greptimedb-client` (locked to 0.1.0) of package `vector v0.29.0 (/home/sunng/opensource/vector)`
versions that meet the requirements `=0.11.6` are: 0.11.6

all possible versions conflict with previously selected packages.

  previously selected package `prost-build v0.11.8`
    ... which satisfies dependency `prost-build = "^0.11.8"` of package `opentelemetry-proto v0.1.0 (/home/sunng/opensource/vector/lib/opentelemetry-proto)`
    ... which satisfies path dependency `opentelemetry-proto` (locked to 0.1.0) of package `vector v0.29.0 (/home/sunng/opensource/vector)`

failed to select a version for `prost-build` which could resolve this conflict
```

cargo seems to require consistent version across all build-dependencies.

Judging from the commit history, it seems vector doesn't depends on a particular version of prost to compile. Here I proposal to make prost version requirement looser by remove the patch part so it works in more conditions. 