### PR TITLE
enhancement(aws provider): Let `region` be configured for default authentication

### DIFF
--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -74,7 +74,8 @@ async fn firehose_put_records() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
-            ..Default::default()
+            imds: ImdsAuthentication::default(),
+            region: None,
         })),
         endpoints: vec![elasticsearch_address()],
         bulk: BulkConfig {

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -74,7 +74,7 @@ async fn firehose_put_records() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
-            imds: ImdsAuthentication::default(),
+            ..Default::default()
         })),
         endpoints: vec![elasticsearch_address()],
         bulk: BulkConfig {

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -261,7 +261,8 @@ async fn auto_version_aws() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
-            ..Default::default()
+            imds: ImdsAuthentication::default(),
+            region: None,
         })),
         endpoints: vec![aws_server()],
         aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -345,7 +346,8 @@ async fn insert_events_on_aws() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
-                ..Default::default()
+                imds: ImdsAuthentication::default(),
+                region: None,
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -367,7 +369,8 @@ async fn insert_events_on_aws_with_compression() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
-                ..Default::default()
+                imds: ImdsAuthentication::default(),
+                region: None,
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -261,7 +261,7 @@ async fn auto_version_aws() {
     let config = ElasticsearchConfig {
         auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
             load_timeout_secs: Some(5),
-            imds: ImdsAuthentication::default(),
+            ..Default::default()
         })),
         endpoints: vec![aws_server()],
         aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -345,7 +345,7 @@ async fn insert_events_on_aws() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
-                imds: ImdsAuthentication::default(),
+                ..Default::default()
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),
@@ -367,7 +367,7 @@ async fn insert_events_on_aws_with_compression() {
         ElasticsearchConfig {
             auth: Some(ElasticsearchAuth::Aws(AwsAuthentication::Default {
                 load_timeout_secs: Some(5),
-                imds: ImdsAuthentication::default(),
+                ..Default::default()
             })),
             endpoints: vec![aws_server()],
             aws: Some(RegionOrEndpoint::with_region(String::from("localstack"))),


### PR DESCRIPTION
Fixes: #17406

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
