### PR TITLE
chore(observability): remove more deprecated internal metrics

### DIFF
--- a/src/internal_events/batch.rs
+++ b/src/internal_events/batch.rs
@@ -14,8 +14,9 @@ pub struct LargeEventDroppedError {
 
 impl InternalEvent for LargeEventDroppedError {
     fn emit(self) {
+        let reason = "Event larger than batch max_bytes.";
         error!(
-            message = "Event larger than batch max_bytes.",
+            message = reason,
             batch_max_bytes = %self.max_length,
             length = %self.length,
             error_type = error_type::CONDITION_FAILED,
@@ -28,14 +29,6 @@ impl InternalEvent for LargeEventDroppedError {
             "error_type" => error_type::CONDITION_FAILED,
             "stage" => error_stage::SENDING,
         );
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
-            count: 1,
-            reason: "Event larger than batch max_bytes."
-        });
-        // deprecated
-        counter!(
-            "events_discarded_total", 1,
-            "reason" => "oversized",
-        );
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
     }
 }

--- a/src/internal_events/dedupe.rs
+++ b/src/internal_events/dedupe.rs
@@ -1,5 +1,4 @@
 use crate::emit;
-use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
 
 #[derive(Debug)]
@@ -13,6 +12,5 @@ impl InternalEvent for DedupeEventsDropped {
             count: self.count,
             reason: "Events have been found in cache for deduplication.",
         });
-        counter!("events_discarded_total", self.count as u64); // Deprecated
     }
 }

--- a/src/internal_events/filter.rs
+++ b/src/internal_events/filter.rs
@@ -1,4 +1,3 @@
-use metrics::{register_counter, Counter};
 use vector_common::internal_event::{ComponentEventsDropped, Count, Registered, INTENTIONAL};
 
 use crate::register;
@@ -9,11 +8,9 @@ vector_common::registered_event! (
             = register!(ComponentEventsDropped::<INTENTIONAL>::from(
                 "Events matched filter condition."
             )),
-        events_discarded: Counter = register_counter!("events_discarded_total"),
     }
 
     fn emit(&self, data: Count) {
         self.events_dropped.emit(data);
-        self.events_discarded.increment(data.0 as u64);
     }
 );

--- a/src/internal_events/kafka.rs
+++ b/src/internal_events/kafka.rs
@@ -104,8 +104,6 @@ impl InternalEvent for KafkaReadError {
             "error_type" => error_type::READER_FAILED,
             "stage" => error_stage::RECEIVING,
         );
-        // deprecated
-        counter!("events_failed_total", 1);
     }
 }
 

--- a/src/internal_events/loki.rs
+++ b/src/internal_events/loki.rs
@@ -1,35 +1,38 @@
 use crate::emit;
 use metrics::counter;
+use vector_common::internal_event::error_stage;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
 
 #[derive(Debug)]
-pub struct LokiEventUnlabeled;
+pub struct LokiEventUnlabeledError;
 
-impl InternalEvent for LokiEventUnlabeled {
+impl InternalEvent for LokiEventUnlabeledError {
     fn emit(self) {
-        // Deprecated
-        counter!("processing_errors_total", 1,
-                "error_type" => "unlabeled_event");
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => "unlabeled_event",
+            "stage" => error_stage::PROCESSING,
+        );
     }
 }
 
 #[derive(Debug)]
-pub struct LokiOutOfOrderEventDropped {
+pub struct LokiOutOfOrderEventDroppedError {
     pub count: usize,
 }
 
-impl InternalEvent for LokiOutOfOrderEventDropped {
+impl InternalEvent for LokiOutOfOrderEventDroppedError {
     fn emit(self) {
         emit!(ComponentEventsDropped::<INTENTIONAL> {
             count: self.count,
             reason: "out_of_order",
         });
 
-        // Deprecated
-        counter!("events_discarded_total", self.count as u64,
-                "reason" => "out_of_order");
-        counter!("processing_errors_total", 1,
-                "error_type" => "out_of_order");
+        counter!(
+            "component_errors_total", 1,
+            "error_type" => "out_of_order",
+            "stage" => error_stage::PROCESSING,
+        );
     }
 }
 
@@ -47,9 +50,5 @@ impl InternalEvent for LokiOutOfOrderEventRewritten {
             internal_log_rate_limit = true,
         );
         counter!("rewritten_timestamp_events_total", self.count as u64);
-
-        // Deprecated
-        counter!("processing_errors_total", 1,
-                "error_type" => "out_of_order");
     }
 }

--- a/src/internal_events/lua.rs
+++ b/src/internal_events/lua.rs
@@ -43,8 +43,6 @@ impl InternalEvent for LuaScriptError {
             count: 1,
             reason: "Error in lua script.",
         });
-        // deprecated
-        counter!("processing_errors_total", 1);
     }
 }
 
@@ -70,12 +68,6 @@ impl InternalEvent for LuaBuildError {
             "error_type" => error_type::SCRIPT_FAILED,
             "stage" => error_stage:: PROCESSING,
         );
-        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
-            count: 1,
-            reason: "Error in lua build.",
-        });
-        // deprecated
-        counter!("processing_errors_total", 1);
 
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason })
     }

--- a/src/internal_events/metric_to_log.rs
+++ b/src/internal_events/metric_to_log.rs
@@ -27,8 +27,6 @@ impl InternalEvent for MetricToLogSerializeError {
             "error_type" => error_type::ENCODER_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        // deprecated
-        counter!("processing_errors_total", 1, "error_type" => "failed_serialize");
 
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason })
     }

--- a/src/internal_events/parser.rs
+++ b/src/internal_events/parser.rs
@@ -42,8 +42,6 @@ impl InternalEvent for ParserMatchError<'_> {
             "error_type" => error_type::CONDITION_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        // deprecated
-        counter!("processing_errors_total", 1, "error_type" => "failed_match");
     }
 }
 
@@ -75,8 +73,6 @@ impl<const DROP_EVENT: bool> InternalEvent for ParserMissingFieldError<'_, DROP_
             "stage" => error_stage::PROCESSING,
             "field" => self.field.to_string(),
         );
-        // deprecated
-        counter!("processing_errors_total", 1, "error_type" => "missing_field");
 
         if DROP_EVENT {
             emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
@@ -108,8 +104,6 @@ impl<'a> InternalEvent for ParserConversionError<'a> {
             "stage" => error_stage::PROCESSING,
             "name" => self.name.to_string(),
         );
-        // deprecated
-        counter!("processing_errors_total", 1, "error_type" => "type_conversion_failed");
     }
 }
 

--- a/src/internal_events/remap.rs
+++ b/src/internal_events/remap.rs
@@ -34,8 +34,6 @@ impl InternalEvent for RemapMappingError {
                 reason: "Mapping failed with event.",
             });
         }
-        // deprecated
-        counter!("processing_errors_total", 1);
     }
 }
 

--- a/src/internal_events/sample.rs
+++ b/src/internal_events/sample.rs
@@ -1,5 +1,4 @@
 use crate::emit;
-use metrics::counter;
 use vector_core::internal_event::{ComponentEventsDropped, InternalEvent, INTENTIONAL};
 
 #[derive(Debug)]
