### PR TITLE
fix(config): recurse through schema refs when determining eligibility for unevaluated properties

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -723,6 +723,7 @@ MAINPID
 majorly
 MAKECMDGOALS
 Makefiles
+markability
 markdownify
 markdownlintrc
 marketo

--- a/lib/vector-config/src/schema/helpers.rs
+++ b/lib/vector-config/src/schema/helpers.rs
@@ -12,7 +12,7 @@ use crate::{
     num::ConfigurableNumber, Configurable, ConfigurableRef, GenerateError, Metadata, ToValue,
 };
 
-use super::visitors::{DisallowedUnevaluatedPropertiesVisitor, InlineSingleUseReferencesVisitor};
+use super::visitors::{DisallowUnevaluatedPropertiesVisitor, InlineSingleUseReferencesVisitor};
 
 /// Applies metadata to the given schema.
 ///
@@ -482,7 +482,7 @@ pub fn generate_internal_tagged_variant_schema(
 pub fn default_schema_settings() -> SchemaSettings {
     SchemaSettings::new()
         .with_visitor(InlineSingleUseReferencesVisitor::from_settings)
-        .with_visitor(DisallowedUnevaluatedPropertiesVisitor::from_settings)
+        .with_visitor(DisallowUnevaluatedPropertiesVisitor::from_settings)
 }
 
 pub fn generate_root_schema<T>() -> Result<RootSchema, GenerateError>

--- a/lib/vector-config/src/schema/visitors/mod.rs
+++ b/lib/vector-config/src/schema/visitors/mod.rs
@@ -7,4 +7,4 @@ mod unevaluated;
 pub(self) mod test;
 
 pub use self::inline_single::InlineSingleUseReferencesVisitor;
-pub use self::unevaluated::DisallowedUnevaluatedPropertiesVisitor;
+pub use self::unevaluated::DisallowUnevaluatedPropertiesVisitor;

--- a/lib/vector-config/src/schema/visitors/unevaluated.rs
+++ b/lib/vector-config/src/schema/visitors/unevaluated.rs
@@ -237,12 +237,22 @@ fn build_closed_schema_flatten_eligibility_mappings(
             Schema::Object(schema) => schema,
         };
 
+        debug!(
+            "Evaluating schema definition '{}' for markability.",
+            definition_name
+        );
+
         // If a schema itself would not be considered markable, then we don't need to consider the
         // eligibility between parent/child since there's nothing to drive the "now unmark the child
         // schemas" logic.
         if !is_markable_schema(&root_schema.definitions, parent_schema) {
             debug!("Schema definition '{}' not markable.", definition_name);
             continue;
+        } else {
+            debug!(
+                "Schema definition '{}' markable. Collecting referents.",
+                definition_name
+            );
         }
 
         // Collect all referents for this definition, which includes both property-based referents
@@ -250,6 +260,13 @@ fn build_closed_schema_flatten_eligibility_mappings(
         // while subschema-based referents must be unmarked.
         let mut referents = HashSet::new();
         get_referents(parent_schema, &mut referents);
+
+        debug!(
+            "Collected {} referents for '{}': {:?}",
+            referents.len(),
+            definition_name,
+            referents
+        );
 
         // Store the parent/child mapping.
         parent_to_child.insert(SchemaReference::from(definition_name), referents);
@@ -328,12 +345,14 @@ fn is_markable_schema(definitions: &Map<String, Schema>, schema: &SchemaObject) 
     // subschemas: { "type": "null" } and { "$ref": "#/definitions/T" }. If the schema for `T` is,
     // say, just a scalar schema, instead of an object schema... then it wouldn't be marked, and in
     // turn, we wouldn't need to mark the schema for `Option<T>`: there's no properties at all.
-    //
-    // We'll follow schema references in subschemas up to one level deep trying to figure this out.
     if let Some(subschema) = schema.subschemas.as_ref() {
         let subschemas = get_object_subschemas_from_parent(subschema).collect::<Vec<_>>();
 
-        let has_object_subschema = subschemas.iter().any(|schema| is_object_schema(schema));
+        debug!("{} subschemas detected.", subschemas.len());
+
+        let has_object_subschema = subschemas
+            .iter()
+            .any(|schema| is_markable_schema(definitions, schema));
         let has_referenced_object_subschema = subschemas
             .iter()
             .map(|subschema| {
@@ -342,12 +361,34 @@ fn is_markable_schema(definitions: &Map<String, Schema>, schema: &SchemaObject) 
                     .as_ref()
                     .and_then(|reference| {
                         let reference = get_cleaned_schema_reference(reference);
-                        definitions.get(reference)
+                        definitions.get(reference).map(|d| (reference, d))
                     })
-                    .and_then(Schema::as_object)
-                    .map_or(false, is_object_schema)
+                    .and_then(|(definition_name, schema_definition)| {
+                        schema_definition.as_object().map(|s| (definition_name, s))
+                    })
+                    .map_or(false, |(name, schema)| {
+                        debug!(
+                            "Following schema reference '{}' for subschema markability.",
+                            name
+                        );
+                        is_markable_schema(definitions, schema)
+                    })
             })
             .any(identity);
+
+        debug!(
+            "Schema {} object subschema(s) and {} referenced subschemas.",
+            if has_object_subschema {
+                "has"
+            } else {
+                "does not have"
+            },
+            if has_referenced_object_subschema {
+                "has"
+            } else {
+                "does not have"
+            },
+        );
 
         if has_object_subschema || has_referenced_object_subschema {
             return true;

--- a/lib/vector-config/src/schema/visitors/unevaluated.rs
+++ b/lib/vector-config/src/schema/visitors/unevaluated.rs
@@ -361,11 +361,9 @@ fn is_markable_schema(definitions: &Map<String, Schema>, schema: &SchemaObject) 
                     .as_ref()
                     .and_then(|reference| {
                         let reference = get_cleaned_schema_reference(reference);
-                        definitions.get(reference).map(|d| (reference, d))
+                        definitions.get_full(reference)
                     })
-                    .and_then(|(definition_name, schema_definition)| {
-                        schema_definition.as_object().map(|s| (definition_name, s))
-                    })
+                    .and_then(|(_, name, schema)| schema.as_object().map(|schema| (name, schema)))
                     .map_or(false, |(name, schema)| {
                         debug!(
                             "Following schema reference '{}' for subschema markability.",

--- a/lib/vector-config/src/schema/visitors/unevaluated.rs
+++ b/lib/vector-config/src/schema/visitors/unevaluated.rs
@@ -27,12 +27,12 @@ use super::scoped_visit::{
 /// with advanced subschema validation, such as `oneOf` or `allOf`, as `unevaluatedProperties`
 /// cannot simply be applied to any and all schemas indiscriminately.
 #[derive(Debug, Default)]
-pub struct DisallowedUnevaluatedPropertiesVisitor {
+pub struct DisallowUnevaluatedPropertiesVisitor {
     scope_stack: SchemaScopeStack,
     eligible_to_flatten: HashMap<String, HashSet<SchemaReference>>,
 }
 
-impl DisallowedUnevaluatedPropertiesVisitor {
+impl DisallowUnevaluatedPropertiesVisitor {
     pub fn from_settings(_: &SchemaSettings) -> Self {
         Self {
             scope_stack: SchemaScopeStack::default(),
@@ -41,7 +41,7 @@ impl DisallowedUnevaluatedPropertiesVisitor {
     }
 }
 
-impl Visitor for DisallowedUnevaluatedPropertiesVisitor {
+impl Visitor for DisallowUnevaluatedPropertiesVisitor {
     fn visit_root_schema(&mut self, root: &mut RootSchema) {
         let eligible_to_flatten = build_closed_schema_flatten_eligibility_mappings(root);
 
@@ -132,7 +132,7 @@ impl Visitor for DisallowedUnevaluatedPropertiesVisitor {
     }
 }
 
-impl ScopedVisitor for DisallowedUnevaluatedPropertiesVisitor {
+impl ScopedVisitor for DisallowUnevaluatedPropertiesVisitor {
     fn push_schema_scope<S: Into<SchemaReference>>(&mut self, scope: S) {
         self.scope_stack.push(scope.into());
     }
@@ -545,7 +545,7 @@ mod tests {
 
     use crate::schema::visitors::test::{as_schema, assert_schemas_eq};
 
-    use super::DisallowedUnevaluatedPropertiesVisitor;
+    use super::DisallowUnevaluatedPropertiesVisitor;
 
     #[test]
     fn basic_object_schema() {
@@ -556,7 +556,7 @@ mod tests {
             }
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -584,7 +584,7 @@ mod tests {
             }
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -621,7 +621,7 @@ mod tests {
             }]
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -662,7 +662,7 @@ mod tests {
             }]
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -703,7 +703,7 @@ mod tests {
             }]
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -737,7 +737,7 @@ mod tests {
         }));
         let expected_schema = actual_schema.clone();
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         assert_schemas_eq(expected_schema, actual_schema);
@@ -753,7 +753,7 @@ mod tests {
             "additionalProperties": false
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -799,7 +799,7 @@ mod tests {
             }
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -854,7 +854,7 @@ mod tests {
             }
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         let expected_schema = as_schema(json!({
@@ -920,7 +920,7 @@ mod tests {
             }
         }));
 
-        let mut visitor = DisallowedUnevaluatedPropertiesVisitor::default();
+        let mut visitor = DisallowUnevaluatedPropertiesVisitor::default();
         visitor.visit_root_schema(&mut actual_schema);
 
         // Expectations:


### PR DESCRIPTION
## Context

The `DisallowUnevaluatedPropertiesVisitor` visitor handles marking individual schemas, within the overall configuration schema for Vector, to disallow unevaluated properties from being allowed when validating a configuration against said schema.

This involves a chunk of logic to figure out the right schema to place the annotation on, as depending on how schemas are referenced, or combined together, the annotation might need to be added to a parent schema rather than all of its child schemas, and so on.

This logic checks if schemas can be marked with annotation by determining if they represent an object -- aka a struct -- and in doing so, knows how to check if the schema is an object schema, or if it _refers_ to an object schema by way of using _schema references_: a pointer to a schema defined else, rather than defined inline.

This logic was initially added in a way where it would only recurse through a single schema reference before giving up when trying to determine if the given individual schema represented an object schema, or something object schema-like by way of the other schemas it referenced. In some cases, schema references could go two or three levels deep before hitting the "actual" object schemas, which meant that this code was not correctly detecting some schemas as being object schemas, which in turn affected the logic used to determine if those schemas should be annotated or not.

Overall, this leads to `unevaluatedProperties: false` not being applied in the right places, and in turn allows unevaluated properties in some specific areas of the schema to evade the validator. Not good. :)

## Solution

This PR represents a simple change where we recurse through a schema reference until we hit something that represents an object schema or not.

Most of the other changes are logging-related, used for initially debugging the issue, but worth keeping for the future when there's a good chance we'll potentially have to debug issues while looking to tweak the schema output.

Additionally, I've renamed the visitor from `DisallowedUnevaluatedPropertiesVisitor` to `DisallowUnevaluatedPropertiesVisitor` to match the intended active voice verb-noun naming scheme.