### PR TITLE
docs: Add a quickfix to handle special capitalization cases

### DIFF
--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -403,21 +403,21 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
 // Properly capitalize labels, accounting for some exceptions
 // TODO: Replace this with an explicit requirement for a "component_human_name" or similar.
 fn capitalize(s: &str) -> String {
-    let mut iter = s.chars();
-    match iter.next() {
-        None => String::new(),
-        Some(first) => {
-            let name = first.to_uppercase().collect::<String>() + iter.as_str();
-            match name.as_str() {
-                "Amqp" | "Aws" | "Ec2" | "Ecs" | "Gcp" | "Hec" | "Http" | "Nats" | "Nginx"
-                | "Sqs" => name.to_uppercase(),
-                "Eventstoredb" => String::from("EventStoreDB"),
-                "Mongodb" => String::from("MongoDB"),
-                "Opentelemetry" => String::from("OpenTelemetry"),
-                "Postgresql" => String::from("PostgreSQL"),
-                "Pubsub" => String::from("Pub/Sub"),
-                "Statsd" => String::from("StatsD"),
-                _ => name,
+    match s {
+        "Amqp" | "Aws" | "Ec2" | "Ecs" | "Gcp" | "Hec" | "Http" | "Nats" | "Nginx" | "Sqs" => {
+            s.to_uppercase()
+        }
+        "Eventstoredb" => String::from("EventStoreDB"),
+        "Mongodb" => String::from("MongoDB"),
+        "Opentelemetry" => String::from("OpenTelemetry"),
+        "Postgresql" => String::from("PostgreSQL"),
+        "Pubsub" => String::from("Pub/Sub"),
+        "Statsd" => String::from("StatsD"),
+        _ => {
+            let mut iter = s.chars();
+            match iter.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().collect::<String>() + iter.as_str(),
             }
         }
     }

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -409,7 +409,7 @@ fn capitalize(s: &str) -> String {
         Some(first) => {
             let name = first.to_uppercase().collect::<String>() + iter.as_str();
             match name.as_str() {
-                "Ampq" | "Aws" | "Ec2" | "Ecs" | "Gcp" | "Hec" | "Http" | "Nats" | "Nginx"
+                "Amqp" | "Aws" | "Ec2" | "Ecs" | "Gcp" | "Hec" | "Http" | "Nats" | "Nginx"
                 | "Sqs" => name.to_uppercase(),
                 "Eventstoredb" => String::from("EventStoreDB"),
                 "Mongodb" => String::from("MongoDB"),

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -400,11 +400,26 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
     derived.into()
 }
 
+// Properly capitalize labels, accounting for some exceptions
+// TODO: Replace this with an explicit requirement for a "component_human_name" or similar.
 fn capitalize(s: &str) -> String {
     let mut iter = s.chars();
     match iter.next() {
         None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + iter.as_str(),
+        Some(first) => {
+            let name = first.to_uppercase().collect::<String>() + iter.as_str();
+            match name.as_str() {
+                "Ampq" | "Aws" | "Ec2" | "Ecs" | "Gcp" | "Hec" | "Http" | "Nats" | "Nginx"
+                | "Sqs" => name.to_uppercase(),
+                "Eventstoredb" => String::from("EventStoreDB"),
+                "Mongodb" => String::from("MongoDB"),
+                "Opentelemetry" => String::from("OpenTelemetry"),
+                "Postgresql" => String::from("PostgreSQL"),
+                "Pubsub" => String::from("Pub/Sub"),
+                "Statsd" => String::from("StatsD"),
+                _ => name,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Using `typetag` and the naive capitalization strategy caused a number of names to be incorrectly capitalized on the Datadog documentation.

This is a quick resolution to unblock the docs team while we create a more explicit field to be used by both OP and the documentation.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
