### PR TITLE
(dont merge) chore(observability): enable allocation tracing by default to establish baseline

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,7 +161,7 @@ pub struct RootOpts {
 
     /// Set runtime allocation tracing
     #[cfg(feature = "allocation-tracing")]
-    #[arg(long, env = "ALLOCATION_TRACING", default_value = "false")]
+    #[arg(long, env = "ALLOCATION_TRACING", default_value = "true")]
     pub allocation_tracing: bool,
 
     /// Set allocation tracing reporting rate in milliseconds.


### PR DESCRIPTION
This PR is purely for triggering the Regression Detector CI workflow to understand the baseline performance overhead of allocation tracing when enabled, in support of evaluating the differences (if any) in performance overhead with an attempt in #15638 to partially use a batching approach for collecting allocation events.