### PR TITLE
chore(dev): remove editors from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ cargo-timing*.html
 *~
 **/*.rs.bk
 .DS_Store
-.idea/
-.vscode/
-.helix/
 .dir-locals.el
 checkpoints/*
 miniodat


### PR DESCRIPTION
As pointed out here: https://github.com/vectordotdev/vector/pull/17203#discussion_r1175791563

, developers should just utilize a global gitignore for things like personal editor configs.
