### PR TITLE
chore(ci): update unsupported ubuntu version runners

### DIFF
--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sync-install:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get install --yes python3-setuptools python3.6-dev


### PR DESCRIPTION
the `18.04` ubuntu runner is now unsupported.

Two years ago this specific runner was selected for this workflow job due to apparent problems with 20.04.
Hopefully those have been resolved by now.

Ref failure: https://github.com/vectordotdev/vector/actions/runs/4660291736
