### PR TITLE
[single-machine-performance] Update `smp` to 0.7.3

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -41,7 +41,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.7.2"
+          export SMP_CRATE_VERSION="0.7.3"
           export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"


### PR DESCRIPTION
This release adjusts how the `smp` program transmits data to its associated compute cluster. There are no user-facing changes in `smp`'s operation.

REF SMP-419