### PR TITLE
chore(syslog source): remove the remove of source_ip

### DIFF
--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1358,7 +1358,6 @@ mod test {
         fn from(e: Event) -> Self {
             let (value, _) = e.into_log().into_parts();
             let mut fields = value.into_object().unwrap();
-            fields.remove("source_ip");
 
             Self {
                 msgid: fields.remove("msgid").map(value_to_string).unwrap(),


### PR DESCRIPTION
Ref #16818

Whilst going over the postmortem for this bug I noticed that removing this field is not necessary in order to make the tests pass. 