### PR TITLE
fix(docker.rs): configuration error on DOCKER_HOST="tcp://..."

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -53,7 +53,7 @@ pub fn docker(host: Option<String>, tls: Option<DockerTlsConfig>) -> crate::Resu
                 .and_then(|uri| uri.into_parts().scheme);
 
             match scheme.as_ref().map(|scheme| scheme.as_str()) {
-                Some("http") => {
+                Some("http") | Some("tcp") => {
                     let host = get_authority(&host)?;
                     Docker::connect_with_http(&host, DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
                         .map_err(Into::into)


### PR DESCRIPTION
Fix error when using DOCKER_HOST with tcp schema

Example of DOCKER_HOST with tcp: https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-socket-option



<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
