### PR TITLE
feat: adds 'metric_name' field to internal logs for the tag_cardinality_limit component

### DIFF
--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -3,6 +3,7 @@ use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
 
 pub struct TagCardinalityLimitRejectingEvent<'a> {
+    pub metric_name: &'a str,
     pub tag_key: &'a str,
     pub tag_value: &'a str,
 }
@@ -11,6 +12,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
     fn emit(self) {
         debug!(
             message = "Event containing tag with new value after hitting configured 'value_limit'; discarding event.",
+            metric_name = self.metric_name,
             tag_key = self.tag_key,
             tag_value = self.tag_value,
             internal_log_rate_limit = true,
@@ -25,6 +27,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingEvent<'a> {
 }
 
 pub struct TagCardinalityLimitRejectingTag<'a> {
+    pub metric_name: &'a str,
     pub tag_key: &'a str,
     pub tag_value: &'a str,
 }
@@ -33,6 +36,7 @@ impl<'a> InternalEvent for TagCardinalityLimitRejectingTag<'a> {
     fn emit(self) {
         debug!(
             message = "Rejecting tag after hitting configured 'value_limit'.",
+            metric_name = self.metric_name,
             tag_key = self.tag_key,
             tag_value = self.tag_value,
             internal_log_rate_limit = true,

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -90,9 +90,8 @@ impl TagCardinalityLimit {
     }
 
     fn transform_one(&mut self, mut event: Event) -> Option<Event> {
-        let event_clone = event.clone();
-        let metric_name = event_clone.as_metric().name();
         let metric = event.as_mut_metric();
+        let metric_name = metric.name().to_string();
         if let Some(tags_map) = metric.tags_mut() {
             match self.config.limit_exceeded_action {
                 LimitExceededAction::DropEvent => {
@@ -102,7 +101,7 @@ impl TagCardinalityLimit {
                     for (key, value) in tags_map.iter_sets() {
                         if self.tag_limit_exceeded(key, value) {
                             emit!(TagCardinalityLimitRejectingEvent {
-                                metric_name: metric_name,
+                                metric_name: &metric_name,
                                 tag_key: key,
                                 tag_value: &value.to_string(),
                             });
@@ -119,7 +118,7 @@ impl TagCardinalityLimit {
                             true
                         } else {
                             emit!(TagCardinalityLimitRejectingTag {
-                                metric_name: metric_name,
+                                metric_name: &metric_name,
                                 tag_key: key,
                                 tag_value: &value.to_string(),
                             });

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -90,6 +90,8 @@ impl TagCardinalityLimit {
     }
 
     fn transform_one(&mut self, mut event: Event) -> Option<Event> {
+        let event_clone = event.clone();
+        let metric_name = event_clone.as_metric().name();
         let metric = event.as_mut_metric();
         if let Some(tags_map) = metric.tags_mut() {
             match self.config.limit_exceeded_action {
@@ -100,6 +102,7 @@ impl TagCardinalityLimit {
                     for (key, value) in tags_map.iter_sets() {
                         if self.tag_limit_exceeded(key, value) {
                             emit!(TagCardinalityLimitRejectingEvent {
+                                metric_name: metric_name,
                                 tag_key: key,
                                 tag_value: &value.to_string(),
                             });
@@ -116,6 +119,7 @@ impl TagCardinalityLimit {
                             true
                         } else {
                             emit!(TagCardinalityLimitRejectingTag {
+                                metric_name: metric_name,
                                 tag_key: key,
                                 tag_value: &value.to_string(),
                             });


### PR DESCRIPTION
This patch addresses issue #15742 by adding the `metric_name` field to internal logs issued by the tag_cardinality_limit component.