### PR TITLE
chore: start to remove task transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9241,6 +9241,7 @@ dependencies = [
  "criterion",
  "crossterm 0.26.1",
  "csv",
+ "dashmap",
  "derivative",
  "dirs-next",
  "dnsmsg-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,6 +243,7 @@ cidr-utils = { version = "0.5.10", default-features = false }
 clap = { version = "4.1.14", default-features = false, features = ["derive", "error-context", "env", "help", "std", "string", "usage", "wrap_help"] }
 colored = { version = "2.0.0", default-features = false }
 csv = { version = "1.2", default-features = false }
+dashmap = { version = "5.2.0", default-features = false }
 derivative = { version = "2.2.0", default-features = false }
 dirs-next = { version = "2.0.0", default-features = false, optional = true }
 dyn-clone = { version = "1.0.11", default-features = false }

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -49,18 +49,10 @@ fn bench_add_fields(c: &mut Criterion) {
         let (tx, rx) = futures::channel::mpsc::channel::<Event>(1);
 
         let mut rx: Pin<Box<dyn Stream<Item = Event> + Send>> = match transform {
-            Transform::Function(t) => {
-                let mut t = t.clone();
-                Box::pin(rx.flat_map(move |v| {
-                    let mut buf = OutputBuffer::with_capacity(1);
-                    t.transform(&mut buf, v);
-                    stream::iter(buf.into_events())
-                }))
-            }
-            Transform::Synchronous(_t) => {
-                unreachable!("no sync transform used in these benches");
-            }
             Transform::Task(t) => t.transform_events(Box::pin(rx)),
+            _ => {
+                unreachable!("no other transform used in these benches");
+            }
         };
 
         group.bench_function(name.to_owned(), |b| {
@@ -125,18 +117,10 @@ fn bench_field_filter(c: &mut Criterion) {
         let (tx, rx) = futures::channel::mpsc::channel::<Event>(num_events as usize);
 
         let mut rx: Pin<Box<dyn Stream<Item = Event> + Send>> = match transform {
-            Transform::Function(t) => {
-                let mut t = t.clone();
-                Box::pin(rx.flat_map(move |v| {
-                    let mut buf = OutputBuffer::with_capacity(1);
-                    t.transform(&mut buf, v);
-                    stream::iter(buf.into_events())
-                }))
-            }
-            Transform::Synchronous(_t) => {
-                unreachable!("no sync transform used in these benches");
-            }
             Transform::Task(t) => t.transform_events(Box::pin(rx)),
+            _ => {
+                unreachable!("no other transform used in these benches");
+            }
         };
 
         group.bench_function(name.to_owned(), |b| {

--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -23,8 +23,17 @@ pub mod runtime_transform;
 /// While function transforms can be run out of order, or concurrently, task
 /// transforms act as a coordination or barrier point.
 pub enum Transform {
-    Function(Box<dyn FunctionTransform>),
+    // Store function transforms as SyncTransform internally to reduce the variants we need to
+    // worry about actually running. We retain the separate variant to maintain the knowledge that
+    // this transform will not write to multiple outputs.
+    //
+    // TODO: This is a bit silly in the current state because we can't actually take advantage of
+    // that knowledge, so we should come up with a more principled idea of which traits are for
+    // defining components and which are for actually running them. All we're getting right now is a
+    // solution to the previous double-boxing problem.
+    Function(Box<dyn SyncTransform>),
     Synchronous(Box<dyn SyncTransform>),
+    Tick(Box<dyn TickTransform>, tokio::time::Duration),
     Task(Box<dyn TaskTransform<EventArray>>),
 }
 
@@ -48,6 +57,10 @@ impl Transform {
     /// considered a bug and will cause a panic.
     pub fn synchronous(v: impl SyncTransform + 'static) -> Self {
         Transform::Synchronous(Box::new(v))
+    }
+
+    pub fn tick(v: impl TickTransform + 'static, interval: tokio::time::Duration) -> Self {
+        Transform::Tick(Box::new(v), interval)
     }
 
     /// Create a new task transform.
@@ -163,15 +176,23 @@ where
     }
 }
 
-// TODO: this is a bit ugly when we already have the above impl
-impl SyncTransform for Box<dyn FunctionTransform> {
-    fn transform(&mut self, event: Event, output: &mut TransformOutputsBuf) {
-        FunctionTransform::transform(
-            self.as_mut(),
-            output.primary_buffer.as_mut().expect("no default output"),
-            event,
-        );
+// Like [`SyncTransform`] but with the additional ability to be called on an interval independent of
+// the arrival of new input events.
+pub trait TickTransform: Send + Sync {
+    // Called on the provided interval
+    fn tick(&mut self, output: &mut TransformOutputsBuf);
+
+    // Called when an event is received
+    fn transform(&mut self, event: Event, output: &mut TransformOutputsBuf);
+
+    fn transform_all(&mut self, events: EventArray, output: &mut TransformOutputsBuf) {
+        for event in events.into_events() {
+            self.transform(event, output);
+        }
     }
+
+    // Called at the end of the input stream
+    fn finish(&mut self, output: &mut TransformOutputsBuf);
 }
 
 struct TransformOutput {
@@ -295,6 +316,14 @@ impl TransformOutputsBuf {
         Self {
             primary_buffer,
             named_buffers,
+        }
+    }
+
+    /// Convenience method for testing simple transforms
+    pub fn new_with_primary() -> Self {
+        Self {
+            primary_buffer: Some(OutputBuffer::with_capacity(64)),
+            named_buffers: Default::default(),
         }
     }
 

--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -111,7 +111,7 @@ impl Transform {
 ///
 /// * It is an illegal invariant to implement `FunctionTransform` for a
 ///   `TaskTransform` or vice versa.
-pub trait FunctionTransform: Send + dyn_clone::DynClone + Sync {
+pub trait FunctionTransform: Send + dyn_clone::DynClone {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event);
 }
 
@@ -151,7 +151,7 @@ pub trait TaskTransform<T: EventContainer + 'static>: Send + 'static {
 /// multiple outputs. Those outputs must be known in advanced and returned via
 /// `TransformConfig::outputs`. Attempting to send to any output not registered in advance is
 /// considered a bug and will cause a panic.
-pub trait SyncTransform: Send + dyn_clone::DynClone + Sync {
+pub trait SyncTransform: Send + dyn_clone::DynClone {
     fn transform(&mut self, event: Event, output: &mut TransformOutputsBuf);
 
     fn transform_all(&mut self, events: EventArray, output: &mut TransformOutputsBuf) {
@@ -178,7 +178,7 @@ where
 
 // Like [`SyncTransform`] but with the additional ability to be called on an interval independent of
 // the arrival of new input events.
-pub trait TickTransform: Send  {
+pub trait TickTransform: Send {
     // Called on the provided interval
     fn tick(&mut self, output: &mut TransformOutputsBuf);
 

--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -178,7 +178,7 @@ where
 
 // Like [`SyncTransform`] but with the additional ability to be called on an interval independent of
 // the arrival of new input events.
-pub trait TickTransform: Send + Sync {
+pub trait TickTransform: Send  {
     // Called on the provided interval
     fn tick(&mut self, output: &mut TransformOutputsBuf);
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -21,10 +21,7 @@ use k8s_paths_provider::K8sPathsProvider;
 use kube::{
     api::Api,
     config::{self, KubeConfigOptions},
-    runtime::{
-        reflector::{self},
-        watcher, WatchStreamExt,
-    },
+    runtime::{reflector, watcher, WatchStreamExt},
     Client, Config as ClientConfig,
 };
 use lifecycle::Lifecycle;

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -50,7 +50,10 @@ use crate::{
     source_sender::CHUNK_SIZE,
     spawn_named,
     topology::task::TaskError,
-    transforms::{SyncTransform, TaskTransform, Transform, TransformOutputs, TransformOutputsBuf},
+    transforms::{
+        SyncTransform, TaskTransform, TickTransform, Transform, TransformOutputs,
+        TransformOutputsBuf,
+    },
     utilization::wrap,
     SourceSender,
 };
@@ -727,9 +730,10 @@ fn build_transform(
     input_rx: BufferReceiver<EventArray>,
 ) -> (Task, HashMap<OutputId, fanout::ControlChannel>) {
     match transform {
-        // TODO: avoid the double boxing for function transforms here
-        Transform::Function(t) => build_sync_transform(Box::new(t), node, input_rx),
-        Transform::Synchronous(t) => build_sync_transform(t, node, input_rx),
+        Transform::Function(t) | Transform::Synchronous(t) => {
+            build_sync_transform(t, node, input_rx)
+        }
+        Transform::Tick(t, i) => build_tick_transform(t, i, node, input_rx),
         Transform::Task(t) => build_task_transform(
             t,
             input_rx,
@@ -738,6 +742,52 @@ fn build_transform(
             &node.key,
         ),
     }
+}
+
+// TODO: this is almost the same as `build_sync_transform`
+fn build_tick_transform(
+    t: Box<dyn TickTransform>,
+    interval: tokio::time::Duration,
+    node: TransformNode,
+    input_rx: BufferReceiver<EventArray>,
+) -> (Task, HashMap<OutputId, fanout::ControlChannel>) {
+    let (outputs, controls) = TransformOutputs::new(node.outputs);
+
+    let runner = TickRunner::new(
+        t,
+        interval,
+        input_rx,
+        node.input_details.data_type(),
+        outputs,
+    );
+    let transform = runner.run().boxed();
+
+    let transform = async move {
+        debug!("Tick transform starting.");
+
+        match transform.await {
+            Ok(v) => {
+                debug!("Tick transform finished normally.");
+                Ok(v)
+            }
+            Err(e) => {
+                debug!("Tick transform finished with an error.");
+                Err(e)
+            }
+        }
+    };
+
+    let mut output_controls = HashMap::new();
+    for (name, control) in controls {
+        let id = name
+            .map(|name| OutputId::from((&node.key, name)))
+            .unwrap_or_else(|| OutputId::from(&node.key));
+        output_controls.insert(id, control);
+    }
+
+    let task = Task::new(node.key.clone(), node.typetag, transform);
+
+    (task, output_controls)
 }
 
 fn build_sync_transform(
@@ -915,6 +965,100 @@ impl Runner {
                     }
                 }
             }
+        }
+
+        Ok(TaskOutput::Transform)
+    }
+}
+
+// TODO: this is almost the same as `Runner`
+struct TickRunner {
+    transform: Box<dyn TickTransform>,
+    interval: tokio::time::Duration,
+    input_rx: Option<BufferReceiver<EventArray>>,
+    input_type: DataType,
+    outputs: TransformOutputs,
+    timer: crate::utilization::Timer,
+    last_report: Instant,
+    events_received: Registered<EventsReceived>,
+}
+
+impl TickRunner {
+    fn new(
+        transform: Box<dyn TickTransform>,
+        interval: tokio::time::Duration,
+        input_rx: BufferReceiver<EventArray>,
+        input_type: DataType,
+        outputs: TransformOutputs,
+    ) -> Self {
+        Self {
+            transform,
+            interval,
+            input_rx: Some(input_rx),
+            input_type,
+            outputs,
+            timer: crate::utilization::Timer::new(),
+            last_report: Instant::now(),
+            events_received: register!(EventsReceived),
+        }
+    }
+
+    fn on_events_received(&mut self, events: &EventArray) {
+        let stopped = self.timer.stop_wait();
+        if stopped.duration_since(self.last_report).as_secs() >= 5 {
+            self.timer.report();
+            self.last_report = stopped;
+        }
+
+        self.events_received.emit(CountByteSize(
+            events.len(),
+            events.estimated_json_encoded_size_of(),
+        ));
+    }
+
+    async fn send_outputs(&mut self, outputs_buf: &mut TransformOutputsBuf) -> crate::Result<()> {
+        self.timer.start_wait();
+        self.outputs.send(outputs_buf).await
+    }
+
+    async fn run(mut self) -> TaskResult {
+        // 128 is an arbitrary, smallish constant
+        const INLINE_BATCH_SIZE: usize = 128;
+
+        let mut interval = tokio::time::interval(self.interval);
+
+        let mut outputs_buf = self.outputs.new_buf_with_capacity(INLINE_BATCH_SIZE);
+
+        let mut input_rx = self
+            .input_rx
+            .take()
+            .expect("can't run runner twice")
+            .into_stream()
+            .filter(move |events| ready(filter_events_type(events, self.input_type)));
+
+        let mut done = false;
+        self.timer.start_wait();
+        while !done {
+            tokio::select! {
+                _ = interval.tick() => {
+                    self.transform.tick(&mut outputs_buf);
+                }
+                maybe_event_array = input_rx.next() => {
+                    match maybe_event_array {
+                        Some(events) => {
+                            self.on_events_received(&events);
+                            self.transform.transform_all(events, &mut outputs_buf);
+                        }
+                        None => {
+                            self.transform.finish(&mut outputs_buf);
+                            done = true;
+                        }
+                    }
+                }
+            }
+            self.send_outputs(&mut outputs_buf)
+                .await
+                .map_err(TaskError::wrapped)?;
         }
 
         Ok(TaskOutput::Transform)

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -168,7 +168,10 @@ mod tests {
         // We should flush 1 item counter_a_1
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
-        assert_eq!(&counter_a_1, &out.take_primary().into_events().next().unwrap());
+        assert_eq!(
+            &counter_a_1,
+            &out.take_primary().into_events().next().unwrap()
+        );
 
         // A subsequent flush doesn't send out anything
         let mut out = TransformOutputsBuf::new_with_primary();
@@ -186,7 +189,10 @@ mod tests {
         let mut out = TransformOutputsBuf::new_with_primary();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
-        assert_eq!(&counter_a_summed, &out.take_primary().into_events().next().unwrap());
+        assert_eq!(
+            &counter_a_summed,
+            &out.take_primary().into_events().next().unwrap()
+        );
 
         let counter_b_1 = make_metric(
             "counter_b",
@@ -230,7 +236,10 @@ mod tests {
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
-        assert_eq!(&gauge_a_1, &out.take_primary().into_events().next().unwrap());
+        assert_eq!(
+            &gauge_a_1,
+            &out.take_primary().into_events().next().unwrap()
+        );
 
         // A subsequent flush doesn't send out anything
         let mut out = TransformOutputsBuf::new_with_primary();
@@ -248,7 +257,10 @@ mod tests {
         let mut out = TransformOutputsBuf::new_with_primary();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
-        assert_eq!(&gauge_a_2, &out.take_primary().into_events().next().unwrap());
+        assert_eq!(
+            &gauge_a_2,
+            &out.take_primary().into_events().next().unwrap()
+        );
 
         let gauge_b_1 = make_metric(
             "gauge_b",

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -1,7 +1,6 @@
-use std::{future::ready, num::NonZeroUsize, pin::Pin};
+use std::num::NonZeroUsize;
 
 use bytes::Bytes;
-use futures::{Stream, StreamExt};
 use lru::LruCache;
 use vector_config::configurable_component;
 use vector_core::config::{clone_input_definitions, LogNamespace};
@@ -14,7 +13,7 @@ use crate::{
     event::{Event, Value},
     internal_events::DedupeEventsDropped,
     schema,
-    transforms::{TaskTransform, Transform},
+    transforms::{TickTransform, Transform, TransformOutputsBuf},
 };
 
 /// Options to control what fields to match against.
@@ -146,7 +145,10 @@ impl GenerateConfig for DedupeConfig {
 #[typetag::serde(name = "dedupe")]
 impl TransformConfig for DedupeConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::event_task(Dedupe::new(self.clone())))
+        // TODO: we're only using tick here because `FunctionTransform` requires `Clone`. As we
+        // refine the model to better differentiate function-style vs concurrent (which is what
+        // needs `Clone`), this can go away and we can use the more appropriate trait.
+        Ok(Transform::tick(Dedupe::new(self.clone()), tokio::time::Duration::from_secs(60)))
     }
 
     fn input(&self) -> Input {
@@ -269,17 +271,16 @@ fn build_cache_entry(event: &Event, fields: &FieldMatchConfig) -> CacheEntry {
     }
 }
 
-impl TaskTransform<Event> for Dedupe {
-    fn transform(
-        self: Box<Self>,
-        task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
-    where
-        Self: 'static,
-    {
-        let mut inner = self;
-        Box::pin(task.filter_map(move |v| ready(inner.transform_one(v))))
+impl TickTransform for Dedupe {
+    fn transform(&mut self, event: Event, output: &mut TransformOutputsBuf) {
+        if let Some(v) = self.transform_one(event) {
+            output.push(v);
+        }
     }
+
+    fn tick(&mut self, _output: &mut TransformOutputsBuf) {}
+
+    fn finish(&mut self, _output: &mut TransformOutputsBuf) {}
 }
 
 #[cfg(test)]

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -148,7 +148,10 @@ impl TransformConfig for DedupeConfig {
         // TODO: we're only using tick here because `FunctionTransform` requires `Clone`. As we
         // refine the model to better differentiate function-style vs concurrent (which is what
         // needs `Clone`), this can go away and we can use the more appropriate trait.
-        Ok(Transform::tick(Dedupe::new(self.clone()), tokio::time::Duration::from_secs(60)))
+        Ok(Transform::tick(
+            Dedupe::new(self.clone()),
+            tokio::time::Duration::from_secs(60),
+        ))
     }
 
     fn input(&self) -> Input {

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -96,6 +96,12 @@ impl TransformConfig for LuaConfig {
         }
     }
 
+    // This is a stateful transform, so don't allow it to run concurrently even if that's
+    // technically possible with the current transform trait design.
+    fn enable_concurrency(&self) -> bool {
+        false
+    }
+
     fn input(&self) -> Input {
         match self {
             LuaConfig::V1(v1) => v1.config.input(),

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -31,8 +31,8 @@ pub mod tag_cardinality_limit;
 pub mod throttle;
 
 pub use vector_core::transform::{
-    FunctionTransform, OutputBuffer, SyncTransform, TaskTransform, Transform, TransformOutputs,
-    TransformOutputsBuf,
+    FunctionTransform, OutputBuffer, SyncTransform, TaskTransform, TickTransform, Transform,
+    TransformOutputs, TransformOutputsBuf,
 };
 
 #[derive(Debug, Snafu)]

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -103,9 +103,13 @@ impl GenerateConfig for TagCardinalityLimitConfig {
 #[typetag::serde(name = "tag_cardinality_limit")]
 impl TransformConfig for TagCardinalityLimitConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::event_task(TagCardinalityLimit::new(
-            self.clone(),
-        )))
+        // TODO: we're only using tick here because `FunctionTransform` requires `Clone`. As we
+        // refine the model to better differentiate function-style vs concurrent (which is what
+        // needs `Clone`), this can go away and we can use the more appropriate trait.
+        Ok(Transform::tick(
+            TagCardinalityLimit::new(self.clone()),
+            tokio::time::Duration::from_secs(60),
+        ))
     }
 
     fn input(&self) -> Input {

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -1,8 +1,7 @@
-use std::{num::NonZeroU32, pin::Pin, time::Duration};
+use std::{num::NonZeroU32, time::Duration};
 
-use async_stream::stream;
-use futures::{Stream, StreamExt};
-use governor::{clock, Quota, RateLimiter};
+use dashmap::DashMap;
+use governor::{clock, state::InMemoryState, Quota, RateLimiter, middleware::NoOpMiddleware};
 use serde_with::serde_as;
 use snafu::Snafu;
 use vector_config::configurable_component;
@@ -15,7 +14,7 @@ use crate::{
     internal_events::{TemplateRenderingError, ThrottleEventDiscarded},
     schema,
     template::Template,
-    transforms::{TaskTransform, Transform},
+    transforms::{TickTransform, Transform, TransformOutputsBuf},
 };
 
 /// Configuration for the `throttle` transform.
@@ -50,7 +49,8 @@ impl_generate_config_from_default!(ThrottleConfig);
 #[typetag::serde(name = "throttle")]
 impl TransformConfig for ThrottleConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        Throttle::new(self, context, clock::MonotonicClock).map(Transform::event_task)
+        let throttle = Throttle::new(self, context, clock::MonotonicClock)?;
+        Ok(Transform::tick(throttle, self.window_secs * 2))
     }
 
     fn input(&self) -> Input {
@@ -71,13 +71,10 @@ impl TransformConfig for ThrottleConfig {
     }
 }
 
-#[derive(Clone)]
 pub struct Throttle<C: clock::Clock<Instant = I>, I: clock::Reference> {
-    quota: Quota,
-    flush_keys_interval: Duration,
     key_field: Option<Template>,
+    limiter: RateLimiter<Option<String>, DashMap<Option<String>, InMemoryState>, C, NoOpMiddleware<I>>,
     exclude: Option<Condition>,
-    clock: C,
 }
 
 impl<C, I> Throttle<C, I>
@@ -103,6 +100,9 @@ where
             Some(quota) => quota.allow_burst(threshold),
             None => return Err(Box::new(ConfigError::NonZero)),
         };
+
+        let limiter = RateLimiter::dashmap_with_clock(quota, &clock);
+
         let exclude = config
             .exclude
             .as_ref()
@@ -110,92 +110,65 @@ where
             .transpose()?;
 
         Ok(Self {
-            quota,
-            clock,
-            flush_keys_interval,
+            limiter,
             key_field: config.key_field.clone(),
             exclude,
         })
     }
 }
 
-impl<C, I> TaskTransform<Event> for Throttle<C, I>
+impl<C, I> TickTransform for Throttle<C, I>
 where
     C: clock::Clock<Instant = I> + Send + 'static,
     I: clock::Reference + Send + 'static,
 {
-    fn transform(
-        self: Box<Self>,
-        mut input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
-    where
-        Self: 'static,
-    {
-        let mut flush_keys = tokio::time::interval(self.flush_keys_interval * 2);
-
-        let limiter = RateLimiter::dashmap_with_clock(self.quota, &self.clock);
-
-        Box::pin(stream! {
-          loop {
-            let done = tokio::select! {
-                biased;
-
-                maybe_event = input_rx.next() => {
-                    match maybe_event {
-                        None => true,
-                        Some(event) => {
-                            let (throttle, event) = match self.exclude.as_ref() {
-                                Some(condition) => {
-                                    let (result, event) = condition.check(event);
-                                    (!result, event)
-                                },
-                                _ => (true, event)
-                            };
-                            let output = if throttle {
-                                let key = self.key_field.as_ref().and_then(|t| {
-                                    t.render_string(&event)
-                                        .map_err(|error| {
-                                            emit!(TemplateRenderingError {
-                                                error,
-                                                field: Some("key_field"),
-                                                drop_event: false,
-                                            })
-                                        })
-                                        .ok()
-                                });
-
-                                match limiter.check_key(&key) {
-                                    Ok(()) => {
-                                        Some(event)
-                                    }
-                                    _ => {
-                                        if let Some(key) = key {
-                                            emit!(ThrottleEventDiscarded{key})
-                                        } else {
-                                            emit!(ThrottleEventDiscarded{key: "None".to_string()})
-                                        }
-                                        None
-                                    }
-                                }
-                            } else {
-                                Some(event)
-                            };
-                            if let Some(event) = output {
-                                yield event;
-                            }
-                            false
-                        }
-                    }
-                }
-                _ = flush_keys.tick() => {
-                    limiter.retain_recent();
-                    false
-                }
-            };
-            if done { break }
-          }
-        })
+    fn tick(&mut self, _output: &mut TransformOutputsBuf) {
+        self.limiter.retain_recent();
     }
+
+    fn transform(&mut self, event: Event, output: &mut TransformOutputsBuf) {
+        let (throttle, event) = match self.exclude.as_ref() {
+            Some(condition) => {
+                let (result, event) = condition.check(event);
+                (!result, event)
+            }
+            _ => (true, event),
+        };
+        let value = if throttle {
+            let key = self.key_field.as_ref().and_then(|t| {
+                t.render_string(&event)
+                    .map_err(|error| {
+                        emit!(TemplateRenderingError {
+                            error,
+                            field: Some("key_field"),
+                            drop_event: false,
+                        })
+                    })
+                    .ok()
+            });
+
+            match self.limiter.check_key(&key) {
+                Ok(()) => Some(event),
+                _ => {
+                    if let Some(key) = key {
+                        emit!(ThrottleEventDiscarded { key })
+                    } else {
+                        emit!(ThrottleEventDiscarded {
+                            key: "None".to_string()
+                        })
+                    }
+                    None
+                }
+            }
+        } else {
+            Some(event)
+        };
+        if let Some(event) = value {
+            output.push(event);
+        }
+    }
+
+    fn finish(&mut self, _output: &mut TransformOutputsBuf) {}
 }
 
 #[derive(Debug, Snafu)]
@@ -206,10 +179,6 @@ pub enum ConfigError {
 
 #[cfg(test)]
 mod tests {
-    use std::task::Poll;
-
-    use futures::SinkExt;
-
     use super::*;
     use crate::{
         event::LogEvent, test_util::components::assert_transform_compliance,
@@ -234,56 +203,32 @@ window_secs = 5
         )
         .unwrap();
 
-        let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
-            .map(Transform::event_task)
-            .unwrap();
+        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock.clone()).unwrap();
 
-        let throttle = throttle.into_task();
+        let mut out = TransformOutputsBuf::new_with_primary();
+        throttle.transform(LogEvent::default().into(), &mut out);
+        throttle.transform(LogEvent::default().into(), &mut out);
 
-        let (mut tx, rx) = futures::channel::mpsc::channel(10);
-        let mut out_stream = throttle.transform_events(Box::pin(rx));
-
-        // tokio interval is always immediately ready, so we poll once to make sure
-        // we trip it/set the interval in the future
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
-
-        tx.send(LogEvent::default().into()).await.unwrap();
-        tx.send(LogEvent::default().into()).await.unwrap();
-
-        let mut count = 0_u8;
-        while count < 2 {
-            if let Some(_event) = out_stream.next().await {
-                count += 1;
-            } else {
-                panic!("Unexpectedly received None in output stream");
-            }
-        }
-        assert_eq!(2, count);
+        assert_eq!(2, out.len());
 
         clock.advance(Duration::from_secs(2));
 
-        tx.send(LogEvent::default().into()).await.unwrap();
+        throttle.transform(LogEvent::default().into(), &mut out);
 
-        // We should be back to pending, having the second event dropped
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+        // Still only two
+        assert_eq!(2, out.len());
 
         clock.advance(Duration::from_secs(3));
 
-        tx.send(LogEvent::default().into()).await.unwrap();
+        throttle.transform(LogEvent::default().into(), &mut out);
 
         // The rate limiter should now be refreshed and allow an additional event through
-        if let Some(_event) = out_stream.next().await {
-        } else {
-            panic!("Unexpectedly received None in output stream");
-        }
+        assert_eq!(3, out.len());
 
-        // We should be back to pending, having nothing waiting for us
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+        throttle.finish(&mut out);
 
-        tx.disconnect();
-
-        // And still nothing there
-        assert_eq!(Poll::Ready(None), futures::poll!(out_stream.next()));
+        // And still three
+        assert_eq!(3, out.len());
     }
 
     #[tokio::test]
@@ -300,65 +245,40 @@ exists(.special)
         )
         .unwrap();
 
-        let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
-            .map(Transform::event_task)
-            .unwrap();
+        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock.clone()) .unwrap();
 
-        let throttle = throttle.into_task();
+        let mut out = TransformOutputsBuf::new_with_primary();
 
-        let (mut tx, rx) = futures::channel::mpsc::channel(10);
-        let mut out_stream = throttle.transform_events(Box::pin(rx));
+        throttle.transform(LogEvent::default().into(), &mut out);
+        throttle.transform(LogEvent::default().into(), &mut out);
 
-        // tokio interval is always immediately ready, so we poll once to make sure
-        // we trip it/set the interval in the future
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
-
-        tx.send(LogEvent::default().into()).await.unwrap();
-        tx.send(LogEvent::default().into()).await.unwrap();
-
-        let mut count = 0_u8;
-        while count < 2 {
-            if let Some(_event) = out_stream.next().await {
-                count += 1;
-            } else {
-                panic!("Unexpectedly received None in output stream");
-            }
-        }
-        assert_eq!(2, count);
+        assert_eq!(2, out.len());
 
         clock.advance(Duration::from_secs(2));
 
-        tx.send(LogEvent::default().into()).await.unwrap();
+        throttle.transform(LogEvent::default().into(), &mut out);
 
-        // We should be back to pending, having the second event dropped
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+        // Still only two
+        assert_eq!(2, out.len());
 
         let mut special_log = LogEvent::default();
         special_log.insert("special", "true");
-        tx.send(special_log.into()).await.unwrap();
+
+        throttle.transform(special_log.into(), &mut out);
         // The rate limiter should allow this log through regardless of current limit
-        if let Some(_event) = out_stream.next().await {
-        } else {
-            panic!("Unexpectedly received None in output stream");
-        }
+        assert_eq!(3, out.len());
 
         clock.advance(Duration::from_secs(3));
 
-        tx.send(LogEvent::default().into()).await.unwrap();
+        throttle.transform(LogEvent::default().into(), &mut out);
 
         // The rate limiter should now be refreshed and allow an additional event through
-        if let Some(_event) = out_stream.next().await {
-        } else {
-            panic!("Unexpectedly received None in output stream");
-        }
+        assert_eq!(4, out.len());
 
-        // We should be back to pending, having nothing waiting for us
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+        throttle.finish(&mut out);
 
-        tx.disconnect();
-
-        // And still nothing there
-        assert_eq!(Poll::Ready(None), futures::poll!(out_stream.next()));
+        // And nothing more
+        assert_eq!(4, out.len());
     }
 
     #[tokio::test]
@@ -373,43 +293,23 @@ key_field = "{{ bucket }}"
         )
         .unwrap();
 
-        let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
-            .map(Transform::event_task)
-            .unwrap();
+        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock.clone()) .unwrap();
 
-        let throttle = throttle.into_task();
-
-        let (mut tx, rx) = futures::channel::mpsc::channel(10);
-        let mut out_stream = throttle.transform_events(Box::pin(rx));
-
-        // tokio interval is always immediately ready, so we poll once to make sure
-        // we trip it/set the interval in the future
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+        let mut out = TransformOutputsBuf::new_with_primary();
 
         let mut log_a = LogEvent::default();
         log_a.insert("bucket", "a");
         let mut log_b = LogEvent::default();
         log_b.insert("bucket", "b");
-        tx.send(log_a.into()).await.unwrap();
-        tx.send(log_b.into()).await.unwrap();
+        throttle.transform(log_a.into(), &mut out);
+        throttle.transform(log_b.into(), &mut out);
 
-        let mut count = 0_u8;
-        while count < 2 {
-            if let Some(_event) = out_stream.next().await {
-                count += 1;
-            } else {
-                panic!("Unexpectedly received None in output stream");
-            }
-        }
-        assert_eq!(2, count);
+        assert_eq!(2, out.len());
 
-        // We should be back to pending, having nothing waiting for us
-        assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
+        throttle.finish(&mut out);
 
-        tx.disconnect();
-
-        // And still nothing there
-        assert_eq!(Poll::Ready(None), futures::poll!(out_stream.next()));
+        // And nothing more
+        assert_eq!(2, out.len());
     }
 
     #[tokio::test]

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZeroU32, time::Duration};
 
 use dashmap::DashMap;
-use governor::{clock, state::InMemoryState, Quota, RateLimiter, middleware::NoOpMiddleware};
+use governor::{clock, middleware::NoOpMiddleware, state::InMemoryState, Quota, RateLimiter};
 use serde_with::serde_as;
 use snafu::Snafu;
 use vector_config::configurable_component;
@@ -73,7 +73,8 @@ impl TransformConfig for ThrottleConfig {
 
 pub struct Throttle<C: clock::Clock<Instant = I>, I: clock::Reference> {
     key_field: Option<Template>,
-    limiter: RateLimiter<Option<String>, DashMap<Option<String>, InMemoryState>, C, NoOpMiddleware<I>>,
+    limiter:
+        RateLimiter<Option<String>, DashMap<Option<String>, InMemoryState>, C, NoOpMiddleware<I>>,
     exclude: Option<Condition>,
 }
 
@@ -203,7 +204,8 @@ window_secs = 5
         )
         .unwrap();
 
-        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock.clone()).unwrap();
+        let mut throttle =
+            Throttle::new(&config, &TransformContext::default(), clock.clone()).unwrap();
 
         let mut out = TransformOutputsBuf::new_with_primary();
         throttle.transform(LogEvent::default().into(), &mut out);
@@ -245,7 +247,8 @@ exists(.special)
         )
         .unwrap();
 
-        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock.clone()) .unwrap();
+        let mut throttle =
+            Throttle::new(&config, &TransformContext::default(), clock.clone()).unwrap();
 
         let mut out = TransformOutputsBuf::new_with_primary();
 
@@ -293,7 +296,7 @@ key_field = "{{ bucket }}"
         )
         .unwrap();
 
-        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock.clone()) .unwrap();
+        let mut throttle = Throttle::new(&config, &TransformContext::default(), clock).unwrap();
 
         let mut out = TransformOutputsBuf::new_with_primary();
 


### PR DESCRIPTION
The `TaskTransform` trait is an escape hatch that has long outlived its usefulness. It does not work with multiple features (multiple outputs, concurrency, etc) and is needlessly (for many use cases) coupled to our async runtime. Nearly every use of it can and should be replaced by something significantly simpler. This PR does that.

We introduce a new `TickTransform` (open to better names) that is basically a `SyncTransform` (also needs a better name) with the additional ability to have a `tick` method called on a given interval. This is sufficient for nearly every existing `TaskTransform` and lets us simplify their implementation quite a bit (no more `Pin<Box<dyn Stream<Item = Event> + Send>>` 🎉 ). 

The only things preventing `TaskTransform` from being removed completely are the reuse of the `reduce` transform from within the k8s source, where it is used specifically as a stream combinator, and the `lua` v2 transform, which uses its own `RuntimeTransform` that is more powerful and can be tackled as part of a later change.

There's currently quite a bit of duplication with the new `TickRunner`, which I'd like to address before merging, but this should be generally functional.