@@ -7,7 +6,6 @@ pub struct SampleEventDiscarded;
 
 impl InternalEvent for SampleEventDiscarded {
     fn emit(self) {
-        counter!("events_discarded_total", 1); // Deprecated.
         emit!(ComponentEventsDropped::<INTENTIONAL> {
             count: 1,
             reason: "Sample discarded."

--- a/src/internal_events/sematext_metrics.rs
+++ b/src/internal_events/sematext_metrics.rs
@@ -29,8 +29,6 @@ impl<'a> InternalEvent for SematextMetricsInvalidMetricError<'a> {
             "error_type" => error_type::ENCODER_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        // deprecated
-        counter!("processing_errors_total", 1);
 
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
     }

--- a/src/internal_events/statsd_sink.rs
+++ b/src/internal_events/statsd_sink.rs
@@ -31,8 +31,6 @@ impl<'a> InternalEvent for StatsdInvalidMetricError<'a> {
             "error_type" => error_type::ENCODER_FAILED,
             "stage" => error_stage::PROCESSING,
         );
-        // deprecated
-        counter!("processing_errors_total", 1);
 
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { reason, count: 1 });
     }

--- a/src/internal_events/template.rs
+++ b/src/internal_events/template.rs
@@ -33,18 +33,11 @@ impl<'a> InternalEvent for TemplateRenderingError<'a> {
             "stage" => error_stage::PROCESSING,
         );
 
-        // deprecated
-        counter!("processing_errors_total", 1,
-            "error_type" => "render_error");
-
         if self.drop_event {
             emit!(ComponentEventsDropped::<UNINTENTIONAL> {
                 count: 1,
                 reason: "Failed to render template.",
             });
-
-            // deprecated
-            counter!("events_discarded_total", 1);
         }
     }
 }

