### PR TITLE
chore(external docs): correctly mark some sinks as stateful

### DIFF
--- a/website/cue/reference/components/sinks/datadog.cue
+++ b/website/cue/reference/components/sinks/datadog.cue
@@ -7,7 +7,7 @@ components: sinks: _datadog: {
 		development:   string | *"stable"
 		egress_method: "batch"
 		service_providers: ["Datadog"]
-		stateful: false
+		stateful: bool | *false
 	}
 
 	support: {

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -3,7 +3,9 @@ package metadata
 components: sinks: datadog_metrics: {
 	title: "Datadog Metrics"
 
-	classes: sinks._datadog.classes
+	classes: sinks._datadog.classes & {
+		stateful: true
+	}
 
 	features: {
 		acknowledgements: true

--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -3,7 +3,9 @@ package metadata
 components: sinks: datadog_traces: {
 	title: "Datadog Traces"
 
-	classes: sinks._datadog.classes
+	classes: sinks._datadog.classes & {
+		stateful: true
+	}
 
 	features: {
 		acknowledgements: true

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -9,7 +9,7 @@ components: sinks: influxdb_metrics: {
 		development:   "stable"
 		egress_method: "batch"
 		service_providers: ["InfluxData"]
-		stateful: false
+		stateful: true
 	}
 
 	features: {

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -9,7 +9,7 @@ components: sinks: prometheus_remote_write: {
 		development:   "beta"
 		egress_method: "batch"
 		service_providers: ["AWS"]
-		stateful: false
+		stateful: true
 	}
 
 	features: {

--- a/website/cue/reference/components/sinks/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/sematext_metrics.cue
@@ -9,7 +9,7 @@ components: sinks: sematext_metrics: {
 		development:   "beta"
 		service_providers: ["Sematext"]
 		egress_method: "batch"
-		stateful:      false
+		stateful:      true
 	}
 
 	features: {


### PR DESCRIPTION
It was pointed out in discord support that `influxdb_metrics` sink is documented as stateless, but that it's actually keeping state, by nature of using the `MetricNormalize` trait, which keeps a cache of metric data that is modified over time based on incoming batches.

This same behavior is found in `datadog_metrics`, `prometheus_remote_write`, and `sematext_metrics` (also `prometheus_exporter` , but that is already marked stateful).

The `datadog_traces` sink is stateful because it caches for computation of APM stats across batches of input.
