### PR TITLE
chore(ci): Remove ci-sweep tasks

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -92,7 +92,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - run: make ci-sweep
       - run: sudo npm -g install @datadog/datadog-ci
       - run: make test-integration-${{ matrix.test }}
         env:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -56,7 +56,6 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v3
-      - run: make ci-sweep
       - uses: actions/cache@v3
         with:
           path: |

--- a/Makefile
+++ b/Makefile
@@ -635,19 +635,6 @@ generate-component-docs: ## Generate per-component Cue docs from the configurati
 signoff: ## Signsoff all previous commits since branch creation
 	scripts/signoff.sh
 
-ifeq (${CI}, true)
-.PHONY: ci-sweep
-ci-sweep: ## Sweep up the CI to try to get more disk space.
-	@echo "Preparing the CI for build by sweeping up disk space a bit..."
-	df -h
-	sudo apt-get --purge autoremove --yes
-	sudo apt-get clean
-	sudo rm -rf "/opt/*" "/usr/local/*"
-	sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "${AGENT_TOOLSDIRECTORY}"
-	docker system prune --force
-	df -h
-endif
-
 .PHONY: version
 version: ## Get the current Vector version
 	@cargo vdev version


### PR DESCRIPTION
Noticed this still being used in a couple of places that it didn't need to be (it was only useful
for Github hosted runners with tight disk contraints). Once I removed them I found it wasn't being
used anywhere so removed the `make` task.

Saves roughly 3 minutes per test.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
