### PR TITLE
chore(docs): Remove trailing, unmatched quote

### DIFF
--- a/website/content/en/docs/about/concepts.md
+++ b/website/content/en/docs/about/concepts.md
@@ -28,7 +28,7 @@ A **metric** event represents a numerical operation performed on a time series. 
 
 A **trace** event can be thought of as a special kind of log event. As of this writing, the components that support trace events are: the `datadog_agent` source, the `datadog_traces` sink, and the `sample` and `remap` transforms.
 
-If you're interested in using traces with a Vector component that doesn't yet support them, please open an issue so we can have a better understanding of what components to prioritize adding trace support for."
+If you're interested in using traces with a Vector component that doesn't yet support them, please open an issue so we can have a better understanding of what components to prioritize adding trace support for.
 
 ## Components
 


### PR DESCRIPTION
## This Commit

Removes a trailing quote that doesn't match an opening quote.

## Why?

I believe it's a typo.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
