### PR TITLE
fix(datadog_logs sink): Revert renaming host -> hostname

### DIFF
--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -134,7 +134,7 @@ impl crate::sinks::util::encoding::Encoder<Vec<Event>> for JsonEncoding {
             log.rename_key(message_path.as_str(), event_path!("message"));
 
             if let Some(host_path) = log.host_path() {
-                log.rename_key(host_path.as_str(), event_path!("hostname"));
+                log.rename_key(host_path.as_str(), event_path!("host"));
             }
 
             if let Some(Value::Timestamp(ts)) = log.remove(


### PR DESCRIPTION
Fixes #17147

We introduced this change as part of leveraging semantic meanings in sinks. This appears to be correct on the surface based on DD api documentation, however it has caused clear regressions in at least one user's pipelines.

As both `host` and `hostname` can be used interchangeably, it seems we should revert this change to the original behavior and collaborate with the logs intake team to have a better understanding of the desired payload as well a more concrete contract between our products.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
