### PR TITLE
chore(deps): Update fs_extra to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"


### PR DESCRIPTION
Fixes a compile-time warning about code being incompatible with future versions of Rust.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
