### PR TITLE
doc(sinks/aws_kinesis): describe partial failure behavior

### DIFF
--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -182,6 +182,12 @@ impl RetryLogic for KinesisRetryLogic {
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         if let SdkError::ServiceError { err, raw: _ } = error {
+            // Note that if the request partially fails (records sent to one
+            // partition fail but the others do not, for example), Vector
+            // does not retry. This line only covers a failure for the entire
+            // request.
+            //
+            // https://github.com/vectordotdev/vector/issues/359
             if let PutRecordsErrorKind::ProvisionedThroughputExceededException(_) = err.kind {
                 return true;
             }


### PR DESCRIPTION
I assumed that these lines meant that failures would be retried but it does not mean that in many cases, so let's make that explicit and describe the plans to address the behavior.

Updates #359.
Updates #7659.
Updates #16954.
