### PR TITLE
chore(deps): Bump PR limit for Dependabot to 100

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - "domain: deps"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 100
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We seem to be bumping up against this causing dependabot to space out updates. I don't see a great
reason to limit it, but could be missing something since it does have a fairly low default limit of
5.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
