### PR TITLE
fix(ci): Re-add custom builds workflow. Fixes integration test build error.

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -215,3 +215,6 @@ k8s
 
 # ignore long runs of a single character:
 \b([A-Za-z])\g{-1}{3,}\b
+
+# ignore comment in package-msi.sh
+[#].*custom\.a28ecdc.*

--- a/.github/workflows/custom_builds.yml
+++ b/.github/workflows/custom_builds.yml
@@ -1,15 +1,12 @@
-name: Release Suite
+name: Custom Builds
 
 on:
-  push:
-    tags:
-      - v0.*
-      - v1.*
+  workflow_dispatch: {}
 
 jobs:
-  Release:
+  Custom:
     uses: ./.github/workflows/publish.yml
     with:
       git_ref: ${{ github.ref }}
-      channel: release
+      channel: custom
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,5 +10,5 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       git_ref: ${{ github.ref }}
-      mode: Nightly
+      channel: nightly
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,9 @@ on:
       git_ref:
         type: string
         required: true
-      mode:
+        # channel is the dir/namespace packages are organized into.
+        # Options are release/nightly/custom.
+      channel:
         type: string
         required: true
 
@@ -21,6 +23,7 @@ env:
   # observing issues fetching boringssl via HTTPS in the OSX build, seeing if this helps
   # can be removed when we switch back to the upstream openssl-sys crate
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CHANNEL: ${{ inputs.channel }}
 
 jobs:
   generate-publish-metadata:
@@ -545,7 +548,7 @@ jobs:
   publish-github:
     name: Publish to GitHub
     # We only publish to GitHub for versioned releases, not nightlies.
-    if: ${{ inputs.mode == 'Release' }}
+    if: ${{ inputs.channel == 'release' }}
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -615,7 +618,7 @@ jobs:
   publish-homebrew:
     name: Publish to Homebrew
     # We only publish to Homebrew for versioned releases, not nightlies.
-    if: ${{ inputs.mode == 'Release' }}
+    if: ${{ inputs.channel == 'release' }}
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -635,7 +638,7 @@ jobs:
   publish-cloudsmith:
     name: Publish to Cloudsmith
     # We only publish to CloudSmith for versioned releases, not nightlies.
-    if: ${{ inputs.mode == 'Release' }}
+    if: ${{ inputs.channel == 'release' }}
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -748,7 +751,7 @@ jobs:
 
   publish-failure:
     name: Send Publish Failure Notification
-    if: failure()
+    if: ${{ inputs.channel != 'custom' }} && failure()
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -773,4 +776,4 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       uses: Ilshidur/action-discord@0.3.2
       with:
-        args: "${{ inputs.mode }} failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"
+        args: "${{ inputs.channel }} failed: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"

--- a/Makefile
+++ b/Makefile
@@ -527,37 +527,37 @@ package-armv7-unknown-linux-musleabihf: target/artifacts/vector-${VERSION}-armv7
 
 .PHONY: package-deb-x86_64-unknown-linux-gnu
 package-deb-x86_64-unknown-linux-gnu: package-x86_64-unknown-linux-gnu ## Build the x86_64 GNU deb package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-gnu $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-gnu -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
 
 .PHONY: package-deb-x86_64-unknown-linux-musl
 package-deb-x86_64-unknown-linux-musl: package-x86_64-unknown-linux-musl ## Build the x86_64 GNU deb package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-musl $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-musl -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
 
 .PHONY: package-deb-aarch64
 package-deb-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 deb package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=aarch64-unknown-linux-gnu $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=aarch64-unknown-linux-gnu -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
 
 .PHONY: package-deb-armv7-gnu
 package-deb-armv7-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7-unknown-linux-gnueabihf deb package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
 
 # rpms
 
 .PHONY: package-rpm-x86_64-unknown-linux-gnu
 package-rpm-x86_64-unknown-linux-gnu: package-x86_64-unknown-linux-gnu ## Build the x86_64 rpm package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-gnu $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-gnu -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
 
 .PHONY: package-rpm-x86_64-unknown-linux-musl
 package-rpm-x86_64-unknown-linux-musl: package-x86_64-unknown-linux-musl ## Build the x86_64 musl rpm package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-musl $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=x86_64-unknown-linux-musl -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
 
 .PHONY: package-rpm-aarch64
 package-rpm-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 rpm package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=aarch64-unknown-linux-gnu $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=aarch64-unknown-linux-gnu -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
 
 .PHONY: package-rpm-armv7-gnu
 package-rpm-armv7-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7-unknown-linux-gnueabihf rpm package
-	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
 
 ##@ Releasing
 

--- a/distribution/msi/build.sh
+++ b/distribution/msi/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ARCHIVE_VERSION=$1
+PACKAGE_VERSION=$2
 
 echo "Copying ZIP archive..."
 
@@ -14,7 +15,7 @@ sed 's/$/\\/' < vector-"${ARCHIVE_VERSION}"-x86_64-pc-windows-msvc/LICENSE.txt >
 echo -e '\n}' >> LICENSE.rtf
 
 echo "Substituting version..."
-VERSION="${ARCHIVE_VERSION}" envsubst < vector.wxs.tmpl > vector.wxs
+VERSION="${PACKAGE_VERSION}" envsubst < vector.wxs.tmpl > vector.wxs
 
 echo "Building the MSI package..."
 heat dir vector-"${ARCHIVE_VERSION}"-x86_64-pc-windows-msvc \

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -78,6 +78,11 @@ elif [[ "$CHANNEL" == "nightly" ]]; then
     build distroless-static "$VERSION_TAG"
     build distroless-libc "$VERSION_TAG"
   done
+elif [[ "$CHANNEL" == "custom" ]]; then
+  build alpine "$VERSION"
+  build debian "$VERSION"
+  build distroless-static "$VERSION"
+  build distroless-libc "$VERSION"
 elif [[ "$CHANNEL" == "test" ]]; then
   build "${BASE:-"alpine"}" "${TAG:-"test"}"
   build "${BASE:-"distroless-libc"}" "${TAG:-"test"}"

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     zlib1g-dev \
     unzip \
+    git \
   && rm -rf /var/lib/apt/lists/*
 
 RUN rustup run "${RUST_VERSION}" cargo install cargo-nextest --version 0.9.25 --locked

--- a/scripts/package-msi.sh
+++ b/scripts/package-msi.sh
@@ -17,6 +17,21 @@ cp target/artifacts/vector-"${ARCHIVE_VERSION}"-x86_64-pc-windows-msvc.zip targe
 pushd target/msi-x64
 # shellcheck disable=SC2016
 powershell '$progressPreference = "silentlyContinue"; Expand-Archive vector-'"$ARCHIVE_VERSION"'-x86_64-pc-windows-msvc.zip'
-./build.sh "${ARCHIVE_VERSION}"
+
+# Building the MSI package requires the version to be purely numerical (eg 0.0.0),
+# which is not the case if with custom build workflow.
+# This specifically works around the following issue:
+#     C:\a\vector\vector\target\msi-x64\vector.wxs(6) : error CNDL0108 : The Product/@Version attribute's value, '0.29.0.custom.a28ecdc', is not a valid version.
+#     Legal version values should look like 'x.x.x.x' where x is an integer from 0 to 65534.
+# , by  changing "0.29.0.custom.a28ecdc" -> "0.29.0".
+CHANNEL="${CHANNEL:-"$(cargo vdev release channel)"}"
+
+if [[ "$CHANNEL" == "custom" ]]; then
+    PACKAGE_VERSION="${ARCHIVE_VERSION%.custom*}"
+else
+    PACKAGE_VERSION="${ARCHIVE_VERSION}"
+fi
+
+./build.sh "${ARCHIVE_VERSION}" "${PACKAGE_VERSION}"
 popd
 cp target/msi-x64/vector.msi target/artifacts/vector-"${ARCHIVE_VERSION}"-x64.msi

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -17,7 +17,7 @@ TARGET="${TARGET:?"You must specify a target triple, ex: x86_64-apple-darwin"}"
 # Local vars
 #
 
-PACKAGE_VERSION="$(cargo vdev version)"
+PACKAGE_VERSION="${VECTOR_VERSION:-"$(cargo vdev version)"}"
 ARCHIVE_NAME="vector-$PACKAGE_VERSION-$TARGET.tar.gz"
 ARCHIVE_PATH="target/artifacts/$ARCHIVE_NAME"
 

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -21,7 +21,6 @@ export AWS_REGION=us-east-1
 
 td="$(mktemp -d)"
 cp -av "target/artifacts/." "$td"
-ls "$td"
 
 td_nightly="$(mktemp -d)"
 cp -av "target/artifacts/." "$td_nightly"
@@ -79,6 +78,7 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   verify_artifact \
     "https://packages.timber.io/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-gnu.tar.gz" \
     "$td_nightly/vector-nightly-x86_64-unknown-linux-gnu.tar.gz"
+
 elif [[ "$CHANNEL" == "latest" ]]; then
   VERSION_EXACT="$VERSION"
   # shellcheck disable=SC2001
@@ -128,6 +128,21 @@ elif [[ "$CHANNEL" == "latest" ]]; then
   verify_artifact \
     "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
     "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
+
+elif [[ "$CHANNEL" == "custom" ]]; then
+
+  # Add custom files
+  echo "Uploading all artifacts to s3://packages.timber.io/vector/custom"
+  aws s3 cp "$td" "s3://packages.timber.io/vector/custom/$VERSION" --recursive --sse --acl public-read
+  echo "Uploaded archives"
+
+  # Verify that the files exist and can be downloaded
+  echo "Waiting for $VERIFY_TIMEOUT seconds before running the verifications"
+  sleep "$VERIFY_TIMEOUT"
+  verify_artifact \
+    "https://packages.timber.io/vector/custom/$VERSION/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz" \
+    "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
+
 fi
 
 #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,17 @@ pub fn vector_version() -> impl std::fmt::Display {
     let pkg_version = format!("{}-nightly", built_info::PKG_VERSION);
 
     #[cfg(not(feature = "nightly"))]
-    let pkg_version = built_info::PKG_VERSION;
+    let pkg_version = match built_info::DEBUG {
+        // If any debug info is included, consider it a non-release build.
+        "1" | "2" | "true" => {
+            format!(
+                "{}-custom-{}",
+                built_info::PKG_VERSION,
+                built_info::GIT_SHORT_HASH
+            )
+        }
+        _ => built_info::PKG_VERSION.to_string(),
+    };
 
     pkg_version
 }

--- a/vdev/src/app.rs
+++ b/vdev/src/app.rs
@@ -7,7 +7,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use log::LevelFilter;
 use once_cell::sync::{Lazy, OnceCell};
 
-use crate::{config::Config, platform, util};
+use crate::{config::Config, git, platform, util};
 
 // Use the `bash` interpreter included as part of the standard `git` install for our default shell
 // if nothing is specified in the environment.
@@ -44,8 +44,9 @@ pub fn set_repo_dir() -> Result<()> {
 }
 
 pub fn version() -> Result<String> {
-    let version = env::var("VERSION").or_else(|_| util::read_version())?;
-    let channel = env::var("CHANNEL").or_else(|_| util::release_channel().map(Into::into))?;
+    let mut version = util::get_version()?;
+
+    let channel = util::get_channel();
 
     if channel == "latest" {
         let head = util::git_head()?;
@@ -57,6 +58,14 @@ pub fn version() -> Result<String> {
         if tag != format!("v{version}") {
             bail!("On latest release channel and tag {tag:?} is different from Cargo.toml {version:?}. Aborting");
         }
+
+    // extend version for custom builds if not already
+    } else if channel == "custom" && !version.contains("custom") {
+        let sha = git::get_git_sha()?;
+
+        // use '.' instead of '-' or '_' to avoid issues with rpm and deb package naming
+        // format requirements.
+        version = format!("{version}.custom.{sha}");
     }
 
     Ok(version)

--- a/vdev/src/commands/build/publish_metadata.rs
+++ b/vdev/src/commands/build/publish_metadata.rs
@@ -19,19 +19,19 @@ pub struct Cli {}
 impl Cli {
     pub fn exec(self) -> Result<()> {
         // Generate the Vector version and build description.
-        let version = util::read_version()?;
+        let version = util::get_version()?;
 
         let git_sha = git::get_git_sha()?;
         let current_date = Local::today().naive_local().to_string();
         let build_desc = format!("{git_sha} {current_date}");
 
         // Figure out what our release channel is.
-        let channel = util::release_channel()?;
+        let channel = util::get_channel();
 
         // Depending on the channel, this influences which Cloudsmith repository we publish to.
-        let cloudsmith_repo = match channel {
+        let cloudsmith_repo = match channel.as_str() {
             "nightly" => "vector-nightly",
-            _ => "vector"
+            _ => "vector",
         };
 
         let mut output_file: Box<dyn Write> = match env::var("GITHUB_OUTPUT") {
@@ -41,7 +41,7 @@ impl Cli {
                     .create(true)
                     .open(file_name)?;
                 Box::new(file)
-            },
+            }
             _ => Box::new(io::stdout()),
         };
         writeln!(output_file, "vector_version={version}")?;

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -90,7 +90,8 @@ cli_commands! {
     mod version,
 }
 
-/// This macro creates a wrapper for an existing script
+/// This macro creates a wrapper for an existing script.
+/// `pre` provides the option to execute an expression before running the script.
 #[macro_export]
 macro_rules! script_wrapper {
     ( $mod:ident = $doc:literal => $script:literal ) => {

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -91,7 +91,6 @@ cli_commands! {
 }
 
 /// This macro creates a wrapper for an existing script.
-/// `pre` provides the option to execute an expression before running the script.
 #[macro_export]
 macro_rules! script_wrapper {
     ( $mod:ident = $doc:literal => $script:literal ) => {

--- a/vdev/src/commands/release/channel.rs
+++ b/vdev/src/commands/release/channel.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 
-use crate::util;
+use crate::util::get_channel;
 
-/// Determine the appropriate release channel (nightly or latest) based on Git HEAD.
+/// Provide the release channel (latest/nightly/custom).
+/// This command is intended for use only within GitHub build workflows.
 // This script is used across various release scripts to determine where distribute archives,
 // packages, etc.
 #[derive(clap::Args, Debug)]
@@ -11,7 +12,9 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        println!("{}", util::release_channel()?);
+        let channel = get_channel();
+
+        println!("{channel}");
         Ok(())
     }
 }

--- a/vdev/src/commands/release/github.rs
+++ b/vdev/src/commands/release/github.rs
@@ -1,30 +1,30 @@
-use anyhow::{Result, Ok};
-use std::process::Command;
-use std::env;
 use crate::app::CommandExt as _;
 use crate::util;
+use anyhow::{Ok, Result};
+use std::process::Command;
 
 /// Uploads target/artifacts to GitHub releases
 #[derive(clap::Args, Debug)]
 #[command()]
-pub struct Cli {
-}
+pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let version = env::var("VECTOR_VERSION").or_else(|_| util::read_version())?;
+        let version = util::get_version()?;
         let mut command = Command::new("gh");
         command.in_repo();
-        command.args(["release",
-                "--repo",
-                "vectordotdev/vector",
-                "create",
-                &format!("v{version}"),
-                "--title",
-                &format!("v{version}"),
-                "--notes",
-                &format!("[View release notes](https://vector.dev/releases/{version})"),
-                "target/artifacts/*"]);
+        command.args([
+            "release",
+            "--repo",
+            "vectordotdev/vector",
+            "create",
+            &format!("v{version}"),
+            "--title",
+            &format!("v{version}"),
+            "--notes",
+            &format!("[View release notes](https://vector.dev/releases/{version})"),
+            "target/artifacts/*",
+        ]);
         command.check_run()?;
         Ok(())
     }

--- a/vdev/src/util.rs
+++ b/vdev/src/util.rs
@@ -33,6 +33,13 @@ pub fn read_version() -> Result<String> {
     CargoToml::load().map(|cargo| cargo.package.version)
 }
 
+/// Use the version provided by env vars or default to reading from `Cargo.toml`.
+pub fn get_version() -> Result<String> {
+    std::env::var("VERSION")
+        .or_else(|_| std::env::var("VECTOR_VERSION"))
+        .or_else(|_| read_version())
+}
+
 pub fn git_head() -> Result<Output> {
     Command::new("git")
         .args(["describe", "--exact-match", "--tags", "HEAD"])
@@ -40,15 +47,8 @@ pub fn git_head() -> Result<Output> {
         .context("Could not execute `git`")
 }
 
-/// Calculate the release channel from `git describe`
-pub fn release_channel() -> Result<&'static str> {
-    git_head().map(|output| {
-        if output.status.success() {
-            "latest"
-        } else {
-            "nightly"
-        }
-    })
+pub fn get_channel() -> String {
+    std::env::var("CHANNEL").unwrap_or_else(|_| "custom".to_string())
 }
 
 pub fn exists(path: impl AsRef<Path> + Debug) -> Result<bool> {


### PR DESCRIPTION
Revival of #16281

Fixes the issue with integration tests not building- needed to install git dependency for the container.

From the commit history you can see there is no other functional change from the original PR, thus I am not planning to set the trigger to PR and run the custom builds workflow, because that was already proved in the original PR.

See commit https://github.com/vectordotdev/vector/commit/07aafb69900534c0e1f8aafc4a8dbdccbe780605 , for the fix.
