### PR TITLE
chore(startup): Break up app startup from running

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -263,7 +263,7 @@ pub struct StartedApplication {
         tokio::task::JoinHandle<Result<(), Box<dyn serde::ser::StdError + Send + Sync>>>,
     )>,
     graceful_crash_receiver: mpsc::UnboundedReceiver<()>,
-    signals: SignalPair,
+    pub signals: SignalPair,
     topology_controller: Arc<Mutex<TopologyController>>,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -145,6 +145,16 @@ impl ApplicationConfig {
 }
 
 impl Application {
+    pub fn run() {
+        let (runtime, app) = Self::prepare_start().unwrap_or_else(|code| std::process::exit(code));
+
+        runtime.block_on(app.run());
+    }
+
+    pub fn prepare_start() -> Result<(Runtime, StartedApplication), ExitCode> {
+        Self::prepare().and_then(|(runtime, app)| app.start(&runtime).map(|app| (runtime, app)))
+    }
+
     pub fn prepare() -> Result<(Runtime, Self), ExitCode> {
         let opts = Opts::get_matches().map_err(|error| {
             // Printing to stdout/err can itself fail; ignore it.
@@ -191,22 +201,19 @@ impl Application {
         ))
     }
 
-    pub async fn run(self) {
+    pub fn start(self, runtime: &Runtime) -> Result<StartedApplication, ExitCode> {
         // Any internal_logs sources will have grabbed a copy of the
         // early buffer by this point and set up a subscriber.
         crate::trace::stop_early_buffering();
 
         emit!(VectorStarted);
-        tokio::spawn(heartbeat::heartbeat());
+        runtime.spawn(heartbeat::heartbeat());
 
         let Self {
             require_healthy,
             config,
             signals,
         } = self;
-
-        let mut signal_handler = signals.handler;
-        let mut signal_rx = signals.receiver;
 
         let topology_controller = TopologyController {
             #[cfg(feature = "api")]
@@ -230,17 +237,51 @@ impl Application {
                 }
                 Err(error) => {
                     error!(message = "Error binding control server.", %error);
-                    // TODO: We should exit non-zero here, but `Application::run` isn't set up
-                    // that way, and we'd need to push everything up to the API server start
-                    // into `Application::prepare`.
-                    return;
+                    return Err(exitcode::CONFIG);
                 }
             }
         } else {
             None
         };
 
-        let mut graceful_crash = UnboundedReceiverStream::new(config.graceful_crash_receiver);
+        Ok(StartedApplication {
+            config_paths: config.config_paths,
+            #[cfg(not(windows))]
+            control_server_pieces,
+            graceful_crash_receiver: config.graceful_crash_receiver,
+            signals,
+            topology_controller,
+        })
+    }
+}
+
+pub struct StartedApplication {
+    config_paths: Vec<ConfigPath>,
+    #[cfg(not(windows))]
+    control_server_pieces: Option<(
+        stream_cancel::Trigger,
+        tokio::task::JoinHandle<Result<(), Box<dyn serde::ser::StdError + Send + Sync>>>,
+    )>,
+    graceful_crash_receiver: mpsc::UnboundedReceiver<()>,
+    signals: SignalPair,
+    topology_controller: Arc<Mutex<TopologyController>>,
+}
+
+impl StartedApplication {
+    pub async fn run(self) {
+        let Self {
+            config_paths,
+            #[cfg(not(windows))]
+            control_server_pieces,
+            graceful_crash_receiver,
+            signals,
+            topology_controller,
+        } = self;
+
+        let mut graceful_crash = UnboundedReceiverStream::new(graceful_crash_receiver);
+
+        let mut signal_handler = signals.handler;
+        let mut signal_rx = signals.receiver;
 
         let signal = loop {
             tokio::select! {
@@ -257,7 +298,7 @@ impl Application {
                             let mut topology_controller = topology_controller.lock().await;
 
                             // Reload paths
-                            if let Some(paths) = config::process_paths(&config.config_paths) {
+                            if let Some(paths) = config::process_paths(&config_paths) {
                                 topology_controller.config_paths = paths;
                             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,7 @@ fn main() {
         }
     }
 
-    let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
-        std::process::exit(code);
-    });
-
-    runtime.block_on(app.run());
+    Application::run();
 }
 
 #[cfg(windows)]
@@ -48,11 +44,5 @@ pub fn main() {
     // to run vector as a service. If we fail, we consider that we are in
     // interactive mode and then fallback to console mode.  See
     // https://docs.microsoft.com/en-us/dotnet/api/system.environment.userinteractive?redirectedfrom=MSDN&view=netcore-3.1#System_Environment_UserInteractive
-    vector::vector_windows::run().unwrap_or_else(|_| {
-        let (runtime, app) = Application::prepare().unwrap_or_else(|code| {
-            std::process::exit(code);
-        });
-
-        runtime.block_on(app.run());
-    });
+    vector::vector_windows::run().unwrap_or_else(|_| Application::run());
 }

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -366,7 +366,7 @@ pub fn run() -> Result<()> {
 }
 
 fn run_service(_arguments: Vec<OsString>) -> Result<()> {
-    match Application::prepare() {
+    match Application::prepare_start() {
         Ok((runtime, app)) => {
             let signal_tx = app.signals.handler.clone_tx();
             let event_handler = move |control_event| -> ServiceControlHandlerResult {


### PR DESCRIPTION
This separates out the step of starting the app, which is not async, from the actual async main running loop.

Since #16873 broke the K8S E2E tests, I am breaking up that PR into individual steps to see which one might be have caused the problem. This is part 3 of 5.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
