### PR TITLE
chore(axiom sink): Exit early if AXIOM_TOKEN isn't set in integration tests

### DIFF
--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -158,7 +158,7 @@ mod integration_tests {
         let client = reqwest::Client::new();
         let url = env::var("AXIOM_URL").unwrap();
         let token = env::var("AXIOM_TOKEN").expect("AXIOM_TOKEN environment variable to be set");
-        assert!(!api_key.is_empty(), "$AXIOM_TOKEN required");
+        assert!(!token.is_empty(), "$AXIOM_TOKEN required");
         let dataset = env::var("AXIOM_DATASET").unwrap();
 
         let cx = SinkContext::new_test();

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -155,6 +155,10 @@ mod integration_tests {
 
     #[tokio::test]
     async fn axiom_logs_put_data() {
+        let api_key = std::env::var("AXIOM_TOKEN")
+            .expect("couldn't find the Axiom token in environment variables");
+        assert!(!api_key.is_empty(), "$AXIOM_TOKEN required");
+
         let client = reqwest::Client::new();
         let url = env::var("AXIOM_URL").unwrap();
         let token = env::var("AXIOM_TOKEN").expect("AXIOM_TOKEN environment variable to be set");

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -155,13 +155,10 @@ mod integration_tests {
 
     #[tokio::test]
     async fn axiom_logs_put_data() {
-        let api_key = std::env::var("AXIOM_TOKEN")
-            .expect("couldn't find the Axiom token in environment variables");
-        assert!(!api_key.is_empty(), "$AXIOM_TOKEN required");
-
         let client = reqwest::Client::new();
         let url = env::var("AXIOM_URL").unwrap();
         let token = env::var("AXIOM_TOKEN").expect("AXIOM_TOKEN environment variable to be set");
+        assert!(!api_key.is_empty(), "$AXIOM_TOKEN required");
         let dataset = env::var("AXIOM_DATASET").unwrap();
 
         let cx = SinkContext::new_test();


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
