### PR TITLE
chore(ci): Try to fix apt retries

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -11,7 +11,7 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 export ACCEPT_EULA=Y
 
-echo 'APT::Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 
 apt update --yes
 


### PR DESCRIPTION
https://github.com/ruby/setup-ruby-pkgs/issues/3#issuecomment-608580828 and other online posts make
it seem like the `APT::` prefix shouldn't be there. `man apt.conf` is unclear on the subject so
I figure we can just see if this seems to improve things.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
