### PR TITLE
chore(startup): Split up `Application::run` into logical phases

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -109,6 +109,39 @@ impl ApplicationConfig {
             enterprise,
         })
     }
+
+    /// Configure the API server, if applicable
+    #[cfg(feature = "api")]
+    pub fn setup_api(&self) -> Option<api::Server> {
+        if self.api.enabled {
+            use std::sync::atomic::AtomicBool;
+
+            let api_server = api::Server::start(
+                self.topology.config(),
+                self.topology.watch(),
+                Arc::<AtomicBool>::clone(&self.topology.running),
+            );
+
+            match api_server {
+                Ok(api_server) => {
+                    emit!(ApiStarted {
+                        addr: self.api.address.unwrap(),
+                        playground: self.api.playground
+                    });
+
+                    Some(api_server)
+                }
+                Err(e) => {
+                    error!("An error occurred that Vector couldn't handle: {}.", e);
+                    let _ = self.graceful_crash_sender.send(());
+                    None
+                }
+            }
+        } else {
+            info!(message="API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.");
+            None
+        }
+    }
 }
 
 impl Application {
@@ -160,6 +193,9 @@ impl Application {
         // early buffer by this point and set up a subscriber.
         crate::trace::stop_early_buffering();
 
+        emit!(VectorStarted);
+        tokio::spawn(heartbeat::heartbeat());
+
         let Self {
             require_healthy,
             config,
@@ -169,52 +205,14 @@ impl Application {
         let mut signal_handler = signals.handler;
         let mut signal_rx = signals.receiver;
 
-        let topology = config.topology;
-        let config_paths = config.config_paths;
-
-        emit!(VectorStarted);
-        tokio::spawn(heartbeat::heartbeat());
-
-        // Configure the API server, if applicable.
-        #[cfg(feature = "api")]
-        // Assigned to prevent the API terminating when falling out of scope.
-        let api_server = if config.api.enabled {
-            use std::sync::atomic::AtomicBool;
-
-            let api_server = api::Server::start(
-                topology.config(),
-                topology.watch(),
-                Arc::<AtomicBool>::clone(&topology.running),
-            );
-
-            match api_server {
-                Ok(api_server) => {
-                    emit!(ApiStarted {
-                        addr: config.api.address.unwrap(),
-                        playground: config.api.playground
-                    });
-
-                    Some(api_server)
-                }
-                Err(e) => {
-                    error!("An error occurred that Vector couldn't handle: {}.", e);
-                    let _ = config.graceful_crash_sender.send(());
-                    None
-                }
-            }
-        } else {
-            info!(message="API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.");
-            None
-        };
-
         let topology_controller = TopologyController {
-            topology,
-            config_paths: config_paths.clone(),
+            #[cfg(feature = "api")]
+            api_server: config.setup_api(),
+            topology: config.topology,
+            config_paths: config.config_paths.clone(),
             require_healthy,
             #[cfg(feature = "enterprise")]
             enterprise_reporter: config.enterprise,
-            #[cfg(feature = "api")]
-            api_server,
         };
         let topology_controller = Arc::new(Mutex::new(topology_controller));
 
@@ -256,7 +254,7 @@ impl Application {
                             let mut topology_controller = topology_controller.lock().await;
 
                             // Reload paths
-                            if let Some(paths) = config::process_paths(&config_paths) {
+                            if let Some(paths) = config::process_paths(&config.config_paths) {
                                 topology_controller.config_paths = paths;
                             }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,9 +7,12 @@ use futures::StreamExt;
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
 use once_cell::race::OnceNonZeroUsize;
+use serde::ser::StdError;
+use stream_cancel::Trigger;
 use tokio::{
     runtime::{self, Runtime},
     sync::{mpsc, Mutex},
+    task::JoinHandle,
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -28,7 +31,7 @@ use crate::{
     cli::{handle_config_errors, LogFormat, Opts},
     config::{self, Config, ConfigPath},
     heartbeat,
-    signal::{SignalHandler, SignalPair, SignalTo},
+    signal::{SignalHandler, SignalPair, SignalRx, SignalTo},
     topology::{self, ReloadOutcome, RunningTopology, TopologyController},
     trace,
 };
@@ -264,6 +267,10 @@ pub struct StartedApplication {
 
 impl StartedApplication {
     pub async fn run(self) {
+        self.main().await.shutdown().await
+    }
+
+    pub async fn main(self) -> FinishedApplication {
         let Self {
             config_paths,
             control_server_pieces,
@@ -319,6 +326,37 @@ impl StartedApplication {
                 else => unreachable!("Signal streams never end"),
             }
         };
+
+        FinishedApplication {
+            #[cfg(not(windows))]
+            control_server_pieces,
+            signal,
+            signal_rx,
+            topology_controller,
+        }
+    }
+}
+
+pub struct FinishedApplication {
+    #[cfg(not(windows))]
+    control_server_pieces: Option<(
+        Trigger,
+        JoinHandle<Result<(), Box<dyn StdError + Send + Sync>>>,
+    )>,
+    signal: SignalTo,
+    signal_rx: SignalRx,
+    topology_controller: Arc<Mutex<TopologyController>>,
+}
+
+impl FinishedApplication {
+    pub async fn shutdown(self) {
+        let FinishedApplication {
+            #[cfg(not(windows))]
+            control_server_pieces,
+            signal,
+            mut signal_rx,
+            topology_controller,
+        } = self;
 
         // Shut down the control server, if running
         #[cfg(not(windows))]

--- a/src/control_server.rs
+++ b/src/control_server.rs
@@ -13,6 +13,7 @@ use axum::{
 use futures::FutureExt;
 use http::StatusCode;
 use hyper::server::{self, conn::Http};
+use serde::ser::StdError;
 use serde_json::json;
 use stream_cancel::Tripwire;
 use tokio::{net::UnixListener, sync::Mutex};
@@ -29,6 +30,9 @@ pub struct ControlServer {
     shutdown_signal: Tripwire,
     socket_path: PathBuf,
 }
+
+pub type Handle = tokio::task::JoinHandle<Result<(), Box<dyn StdError + Send + Sync>>>;
+pub type Pieces = (stream_cancel::Trigger, Handle);
 
 impl ControlServer {
     pub fn bind(
@@ -47,6 +51,18 @@ impl ControlServer {
             topology_controller,
             shutdown_signal,
             socket_path: socket_path.as_ref().to_path_buf(),
+        })
+    }
+
+    pub fn start(
+        socket_path: impl AsRef<Path>,
+        topology_controller: &Arc<Mutex<TopologyController>>,
+        runtime: &tokio::runtime::Runtime,
+    ) -> Result<Pieces, Box<dyn StdError + Send + Sync>> {
+        let (shutdown_trigger, tripwire) = stream_cancel::Tripwire::new();
+        Self::bind(socket_path, Arc::clone(topology_controller), tripwire).map(|control_server| {
+            let server_handle = runtime.spawn(control_server.run());
+            (shutdown_trigger, server_handle)
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,7 @@ fn main() {
         }
     }
 
-    let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
-        std::process::exit(code);
-    });
-
-    runtime.block_on(app.run());
+    Application::run();
 }
 
 #[cfg(windows)]
@@ -48,11 +44,5 @@ pub fn main() {
     // to run vector as a service. If we fail, we consider that we are in
     // interactive mode and then fallback to console mode.  See
     // https://docs.microsoft.com/en-us/dotnet/api/system.environment.userinteractive?redirectedfrom=MSDN&view=netcore-3.1#System_Environment_UserInteractive
-    vector::vector_windows::run().unwrap_or_else(|_| {
-        let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
-            std::process::exit(code);
-        });
-
-        runtime.block_on(app.run());
-    });
+    vector::vector_windows::run().unwrap_or_else(|_| Application::run());
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -142,12 +142,11 @@ fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> {
 
     // The `signal` function must be run within the context of a Tokio runtime.
     runtime.block_on(async {
-        let mut sigint =
-            signal(SignalKind::interrupt()).expect("Signal handlers should not panic.");
+        let mut sigint = signal(SignalKind::interrupt()).expect("Failed to set up SIGINT handler.");
         let mut sigterm =
-            signal(SignalKind::terminate()).expect("Signal handlers should not panic.");
-        let mut sigquit = signal(SignalKind::quit()).expect("Signal handlers should not panic.");
-        let mut sighup = signal(SignalKind::hangup()).expect("Signal handlers should not panic.");
+            signal(SignalKind::terminate()).expect("Failed to set up SIGTERM handler.");
+        let mut sigquit = signal(SignalKind::quit()).expect("Failed to set up SIGQUIT handler.");
+        let mut sighup = signal(SignalKind::hangup()).expect("Failed to set up SIGHUP handler.");
 
         // Strictly speaking, setting up this stream does not need to be created within the async
         // block, but keeping it in the same block makes variable naming simpler.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -167,7 +167,7 @@ fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> {
 
 /// Signals from OS/user.
 #[cfg(windows)]
-async fn os_signals(_: &Runtime) -> impl Stream<Item = SignalTo> {
+fn os_signals(_: &Runtime) -> impl Stream<Item = SignalTo> {
     use futures::future::FutureExt;
 
     async_stream::stream! {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use tokio::sync::broadcast;
+use tokio::{runtime::Runtime, sync::broadcast};
 use tokio_stream::{Stream, StreamExt};
 
 use super::config::ConfigBuilder;
@@ -31,9 +31,9 @@ pub struct SignalPair {
 
 impl SignalPair {
     /// Create a new signal handler pair, and set them up to receive OS signals.
-    pub async fn new() -> Self {
+    pub fn new(runtime: &Runtime) -> Self {
         let (handler, receiver) = SignalHandler::new();
-        handler.forever(os_signals()).await;
+        handler.forever(runtime, os_signals());
         Self { handler, receiver }
     }
 }
@@ -70,17 +70,14 @@ impl SignalHandler {
 
     /// Takes a stream who's elements are convertible to `SignalTo`, and spawns a permanent
     /// task for transmitting to the receiver.
-    // This is not actually an async function, but it does call `tokio::spawn` which MUST be run in
-    // the context of an async reactor. Marking this as `async` enforces that requirement even
-    // though it never actually uses `await`.
-    async fn forever<T, S>(&self, stream: S)
+    fn forever<T, S>(&self, runtime: &Runtime, stream: S)
     where
         T: Into<SignalTo> + Send + Sync,
         S: Stream<Item = T> + 'static + Send,
     {
         let tx = self.tx.clone();
 
-        tokio::spawn(async move {
+        runtime.spawn(async move {
             tokio::pin!(stream);
 
             while let Some(value) = stream.next().await {

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -366,7 +366,7 @@ pub fn run() -> Result<()> {
 }
 
 fn run_service(_arguments: Vec<OsString>) -> Result<()> {
-    match Application::prepare() {
+    match Application::prepare_start() {
         Ok((runtime, app)) => {
             let signal_tx = app.signals.handler.clone_tx();
             let event_handler = move |control_event| -> ServiceControlHandlerResult {


### PR DESCRIPTION
This breaks up the application run process into three logical phases: starting, main loop, and shutdown, each in their own method. Separate structs are used in each phase to encode the proper flow of control in the type system.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
