### PR TITLE
chore(dev): ignore `.helix` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cargo-timing*.html
 .DS_Store
 .idea/
 .vscode/
+.helix/
 .dir-locals.el
 checkpoints/*
 miniodat


### PR DESCRIPTION
It is useful to extend the global helix configurations for project specific needs, for example you can add feature flags to be compiled. For example when adding or modifying integration tests.
