### PR TITLE
chore(enterprise): Extend library functionality for secret scanning

### DIFF
--- a/src/config/loading/secret.rs
+++ b/src/config/loading/secret.rs
@@ -26,8 +26,8 @@ use crate::{
 // - "SECRET[backend..secret.name]" will match and capture "backend" and ".secret.name"
 // - "SECRET[secret_name]" will not match
 // - "SECRET[.secret.name]" will not match
-static COLLECTOR: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]").unwrap());
+pub const SECRET_BACKEND_PATTERN: &str = r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]";
+static COLLECTOR: Lazy<Regex> = Lazy::new(|| Regex::new(SECRET_BACKEND_PATTERN).unwrap());
 
 /// Helper type for specifically deserializing secrets backends.
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/config/loading/secret.rs
+++ b/src/config/loading/secret.rs
@@ -26,8 +26,8 @@ use crate::{
 // - "SECRET[backend..secret.name]" will match and capture "backend" and ".secret.name"
 // - "SECRET[secret_name]" will not match
 // - "SECRET[.secret.name]" will not match
-pub const SECRET_BACKEND_PATTERN: &str = r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]";
-static COLLECTOR: Lazy<Regex> = Lazy::new(|| Regex::new(SECRET_BACKEND_PATTERN).unwrap());
+pub static COLLECTOR: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]").unwrap());
 
 /// Helper type for specifically deserializing secrets backends.
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -59,7 +59,7 @@ pub use transform::{
 };
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
-pub use vars::ENVIRONMENT_VARIABLE_INTERPOLATION_PATTERN;
+pub use vars::{interpolate, ENVIRONMENT_VARIABLE_INTERPOLATION_PATTERN};
 pub use vector_core::config::{
     init_log_schema, log_schema, proxy::ProxyConfig, LogSchema, OutputId,
 };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,8 +48,8 @@ pub use format::{Format, FormatHint};
 pub use id::{ComponentKey, Inputs};
 pub use loading::{
     load, load_builder_from_paths, load_from_paths, load_from_paths_with_provider_and_secrets,
-    load_from_str, load_source_from_paths, merge_path_lists, process_paths, CONFIG_PATHS,
-    SECRET_BACKEND_PATTERN,
+    load_from_str, load_source_from_paths, merge_path_lists, process_paths, COLLECTOR,
+    CONFIG_PATHS,
 };
 pub use provider::ProviderConfig;
 pub use secret::SecretBackend;
@@ -60,7 +60,7 @@ pub use transform::{
 };
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
-pub use vars::{interpolate, ENVIRONMENT_VARIABLE_INTERPOLATION_PATTERN};
+pub use vars::{interpolate, ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX};
 pub use vector_core::config::{
     init_log_schema, log_schema, proxy::ProxyConfig, LogSchema, OutputId,
 };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,7 @@ pub use id::{ComponentKey, Inputs};
 pub use loading::{
     load, load_builder_from_paths, load_from_paths, load_from_paths_with_provider_and_secrets,
     load_from_str, load_source_from_paths, merge_path_lists, process_paths, CONFIG_PATHS,
+    SECRET_BACKEND_PATTERN,
 };
 pub use provider::ProviderConfig;
 pub use secret::SecretBackend;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -59,6 +59,7 @@ pub use transform::{
 };
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
+pub use vars::ENVIRONMENT_VARIABLE_INTERPOLATION_PATTERN;
 pub use vector_core::config::{
     init_log_schema, log_schema, proxy::ProxyConfig, LogSchema, OutputId,
 };


### PR DESCRIPTION
Ref OPB-710

This PR
- Exposes patterns and the `interpolate` function for use in OPW. This will help deduplicate some logic and reduce maintenance burden. We use the patterns themselves in secret scanning logic, and will use the `interpolate` function in bootstrap-related logic.