### PR TITLE
chore(docs): update the `v0.28.0` upgrade guide with note about `datadog_logs` sink `hostname` key

### DIFF
--- a/website/content/en/highlights/2023-02-28-0-28-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-02-28-0-28-0-upgrade-guide.md
@@ -2,7 +2,7 @@
 date: "2023-02-18"
 title: "0.28 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.28.0"
-authors: ["spencergilbert"]
+authors: ["spencergilbert", "neuronull"]
 release: "0.28.0"
 hide_on_release_notes: false
 badges:
@@ -15,6 +15,7 @@ Vector's 0.28.0 release includes **breaking changes**:
 2. [Removal of metadata functions](#metadata-functions-removal)
 3. [Removal of the `apex` sink](#apex-removal)
 4. [Removal of the `disk_v1` buffer type](#disk_v1-removal)
+4. [Renaming of `host` to `hostname` in `datadog_logs`](#host-rename-dd-logs)
 
 and **deprecations**:
 
@@ -75,6 +76,12 @@ the default for `type = "disk"`](/highlights/2022-04-06-disk-buffer-v2-stable/) 
 this migration. Also see [the blog post about the introduction of the new disk buffer
 implementation](/highlights/2022-02-08-disk-buffer-v2-beta/) for the reasons the new disk buffer
 implementation was introduced.
+
+#### Renaming of `host` to `hostname` in `datadog_logs` {#host-rename-dd-logs}
+
+In the `datadog_logs` sink, if an event contained the `host` key from either the global
+log schema, or the host path of the event, it was renamed to `host`. This was changed to rename it
+to `hostname`, to match the Datadog Agent intake API.
 
 ### Deprecation notices
 


### PR DESCRIPTION
Ref: https://github.com/vectordotdev/vector/issues/17147