### PR TITLE
chore(ci): Fix event assertions for `aws_ec2_metadata` transform

### DIFF
--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -725,6 +725,7 @@ mod integration_tests {
     use std::collections::BTreeMap;
     use vrl::value::Value;
     use warp::Filter;
+    use vector_common::assert_event_data_eq;
 
     fn ec2_metadata_address() -> String {
         std::env::var("EC2_METADATA_ADDRESS").unwrap_or_else(|_| "http://localhost:1338".into())
@@ -855,7 +856,7 @@ mod integration_tests {
 
             drop(tx);
             topology.stop().await;
-            assert_eq!(out.recv().await, None);
+            assert_event_data_eq!(out.recv().await, None);
         })
         .await;
     }
@@ -952,7 +953,7 @@ mod integration_tests {
             tx.send(metric.into()).await.unwrap();
 
             let event = out.recv().await.unwrap();
-            assert_eq!(event.into_metric(), expected_metric);
+            assert_event_data_eq!(event.into_metric(), expected_metric);
 
             drop(tx);
             topology.stop().await;
@@ -997,7 +998,7 @@ mod integration_tests {
             tx.send(log.into()).await.unwrap();
 
             let event = out.recv().await.unwrap();
-            assert_eq!(event.into_log(), expected_log);
+            assert_event_data_eq!(event.into_log(), expected_log);
 
             drop(tx);
             topology.stop().await;
@@ -1041,7 +1042,7 @@ mod integration_tests {
             tx.send(metric.into()).await.unwrap();
 
             let event = out.recv().await.unwrap();
-            assert_eq!(event.into_metric(), expected_metric);
+            assert_event_data_eq!(event.into_metric(), expected_metric);
 
             drop(tx);
             topology.stop().await;

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -723,9 +723,9 @@ mod integration_tests {
         transforms::test::create_topology,
     };
     use std::collections::BTreeMap;
+    use vector_common::assert_event_data_eq;
     use vrl::value::Value;
     use warp::Filter;
-    use vector_common::assert_event_data_eq;
 
     fn ec2_metadata_address() -> String {
         std::env::var("EC2_METADATA_ADDRESS").unwrap_or_else(|_| "http://localhost:1338".into())
@@ -852,11 +852,11 @@ mod integration_tests {
             tx.send(log.into()).await.unwrap();
 
             let event = out.recv().await.unwrap();
-            assert_eq!(event.into_log(), expected_log);
+            assert_event_data_eq!(event.into_log(), expected_log);
 
             drop(tx);
             topology.stop().await;
-            assert_event_data_eq!(out.recv().await, None);
+            assert_eq!(out.recv().await, None);
         })
         .await;
     }


### PR DESCRIPTION
These were comparing metadata which broke after https://github.com/vectordotdev/vector/pull/17369 since the metadata (like cached estimated JSON size) were, expectedly, different.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
