### PR TITLE
chore(ci): Disable `appsignal` integration test until CA issues are resolved

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,7 +57,8 @@ jobs:
       matrix:
         include:
           - test: 'amqp'
-          - test: 'appsignal'
+            # TODO: re-enable when the issue with the root CA is sorted out
+            #- test: 'appsignal'
           - test: 'aws'
           - test: 'axiom'
           - test: 'azure'


### PR DESCRIPTION
The test is failing on master, seemingly the root CA is not trusted in the debian CA store.