### PR TITLE
fix(config): avoid resetting `unevaluatedProperties` value on subsequent visits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,16 @@ dependencies = [
 
 [[package]]
 name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ctor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
@@ -4169,7 +4179,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
 dependencies = [
- "ctor",
+ "ctor 0.2.0",
  "ghost",
 ]
 
@@ -5735,6 +5745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6186,6 +6205,18 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor 0.1.26",
+ "diff",
+ "output_vt100",
+ "yansi",
 ]
 
 [[package]]
@@ -9606,6 +9637,7 @@ dependencies = [
  "inventory",
  "no-proxy",
  "num-traits",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_with 2.3.1",
@@ -10455,6 +10487,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/lib/vector-config-common/src/schema/json_schema.rs
+++ b/lib/vector-config-common/src/schema/json_schema.rs
@@ -498,13 +498,13 @@ pub struct ObjectValidation {
     /// The `additionalProperties` keyword.
     ///
     /// See [JSON Schema 9.3.2.3. "additionalProperties"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.3).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_none_or_default_true")]
     pub additional_properties: Option<Box<Schema>>,
 
     /// The `unevaluatedProperties` keyword.
     ///
     /// See [JSON Schema 9.3.2.4. "unevaluatedProperties"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.4).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_none_or_default_true")]
     pub unevaluated_properties: Option<Box<Schema>>,
 
     /// The `propertyNames` keyword.
@@ -558,5 +558,12 @@ impl<T: PartialEq> SingleOrVec<T> {
             SingleOrVec::Single(s) => s.deref() == x,
             SingleOrVec::Vec(v) => v.contains(x),
         }
+    }
+}
+
+fn is_none_or_default_true(field: &Option<Box<Schema>>) -> bool {
+    match field {
+        None => true,
+        Some(value) => matches!(value.as_ref(), Schema::Bool(true)),
     }
 }

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -30,4 +30,5 @@ vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
 
 [dev-dependencies]
+pretty_assertions = { version = "1.3.0", default-features = false, features = ["std"] }
 serde_with = { version = "2.3.1", default-features = false, features = ["std", "macros"] }

