### PR TITLE
chore(ci): restrict k8s workflow runs

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -4,10 +4,13 @@
 #    - manual dispatch in GH UI
 #    - on a PR commit if the kubernetes_logs source was changed
 #    - in the merge queue
+#    - on a schedule at midnight UTC Tue-Sat
 #    - on demand by either of the following comments in a PR:
 #        - '/ci-run-k8s'
 #        - '/ci-run-all'
 #
+# If the workflow trigger is the nightly schedule, all the k8s versions
+# are run in the matrix, otherwise, only the latest is run.
 
 name: K8S E2E Suite
 

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -18,10 +18,12 @@ on:
     types: [created]
   merge_group:
     types: [checks_requested]
+  schedule:
+    # At midnight UTC Tue-Sat
+    - cron: '0 0 * * 2-6'
 
 concurrency:
-  # `github.event.number` exists for PRs, issue.id for comments, merge_group for merge queue otherwise fall back to SHA
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.issue.id || github.event.merge_group.base_sha || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.event.issue.id || github.event.merge_group.base_sha || github.event.schedule || github.sha }}
 
   cancel-in-progress: true
 
@@ -151,11 +153,11 @@ jobs:
             // https://cloud.google.com/kubernetes-engine/docs/release-notes
             // https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
             const kubernetes_version = [
-              { version: "v1.23.3", is_essential: true },
-              { version: "v1.22.5", is_essential: true },
-              { version: "v1.21.8", is_essential: true },
-              { version: "v1.20.14", is_essential: true },
-              { version: "v1.19.8" },
+              { version: "v1.23.3",  is_essential: true  },
+              { version: "v1.22.5",  is_essential: false },
+              { version: "v1.21.8",  is_essential: false },
+              { version: "v1.20.14", is_essential: false },
+              { version: "v1.19.8",  is_essential: false },
             ]
             const container_runtime = [
               "docker",
@@ -164,12 +166,9 @@ jobs:
               // "crio",
             ]
 
-            // Planning.
-            const is_in_pull_request = !!context.payload.pull_request;
-            const should_test_all_targets = (
-              !is_in_pull_request
-            )
-            const filter_targets = array => array.filter(val => should_test_all_targets || val.is_essential)
+            // Run all versions if triggered by nightly schedule. Otherwise only run latest.
+            const run_all = context.eventName == "schedule";
+            const filter_targets = array => array.filter(val => run_all || val.is_essential)
 
             const matrix = {
               minikube_version,
@@ -237,7 +236,7 @@ jobs:
           status: 'failure'
 
   final-result:
-    name: K8s E2E Test Suite
+    name: K8s E2E Suite
     runs-on: ubuntu-latest
     needs: test-e2e-kubernetes
     if: |


### PR DESCRIPTION
Restricts the running of k8s tests.
We now run all versions once nightly on weeknights.
Otherwise,  run only the latest version.

To track the workflow, we will setup the slack GH App to subscribe to the workflow.