### PR TITLE
fix(releasing): Fix globbing of release artifacts for GitHub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9366,6 +9366,7 @@ dependencies = [
  "confy",
  "directories 5.0.0",
  "dunce",
+ "glob",
  "hashlink",
  "hex",
  "indicatif",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -19,6 +19,7 @@ confy = "0.5.1"
 directories = "5.0.0"
 # remove this when stabilized https://doc.rust-lang.org/stable/std/path/fn.absolute.html
 dunce = "1.0.3"
+glob = { version = "0.3.1", default-features = false }
 hashlink = { version = "0.8.1", features = ["serde_impl"] }
 hex = "0.4.3"
 indicatif = { version = "0.17.3", features = ["improved_unicode"] }

--- a/vdev/src/commands/release/github.rs
+++ b/vdev/src/commands/release/github.rs
@@ -1,6 +1,7 @@
 use crate::app::CommandExt as _;
 use crate::util;
-use anyhow::{Ok, Result};
+use anyhow::{anyhow, Ok, Result};
+use glob::glob;
 use std::process::Command;
 
 /// Uploads target/artifacts to GitHub releases
@@ -10,21 +11,34 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
+        let artifacts = glob("target/artifacts/*")
+            .expect("failed to read glob pattern")
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow!("failed to read path: {}", e))?
+            .into_iter()
+            .map(|p| p.into_os_string().into_string())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow!("failed to turn path into string: {:?}", e))?;
+
         let version = util::get_version()?;
         let mut command = Command::new("gh");
         command.in_repo();
-        command.args([
-            "release",
-            "--repo",
-            "vectordotdev/vector",
-            "create",
-            &format!("v{version}"),
-            "--title",
-            &format!("v{version}"),
-            "--notes",
-            &format!("[View release notes](https://vector.dev/releases/{version})"),
-            "target/artifacts/*",
-        ]);
+        command.args(
+            [
+                "release",
+                "--repo",
+                "vectordotdev/vector",
+                "create",
+                &format!("v{version}"),
+                "--title",
+                &format!("v{version}"),
+                "--notes",
+                &format!("[View release notes](https://vector.dev/releases/{version})"),
+            ]
+            .map(String::from)
+            .into_iter()
+            .chain(artifacts),
+        );
         command.check_run()?;
         Ok(())
     }


### PR DESCRIPTION
Since this was moved to vdev, we lost the automatic shell globbing. This introduces the `glob` crate
to handle it. I tested it locally by swapping `gh` with `echo` and adding dummy files:

```
vector on  v0.29 [$!] is 📦 v0.29.0 via  v19.4.0 via 💎 v2.7.4 via 🦀 v1.66.1 on ☁️
❯ touch target/artifacts/{foo,bar}

vector on  v0.29 [$!] is 📦 v0.29.0 via  v19.4.0 via 💎 v2.7.4 via 🦀 v1.66.1 on ☁️
❯ cargo vdev release github
release --repo vectordotdev/vector create v0.29.0 --title v0.29.0 --notes [View release notes](https://vector.dev/releases/0.29.0) target/artifacts/bar target/artifacts/foo
```

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
