### PR TITLE
chore(docs): Remove unneeded `yaml` dependency from website

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -58,8 +58,7 @@
     "tocbot": "^4.12.2",
     "topojson-client": "^3.1.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.3",
-    "yaml": "^1.10.2"
+    "typescript": "^4.1.3"
   },
   "browserslist": [
     "since 2017-06"


### PR DESCRIPTION
Seems to build and run fine without it.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