--- a/lib/vector-config/src/schema/visitors/unevaluated.rs
+++ b/lib/vector-config/src/schema/visitors/unevaluated.rs
@@ -14,7 +14,7 @@ use vector_config_common::schema::{
 /// that unknown properties are not allowed, but also in a way that doesn't interact incorrectly
 /// with advanced subschema validation, such as `oneOf` or `allOf`, as `unevaluatedProperties`
 /// cannot simply be applied to any and all schemas indiscriminately.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DisallowedUnevaluatedPropertiesVisitor;
 
 impl DisallowedUnevaluatedPropertiesVisitor {
@@ -33,25 +33,14 @@ impl Visitor for DisallowedUnevaluatedPropertiesVisitor {
         // fashion, applying the unevaluated properties change from the bottom up.
         visit_schema_object(self, definitions, schema);
 
-        // If this schema is an object schema (`type` of `object`) or has any subschema validation
-        // (`allOf`/`oneOf`/`anyOf`, `if`/`then`/`else`, `$ref`, etc) then we'll set
-        // `unevaluatedProperties` to `false`.
+        // Next, see if this schema has any subschema validation: `allOf`, `oneOf`, or `anyOf`.
         //
-        // Crucially, if this schema has any subschema validation and those subschemas have
-        // `unevaluatedProperties` set, we will _remove_ it, as subschema validation is
-        // fundamentally incompatible in this way: since a subschema is validated against the
-        // entirety of the JSON instance passed in at the level of `allOf`, `oneOf`, and so on, each
-        // subschema will implicitly be forced to observe other, potentially unrelated properties,
-        // and so would naturally fail validation if `unevaluatedProperties` was present in the
-        // subschema and set to `false`.
-
-        // Next, see if this schema has any subschema validation, specifically `allOf` and `oneOf`.
         // If so, we ensure that none of them have `unevaluatedProperties` set at all. We do this
-        // because subschema validation involves seeing the entire JSON instance, or seeing a value
-        // that's unrelated: we know that some schemas in a `oneOf` won't match, and that's fine,
-        // but if they're marked with `unevaluatedProperties: false`, they'll fail... which is why
-        // we remove that from the subschemas  themselves but essentially hoist it up to the level
-        // of the `allOf`/`oneOf`, where it can ensure the correct behavior.
+        // because subschema validation involves each subschema seeing the entire JSON instance, or
+        // seeing a value that's unrelated: we know that some schemas in a `oneOf` won't match, and
+        // that's fine, but if they're marked with `unevaluatedProperties: false`, they'll fail...
+        // which is why we remove that from the subschemas themselves but essentially hoist it up
+        // to the level of the `allOf`/`oneOf`/`anyOf`, where it can apply the correct behavior.
         let mut had_relevant_subschemas = false;
         if let Some(subschemas) = get_subschema_validators(schema) {
             had_relevant_subschemas = true;
@@ -87,11 +76,16 @@ impl Visitor for DisallowedUnevaluatedPropertiesVisitor {
 }
 
 fn mark_schema_closed(schema: &mut SchemaObject) {
-    // We only mark the schema as closed if it also does not have `additionalProperties` set to a
-    // non-boolean schema. It is a logical inconsistency otherwise.
-
     // Make sure this schema doesn't also have `additionalProperties` set to a non-boolean schema,
-    // as it would be a logical consistency to then also set `unevaluatedProperties` to `false`.
+    // as it would be a logical inconsistency to then also set `unevaluatedProperties` to `false`.
+    //
+    // TODO: We may want to consider dropping `additionalProperties` entirely here if it's a boolean
+    // schema, as `unevaluatedProperties` would provide the equivalent behavior, and it avoids us
+    // running into weird validation issues where `additionalProperties` gets used in situations it
+    // can't handle, the same ones we switched to using `unevaluatedProperties` for in the first
+    // place... but realistically, we don't ourselves generated boolean schemas for
+    // `additionalProperties` through normal means, so it's not currently an issue that should even
+    // occur.
     if let Some(Schema::Object(_)) = schema
         .object()
         .additional_properties
@@ -101,9 +95,9 @@ fn mark_schema_closed(schema: &mut SchemaObject) {
         return;
     }
 
-    // As well, if `unevaluatedProperties` is already set, then we don't do anything. By
-    // default, the field on the Rust side will be unset, so if it's been set explicitly,
-    // that means another usage of this schema requires that it not be set to `false`.
+    // As well, if `unevaluatedProperties` is already set, then we don't do anything. By default,
+    // the field on the Rust side will be unset, so if it's been set explicitly, that means another
+    // usage of this schema requires that it not be set to `false`.
     if schema
         .object
         .as_ref()
@@ -160,5 +154,315 @@ fn get_subschema_validators(schema: &mut SchemaObject) -> Option<Vec<&mut Schema
         None
     } else {
         Some(validators)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use serde_json::{json, Value};
+    use vector_config_common::schema::{visit::Visitor, RootSchema};
+
+    use super::DisallowedUnevaluatedPropertiesVisitor;
+
+    fn as_schema(value: Value) -> RootSchema {
+        serde_json::from_value(value).expect("should not fail to deserialize schema")
+    }
+
+    fn assert_schemas_eq(expected: RootSchema, actual: RootSchema) {
+        let expected_json = serde_json::to_string_pretty(&expected).expect("should not fail");
+        let actual_json = serde_json::to_string_pretty(&actual).expect("should not fail");
+
+        assert_eq!(expected_json, actual_json);
+    }
+
+    #[test]
+    fn basic_object_schema() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" }
+            }
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" }
+            },
+            "unevaluatedProperties": false
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn basic_object_schema_through_ref() {
+        let mut actual_schema = as_schema(json!({
+            "$ref": "#/definitions/simple",
+            "definitions": {
+                "simple": {
+                    "type": "object",
+                    "properties": {
+                        "a": { "type": "string" }
+                    }
+                }
+            }
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "$ref": "#/definitions/simple",
+            "definitions": {
+                "simple": {
+                    "type": "object",
+                    "properties": {
+                        "a": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            }
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn all_of_with_basic_object_schemas() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "allOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "string" }
+                }
+            }]
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "type": "object",
+            "allOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "string" }
+                }
+            }],
+            "unevaluatedProperties": false
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn one_of_with_basic_object_schemas() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "oneOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "string" }
+                }
+            }]
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "type": "object",
+            "oneOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "string" }
+                }
+            }],
+            "unevaluatedProperties": false
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn any_of_with_basic_object_schemas() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "anyOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "string" }
+                }
+            }]
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "type": "object",
+            "anyOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "b": { "type": "string" }
+                }
+            }],
+            "unevaluatedProperties": false
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn ignores_object_schema_with_non_boolean_additional_properties() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" }
+            },
+            "additionalProperties": { "type": "number" }
+        }));
+        let expected_schema = actual_schema.clone();
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn object_schema_with_boolean_additional_properties() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" }
+            },
+            "additionalProperties": false
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" }
+            },
+            "additionalProperties": false,
+            "unevaluatedProperties": false
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
+    }
+
+    #[test]
+    fn all_of_with_object_props_using_schema_refs() {
+        let mut actual_schema = as_schema(json!({
+            "type": "object",
+            "allOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "$ref": "#/definitions/subschema" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "aa": {
+                        "type": "object",
+                        "properties": {
+                            "a": { "$ref": "#/definitions/subschema" }
+                        }
+                    }
+                }
+            }],
+            "definitions": {
+                "subschema": {
+                    "type": "object",
+                    "properties": {
+                        "f": { "type": "string" }
+                    }
+                }
+            }
+        }));
+
+        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        visitor.visit_root_schema(&mut actual_schema);
+
+        let expected_schema = as_schema(json!({
+            "type": "object",
+            "allOf": [{
+                "type": "object",
+                "properties": {
+                    "a": { "$ref": "#/definitions/subschema" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "aa": {
+                        "type": "object",
+                        "properties": {
+                            "a": { "$ref": "#/definitions/subschema" }
+                        },
+                        "unevaluatedProperties": false
+                    }
+                }
+            }],
+            "definitions": {
+                "subschema": {
+                    "type": "object",
+                    "properties": {
+                        "f": { "type": "string" }
+                    },
+                    "unevaluatedProperties": false
+                }
+            },
+            "unevaluatedProperties": false
+        }));
+
+        assert_schemas_eq(expected_schema, actual_schema);
     }
 }


