### PR TITLE
chore(topology): Reintroduce the topology controller

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,6 @@ use exitcode::ExitCode;
 use futures::StreamExt;
 #[cfg(feature = "enterprise")]
 use futures_util::future::BoxFuture;
-use futures_util::FutureExt;
 use once_cell::race::OnceNonZeroUsize;
 use tokio::{
     runtime::{self, Runtime},
@@ -210,7 +209,7 @@ impl Application {
             signals,
         } = self;
 
-        let topology_controller = TopologyController {
+        let topology_controller = Arc::new(Mutex::new(TopologyController {
             #[cfg(feature = "api")]
             api_server: config.setup_api(runtime),
             topology: config.topology,
@@ -218,8 +217,7 @@ impl Application {
             require_healthy,
             #[cfg(feature = "enterprise")]
             enterprise_reporter: config.enterprise,
-        };
-        let topology_controller = Arc::new(Mutex::new(topology_controller));
+        }));
 
         Ok(StartedApplication {
             config_paths: config.config_paths,
@@ -290,7 +288,7 @@ impl StartedApplication {
                 }
                 // Trigger graceful shutdown if a component crashed, or all sources have ended.
                 _ = graceful_crash.next() => break SignalTo::Shutdown,
-                _ = sources_finished(Arc::clone(&topology_controller)) => {
+                _ = TopologyController::sources_finished(Arc::clone(&topology_controller)) => {
                     info!("All sources have finished.");
                     break SignalTo::Shutdown
                 } ,
@@ -344,40 +342,6 @@ impl FinishedApplication {
                 drop(topology_controller);
             }
             _ => unreachable!(),
-        }
-    }
-}
-
-// The `sources_finished` method on `RunningTopology` only considers sources that are currently
-// running at the time the method is called. This presents a problem when the set of running
-// sources can change while we are waiting on the resulting future to resolve.
-//
-// This function resolves that issue by waiting in two stages. The first is the usual asynchronous
-// wait for the future to complete. When it does, we know that all of the sources that existed when
-// the future was built have finished, but we don't know if that's because they were replaced as
-// part of a reload (in which case we don't want to return yet). To differentiate, we acquire the
-// lock on the topology, create a new future, and check whether it resolves immediately or not. If
-// it does resolve, we know all sources are truly finished because we held the lock during the
-// check, preventing anyone else from adding new sources. If it does not resolve, that indicates
-// that new sources have been added since our original call and we should start the process over to
-// continue waiting.
-async fn sources_finished(mutex: Arc<Mutex<TopologyController>>) {
-    loop {
-        // Do an initial async wait while the topology is running, making sure not the hold the
-        // mutex lock while we wait on sources to finish.
-        let initial = {
-            let tc = mutex.lock().await;
-            tc.topology.sources_finished()
-        };
-        initial.await;
-
-        // Once the initial signal is tripped, hold lock on the topology while checking again. This
-        // ensures that no other task is adding new sources.
-        let top = mutex.lock().await;
-        if top.topology.sources_finished().now_or_never().is_some() {
-            return;
-        } else {
-            continue;
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,7 @@ impl ApplicationConfig {
             match api::Server::start(
                 self.topology.config(),
                 self.topology.watch(),
-                Arc::clone(&self.topology.running),
+                std::sync::Arc::clone(&self.topology.running),
                 runtime,
             ) {
                 Ok(api_server) => {
@@ -320,8 +320,8 @@ impl FinishedApplication {
             topology_controller,
         } = self;
 
-        // At this point, we'll have the only reference to the topology controller and can safely
-        // remove it from the Arc/Mutex to shut down the topology.
+        // At this point, we'll have the only reference to the shared topology controller and can
+        // safely remove it from the wrapper to shut down the topology.
         let topology_controller = topology_controller
             .try_into_inner()
             .expect("fail to unwrap topology controller")

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -1,0 +1,104 @@
+#[cfg(feature = "enterprise")]
+use futures_util::future::BoxFuture;
+
+#[cfg(feature = "api")]
+use crate::api;
+#[cfg(feature = "enterprise")]
+use crate::config::enterprise::{
+    report_on_reload, EnterpriseError, EnterpriseMetadata, EnterpriseReporter,
+};
+use crate::internal_events::{
+    VectorConfigLoadError, VectorRecoveryError, VectorReloadError, VectorReloaded,
+};
+use crate::{config, topology::RunningTopology};
+
+pub struct TopologyController {
+    pub topology: RunningTopology,
+    pub config_paths: Vec<config::ConfigPath>,
+    pub require_healthy: Option<bool>,
+    #[cfg(feature = "enterprise")]
+    pub enterprise_reporter: Option<EnterpriseReporter<BoxFuture<'static, ()>>>,
+    #[cfg(feature = "api")]
+    pub api_server: Option<api::Server>,
+}
+
+impl std::fmt::Debug for TopologyController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopologyController")
+            .field("config_paths", &self.config_paths)
+            .field("require_healthy", &self.require_healthy)
+            .finish()
+    }
+}
+
+pub enum ReloadOutcome {
+    NoConfig,
+    MissingApiKey,
+    Success,
+    RolledBack,
+    FatalError,
+}
+
+impl TopologyController {
+    pub async fn reload(&mut self, new_config: Option<config::Config>) -> ReloadOutcome {
+        if new_config.is_none() {
+            emit!(VectorConfigLoadError);
+            return ReloadOutcome::NoConfig;
+        }
+        let mut new_config = new_config.unwrap();
+
+        new_config
+            .healthchecks
+            .set_require_healthy(self.require_healthy);
+
+        #[cfg(feature = "enterprise")]
+        // Augment config to enable observability within Datadog, if applicable.
+        match EnterpriseMetadata::try_from(&new_config) {
+            Ok(metadata) => {
+                if let Some(e) = report_on_reload(
+                    &mut new_config,
+                    metadata,
+                    self.config_paths.clone(),
+                    self.enterprise_reporter.as_ref(),
+                ) {
+                    self.enterprise_reporter = Some(e);
+                }
+            }
+            Err(err) => {
+                if let EnterpriseError::MissingApiKey = err {
+                    emit!(VectorReloadError);
+                    return ReloadOutcome::MissingApiKey;
+                }
+            }
+        }
+
+        match self.topology.reload_config_and_respawn(new_config).await {
+            Ok(true) => {
+                #[cfg(feature = "api")]
+                // Pass the new config to the API server.
+                if let Some(ref api_server) = self.api_server {
+                    api_server.update_config(self.topology.config());
+                }
+
+                emit!(VectorReloaded {
+                    config_paths: &self.config_paths
+                });
+                ReloadOutcome::Success
+            }
+            Ok(false) => {
+                emit!(VectorReloadError);
+                ReloadOutcome::RolledBack
+            }
+            // Trigger graceful shutdown for what remains of the topology
+            Err(()) => {
+                emit!(VectorReloadError);
+                emit!(VectorRecoveryError);
+                ReloadOutcome::FatalError
+            }
+        }
+    }
+
+    pub async fn stop(self) {
+        self.topology.stop().await;
+    }
+}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -25,7 +25,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-pub use controller::{ReloadOutcome, TopologyController};
+pub use controller::{ReloadOutcome, SharedTopologyController, TopologyController};
 use futures::{Future, FutureExt};
 pub(super) use running::RunningTopology;
 use tokio::sync::{mpsc, watch};

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -11,6 +11,7 @@ pub(super) use vector_core::fanout;
 pub mod schema;
 
 pub mod builder;
+mod controller;
 mod ready_arrays;
 mod running;
 mod task;
@@ -24,6 +25,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+pub use controller::{ReloadOutcome, TopologyController};
 use futures::{Future, FutureExt};
 pub(super) use running::RunningTopology;
 use tokio::sync::{mpsc, watch};


### PR DESCRIPTION
This introduces the functionality required to better manage topology operations
from outside the main app routines.

This was introduced along with the experimental reload API in #15856 and subsequently removed in #16955.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
