### PR TITLE
fix(splunk_hec sink): use date from 1999 days ago for auto_extracted timestamp integration test

### DIFF
--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryFrom, iter, num::NonZeroU8};
 
-use chrono::{TimeZone, Utc};
+use chrono::{TimeZone, Timelike, Utc};
 use codecs::{JsonSerializerConfig, TextSerializerConfig};
 use futures::{future::ready, stream};
 use lookup::lookup_v2::OptionalValuePath;
@@ -427,8 +427,12 @@ async fn splunk_auto_extracted_timestamp() {
         let (sink, _) = config.build(cx).await.unwrap();
 
         // With auto_extract_timestamp switched the timestamp comes from the message.
-        let message = "this message is on 2017-10-01 03:00:00";
-        let mut event = LogEvent::from(message);
+        // Note that as per <https://docs.splunk.com/Documentation/Splunk/latest/Data/Configuretimestamprecognition>
+        // the max age of timestamps is 2,000 days old. So we will test with a timestamp that
+        // is within that limit.
+        let date = Utc::now().with_nanosecond(0).unwrap() - chrono::Duration::days(1999);
+        let message = format!("this message is on {}", date.format("%Y-%m-%d %H:%M:%S"));
+        let mut event = LogEvent::from(message.as_str());
 
         event.insert(
             "timestamp",
@@ -441,14 +445,16 @@ async fn splunk_auto_extracted_timestamp() {
 
         run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
-        let entry = find_entry(message).await;
+        let entry = find_entry(&message).await;
+
+        // `"2017-10-05T14:33:42.000+00:00
 
         assert_eq!(
             format!("{{\"message\":\"{}\"}}", message),
             entry["_raw"].as_str().unwrap()
         );
         assert_eq!(
-            "2017-10-01T03:00:00.000+00:00",
+            &format!("{}", date.format("%Y-%m-%dT%H:%M:%S%.3f%:z")),
             entry["_time"].as_str().unwrap()
         );
     }
@@ -474,8 +480,9 @@ async fn splunk_non_auto_extracted_timestamp() {
         };
 
         let (sink, _) = config.build(cx).await.unwrap();
-        let message = "this message is on 2019-10-01 00:00:00";
-        let mut event = LogEvent::from(message);
+        let date = Utc::now().with_nanosecond(0).unwrap() - chrono::Duration::days(1999);
+        let message = format!("this message is on {}", date.format("%Y-%m-%d %H:%M:%S"));
+        let mut event = LogEvent::from(message.as_str());
 
         // With auto_extract_timestamp switched off the timestamp comes from the event timestamp.
         event.insert(
@@ -489,7 +496,7 @@ async fn splunk_non_auto_extracted_timestamp() {
 
         run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
-        let entry = find_entry(message).await;
+        let entry = find_entry(&message).await;
 
         assert_eq!(
             format!("{{\"message\":\"{}\"}}", message),

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -428,7 +428,7 @@ async fn splunk_auto_extracted_timestamp() {
 
         // With auto_extract_timestamp switched the timestamp comes from the message.
         // Note that as per <https://docs.splunk.com/Documentation/Splunk/latest/Data/Configuretimestamprecognition>
-        // the max age of timestamps is 2,000 days old. So we will test with a timestamp that
+        // by default, the max age of timestamps is 2,000 days old. So we will test with a timestamp that
         // is within that limit.
         let date = Utc::now().with_nanosecond(0).unwrap() - chrono::Duration::days(1999);
         let message = format!("this message is on {}", date.format("%Y-%m-%d %H:%M:%S"));
@@ -446,8 +446,6 @@ async fn splunk_auto_extracted_timestamp() {
         run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
         let entry = find_entry(&message).await;
-
-        // `"2017-10-05T14:33:42.000+00:00
 
         assert_eq!(
             format!("{{\"message\":\"{}\"}}", message),


### PR DESCRIPTION
From [here](https://docs.splunk.com/Documentation/Splunk/latest/Data/Configuretimestamprecognition) by default timestamps over 2000 days old are ignored. 

This updates the integration test to calculate a date 1999 days ago to use in the test.