### PR TITLE
chore(ci): Ignore RUSTSEC-2023-0029

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,3 +24,12 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
 ]
+
+[advisories]
+ignore = [
+    # The NATS official Rust clients are vulnerable to MitM when using TLS
+    #
+    # Will be resolved when we switch to `async_nats` crate
+    # https://github.com/vectordotdev/vector/pull/15533
+    "RUSTSEC-2023-0029",
+]


### PR DESCRIPTION
Will be fixed [by switch to `async_nats` crate](https://github.com/vectordotdev/vector/pull/15533). There is no fix for the `nats` crate yet.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
