### PR TITLE
chore(deps): Upgrade Debian to bullseye for distroless image

### DIFF
--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -7,7 +7,7 @@ RUN dpkg -i vector_*_"$(dpkg --print-architecture)".deb
 
 RUN mkdir -p /var/lib/vector
 
-FROM gcr.io/distroless/cc-debian10
+FROM gcr.io/distroless/cc-debian11
 
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Hello ! :wave: 

Very simple PR to upgrade the Debian version in the distroless-libc Dockerfile (the first image is Debian 11 but the final one if Debian 10, hence the presence of vulnerabilities)