### PR TITLE
enhancement(aws_s3 sink): Add `parquet codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.2.9",
  "once_cell",
  "version_check",
@@ -80,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -251,6 +267,93 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "arrow-array"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a27466d897d99654357a6d95dc0a26931d9e4306e60c14fc31a894edb86579"
+dependencies = [
+ "ahash 0.8.2",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half 2.2.1",
+ "hashbrown 0.13.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9405b78106a9d767c7b97c78a70ee1b23ee51a74f5188a821a716d9a85d1af2b"
+dependencies = [
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ec5a79a87783dc828b7ff8f89f62880b3f553bc5f5b932a82f4a1035024b4"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "lexical-core",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f710d98964d2c069b8baf566130045e79e11baa105623f038a6c942f805681"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c99787cb8fabc187285da9e7182d22f2b80ecfac61ca0a42c4299e9eecdf903"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41d058b2895a12f46dfafc306ee3529ad9660406be0ab8a7967d5e27c417e"
+
+[[package]]
+name = "arrow-select"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fcbdda2772b7e712e77444f3a71f4ee517095aceb993b35de71de41c70d9b4f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
 
 [[package]]
 name = "ascii"
@@ -1591,6 +1694,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bson"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -2033,6 +2157,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "ordered-float 3.7.0",
+ "parquet",
  "prost",
  "regex",
  "serde",
@@ -2186,6 +2311,28 @@ name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
+name = "const-random"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+dependencies = [
+ "getrandom 0.2.9",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "convert_case"
@@ -3242,6 +3389,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
+name = "flatbuffers"
+version = "23.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f5399c2c9c50ae9418e522842ad362f61ee48b346ac106807bd355a8a7c619"
+dependencies = [
+ "bitflags",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3797,16 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [
+ "crunchy",
+ "num-traits",
+]
 
 [[package]]
 name = "hash_hasher"
@@ -4206,6 +4373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "inventory"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4610,6 +4783,70 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -5350,6 +5587,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.1",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,12 +5642,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -5789,6 +6063,37 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "parquet"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a1e6fa27f09ebddba280f5966ef435f3ac4d74cfc3ffe370fd3fd59c2e004d"
+dependencies = [
+ "ahash 0.8.2",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.21.0",
+ "brotli",
+ "bytes 1.4.0",
+ "chrono",
+ "flate2",
+ "hashbrown 0.13.2",
+ "lz4",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]
@@ -7323,6 +7628,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b44e8fc93a14e66336d230954dda83d18b4605ccace8fe09bc7514a71ad0bc"
+
+[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8184,6 +8495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.0",
+]
+
+[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.5.2+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9021,7 +9343,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1ee6bfd0a27bf614353809a035cf6880b74239ec6c5e39a7b2860ca16809137"
 dependencies = [
- "num-rational",
+ "num-rational 0.3.2",
  "num-traits",
  "typenum",
 ]

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -1,42 +1,43 @@
 [package]
-name = "codecs"
-version = "0.1.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
+name = "codecs"
 publish = false
+version = "0.1.0"
 
 [dependencies]
-apache-avro = { version = "0.14.0", default-features = false }
-bytes = { version = "1", default-features = false }
-chrono = { version = "0.4", default-features = false }
-csv = { version = "1.2", default-features = false }
-derivative = { version = "2", default-features = false }
-dyn-clone = { version = "1", default-features = false }
-lookup = { package = "vector-lookup", path = "../vector-lookup", default-features = false }
-memchr = { version = "2", default-features = false }
-once_cell = { version = "1.17", default-features = false }
-ordered-float = { version = "3.7.0", default-features = false }
-prost = { version = "0.11.8", default-features = false, features = ["std"] }
-regex = { version = "1.8.1", default-features = false, features = ["std", "perf"] }
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1", default-features = false }
-smallvec = { version = "1", default-features = false, features = ["union"] }
-snafu = { version = "0.7.4", default-features = false, features = ["futures"] }
-syslog_loose = { version = "0.18", default-features = false, optional = true }
-tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
-tracing = { version = "0.1", default-features = false }
-vrl = { git = "https://github.com/vectordotdev/vrl", rev = "v0.3.0", default-features = false, features = ["value"] }
-vector-common = { path = "../vector-common", default-features = false }
-vector-config = { path = "../vector-config", default-features = false }
-vector-config-common = { path = "../vector-config-common", default-features = false }
-vector-config-macros = { path = "../vector-config-macros", default-features = false }
-vector-core = { path = "../vector-core", default-features = false }
+apache-avro = {version = "0.14.0", default-features = false}
+bytes = {version = "1", default-features = false}
+chrono = {version = "0.4", default-features = false}
+csv = {version = "1.2", default-features = false}
+derivative = {version = "2", default-features = false}
+dyn-clone = {version = "1", default-features = false}
+lookup = {package = "vector-lookup", path = "../vector-lookup", default-features = false}
+memchr = {version = "2", default-features = false}
+once_cell = {version = "1.17", default-features = false}
+ordered-float = {version = "3.7.0", default-features = false}
+parquet = {version = "39.0.0", default-feature = false}
+prost = {version = "0.11.8", default-features = false, features = ["std"]}
+regex = {version = "1.8.1", default-features = false, features = ["std", "perf"]}
+serde = {version = "1", default-features = false, features = ["derive"]}
+serde_json = {version = "1", default-features = false}
+smallvec = {version = "1", default-features = false, features = ["union"]}
+snafu = {version = "0.7.4", default-features = false, features = ["futures"]}
+syslog_loose = {version = "0.18", default-features = false, optional = true}
+tokio-util = {version = "0.7", default-features = false, features = ["codec"]}
+tracing = {version = "0.1", default-features = false}
+vector-common = {path = "../vector-common", default-features = false}
+vector-config = {path = "../vector-config", default-features = false}
+vector-config-common = {path = "../vector-config-common", default-features = false}
+vector-config-macros = {path = "../vector-config-macros", default-features = false}
+vector-core = {path = "../vector-core", default-features = false}
+vrl = {git = "https://github.com/vectordotdev/vrl", rev = "v0.3.0", default-features = false, features = ["value"]}
 
 [dev-dependencies]
-futures = { version = "0.3", default-features = false }
-indoc = { version = "2", default-features = false }
-tokio = { version = "1", features = ["test-util"] }
+futures = {version = "0.3", default-features = false}
+indoc = {version = "2", default-features = false}
 similar-asserts = "1.4.2"
+tokio = {version = "1", features = ["test-util"]}
 
 [features]
 syslog = ["dep:syslog_loose"]

--- a/lib/codecs/src/encoding/format/mod.rs
+++ b/lib/codecs/src/encoding/format/mod.rs
@@ -10,12 +10,14 @@ mod json;
 mod logfmt;
 mod native;
 mod native_json;
+mod parquet;
 mod raw_message;
 mod text;
 
 use std::fmt::Debug;
 
 pub use self::csv::{CsvSerializer, CsvSerializerConfig};
+pub use self::parquet::{ParquetSerializer, ParquetSerializerConfig, ParquetSerializerOptions};
 pub use avro::{AvroSerializer, AvroSerializerConfig, AvroSerializerOptions};
 use dyn_clone::DynClone;
 pub use gelf::{GelfSerializer, GelfSerializerConfig};

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -1,0 +1,663 @@
+use core::panic;
+use std::{io, sync::Arc};
+
+use bytes::{BufMut, BytesMut};
+use parquet::{
+    basic::Repetition,
+    column::writer::{ColumnWriter::*, ColumnWriterImpl},
+    data_type::DataType,
+    errors::ParquetError,
+    file::{properties::WriterProperties, writer::SerializedFileWriter},
+    schema::{
+        parser::parse_message_type,
+        types::{ColumnDescriptor, Type, TypePtr},
+    },
+};
+use serde::{Deserialize, Serialize};
+use snafu::*;
+use tokio_util::codec::Encoder;
+
+use vector_config::configurable_component;
+use vector_core::{
+    config,
+    event::{Event, Value},
+    schema,
+};
+
+use crate::encoding::BuildError;
+
+/// Errors that can occur during Parquet serialization.
+#[derive(Debug, Snafu)]
+pub enum ParquetSerializerError {
+    #[snafu(display(r#"Event does not contain required field. field = "{}""#, field))]
+    MissingField {
+        field: String,
+    },
+    #[snafu(display(
+        r#"Event contains a value with an invalid type. field = "{}" type = "{}" expected type = "{}""#,
+        field,
+        actual_type,
+        expected_type
+    ))]
+    InvalidValueType {
+        field: String,
+        actual_type: String,
+        expected_type: String,
+    },
+    #[snafu(display("Failed to write. error: {}", error))]
+    ParquetError {
+        error: ParquetError,
+    },
+    // TODO: Can this actually happen?
+    IoError {
+        source: io::Error,
+    },
+}
+
+impl ParquetSerializerError {
+    fn invalid_type(
+        desc: &ColumnDescriptor,
+        value: &Value,
+        expected: &str,
+    ) -> ParquetSerializerError {
+        ParquetSerializerError::InvalidValueType {
+            field: desc.name().to_string(),
+            actual_type: value.kind_str().to_string(),
+            expected_type: expected.to_string(),
+        }
+    }
+}
+
+impl From<ParquetError> for ParquetSerializerError {
+    fn from(error: ParquetError) -> Self {
+        Self::ParquetError { error }
+    }
+}
+
+impl From<io::Error> for ParquetSerializerError {
+    fn from(source: io::Error) -> Self {
+        Self::IoError { source }
+    }
+}
+
+/// Config used to build a `ParquetSerializer`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ParquetSerializerConfig {
+    /// Options for the Parquet serializer.
+    pub parquet: ParquetSerializerOptions,
+}
+
+impl ParquetSerializerConfig {
+    /// Creates a new `ParquetSerializerConfig`.
+    pub const fn new(schema: String) -> Self {
+        Self {
+            parquet: ParquetSerializerOptions { schema },
+        }
+    }
+
+    /// Build the `ParquetSerializerConfig` from this configuration.
+    pub fn build(&self) -> Result<ParquetSerializer, BuildError> {
+        let schema = parse_message_type(&self.parquet.schema)
+            .map_err(|error| format!("Failed building Parquet serializer: {}", error))?;
+        Ok(ParquetSerializer {
+            schema: Arc::new(schema),
+        })
+    }
+
+    /// The data type of events that are accepted by `ParquetSerializer`.
+    pub fn input_type(&self) -> config::DataType {
+        config::DataType::Log
+    }
+
+    /// The schema required by the serializer.
+    pub fn schema_requirement(&self) -> schema::Requirement {
+        // TODO: Convert the Parquet schema to a vector schema requirement.
+        // NOTE: This isn't yet doable. We don't have meanings to
+        // to specify for requirement.
+        schema::Requirement::empty()
+    }
+}
+
+/// Options for the Parquet serializer.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub struct ParquetSerializerOptions {
+    /// The Parquet schema.
+    #[configurable(metadata(docs::examples = r#"message test {
+        required group data {
+            required binary name;
+            repeated int64 values;
+        }
+    }"#))]
+    pub schema: String,
+}
+
+/// Serializer that converts `Vec<Event>` to bytes using the Apache Parquet format.
+#[derive(Debug, Clone)]
+pub struct ParquetSerializer {
+    schema: TypePtr,
+}
+
+impl ParquetSerializer {
+    /// Creates a new `ParquetSerializer`.
+    pub const fn new(schema: TypePtr) -> Self {
+        Self { schema }
+    }
+}
+
+impl ParquetSerializer {
+    fn process<T: DataType>(
+        &self,
+        events: &[Event],
+        desc: &ColumnDescriptor,
+        extractor: impl Fn(&Value) -> Result<<T as DataType>::T, ParquetSerializerError>,
+        writer: &mut ColumnWriterImpl<T>,
+    ) -> Result<(), ParquetSerializerError> {
+        let mut column = Column::<<T as DataType>::T, _>::new(&*self.schema, desc, extractor);
+        column.extract_column(events)?;
+        let written_values = writer.write_batch(
+            &column.values,
+            column.def_levels.as_ref().map(|vec| vec.as_slice()),
+            column.rep_levels.as_ref().map(|vec| vec.as_slice()),
+        )?;
+
+        assert_eq!(written_values, column.values.len());
+        Ok(())
+    }
+}
+
+impl Encoder<Vec<Event>> for ParquetSerializer {
+    type Error = vector_common::Error;
+
+    /// Builds columns from events and writes them to the writer.
+    ///
+    /// Expects that all events satisfy the schema, else whole batch can fail.
+    fn encode(&mut self, events: Vec<Event>, buffer: &mut BytesMut) -> Result<(), Self::Error> {
+        // Encode events
+        let props = Arc::new(WriterProperties::builder().build());
+        let mut parquet_writer =
+            SerializedFileWriter::new(buffer.writer(), self.schema.clone(), props)?;
+
+        let mut row_group_writer = parquet_writer.next_row_group()?;
+        while let Some(mut column_writer) = row_group_writer.next_column()? {
+            match column_writer.untyped() {
+                BoolColumnWriter(ref mut writer) => {
+                    let desc = writer.get_descriptor().clone();
+                    self.process(
+                        &events,
+                        &desc,
+                        |value| match value {
+                            Value::Boolean(value) => Ok(*value),
+                            _ => Err(ParquetSerializerError::invalid_type(
+                                &desc, value, "boolean",
+                            )),
+                        },
+                        writer,
+                    )?
+                }
+                Int64ColumnWriter(writer) => {
+                    let desc = writer.get_descriptor().clone();
+                    self.process(
+                        &events,
+                        &desc,
+                        |value| match value {
+                            Value::Integer(value) => Ok(*value),
+                            _ => Err(ParquetSerializerError::invalid_type(
+                                &desc, value, "integer",
+                            )),
+                        },
+                        writer,
+                    )?
+                }
+                DoubleColumnWriter(writer) => {
+                    let desc = writer.get_descriptor().clone();
+                    self.process(
+                        &events,
+                        &desc,
+                        |value| match value {
+                            Value::Float(value) => Ok(value.into_inner()),
+                            _ => Err(ParquetSerializerError::invalid_type(&desc, value, "float")),
+                        },
+                        writer,
+                    )?
+                }
+                ByteArrayColumnWriter(writer) => {
+                    let desc = writer.get_descriptor().clone();
+                    self.process(
+                        &events,
+                        &desc,
+                        |value| match value {
+                            Value::Bytes(value) => Ok(value.clone().into()),
+                            _ => Err(ParquetSerializerError::invalid_type(&desc, value, "string")),
+                        },
+                        writer,
+                    )?
+                }
+                FixedLenByteArrayColumnWriter(_) => {
+                    panic!("Fixed len byte array is not supported.");
+                }
+                Int32ColumnWriter(_) => panic!("Int32 is not supported."),
+                Int96ColumnWriter(_) => panic!("Int96 is not supported."),
+                FloatColumnWriter(_) => panic!("Float32 is not supported."),
+            }
+            column_writer.close()?;
+        }
+
+        row_group_writer.close()?;
+        parquet_writer.close()?;
+
+        Ok(())
+    }
+}
+
+struct Column<'a, T, F: Fn(&Value) -> Result<T, ParquetSerializerError>> {
+    column: &'a ColumnDescriptor,
+    levels: Vec<&'a Type>,
+    extract: F,
+    values: Vec<T>,
+    // If present encodes definition level. From 0 to column.max_def_level() inclusive.
+    // With any value bellow max encoding null on that level.
+    // One thing to keep in mind, if a column is required on some "level" then that level is not counted here.
+    // This is needed when values are optional.
+    // In case of null, that value is skipped in values.
+    def_levels: Option<Vec<i16>>,
+    // If present encodes repetition level.
+    // From 0 to column.max_rep_level() inclusive. With 0 starting a new record and any value bellow max encoding
+    // starting new list at that level. With max level just adding element to leaf list.
+    // This is needed when values are repeated. Where that repetition can have multiple nested levels.
+    rep_levels: Option<Vec<i16>>,
+}
+
+impl<'a, T, F: Fn(&Value) -> Result<T, ParquetSerializerError>> Column<'a, T, F> {
+    fn new(schema: &'a Type, column: &'a ColumnDescriptor, extract: F) -> Self {
+        let mut levels = vec![schema];
+        for part in column.path().parts() {
+            match &levels[levels.len() - 1] {
+                Type::GroupType { fields, .. } => {
+                    let field = fields
+                        .iter()
+                        .find(|field| field.name() == part)
+                        .expect("Field not found in schema.");
+                    levels.push(field);
+                }
+                Type::PrimitiveType { .. } => unreachable!(),
+            }
+        }
+
+        let def_levels = if levels.iter().any(|ty| ty.is_optional()) {
+            Some(Vec::new())
+        } else {
+            None
+        };
+
+        let rep_levels = if levels.iter().any(|ty| {
+            let info = ty.get_basic_info();
+            info.has_repetition() && info.repetition() == Repetition::REPEATED
+        }) {
+            Some(Vec::new())
+        } else {
+            None
+        };
+
+        Self {
+            column,
+            levels,
+            extract,
+            values: Vec::new(),
+            def_levels,
+            rep_levels,
+        }
+    }
+
+    fn extract_column(&mut self, events: &[Event]) -> Result<(), ParquetSerializerError> {
+        for event in events {
+            match event {
+                Event::Log(log) => {
+                    self.extract_value(log.value(), 0, 0, 0, 1)?;
+                }
+                Event::Trace(trace) => {
+                    self.extract_value(trace.value(), 0, 0, 0, 1)?;
+                }
+                Event::Metric(_) => {
+                    panic!("Metrics are not supported.");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Will push at least one value, or error.
+    fn extract_value(
+        &mut self,
+        value: &Value,
+        start_rep_level: i16,
+        rep_level: i16,
+        def_level: i16,
+        level: usize,
+    ) -> Result<(), ParquetSerializerError> {
+        if let Some(part) = self.levels.get(level) {
+            match value {
+                Value::Object(object) => {
+                    if let Some(value) = object.get(part.name()) {
+                        let info = part.get_basic_info();
+                        if info.has_repetition() && info.repetition() == Repetition::REPEATED {
+                            self.extract_flat(
+                                value,
+                                start_rep_level,
+                                rep_level + 1,
+                                def_level + 1,
+                                level + 1,
+                            )
+                        } else {
+                            self.extract_value(
+                                value,
+                                start_rep_level,
+                                rep_level,
+                                if part.is_optional() {
+                                    def_level + 1
+                                } else {
+                                    def_level
+                                },
+                                level + 1,
+                            )
+                        }
+                    } else if part.is_optional() {
+                        self.push_value(None, start_rep_level, def_level);
+                        Ok(())
+                    } else {
+                        // Illegal null, error
+                        Err(ParquetSerializerError::MissingField {
+                            field: self.path(level),
+                        })
+                    }
+                }
+                Value::Null => {
+                    if part.is_optional() {
+                        self.push_value(None, start_rep_level, def_level);
+                        Ok(())
+                    } else {
+                        // Illegal null, error
+                        Err(ParquetSerializerError::MissingField {
+                            field: self.path(level),
+                        })
+                    }
+                }
+                // Invalid type, error
+                value => Err(ParquetSerializerError::InvalidValueType {
+                    field: self.path(level),
+                    actual_type: value.kind_str().to_string(),
+                    expected_type: "object".to_string(),
+                }),
+            }
+        } else {
+            match value {
+                Value::Null => {
+                    if self.column.self_type().is_optional() {
+                        self.push_value(None, start_rep_level, def_level);
+                        Ok(())
+                    } else {
+                        // Illegal null, error
+                        Err(ParquetSerializerError::MissingField {
+                            field: self.path(level),
+                        })
+                    }
+                }
+                value => {
+                    let value = (self.extract)(value)?;
+                    self.push_value(Some(value), start_rep_level, def_level);
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// Will push at least one value, or error.
+    fn extract_flat(
+        &mut self,
+        value: &Value,
+        start_rep_level: i16,
+        rep_level: i16,
+        def_level: i16,
+        level: usize,
+    ) -> Result<(), ParquetSerializerError> {
+        match value {
+            Value::Array(array) => {
+                let mut next_rep_level = start_rep_level;
+                for value in array {
+                    self.extract_flat(value, next_rep_level, rep_level, def_level, level)?;
+                    next_rep_level = rep_level;
+                }
+                Ok(())
+            }
+            _ => self.extract_value(value, start_rep_level, rep_level, def_level, level),
+        }
+    }
+
+    fn push_value(&mut self, value: Option<T>, rep_level: i16, def_level: i16) {
+        if let Some(rep_levels) = &mut self.rep_levels {
+            rep_levels.push(rep_level);
+        }
+        if let Some(def_levels) = &mut self.def_levels {
+            def_levels.push(def_level);
+        }
+        if let Some(value) = value {
+            self.values.push(value);
+        }
+    }
+
+    fn path(&self, level: usize) -> String {
+        let mut path = String::new();
+        for level in &self.levels[1..level] {
+            path.push_str(level.name());
+            path.push('.');
+        }
+        path.push_str(self.levels[level].name());
+        path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use parquet::{
+        column::reader::{ColumnReader, ColumnReaderImpl},
+        file::reader::*,
+        file::serialized_reader::SerializedFileReader,
+        schema::parser::parse_message_type,
+    };
+    use similar_asserts::assert_eq;
+    use std::panic;
+    use std::{collections::HashSet, sync::Arc};
+    use vector_core::event::LogEvent;
+    use vrl::value::btreemap;
+
+    macro_rules! log_event {
+        ($($key:expr => $value:expr),*  $(,)?) => {
+            #[allow(unused_variables)]
+            {
+                let mut event = Event::Log(LogEvent::default());
+                let log = event.as_mut_log();
+                $(
+                    log.insert($key, $value);
+                )*
+                event
+            }
+        };
+    }
+
+    fn assert_column<T: DataType>(
+        count: usize,
+        expect_values: &[<T as DataType>::T],
+        expect_rep_levels: Option<&[i16]>,
+        expect_def_levels: Option<&[i16]>,
+        mut column_reader: ColumnReaderImpl<T>,
+    ) where
+        <T as DataType>::T: Default,
+    {
+        let mut values = Vec::new();
+        values.resize(count, <T as DataType>::T::default());
+        let mut def_levels = Vec::new();
+        def_levels.resize(count, 0);
+        let mut rep_levels = Vec::new();
+        rep_levels.resize(count, 0);
+        let (read, level) = column_reader
+            .read_batch(
+                count,
+                Some(def_levels.as_mut_slice()).filter(|_| expect_def_levels.is_some()),
+                Some(rep_levels.as_mut_slice()).filter(|_| expect_rep_levels.is_some()),
+                &mut values,
+            )
+            .unwrap();
+
+        assert_eq!(level, count);
+        if expect_def_levels.is_some() {
+            assert_eq!(def_levels, expect_def_levels.unwrap());
+        }
+        if expect_rep_levels.is_some() {
+            assert_eq!(rep_levels, expect_rep_levels.unwrap());
+        }
+        assert_eq!(&values[..read], expect_values);
+    }
+
+    #[test]
+    fn test_serialize() {
+        let message_type = r#"
+            message test {
+                required group a {
+                    required boolean b;
+                    optional int64 c;
+                }
+                optional group d {
+                    optional int64 e;
+                }
+                required group f {
+                    repeated int64 g;
+                }
+                required binary h;
+                repeated group i {
+                    required int64 j;
+                    repeated double k;
+                }
+            }
+            "#;
+
+        let events = vec![
+            log_event! {
+            "a.b" => true,
+            "a.c" => 2,
+            "d.e" => 3,
+            "f.g" => vec![4, 5],
+            "h" => "hello",
+            "i" => vec![btreemap! {
+                    "j" => 6,
+                    "k" => vec![7.0, 8.0]
+                }]
+            },
+            log_event! {
+            "a.b" => false,
+            "f" => Value::Object(Default::default()),
+            "h" => "world",
+            "i" => vec![
+                btreemap! {
+                    "j" => 9,
+                    "k" => vec![10.0]
+                }, btreemap! {
+                    "j" => 11,
+                }]
+            },
+        ];
+
+        let schema = Arc::new(parse_message_type(message_type).unwrap());
+        let mut encoder = ParquetSerializer::new(schema);
+
+        let mut buffer = BytesMut::new();
+        encoder.encode(events, &mut buffer).unwrap();
+
+        let reader = SerializedFileReader::new(buffer.freeze()).unwrap();
+
+        let parquet_metadata = reader.metadata();
+        assert_eq!(parquet_metadata.num_row_groups(), 1);
+
+        let row_group_reader = reader.get_row_group(0).unwrap();
+        assert_eq!(row_group_reader.num_columns(), 7);
+
+        let metadata = row_group_reader.metadata();
+        let mut visited = HashSet::new();
+        for (i, column) in metadata.columns().iter().enumerate() {
+            match column.column_path().string().as_str() {
+                "a.b" => {
+                    assert!(visited.insert("a.b"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::BoolColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(2, &[true, false], None, None, reader);
+                }
+                "a.c" => {
+                    assert!(visited.insert("a.c"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::Int64ColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(2, &[2], None, Some(&[1, 0]), reader);
+                }
+                "d.e" => {
+                    assert!(visited.insert("d.e"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::Int64ColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(2, &[3], None, Some(&[2, 0]), reader);
+                }
+                "f.g" => {
+                    assert!(visited.insert("f.g"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::Int64ColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(3, &[4, 5], Some(&[0, 1, 0]), Some(&[1, 1, 0]), reader);
+                }
+                "h" => {
+                    assert!(visited.insert("h"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::ByteArrayColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(
+                        2,
+                        &[Bytes::from("hello").into(), Bytes::from("world").into()],
+                        None,
+                        None,
+                        reader,
+                    );
+                }
+                "i.j" => {
+                    assert!(visited.insert("i.j"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::Int64ColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(3, &[6, 9, 11], Some(&[0, 0, 1]), Some(&[1, 1, 1]), reader);
+                }
+                "i.k" => {
+                    assert!(visited.insert("i.k"));
+                    let reader = match row_group_reader.get_column_reader(i).unwrap() {
+                        ColumnReader::DoubleColumnReader(r) => r,
+                        _ => panic!("Wrong column type"),
+                    };
+                    assert_column(
+                        4,
+                        &[7.0, 8.0, 10.0],
+                        Some(&[0, 2, 0, 1]),
+                        Some(&[2, 2, 2, 1]),
+                        reader,
+                    );
+                }
+                _ => panic!("Unexpected column"),
+            }
+        }
+
+        assert_eq!(visited.len(), 7);
+    }
+}

--- a/src/codecs/encoding/config.rs
+++ b/src/codecs/encoding/config.rs
@@ -1,6 +1,6 @@
 use crate::codecs::Transformer;
 use codecs::{
-    encoding::{Framer, FramingConfig, Serializer, SerializerConfig},
+    encoding::{BatchSerializer, Framer, FramingConfig, Serializer, SerializerConfig},
     CharacterDelimitedEncoder, LengthDelimitedEncoder, NewlineDelimitedEncoder,
 };
 use vector_config::configurable_component;
@@ -119,6 +119,13 @@ impl EncodingConfigWithFraming {
         };
 
         Ok((framer, serializer))
+    }
+
+    /// Build `BatchSerializer` for this config.
+    /// None if serializer is not batched.
+    pub fn build_batched(&self) -> crate::Result<Option<BatchSerializer>> {
+        let serializer = self.encoding.config().build_batched()?;
+        Ok(serializer)
     }
 }
 

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -189,6 +189,7 @@ fn serializer_config_to_deserializer(config: &SerializerConfig) -> decoding::Des
         SerializerConfig::Native => DeserializerConfig::Native,
         SerializerConfig::NativeJson => DeserializerConfig::NativeJson,
         SerializerConfig::RawMessage | SerializerConfig::Text(_) => DeserializerConfig::Bytes,
+        SerializerConfig::Parquet { .. } => todo!(),
     };
 
     deserializer_config.build()

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use std::{convert::TryInto, sync::Arc};
 
 use aws_sdk_s3::Client as S3Client;
 use codecs::{
@@ -14,6 +14,7 @@ use crate::{
     aws::{AwsAuthentication, RegionOrEndpoint},
     codecs::{Encoder, EncodingConfigWithFraming, SinkType},
     config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    event::Event,
     sinks::{
         s3_common::{
             self,
@@ -206,8 +207,14 @@ impl S3SinkConfig {
         let partitioner = S3KeyPartitioner::new(key_prefix, ssekms_key_id);
 
         let transformer = self.encoding.transformer();
-        let (framer, serializer) = self.encoding.build(SinkType::MessageBased)?;
-        let encoder = Encoder::<Framer>::new(framer, serializer);
+        let encoder = if let Some(serializer) = self.encoding.build_batched()? {
+            Arc::new((transformer, serializer))
+                as Arc<dyn crate::sinks::util::encoding::Encoder<Vec<Event>> + Send + Sync>
+        } else {
+            let (framer, serializer) = self.encoding.build(SinkType::MessageBased)?;
+            let encoder = Encoder::<Framer>::new(framer, serializer);
+            Arc::new((transformer, encoder)) as _
+        };
 
         let request_options = S3RequestOptions {
             bucket: self.bucket.clone(),
@@ -215,7 +222,7 @@ impl S3SinkConfig {
             filename_extension: self.filename_extension.clone(),
             filename_time_format: self.filename_time_format.clone(),
             filename_append_uuid: self.filename_append_uuid,
-            encoder: (transformer, encoder),
+            encoder,
             compression: self.compression,
         };
 


### PR DESCRIPTION
Closes #1374

Implementation of `parquet` codec for `aws_s3` sink.

Usage, as with `avro` codec, specify codec as `parquet` and define `encoding.parquet.schema`.
Example:
```
[sinks.test_aws.encoding]
  codec = "parquet"
  parquet.schema = '''
  	message test {
  	    required binary message; 
  	}
  '''
```

Currently there is no enforcement of the schema before the coder so if a single event doesn't satisfy the schema it will fail the entire batch. 

_Is not meant for merger_, will remain in draft until batch codecs have landed. Regarding that, the encoding itself is generic, what's not so ok is the way it's woven into current codec abstractions. It can also be viewed as a test case of where the problematic spots are.

### Todo/Extensions
- [ ] Documentation
- [ ] Logical types
- [ ] Column compression
- [ ] Event definition/schema mismatch
       * Try to enforce schema in the sink through `schema_requirement`. Unfortunately it doesn't seem possible at the moment. The problem is in parquet schema not having meaning for it's fields which `schema_requirement` requires.
       * Or to fail only invalid event not the whole batch.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