--- a/src/internal_events/throttle.rs
+++ b/src/internal_events/throttle.rs
@@ -9,7 +9,15 @@ pub(crate) struct ThrottleEventDiscarded {
 
 impl InternalEvent for ThrottleEventDiscarded {
     fn emit(self) {
-        debug!(message = "Rate limit exceeded.", key = ?self.key); // Deprecated.
+        // TODO: Technically, the Component Specification states that the discarded events metric
+        // must _only_ have the `intentional` tag, in addition to the core tags like
+        // `component_kind`, etc, and nothing else.
+        //
+        // That doesn't give us the leeway to specify which throttle bucket the events are being
+        // discarded for... but including the key/bucket as a tag does seem useful and so I wonder
+        // if we should change the specification wording? Sort of a similar situation to the
+        // `error_code` tag for the component errors metric, where it's meant to be optional and
+        // only specified when relevant.
         counter!(
             "events_discarded_total", 1,
             "key" => self.key,

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -29,7 +29,7 @@ use crate::{
     codecs::{Encoder, Transformer},
     http::{get_http_scheme_from_uri, HttpClient},
     internal_events::{
-        LokiEventUnlabeled, LokiOutOfOrderEventDropped, LokiOutOfOrderEventRewritten,
+        LokiEventUnlabeledError, LokiOutOfOrderEventDroppedError, LokiOutOfOrderEventRewritten,
         SinkRequestBuildError, TemplateRenderingError,
     },
     sinks::util::{
@@ -288,7 +288,7 @@ impl EventEncoder {
         // `{agent="vector"}` label. This can happen if the only
         // label is a templatable one but the event doesn't match.
         if labels.is_empty() {
-            emit!(LokiEventUnlabeled);
+            emit!(LokiEventUnlabeledError);
             labels = vec![("agent".to_string(), "vector".to_string())]
         }
 
@@ -486,7 +486,7 @@ impl LokiSink {
                     }
                     Some((partition, result))
                 } else {
-                    emit!(LokiOutOfOrderEventDropped { count: batch.len() });
+                    emit!(LokiOutOfOrderEventDroppedError { count: batch.len() });
                     None
                 }
             })

--- a/website/content/en/highlights/2023-07-05-0-31-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-07-05-0-31-0-upgrade-guide.md
@@ -22,12 +22,12 @@ We cover them below to help you upgrade quickly:
 #### Removal of various deprecated internal metrics {#deprecated-internal-metrics}
 
 Over the course of many of the previous releases, we've been working to deprecate the usage of older
-internal metrics as we worked towards implementing full support for the
-[Component Specification][component_spec], which dictates the basic metrics that all components, or
-the basic metrics all components of a specific type, are expected to emit.
+internal metrics as we worked towards implementing full support for the [Component
+Specification][component_spec], which dictates the basic metrics that all components, or the basic
+metrics all components of a specific type, are expected to emit.
 
-We've made enough progress here that we've gone ahead and removed many of the deprecated metrics
-from this release. First, below is a list of all metrics we've removed:
+We've made enough progress on this work that we've gone ahead and removed many of the deprecated
+metrics from this release. First, below is a list of all metrics we've removed:
 
 - `events_in_total` (superceded by `component_received_events_total`)
 - `events_out_total` (superceded by `component_sent_events_total`)
@@ -39,16 +39,11 @@ from this release. First, below is a list of all metrics we've removed:
 - `events_failed_total` (superceded by `component_errors_total`)
 
 Most of the removals have straightforward replacements, but the `processed_`-prefixed metrics
-involve a small amount of logic.
-
-For sources, `processed_bytes_total` is superceded by `component_received_bytes_total`, and
-`processed_events_total` is superceded by `component_received_events_total`. For sinks,
-`processed_bytes_total` is superceded by `component_sent_bytes_total`, and `processed_events_total`
-is superceded by `component_sent_events_total`. Essentially, the previous metrics dealt with the
-bytes/event totals as events flowed into and out of Vector, such that "processing" events in a
-source meant receiving them, and "processing" events in a sink meant sending them out. The newer
-metrics, `component_received_*` and `component_sent_*`, are meant to be self-documenting and
-consistent across all components.
+involve a small amount of logic. For **sources**, `processed_bytes_total` is superceded by
+`component_received_bytes_total`, and `processed_events_total` is superceded by
+`component_received_events_total`. For **sinks**, `processed_bytes_total` is superceded by
+`component_sent_bytes_total`, and `processed_events_total` is superceded by
+`component_sent_events_total`.
 
 A small note is that a small number of components still emit some of these metrics, as they provided
 additional tags and information that is disallowed by the Component Specification. They will be

--- a/website/content/en/highlights/2023-07-05-0-31-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-07-05-0-31-0-upgrade-guide.md
@@ -1,0 +1,56 @@
+---
+date: "2023-07-05"
+title: "0.31 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.31.0"
+authors: ["tobz"]
+release: "0.31.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.31.0 release includes **breaking changes**:
+
+1. [Removal of various deprecated internal metrics](#deprecated-internal-metrics)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Breaking changes
+
+#### Removal of various deprecated internal metrics {#deprecated-internal-metrics}
+
+Over the course of many of the previous releases, we've been working to deprecate the usage of older
+internal metrics as we worked towards implementing full support for the
+[Component Specification][component_spec], which dictates the basic metrics that all components, or
+the basic metrics all components of a specific type, are expected to emit.
+
+We've made enough progress here that we've gone ahead and removed many of the deprecated metrics
+from this release. First, below is a list of all metrics we've removed:
+
+- `events_in_total` (superceded by `component_received_events_total`)
+- `events_out_total` (superceded by `component_sent_events_total`)
+- `processed_bytes_total` (superceded by either `component_received_bytes_total` or
+  `component_sent_bytes_total`, more below)
+- `processed_events_total` (superceded by either `component_received_events_total` or
+  `component_sent_events_total`, more below)
+- `processing_errors_total` (superceded by `component_errors_total`)
+- `events_failed_total` (superceded by `component_errors_total`)
+
+Most of the removals have straightforward replacements, but the `processed_`-prefixed metrics
+involve a small amount of logic.
+
+For sources, `processed_bytes_total` is superceded by `component_received_bytes_total`, and
+`processed_events_total` is superceded by `component_received_events_total`. For sinks,
+`processed_bytes_total` is superceded by `component_sent_bytes_total`, and `processed_events_total`
+is superceded by `component_sent_events_total`. Essentially, the previous metrics dealt with the
+bytes/event totals as events flowed into and out of Vector, such that "processing" events in a
+source meant receiving them, and "processing" events in a sink meant sending them out. The newer
+metrics, `component_received_*` and `component_sent_*`, are meant to be self-documenting and
+consistent across all components.
+
+A small note is that a small number of components still emit some of these metrics, as they provided
+additional tags and information that is disallowed by the Component Specification. They will be
+removed in a future version once we can rectify those discrepancies, but they are effectively
+removed as of this release: you cannot depend on them still existing.

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -652,16 +652,21 @@ components: sinks: [Name=string]: {
 	}
 
 	telemetry: metrics: {
-		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 		buffer_byte_size:                     components.sources.internal_metrics.output.metrics.buffer_byte_size
+		buffer_discarded_events_total:        components.sources.internal_metrics.output.metrics.buffer_discarded_events_total
 		buffer_events:                        components.sources.internal_metrics.output.metrics.buffer_events
 		buffer_received_events_total:         components.sources.internal_metrics.output.metrics.buffer_received_events_total
 		buffer_received_event_bytes_total:    components.sources.internal_metrics.output.metrics.buffer_received_event_bytes_total
 		buffer_sent_events_total:             components.sources.internal_metrics.output.metrics.buffer_sent_events_total
 		buffer_sent_event_bytes_total:        components.sources.internal_metrics.output.metrics.buffer_sent_event_bytes_total
-		buffer_discarded_events_total:        components.sources.internal_metrics.output.metrics.buffer_discarded_events_total
+		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
+		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
+		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
+		component_sent_bytes_total:           components.sources.internal_metrics.output.metrics.component_sent_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/components/sinks/amqp.cue
+++ b/website/cue/reference/components/sinks/amqp.cue
@@ -59,9 +59,4 @@ components: sinks: amqp: {
 	}
 
 	how_it_works: components._amqp.how_it_works
-
-	telemetry: metrics: {
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -110,11 +110,4 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -114,9 +114,4 @@ components: sinks: aws_cloudwatch_metrics: components._aws & {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -99,9 +99,4 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -141,10 +141,4 @@ components: sinks: aws_kinesis_streams: components._aws & {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -216,12 +216,4 @@ components: sinks: aws_s3: components._aws & {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/aws_sqs.cue
@@ -93,11 +93,4 @@ components: sinks: aws_sqs: components._aws & {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -90,12 +90,4 @@ components: sinks: axiom: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/azure_blob.cue
+++ b/website/cue/reference/components/sinks/azure_blob.cue
@@ -125,10 +125,6 @@ components: sinks: azure_blob: {
 	}
 
 	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 		http_error_response_total:        components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
 	}

--- a/website/cue/reference/components/sinks/azure_blob.cue
+++ b/website/cue/reference/components/sinks/azure_blob.cue
@@ -125,7 +125,7 @@ components: sinks: azure_blob: {
 	}
 
 	telemetry: metrics: {
-		http_error_response_total:        components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/azure_monitor_logs.cue
@@ -68,10 +68,4 @@ components: sinks: azure_monitor_logs: {
 		metrics: null
 		traces:  false
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/blackhole.cue
+++ b/website/cue/reference/components/sinks/blackhole.cue
@@ -44,7 +44,4 @@ components: sinks: blackhole: {
 		}
 		traces: true
 	}
-
-	telemetry: metrics: {
-	}
 }

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -80,10 +80,4 @@ components: sinks: clickhouse: {
 		metrics: null
 		traces:  false
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/console.cue
+++ b/website/cue/reference/components/sinks/console.cue
@@ -55,8 +55,4 @@ components: sinks: console: {
 		}
 		traces: true
 	}
-
-	telemetry: metrics: {
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/databend.cue
+++ b/website/cue/reference/components/sinks/databend.cue
@@ -101,10 +101,4 @@ components: sinks: databend: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/datadog_archives.cue
+++ b/website/cue/reference/components/sinks/datadog_archives.cue
@@ -245,12 +245,4 @@ components: sinks: datadog_archives: {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/datadog_events.cue
+++ b/website/cue/reference/components/sinks/datadog_events.cue
@@ -52,10 +52,4 @@ components: sinks: datadog_events: {
 		metrics: null
 		traces:  false
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/datadog_metrics.cue
@@ -71,9 +71,4 @@ components: sinks: datadog_metrics: {
 		}
 		traces: false
 	}
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -75,11 +75,4 @@ components: sinks: datadog_traces: {
 		metrics: null
 		traces:  true
 	}
-
-	telemetry: metrics: {
-		component_discarded_events_total: components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:           components.sources.internal_metrics.output.metrics.component_errors_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -134,12 +134,4 @@ components: sinks: elasticsearch: {
 
 		aws_authentication: components._aws.how_it_works.aws_authentication
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -74,12 +74,4 @@ components: sinks: file: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
@@ -79,11 +79,4 @@ components: sinks: gcp_chronicle_unstructured: {
 
 	how_it_works: {
 	}
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -179,11 +179,4 @@ components: sinks: gcp_cloud_storage: {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -93,10 +93,4 @@ components: sinks: gcp_pubsub: {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -115,10 +115,4 @@ components: sinks: gcp_stackdriver_logs: {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -103,10 +103,4 @@ components: sinks: gcp_stackdriver_metrics: {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/honeycomb.cue
+++ b/website/cue/reference/components/sinks/honeycomb.cue
@@ -77,10 +77,4 @@ components: sinks: honeycomb: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -93,6 +93,6 @@ components: sinks: http: {
 	}
 
 	telemetry: metrics: {
-		http_bad_requests_total:          components.sources.internal_metrics.output.metrics.http_bad_requests_total
+		http_bad_requests_total: components.sources.internal_metrics.output.metrics.http_bad_requests_total
 	}
 }

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -93,10 +93,6 @@ components: sinks: http: {
 	}
 
 	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
 		http_bad_requests_total:          components.sources.internal_metrics.output.metrics.http_bad_requests_total
 	}
 }

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -150,10 +150,4 @@ components: sinks: _humio: {
 			}
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/humio_logs.cue
+++ b/website/cue/reference/components/sinks/humio_logs.cue
@@ -15,7 +15,6 @@ components: sinks: humio_logs: {
 	features:      sinks._humio.features
 	support:       sinks._humio.support
 	configuration: base.components.sinks.humio_logs.configuration
-	telemetry:     sinks._humio.telemetry
 
 	input: {
 		logs:    true

--- a/website/cue/reference/components/sinks/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/humio_metrics.cue
@@ -7,7 +7,6 @@ components: sinks: humio_metrics: {
 	features:      sinks._humio.features
 	support:       sinks._humio.support
 	configuration: base.components.sinks.humio_metrics.configuration
-	telemetry:     sinks._humio.telemetry
 
 	input: {
 		logs: false

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -97,10 +97,4 @@ components: sinks: influxdb_logs: {
 			]
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -189,9 +189,4 @@ components: sinks: influxdb_metrics: {
 			output: "\(_name),metric_type=summary,host=\(_host) count=6i,quantile_0.01=1.5,quantile_0.5=2,quantile_0.99=3,sum=12.1 1542182950000000011"
 		},
 	]
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/kafka.cue
+++ b/website/cue/reference/components/sinks/kafka.cue
@@ -69,11 +69,6 @@ components: sinks: kafka: {
 	how_it_works: components._kafka.how_it_works
 
 	telemetry: metrics: {
-		component_sent_events_total:         components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total:    components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		component_sent_bytes_total:          components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		events_discarded_total:              components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:             components.sources.internal_metrics.output.metrics.processing_errors_total
 		kafka_queue_messages:                components.sources.internal_metrics.output.metrics.kafka_queue_messages
 		kafka_queue_messages_bytes:          components.sources.internal_metrics.output.metrics.kafka_queue_messages_bytes
 		kafka_requests_total:                components.sources.internal_metrics.output.metrics.kafka_requests_total

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -159,11 +159,6 @@ components: sinks: loki: {
 	}
 
 	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 		streams_total:                    components.sources.internal_metrics.output.metrics.streams_total
 	}
 }

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -159,6 +159,6 @@ components: sinks: loki: {
 	}
 
 	telemetry: metrics: {
-		streams_total:                    components.sources.internal_metrics.output.metrics.streams_total
+		streams_total: components.sources.internal_metrics.output.metrics.streams_total
 	}
 }

--- a/website/cue/reference/components/sinks/mezmo.cue
+++ b/website/cue/reference/components/sinks/mezmo.cue
@@ -62,12 +62,4 @@ components: sinks: mezmo: {
 		metrics: null
 		traces:  false
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		events_discarded_total:           components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -64,8 +64,6 @@ components: sinks: nats: {
 	how_it_works: components._nats.how_it_works
 
 	telemetry: metrics: {
-		events_discarded_total:  components.sources.internal_metrics.output.metrics.events_discarded_total
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
 		send_errors_total:       components.sources.internal_metrics.output.metrics.send_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -64,6 +64,6 @@ components: sinks: nats: {
 	how_it_works: components._nats.how_it_works
 
 	telemetry: metrics: {
-		send_errors_total:       components.sources.internal_metrics.output.metrics.send_errors_total
+		send_errors_total: components.sources.internal_metrics.output.metrics.send_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -101,10 +101,4 @@ components: sinks: prometheus_remote_write: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/pulsar.cue
+++ b/website/cue/reference/components/sinks/pulsar.cue
@@ -65,6 +65,6 @@ components: sinks: pulsar: {
 	}
 
 	telemetry: metrics: {
-		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
+		encode_errors_total: components.sources.internal_metrics.output.metrics.encode_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/pulsar.cue
+++ b/website/cue/reference/components/sinks/pulsar.cue
@@ -65,8 +65,6 @@ components: sinks: pulsar: {
 	}
 
 	telemetry: metrics: {
-		component_discarded_events_total: components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:           components.sources.internal_metrics.output.metrics.component_errors_total
 		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -75,8 +75,6 @@ components: sinks: redis: {
 	}
 
 	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		send_errors_total:                components.sources.internal_metrics.output.metrics.send_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -75,6 +75,6 @@ components: sinks: redis: {
 	}
 
 	telemetry: metrics: {
-		send_errors_total:                components.sources.internal_metrics.output.metrics.send_errors_total
+		send_errors_total: components.sources.internal_metrics.output.metrics.send_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/sematext_metrics.cue
@@ -64,9 +64,6 @@ components: sinks: sematext_metrics: {
 	}
 
 	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/sematext_metrics.cue
@@ -64,6 +64,6 @@ components: sinks: sematext_metrics: {
 	}
 
 	telemetry: metrics: {
-		encode_errors_total:              components.sources.internal_metrics.output.metrics.encode_errors_total
+		encode_errors_total: components.sources.internal_metrics.output.metrics.encode_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -82,11 +82,6 @@ components: sinks: splunk_hec_logs: {
 	}
 
 	telemetry: metrics: {
-		component_discarded_events_total: components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:           components.sources.internal_metrics.output.metrics.component_errors_total
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
 		requests_received_total:          components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -82,8 +82,8 @@ components: sinks: splunk_hec_logs: {
 	}
 
 	telemetry: metrics: {
-		http_request_errors_total:        components.sources.internal_metrics.output.metrics.http_request_errors_total
-		requests_received_total:          components.sources.internal_metrics.output.metrics.requests_received_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}
 
 	how_it_works: sinks._splunk_hec.how_it_works

--- a/website/cue/reference/components/sinks/statsd.cue
+++ b/website/cue/reference/components/sinks/statsd.cue
@@ -48,10 +48,4 @@ components: sinks: statsd: {
 	}
 
 	configuration: base.components.sinks.statsd.configuration
-
-	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		processing_errors_total:          components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -80,9 +80,6 @@ components: sinks: vector: {
 	how_it_works: components.sources.vector.how_it_works
 
 	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		protobuf_decode_errors_total:     components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -80,6 +80,6 @@ components: sinks: vector: {
 	how_it_works: components.sources.vector.how_it_works
 
 	telemetry: metrics: {
-		protobuf_decode_errors_total:     components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
+		protobuf_decode_errors_total: components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/webhdfs.cue
+++ b/website/cue/reference/components/sinks/webhdfs.cue
@@ -50,10 +50,4 @@ components: sinks: webhdfs: {
 		metrics: null
 		traces:  false
 	}
-
-	telemetry: metrics: {
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sinks/websocket.cue
+++ b/website/cue/reference/components/sinks/websocket.cue
@@ -73,10 +73,10 @@ components: sinks: websocket: {
 	}
 
 	telemetry: metrics: {
-		open_connections:                 components.sources.internal_metrics.output.metrics.open_connections
-		connection_established_total:     components.sources.internal_metrics.output.metrics.connection_established_total
-		connection_failed_total:          components.sources.internal_metrics.output.metrics.connection_failed_total
-		connection_shutdown_total:        components.sources.internal_metrics.output.metrics.connection_shutdown_total
-		connection_errors_total:          components.sources.internal_metrics.output.metrics.connection_errors_total
+		open_connections:             components.sources.internal_metrics.output.metrics.open_connections
+		connection_established_total: components.sources.internal_metrics.output.metrics.connection_established_total
+		connection_failed_total:      components.sources.internal_metrics.output.metrics.connection_failed_total
+		connection_shutdown_total:    components.sources.internal_metrics.output.metrics.connection_shutdown_total
+		connection_errors_total:      components.sources.internal_metrics.output.metrics.connection_errors_total
 	}
 }

--- a/website/cue/reference/components/sinks/websocket.cue
+++ b/website/cue/reference/components/sinks/websocket.cue
@@ -78,8 +78,5 @@ components: sinks: websocket: {
 		connection_failed_total:          components.sources.internal_metrics.output.metrics.connection_failed_total
 		connection_shutdown_total:        components.sources.internal_metrics.output.metrics.connection_shutdown_total
 		connection_errors_total:          components.sources.internal_metrics.output.metrics.connection_errors_total
-		component_sent_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_bytes_total
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -403,7 +403,7 @@ components: sources: [Name=string]: {
 	telemetry: metrics: {
 		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
 		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_count:       components.sources.internal_metrics.output.metrics.component_received_bytes_count
+		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
 		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
 		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -401,8 +401,14 @@ components: sources: [Name=string]: {
 	}
 
 	telemetry: metrics: {
-		component_sent_events_total:      components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total: components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		source_lag_time_seconds:          components.sources.internal_metrics.output.metrics.source_lag_time_seconds
+		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
+		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
+		component_received_bytes_count:       components.sources.internal_metrics.output.metrics.component_received_bytes_count
+		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
+		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
+		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		source_lag_time_seconds:              components.sources.internal_metrics.output.metrics.source_lag_time_seconds
 	}
 }

--- a/website/cue/reference/components/sources/amqp.cue
+++ b/website/cue/reference/components/sources/amqp.cue
@@ -79,7 +79,6 @@ components: sources: amqp: {
 
 	telemetry: metrics: {
 		consumer_offset_updates_failed_total: components.sources.internal_metrics.output.metrics.consumer_offset_updates_failed_total
-		events_failed_total:                  components.sources.internal_metrics.output.metrics.events_failed_total
 	}
 
 	how_it_works: components._amqp.how_it_works

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -161,10 +161,10 @@ components: sources: apache_metrics: {
 	how_it_works: {}
 
 	telemetry: metrics: {
-		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -161,11 +161,6 @@ components: sources: apache_metrics: {
 	how_it_works: {}
 
 	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -185,10 +185,10 @@ components: sources: aws_ecs_metrics: {
 	}
 
 	telemetry: metrics: {
-		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -185,13 +185,6 @@ components: sources: aws_ecs_metrics: {
 	}
 
 	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -187,13 +187,6 @@ components: sources: aws_kinesis_firehose: {
 	}
 
 	telemetry: metrics: {
-		component_errors_total:                components.sources.internal_metrics.output.metrics.component_errors_total
-		component_discarded_events_total:      components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_sent_events_total:           components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total:      components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		component_received_bytes_total:        components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:       components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total:  components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		request_read_errors_total:             components.sources.internal_metrics.output.metrics.request_read_errors_total
 		requests_received_total:               components.sources.internal_metrics.output.metrics.requests_received_total
 		request_automatic_decode_errors_total: components.sources.internal_metrics.output.metrics.request_automatic_decode_errors_total

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -162,11 +162,6 @@ components: sources: aws_s3: components._aws & {
 	]
 
 	telemetry: metrics: {
-		component_discarded_events_total:       components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:                 components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:         components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:        components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total:   components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		sqs_message_delete_failed_total:        components.sources.internal_metrics.output.metrics.sqs_message_delete_failed_total
 		sqs_message_delete_succeeded_total:     components.sources.internal_metrics.output.metrics.sqs_message_delete_succeeded_total
 		sqs_message_processing_failed_total:    components.sources.internal_metrics.output.metrics.sqs_message_processing_failed_total

--- a/website/cue/reference/components/sources/aws_sqs.cue
+++ b/website/cue/reference/components/sources/aws_sqs.cue
@@ -83,7 +83,7 @@ components: sources: aws_sqs: components._aws & {
 	}
 
 	telemetry: metrics: {
-		sqs_message_delete_failed_total:      components.sources.internal_metrics.output.metrics.sqs_message_delete_failed_total
+		sqs_message_delete_failed_total: components.sources.internal_metrics.output.metrics.sqs_message_delete_failed_total
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sources/aws_sqs.cue
+++ b/website/cue/reference/components/sources/aws_sqs.cue
@@ -83,9 +83,6 @@ components: sources: aws_sqs: components._aws & {
 	}
 
 	telemetry: metrics: {
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
 		sqs_message_delete_failed_total:      components.sources.internal_metrics.output.metrics.sqs_message_delete_failed_total
 	}
 

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -217,12 +217,4 @@ components: sources: datadog_agent: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-	}
 }

--- a/website/cue/reference/components/sources/demo_logs.cue
+++ b/website/cue/reference/components/sources/demo_logs.cue
@@ -55,12 +55,4 @@ components: sources: demo_logs: {
 			}
 		}
 	}
-
-	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -1172,8 +1172,5 @@ components: sources: dnstap: {
 
 	telemetry: metrics: {
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -1171,6 +1171,6 @@ components: sources: dnstap: {
 	}
 
 	telemetry: metrics: {
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
+		parse_errors_total: components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -214,10 +214,5 @@ components: sources: docker_logs: {
 		containers_unwatched_total:            components.sources.internal_metrics.output.metrics.containers_unwatched_total
 		containers_watched_total:              components.sources.internal_metrics.output.metrics.containers_watched_total
 		logging_driver_errors_total:           components.sources.internal_metrics.output.metrics.logging_driver_errors_total
-		component_discarded_events_total:      components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:                components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:        components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:       components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total:  components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/eventstoredb_metrics.cue
@@ -116,7 +116,7 @@ components: sources: eventstoredb_metrics: {
 		}
 	}
 	telemetry: metrics: {
-		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/eventstoredb_metrics.cue
@@ -118,9 +118,5 @@ components: sources: eventstoredb_metrics: {
 	telemetry: metrics: {
 		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/exec.cue
+++ b/website/cue/reference/components/sources/exec.cue
@@ -128,10 +128,5 @@ components: sources: exec: {
 	telemetry: metrics: {
 		command_executed_total:               components.sources.internal_metrics.output.metrics.command_executed_total
 		command_execution_duration_seconds:   components.sources.internal_metrics.output.metrics.command_execution_duration_seconds
-		processing_errors_total:              components.sources.internal_metrics.output.metrics.processing_errors_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/exec.cue
+++ b/website/cue/reference/components/sources/exec.cue
@@ -126,7 +126,7 @@ components: sources: exec: {
 	}
 
 	telemetry: metrics: {
-		command_executed_total:               components.sources.internal_metrics.output.metrics.command_executed_total
-		command_execution_duration_seconds:   components.sources.internal_metrics.output.metrics.command_execution_duration_seconds
+		command_executed_total:             components.sources.internal_metrics.output.metrics.command_executed_total
+		command_execution_duration_seconds: components.sources.internal_metrics.output.metrics.command_execution_duration_seconds
 	}
 }

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -423,10 +423,6 @@ components: sources: file: {
 	}
 
 	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		checkpoint_write_errors_total:        components.sources.internal_metrics.output.metrics.checkpoint_write_errors_total
 		checkpoints_total:                    components.sources.internal_metrics.output.metrics.checkpoints_total
 		checksum_errors_total:                components.sources.internal_metrics.output.metrics.checksum_errors_total

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -423,16 +423,16 @@ components: sources: file: {
 	}
 
 	telemetry: metrics: {
-		checkpoint_write_errors_total:        components.sources.internal_metrics.output.metrics.checkpoint_write_errors_total
-		checkpoints_total:                    components.sources.internal_metrics.output.metrics.checkpoints_total
-		checksum_errors_total:                components.sources.internal_metrics.output.metrics.checksum_errors_total
-		file_delete_errors_total:             components.sources.internal_metrics.output.metrics.file_delete_errors_total
-		file_watch_errors_total:              components.sources.internal_metrics.output.metrics.file_watch_errors_total
-		files_added_total:                    components.sources.internal_metrics.output.metrics.files_added_total
-		files_deleted_total:                  components.sources.internal_metrics.output.metrics.files_deleted_total
-		files_resumed_total:                  components.sources.internal_metrics.output.metrics.files_resumed_total
-		files_unwatched_total:                components.sources.internal_metrics.output.metrics.files_unwatched_total
-		fingerprint_read_errors_total:        components.sources.internal_metrics.output.metrics.fingerprint_read_errors_total
-		glob_errors_total:                    components.sources.internal_metrics.output.metrics.glob_errors_total
+		checkpoint_write_errors_total: components.sources.internal_metrics.output.metrics.checkpoint_write_errors_total
+		checkpoints_total:             components.sources.internal_metrics.output.metrics.checkpoints_total
+		checksum_errors_total:         components.sources.internal_metrics.output.metrics.checksum_errors_total
+		file_delete_errors_total:      components.sources.internal_metrics.output.metrics.file_delete_errors_total
+		file_watch_errors_total:       components.sources.internal_metrics.output.metrics.file_watch_errors_total
+		files_added_total:             components.sources.internal_metrics.output.metrics.files_added_total
+		files_deleted_total:           components.sources.internal_metrics.output.metrics.files_deleted_total
+		files_resumed_total:           components.sources.internal_metrics.output.metrics.files_resumed_total
+		files_unwatched_total:         components.sources.internal_metrics.output.metrics.files_unwatched_total
+		fingerprint_read_errors_total: components.sources.internal_metrics.output.metrics.fingerprint_read_errors_total
+		glob_errors_total:             components.sources.internal_metrics.output.metrics.glob_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/file_descriptor.cue
+++ b/website/cue/reference/components/sources/file_descriptor.cue
@@ -77,12 +77,4 @@ components: sources: file_descriptor: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-	}
 }

--- a/website/cue/reference/components/sources/fluent.cue
+++ b/website/cue/reference/components/sources/fluent.cue
@@ -178,7 +178,5 @@ components: sources: fluent: {
 
 	telemetry: metrics: {
 		decode_errors_total:             components.sources.internal_metrics.output.metrics.decode_errors_total
-		component_received_bytes_total:  components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total: components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/fluent.cue
+++ b/website/cue/reference/components/sources/fluent.cue
@@ -177,6 +177,6 @@ components: sources: fluent: {
 	}
 
 	telemetry: metrics: {
-		decode_errors_total:             components.sources.internal_metrics.output.metrics.decode_errors_total
+		decode_errors_total: components.sources.internal_metrics.output.metrics.decode_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -99,12 +99,6 @@ components: sources: gcp_pubsub: {
 		}
 	}
 
-	telemetry: metrics: {
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-	}
-
 	how_it_works: {
 		gcp_pubsub: {
 			title: "GCP Pub/Sub"

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -101,10 +101,6 @@ components: sources: heroku_logs: {
 	}
 
 	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		request_read_errors_total:            components.sources.internal_metrics.output.metrics.request_read_errors_total
 		requests_received_total:              components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -101,7 +101,7 @@ components: sources: heroku_logs: {
 	}
 
 	telemetry: metrics: {
-		request_read_errors_total:            components.sources.internal_metrics.output.metrics.request_read_errors_total
-		requests_received_total:              components.sources.internal_metrics.output.metrics.requests_received_total
+		request_read_errors_total: components.sources.internal_metrics.output.metrics.request_read_errors_total
+		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}
 }

--- a/website/cue/reference/components/sources/host_metrics.cue
+++ b/website/cue/reference/components/sources/host_metrics.cue
@@ -257,12 +257,4 @@ components: sources: host_metrics: {
 		}
 		_network_nomac: _network_gauge & {relevant_when: "OS is not macOS"}
 	}
-
-	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sources/http_client.cue
+++ b/website/cue/reference/components/sources/http_client.cue
@@ -139,10 +139,10 @@ components: sources: http_client: {
 	}
 
 	telemetry: metrics: {
-		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/website/cue/reference/components/sources/http_client.cue
+++ b/website/cue/reference/components/sources/http_client.cue
@@ -142,11 +142,6 @@ components: sources: http_client: {
 		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
 		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -178,13 +178,8 @@ components: sources: http_server: {
 	]
 
 	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		http_bad_requests_total:              components.sources.internal_metrics.output.metrics.http_bad_requests_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -178,8 +178,8 @@ components: sources: http_server: {
 	]
 
 	telemetry: metrics: {
-		http_bad_requests_total:              components.sources.internal_metrics.output.metrics.http_bad_requests_total
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
+		http_bad_requests_total: components.sources.internal_metrics.output.metrics.http_bad_requests_total
+		parse_errors_total:      components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sources/internal_logs.cue
+++ b/website/cue/reference/components/sources/internal_logs.cue
@@ -132,11 +132,4 @@ components: sources: internal_logs: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-	}
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -374,12 +374,6 @@ components: sources: internal_metrics: {
 				reason: _reason
 			}
 		}
-		events_failed_total: {
-			description:       "The total number of failures to read a Kafka message."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
 		buffer_byte_size: {
 			description:       "The number of bytes current in the buffer."
 			type:              "gauge"
@@ -819,14 +813,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
-		processing_errors_total: {
-			description:       "The total number of processing errors encountered by this component. This metric is deprecated in favor of `component_errors_total`."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags & {
-				error_type: _error_type
-			}
-		}
 		protobuf_decode_errors_total: {
 			description:       "The total number of [Protocol Buffers](\(urls.protobuf)) errors thrown during communication between Vector instances."
 			type:              "counter"
@@ -1224,12 +1210,5 @@ components: sources: internal_metrics: {
 				tag from the environment.
 				"""
 		}
-	}
-
-	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -151,9 +151,6 @@ components: sources: journald: {
 	}
 
 	telemetry: metrics: {
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		invalid_record_total:                 components.sources.internal_metrics.output.metrics.invalid_record_total
 		invalid_record_bytes_total:           components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
 	}

--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -151,7 +151,7 @@ components: sources: journald: {
 	}
 
 	telemetry: metrics: {
-		invalid_record_total:                 components.sources.internal_metrics.output.metrics.invalid_record_total
-		invalid_record_bytes_total:           components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
+		invalid_record_total:       components.sources.internal_metrics.output.metrics.invalid_record_total
+		invalid_record_bytes_total: components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/kafka.cue
+++ b/website/cue/reference/components/sources/kafka.cue
@@ -87,7 +87,6 @@ components: sources: kafka: {
 	}
 
 	telemetry: metrics: {
-		events_failed_total:                  components.sources.internal_metrics.output.metrics.events_failed_total
 		consumer_offset_updates_failed_total: components.sources.internal_metrics.output.metrics.consumer_offset_updates_failed_total
 		kafka_queue_messages:                 components.sources.internal_metrics.output.metrics.kafka_queue_messages
 		kafka_queue_messages_bytes:           components.sources.internal_metrics.output.metrics.kafka_queue_messages_bytes
@@ -100,11 +99,6 @@ components: sources: kafka: {
 		kafka_consumed_messages_total:        components.sources.internal_metrics.output.metrics.kafka_consumed_messages_total
 		kafka_consumed_messages_bytes_total:  components.sources.internal_metrics.output.metrics.kafka_consumed_messages_bytes_total
 		kafka_consumer_lag:                   components.sources.internal_metrics.output.metrics.kafka_consumer_lag
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 
 	how_it_works: components._kafka.how_it_works

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -477,10 +477,5 @@ components: sources: kubernetes_logs: {
 		k8s_watch_stream_failed_total:          components.sources.internal_metrics.output.metrics.k8s_watch_stream_failed_total
 		k8s_watch_stream_items_obtained_total:  components.sources.internal_metrics.output.metrics.k8s_watch_stream_items_obtained_total
 		k8s_watcher_http_error_total:           components.sources.internal_metrics.output.metrics.k8s_watcher_http_error_total
-		component_discarded_events_total:       components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:                 components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:         components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total:   components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:        components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -309,7 +309,5 @@ components: sources: logstash: {
 		connection_send_ack_errors_total: components.sources.internal_metrics.output.metrics.connection_send_ack_errors_total
 		decode_errors_total:              components.sources.internal_metrics.output.metrics.decode_errors_total
 		open_connections:                 components.sources.internal_metrics.output.metrics.open_connections
-		component_received_bytes_total:   components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:  components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/mongodb_metrics.cue
@@ -722,9 +722,9 @@ components: sources: mongodb_metrics: {
 	}
 
 	telemetry: metrics: {
-		collect_completed_total:          components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_seconds:         components.sources.internal_metrics.output.metrics.collect_duration_seconds
-		parse_errors_total:               components.sources.internal_metrics.output.metrics.parse_errors_total
-		request_errors_total:             components.sources.internal_metrics.output.metrics.request_errors_total
+		collect_completed_total:  components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
+		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/mongodb_metrics.cue
@@ -726,12 +726,5 @@ components: sources: mongodb_metrics: {
 		collect_duration_seconds:         components.sources.internal_metrics.output.metrics.collect_duration_seconds
 		parse_errors_total:               components.sources.internal_metrics.output.metrics.parse_errors_total
 		request_errors_total:             components.sources.internal_metrics.output.metrics.request_errors_total
-		component_discarded_events_total: components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:           components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:   components.sources.internal_metrics.output.metrics.component_received_bytes_total & {
-			description: "The number of deserialized bytes from the returned BSON documents"
-		}
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/nats.cue
+++ b/website/cue/reference/components/sources/nats.cue
@@ -68,13 +68,5 @@ components: sources: nats: {
 		}
 	}
 
-	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-	}
-
 	how_it_works: components._nats.how_it_works
 }

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -128,9 +128,9 @@ components: sources: nginx_metrics: {
 	}
 
 	telemetry: metrics: {
-		collect_completed_total:         components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_seconds:        components.sources.internal_metrics.output.metrics.collect_duration_seconds
-		http_request_errors_total:       components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:              components.sources.internal_metrics.output.metrics.parse_errors_total
+		collect_completed_total:   components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds:  components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -132,6 +132,5 @@ components: sources: nginx_metrics: {
 		collect_duration_seconds:        components.sources.internal_metrics.output.metrics.collect_duration_seconds
 		http_request_errors_total:       components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:              components.sources.internal_metrics.output.metrics.parse_errors_total
-		component_received_events_total: components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -194,14 +194,6 @@ components: sources: opentelemetry: {
 		}
 	}
 
-	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-	}
-
 	how_it_works: {
 		tls: {
 			title: "Transport Layer Security (TLS)"

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -71,11 +71,6 @@ components: sources: postgresql_metrics: {
 	telemetry: metrics: {
 		collect_completed_total:              components.sources.internal_metrics.output.metrics.collect_completed_total
 		collect_duration_seconds:             components.sources.internal_metrics.output.metrics.collect_duration_seconds
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		request_errors_total:                 components.sources.internal_metrics.output.metrics.request_errors_total
 	}
 

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -69,9 +69,9 @@ components: sources: postgresql_metrics: {
 	}
 
 	telemetry: metrics: {
-		collect_completed_total:              components.sources.internal_metrics.output.metrics.collect_completed_total
-		collect_duration_seconds:             components.sources.internal_metrics.output.metrics.collect_duration_seconds
-		request_errors_total:                 components.sources.internal_metrics.output.metrics.request_errors_total
+		collect_completed_total:  components.sources.internal_metrics.output.metrics.collect_completed_total
+		collect_duration_seconds: components.sources.internal_metrics.output.metrics.collect_duration_seconds
+		request_errors_total:     components.sources.internal_metrics.output.metrics.request_errors_total
 	}
 
 	output: metrics: {

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -84,10 +84,6 @@ components: sources: prometheus_remote_write: {
 	}
 
 	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
 		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
 		requests_received_total:              components.sources.internal_metrics.output.metrics.requests_received_total

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -84,9 +84,9 @@ components: sources: prometheus_remote_write: {
 	}
 
 	telemetry: metrics: {
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
-		requests_received_total:              components.sources.internal_metrics.output.metrics.requests_received_total
-		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
+		parse_errors_total:       components.sources.internal_metrics.output.metrics.parse_errors_total
+		requests_completed_total: components.sources.internal_metrics.output.metrics.requests_completed_total
+		requests_received_total:  components.sources.internal_metrics.output.metrics.requests_received_total
+		request_duration_seconds: components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -100,11 +100,6 @@ components: sources: prometheus_scrape: {
 		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
 		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
 		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
 		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -97,10 +97,10 @@ components: sources: prometheus_scrape: {
 	}
 
 	telemetry: metrics: {
-		http_error_response_total:            components.sources.internal_metrics.output.metrics.http_error_response_total
-		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
-		parse_errors_total:                   components.sources.internal_metrics.output.metrics.parse_errors_total
-		requests_completed_total:             components.sources.internal_metrics.output.metrics.requests_completed_total
-		request_duration_seconds:             components.sources.internal_metrics.output.metrics.request_duration_seconds
+		http_error_response_total: components.sources.internal_metrics.output.metrics.http_error_response_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		parse_errors_total:        components.sources.internal_metrics.output.metrics.parse_errors_total
+		requests_completed_total:  components.sources.internal_metrics.output.metrics.requests_completed_total
+		request_duration_seconds:  components.sources.internal_metrics.output.metrics.request_duration_seconds
 	}
 }

--- a/website/cue/reference/components/sources/redis.cue
+++ b/website/cue/reference/components/sources/redis.cue
@@ -95,8 +95,4 @@ components: sources: redis: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -118,10 +118,5 @@ components: sources: socket: {
 		connection_send_errors_total:         components.sources.internal_metrics.output.metrics.connection_send_errors_total
 		connection_send_ack_errors_total:     components.sources.internal_metrics.output.metrics.connection_send_ack_errors_total
 		connection_shutdown_total:            components.sources.internal_metrics.output.metrics.connection_shutdown_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 	}
 }

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -111,12 +111,12 @@ components: sources: socket: {
 	]
 
 	telemetry: metrics: {
-		connection_errors_total:              components.sources.internal_metrics.output.metrics.connection_errors_total
-		connection_failed_total:              components.sources.internal_metrics.output.metrics.connection_failed_total
-		connection_established_total:         components.sources.internal_metrics.output.metrics.connection_established_total
-		connection_failed_total:              components.sources.internal_metrics.output.metrics.connection_failed_total
-		connection_send_errors_total:         components.sources.internal_metrics.output.metrics.connection_send_errors_total
-		connection_send_ack_errors_total:     components.sources.internal_metrics.output.metrics.connection_send_ack_errors_total
-		connection_shutdown_total:            components.sources.internal_metrics.output.metrics.connection_shutdown_total
+		connection_errors_total:          components.sources.internal_metrics.output.metrics.connection_errors_total
+		connection_failed_total:          components.sources.internal_metrics.output.metrics.connection_failed_total
+		connection_established_total:     components.sources.internal_metrics.output.metrics.connection_established_total
+		connection_failed_total:          components.sources.internal_metrics.output.metrics.connection_failed_total
+		connection_send_errors_total:     components.sources.internal_metrics.output.metrics.connection_send_errors_total
+		connection_send_ack_errors_total: components.sources.internal_metrics.output.metrics.connection_send_ack_errors_total
+		connection_shutdown_total:        components.sources.internal_metrics.output.metrics.connection_shutdown_total
 	}
 }

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -79,8 +79,8 @@ components: sources: splunk_hec: {
 	}
 
 	telemetry: metrics: {
-		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
-		requests_received_total:              components.sources.internal_metrics.output.metrics.requests_received_total
+		http_request_errors_total: components.sources.internal_metrics.output.metrics.http_request_errors_total
+		requests_received_total:   components.sources.internal_metrics.output.metrics.requests_received_total
 	}
 
 	how_it_works: {

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -79,10 +79,6 @@ components: sources: splunk_hec: {
 	}
 
 	telemetry: metrics: {
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		http_request_errors_total:            components.sources.internal_metrics.output.metrics.http_request_errors_total
 		requests_received_total:              components.sources.internal_metrics.output.metrics.requests_received_total
 	}

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -82,10 +82,5 @@ components: sources: statsd: {
 		connection_errors_total:              components.sources.internal_metrics.output.metrics.connection_errors_total
 		invalid_record_total:                 components.sources.internal_metrics.output.metrics.invalid_record_total
 		invalid_record_bytes_total:           components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -79,8 +79,8 @@ components: sources: statsd: {
 	}
 
 	telemetry: metrics: {
-		connection_errors_total:              components.sources.internal_metrics.output.metrics.connection_errors_total
-		invalid_record_total:                 components.sources.internal_metrics.output.metrics.invalid_record_total
-		invalid_record_bytes_total:           components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
+		connection_errors_total:    components.sources.internal_metrics.output.metrics.connection_errors_total
+		invalid_record_total:       components.sources.internal_metrics.output.metrics.invalid_record_total
+		invalid_record_bytes_total: components.sources.internal_metrics.output.metrics.invalid_record_bytes_total
 	}
 }

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -85,11 +85,6 @@ components: sources: stdin: {
 	}
 
 	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		stdin_reads_failed_total:             components.sources.internal_metrics.output.metrics.stdin_reads_failed_total
 	}
 }

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -85,6 +85,6 @@ components: sources: stdin: {
 	}
 
 	telemetry: metrics: {
-		stdin_reads_failed_total:             components.sources.internal_metrics.output.metrics.stdin_reads_failed_total
+		stdin_reads_failed_total: components.sources.internal_metrics.output.metrics.stdin_reads_failed_total
 	}
 }

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -206,8 +206,6 @@ components: sources: syslog: {
 
 	telemetry: metrics: {
 		connection_read_errors_total:    components.sources.internal_metrics.output.metrics.connection_read_errors_total
-		component_received_bytes_total:  components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total: components.sources.internal_metrics.output.metrics.component_received_events_total
 		utf8_convert_errors_total:       components.sources.internal_metrics.output.metrics.utf8_convert_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -205,7 +205,7 @@ components: sources: syslog: {
 	}
 
 	telemetry: metrics: {
-		connection_read_errors_total:    components.sources.internal_metrics.output.metrics.connection_read_errors_total
-		utf8_convert_errors_total:       components.sources.internal_metrics.output.metrics.utf8_convert_errors_total
+		connection_read_errors_total: components.sources.internal_metrics.output.metrics.connection_read_errors_total
+		utf8_convert_errors_total:    components.sources.internal_metrics.output.metrics.utf8_convert_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -100,6 +100,6 @@ components: sources: vector: {
 	}
 
 	telemetry: metrics: {
-		protobuf_decode_errors_total:         components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
+		protobuf_decode_errors_total: components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
 	}
 }

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -100,11 +100,6 @@ components: sources: vector: {
 	}
 
 	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_bytes_total:       components.sources.internal_metrics.output.metrics.component_received_bytes_total
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		protobuf_decode_errors_total:         components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
 	}
 }

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -13,11 +13,13 @@ components: transforms: [Name=string]: {
 	configuration: base.components.transforms.configuration
 
 	telemetry: metrics: {
+		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
+		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
 		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
 		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
 		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/components/transforms/dedupe.cue
+++ b/website/cue/reference/components/transforms/dedupe.cue
@@ -93,8 +93,4 @@ components: transforms: dedupe: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total
-	}
 }

--- a/website/cue/reference/components/transforms/filter.cue
+++ b/website/cue/reference/components/transforms/filter.cue
@@ -69,8 +69,4 @@ components: transforms: filter: {
 			]
 		},
 	]
-
-	telemetry: metrics: {
-		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total
-	}
 }

--- a/website/cue/reference/components/transforms/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/log_to_metric.cue
@@ -326,8 +326,4 @@ components: transforms: log_to_metric: {
 				"""
 		}
 	}
-
-	telemetry: metrics: {
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/transforms/lua.cue
+++ b/website/cue/reference/components/transforms/lua.cue
@@ -309,6 +309,5 @@ components: transforms: lua: {
 
 	telemetry: metrics: {
 		lua_memory_used_bytes:   components.sources.internal_metrics.output.metrics.lua_memory_used_bytes
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
 	}
 }

--- a/website/cue/reference/components/transforms/lua.cue
+++ b/website/cue/reference/components/transforms/lua.cue
@@ -308,6 +308,6 @@ components: transforms: lua: {
 	}
 
 	telemetry: metrics: {
-		lua_memory_used_bytes:   components.sources.internal_metrics.output.metrics.lua_memory_used_bytes
+		lua_memory_used_bytes: components.sources.internal_metrics.output.metrics.lua_memory_used_bytes
 	}
 }

--- a/website/cue/reference/components/transforms/metric_to_log.cue
+++ b/website/cue/reference/components/transforms/metric_to_log.cue
@@ -92,8 +92,4 @@ components: transforms: metric_to_log: {
 	]
 
 	how_it_works: {}
-
-	telemetry: metrics: {
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -154,8 +154,4 @@ components: transforms: "remap": {
 				"""
 		},
 	]
-
-	telemetry: metrics: {
-		processing_errors_total: components.sources.internal_metrics.output.metrics.processing_errors_total
-	}
 }

--- a/website/cue/reference/components/transforms/sample.cue
+++ b/website/cue/reference/components/transforms/sample.cue
@@ -31,8 +31,4 @@ components: transforms: sample: {
 		metrics: null
 		traces:  true
 	}
-
-	telemetry: metrics: {
-		events_discarded_total: components.sources.internal_metrics.output.metrics.events_discarded_total
-	}
 }


### PR DESCRIPTION
This is a follow-up PR to #17516, which does a few things:

- completely removes `processing_errors_total`, `events_failed_total`, and `events_discarded_total`, with one exception (see reviewer notes)
- adds a 0.31 upgrade guide which covers the removal of these metrics and the metrics removed in #17516 
- updates the Cue files for all components to derive their Component Specification-related metrics descriptions at the component type level (see reviewer notes)

## Reviewer Notes

### One dangling reference to `events_discarded_total`

There's still one dangling reference to this deprecated metric for the `throttle` transform. I left a TODO comment in the code, but essentially, it currently specifies a tag (which bucket key was throttled) for `events_discarded_total` which can't be translated directly to `component_discarded_events_total` as the specification disallows custom tags.

We'll probably need to quickly talk about whether the specification is too rigid or if we actually want to emit that tag at all.

### Updated Cue files for common component metrics

I followed the Component Specification here, since technically all components receive and send events, and can drop or discard those events. This touched a vast majority of the component Cue files, and should bring them up to a far more consistent state than the previous set of circumstances.

There's definitely something to be said for even pushing up the abstraction of how components inherit that `telemetry: metrics { ... }` stuff so it's driven by component type rather than hard-coded in the per-component-type Cue file (`sources.cue`, etc)... but this felt like a reasonable middle ground to leave it at for now.

