### PR TITLE
docs: Adjust doc comment locations

### DIFF
--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -21,38 +21,6 @@ use crate::{
 };
 
 /// Configuration for the `webhdfs` sink.
-///
-/// The Hadoop Distributed File System (HDFS) is a distributed file system
-/// designed to run on commodity hardware. HDFS consists of a namenode and a
-/// datanode. We will send rpc to namenode to know which datanode to send
-/// and receive data to. Also, HDFS will rebalance data across the cluster
-/// to make sure each file has enough redundancy.
-///
-/// ```txt
-///                     ┌───────────────┐
-///                     │  Data Node 2  │
-///                     └───────────────┘
-///                             ▲
-/// ┌───────────────┐           │            ┌───────────────┐
-/// │  Data Node 1  │◄──────────┼───────────►│  Data Node 3  │
-/// └───────────────┘           │            └───────────────┘
-///                     ┌───────┴───────┐
-///                     │   Name Node   │
-///                     └───────────────┘
-///                             ▲
-///                             │
-///                      ┌──────┴─────┐
-///                      │   Vector   │
-///                      └────────────┘
-/// ```
-///
-/// WebHDFS will connect to the HTTP RESTful API of HDFS.
-///
-/// For more information, please refer to:
-///
-/// - [HDFS Users Guide](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html)
-/// - [WebHDFS REST API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html)
-/// - [opendal::services::webhdfs](https://docs.rs/opendal/latest/opendal/services/struct.Webhdfs.html)
 #[configurable_component(sink("webhdfs"))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]

--- a/src/sinks/webhdfs/mod.rs
+++ b/src/sinks/webhdfs/mod.rs
@@ -1,6 +1,36 @@
 //! `webhdfs` sink.
 //!
-//! This sink will send it's output to WEBHDFS.
+//! The Hadoop Distributed File System (HDFS) is a distributed file system
+//! designed to run on commodity hardware. HDFS consists of a namenode and a
+//! datanode. We will send rpc to namenode to know which datanode to send
+//! and receive data to. Also, HDFS will rebalance data across the cluster
+//! to make sure each file has enough redundancy.
+//!
+//! ```txt
+//!                     ┌───────────────┐
+//!                     │  Data Node 2  │
+//!                     └───────────────┘
+//!                             ▲
+//! ┌───────────────┐           │            ┌───────────────┐
+//! │  Data Node 1  │◄──────────┼───────────►│  Data Node 3  │
+//! └───────────────┘           │            └───────────────┘
+//!                     ┌───────┴───────┐
+//!                     │   Name Node   │
+//!                     └───────────────┘
+//!                             ▲
+//!                             │
+//!                      ┌──────┴─────┐
+//!                      │   Vector   │
+//!                      └────────────┘
+//! ```
+//!
+//! WebHDFS will connect to the HTTP RESTful API of HDFS.
+//!
+//! For more information, please refer to:
+//!
+//! - [HDFS Users Guide](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html)
+//! - [WebHDFS REST API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html)
+//! - [opendal::services::webhdfs](https://docs.rs/opendal/latest/opendal/services/struct.Webhdfs.html)
 //!
 //! `webhdfs` is an OpenDal based services. This mod itself only provide
 //! config to build an [`crate::sinks::opendal_common::OpenDalSink`]. All real implement are powered by


### PR DESCRIPTION
This was being pulled into the `webhdfs` description in the OP docs, rather than just the usual "configuration for the foo component"
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
