### PR TITLE
chore(ci): fix failure notify job conditional in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -548,7 +548,7 @@ jobs:
   publish-github:
     name: Publish to GitHub
     # We only publish to GitHub for versioned releases, not nightlies.
-    if: ${{ inputs.channel == 'release' }}
+    if: inputs.channel == 'release'
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -618,7 +618,7 @@ jobs:
   publish-homebrew:
     name: Publish to Homebrew
     # We only publish to Homebrew for versioned releases, not nightlies.
-    if: ${{ inputs.channel == 'release' }}
+    if: inputs.channel == 'release'
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -638,7 +638,7 @@ jobs:
   publish-cloudsmith:
     name: Publish to Cloudsmith
     # We only publish to CloudSmith for versioned releases, not nightlies.
-    if: ${{ inputs.channel == 'release' }}
+    if:  inputs.channel == 'release'
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata
@@ -751,7 +751,7 @@ jobs:
 
   publish-failure:
     name: Send Publish Failure Notification
-    if: ${{ inputs.channel != 'custom' }} && failure()
+    if: failure() && inputs.channel != 'custom'
     runs-on: ubuntu-20.04
     needs:
       - generate-publish-metadata


### PR DESCRIPTION
The syntax of the conditional for the publish workflow's failure notification job had a bug where an explicit expression was defined and was paired with an implicit expression. This resulted in the job running when it shouldn't.
Removed the explicit expression syntax from the other job conditionals to avoid potentially doing that in the future.
