### PR TITLE
chore(ci): Disable scheduled runs of Baseline Timings workflow

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -1,3 +1,7 @@
+# Executes various builds of vector to time the results in order to track build times.
+#
+# This workflow is unrelated to the Regression workflow.
+
 name: Baseline Timings
 
 on:

--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -2,8 +2,6 @@ name: Baseline Timings
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 */2 * * *"
 
 env:
   CI: true


### PR DESCRIPTION
We haven't focused on this as much lately so dropping this back to just on demand.
