### PR TITLE
chore(deps): Update h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes 1.4.0",
  "fnv",


### PR DESCRIPTION
cargo deny is flagging vulernability in h2, and thus the checks are failing.

https://github.com/vectordotdev/vector/actions/runs/4758498516/jobs/8456646415

See https://github.com/hyperium/hyper/issues/2877#issuecomment-1507135950
