### PR TITLE
chore(docs): update datadog agent source with template

### DIFF
--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -56,43 +56,66 @@ pub const LOGS: &str = "logs";
 pub const METRICS: &str = "metrics";
 pub const TRACES: &str = "traces";
 
+/// Datadog Agent
+///
 /// Configuration for the `datadog_agent` source.
+///
+/// The `datadog_agent` source receives logs and metrics from the Datadog Agent over HTTP
+/// or HTTPS. The source listens on a user-defined address and port.
 #[configurable_component(source(
     "datadog_agent",
     "Receive logs, metrics, and traces collected by a Datadog Agent."
 ))]
 #[derive(Clone, Debug)]
 pub struct DatadogAgentConfig {
+    /// address
+    ///
     /// The socket address to accept connections on.
     ///
     /// It _must_ include a port.
+    ///
+    /// # Examples
+    ///
+    /// sources:
+    ///  my_source_id:
+    ///  type: datadog_agent
+  address: 0.0.0.0:80
     #[configurable(metadata(docs::examples = "0.0.0.0:80"))]
     #[configurable(metadata(docs::examples = "localhost:80"))]
     address: SocketAddr,
 
+    /// store_api_key
+    ///
     /// If this is set to `true`, when incoming events contain a Datadog API key, it is
     /// stored in the event metadata and used if the event is sent to a Datadog sink.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_true")]
     store_api_key: bool,
 
+    /// disable_logs
+    ///
     /// If this is set to `true`, logs are not accepted by the component.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     disable_logs: bool,
 
+    ///disable_metrics
+    ///
     /// If this is set to `true`, metrics are not accepted by the component.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     disable_metrics: bool,
 
+    /// disable_traces
+    ///
     /// If this is set to `true`, traces are not accepted by the component.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     disable_traces: bool,
 
-    /// If this is set to `true` logs, metrics, and traces are sent to different outputs.
+    /// multiple_outputs
     ///
+    /// If this is set to `true` logs, metrics, and traces are sent to different outputs.
     ///
     /// For a source component named `agent`, the received logs, metrics, and traces can then be
     /// configured as input to other components by specifying `agent.logs`, `agent.metrics`, and
@@ -101,7 +124,9 @@ pub struct DatadogAgentConfig {
     #[serde(default = "crate::serde::default_false")]
     multiple_outputs: bool,
 
-    /// The namespace to use for logs. This overrides the global setting.
+    /// log_namespace
+    ///
+    /// The namespace used for logs. This overrides the global setting.
     #[serde(default)]
     #[configurable(metadata(docs::hidden))]
     log_namespace: Option<bool>,

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -79,7 +79,7 @@ pub struct DatadogAgentConfig {
     /// sources:
     ///  my_source_id:
     ///  type: datadog_agent
-  address: 0.0.0.0:80
+    ///  address: 0.0.0.0:80
     #[configurable(metadata(docs::examples = "0.0.0.0:80"))]
     #[configurable(metadata(docs::examples = "localhost:80"))]
     address: SocketAddr,


### PR DESCRIPTION
Update Datadog Agent source with template format to see if this is what we are looking to do.

Update: **This is a test PR**. Keeping it to see how the changes affect Vector docs.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
