### PR TITLE
Improve tokio::select behavior for kafka source and finalizers

### DIFF
--- a/lib/vector-common/src/finalizer.rs
+++ b/lib/vector-common/src/finalizer.rs
@@ -119,7 +119,8 @@ where
                     // Drop all the existing status receivers and start over.
                     status_receivers = S::default();
                 },
-                // Prefer to remove finalizers than to add new finalizers.
+                // Prefer to remove finalizers than to add new finalizers to prevent unbounded
+                // growth under load.
                 finished = status_receivers.next(), if !status_receivers.is_empty() => match finished {
                     Some((status, entry)) => yield (status, entry),
                     // The `is_empty` guard above prevents this from being reachable.

--- a/lib/vector-common/src/finalizer.rs
+++ b/lib/vector-common/src/finalizer.rs
@@ -119,6 +119,12 @@ where
                     // Drop all the existing status receivers and start over.
                     status_receivers = S::default();
                 },
+                // Prefer to remove finalizers than to add new finalizers.
+                finished = status_receivers.next(), if !status_receivers.is_empty() => match finished {
+                    Some((status, entry)) => yield (status, entry),
+                    // The `is_empty` guard above prevents this from being reachable.
+                    None => unreachable!(),
+                },
                 // Only poll for new entries until shutdown is flagged.
                 new_entry = new_entries.recv() => match new_entry {
                     Some((receiver, entry)) => {
@@ -129,11 +135,6 @@ where
                     }
                     // The end of the new entry channel signals shutdown
                     None => break,
-                },
-                finished = status_receivers.next(), if !status_receivers.is_empty() => match finished {
-                    Some((status, entry)) => yield (status, entry),
-                    // The `is_empty` guard above prevents this from being reachable.
-                    None => unreachable!(),
                 },
             }
         }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -392,6 +392,7 @@ async fn kafka_source(
 
     loop {
         tokio::select! {
+            biased;
             _ = &mut shutdown => break,
             entry = ack_stream.next() => if let Some((status, entry)) = entry {
                 if status == BatchStatus::Delivered {


### PR DESCRIPTION
- fix(kafka source): Bias the tokio::select
- chore: Reorder finalizer tokio::select to remove existing finalizers before adding new finalizers

Might close #17276

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
