### PR TITLE
feat(component spec validation tests): add partial support for `component_discarded_events_total` metrics

### DIFF
--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -18,6 +18,11 @@ pub enum TestEvent {
     /// For transforms and sinks, generally, the only way to cause an error is if the event itself
     /// is malformed in some way, which can be achieved without this test event variant.
     Modified { modified: bool, event: EventData },
+
+    /// The event is interrupted by the external resource. This is used to test
+    /// the failure path where a connection is interrupted while the event is
+    /// being processed.
+    Interrupted { interrupted: bool, event: EventData },
 }
 
 impl TestEvent {
@@ -25,6 +30,7 @@ impl TestEvent {
         match self {
             Self::Passthrough(event) => event.into_event(),
             Self::Modified { event, .. } => event.into_event(),
+            Self::Interrupted { event, .. } => event.into_event(),
         }
     }
 }

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -415,6 +415,14 @@ pub fn encode_test_event(
                 .encode(event.into_event(), buf)
                 .expect("should not fail to encode input event");
         }
+        TestEvent::Interrupted {
+            interrupted: _,
+            event,
+        } => {
+            encoder
+                .encode(event.into_event(), buf)
+                .expect("should not fail to encode input event");
+        }
         TestEvent::Modified { event, .. } => {
             // This is a little fragile, but we check what serializer this encoder uses, and based
             // on `Serializer::supports_json`, we choose an opposing codec. For example, if the


### PR DESCRIPTION
#16842

This introduces a test function that can verify the `component_discarded_events_total` metric total according to a new test event type: `TestEvent::Interrupted`. 

I don't actually introduce any actual test harness support for this metric here since it is going to be an involved process per component. We'll have to bring up the full integration test harness, then interrupt the event transmission process midway through in order to trigger these errors. I imagine that we will only do this to our most important integrations due to the high cost of implementing support for this metric. 