### PR TITLE
chore(ci): Ignore gardener issue comment workflow again

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -69,7 +69,7 @@
 ^\.github/actions/spelling/
 ^\Q.cargo/config.toml\E$
 ^\Q.github/workflows/spelling.yml\E$
-^\Q.github/workflows/gardner_issue_comment.yml\E$
+^\Q.github/workflows/gardener_issue_comment.yml\E$
 ^\Qbenches/codecs/moby_dick.txt\E$
 ^\Qbenches/dnstap/mod.rs\E$
 ^\Qbenches/transform/route.rs\E$


### PR DESCRIPTION
Had a typo in https://github.com/vectordotdev/vector/pull/16947 :(

This workflow only runs from `master` so the only way to test changes in CI is to update `master`.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
