### PR TITLE
chore(config): Clean up helper environment variable after schema gen

### DIFF
--- a/lib/vector-config/src/schema/helpers.rs
+++ b/lib/vector-config/src/schema/helpers.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeSet, mem};
+use std::{cell::RefCell, collections::BTreeSet, env, mem};
 
 use indexmap::IndexMap;
 use serde_json::{Map, Value};
@@ -464,15 +464,17 @@ pub fn generate_root_schema<T>() -> Result<RootSchema, GenerateError>
 where
     T: Configurable + 'static,
 {
-    // Set env variable to enable generating all schemas, including platform-specific ones.
-    std::env::set_var("VECTOR_GENERATE_SCHEMA", "true");
-
     let schema_settings =
         SchemaSettings::new().with_visitor(DisallowedUnevaluatedPropertiesVisitor::from_settings);
     let schema_gen = RefCell::new(schema_settings.into_generator());
 
+    // Set env variable to enable generating all schemas, including platform-specific ones.
+    env::set_var("VECTOR_GENERATE_SCHEMA", "true");
+
     let schema =
         get_or_generate_schema(&T::as_configurable_ref(), &schema_gen, Some(T::metadata()))?;
+
+    env::remove_var("VECTOR_GENERATE_SCHEMA");
 
     Ok(schema_gen.into_inner().into_root_schema(schema))
 }


### PR DESCRIPTION
When generating the schema, Vector sets `$VECTOR_GENERATE_SCHEMA` which causes the `host_metrics` source to unconditionally emit config bits for cgroups, which are normally only present on Linux. Since, normally, Vector exits after generating the schema, this variable was never cleaned up. This change removes it immediately after generating the schema, which is useful for using the schema within a running program.

This just solves the most immediate problem. The longer term solution is to eliminate the need for this hack, but the path to that is unclear.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
