### PR TITLE
chore(ci): re-enable `appsignal` integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,8 +57,7 @@ jobs:
       matrix:
         include:
           - test: 'amqp'
-            # TODO: re-enable when the issue with the root CA is sorted out
-            #- test: 'appsignal'
+          - test: 'appsignal'
           - test: 'aws'
           - test: 'axiom'
           - test: 'azure'


### PR DESCRIPTION
The AppSignal endpoint certificate has been repaired.