### PR TITLE
chore(ci): use python v3.8 in ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install --yes python3-setuptools python3.6-dev
+      - run: sudo apt-get install --yes python3-setuptools python3.8-dev
       - run: pip3 install awscli --upgrade --user
       - env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"


### PR DESCRIPTION
to fix

```
Run sudo apt-get install --yes python3-setuptools python3.6-dev
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python3.[6](https://github.com/vectordotdev/vector/actions/runs/4672570181/jobs/8274890659#step:3:7)-dev
E: Couldn't find any package by glob 'python3.6-dev'
E: Couldn't find any package by regex 'python3.6-dev'
```
