### PR TITLE
chore(topology): split `build_pieces` into smaller functions

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -497,6 +497,7 @@ async fn build_transforms(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn build_sinks(
     config: &super::Config,
     diff: &ConfigDiff,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -142,12 +142,11 @@ pub struct Pieces {
 pub async fn build_pieces(
     config: &super::Config,
     diff: &ConfigDiff,
-    mut buffers: HashMap<ComponentKey, BuiltBuffer>,
+    buffers: HashMap<ComponentKey, BuiltBuffer>,
 ) -> Result<Pieces, Vec<String>> {
     let mut inputs = HashMap::new();
     let mut outputs = HashMap::new();
     let mut tasks = HashMap::new();
-    let mut source_tasks = HashMap::new();
     let mut healthchecks = HashMap::new();
     let mut shutdown_coordinator = SourceShutdownCoordinator::default();
     let mut detach_triggers = HashMap::new();
@@ -156,6 +155,335 @@ pub async fn build_pieces(
 
     let (enrichment_tables, enrichment_errors) = load_enrichment_tables(config, diff).await;
     errors.extend(enrichment_errors);
+
+    let source_tasks = build_sources(
+        config,
+        diff,
+        &mut shutdown_coordinator,
+        &mut errors,
+        &mut outputs,
+        &mut tasks,
+    )
+    .await;
+
+    build_transforms(
+        config,
+        diff,
+        enrichment_tables,
+        &mut errors,
+        &mut inputs,
+        &mut outputs,
+        &mut tasks,
+    )
+    .await;
+
+    build_sinks(
+        config,
+        diff,
+        &mut errors,
+        buffers,
+        &mut inputs,
+        &mut healthchecks,
+        &mut tasks,
+        &mut detach_triggers,
+    )
+    .await;
+
+    // We should have all the data for the enrichment tables loaded now, so switch them over to
+    // readonly.
+    enrichment_tables.finish_load();
+
+    let mut finalized_outputs = HashMap::new();
+    for (id, output) in outputs {
+        let entry = finalized_outputs
+            .entry(id.component)
+            .or_insert_with(HashMap::new);
+        entry.insert(id.port, output);
+    }
+
+    if errors.is_empty() {
+        let pieces = Pieces {
+            inputs,
+            outputs: finalized_outputs,
+            tasks,
+            source_tasks,
+            healthchecks,
+            shutdown_coordinator,
+            detach_triggers,
+        };
+
+        Ok(pieces)
+    } else {
+        Err(errors)
+    }
+}
+
+async fn build_sinks(
+    config: &crate::config::Config,
+    diff: &ConfigDiff,
+    errors: &mut Vec<String>,
+    mut buffers: HashMap<ComponentKey, BuiltBuffer>,
+    inputs: &mut HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
+    healthchecks: &mut HashMap<ComponentKey, Task>,
+    tasks: &mut HashMap<ComponentKey, Task>,
+    detach_triggers: &mut HashMap<ComponentKey, Trigger>,
+) {
+    // Build sinks
+    for (key, sink) in config
+        .sinks()
+        .filter(|(key, _)| diff.sinks.contains_new(key))
+    {
+        debug!(component = %key, "Building new sink.");
+
+        let sink_inputs = &sink.inputs;
+        let healthcheck = sink.healthcheck();
+        let enable_healthcheck = healthcheck.enabled && config.healthchecks.enabled;
+
+        let typetag = sink.inner.get_component_name();
+        let input_type = sink.inner.input().data_type();
+
+        // At this point, we've validated that all transforms are valid, including any
+        // transform that mutates the schema provided by their sources. We can now validate the
+        // schema expectations of each individual sink.
+        if let Err(mut err) = schema::validate_sink_expectations(key, sink, config) {
+            errors.append(&mut err);
+        };
+
+        let (tx, rx) = if let Some(buffer) = buffers.remove(key) {
+            buffer
+        } else {
+            let buffer_type = match sink.buffer.stages().first().expect("cant ever be empty") {
+                BufferType::Memory { .. } => "memory",
+                BufferType::DiskV2 { .. } => "disk",
+            };
+            let buffer_span = error_span!(
+                "sink",
+                component_kind = "sink",
+                component_id = %key.id(),
+                component_type = typetag,
+                component_name = %key.id(),
+                buffer_type,
+            );
+            let buffer = sink
+                .buffer
+                .build(config.global.data_dir.clone(), key.to_string(), buffer_span)
+                .await;
+            match buffer {
+                Err(error) => {
+                    errors.push(format!("Sink \"{}\": {}", key, error));
+                    continue;
+                }
+                Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
+            }
+        };
+
+        let cx = SinkContext {
+            healthcheck,
+            globals: config.global.clone(),
+            proxy: ProxyConfig::merge_with_env(&config.global.proxy, sink.proxy()),
+            schema: config.schema,
+        };
+
+        let (sink, healthcheck) = match sink.inner.build(cx).await {
+            Err(error) => {
+                errors.push(format!("Sink \"{}\": {}", key, error));
+                continue;
+            }
+            Ok(built) => built,
+        };
+
+        let (trigger, tripwire) = Tripwire::new();
+
+        let sink = async move {
+            debug!("Sink starting.");
+
+            // Why is this Arc<Mutex<Option<_>>> needed you ask.
+            // In case when this function build_pieces errors
+            // this future won't be run so this rx won't be taken
+            // which will enable us to reuse rx to rebuild
+            // old configuration by passing this Arc<Mutex<Option<_>>>
+            // yet again.
+            let rx = rx
+                .lock()
+                .unwrap()
+                .take()
+                .expect("Task started but input has been taken.");
+
+            let mut rx = wrap(rx);
+
+            let events_received = register!(EventsReceived);
+            sink.run(
+                rx.by_ref()
+                    .filter(|events: &EventArray| ready(filter_events_type(events, input_type)))
+                    .inspect(|events| {
+                        events_received.emit(CountByteSize(
+                            events.len(),
+                            events.estimated_json_encoded_size_of(),
+                        ))
+                    })
+                    .take_until_if(tripwire),
+            )
+            .await
+            .map(|_| {
+                debug!("Sink finished normally.");
+                TaskOutput::Sink(rx)
+            })
+            .map_err(|_| {
+                debug!("Sink finished with an error.");
+                TaskError::Opaque
+            })
+        };
+
+        let task = Task::new(key.clone(), typetag, sink);
+
+        let component_key = key.clone();
+        let healthcheck_task = async move {
+            if enable_healthcheck {
+                let duration = Duration::from_secs(10);
+                timeout(duration, healthcheck)
+                    .map(|result| match result {
+                        Ok(Ok(_)) => {
+                            info!("Healthcheck passed.");
+                            Ok(TaskOutput::Healthcheck)
+                        }
+                        Ok(Err(error)) => {
+                            error!(
+                                msg = "Healthcheck failed.",
+                                %error,
+                                component_kind = "sink",
+                                component_type = typetag,
+                                component_id = %component_key.id(),
+                                // maintained for compatibility
+                                component_name = %component_key.id(),
+                            );
+                            Err(TaskError::wrapped(error))
+                        }
+                        Err(e) => {
+                            error!(
+                                msg = "Healthcheck timed out.",
+                                component_kind = "sink",
+                                component_type = typetag,
+                                component_id = %component_key.id(),
+                                // maintained for compatibility
+                                component_name = %component_key.id(),
+                            );
+                            Err(TaskError::wrapped(Box::new(e)))
+                        }
+                    })
+                    .await
+            } else {
+                info!("Healthcheck disabled.");
+                Ok(TaskOutput::Healthcheck)
+            }
+        };
+
+        let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
+
+        inputs.insert(key.clone(), (tx, sink_inputs.clone()));
+        healthchecks.insert(key.clone(), healthcheck_task);
+        tasks.insert(key.clone(), task);
+        detach_triggers.insert(key.clone(), trigger);
+    }
+}
+
+async fn build_transforms(
+    config: &crate::config::Config,
+    diff: &ConfigDiff,
+    enrichment_tables: &enrichment::TableRegistry,
+    errors: &mut Vec<String>,
+    inputs: &mut HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
+    outputs: &mut HashMap<OutputId, tokio::sync::mpsc::UnboundedSender<fanout::ControlMessage>>,
+    tasks: &mut HashMap<ComponentKey, Task>,
+) {
+    let mut definition_cache = HashMap::default();
+
+    // Build transforms
+    for (key, transform) in config
+        .transforms()
+        .filter(|(key, _)| diff.transforms.contains_new(key))
+    {
+        debug!(component = %key, "Building new transform.");
+
+        let input_definitions =
+            schema::input_definitions(&transform.inputs, config, &mut definition_cache);
+
+        let merged_definition: Definition = input_definitions
+            .iter()
+            .map(|(_output_id, definition)| definition.clone())
+            .reduce(Definition::merge)
+            // We may not have any definitions if all the inputs are from metrics sources.
+            .unwrap_or_else(Definition::any);
+
+        let span = error_span!(
+            "transform",
+            component_kind = "transform",
+            component_id = %key.id(),
+            component_type = %transform.inner.get_component_name(),
+            // maintained for compatibility
+            component_name = %key.id(),
+        );
+
+        // Create a map of the outputs to the list of possible definitions from those outputs.
+        let schema_definitions = transform
+            .inner
+            .outputs(&input_definitions, config.schema.log_namespace())
+            .into_iter()
+            .map(|output| (output.port, output.log_schema_definitions))
+            .collect::<HashMap<_, _>>();
+
+        let context = TransformContext {
+            key: Some(key.clone()),
+            globals: config.global.clone(),
+            enrichment_tables: enrichment_tables.clone(),
+            schema_definitions,
+            merged_schema_definition: merged_definition.clone(),
+            schema: config.schema,
+        };
+
+        let node = TransformNode::from_parts(
+            key.clone(),
+            transform,
+            &input_definitions,
+            config.schema.log_namespace(),
+        );
+
+        let transform = match transform
+            .inner
+            .build(&context)
+            .instrument(span.clone())
+            .await
+        {
+            Err(error) => {
+                errors.push(format!("Transform \"{}\": {}", key, error));
+                continue;
+            }
+            Ok(transform) => transform,
+        };
+
+        let (input_tx, input_rx) =
+            TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block).await;
+
+        inputs.insert(key.clone(), (input_tx, node.inputs.clone()));
+
+        let (transform_task, transform_outputs) = {
+            let _span = span.enter();
+            build_transform(transform, node, input_rx)
+        };
+
+        outputs.extend(transform_outputs);
+        tasks.insert(key.clone(), transform_task);
+    }
+}
+
+async fn build_sources(
+    config: &crate::config::Config,
+    diff: &ConfigDiff,
+    shutdown_coordinator: &mut SourceShutdownCoordinator,
+    errors: &mut Vec<String>,
+    outputs: &mut HashMap<OutputId, tokio::sync::mpsc::UnboundedSender<fanout::ControlMessage>>,
+    tasks: &mut HashMap<ComponentKey, Task>,
+) -> HashMap<ComponentKey, Task> {
+    let mut source_tasks = HashMap::new();
 
     // Build sources
     for (key, source) in config
@@ -334,269 +662,7 @@ pub async fn build_pieces(
         source_tasks.insert(key.clone(), server);
     }
 
-    let mut definition_cache = HashMap::default();
-
-    // Build transforms
-    for (key, transform) in config
-        .transforms()
-        .filter(|(key, _)| diff.transforms.contains_new(key))
-    {
-        debug!(component = %key, "Building new transform.");
-
-        let input_definitions =
-            schema::input_definitions(&transform.inputs, config, &mut definition_cache);
-
-        let merged_definition: Definition = input_definitions
-            .iter()
-            .map(|(_output_id, definition)| definition.clone())
-            .reduce(Definition::merge)
-            // We may not have any definitions if all the inputs are from metrics sources.
-            .unwrap_or_else(Definition::any);
-
-        let span = error_span!(
-            "transform",
-            component_kind = "transform",
-            component_id = %key.id(),
-            component_type = %transform.inner.get_component_name(),
-            // maintained for compatibility
-            component_name = %key.id(),
-        );
-
-        // Create a map of the outputs to the list of possible definitions from those outputs.
-        let schema_definitions = transform
-            .inner
-            .outputs(&input_definitions, config.schema.log_namespace())
-            .into_iter()
-            .map(|output| (output.port, output.log_schema_definitions))
-            .collect::<HashMap<_, _>>();
-
-        let context = TransformContext {
-            key: Some(key.clone()),
-            globals: config.global.clone(),
-            enrichment_tables: enrichment_tables.clone(),
-            schema_definitions,
-            merged_schema_definition: merged_definition.clone(),
-            schema: config.schema,
-        };
-
-        let node = TransformNode::from_parts(
-            key.clone(),
-            transform,
-            &input_definitions,
-            config.schema.log_namespace(),
-        );
-
-        let transform = match transform
-            .inner
-            .build(&context)
-            .instrument(span.clone())
-            .await
-        {
-            Err(error) => {
-                errors.push(format!("Transform \"{}\": {}", key, error));
-                continue;
-            }
-            Ok(transform) => transform,
-        };
-
-        let (input_tx, input_rx) =
-            TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block).await;
-
-        inputs.insert(key.clone(), (input_tx, node.inputs.clone()));
-
-        let (transform_task, transform_outputs) = {
-            let _span = span.enter();
-            build_transform(transform, node, input_rx)
-        };
-
-        outputs.extend(transform_outputs);
-        tasks.insert(key.clone(), transform_task);
-    }
-
-    // Build sinks
-    for (key, sink) in config
-        .sinks()
-        .filter(|(key, _)| diff.sinks.contains_new(key))
-    {
-        debug!(component = %key, "Building new sink.");
-
-        let sink_inputs = &sink.inputs;
-        let healthcheck = sink.healthcheck();
-        let enable_healthcheck = healthcheck.enabled && config.healthchecks.enabled;
-
-        let typetag = sink.inner.get_component_name();
-        let input_type = sink.inner.input().data_type();
-
-        // At this point, we've validated that all transforms are valid, including any
-        // transform that mutates the schema provided by their sources. We can now validate the
-        // schema expectations of each individual sink.
-        if let Err(mut err) = schema::validate_sink_expectations(key, sink, config) {
-            errors.append(&mut err);
-        };
-
-        let (tx, rx) = if let Some(buffer) = buffers.remove(key) {
-            buffer
-        } else {
-            let buffer_type = match sink.buffer.stages().first().expect("cant ever be empty") {
-                BufferType::Memory { .. } => "memory",
-                BufferType::DiskV2 { .. } => "disk",
-            };
-            let buffer_span = error_span!(
-                "sink",
-                component_kind = "sink",
-                component_id = %key.id(),
-                component_type = typetag,
-                component_name = %key.id(),
-                buffer_type,
-            );
-            let buffer = sink
-                .buffer
-                .build(config.global.data_dir.clone(), key.to_string(), buffer_span)
-                .await;
-            match buffer {
-                Err(error) => {
-                    errors.push(format!("Sink \"{}\": {}", key, error));
-                    continue;
-                }
-                Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
-            }
-        };
-
-        let cx = SinkContext {
-            healthcheck,
-            globals: config.global.clone(),
-            proxy: ProxyConfig::merge_with_env(&config.global.proxy, sink.proxy()),
-            schema: config.schema,
-        };
-
-        let (sink, healthcheck) = match sink.inner.build(cx).await {
-            Err(error) => {
-                errors.push(format!("Sink \"{}\": {}", key, error));
-                continue;
-            }
-            Ok(built) => built,
-        };
-
-        let (trigger, tripwire) = Tripwire::new();
-
-        let sink = async move {
-            debug!("Sink starting.");
-
-            // Why is this Arc<Mutex<Option<_>>> needed you ask.
-            // In case when this function build_pieces errors
-            // this future won't be run so this rx won't be taken
-            // which will enable us to reuse rx to rebuild
-            // old configuration by passing this Arc<Mutex<Option<_>>>
-            // yet again.
-            let rx = rx
-                .lock()
-                .unwrap()
-                .take()
-                .expect("Task started but input has been taken.");
-
-            let mut rx = wrap(rx);
-
-            let events_received = register!(EventsReceived);
-            sink.run(
-                rx.by_ref()
-                    .filter(|events: &EventArray| ready(filter_events_type(events, input_type)))
-                    .inspect(|events| {
-                        events_received.emit(CountByteSize(
-                            events.len(),
-                            events.estimated_json_encoded_size_of(),
-                        ))
-                    })
-                    .take_until_if(tripwire),
-            )
-            .await
-            .map(|_| {
-                debug!("Sink finished normally.");
-                TaskOutput::Sink(rx)
-            })
-            .map_err(|_| {
-                debug!("Sink finished with an error.");
-                TaskError::Opaque
-            })
-        };
-
-        let task = Task::new(key.clone(), typetag, sink);
-
-        let component_key = key.clone();
-        let healthcheck_task = async move {
-            if enable_healthcheck {
-                let duration = Duration::from_secs(10);
-                timeout(duration, healthcheck)
-                    .map(|result| match result {
-                        Ok(Ok(_)) => {
-                            info!("Healthcheck passed.");
-                            Ok(TaskOutput::Healthcheck)
-                        }
-                        Ok(Err(error)) => {
-                            error!(
-                                msg = "Healthcheck failed.",
-                                %error,
-                                component_kind = "sink",
-                                component_type = typetag,
-                                component_id = %component_key.id(),
-                                // maintained for compatibility
-                                component_name = %component_key.id(),
-                            );
-                            Err(TaskError::wrapped(error))
-                        }
-                        Err(e) => {
-                            error!(
-                                msg = "Healthcheck timed out.",
-                                component_kind = "sink",
-                                component_type = typetag,
-                                component_id = %component_key.id(),
-                                // maintained for compatibility
-                                component_name = %component_key.id(),
-                            );
-                            Err(TaskError::wrapped(Box::new(e)))
-                        }
-                    })
-                    .await
-            } else {
-                info!("Healthcheck disabled.");
-                Ok(TaskOutput::Healthcheck)
-            }
-        };
-
-        let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
-
-        inputs.insert(key.clone(), (tx, sink_inputs.clone()));
-        healthchecks.insert(key.clone(), healthcheck_task);
-        tasks.insert(key.clone(), task);
-        detach_triggers.insert(key.clone(), trigger);
-    }
-
-    // We should have all the data for the enrichment tables loaded now, so switch them over to
-    // readonly.
-    enrichment_tables.finish_load();
-
-    let mut finalized_outputs = HashMap::new();
-    for (id, output) in outputs {
-        let entry = finalized_outputs
-            .entry(id.component)
-            .or_insert_with(HashMap::new);
-        entry.insert(id.port, output);
-    }
-
-    if errors.is_empty() {
-        let pieces = Pieces {
-            inputs,
-            outputs: finalized_outputs,
-            tasks,
-            source_tasks,
-            healthchecks,
-            shutdown_coordinator,
-            detach_triggers,
-        };
-
-        Ok(pieces)
-    } else {
-        Err(errors)
-    }
+    source_tasks
 }
 
 const fn filter_events_type(events: &EventArray, data_type: DataType) -> bool {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 use stream_cancel::{StreamExt as StreamCancelExt, Trigger, Tripwire};
 use tokio::{
     select,
-    sync::oneshot,
+    sync::{mpsc::UnboundedSender, oneshot},
     time::{timeout, Duration},
 };
 use tracing::Instrument;
@@ -219,11 +219,11 @@ pub async fn build_pieces(
 }
 
 async fn build_sources(
-    config: &crate::config::Config,
+    config: &super::Config,
     diff: &ConfigDiff,
     shutdown_coordinator: &mut SourceShutdownCoordinator,
     errors: &mut Vec<String>,
-    outputs: &mut HashMap<OutputId, tokio::sync::mpsc::UnboundedSender<fanout::ControlMessage>>,
+    outputs: &mut HashMap<OutputId, UnboundedSender<fanout::ControlMessage>>,
     tasks: &mut HashMap<ComponentKey, Task>,
 ) -> HashMap<ComponentKey, Task> {
     let mut source_tasks = HashMap::new();
@@ -409,12 +409,12 @@ async fn build_sources(
 }
 
 async fn build_transforms(
-    config: &crate::config::Config,
+    config: &super::Config,
     diff: &ConfigDiff,
     enrichment_tables: &enrichment::TableRegistry,
     errors: &mut Vec<String>,
     inputs: &mut HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
-    outputs: &mut HashMap<OutputId, tokio::sync::mpsc::UnboundedSender<fanout::ControlMessage>>,
+    outputs: &mut HashMap<OutputId, UnboundedSender<fanout::ControlMessage>>,
     tasks: &mut HashMap<ComponentKey, Task>,
 ) {
     let mut definition_cache = HashMap::default();
@@ -498,7 +498,7 @@ async fn build_transforms(
 }
 
 async fn build_sinks(
-    config: &crate::config::Config,
+    config: &super::Config,
     diff: &ConfigDiff,
     errors: &mut Vec<String>,
     mut buffers: HashMap<ComponentKey, BuiltBuffer>,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -72,60 +72,572 @@ static TRANSFORM_CONCURRENCY_LIMIT: Lazy<usize> = Lazy::new(|| {
         .unwrap_or_else(crate::num_threads)
 });
 
-pub(self) async fn load_enrichment_tables<'a>(
+/// Builds only the new pieces, and doesn't check their topology.
+pub async fn build_pieces(
+    config: &super::Config,
+    diff: &ConfigDiff,
+    buffers: HashMap<ComponentKey, BuiltBuffer>,
+) -> Result<Pieces, Vec<String>> {
+    Builder::new(config, diff, buffers).build().await
+}
+
+struct Builder<'a> {
     config: &'a super::Config,
     diff: &'a ConfigDiff,
-) -> (&'static enrichment::TableRegistry, Vec<String>) {
-    let mut enrichment_tables = HashMap::new();
+    shutdown_coordinator: SourceShutdownCoordinator,
+    errors: Vec<String>,
+    outputs: HashMap<OutputId, UnboundedSender<fanout::ControlMessage>>,
+    tasks: HashMap<ComponentKey, Task>,
+    buffers: HashMap<ComponentKey, BuiltBuffer>,
+    inputs: HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
+    healthchecks: HashMap<ComponentKey, Task>,
+    detach_triggers: HashMap<ComponentKey, Trigger>,
+}
 
-    let mut errors = vec![];
-
-    // Build enrichment tables
-    'tables: for (name, table) in config.enrichment_tables.iter() {
-        let table_name = name.to_string();
-        if ENRICHMENT_TABLES.needs_reload(&table_name) {
-            let indexes = if !diff.enrichment_tables.is_added(name) {
-                // If this is an existing enrichment table, we need to store the indexes to reapply
-                // them again post load.
-                Some(ENRICHMENT_TABLES.index_fields(&table_name))
-            } else {
-                None
-            };
-
-            let mut table = match table.inner.build(&config.global).await {
-                Ok(table) => table,
-                Err(error) => {
-                    errors.push(format!("Enrichment Table \"{}\": {}", name, error));
-                    continue;
-                }
-            };
-
-            if let Some(indexes) = indexes {
-                for (case, index) in indexes {
-                    match table
-                        .add_index(case, &index.iter().map(|s| s.as_ref()).collect::<Vec<_>>())
-                    {
-                        Ok(_) => (),
-                        Err(error) => {
-                            // If there is an error adding an index we do not want to use the reloaded
-                            // data, the previously loaded data will still need to be used.
-                            // Just report the error and continue.
-                            error!(message = "Unable to add index to reloaded enrichment table.",
-                                    table = ?name.to_string(),
-                                    %error);
-                            continue 'tables;
-                        }
-                    }
-                }
-            }
-
-            enrichment_tables.insert(table_name, table);
+impl<'a> Builder<'a> {
+    fn new(
+        config: &'a super::Config,
+        diff: &'a ConfigDiff,
+        buffers: HashMap<ComponentKey, BuiltBuffer>,
+    ) -> Self {
+        Self {
+            config,
+            diff,
+            buffers,
+            shutdown_coordinator: SourceShutdownCoordinator::default(),
+            errors: vec![],
+            outputs: HashMap::new(),
+            tasks: HashMap::new(),
+            inputs: HashMap::new(),
+            healthchecks: HashMap::new(),
+            detach_triggers: HashMap::new(),
         }
     }
 
-    ENRICHMENT_TABLES.load(enrichment_tables);
+    /// Builds the new pieces of the topology found in `self.diff`.
+    async fn build(mut self) -> Result<Pieces, Vec<String>> {
+        let enrichment_tables = self.load_enrichment_tables().await;
+        let source_tasks = self.build_sources().await;
+        self.build_transforms(enrichment_tables).await;
+        self.build_sinks().await;
 
-    (&ENRICHMENT_TABLES, errors)
+        // We should have all the data for the enrichment tables loaded now, so switch them over to
+        // readonly.
+        enrichment_tables.finish_load();
+
+        if self.errors.is_empty() {
+            Ok(Pieces {
+                inputs: self.inputs,
+                outputs: Self::finalize_outputs(self.outputs),
+                tasks: self.tasks,
+                source_tasks,
+                healthchecks: self.healthchecks,
+                shutdown_coordinator: self.shutdown_coordinator,
+                detach_triggers: self.detach_triggers,
+            })
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    fn finalize_outputs(
+        outputs: HashMap<OutputId, UnboundedSender<fanout::ControlMessage>>,
+    ) -> HashMap<ComponentKey, HashMap<Option<String>, UnboundedSender<fanout::ControlMessage>>>
+    {
+        let mut finalized_outputs = HashMap::new();
+        for (id, output) in outputs {
+            let entry = finalized_outputs
+                .entry(id.component)
+                .or_insert_with(HashMap::new);
+            entry.insert(id.port, output);
+        }
+
+        finalized_outputs
+    }
+
+    /// Loads, or reloads the enrichment tables.
+    /// The tables are stored in the `ENRICHMENT_TABLES` global variable.
+    async fn load_enrichment_tables(&mut self) -> &'static enrichment::TableRegistry {
+        let mut enrichment_tables = HashMap::new();
+
+        // Build enrichment tables
+        'tables: for (name, table) in self.config.enrichment_tables.iter() {
+            let table_name = name.to_string();
+            if ENRICHMENT_TABLES.needs_reload(&table_name) {
+                let indexes = if !self.diff.enrichment_tables.is_added(name) {
+                    // If this is an existing enrichment table, we need to store the indexes to reapply
+                    // them again post load.
+                    Some(ENRICHMENT_TABLES.index_fields(&table_name))
+                } else {
+                    None
+                };
+
+                let mut table = match table.inner.build(&self.config.global).await {
+                    Ok(table) => table,
+                    Err(error) => {
+                        self.errors
+                            .push(format!("Enrichment Table \"{}\": {}", name, error));
+                        continue;
+                    }
+                };
+
+                if let Some(indexes) = indexes {
+                    for (case, index) in indexes {
+                        match table
+                            .add_index(case, &index.iter().map(|s| s.as_ref()).collect::<Vec<_>>())
+                        {
+                            Ok(_) => (),
+                            Err(error) => {
+                                // If there is an error adding an index we do not want to use the reloaded
+                                // data, the previously loaded data will still need to be used.
+                                // Just report the error and continue.
+                                error!(message = "Unable to add index to reloaded enrichment table.",
+                                    table = ?name.to_string(),
+                                    %error);
+                                continue 'tables;
+                            }
+                        }
+                    }
+                }
+
+                enrichment_tables.insert(table_name, table);
+            }
+        }
+
+        ENRICHMENT_TABLES.load(enrichment_tables);
+
+        &ENRICHMENT_TABLES
+    }
+
+    async fn build_sources(&mut self) -> HashMap<ComponentKey, Task> {
+        let mut source_tasks = HashMap::new();
+
+        for (key, source) in self
+            .config
+            .sources()
+            .filter(|(key, _)| self.diff.sources.contains_new(key))
+        {
+            debug!(component = %key, "Building new source.");
+
+            let typetag = source.inner.get_component_name();
+            let source_outputs = source.inner.outputs(self.config.schema.log_namespace());
+
+            let span = error_span!(
+                "source",
+                component_kind = "source",
+                component_id = %key.id(),
+                component_type = %source.inner.get_component_name(),
+                // maintained for compatibility
+                component_name = %key.id(),
+            );
+            let _entered_span = span.enter();
+
+            let task_name = format!(
+                ">> {} ({}, pump) >>",
+                source.inner.get_component_name(),
+                key.id()
+            );
+
+            let mut builder = SourceSender::builder().with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
+            let mut pumps = Vec::new();
+            let mut controls = HashMap::new();
+            let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
+
+            for output in source_outputs.into_iter() {
+                let mut rx = builder.add_source_output(output.clone());
+
+                let (mut fanout, control) = Fanout::new();
+                let pump = async move {
+                    debug!("Source pump starting.");
+
+                    while let Some(array) = rx.next().await {
+                        fanout.send(array).await.map_err(|e| {
+                            debug!("Source pump finished with an error.");
+                            TaskError::wrapped(e)
+                        })?;
+                    }
+
+                    debug!("Source pump finished normally.");
+                    Ok(TaskOutput::Source)
+                };
+
+                pumps.push(pump.instrument(span.clone()));
+                controls.insert(
+                    OutputId {
+                        component: key.clone(),
+                        port: output.port.clone(),
+                    },
+                    control,
+                );
+
+                let port = output.port.clone();
+                if let Some(definition) = output.schema_definition(self.config.schema.enabled) {
+                    schema_definitions.insert(port, definition);
+                }
+            }
+
+            let (pump_error_tx, mut pump_error_rx) = oneshot::channel();
+            let pump = async move {
+                debug!("Source pump supervisor starting.");
+
+                // Spawn all of the per-output pumps and then await their completion.
+                //
+                // If any of the pumps complete with an error, or panic/are cancelled, we return
+                // immediately.
+                let mut handles = FuturesUnordered::new();
+                for pump in pumps {
+                    handles.push(spawn_named(pump, task_name.as_ref()));
+                }
+
+                let mut had_pump_error = false;
+                while let Some(output) = handles.try_next().await? {
+                    if let Err(e) = output {
+                        // Immediately send the error to the source's wrapper future, but ignore any
+                        // errors during the send, since nested errors wouldn't make any sense here.
+                        let _ = pump_error_tx.send(e);
+                        had_pump_error = true;
+                        break;
+                    }
+                }
+
+                if had_pump_error {
+                    debug!("Source pump supervisor task finished with an error.");
+                } else {
+                    debug!("Source pump supervisor task finished normally.");
+                }
+                Ok(TaskOutput::Source)
+            };
+            let pump = Task::new(key.clone(), typetag, pump);
+
+            let pipeline = builder.build();
+
+            let (shutdown_signal, force_shutdown_tripwire) =
+                self.shutdown_coordinator.register_source(key);
+
+            let context = SourceContext {
+                key: key.clone(),
+                globals: self.config.global.clone(),
+                shutdown: shutdown_signal,
+                out: pipeline,
+                proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, &source.proxy),
+                acknowledgements: source.sink_acknowledgements,
+                schema_definitions,
+                schema: self.config.schema,
+            };
+            let source = source.inner.build(context).await;
+            let server = match source {
+                Err(error) => {
+                    self.errors.push(format!("Source \"{}\": {}", key, error));
+                    continue;
+                }
+                Ok(server) => server,
+            };
+
+            // Build a wrapper future that drives the actual source future, but returns early if we've
+            // been signalled to forcefully shutdown, or if the source pump encounters an error.
+            //
+            // The forceful shutdown will only resolve if the source itself doesn't shutdown gracefully
+            // within the alloted time window. This can occur normally for certain sources, like stdin,
+            // where the I/O is blocking (in a separate thread) and won't wake up to check if it's time
+            // to shutdown unless some input is given.
+            let server = async move {
+                debug!("Source starting.");
+
+                let mut result = select! {
+                    biased;
+
+                    // We've been told that we must forcefully shut down.
+                    _ = force_shutdown_tripwire => Ok(()),
+
+                    // The source pump encountered an error, which we're now bubbling up here to stop
+                    // the source as well, since the source running makes no sense without the pump.
+                    //
+                    // We only match receiving a message, not the error of the sender being dropped,
+                    // just to keep things simpler.
+                    Ok(e) = &mut pump_error_rx => Err(e),
+
+                    // The source finished normally.
+                    result = server => result.map_err(|_| TaskError::Opaque),
+                };
+
+                // Even though we already tried to receive any pump task error above, we may have exited
+                // on the source itself returning an error due to task scheduling, where the pump task
+                // encountered an error, sent it over the oneshot, but we were polling the source
+                // already and hit an error trying to send to the now-shutdown pump task.
+                //
+                // Since the error from the source is opaque at the moment (i.e. `()`), we try a final
+                // time to see if the pump task encountered an error, using _that_ instead if so, to
+                // propagate the true error that caused the source to have to stop.
+                if let Ok(e) = pump_error_rx.try_recv() {
+                    result = Err(e);
+                }
+
+                match result {
+                    Ok(()) => {
+                        debug!("Source finished normally.");
+                        Ok(TaskOutput::Source)
+                    }
+                    Err(e) => {
+                        debug!("Source finished with an error.");
+                        Err(e)
+                    }
+                }
+            };
+            let server = Task::new(key.clone(), typetag, server);
+
+            self.outputs.extend(controls);
+            self.tasks.insert(key.clone(), pump);
+            source_tasks.insert(key.clone(), server);
+        }
+
+        source_tasks
+    }
+
+    async fn build_transforms(&mut self, enrichment_tables: &enrichment::TableRegistry) {
+        let mut definition_cache = HashMap::default();
+
+        for (key, transform) in self
+            .config
+            .transforms()
+            .filter(|(key, _)| self.diff.transforms.contains_new(key))
+        {
+            debug!(component = %key, "Building new transform.");
+
+            let input_definitions =
+                schema::input_definitions(&transform.inputs, self.config, &mut definition_cache);
+
+            let merged_definition: Definition = input_definitions
+                .iter()
+                .map(|(_output_id, definition)| definition.clone())
+                .reduce(Definition::merge)
+                // We may not have any definitions if all the inputs are from metrics sources.
+                .unwrap_or_else(Definition::any);
+
+            let span = error_span!(
+                "transform",
+                component_kind = "transform",
+                component_id = %key.id(),
+                component_type = %transform.inner.get_component_name(),
+                // maintained for compatibility
+                component_name = %key.id(),
+            );
+
+            // Create a map of the outputs to the list of possible definitions from those outputs.
+            let schema_definitions = transform
+                .inner
+                .outputs(&input_definitions, self.config.schema.log_namespace())
+                .into_iter()
+                .map(|output| (output.port, output.log_schema_definitions))
+                .collect::<HashMap<_, _>>();
+
+            let context = TransformContext {
+                key: Some(key.clone()),
+                globals: self.config.global.clone(),
+                enrichment_tables: enrichment_tables.clone(),
+                schema_definitions,
+                merged_schema_definition: merged_definition.clone(),
+                schema: self.config.schema,
+            };
+
+            let node = TransformNode::from_parts(
+                key.clone(),
+                transform,
+                &input_definitions,
+                self.config.schema.log_namespace(),
+            );
+
+            let transform = match transform
+                .inner
+                .build(&context)
+                .instrument(span.clone())
+                .await
+            {
+                Err(error) => {
+                    self.errors
+                        .push(format!("Transform \"{}\": {}", key, error));
+                    continue;
+                }
+                Ok(transform) => transform,
+            };
+
+            let (input_tx, input_rx) =
+                TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block).await;
+
+            self.inputs
+                .insert(key.clone(), (input_tx, node.inputs.clone()));
+
+            let (transform_task, transform_outputs) = {
+                let _span = span.enter();
+                build_transform(transform, node, input_rx)
+            };
+
+            self.outputs.extend(transform_outputs);
+            self.tasks.insert(key.clone(), transform_task);
+        }
+    }
+
+    async fn build_sinks(&mut self) {
+        for (key, sink) in self
+            .config
+            .sinks()
+            .filter(|(key, _)| self.diff.sinks.contains_new(key))
+        {
+            debug!(component = %key, "Building new sink.");
+
+            let sink_inputs = &sink.inputs;
+            let healthcheck = sink.healthcheck();
+            let enable_healthcheck = healthcheck.enabled && self.config.healthchecks.enabled;
+
+            let typetag = sink.inner.get_component_name();
+            let input_type = sink.inner.input().data_type();
+
+            // At this point, we've validated that all transforms are valid, including any
+            // transform that mutates the schema provided by their sources. We can now validate the
+            // schema expectations of each individual sink.
+            if let Err(mut err) = schema::validate_sink_expectations(key, sink, self.config) {
+                self.errors.append(&mut err);
+            };
+
+            let (tx, rx) = if let Some(buffer) = self.buffers.remove(key) {
+                buffer
+            } else {
+                let buffer_type = match sink.buffer.stages().first().expect("cant ever be empty") {
+                    BufferType::Memory { .. } => "memory",
+                    BufferType::DiskV2 { .. } => "disk",
+                };
+                let buffer_span = error_span!(
+                    "sink",
+                    component_kind = "sink",
+                    component_id = %key.id(),
+                    component_type = typetag,
+                    component_name = %key.id(),
+                    buffer_type,
+                );
+                let buffer = sink
+                    .buffer
+                    .build(
+                        self.config.global.data_dir.clone(),
+                        key.to_string(),
+                        buffer_span,
+                    )
+                    .await;
+                match buffer {
+                    Err(error) => {
+                        self.errors.push(format!("Sink \"{}\": {}", key, error));
+                        continue;
+                    }
+                    Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
+                }
+            };
+
+            let cx = SinkContext {
+                healthcheck,
+                globals: self.config.global.clone(),
+                proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
+                schema: self.config.schema,
+            };
+
+            let (sink, healthcheck) = match sink.inner.build(cx).await {
+                Err(error) => {
+                    self.errors.push(format!("Sink \"{}\": {}", key, error));
+                    continue;
+                }
+                Ok(built) => built,
+            };
+
+            let (trigger, tripwire) = Tripwire::new();
+
+            let sink = async move {
+                debug!("Sink starting.");
+
+                // Why is this Arc<Mutex<Option<_>>> needed you ask.
+                // In case when this function build_pieces errors
+                // this future won't be run so this rx won't be taken
+                // which will enable us to reuse rx to rebuild
+                // old configuration by passing this Arc<Mutex<Option<_>>>
+                // yet again.
+                let rx = rx
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("Task started but input has been taken.");
+
+                let mut rx = wrap(rx);
+
+                let events_received = register!(EventsReceived);
+                sink.run(
+                    rx.by_ref()
+                        .filter(|events: &EventArray| ready(filter_events_type(events, input_type)))
+                        .inspect(|events| {
+                            events_received.emit(CountByteSize(
+                                events.len(),
+                                events.estimated_json_encoded_size_of(),
+                            ))
+                        })
+                        .take_until_if(tripwire),
+                )
+                .await
+                .map(|_| {
+                    debug!("Sink finished normally.");
+                    TaskOutput::Sink(rx)
+                })
+                .map_err(|_| {
+                    debug!("Sink finished with an error.");
+                    TaskError::Opaque
+                })
+            };
+
+            let task = Task::new(key.clone(), typetag, sink);
+
+            let component_key = key.clone();
+            let healthcheck_task = async move {
+                if enable_healthcheck {
+                    let duration = Duration::from_secs(10);
+                    timeout(duration, healthcheck)
+                        .map(|result| match result {
+                            Ok(Ok(_)) => {
+                                info!("Healthcheck passed.");
+                                Ok(TaskOutput::Healthcheck)
+                            }
+                            Ok(Err(error)) => {
+                                error!(
+                                    msg = "Healthcheck failed.",
+                                    %error,
+                                    component_kind = "sink",
+                                    component_type = typetag,
+                                    component_id = %component_key.id(),
+                                    // maintained for compatibility
+                                    component_name = %component_key.id(),
+                                );
+                                Err(TaskError::wrapped(error))
+                            }
+                            Err(e) => {
+                                error!(
+                                    msg = "Healthcheck timed out.",
+                                    component_kind = "sink",
+                                    component_type = typetag,
+                                    component_id = %component_key.id(),
+                                    // maintained for compatibility
+                                    component_name = %component_key.id(),
+                                );
+                                Err(TaskError::wrapped(Box::new(e)))
+                            }
+                        })
+                        .await
+                } else {
+                    info!("Healthcheck disabled.");
+                    Ok(TaskOutput::Healthcheck)
+                }
+            };
+
+            let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
+
+            self.inputs.insert(key.clone(), (tx, sink_inputs.clone()));
+            self.healthchecks.insert(key.clone(), healthcheck_task);
+            self.tasks.insert(key.clone(), task);
+            self.detach_triggers.insert(key.clone(), trigger);
+        }
+    }
 }
 
 pub struct Pieces {
@@ -136,534 +648,6 @@ pub struct Pieces {
     pub(super) healthchecks: HashMap<ComponentKey, Task>,
     pub(crate) shutdown_coordinator: SourceShutdownCoordinator,
     pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,
-}
-
-/// Builds only the new pieces, and doesn't check their topology.
-pub async fn build_pieces(
-    config: &super::Config,
-    diff: &ConfigDiff,
-    buffers: HashMap<ComponentKey, BuiltBuffer>,
-) -> Result<Pieces, Vec<String>> {
-    let mut inputs = HashMap::new();
-    let mut outputs = HashMap::new();
-    let mut tasks = HashMap::new();
-    let mut healthchecks = HashMap::new();
-    let mut shutdown_coordinator = SourceShutdownCoordinator::default();
-    let mut detach_triggers = HashMap::new();
-
-    let mut errors = vec![];
-
-    let (enrichment_tables, enrichment_errors) = load_enrichment_tables(config, diff).await;
-    errors.extend(enrichment_errors);
-
-    let source_tasks = build_sources(
-        config,
-        diff,
-        &mut shutdown_coordinator,
-        &mut errors,
-        &mut outputs,
-        &mut tasks,
-    )
-    .await;
-
-    build_transforms(
-        config,
-        diff,
-        enrichment_tables,
-        &mut errors,
-        &mut inputs,
-        &mut outputs,
-        &mut tasks,
-    )
-    .await;
-
-    build_sinks(
-        config,
-        diff,
-        &mut errors,
-        buffers,
-        &mut inputs,
-        &mut healthchecks,
-        &mut tasks,
-        &mut detach_triggers,
-    )
-    .await;
-
-    // We should have all the data for the enrichment tables loaded now, so switch them over to
-    // readonly.
-    enrichment_tables.finish_load();
-
-    let mut finalized_outputs = HashMap::new();
-    for (id, output) in outputs {
-        let entry = finalized_outputs
-            .entry(id.component)
-            .or_insert_with(HashMap::new);
-        entry.insert(id.port, output);
-    }
-
-    if errors.is_empty() {
-        let pieces = Pieces {
-            inputs,
-            outputs: finalized_outputs,
-            tasks,
-            source_tasks,
-            healthchecks,
-            shutdown_coordinator,
-            detach_triggers,
-        };
-
-        Ok(pieces)
-    } else {
-        Err(errors)
-    }
-}
-
-async fn build_sources(
-    config: &super::Config,
-    diff: &ConfigDiff,
-    shutdown_coordinator: &mut SourceShutdownCoordinator,
-    errors: &mut Vec<String>,
-    outputs: &mut HashMap<OutputId, UnboundedSender<fanout::ControlMessage>>,
-    tasks: &mut HashMap<ComponentKey, Task>,
-) -> HashMap<ComponentKey, Task> {
-    let mut source_tasks = HashMap::new();
-
-    // Build sources
-    for (key, source) in config
-        .sources()
-        .filter(|(key, _)| diff.sources.contains_new(key))
-    {
-        debug!(component = %key, "Building new source.");
-
-        let typetag = source.inner.get_component_name();
-        let source_outputs = source.inner.outputs(config.schema.log_namespace());
-
-        let span = error_span!(
-            "source",
-            component_kind = "source",
-            component_id = %key.id(),
-            component_type = %source.inner.get_component_name(),
-            // maintained for compatibility
-            component_name = %key.id(),
-        );
-        let _entered_span = span.enter();
-
-        let task_name = format!(
-            ">> {} ({}, pump) >>",
-            source.inner.get_component_name(),
-            key.id()
-        );
-
-        let mut builder = SourceSender::builder().with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
-        let mut pumps = Vec::new();
-        let mut controls = HashMap::new();
-        let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
-
-        for output in source_outputs.into_iter() {
-            let mut rx = builder.add_source_output(output.clone());
-
-            let (mut fanout, control) = Fanout::new();
-            let pump = async move {
-                debug!("Source pump starting.");
-
-                while let Some(array) = rx.next().await {
-                    fanout.send(array).await.map_err(|e| {
-                        debug!("Source pump finished with an error.");
-                        TaskError::wrapped(e)
-                    })?;
-                }
-
-                debug!("Source pump finished normally.");
-                Ok(TaskOutput::Source)
-            };
-
-            pumps.push(pump.instrument(span.clone()));
-            controls.insert(
-                OutputId {
-                    component: key.clone(),
-                    port: output.port.clone(),
-                },
-                control,
-            );
-
-            let port = output.port.clone();
-            if let Some(definition) = output.schema_definition(config.schema.enabled) {
-                schema_definitions.insert(port, definition);
-            }
-        }
-
-        let (pump_error_tx, mut pump_error_rx) = oneshot::channel();
-        let pump = async move {
-            debug!("Source pump supervisor starting.");
-
-            // Spawn all of the per-output pumps and then await their completion.
-            //
-            // If any of the pumps complete with an error, or panic/are cancelled, we return
-            // immediately.
-            let mut handles = FuturesUnordered::new();
-            for pump in pumps {
-                handles.push(spawn_named(pump, task_name.as_ref()));
-            }
-
-            let mut had_pump_error = false;
-            while let Some(output) = handles.try_next().await? {
-                if let Err(e) = output {
-                    // Immediately send the error to the source's wrapper future, but ignore any
-                    // errors during the send, since nested errors wouldn't make any sense here.
-                    let _ = pump_error_tx.send(e);
-                    had_pump_error = true;
-                    break;
-                }
-            }
-
-            if had_pump_error {
-                debug!("Source pump supervisor task finished with an error.");
-            } else {
-                debug!("Source pump supervisor task finished normally.");
-            }
-            Ok(TaskOutput::Source)
-        };
-        let pump = Task::new(key.clone(), typetag, pump);
-
-        let pipeline = builder.build();
-
-        let (shutdown_signal, force_shutdown_tripwire) = shutdown_coordinator.register_source(key);
-
-        let context = SourceContext {
-            key: key.clone(),
-            globals: config.global.clone(),
-            shutdown: shutdown_signal,
-            out: pipeline,
-            proxy: ProxyConfig::merge_with_env(&config.global.proxy, &source.proxy),
-            acknowledgements: source.sink_acknowledgements,
-            schema_definitions,
-            schema: config.schema,
-        };
-        let source = source.inner.build(context).await;
-        let server = match source {
-            Err(error) => {
-                errors.push(format!("Source \"{}\": {}", key, error));
-                continue;
-            }
-            Ok(server) => server,
-        };
-
-        // Build a wrapper future that drives the actual source future, but returns early if we've
-        // been signalled to forcefully shutdown, or if the source pump encounters an error.
-        //
-        // The forceful shutdown will only resolve if the source itself doesn't shutdown gracefully
-        // within the alloted time window. This can occur normally for certain sources, like stdin,
-        // where the I/O is blocking (in a separate thread) and won't wake up to check if it's time
-        // to shutdown unless some input is given.
-        let server = async move {
-            debug!("Source starting.");
-
-            let mut result = select! {
-                biased;
-
-                // We've been told that we must forcefully shut down.
-                _ = force_shutdown_tripwire => Ok(()),
-
-                // The source pump encountered an error, which we're now bubbling up here to stop
-                // the source as well, since the source running makes no sense without the pump.
-                //
-                // We only match receiving a message, not the error of the sender being dropped,
-                // just to keep things simpler.
-                Ok(e) = &mut pump_error_rx => Err(e),
-
-                // The source finished normally.
-                result = server => result.map_err(|_| TaskError::Opaque),
-            };
-
-            // Even though we already tried to receive any pump task error above, we may have exited
-            // on the source itself returning an error due to task scheduling, where the pump task
-            // encountered an error, sent it over the oneshot, but we were polling the source
-            // already and hit an error trying to send to the now-shutdown pump task.
-            //
-            // Since the error from the source is opaque at the moment (i.e. `()`), we try a final
-            // time to see if the pump task encountered an error, using _that_ instead if so, to
-            // propagate the true error that caused the source to have to stop.
-            if let Ok(e) = pump_error_rx.try_recv() {
-                result = Err(e);
-            }
-
-            match result {
-                Ok(()) => {
-                    debug!("Source finished normally.");
-                    Ok(TaskOutput::Source)
-                }
-                Err(e) => {
-                    debug!("Source finished with an error.");
-                    Err(e)
-                }
-            }
-        };
-        let server = Task::new(key.clone(), typetag, server);
-
-        outputs.extend(controls);
-        tasks.insert(key.clone(), pump);
-        source_tasks.insert(key.clone(), server);
-    }
-
-    source_tasks
-}
-
-async fn build_transforms(
-    config: &super::Config,
-    diff: &ConfigDiff,
-    enrichment_tables: &enrichment::TableRegistry,
-    errors: &mut Vec<String>,
-    inputs: &mut HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
-    outputs: &mut HashMap<OutputId, UnboundedSender<fanout::ControlMessage>>,
-    tasks: &mut HashMap<ComponentKey, Task>,
-) {
-    let mut definition_cache = HashMap::default();
-
-    // Build transforms
-    for (key, transform) in config
-        .transforms()
-        .filter(|(key, _)| diff.transforms.contains_new(key))
-    {
-        debug!(component = %key, "Building new transform.");
-
-        let input_definitions =
-            schema::input_definitions(&transform.inputs, config, &mut definition_cache);
-
-        let merged_definition: Definition = input_definitions
-            .iter()
-            .map(|(_output_id, definition)| definition.clone())
-            .reduce(Definition::merge)
-            // We may not have any definitions if all the inputs are from metrics sources.
-            .unwrap_or_else(Definition::any);
-
-        let span = error_span!(
-            "transform",
-            component_kind = "transform",
-            component_id = %key.id(),
-            component_type = %transform.inner.get_component_name(),
-            // maintained for compatibility
-            component_name = %key.id(),
-        );
-
-        // Create a map of the outputs to the list of possible definitions from those outputs.
-        let schema_definitions = transform
-            .inner
-            .outputs(&input_definitions, config.schema.log_namespace())
-            .into_iter()
-            .map(|output| (output.port, output.log_schema_definitions))
-            .collect::<HashMap<_, _>>();
-
-        let context = TransformContext {
-            key: Some(key.clone()),
-            globals: config.global.clone(),
-            enrichment_tables: enrichment_tables.clone(),
-            schema_definitions,
-            merged_schema_definition: merged_definition.clone(),
-            schema: config.schema,
-        };
-
-        let node = TransformNode::from_parts(
-            key.clone(),
-            transform,
-            &input_definitions,
-            config.schema.log_namespace(),
-        );
-
-        let transform = match transform
-            .inner
-            .build(&context)
-            .instrument(span.clone())
-            .await
-        {
-            Err(error) => {
-                errors.push(format!("Transform \"{}\": {}", key, error));
-                continue;
-            }
-            Ok(transform) => transform,
-        };
-
-        let (input_tx, input_rx) =
-            TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block).await;
-
-        inputs.insert(key.clone(), (input_tx, node.inputs.clone()));
-
-        let (transform_task, transform_outputs) = {
-            let _span = span.enter();
-            build_transform(transform, node, input_rx)
-        };
-
-        outputs.extend(transform_outputs);
-        tasks.insert(key.clone(), transform_task);
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn build_sinks(
-    config: &super::Config,
-    diff: &ConfigDiff,
-    errors: &mut Vec<String>,
-    mut buffers: HashMap<ComponentKey, BuiltBuffer>,
-    inputs: &mut HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
-    healthchecks: &mut HashMap<ComponentKey, Task>,
-    tasks: &mut HashMap<ComponentKey, Task>,
-    detach_triggers: &mut HashMap<ComponentKey, Trigger>,
-) {
-    // Build sinks
-    for (key, sink) in config
-        .sinks()
-        .filter(|(key, _)| diff.sinks.contains_new(key))
-    {
-        debug!(component = %key, "Building new sink.");
-
-        let sink_inputs = &sink.inputs;
-        let healthcheck = sink.healthcheck();
-        let enable_healthcheck = healthcheck.enabled && config.healthchecks.enabled;
-
-        let typetag = sink.inner.get_component_name();
-        let input_type = sink.inner.input().data_type();
-
-        // At this point, we've validated that all transforms are valid, including any
-        // transform that mutates the schema provided by their sources. We can now validate the
-        // schema expectations of each individual sink.
-        if let Err(mut err) = schema::validate_sink_expectations(key, sink, config) {
-            errors.append(&mut err);
-        };
-
-        let (tx, rx) = if let Some(buffer) = buffers.remove(key) {
-            buffer
-        } else {
-            let buffer_type = match sink.buffer.stages().first().expect("cant ever be empty") {
-                BufferType::Memory { .. } => "memory",
-                BufferType::DiskV2 { .. } => "disk",
-            };
-            let buffer_span = error_span!(
-                "sink",
-                component_kind = "sink",
-                component_id = %key.id(),
-                component_type = typetag,
-                component_name = %key.id(),
-                buffer_type,
-            );
-            let buffer = sink
-                .buffer
-                .build(config.global.data_dir.clone(), key.to_string(), buffer_span)
-                .await;
-            match buffer {
-                Err(error) => {
-                    errors.push(format!("Sink \"{}\": {}", key, error));
-                    continue;
-                }
-                Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
-            }
-        };
-
-        let cx = SinkContext {
-            healthcheck,
-            globals: config.global.clone(),
-            proxy: ProxyConfig::merge_with_env(&config.global.proxy, sink.proxy()),
-            schema: config.schema,
-        };
-
-        let (sink, healthcheck) = match sink.inner.build(cx).await {
-            Err(error) => {
-                errors.push(format!("Sink \"{}\": {}", key, error));
-                continue;
-            }
-            Ok(built) => built,
-        };
-
-        let (trigger, tripwire) = Tripwire::new();
-
-        let sink = async move {
-            debug!("Sink starting.");
-
-            // Why is this Arc<Mutex<Option<_>>> needed you ask.
-            // In case when this function build_pieces errors
-            // this future won't be run so this rx won't be taken
-            // which will enable us to reuse rx to rebuild
-            // old configuration by passing this Arc<Mutex<Option<_>>>
-            // yet again.
-            let rx = rx
-                .lock()
-                .unwrap()
-                .take()
-                .expect("Task started but input has been taken.");
-
-            let mut rx = wrap(rx);
-
-            let events_received = register!(EventsReceived);
-            sink.run(
-                rx.by_ref()
-                    .filter(|events: &EventArray| ready(filter_events_type(events, input_type)))
-                    .inspect(|events| {
-                        events_received.emit(CountByteSize(
-                            events.len(),
-                            events.estimated_json_encoded_size_of(),
-                        ))
-                    })
-                    .take_until_if(tripwire),
-            )
-            .await
-            .map(|_| {
-                debug!("Sink finished normally.");
-                TaskOutput::Sink(rx)
-            })
-            .map_err(|_| {
-                debug!("Sink finished with an error.");
-                TaskError::Opaque
-            })
-        };
-
-        let task = Task::new(key.clone(), typetag, sink);
-
-        let component_key = key.clone();
-        let healthcheck_task = async move {
-            if enable_healthcheck {
-                let duration = Duration::from_secs(10);
-                timeout(duration, healthcheck)
-                    .map(|result| match result {
-                        Ok(Ok(_)) => {
-                            info!("Healthcheck passed.");
-                            Ok(TaskOutput::Healthcheck)
-                        }
-                        Ok(Err(error)) => {
-                            error!(
-                                msg = "Healthcheck failed.",
-                                %error,
-                                component_kind = "sink",
-                                component_type = typetag,
-                                component_id = %component_key.id(),
-                                // maintained for compatibility
-                                component_name = %component_key.id(),
-                            );
-                            Err(TaskError::wrapped(error))
-                        }
-                        Err(e) => {
-                            error!(
-                                msg = "Healthcheck timed out.",
-                                component_kind = "sink",
-                                component_type = typetag,
-                                component_id = %component_key.id(),
-                                // maintained for compatibility
-                                component_name = %component_key.id(),
-                            );
-                            Err(TaskError::wrapped(Box::new(e)))
-                        }
-                    })
-                    .await
-            } else {
-                info!("Healthcheck disabled.");
-                Ok(TaskOutput::Healthcheck)
-            }
-        };
-
-        let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
-
-        inputs.insert(key.clone(), (tx, sink_inputs.clone()));
-        healthchecks.insert(key.clone(), healthcheck_task);
-        tasks.insert(key.clone(), task);
-        detach_triggers.insert(key.clone(), trigger);
-    }
 }
 
 const fn filter_events_type(events: &EventArray, data_type: DataType) -> bool {


### PR DESCRIPTION
A tiny refactor, this function was getting a bit too long.