### PR TITLE
fix(core): Fix Value::Float comparisons

### DIFF
--- a/lib/vrl/value/src/value/regex.rs
+++ b/lib/vrl/value/src/value/regex.rs
@@ -38,6 +38,8 @@ impl ValueRegex {
     }
 }
 
+impl Eq for ValueRegex {}
+
 impl PartialEq for ValueRegex {
     fn eq(&self, other: &Self) -> bool {
         self.0.as_str() == other.0.as_str()


### PR DESCRIPTION
The `PartialEq` method was only comparing the integer portions which would result in things like
`1.4` and `1.2` matching. The custom `PartialEq` and `Hash` implementations predataded use of
`ordered_float::NotNan` for our `Value::Float` type, which provides the `Hash` and `PartialEq` trait
implementations for us. Previously we used a raw `f64` which is why these custom implementations
were necessary.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
