### PR TITLE
datadog-vale changes pt 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -14,7 +14,7 @@ Before the release:
 - [ ] Run `cargo vdev build release-cue` to generate a new cue file for the release
 - [ ] Add `changelog` key to generated cue file
   - [ ] `git log --no-merges --cherry-pick --right-only <last release tag>...`
-  - [ ] Should be hand-written list of changes
+  - [ ] Should be handwritten list of changes
         ([example](https://github.com/vectordotdev/vector/blob/9fecdc8b5c45c613de2d01d4d2aee22be3a2e570/website/cue/reference/releases/0.19.0.cue#L44))
   - [ ] Add description key to the generated cue file with a description of the release (see
         previous releases for examples).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -26,9 +26,9 @@ you are observing.
 
 Essential details to include:
 
-- Errors- for each error, please provide the full error message snippet, and
+- Errors: for each error, please provide the full error message snippet, and
   details such as where the error is observed, at what stage in the process
-  (e.g. at boot time, after some specific condition etc.).
+  (for example at boot time, after some specific condition etc.).
 - What is the version of Vector (and the Helm chart if deploying via Helm) and
   the versions of any other systems in use (like Elasticsearch, NATS, etc.).
 - What is your Vector configuration. See the below section on [how to format

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,29 @@
+StylesPath = "../../DataDog/datadog-vale/styles"
+MinAlertLevel = error
+; StylesPath = ".github/styles"
+; MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = Datadog
+Datadog.Trademarks = NO
+BlockIgnores = (?s) *({{< ?code-block [^>]* >}}.*?{{< ?/ ?code-block >}})
+TokenIgnores = ({{< ?site-region [^>]* >}})
+
+[*.html]
+BasedOnStyles = Datadog
+; Datadog.Trademarks = YES
+; Datadog.abbreviations = NO
+; Datadog.americanspelling = NO
+; Datadog.dashes = NO
+; Datadog.endash = NO
+; Datadog.gender = NO
+; Datadog.headings = NO
+; Datadog.inclusive = NO
+; Datadog.links = NO
+; Datadog.oxfordcomma = NO
+; Datadog.pronouns = NO
+; Datadog.sentencelength = NO
+; Datadog.spaces = NO
+; Datadog.tense = NO
+; Datadog.words = YES
+; Datadog.quotes = NO

--- a/STYLE.md
+++ b/STYLE.md
@@ -10,13 +10,13 @@ think you could try doing it this way" into "we always do X this way: <link to s
 ## Formatting
 
 At a high-level, code formatting is straightforward: we use the native `rustfmt` exclusively, and
-comprehensively.  All Rust source code within the repository should be formatted using `rustfmt`.
+comprehensively. All Rust source code within the repository should be formatted using `rustfmt`.
 
 You can acquire `rustfmt` -- which is invoked as `cargo fmt` -- by following the directions listed
 out [in the rustfmt repository](https://github.com/rust-lang/rustfmt#on-the-stable-toolchain).
 
 Vector has its own formatting rules (`.rustfmt.toml`) that will automatically be used when you run
-`cargo fmt` within the repository.  If you're ever in doubt, you can also run `make check-fmt` which
+`cargo fmt` within the repository. If you're ever in doubt, you can also run `make check-fmt` which
 will invoke `cargo fmt` in a dry-run mode, checking to see if any changed files are not currently
 formatted correctly.
 
@@ -39,7 +39,7 @@ informed about errors, warnings, and so on.
 
 ### `src/`: main binary and all related functionality
 
-The bulk of functional code resides in the `src/` directory/crate.  When we refer to functional
+The bulk of functional code resides in the `src/` directory/crate. When we refer to functional
 code, we're talking about code that powers user-visible aspects of Vector, such as the sources,
 transforms, and sinks themselves. There is also, of course, the requisite glue code such as parsing
 command-line arguments, reading the configuration, constructing and configuring components, and
@@ -60,7 +60,7 @@ metadata by utilizing [spans](https://docs.rs/tracing/latest/tracing/#spans).
 #### Basic Usage
 
 For logging, we use `tracing`'s event macros which should look very similar to almost all other
-logging libraries, with names that emulate the logging level being used i.e. `info!("A wild log has
+logging libraries, with names that emulate the logging level being used that is `info!("A wild log has
 appeared.");`.
 
 All of tracing's event macros -- `trace!`, `debug!`, `info!`, `warn!`, and `error!` -- support the
@@ -74,8 +74,8 @@ info!("Server has started.");
 debug!("User connected: {}", username);
 
 // Adding structured fields to the even, mixing and matching the message format:
-trace!(bytes_sent = 22, "Sent heartbeat packet to client.")`
-error!(client_addr = %conn.get_ref().peer_addr, "Client actor received malformed packet: {}", parse_err.to_string())
+trace!(bytes_sent = 22, "Sent heartbeat packet to client.");
+error!(client_addr = %conn.get_ref().peer_addr, "Client actor received malformed packet: {}", parse_err.to_string());
 ```
 
 While this does not cover all the permutations of what the macros in `tracing` support, these
@@ -104,13 +104,13 @@ debug!(%client_id, "Client entered authentication phase.");
 In general, there are both a few rules and a few suggestions to follow when it comes to writing a
 (good) log message:
 
-- Messages must be written in English. No preference on which specific English dialect is used e.g.
+- Messages must be written in English. No preference on which specific English dialect is used for example
   American English, British English, Canadian English, etc.
 - Sentences must be capitalized, and end with a period.
 - Proper spelling and grammar when possible. Not all of us are native English speakers, and so this
   is simply an ask, but not a hard requirement.
-- Identifiers, or passages of note, should be called out by some means i.e. wrapping them in
-  backticks or quotes.  Wrapping with special characters can be helpful in drawing the users eye to
+- Identifiers, or passages of note, should be called out by some means that is wrapping them in
+  backticks or quotes. Wrapping with special characters can be helpful in drawing the users eye to
   anything of importance.
 - If it's longer than one or two sentences, it's probably better suited as a single sentence briefly
   explaining the event, with a link to external documentation that explains further.
@@ -119,18 +119,18 @@ In general, there are both a few rules and a few suggestions to follow when it c
 
 Similarly, choosing the right level can be important, both from the perspective of making it easy
 for users to grok what they should pay attention to, but also to avoid the performance overhead of
-excess logging (even if we filter it out and it never makes it to the console).
+excess logging (even if we filter it out, and it never makes it to the console).
 
 - **TRACE**: Typically contains a high level of detail for deep/rich debugging.
 
   As trace logging is typically reached for when instrumenting algorithms and core pieces of logic,
   care should be taken to avoid trace logging being added to tight loops, or commonly used
-  codepaths, where possible. Even when disabled, there can still be a small overhead associated with
+  code-paths, where possible. Even when disabled, there can still be a small overhead associated with
   logging an event at all.
 - **DEBUG**: Basic information that can be helpful for initially debugging issues.
 
   Should typically not be used for things that happen per-event, or scales with event throughput,
-  but in some cases -- i.e. if it happens every 1000th event, etc -- it can safely be used.
+  but in some cases -- that is if it happens every 1000th event, etc. -- it can safely be used.
 - **INFO**: Common information about normal processes.
 
   This includes logical/temporal events such as notifications when components are stopped and
@@ -176,7 +176,7 @@ increment_counter!("requests_processed_total", "service" => "admin_grpc");
 gauge!("bytes_allocated", 42.0);
 increment_gauge!("bytes_allocated", 2048.0, "table_name" => self.table_name.to_string());
 increment_gauge!("bytes_allocated", 512.0, "table_name" => self.table_name.to_string());
-decrement_gauge!("bytes_allocated", 2560.0, "table_name" => self.table_name.to_string())
+decrement_gauge!("bytes_allocated", 2560.0, "table_name" => self.table_name.to_string());
 
 // Histograms simply record a measurement, but there's a fun little trait that `metrics`
 // uses called `IntoF64` that lets custom types provide a way to convert themselves to a
@@ -190,8 +190,8 @@ histogram!("request_duration_ns", 742_130, "endpoint" => "frontend");
 
 Many values can appear, at first, to be best tracked as a gauge: current connection count, in-flight
 request count, and so on. However, in some cases, the value being measured may change too frequently
-to be reliably tracked.  Metrics are typically collected on an interval, which is fine for counters
-and histograms: they're purely additive.  However, since a gauge is simply the _latest_ value, you
+to be reliably tracked. Metrics are typically collected on an interval, which is fine for counters
+and histograms: they're purely additive. However, since a gauge is simply the _latest_ value, you
 cannot know _how_ it's changed since the last time you've observed it.
 
 This is a common problem where a gauge tracks something like a queue size. If there's an event where
@@ -204,7 +204,7 @@ the equivalent of the "current" value. In our example above, we might have `queu
 `queued_items_popped`, and if `queue_items_pushed` equals 100, and `queued_items_popped` equals 80,
 we know our queue size is 20. More importantly, if we queried both of them at the same time, and
 they were both zero, and then queried them both a second later, and saw that both were 100,000, we
-would know that the queue size was _currently_ zero but we'd also know that we just processed
+would know that the queue size was _currently_ zero, but we'd also know that we just processed
 100,000 items in the past second.
 
 #### Best Practices
@@ -217,10 +217,10 @@ would know that the queue size was _currently_ zero but we'd also know that we j
   [Component
   Specification](https://github.com/vectordotdev/vector/blob/master/docs/specs/component.md).
 - **Don't** emit metrics in tight loops. Each metric emission carries an overhead, and emitting them
-  in tight loops can cause that overhead to become noticable in terms of CPU usage and throughput
+  in tight loops can cause that overhead to become noticeable in terms of CPU usage and throughput
   reduction. Instead of incrementing a counter every time a loop iteration occurs, you might
   consider incrementing a local variable instead, and then emitting that sum after the loop is over.
-- **Don't** update a counter to measure the total number of operations/events/etc if you're already
+- **Don't** update a counter to measure the total number of operations/events/etc. if you're already
   tracking a histogram of those operations/events/etc. Histograms have a `count` property that
   counts how many samples the histogram has recorded, as well as a `sum` property that is a sum of
   the value of all samples the histogram has recorded. This means you can potentially get three
@@ -278,7 +278,7 @@ we prefer **[`once_cell`](https://docs.rs/once_cell)**. It is slightly faster th
 
 If you're working with data that _changes over time_, but has a very high read-to-write ratio, such
 as _many readers_, but _one writer_ and infrequent writes, we prefer
-**[`arc-swap`](https://docs.rs/arc-swap)**.  The main feature of this crate is allowing a piece of
+**[`arc-swap`](https://docs.rs/arc-swap)**. The main feature of this crate is allowing a piece of
 data to be atomically updated while being shared concurrently. It does this by wrapping all data in
 `Arc<T>` to provide the safe, concurrent access, while adding the ability to atomically swap the
 `Arc<T>` itself. As it cannot be constructed in a const fashion, `arc-swap` pairs well with
@@ -286,8 +286,8 @@ data to be atomically updated while being shared concurrently. It does this by w
 
 #### Concurrent data structures
 
-When there is a need for a concurrent and _indexable_ storage, we prefer
-**[`sharded-slab`](https://docs.rs/sharded-slab)**.  This crate provides a means to insert items
+When there is a need for a concurrent and _index-able_ storage, we prefer
+**[`sharded-slab`](https://docs.rs/sharded-slab)**. This crate provides a means to insert items
 such that the caller gets back to the index by which it can access the item again in the future.
 Additionally, when an item is removed, its storage can be reused by future inserts, making
 `sharded-slab` a good choice for long-running processes where memory allocation reduction is
@@ -296,8 +296,8 @@ itself for use cases where pooling is desired.
 
 ### Synchronization
 
-Synchronization can be a very common sight when writing multi-threaded code in any language, and
-this document does not aim to familiarize you with all of the common synchronization primitives and
+Synchronization can be a very common sight when writing multithreaded code in any language, and
+this document does not aim to familiarize you with all the common synchronization primitives and
 their intended usage. Instead, however, there are some caveats that you must be aware of when using
 synchronization primitives in synchronous versus asynchronous code.
 
@@ -308,8 +308,8 @@ and have been improving over time in terms of performance. However, developers m
 using these primitives in asynchronous code, as their behavior can sometimes adversely affect the
 performance and correctness of Vector.
 
-To wit, developers must exercise caution when using synchronous (i.e. `std::sync`, `parking_lot`,
-etc) synchronization primitives in asynchronous code, as they can be used in a way that deadlocks
+To wit, developers must exercise caution when using synchronous (that is `std::sync`, `parking_lot`,
+etc.) synchronization primitives in asynchronous code, as they can be used in a way that deadlocks
 the asynchronous runtime even though the code compiles and appears to be correct. In some cases,
 you'll need to use an asynchronous-specific synchronization primitives, namely the ones from `tokio`
 itself. The documentation on `tokio`'s own

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -26,7 +26,7 @@ Please see the [FAQ](#faq) section for more info.**
 
 Vector adheres to the [Semantic Versioning 2.0] convention. In summary:
 
-* Versions follow the `MAJOR.MINOR.PATCH` format (i.e., `2.5.1`)
+* Versions follow the `MAJOR.MINOR.PATCH` format (that is, `2.5.1`)
 * `PATCH` increments only when backward compatible bug fixes are introduced.
 * `MINOR` increments only when new, backward compatible functionality is introduced.
 * `MAJOR` increments if any backwards incompatible changes are introduced.
@@ -112,8 +112,7 @@ As defined by [Semantic Versioning]:
 > any time.
 
 And while this is true to the spec, Vector takes breaking changes *very*
-seriously during this phase. What's outlined in the
-[major versions](#major-versions-breaking-changes) section still holds true
+seriously during this phase. What's outlined in the major versions section still holds true
 here. Each minor release bump will include an upgrade guide in the
 [release notes] if necessary.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,7 +120,7 @@ Sinks have two components that make building them somewhat more complex than
 either sources or transforms: healthchecks and buffers.
 
 Healthchecks are one-off tasks that run at startup with the goal of discovering
-any issues that may prevent the sink from running properly (e.g. permissions
+any issues that may prevent the sink from running properly (for example permissions
 or connectivity issues) and notifying the user in a nice way. They can be
 enabled or disabled both individually and at a global level, and the user can
 choose whether a failing healthcheck should prevent Vector from starting.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -86,7 +86,7 @@ make environment CLI_OPTS="--publish 3000:2000"
 
 Now you can use the jobs detailed in **"Bring your own toolbox"** below.
 
-Want to run from outside of the environment? _Clever. Good thinking._ You can run any of the following:
+Want to run from outside the environment? _Clever. Good thinking._ You can run any of the following:
 
 ```bash
 # Validate your code can compile
@@ -204,7 +204,7 @@ make fmt
 - Events should be capitalized and end with a period, `.`.
 - Never use `e` or `err` - always spell out `error` to enrich logs and make it
   clear what the output is.
-- Prefer Display over Debug, `%error` and not `?error`.
+- Prefer Display to Debug, `%error` and not `?error`.
 
 Nope!
 
@@ -284,7 +284,7 @@ This leads to a general strategy of mimicking what the sink itself does.
 Unfortunately, the fact that health checks don't have real events available to
 them leads to some limitations here. The most obvious example of this is with
 sinks where the exact target of a write depends on the value of some field in
-the event (e.g. an interpolated Kinesis stream name). It also pops up for sinks
+the event (for example an interpolated Kinesis stream name). It also pops up for sinks
 where incoming events are expected to conform to a specific schema. In both
 cases, random test data is reasonably likely to trigger a potential
 false-negative result. Even in simpler cases, we need to think about the effects
@@ -293,7 +293,7 @@ invasive. The answer usually depends on the system we're interfacing with.
 
 In some cases, like the Kinesis example above, the right thing to do might be
 nothing at all. If we require dynamic information to figure out what entity
-(i.e. Kinesis stream in this case) that we're even dealing with, odds are very
+(that is Kinesis stream in this case) that we're even dealing with, odds are very
 low that we'll be able to come up with a way to meaningfully validate that it's
 in working order. It's perfectly valid to have a health check that falls back to
 doing nothing when there is a data dependency like this.
@@ -302,7 +302,7 @@ With all that in mind, here is a simple checklist to go over when writing a new
 health check:
 
 - [ ] Does this check perform different fallible operations from the sink itself?
-- [ ] Does this check have side effects the user would consider undesirable (e.g. data pollution)?
+- [ ] Does this check have side effects the user would consider undesirable (for example data pollution)?
 - [ ] Are there situations where this check would fail but the sink would operate normally?
 
 Not all the answers need to be a hard "no", but we should think about the

--- a/docs/USER_EXPERIENCE_DESIGN.md
+++ b/docs/USER_EXPERIENCE_DESIGN.md
@@ -57,7 +57,7 @@ Examples:
 - Avoiding analytics specific use cases.
 - Leaning into tools like Kafka instead of trying to completely replace them.
 - Building a data processing DSL optimized our [design goals](#goals) as opposed
-  to offering multiple languages for processing (i.e., javascript)
+  to offering multiple languages for processing (for example, JavaScript)
 
 ### Be opinionated & reduce decisions
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -2,8 +2,8 @@
 
 This document specifies Vector's buffer behavior for the development of Vector.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
-“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
 - [Scope](#scope)

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -3,8 +3,8 @@
 This document specifies Vector Component behavior (source, transforms, and
 sinks) for the development of Vector.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
-“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
 - [Component Specification](#component-specification)
@@ -59,13 +59,13 @@ follow the following guidelines.
 - MUST be a noun named after the protocol or service that the component
   integrates with.
 - MAY be suffixed with the event type only if the component is specific to
-  that type, `logs`, `metrics`, or `traces` (e.g., `kubernetes_logs`,
+  that type, `logs`, `metrics`, or `traces` (for example, `kubernetes_logs`,
   `apache_metrics`).
 
 ### Transform naming
 
 - MUST only contain ASCII alphanumeric, lowercase, and underscores.
-- MUST be a verb describing the broad purpose of the transform (e.g., `route`,
+- MUST be a verb describing the broad purpose of the transform (for example, `route`,
   `sample`, `delegate`).
 
 ## Configuration
@@ -141,7 +141,7 @@ and filtering bytes from the upstream source and before the creation of a Vector
       represented by the `Content-Length` header.
     - For files, the total number of bytes read from the file excluding the
       delimiter.
-  - `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
+  - `protocol` - The protocol used to send the bytes (for example, `tcp`, `udp`,
     `unix`, `http`, `https`, `file`, etc.).
   - `http_path` - If relevant, the HTTP path, excluding query strings.
   - `socket` - If relevant, the socket number that bytes were received from.
@@ -170,7 +170,7 @@ sending it, like the `prometheus_exporter` sink, SHOULD NOT publish this metric.
       represented by the `Content-Length` header.
     - For files, the total number of bytes written to the file excluding the
       delimiter.
-  - `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
+  - `protocol` - The protocol used to send the bytes (for example, `tcp`, `udp`,
     `unix`, `http`, `https`, `file`, etc.).
   - `endpoint` - If relevant, the endpoint that the bytes were sent to. For
     HTTP, this MUST be the host and path only, excluding the query string.

--- a/docs/specs/configuration.md
+++ b/docs/specs/configuration.md
@@ -2,8 +2,8 @@
 
 This document specifies Vector's configuration for the development of Vector.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
-“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
 - [Introduction](#introduction)
@@ -56,17 +56,17 @@ under entities and also used to define global Vector behavior.
 #### Entity naming
 
 - MUST only contain ASCII alphanumeric, lowercase, and underscores
-  - The `.` character is reserved for special purposes (e.g., error stream routing)
-- MUST be in snake case format when multiple words are used (e.g., `timeout_seconds`)
+  - The `.` character is reserved for special purposes (for example, error stream routing)
+- MUST be in snake case format when multiple words are used (for example, `timeout_seconds`)
 
 #### Option naming
 
 - MUST only contain ASCII alphanumeric, lowercase, and underscores
-- MUST be in snake case format when multiple words are used (e.g., `timeout_seconds`)
-- SHOULD use nouns, not verbs, as names (e.g., `fingerprint` instead of `fingerprinting`)
-- MUST suffix options with their _full_ unit name (e.g., `_seconds`, `_bytes`, etc.)
-- SHOULD consistent with units within the same scope. (e.g., don't mix seconds and milliseconds)
-- MUST NOT repeat the name space in the option name (e.g., `fingerprint.bytes` instead of `fingerprint.fingerprint_bytes`)
+- MUST be in snake case format when multiple words are used (for example, `timeout_seconds`)
+- SHOULD use nouns, not verbs, as names (for example, `fingerprint` instead of `fingerprinting`)
+- MUST suffix options with their _full_ unit name (for example, `_seconds`, `_bytes`, etc.)
+- SHOULD consistent with units within the same scope. (for example, don't mix seconds and milliseconds)
+- MUST NOT repeat the name space in the option name (for example, `fingerprint.bytes` instead of `fingerprint.fingerprint_bytes`)
 
 ### Types
 

--- a/docs/specs/instrumentation.md
+++ b/docs/specs/instrumentation.md
@@ -2,8 +2,8 @@
 
 This document specifies Vector's instrumentation for the development of Vector.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
-“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
 - [Introduction](#introduction)
@@ -20,7 +20,7 @@ interpreted as described in [RFC 2119].
 ## Introduction
 
 Vector's telemetry drives various interfaces that operators depend on to manage
-mission critical Vector deployments. Therefore, Vector's telemetry should be
+mission-critical Vector deployments. Therefore, Vector's telemetry should be
 high quality and treated as a first class feature in the development of Vector.
 This document strives to guide developers towards achieving this.
 
@@ -45,8 +45,8 @@ event names MUST adhere to the following rules:
 - MUST be in [camelcase] format
 - MUST follow the `<Namespace><Noun><Verb>[Error]` template
   - `Namespace` - the [internal domain](#namespaces) the event belongs to
-  - `Noun` - the subject of the event (e.g., `Bytes`, `Events`)
-  - `Verb` - the past tense verb describing when the event occurred (e.g., `Received`, `Sent`, `Processes`)
+  - `Noun` - the subject of the event (for example, `Bytes`, `Events`)
+  - `Verb` - the past tense verb describing when the event occurred (for example, `Received`, `Sent`, `Processes`)
   - `[Error]` - if the event is an error it MUST end with `Error`
 
 ### Metric naming
@@ -57,10 +57,10 @@ Vector broadly follows the [Prometheus metric naming standards]:
 - MUST be in [snakecase] format
 - MUST follow the `<namespace>_<name>_<unit>_[total]` template
   - `namespace` - the [internal domain](#namespaces) the event belongs to
-  - `name` - is one or more words that describes the measurement (e.g., `memory_rss`, `requests`)
-  - `unit` - MUST be a single [base unit] in plural form, if applicable (e.g., `seconds`, `bytes`)
-  - Counters MUST end with `total` (e.g., `disk_written_bytes_total`, `http_requests_total`)
-- SHOULD be broad in purpose and use tags to differentiate characteristics of the measurement (e.g., `host_cpu_seconds_total{cpu="0",mode="idle"}`)
+  - `name` - is one or more words that describes the measurement (for example, `memory_rss`, `requests`)
+  - `unit` - MUST be a single [base unit] in plural form, if applicable (for example, `seconds`, `bytes`)
+  - Counters MUST end with `total` (for example, `disk_written_bytes_total`, `http_requests_total`)
+- SHOULD be broad in purpose and use tags to differentiate characteristics of the measurement (for example, `host_cpu_seconds_total{cpu="0",mode="idle"}`)
 
 ## Emission
 
@@ -153,7 +153,7 @@ know if the client will retry them.
   - MUST increment the `<namespace>_discarded_events_total` counter by the
     number of events discarded.
   - MUST only include the `intentional` property and component properties that
-    are inherited implicitly (e.g. `component_type`).
+    are inherited implicitly (for example, `component_type`).
 - Logs
   - MUST log a `Events dropped` message.
   - MUST include the defined properties as key-value pairs.

--- a/docs/specs/target.md
+++ b/docs/specs/target.md
@@ -3,8 +3,8 @@
 This document specifies requirements for installation targets for the
 integration of Vector.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
-“SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119].
 
 Other words, such as "agent", "aggregator", "node", and "service" are to be
@@ -60,13 +60,13 @@ architectures:
 
 - Targets MUST support the [agent architecture][agent_architecture] by
   providing a single command that deploys Vector and achieves the
-  [agent architecture requirements](#agent-architecture).
+  [agent architecture requirements](#4-agent-architecture).
 - Targets SHOULD support the [aggregator architecture][aggregator_architecture] by
   providing a single command that deploys Vector and achieves the
-  [aggregator architecture requirements](#aggregator-architecture).
+  [aggregator architecture requirements](#5-aggregator-architecture).
 - Targets MAY support the [unified architecture][unified_architecture] by
   providing a single command that deploys Vector and achieves the
-  [unified architecture requirements](#unified-architecture).
+  [unified architecture requirements](#6-unified-architecture).
 
 ### 4. Agent Architecture
 
@@ -122,8 +122,8 @@ targets:
 - Scaling
   - SHOULD provide facilities for provisioning a load balancer to enable horizontal scaling
     out of the box. MUST be overridable by the user.
-    - Cloud-managed load balancers (i.e., AWS NLB) SHOULD be supported in addition to
-      self-managed load balancers (i.e., HAProxy).
+    - Cloud-managed load balancers (that is an AWS NLB) SHOULD be supported in addition to
+      self-managed load balancers (that is a HAProxy).
     - Cloud-managed load balancers SHOULD be prioritized by default over self-managed
       load balancers.
     - Network load balancers (layer-4) SHOULD be prioritized over HTTP load balancers (layer-7)
@@ -166,7 +166,7 @@ targets as there is little added benefit.
     - Vector SHOULD be run under an unprivileged, dedicated service account.
     - Vector's service account SHOULD NOT have the ability to overwrite Vector's
       binary or configuration files. The only directory the Vector service
-      account should write to is Vector’s data directory.
+      account should write to is Vector's data directory.
 - Network hardening
   - Configured sources and sinks SHOULD use encrypted channels by default.
 

--- a/docs/tutorials/sinks/1_basic_sink.md
+++ b/docs/tutorials/sinks/1_basic_sink.md
@@ -19,7 +19,7 @@ Provide some module level comments to explain what the sink does.
 
 # Imports
 
-Let's setup all the imports we will need for the tutorial:
+First, setup all the imports we will need for the tutorial:
 
 ```rust
 use super::Healthcheck;
@@ -61,7 +61,7 @@ is used by Vector to generate documentation from the struct. To do this, doc
 comments must be included above the struct - Vector won't compile if they
 aren't.
 
-We also include a single member in our struct - `acknowledgements`.  This
+We also include a single member in our struct - `acknowledgements`. This
 struct configures end-to-end acknowledgements for the sink, which is the ability
 for the sink to inform the upstream sources if the event has been successfully
 delivered. See Vector's [documentation][acknowledgements] for more details. We
@@ -129,7 +129,7 @@ Lets implement `BasicSink`.
 struct BasicSink;
 ```
 
-Our sink is so basic it has no properties to determine it's behaviour.
+Our sink is so basic it has no properties to determine its behaviour.
 
 For it to work with Vector it must implement the [`StreamSink`][stream_sink]
 trait:
@@ -177,7 +177,7 @@ representation of the object.
 ## Feature flag
 
 Each sink is kept behind a feature flag which allows copies of Vector to be
-build with just the components required. We need to add this feature to the
+built with just the components required. We need to add this feature to the
 `Cargo.toml`.
 
 ```diff
@@ -297,7 +297,7 @@ we retry delivery, we update the status with [`EventStatus::Rejected`][event_sta
 
 # Emitting internal events
 
-Vector should be observable. It emit events about how it is running so users
+Vector should be observable. It emits events about how it is running so users
 can introspect its state to allow users to determine how healthy it is running.
 Our sink must emit some metric when an event has been delivered to update the
 count of how many events have been delivered.
@@ -333,7 +333,7 @@ emit the event. Change the body of `run_inner` to look like the following:
 
 ## EventSent
 
-[`EventSent`][events_sent] is emmitted by each component in Vector to
+[`EventSent`][events_sent] is emitted by each component in Vector to
 instrument how many bytes have been sent to the next downstream component.
 
 Add the following after emitting `BytesSent`:

--- a/docs/tutorials/sinks/2_http_sink.md
+++ b/docs/tutorials/sinks/2_http_sink.md
@@ -136,8 +136,8 @@ writes these bytes:
 
 Next we create a request builder that turns the event into a request. The
 request that we build here is a struct containing any data required by a [Tower
-service][tower] that is responsible for actually sending the data  to the
-sink's final destination external to Vector, in this case the HTTP endpoint..
+service][tower] that is responsible for actually sending the data to the
+sink's final destination external to Vector, in this case the HTTP endpoint.
 We will build this service shortly.
 
 The request looks like:
@@ -236,7 +236,7 @@ we described earlier.
 The following functions for the [`RequestBuilder`][request_builder] trait need
 implementing:
 
-[*compression*][request_builder_compression] -  The payload for the built request can be compressed. Here we return
+[*compression*][request_builder_compression] - The payload for the built request can be compressed. Here we return
 [`Compression::None`][compression_none] to indicate that we will not be compressing.
 
 ```rust
@@ -245,7 +245,7 @@ implementing:
     }
 ```
 
-[*encoder*][request_builder_encoder] -  We return the encoder to use. This is the `BasicEncoder` defined earlier.
+[*encoder*][request_builder_encoder] - We return the encoder to use. This is the `BasicEncoder` defined earlier.
 
 ```rust
     fn encoder(&self) -> &Self::Encoder {

--- a/lib/codecs/tests/data/native_encoding/README.md
+++ b/lib/codecs/tests/data/native_encoding/README.md
@@ -6,7 +6,7 @@ and we test that all the examples can be successfully parsed, parse the same
 across both formats, and match the current serialized format.
 
 In order to avoid small inherent serialization differences between JSON and
-protobuf (e.g. float handling), some changes were made to the `Arbitrary`
+protobuf (for example float handling), some changes were made to the `Arbitrary`
 implementation for `Event` to give simpler values. These are not changes we want
 in most property testing scenarios, but they are appropriate in this case where
 we only care about the overall structure of the events. The diff needed is

--- a/lib/vector-vrl/tests/README.md
+++ b/lib/vector-vrl/tests/README.md
@@ -48,7 +48,7 @@ which tests go where.
 
 - **I've made changes to VRL, resulting in many broken tests!**
 
-  This is an unfortunate — but expected — side-effect of using "UI testing".
+  This is an unfortunate—but expected—side effect of using "UI testing".
 
   We're planning on adding a `--update-tests` flag to mass-update existing tests
   in one go, but until then, you'll have to update tests manually.

--- a/testing/github-10430/steps.md
+++ b/testing/github-10430/steps.md
@@ -3,19 +3,19 @@
 Add logic to `buffers::disk::open` which checks for the "old style" vs "new style" buffer data
 directories for the given buffer ID, and either renames the old-style path to the new-style path if
 the new-style path doesn't already exist, or emits a warning if both exist and there is data left in
-the old-style buffer.  If there is no data left, then we rename the old-style directory by appending
+the old-style buffer. If there is no data left, then we rename the old-style directory by appending
 `_old` to it, which stops the logic from seeing it the next time, but leaves it around in case
 something about the code to read the buffer size is wrong and there _is_ still data left.
 
 ## Testing Plan
 
-Start by grabbing Vector binaries for 0.18.1, 0.19.0, and build one from the fix branch.  We'll use
+Start by grabbing Vector binaries for 0.18.1, 0.19.0, and build one from the fix branch. We'll use
 a simple configuration that will read records from stdin and attempt to send them to an HTTP sink.
 
-For the HTTP sink, we'll simply set it to a nonexistent endpoint.  Since Vector will retry
+For the HTTP sink, we'll simply set it to a nonexistent endpoint. Since Vector will retry
 "connection refused" errors, and retry them infinitely, the messages will never be acknowledged,
-which ensures they remain in the buffer.  For the purposes of verifying that the same data that went
-in is still present after renaming the data directory, etc, we can use `netcat` to listen on the
+which ensures they remain in the buffer. For the purposes of verifying that the same data that went
+in is still present after renaming the data directory, etc., we can use `netcat` to listen on the
 port and inspect the HTTP request made by the sink.
 
 ## Test Cases
@@ -28,7 +28,7 @@ port and inspect the HTTP request made by the sink.
     - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
       data directory, but don't send any data through.
     - Run the fix binary and ensure that it renames the old-style buffer data directory to the
-      new-style buffer data directory.  Again, send no data through.
+      new-style buffer data directory. Again, send no data through.
 3. Ensure that the old-style buffer data directory gets migrated when there's no new-style buffer
   data directory and the old-style buffer has data:
     - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer

--- a/testing/github-10895/steps.md
+++ b/testing/github-10895/steps.md
@@ -10,24 +10,24 @@ confident that our changes here haven't yet again introduced a regression.
 
 ## Testing Plan
 
-Start by grabbing Vector binaries for 0.18.1 and 0.19.1, and build one from the PR branch.  We'll
+Start by grabbing Vector binaries for 0.18.1 and 0.19.1, and build one from the PR branch. We'll
 use the same configuration as the testing for #10430, which is a stdin source and HTTP sink,
-although we won't actually _use_ them.  In this case, we just need a valid configuration that will
+although we won't actually _use_ them. In this case, we just need a valid configuration that will
 also create a buffer.
 
 ## Test Case(s)
 
-1. Establish a baseline of ther "old to new" migration behavior from 0.18.1 to 0.19.1:
+1. Establish a baseline of the "old to new" migration behavior from 0.18.1 to 0.19.1:
     - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
     data directory, but don't send any data through.
     - Run the PR binary and ensure that it renames the old-style buffer data directory to the
-    new-style buffer data directory.  Again, send no data through.
+    new-style buffer data directory. Again, send no data through.
     - No other data directories for the buffer should exist.
 2. Ensure that the "old to new" migration logic still works from 0.18.1 (old) to the PR (new) version:
     - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
     data directory, but don't send any data through.
     - Run the PR binary and ensure that it renames the old-style buffer data directory to the
-    new-style buffer data directory.  Again, send no data through.
+    new-style buffer data directory. Again, send no data through.
     - No other data directories for the buffer should exist.
     - Crucially, each step should appear identical to the output in test case #1.
 3. Ensure that the "new" style name still holds through from 0.19.1 to the PR version:

--- a/testing/github-11039/steps.md
+++ b/testing/github-11039/steps.md
@@ -5,19 +5,19 @@ versions of Vector can buffer items using different codecs or event schemas, whi
 supporting previous versions during deprecation periods.
 
 This primarily changes disk buffer v2 code, which is not yet officially released, so we're cool with
-the breaking change there.  This testing focuses on the changes to disk buffer v1, which as designed
+the breaking change there. This testing focuses on the changes to disk buffer v1, which as designed
 should be a no-op, but to avoid data loss and another #10430-esque issue... we want to explicitly
 test before merging.
 
 ## Testing Plan
 
-Start by grabbing a Vector binary for 0.19.0, and build one from the PR branch.  We'll use
+Start by grabbing a Vector binary for 0.19.0, and build one from the PR branch. We'll use
 a simple configuration that will read records from stdin and attempt to send them to an HTTP sink.
 
-For the HTTP sink, we'll simply set it to a nonexistent endpoint.  Since Vector will retry
+For the HTTP sink, we'll simply set it to a nonexistent endpoint. Since Vector will retry
 "connection refused" errors, and retry them infinitely, the messages will never be acknowledged,
-which ensures they remain in the buffer.  For the purposes of verifying that the same data that went
-in is still present after renaming the data directory, etc, we can use `netcat` (binary is called
+which ensures they remain in the buffer. For the purposes of verifying that the same data that went
+in is still present after renaming the data directory, etc., we can use `netcat` (binary is called
 `nc`) to listen on the port and inspect the HTTP request made by the sink.
 
 ## Test Case(s)

--- a/testing/github-11072/steps.md
+++ b/testing/github-11072/steps.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-As this PR introduces `EventArray`, it represents a change to the type flowing through buffers.  In
+As this PR introduces `EventArray`, it represents a change to the type flowing through buffers. In
 order to prevent a backwards-incompatible change, this PR adds a change that allows the encoding
 scheme to try to decode as either `EventArray` or `Event` in order to be able to load older buffer
 files and continue processing them while using `EventArray` going forward.
@@ -12,14 +12,14 @@ newer code.
 
 ## Plan
 
-Start by grabbing a Vector binary for 0.19.0, and build one from the PR branch.  We'll use a simple
+Start by grabbing a Vector binary for 0.19.0, and build one from the PR branch. We'll use a simple
 configuration that will read records from stdin and attempt to send them to an HTTP sink.
 
 For the HTTP sink, we'll have one configuration that uses an invalid port and another, an identical
 version, which has the correct port. Since Vector will retry "connection refused" errors, and retry
 them infinitely, the messages will never be acknowledged, which ensures they remain in the buffer.
 For the purposes of verifying that the same data that went in is still present after renaming the
-data directory, etc, we can use `dummyhttp` (a Rust project for serving up a simplistic HTTP
+data directory, etc., we can use `dummyhttp` (a Rust project for serving up a simplistic HTTP
 endpoint that can be configured to respond a certain way) to listen on the port and inspect the HTTP
 request made by the sink.
 
@@ -32,7 +32,7 @@ request made by the sink.
      `five-lines-first` file should be piped to STDIN.
    - Stop Vector.
    - Run the PR binary, using the "right" configuration, and ensure that it reads the records from
-     the buffer and sends them to the HTTP sink.  This should be five records: all five from the run
+     the buffer and sends them to the HTTP sink. This should be five records: all five from the run
      using Vector 0.19.0.
 
 2. Ensure that records written to a v1 disk buffer from a version of Vector without this change can
@@ -46,5 +46,5 @@ request made by the sink.
      piped to STDIN.
    - Stop Vector.
    - Run the PR binary, using the "right" configuration, and ensure that it reads all the records
-     from the buffer and sends them to the HTTP sink.  This should be ten records: all five from
+     from the buffer and sends them to the HTTP sink. This should be ten records: all five from
      `five-lines-first`, and all five from `five-lines-second`.

--- a/testing/github-12069/steps.md
+++ b/testing/github-12069/steps.md
@@ -17,18 +17,18 @@ buffer with a binary built from this PR.
 
 ## Plan
 
-Start by grabbing a Vector binary for 0.20.0, and build one from the PR branch.  We'll use a simple
+Start by grabbing a Vector binary for 0.20.0, and build one from the PR branch. We'll use a simple
 configuration that will read records from stdin and attempt to send them to an HTTP sink.
 
 For the HTTP sink, we'll have one configuration that uses an invalid port and another, an identical
 version, which has the correct port. Since Vector will retry "connection refused" errors, and retry
 them infinitely, the messages will never be acknowledged, which ensures they remain in the buffer.
 For the purposes of verifying that the same data that went in is still present after migrating the
-disk v1 buffer, etc, we can use `dummyhttp` (a Rust project for serving up a simplistic HTTP
+disk v1 buffer, etc., we can use `dummyhttp` (a Rust project for serving up a simplistic HTTP
 endpoint that can be configured to respond a certain way) to listen on the port and inspect the HTTP
 request made by the sink.
 
-For generating logs so we can fill up our disk buffers to their limit, we'll use [`flog`][flog]
+For generating logs, so we can fill up our disk buffers to their limit, we'll use [`flog`][flog]
 which is a handy tool for generating fake logs, and a lot of them very quickly.
 
 ## Test Case(s)
@@ -75,7 +75,7 @@ which is a handy tool for generating fake logs, and a lot of them very quickly.
    - Observe that the old buffer data directory is the only one that exists.
    - Run the PR binary, using the "wrong big buffer" configuration. Do not feed any input to STDIN.
    - Vector should immediately exit after reporting that the old buffer has been migrated.
-   - Observe that the old buffer directory is now gone, and the new one should exist.  Likewise, the
+   - Observe that the old buffer directory is now gone, and the new one should exist. Likewise, the
      new one should be the same size or larger than the old one.
 
 [flog]: https://github.com/mingrammer/flog


### PR DESCRIPTION
- chore: Cleaning up reported errors from datadog-vale
- +temporary vale config

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
