### PR TITLE
enhancement(core): add unit test (ignored) for support for encoding special chars in `ProxyConfig`

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -218,3 +218,6 @@ k8s
 
 # ignore comment in package-msi.sh
 [#].*custom\.a28ecdc.*
+
+# ignore specific user:password string containing special chars for unit testing
+user:P@ssw0rd

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -356,4 +356,26 @@ mod tests {
             expected_header_value.as_ref().ok()
         );
     }
+
+    #[ignore]
+    #[test]
+    fn build_proxy_with_special_chars_url_encoded() {
+        let config = ProxyConfig {
+            http: Some("http://user:P%40ssw0rd@1.2.3.4:5678".into()),
+            https: Some("https://user:P%40ssw0rd@2.3.4.5:9876".into()),
+            ..Default::default()
+        };
+        let first = config
+            .http_proxy()
+            .expect("should not be an error")
+            .expect("should not be None");
+        let encoded_header = format!("Basic {}", BASE64_STANDARD.encode("user:P@ssw0rd"));
+        let expected_header_value = HeaderValue::from_str(encoded_header.as_str());
+
+        assert_eq!(
+            first.headers().get("authorization"),
+            expected_header_value.as_ref().ok()
+        );
+    }
+
 }

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -377,5 +377,4 @@ mod tests {
             expected_header_value.as_ref().ok()
         );
     }
-
 }


### PR DESCRIPTION
Ref: #17125

This adds the unit test proposed. It fails as expected, marking ignored so we can remove that line when the issue is worked on.

Before the ignore:
```
running 1 test
test config::proxy::tests::build_proxy_with_special_chars_url_encoded ... FAILED

failures:

---- config::proxy::tests::build_proxy_with_special_chars_url_encoded stdout ----
thread 'config::proxy::tests::build_proxy_with_special_chars_url_encoded' panicked at 'assertion failed: `(left == right)`
  left: `Some("Basic dXNlcjpQJTQwc3N3MHJk")`,
 right: `Some("Basic dXNlcjpQQHNzdzByZA==")`', lib/vector-core/src/config/proxy.rs:374:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After the ignore:
```
running 1 test
test config::proxy::tests::build_proxy_with_special_chars_url_encoded ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 156 filtered out; finished in 0.00s
```





