### PR TITLE
feat(new avro decoder): new `avro` decoder

### DIFF
--- a/lib/codecs/src/decoding/format/avro.rs
+++ b/lib/codecs/src/decoding/format/avro.rs
@@ -1,0 +1,284 @@
+use std::collections::BTreeMap;
+
+use super::Deserializer;
+use crate::encoding::AvroSerializerOptions;
+use bytes::Buf;
+use bytes::Bytes;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
+use smallvec::{smallvec, SmallVec};
+use vector_config::configurable_component;
+use vector_core::{
+    config::{DataType, LogNamespace},
+    event::{Event, LogEvent},
+    schema,
+};
+use vrl::value::Value;
+
+/// Config used to build a `AvroDeserializer`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AvroDeserializerConfig {
+    /// Options for the Avro deserializer.
+    pub avro: AvroDeserializerOptions,
+}
+
+impl AvroDeserializerConfig {
+    /// Creates a new `AvroDeserializerConfig`.
+    pub const fn new(schema: String, strip_schema_id_prefix: bool) -> Self {
+        Self {
+            avro: AvroDeserializerOptions {
+                schema,
+                strip_schema_id_prefix,
+            },
+        }
+    }
+
+    /// Build the `AvroDeserializer` from this configuration.
+    pub fn build(&self) -> AvroDeserializer {
+        let schema = apache_avro::Schema::parse_str(&self.avro.schema)
+            .map_err(|error| format!("Failed building Avro serializer: {}", error))
+            .unwrap();
+        AvroDeserializer {
+            schema,
+            strip_schema_id_prefix: self.avro.strip_schema_id_prefix,
+        }
+    }
+
+    /// The data type of events that are accepted by `AvroDeserializer`.
+    pub fn output_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    /// The schema required by the serializer.
+    pub fn schema_definition(&self, _log_namespace: LogNamespace) -> schema::Definition {
+        // TODO: Convert the Avro schema to a vector schema definition.
+        schema::Definition::any()
+    }
+}
+
+impl From<&AvroDeserializerOptions> for AvroSerializerOptions {
+    fn from(value: &AvroDeserializerOptions) -> Self {
+        Self {
+            schema: value.schema.clone(),
+        }
+    }
+}
+/// Apache Avro serializer options.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub struct AvroDeserializerOptions {
+    /// The Avro schema.
+    #[configurable(metadata(
+        docs::examples = r#"{ "type": "record", "name": "log", "fields": [{ "name": "message", "type": "string" }] }"#
+    ))]
+    pub schema: String,
+
+    /// for avro datum encoded in kafka messages, the bytes are prefixed with the schema id.  Set this to true to strip the schema id prefix.
+    pub strip_schema_id_prefix: bool,
+}
+
+/// Serializer that converts bytes to an `Event` using the Apache Avro format.
+#[derive(Debug, Clone)]
+pub struct AvroDeserializer {
+    schema: apache_avro::Schema,
+    strip_schema_id_prefix: bool,
+}
+
+impl AvroDeserializer {
+    /// Creates a new `AvroDeserializer`.
+    pub const fn new(schema: apache_avro::Schema, strip_schema_id_prefix: bool) -> Self {
+        Self {
+            schema,
+            strip_schema_id_prefix,
+        }
+    }
+
+    /// Deserializes the given bytes, which will always produce a single `LogEvent`.
+    pub fn parse_single(
+        &self,
+        bytes: Bytes,
+        _log_namespace: LogNamespace,
+    ) -> vector_common::Result<LogEvent> {
+        let bytes = if self.strip_schema_id_prefix {
+            if bytes.len() > 4 && bytes[0] == 0 {
+                bytes.slice(5..)
+            } else {
+                return Err(vector_common::Error::from(
+                    "Expected avro datum to be prefixed with schema id",
+                ));
+            }
+        } else {
+            bytes
+        };
+
+        let value = apache_avro::from_avro_datum(&self.schema, &mut bytes.reader(), None)?;
+
+        let apache_avro::types::Value::Record(fields) = value else {
+            return Err(vector_common::Error::from("Expected an avro Record"));
+        };
+
+        let mut log = LogEvent::default();
+        for (k, v) in fields {
+            log.insert(k.as_str(), try_from(v)?);
+        }
+        Ok(log)
+    }
+}
+
+impl Deserializer for AvroDeserializer {
+    fn parse(
+        &self,
+        bytes: Bytes,
+        log_namespace: LogNamespace,
+    ) -> vector_common::Result<SmallVec<[Event; 1]>> {
+        let log = self.parse_single(bytes, log_namespace)?;
+        Ok(smallvec![log.into()])
+    }
+}
+
+// can't use std::convert::TryFrom because of orphan rules
+pub fn try_from(value: apache_avro::types::Value) -> vector_common::Result<vrl::value::Value> {
+    // very similar to avro to json see `impl std::convert::TryFrom<apache_avro::types::Value> for serde_json::Value`
+    // LogEvent has native support for bytes, so it is used for Bytes and Fixed
+    match value {
+        apache_avro::types::Value::Array(array) => {
+            let mut vector = Vec::new();
+            for item in array {
+                vector.push(try_from(item)?);
+            }
+            Ok(Value::Array(vector))
+        }
+        apache_avro::types::Value::Boolean(boolean) => Ok(Value::from(boolean)),
+        apache_avro::types::Value::Bytes(bytes) => Ok(Value::from(bytes)),
+        apache_avro::types::Value::Date(d) => Ok(Value::from(d)),
+        apache_avro::types::Value::Decimal(ref d) => Ok(<Vec<u8>>::try_from(d)
+            .map(|vec| Value::Array(vec.into_iter().map(Value::from).collect()))?),
+        apache_avro::types::Value::Double(double) => Ok(Value::from(double)),
+        apache_avro::types::Value::Duration(d) => Ok(Value::Array(
+            <[u8; 12]>::from(d).into_iter().map(Value::from).collect(),
+        )),
+        apache_avro::types::Value::Enum(_, string) => Ok(Value::from(string)),
+        apache_avro::types::Value::Fixed(_, bytes) => Ok(Value::from(bytes)),
+        apache_avro::types::Value::Float(float) => Ok(Value::from(float as f64)),
+        apache_avro::types::Value::Int(int) => Ok(Value::from(int)),
+        apache_avro::types::Value::Long(long) => Ok(Value::from(long)),
+        apache_avro::types::Value::Map(items) => items
+            .into_iter()
+            .map(|(key, value)| try_from(value).map(|v| (key, v)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|v| Value::Object(v.into_iter().collect())),
+        apache_avro::types::Value::Null => Ok(Value::Null),
+        apache_avro::types::Value::Record(items) => items
+            .into_iter()
+            .map(|(key, value)| try_from(value).map(|v| (key, v)))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|v| Value::Object(v.into_iter().collect())),
+        apache_avro::types::Value::String(string) => Ok(Value::from(string)),
+        apache_avro::types::Value::TimeMicros(time_micros) => Ok(Value::from(time_micros)),
+        apache_avro::types::Value::TimeMillis(time_millis) => Ok(Value::from(time_millis)),
+        apache_avro::types::Value::TimestampMicros(timestamp_micros) => {
+            Ok(Value::from(timestamp_micros))
+        }
+        apache_avro::types::Value::TimestampMillis(timestamp_millis) => {
+            Ok(Value::from(timestamp_millis))
+        }
+        apache_avro::types::Value::Union(_, v) => try_from(*v),
+        apache_avro::types::Value::Uuid(uuid) => Ok(Value::from(uuid.as_hyphenated().to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use apache_avro::{types::Record, Schema};
+    use bytes::BytesMut;
+    use vector_common::btreemap;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_avro() {
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        struct Log {
+            message: String,
+        }
+
+        let schema = r#"
+            {
+                "type": "record",
+                "name": "log",
+                "fields": [
+                    {
+                        "name": "message",
+                        "type": "string"
+                    }
+                ]
+            }
+        "#
+        .to_owned();
+        let schema = Schema::parse_str(&schema).unwrap();
+
+        let event = Log {
+            message: "hello from avro".to_owned(),
+        };
+        let record_value = apache_avro::to_value(event).unwrap();
+        let record_datum = apache_avro::to_avro_datum(&schema, record_value).unwrap();
+        let record_bytes = Bytes::from(record_datum);
+
+        let deserializer = AvroDeserializer::new(schema, false);
+        let events = deserializer
+            .parse(record_bytes, LogNamespace::Vector)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+
+        assert_eq!(
+            events[0].as_log().get("message").unwrap(),
+            &Value::from("hello from avro")
+        );
+    }
+
+    #[test]
+    fn deserialize_avro_strip_schema_id_prefix() {
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        struct Log {
+            message: String,
+        }
+
+        let schema = r#"
+            {
+                "type": "record",
+                "name": "log",
+                "fields": [
+                    {
+                        "name": "message",
+                        "type": "string"
+                    }
+                ]
+            }
+        "#
+        .to_owned();
+        let schema = Schema::parse_str(&schema).unwrap();
+
+        let event = Log {
+            message: "hello from avro".to_owned(),
+        };
+        let record_value = apache_avro::to_value(event).unwrap();
+        let record_datum = apache_avro::to_avro_datum(&schema, record_value).unwrap();
+
+        let mut bytes = BytesMut::new();
+        bytes.extend([0, 0, 0, 0, 0]); // 0 prefix + 4 byte schema id
+        bytes.extend(record_datum);
+
+        let deserializer = AvroDeserializer::new(schema, true);
+        let events = deserializer
+            .parse(bytes.freeze(), LogNamespace::Vector)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+
+        assert_eq!(
+            events[0].as_log().get("message").unwrap(),
+            &Value::from("hello from avro")
+        );
+    }
+}

--- a/lib/codecs/src/decoding/format/mod.rs
+++ b/lib/codecs/src/decoding/format/mod.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 
+mod avro;
 mod bytes;
 mod gelf;
 mod json;
@@ -12,6 +13,7 @@ mod native_json;
 mod syslog;
 
 use ::bytes::Bytes;
+pub use avro::{AvroDeserializer, AvroDeserializerConfig, AvroDeserializerOptions};
 use dyn_clone::DynClone;
 pub use gelf::{GelfDeserializer, GelfDeserializerConfig};
 pub use json::{JsonDeserializer, JsonDeserializerConfig};

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -30,6 +30,8 @@ use vector_core::{
     schema,
 };
 
+use self::format::{AvroDeserializer, AvroDeserializerConfig, AvroDeserializerOptions};
+
 /// An error that occurred while decoding structured events from a byte stream /
 /// byte messages.
 #[derive(Debug)]
@@ -275,6 +277,14 @@ pub enum DeserializerConfig {
     ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
     Gelf,
+
+    /// Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+    ///
+    /// [apache_avro]: https://avro.apache.org/
+    Avro {
+        /// Apache Avro-specific encoder options.
+        avro: AvroDeserializerOptions,
+    },
 }
 
 impl From<BytesDeserializerConfig> for DeserializerConfig {
@@ -306,6 +316,9 @@ impl DeserializerConfig {
     /// Build the `Deserializer` from this configuration.
     pub fn build(&self) -> Deserializer {
         match self {
+            DeserializerConfig::Avro { avro } => {
+                Deserializer::Avro(AvroDeserializerConfig { avro: avro.clone() }.build())
+            }
             DeserializerConfig::Bytes => Deserializer::Bytes(BytesDeserializerConfig.build()),
             DeserializerConfig::Json => Deserializer::Json(JsonDeserializerConfig.build()),
             #[cfg(feature = "syslog")]
@@ -323,6 +336,7 @@ impl DeserializerConfig {
     /// Return an appropriate default framer for the given deserializer
     pub fn default_stream_framing(&self) -> FramingConfig {
         match self {
+            DeserializerConfig::Avro { .. } => FramingConfig::Bytes,
             DeserializerConfig::Native => FramingConfig::LengthDelimited,
             DeserializerConfig::Bytes
             | DeserializerConfig::Json
@@ -340,6 +354,9 @@ impl DeserializerConfig {
     /// Return the type of event build by this deserializer.
     pub fn output_type(&self) -> DataType {
         match self {
+            DeserializerConfig::Avro { avro } => {
+                AvroDeserializerConfig { avro: avro.clone() }.output_type()
+            }
             DeserializerConfig::Bytes => BytesDeserializerConfig.output_type(),
             DeserializerConfig::Json => JsonDeserializerConfig.output_type(),
             #[cfg(feature = "syslog")]
@@ -353,6 +370,9 @@ impl DeserializerConfig {
     /// The schema produced by the deserializer.
     pub fn schema_definition(&self, log_namespace: LogNamespace) -> schema::Definition {
         match self {
+            DeserializerConfig::Avro { avro } => {
+                AvroDeserializerConfig { avro: avro.clone() }.schema_definition(log_namespace)
+            }
             DeserializerConfig::Bytes => BytesDeserializerConfig.schema_definition(log_namespace),
             DeserializerConfig::Json => JsonDeserializerConfig.schema_definition(log_namespace),
             #[cfg(feature = "syslog")]
@@ -386,7 +406,9 @@ impl DeserializerConfig {
                         },
                 },
             ) => "application/json",
-            (DeserializerConfig::Native, _) => "application/octet-stream",
+            (DeserializerConfig::Native, _) | (DeserializerConfig::Avro { .. }, _) => {
+                "application/octet-stream"
+            }
             (
                 DeserializerConfig::Json
                 | DeserializerConfig::NativeJson
@@ -403,6 +425,8 @@ impl DeserializerConfig {
 /// Parse structured events from bytes.
 #[derive(Clone)]
 pub enum Deserializer {
+    /// Uses a `AvroDeserializer` for deserialization.
+    Avro(AvroDeserializer),
     /// Uses a `BytesDeserializer` for deserialization.
     Bytes(BytesDeserializer),
     /// Uses a `JsonDeserializer` for deserialization.
@@ -427,6 +451,7 @@ impl format::Deserializer for Deserializer {
         log_namespace: LogNamespace,
     ) -> vector_common::Result<SmallVec<[Event; 1]>> {
         match self {
+            Deserializer::Avro(deserializer) => deserializer.parse(bytes, log_namespace),
             Deserializer::Bytes(deserializer) => deserializer.parse(bytes, log_namespace),
             Deserializer::Json(deserializer) => deserializer.parse(bytes, log_namespace),
             #[cfg(feature = "syslog")]

--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -2,7 +2,8 @@
 //! byte messages, byte frames and structured events.
 
 #![deny(missing_docs)]
-#![deny(warnings)]
+// #![deny(warnings)]
+#![allow(unused_imports)]
 
 pub mod decoding;
 pub mod encoding;

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -150,6 +150,7 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         DeserializerConfig::Native => SerializerConfig::Native,
         DeserializerConfig::NativeJson => SerializerConfig::NativeJson,
         DeserializerConfig::Gelf => SerializerConfig::Gelf,
+        DeserializerConfig::Avro { avro } => SerializerConfig::Avro { avro: avro.into() },
     };
 
     serializer_config

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -212,6 +212,11 @@ components: sources: [Name=string]: {
 											[vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
 											[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 											"""
+										avro: """
+											Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+											[apache_avro]: https://avro.apache.org/
+											"""
 									}
 								}
 							}

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -91,6 +91,11 @@ base: components: sources: amqp: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -94,6 +94,11 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -180,6 +180,11 @@ base: components: sources: aws_s3: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -175,6 +175,11 @@ base: components: sources: aws_sqs: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -76,6 +76,11 @@ base: components: sources: datadog_agent: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -55,6 +55,11 @@ base: components: sources: demo_logs: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -51,6 +51,11 @@ base: components: sources: exec: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -46,6 +46,11 @@ base: components: sources: file_descriptor: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -122,6 +122,11 @@ base: components: sources: gcp_pubsub: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -88,6 +88,11 @@ base: components: sources: heroku_logs: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -90,6 +90,11 @@ base: components: sources: http: configuration: {
 					[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 					[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 					"""
+				avro: """
+					Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+					[apache_avro]: https://avro.apache.org/
+					"""
 			}
 		}
 	}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -88,6 +88,11 @@ base: components: sources: http_client: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -90,6 +90,11 @@ base: components: sources: http_server: configuration: {
 					[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 					[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 					"""
+				avro: """
+					Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+					[apache_avro]: https://avro.apache.org/
+					"""
 			}
 		}
 	}

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -100,6 +100,11 @@ base: components: sources: kafka: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -143,6 +143,11 @@ base: components: sources: nats: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -61,6 +61,11 @@ base: components: sources: redis: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -63,6 +63,11 @@ base: components: sources: socket: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -46,6 +46,11 @@ base: components: sources: stdin: configuration: {
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
+					avro: """
+						Decodes the raw bytes as an [Apache Avro][apache_avro] record.
+
+						[apache_avro]: https://avro.apache.org/
+						"""
 				}
 			}
 		}


### PR DESCRIPTION
**Apache Avro Message Format Decoder Implementation**

This repository features an  implementation of a decoder for the Apache Avro message format. Key features of this implementation include:

- **Single `schema` operation**: The decoder operates on a single `schema` that is predefined within the configuration.

- **Support for `strip_schema_id_prefix`**: This feature is incredibly handy when working with Kafka messages that incorporate a 'magic byte' and a schema id into the message bytes.

Currently, we're working on documentation to detail the configuration of the codec. Unfortunately, we haven't been able to locate any existing decoder configuration documentation to reference. Should anyone possess familiarity with this topic, your help would be most welcome.