### PR TITLE
fix(influxdb_logs): encode influx line when no tags present

### DIFF
--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -608,16 +608,12 @@ mod tests {
         let line = std::str::from_utf8(&bytes).unwrap();
         assert!(line.starts_with("vector "));
 
-       let line_protocol = split_line_protocol(line);
+        let line_protocol = split_line_protocol(line);
         assert_eq!("vector", line_protocol.0);
         assert_eq!("", line_protocol.1);
         assert_fields(
             line_protocol.2,
-            [
-                "value=100i",
-                "message=\"hello\""
-            ]
-            .to_vec(),
+            ["value=100i", "message=\"hello\""].to_vec(),
         );
 
         assert_eq!("1542182950000000011\n", line_protocol.3);

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -599,6 +599,7 @@ mod tests {
             "vector",
             [].to_vec(),
         );
+        // exclude default metric_type tag so to emit empty tags
         sink.transformer
             .set_except_fields(Some(vec!["metric_type".into()]))
             .unwrap();
@@ -606,11 +607,14 @@ mod tests {
 
         let bytes = encoder.encode_event(event).unwrap();
         let line = std::str::from_utf8(&bytes).unwrap();
-        assert!(line.starts_with("vector "));
+        assert!(
+            line.starts_with("vector "),
+            "measurement (without tags) should ends with space ' '"
+        );
 
         let line_protocol = split_line_protocol(line);
         assert_eq!("vector", line_protocol.0);
-        assert_eq!("", line_protocol.1);
+        assert_eq!("", line_protocol.1, "tags should be empty");
         assert_fields(
             line_protocol.2,
             ["value=100i", "message=\"hello\""].to_vec(),

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -592,24 +592,32 @@ mod tests {
         event.as_mut_log().insert("value", 100);
         event.as_mut_log().insert("timestamp", ts());
 
-        let sink = create_sink(
+        let mut sink = create_sink(
             "http://localhost:9999",
             "my-token",
             ProtocolVersion::V2,
             "vector",
-            ["metric_type"].to_vec(),
+            [].to_vec(),
         );
+        sink.transformer
+            .set_except_fields(Some(vec!["metric_type".into()]))
+            .unwrap();
         let mut encoder = sink.build_encoder();
 
         let bytes = encoder.encode_event(event).unwrap();
-        let string = std::str::from_utf8(&bytes).unwrap();
+        let line = std::str::from_utf8(&bytes).unwrap();
+        assert!(line.starts_with("vector "));
 
-        let line_protocol = split_line_protocol(string);
+       let line_protocol = split_line_protocol(line);
         assert_eq!("vector", line_protocol.0);
-        assert_eq!("metric_type=logs", line_protocol.1);
+        assert_eq!("", line_protocol.1);
         assert_fields(
-            line_protocol.2.to_string(),
-            ["value=100i", "message=\"hello\""].to_vec(),
+            line_protocol.2,
+            [
+                "value=100i",
+                "message=\"hello\""
+            ]
+            .to_vec(),
         );
 
         assert_eq!("1542182950000000011\n", line_protocol.3);

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -447,9 +447,9 @@ pub mod test_util {
     //
     pub(crate) fn split_line_protocol(line_protocol: &str) -> (&str, &str, String, &str) {
         // tags and ts may not be present
-        let parts: Vec<&str> = line_protocol.splitn(2, " ").collect();
-        let (measurement, tags) = parts[0].split_once(",").unwrap_or((parts[0], ""));
-        let (fields, ts) = parts[1].split_once(" ").unwrap_or((parts[1], ""));
+        let parts: Vec<&str> = line_protocol.splitn(2, ' ').collect();
+        let (measurement, tags) = parts[0].split_once(',').unwrap_or((parts[0], ""));
+        let (fields, ts) = parts[1].split_once(' ').unwrap_or((parts[1], ""));
 
         (measurement, tags, fields.to_string(), ts)
     }


### PR DESCRIPTION
When trying to sink log without tags into influxdb, influxdb will error out `expected tag key after comma`. Which means the comma `,` should be omitted if there are no tags.

```
logs, message="hello world" # current behavior, which is invalid
logs message="hello world"  # expected behavior
```

Close #17020  