### PR TITLE
vdev: Move the `build` subcommand to `build vector`

### DIFF
--- a/vdev/src/commands/build/mod.rs
+++ b/vdev/src/commands/build/mod.rs
@@ -1,0 +1,4 @@
+crate::cli_subcommands! {
+    "Build components..."
+    mod vector,
+}

--- a/vdev/src/commands/build/vector.rs
+++ b/vdev/src/commands/build/vector.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use crate::app::CommandExt as _;
 use crate::platform;
 
-/// Build Vector
+/// Build the `vector` executable.
 #[derive(Args, Debug)]
 #[command()]
 pub struct Cli {


### PR DESCRIPTION
This will allow for more subcommands to be set up under `build`. AFAICT this command is not currently used anywhere in CI.

This is the first part of #16809 
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
