### PR TITLE
chore(releasing): Bump Vector version to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9394,7 +9394,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "apache-avro",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
Now that 0.29.0 is released.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
