### PR TITLE
chore: fix ComponentValidation's from_transform

### DIFF
--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -81,7 +81,7 @@ impl ValidationConfiguration {
     pub fn from_transform(component_name: &'static str, config: impl Into<BoxedTransform>) -> Self {
         Self {
             component_name,
-            component_type: ComponentType::Source,
+            component_type: ComponentType::Transform,
             component_configuration: ComponentConfiguration::Transform(config.into()),
             external_resource: None,
         }


### PR DESCRIPTION
Noticed this while updating sources to use typetag

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
