### PR TITLE
chore(startup): [revert] Split up `Application::run` into logical phases

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,11 @@ fn main() {
         }
     }
 
-    Application::run();
+    let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
+        std::process::exit(code);
+    });
+
+    runtime.block_on(app.run());
 }
 
 #[cfg(windows)]
@@ -44,5 +48,11 @@ pub fn main() {
     // to run vector as a service. If we fail, we consider that we are in
     // interactive mode and then fallback to console mode.  See
     // https://docs.microsoft.com/en-us/dotnet/api/system.environment.userinteractive?redirectedfrom=MSDN&view=netcore-3.1#System_Environment_UserInteractive
-    vector::vector_windows::run().unwrap_or_else(|_| Application::run());
+    vector::vector_windows::run().unwrap_or_else(|_| {
+        let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
+            std::process::exit(code);
+        });
+
+        runtime.block_on(app.run());
+    });
 }

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -366,7 +366,7 @@ pub fn run() -> Result<()> {
 }
 
 fn run_service(_arguments: Vec<OsString>) -> Result<()> {
-    match Application::prepare_start() {
+    match Application::prepare() {
         Ok((runtime, app)) => {
             let signal_tx = app.signals.handler.clone_tx();
             let event_handler = move |control_event| -> ServiceControlHandlerResult {


### PR DESCRIPTION
Reverts vectordotdev/vector#16873

This looks to maybe be causing k8s test failures. Reverting to see if they pass here.