### PR TITLE
fix(gcp_stackdriver_metrics sink): Call function to regenerate auth token

### DIFF
--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -108,13 +108,13 @@ impl SinkConfig for StackdriverConfig {
         let client = HttpClient::new(tls_settings, cx.proxy())?;
         let batch_settings = self.batch.into_batch_settings()?;
 
+        auth.spawn_regenerate_token();
         let sink = HttpEventSink {
             config: self.clone(),
             started,
             auth,
         };
 
-        auth.spawn_regenerate_token();
         let sink = BatchedHttpSink::new(
             sink,
             MetricsBuffer::new(batch_settings.size),

--- a/src/sinks/gcp/stackdriver_metrics.rs
+++ b/src/sinks/gcp/stackdriver_metrics.rs
@@ -114,6 +114,7 @@ impl SinkConfig for StackdriverConfig {
             auth,
         };
 
+        auth.spawn_regenerate_token();
         let sink = BatchedHttpSink::new(
             sink,
             MetricsBuffer::new(batch_settings.size),


### PR DESCRIPTION
Closes #17263

Looks to have just been missed for this one sink, the other four GCP sinks appear to be calling it correctly. It strikes me that we should try and share more of the code between these sinks where possible to avoid these sorts of issues slipping in.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
