### PR TITLE
chore(docs): Add Enterprise link and update Support link

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -143,8 +143,13 @@ weight = 5
 
 [[languages.en.menus.navbar]]
 name = "Support"
-url = "https://www.datadoghq.com/product/observability-pipelines"
+url = "/community"
 weight = 6
+
+[[languages.en.menus.navbar]]
+name = "Enterprise"
+url = "https://www.datadoghq.com/product/observability-pipelines"
+weight = 7
 
 # Footer menu
 [[languages.en.menus.footer]]


### PR DESCRIPTION
Having Support link to Observability Pipelines has proven to be confusing to users now that it is
separate from Vector. Instead I link to /community and then add an Enterprise link to point to
Observability Pipelines.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
