### PR TITLE
chore: Fix docs::label generation

### DIFF
--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -404,15 +404,15 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
 // TODO: Replace this with an explicit requirement for a "component_human_name" or similar.
 fn capitalize(s: &str) -> String {
     match s {
-        "Amqp" | "Aws" | "Ec2" | "Ecs" | "Gcp" | "Hec" | "Http" | "Nats" | "Nginx" | "Sqs" => {
+        "amqp" | "aws" | "ec2" | "ecs" | "gcp" | "hec" | "http" | "nats" | "nginx" | "sqs" => {
             s.to_uppercase()
         }
-        "Eventstoredb" => String::from("EventStoreDB"),
-        "Mongodb" => String::from("MongoDB"),
-        "Opentelemetry" => String::from("OpenTelemetry"),
-        "Postgresql" => String::from("PostgreSQL"),
-        "Pubsub" => String::from("Pub/Sub"),
-        "Statsd" => String::from("StatsD"),
+        "eventstoredb" => String::from("EventStoreDB"),
+        "mongodb" => String::from("MongoDB"),
+        "opentelemetry" => String::from("OpenTelemetry"),
+        "postgresql" => String::from("PostgreSQL"),
+        "pubsub" => String::from("Pub/Sub"),
+        "statsd" => String::from("StatsD"),
         _ => {
             let mut iter = s.chars();
             match iter.next() {

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -403,7 +403,8 @@ pub fn configurable_component_impl(args: TokenStream, item: TokenStream) -> Toke
 // Properly capitalize labels, accounting for some exceptions
 // TODO: Replace this with an explicit requirement for a "component_human_name" or similar.
 fn capitalize(s: &str) -> String {
-    match s {
+    let as_lower = s.to_lowercase();
+    match as_lower.as_str() {
         "amqp" | "aws" | "ec2" | "ecs" | "gcp" | "hec" | "http" | "nats" | "nginx" | "sqs" => {
             s.to_uppercase()
         }


### PR DESCRIPTION
The ordering here was switched at the last minute, and the casing of the matches wasn't which broke the desired behavior.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
