### PR TITLE
chore(buffers): Add `Send` bound on `IntoBuffer` trait

### DIFF
--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -14,7 +14,7 @@ use crate::{
 
 /// Value that can be used as a stage in a buffer topology.
 #[async_trait]
-pub trait IntoBuffer<T: Bufferable> {
+pub trait IntoBuffer<T: Bufferable>: Send {
     /// Gets whether or not this buffer stage provides its own instrumentation, or if it should be
     /// instrumented from the outside.
     ///


### PR DESCRIPTION
This missing bound on `IntoBuffer`  missed during the reintroduction of the shared topology controller #17027 prevents its full usage for Vector as a library.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
