### PR TITLE
docs: Unify the http component descriptions

### DIFF
--- a/website/content/en/docs/reference/configuration/sinks/http.md
+++ b/website/content/en/docs/reference/configuration/sinks/http.md
@@ -1,9 +1,9 @@
 ---
 title: HTTP
-description: Deliver observability event data to an HTTP server
+description: Deliver observability data to an [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) server
 kind: sink
 layout: component
-tags: ["http", "component", "sink"]
+tags: ["http", "client", "component", "sink", "logs", "metrics", "traces"]
 ---
 
 {{/*

--- a/website/content/en/docs/reference/configuration/sources/http_client.md
+++ b/website/content/en/docs/reference/configuration/sources/http_client.md
@@ -1,9 +1,9 @@
 ---
 title: HTTP Client
-description: Pull observability data from an [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Client_request) server at a configured interval.
+description: Pull observability data from an [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) server at a configured interval
 kind: source
 layout: component
-tags: ["http", "client", "scrape", "component", "source", "logs", "metrics", traces"]
+tags: ["http", "client", "scrape", "component", "source", "logs", "metrics", "traces"]
 ---
 
 {{/*

--- a/website/content/en/docs/reference/configuration/sources/http_server.md
+++ b/website/content/en/docs/reference/configuration/sources/http_server.md
@@ -1,6 +1,6 @@
 ---
 title: HTTP Server
-description: Receives observability data from an [HTTP client request](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Client_request)
+description: Receive observability data from an [HTTP client request](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Client_request)
 kind: source
 layout: component
 tags: ["http", "server", "component", "source", "logs", "metrics", "traces"]

--- a/website/content/en/docs/reference/configuration/sources/http_server.md
+++ b/website/content/en/docs/reference/configuration/sources/http_server.md
@@ -1,9 +1,9 @@
 ---
 title: HTTP Server
-description: Receive logs emitted by an [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Client_request) server.
+description: Receives observability data from an [HTTP client request](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Client_request)
 kind: source
 layout: component
-tags: ["http", "server", "component", "source", "logs"]
+tags: ["http", "server", "component", "source", "logs", "metrics", "traces"]
 aliases: ["/docs/reference/configuration/sources/http"]
 ---
 


### PR DESCRIPTION
After getting another questions about the purpose of the http sources, I rewrote and unified the description for all three - as well as updating the tags.

We should include a "proper" way of writing descriptions in a style guide for our documentation.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
