### PR TITLE
chore(remap transform): Always clone event

### DIFF
--- a/regression/cases/datadog_agent_remap_blackhole_errors/lading/lading.yaml
+++ b/regression/cases/datadog_agent_remap_blackhole_errors/lading/lading.yaml
@@ -1,0 +1,13 @@
+generator:
+  - http:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+        59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      headers:
+        dd-api-key: "DEADBEEF"
+      target_uri: "http://localhost:8282/v1/input"
+      bytes_per_second: "500 Mb"
+      parallel_connections: 10
+      method:
+        post:
+          variant: "datadog_log"
+          maximum_prebuild_cache_size_bytes: "256 Mb"

--- a/regression/cases/datadog_agent_remap_blackhole_errors/vector/vector.toml
+++ b/regression/cases/datadog_agent_remap_blackhole_errors/vector/vector.toml
@@ -25,7 +25,7 @@ source = '''
 .hostname = "vector"
 
 if random_bool() {
-  abort!("ohno")
+  abort
 }
 '''
 

--- a/regression/cases/datadog_agent_remap_blackhole_errors/vector/vector.toml
+++ b/regression/cases/datadog_agent_remap_blackhole_errors/vector/vector.toml
@@ -1,0 +1,44 @@
+data_dir = "/var/lib/vector"
+
+##
+## Sources
+##
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sources.datadog_agent]
+type = "datadog_agent"
+acknowledgements = false
+address = "0.0.0.0:8282"
+
+##
+## Transforms
+##
+
+[transforms.remap]
+type = "remap"
+inputs = ["datadog_agent"]
+drop_on_abort = false
+drop_on_error = false
+source = '''
+.hostname = "vector"
+
+if random_bool() {
+  abort!("ohno")
+}
+'''
+
+##
+## Sinks
+##
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:9090"
+
+[sinks.blackhole]
+type = "blackhole"
+print_interval_secs = 0
+inputs = ["remap"]


### PR DESCRIPTION
Rather than only if the event will be needed for routing on failure or abort. Should result in more
consistent performance and a simpler mental model.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
