### PR TITLE
fix(docs, releasing): dpkg install docs use the correct package name

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/dpkg.md
+++ b/website/content/en/docs/setup/installation/package-managers/dpkg.md
@@ -12,9 +12,9 @@ weight: 2
 curl \
   --proto '=https' \
   --tlsv1.2 -O \
-  https://packages.timber.io/vector/{{< version >}}/vector-{{< version >}}-amd64.deb
+  https://packages.timber.io/vector/{{< version >}}/vector_{{< version >}}-1_amd64.deb
 
-sudo dpkg -i vector-{{< version >}}-amd64.deb
+sudo dpkg -i vector_{{< version >}}-1_amd64.deb
 ```
 
 ## Other actions

--- a/website/cue/reference/administration/interfaces/dpkg.cue
+++ b/website/cue/reference/administration/interfaces/dpkg.cue
@@ -20,8 +20,8 @@ administration: interfaces: dpkg: {
 	role_implementations: [Name=string]: {
 		commands: role_implementations._systemd_commands & {
 			install: #"""
-				curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/{version}/vector-{version}-{arch}.deb && \
-					sudo dpkg -i vector-{version}-{arch}.deb
+				curl --proto '=https' --tlsv1.2 -O https://packages.timber.io/vector/{version}/vector_{version}-1_{arch}.deb && \
+					sudo dpkg -i vector_{version}-1_{arch}.deb
 				"""#
 			uninstall: "sudo dpkg -r vector"
 			upgrade:   null


### PR DESCRIPTION
Fixes: #16882

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
