### PR TITLE
chore: remove transform type coercion

### DIFF
--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -40,34 +40,6 @@ impl Transform {
         Transform::Function(Box::new(v))
     }
 
-    /// Mutably borrow the inner transform as a function transform.
-    ///
-    /// # Panics
-    ///
-    /// If the transform is not a [`FunctionTransform`] this will panic.
-    pub fn as_function(&mut self) -> &mut Box<dyn FunctionTransform> {
-        match self {
-            Transform::Function(t) => t,
-            _ => panic!(
-                "Called `Transform::as_function` on something that was not a function variant."
-            ),
-        }
-    }
-
-    /// Transmute the inner transform into a function transform.
-    ///
-    /// # Panics
-    ///
-    /// If the transform is not a [`FunctionTransform`] this will panic.
-    pub fn into_function(self) -> Box<dyn FunctionTransform> {
-        match self {
-            Transform::Function(t) => t,
-            _ => panic!(
-                "Called `Transform::into_function` on something that was not a function variant."
-            ),
-        }
-    }
-
     /// Create a new synchronous transform.
     ///
     /// This is a broader trait than the simple [`FunctionTransform`] in that it allows transforms
@@ -102,20 +74,6 @@ impl Transform {
     /// TODO
     pub fn event_task(v: impl TaskTransform<Event> + 'static) -> Self {
         Transform::Task(Box::new(WrapEventTask(v)))
-    }
-
-    /// Mutably borrow the inner transform as a task transform.
-    ///
-    /// # Panics
-    ///
-    /// If the transform is a [`FunctionTransform`] this will panic.
-    pub fn as_task(&mut self) -> &mut Box<dyn TaskTransform<EventArray>> {
-        match self {
-            Transform::Task(t) => t,
-            _ => {
-                panic!("Called `Transform::as_task` on something that was not a task variant.")
-            }
-        }
     }
 
     /// Transmute the inner transform into a task transform.

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -155,7 +155,7 @@ impl SinkConfig for HumioMetricsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let transform = self
             .transform
-            .build(&TransformContext::new_with_globals(cx.globals.clone()));
+            .build_transform(&TransformContext::new_with_globals(cx.globals.clone()));
 
         let sink = HumioLogsConfig {
             token: self.token.clone(),

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -6,7 +6,7 @@ use indoc::indoc;
 use lookup::lookup_v2::OptionalValuePath;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;
-use vector_core::{sink::StreamSink, transform::Transform};
+use vector_core::sink::StreamSink;
 
 use super::{
     host_key,
@@ -14,8 +14,7 @@ use super::{
 };
 use crate::{
     config::{
-        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, TransformConfig,
-        TransformContext,
+        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, TransformContext,
     },
     event::{Event, EventArray, EventContainer},
     sinks::{
@@ -25,7 +24,10 @@ use crate::{
     },
     template::Template,
     tls::TlsConfig,
-    transforms::{metric_to_log::MetricToLogConfig, OutputBuffer},
+    transforms::{
+        metric_to_log::{MetricToLog, MetricToLogConfig},
+        FunctionTransform, OutputBuffer,
+    },
 };
 
 /// Configuration for the `humio_metrics` sink.
@@ -153,9 +155,7 @@ impl SinkConfig for HumioMetricsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let transform = self
             .transform
-            .clone()
-            .build(&TransformContext::new_with_globals(cx.globals.clone()))
-            .await?;
+            .build(&TransformContext::new_with_globals(cx.globals.clone()));
 
         let sink = HumioLogsConfig {
             token: self.token.clone(),
@@ -199,7 +199,7 @@ impl SinkConfig for HumioMetricsConfig {
 
 pub struct HumioMetricsSink {
     inner: VectorSink,
-    transform: Transform,
+    transform: MetricToLog,
 }
 
 #[async_trait]
@@ -210,7 +210,7 @@ impl StreamSink<EventArray> for HumioMetricsSink {
             .run(input.map(move |events| {
                 let mut buf = OutputBuffer::with_capacity(events.len());
                 for event in events.into_events() {
-                    transform.as_function().transform(&mut buf, event);
+                    transform.transform(&mut buf, event);
                 }
                 // Awkward but necessary for the `EventArray` type
                 let events = buf.into_events().map(Event::into_log).collect::<Vec<_>>();

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -188,7 +188,7 @@ pub mod tests {
     use bytes::Bytes;
 
     use super::{super::test_util, *};
-    use crate::{event::LogEvent, test_util::trace_init, transforms::Transform};
+    use crate::{event::LogEvent, test_util::trace_init};
     use vrl::value::value;
 
     fn make_long_string(base: &str, len: usize) -> String {

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -286,7 +286,7 @@ pub mod tests {
     fn test_parsing_valid_vector_namespace() {
         trace_init();
         test_util::test_parser(
-            || Transform::function(Cri::new(LogNamespace::Vector)),
+            || Cri::new(LogNamespace::Vector),
             |bytes| Event::Log(LogEvent::from(value!(bytes))),
             valid_cases(LogNamespace::Vector),
         );
@@ -296,7 +296,7 @@ pub mod tests {
     fn test_parsing_valid_legacy_namespace() {
         trace_init();
         test_util::test_parser(
-            || Transform::function(Cri::new(LogNamespace::Legacy)),
+            || Cri::new(LogNamespace::Legacy),
             |bytes| Event::Log(LogEvent::from(bytes)),
             valid_cases(LogNamespace::Legacy),
         );

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -316,9 +316,9 @@ pub mod tests {
 
         test_util::test_parser(
             || {
-                Transform::function(Docker {
+                Docker {
                     log_namespace: LogNamespace::Vector,
-                })
+                }
             },
             |bytes| Event::Log(LogEvent::from(value!(bytes))),
             valid_cases(LogNamespace::Vector),
@@ -330,10 +330,8 @@ pub mod tests {
         trace_init();
 
         test_util::test_parser(
-            || {
-                Transform::function(Docker {
-                    log_namespace: LogNamespace::Legacy,
-                })
+            || Docker {
+                log_namespace: LogNamespace::Legacy,
             },
             |bytes| Event::Log(LogEvent::from(bytes)),
             valid_cases(LogNamespace::Legacy),

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -206,7 +206,7 @@ enum NormalizationError {
 #[cfg(test)]
 pub mod tests {
     use super::{super::test_util, *};
-    use crate::{test_util::trace_init, transforms::Transform};
+    use crate::test_util::trace_init;
     use vrl::value::value;
 
     fn make_long_string(base: &str, len: usize) -> String {

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -315,10 +315,8 @@ pub mod tests {
         trace_init();
 
         test_util::test_parser(
-            || {
-                Docker {
-                    log_namespace: LogNamespace::Vector,
-                }
+            || Docker {
+                log_namespace: LogNamespace::Vector,
             },
             |bytes| Event::Log(LogEvent::from(value!(bytes))),
             valid_cases(LogNamespace::Vector),

--- a/src/sources/kubernetes_logs/parser/mod.rs
+++ b/src/sources/kubernetes_logs/parser/mod.rs
@@ -117,7 +117,7 @@ mod tests {
     fn test_parsing_valid_legacy_namespace() {
         trace_init();
         test_util::test_parser(
-            || Transform::function(Parser::new(LogNamespace::Legacy)),
+            || Parser::new(LogNamespace::Legacy),
             |bytes| Event::Log(LogEvent::from(bytes)),
             valid_cases(LogNamespace::Legacy),
         );

--- a/src/sources/kubernetes_logs/parser/mod.rs
+++ b/src/sources/kubernetes_logs/parser/mod.rs
@@ -107,7 +107,7 @@ mod tests {
     fn test_parsing_valid_vector_namespace() {
         trace_init();
         test_util::test_parser(
-            || Transform::function(Parser::new(LogNamespace::Vector)),
+            || Parser::new(LogNamespace::Vector),
             |bytes| Event::Log(LogEvent::from(value!(bytes))),
             valid_cases(LogNamespace::Vector),
         );

--- a/src/sources/kubernetes_logs/parser/mod.rs
+++ b/src/sources/kubernetes_logs/parser/mod.rs
@@ -87,7 +87,7 @@ mod tests {
     use vrl::value::value;
 
     use super::*;
-    use crate::{event::Event, event::LogEvent, test_util::trace_init, transforms::Transform};
+    use crate::{event::Event, event::LogEvent, test_util::trace_init};
 
     /// Picker has to work for all test cases for underlying parsers.
     fn valid_cases(log_namespace: LogNamespace) -> Vec<(Bytes, Vec<Event>)> {

--- a/src/sources/kubernetes_logs/parser/test_util.rs
+++ b/src/sources/kubernetes_logs/parser/test_util.rs
@@ -9,7 +9,7 @@ use vrl::value::{value, Value};
 use crate::{
     event::{Event, LogEvent},
     sources::kubernetes_logs::Config,
-    transforms::{OutputBuffer, FunctionTransform},
+    transforms::{FunctionTransform, OutputBuffer},
 };
 
 /// Build a log event for test purposes.

--- a/src/sources/kubernetes_logs/parser/test_util.rs
+++ b/src/sources/kubernetes_logs/parser/test_util.rs
@@ -9,7 +9,7 @@ use vrl::value::{value, Value};
 use crate::{
     event::{Event, LogEvent},
     sources::kubernetes_logs::Config,
-    transforms::{OutputBuffer, Transform},
+    transforms::{OutputBuffer, FunctionTransform},
 };
 
 /// Build a log event for test purposes.
@@ -58,15 +58,15 @@ pub fn make_log_event(
 /// Shared logic for testing parsers.
 ///
 /// Takes a parser builder and a list of test cases.
-pub fn test_parser<B, L, S>(builder: B, loader: L, cases: Vec<(S, Vec<Event>)>)
+pub fn test_parser<B, L, S, F>(builder: B, loader: L, cases: Vec<(S, Vec<Event>)>)
 where
-    B: Fn() -> Transform,
+    B: Fn() -> F,
+    F: FunctionTransform,
     L: Fn(S) -> Event,
 {
     for (message, expected) in cases {
         let input = loader(message);
         let mut parser = (builder)();
-        let parser = parser.as_function();
         let mut output = OutputBuffer::default();
         parser.transform(&mut output, input);
 

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -682,10 +682,7 @@ mod tests {
             metric_tag_values,
             ..Default::default()
         }
-        .build(&TransformContext::default())
-        .await
-        .unwrap()
-        .into_function()
+        .build_transform(&TransformContext::default())
         .transform(&mut output, counter.into());
 
         assert_eq!(output.len(), 1);

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -64,7 +64,7 @@ pub struct MetricToLogConfig {
 }
 
 impl MetricToLogConfig {
-    pub fn build(&self, context: &TransformContext) -> MetricToLog {
+    pub fn build_transform(&self, context: &TransformContext) -> MetricToLog {
         MetricToLog::new(
             self.host_tag.as_deref(),
             self.timezone.unwrap_or_else(|| context.globals.timezone()),
@@ -90,7 +90,7 @@ impl GenerateConfig for MetricToLogConfig {
 #[typetag::serde(name = "metric_to_log")]
 impl TransformConfig for MetricToLogConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::function(self.build(context)))
+        Ok(Transform::function(self.build_transform(context)))
     }
 
     fn input(&self) -> Input {

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -63,6 +63,17 @@ pub struct MetricToLogConfig {
     pub metric_tag_values: MetricTagValues,
 }
 
+impl MetricToLogConfig {
+    pub fn build(&self, context: &TransformContext) -> MetricToLog {
+        MetricToLog::new(
+            self.host_tag.as_deref(),
+            self.timezone.unwrap_or_else(|| context.globals.timezone()),
+            context.log_namespace(self.log_namespace),
+            self.metric_tag_values,
+        )
+    }
+}
+
 impl GenerateConfig for MetricToLogConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
@@ -79,12 +90,7 @@ impl GenerateConfig for MetricToLogConfig {
 #[typetag::serde(name = "metric_to_log")]
 impl TransformConfig for MetricToLogConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::function(MetricToLog::new(
-            self.host_tag.as_deref(),
-            self.timezone.unwrap_or_else(|| context.globals.timezone()),
-            context.log_namespace(self.log_namespace),
-            self.metric_tag_values,
-        )))
+        Ok(Transform::function(self.build(context)))
     }
 
     fn input(&self) -> Input {


### PR DESCRIPTION
This is just breaking some of the direct coupling that we have to the current `Transform` design, making it a bit easier to change moving forward.