### PR TITLE
chore(core): Simplify calling convention for `init_log_schema`

### DIFF
--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -437,16 +437,7 @@ mod tests {
 
     #[test]
     fn deserialize_syslog_legacy_namespace() {
-        init_log_schema(
-            || {
-                let mut schema = LogSchema::default();
-                schema.set_message_key("legacy_message".to_string());
-                schema.set_message_key("legacy_timestamp".to_string());
-                Ok(schema)
-            },
-            false,
-        )
-        .unwrap();
+        init();
 
         let input =
             Bytes::from("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - MSG");
@@ -462,16 +453,7 @@ mod tests {
 
     #[test]
     fn deserialize_syslog_vector_namespace() {
-        init_log_schema(
-            || {
-                let mut schema = LogSchema::default();
-                schema.set_message_key("legacy_message".to_string());
-                schema.set_message_key("legacy_timestamp".to_string());
-                Ok(schema)
-            },
-            false,
-        )
-        .unwrap();
+        init();
 
         let input =
             Bytes::from("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - MSG");
@@ -481,5 +463,12 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].as_log()["message"], "MSG".into());
         assert!(events[0].as_log()["timestamp"].is_timestamp());
+    }
+
+    fn init() {
+        let mut schema = LogSchema::default();
+        schema.set_message_key("legacy_message".to_string());
+        schema.set_message_key("legacy_timestamp".to_string());
+        init_log_schema(schema, false);
     }
 }

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -17,17 +17,11 @@ static LOG_SCHEMA_DEFAULT: Lazy<LogSchema> = Lazy::new(LogSchema::default);
 /// # Panics
 ///
 /// If deny is set, will panic if schema has already been set.
-pub fn init_log_schema<F>(builder: F, deny_if_set: bool) -> Result<(), Vec<String>>
-where
-    F: FnOnce() -> Result<LogSchema, Vec<String>>,
-{
-    let log_schema = builder()?;
+pub fn init_log_schema(log_schema: LogSchema, deny_if_set: bool) {
     assert!(
         !(LOG_SCHEMA.set(log_schema).is_err() && deny_if_set),
         "Couldn't set schema"
     );
-
-    Ok(())
 }
 
 /// Components should use global `LogSchema` returned by this function.  The

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -436,15 +436,9 @@ mod test {
     fn test_insert_standard_vector_source_metadata() {
         let nested_path = "a.b.c.d";
 
-        init_log_schema(
-            || {
-                let mut schema = LogSchema::default();
-                schema.set_source_type_key(nested_path.to_owned());
-                Ok(schema)
-            },
-            false,
-        )
-        .unwrap();
+        let mut schema = LogSchema::default();
+        schema.set_source_type_key(nested_path.to_owned());
+        init_log_schema(schema, false);
 
         let namespace = LogNamespace::Legacy;
         let mut event = LogEvent::from("log");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,13 +64,9 @@ pub use vector_core::config::{log_schema, proxy::ProxyConfig, LogSchema};
 /// configured log schema defaults.
 /// If deny is set, will panic if schema has already been set.
 pub fn init_log_schema(config_paths: &[ConfigPath], deny_if_set: bool) -> Result<(), Vec<String>> {
-    vector_core::config::init_log_schema(
-        || {
-            let (builder, _) = load_builder_from_paths(config_paths)?;
-            Ok(builder.global.log_schema)
-        },
-        deny_if_set,
-    )
+    let (builder, _) = load_builder_from_paths(config_paths)?;
+    vector_core::config::init_log_schema(builder.global.log_schema, deny_if_set);
+    Ok(())
 }
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]


### PR DESCRIPTION
This function took a closure that was called once at the start of a function. This is semantically equivalent to calling it before the function and passing in the result, which is simpler.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
