### PR TITLE
fix(distribution): Fix architecture detection for ARMv7

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -139,6 +139,7 @@ install_from_archive() {
     assert_nz "$_arch" "arch"
 
     local _archive_arch=""
+
     case "$_arch" in
         x86_64-apple-darwin)
             _archive_arch=$_arch
@@ -152,13 +153,13 @@ install_from_archive() {
         aarch64-*linux*)
             _archive_arch="aarch64-unknown-linux-musl"
             ;;
-	    armv7-*linux*-gnu)
+        armv7-*linux*-gnueabihf)
             _archive_arch="armv7-unknown-linux-gnueabihf"
             ;;
-	    armv7-*linux*-musl)
+        armv7-*linux*-musleabihf)
             _archive_arch="armv7-unknown-linux-musleabihf"
             ;;
-        *)
+          *)
             err "unsupported arch: $_arch"
             ;;
     esac


### PR DESCRIPTION
The patterns were incorrectly matching the the OS for ARMv7 builds which have extra chacters
indicating platform support.

Fixes: https://github.com/vectordotdev/vector/issues/17450

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
