### PR TITLE
fix(schemas): Dont panic with non object field kinds

### DIFF
--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -265,8 +265,9 @@ impl Definition {
     /// A non-root required field means the root type must be an object, so the type will be automatically
     /// restricted to an object.
     ///
+    /// Raises a warning if the path is not root, and the definition does not allow the type to be an object.
+    ///
     /// # Panics
-    /// - If the path is not root, and the definition does not allow the type to be an object.
     /// - Provided path has one or more coalesced segments (e.g. `.(foo | bar)`).
     #[must_use]
     pub fn with_event_field(
@@ -275,10 +276,10 @@ impl Definition {
         kind: Kind,
         meaning: Option<&str>,
     ) -> Self {
-        if !path.is_root() {
-            assert!(
-                self.event_kind.as_object().is_some(),
-                "Setting a field on a value that cannot be an object"
+        if !path.is_root() && self.event_kind.as_object().is_none() {
+            warn!(
+                "Setting a field at `{}` on a value that cannot be an object",
+                path.to_string()
             );
         }
 
@@ -327,8 +328,9 @@ impl Definition {
     /// A non-root required field means the root type must be an object, so the type will be automatically
     /// restricted to an object.
     ///
+    /// Raises a warning if the path is not root, and the definition does not allow the type to be an object.
+    ///
     /// # Panics
-    /// - If the path is not root, and the definition does not allow the type to be an object
     /// - Provided path has one or more coalesced segments (e.g. `.(foo | bar)`).
     #[must_use]
     pub fn with_metadata_field(
@@ -337,10 +339,10 @@ impl Definition {
         kind: Kind,
         meaning: Option<&str>,
     ) -> Self {
-        if !path.is_root() {
-            assert!(
-                self.metadata_kind.as_object().is_some(),
-                "Setting a field on a value that cannot be an object"
+        if !path.is_root() && self.metadata_kind.as_object().is_none() {
+            warn!(
+                "Setting a field at `{}` on a value that cannot be an object",
+                path.to_string()
             );
         }
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -260,7 +260,7 @@ impl TransformConfig for RemapConfig {
                 // If the input definition is `never` this means that the
                 // upstream component has errored whilst loading (for example,
                 // with a VRL compiler error) this means data will never be
-                // recieved from that component.
+                // received from that component.
                 //
                 // This will most likely stop Vector from running, but we
                 // want to continue compiling to retrieve diagnostics. We


### PR DESCRIPTION
Ref #17115 

Currently if you add type information for an event or metadata field and that field is not defined as an Object, Vector panics.

The unfortunate result of this is that if something has gone wrong whilst building up the topology, rather than allowing Vector to report all the errors to allow the problem to be diagnosed, we just get a panic.

This PR changes it so that it produces a warning instead and then continues, which will allow Vector to report better diagnostics around what has gone wrong.

---

Another issue that cropped up while investigating this is that whilst building up the topology the transforms get compiled several times. The first time it gets compiled, the enrichment tables haven't been loaded yet. This means that every transform that loads an enrichment table will error. Normally this doesn't matter, since by the time the transforms are compiled fully the enrichment tables have been loaded. 

However the original bug this is fixing would still cause the panic. Changing it to warnings meant we still received the warnings with perfectly valid configurations. A further change here is for the Remap transform to check if the incoming definition is `never` and just pass this `never` definition downstream.

A quick scan of the transform seems to show that remap is the only transform that needs updating with this check.

