### PR TITLE
chore(deps): Bump Rust to 1.68.1

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,7 @@ load('ext://helm_resource', 'helm_resource', 'helm_repo')
 docker_build(
     ref='timberio/vector',
     context='.',
-    build_args={'RUST_VERSION': '1.66.1'},
+    build_args={'RUST_VERSION': '1.68.1'},
     dockerfile='tilt/Dockerfile'
     )
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.68.1"
 profile = "default"


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
