### PR TITLE
chore: Regen docs for sample and throttle

### DIFF
--- a/website/cue/reference/components/transforms/base/sample.cue
+++ b/website/cue/reference/components/transforms/base/sample.cue
@@ -12,7 +12,7 @@ base: components: transforms: sample: configuration: {
 			sampled.
 
 			Each unique value for the key creates a bucket of related events to be sampled together
-			and the rate is applied to the buckets themselves to sample `1/N` buckets. Overall rate
+			and the rate is applied to the buckets themselves to sample `1/N` buckets.  The overall rate
 			of sampling may differ from the configured one if values in the field are not uniformly
 			distributed. If left unspecified, or if the event doesn’t have `key_field`, then the
 			event is sampled independently.

--- a/website/cue/reference/components/transforms/base/throttle.cue
+++ b/website/cue/reference/components/transforms/base/throttle.cue
@@ -8,7 +8,7 @@ base: components: transforms: throttle: configuration: {
 	}
 	key_field: {
 		description: """
-			The value to group events into a separate buckets to be rate limited independently.
+			The value to group events into separate buckets to be rate limited independently.
 
 			If left unspecified, or if the event doesn't have `key_field`, then the event is not rate
 			limited separately.


### PR DESCRIPTION
#17372 broke CI due to suggestions added during review, which didn't have a following component doc regeneration

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
