### PR TITLE
chore(ci): remove unnecessary dep install

### DIFF
--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install --yes python3-setuptools python3.8-dev
       - run: pip3 install awscli --upgrade --user
       - env:
           AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"


### PR DESCRIPTION
```
Run sudo apt-get install --yes python3-setuptools python3.8-dev
  
Reading package lists...
Building dependency tree...
Reading state information...
python3-setuptools is already the newest version (45.2.0-1ubuntu0.1).
python3.8-dev is already the newest version (3.8.10-0ubuntu1~20.04.7).
python3.8-dev set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
```