### PR DESCRIPTION
## Context

In #16856, support was added for marking specific schema definitions in the overall Vector configuration schema with a field, `unevaluatedProperties`, that indicated that validation should disallow unevaluated properties: if you configure a specific component, but specified a configuration field that doesn't exist for that component, we want to emit an error during schema validation rather than silently ignore it.

In order to achieve this, a visitor implementation was created that visits the schema -- which is inherently a tree-like structure -- in a depth-first fashion, selectively marking (or unmarking) schema definitions with the aforementioned setting depending on how the schema definitions were assembled: there is some logic to when you should or shouldn't apply the setting, for example setting it on a parent schema that does subschema validation, rather than setting it on each individual subschema _and_ the parent schema.

While the logic for selecting which schemas to mark/unmark was naively sound, one consideration that was initially missed was that since some schemas are referenced multiple times, the logic for modifying schema X might cause us to mark it when referenced in one place, but then cause us to unmark when referenced in another place, and vise versa.

This leads to a schema that causes incorrect validation, as `unevaluatedProperties` was no longer being set correctly.

## Solution

This PR introduces a simple change to the logic that ensures the setting is always specified such that marking/unmarking operations can check if they would be, effectively, overriding an existing mark/unmark operation and instead return early.

The setting in question is represented by `Option<Box<Schema>>`, and when set to `None`, this implies that the setting should use its default value of enabled. Our logic to unmark a schema would specify the equivalent of `Some(false)` to do so, so long as the setting was already unset.

Instead, we now affirmatively mark the setting as enabled by setting it to the equivalent of `Some(true)`. This way, we don't bother unmarking a schema that has been observed to have already been marked. Additionally, we've slightly tweaked the serialization logic for the types used to define the JSON Schema objects such that, when the field has the affirmatively enabled value set, it omits serializing the field, avoiding clutter in the serialized output as the value when the setting is not present at all is still the same: a default of enabled/`true`.