### PR TITLE
fix(ci): add missing logic to mark required checks failed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,9 +121,11 @@ jobs:
           - test_name: 'webhdfs'
             if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.int-all == 'true' || needs.changes.outputs.webhdfs == 'true' }}
 
+  # This is a required status check, so it always needs to run if prior jobs failed, in order to mark the status correctly.
   integration:
     name: Integration Test Suite
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - integration-matrix
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,14 +139,23 @@ jobs:
           path: "/tmp/vector-config-schema.json"
         if: success() || failure()
 
+  # This is a required status check, so it always needs to run if prior jobs failed, in order to mark the status correctly.
   all-checks:
     name: Test Suite
     runs-on: ubuntu-20.04
+    if: always()
     needs:
       - checks
       - test-vrl
       - test-linux
+    env:
+      FAILED: ${{ contains(needs.*.result, 'failure') }}
     steps:
-      - name: validate
-        run: echo "OK"
+      - run: |
+          echo "failed=${{ env.FAILED }}"
+          if [[ "$FAILED" == "true" ]] ; then
+            exit 1
+          else
+            exit 0
+          fi
 


### PR DESCRIPTION
- Test Suite and Integration Test Suite are required checks for CI, so their jobs always need to run (relevant if dependent job failed) to correctly mark the final status.
