### PR TITLE
chore(observability): set `sent_event` and `received_event` metrics to estimated json size

### DIFF
--- a/src/sinks/amqp/request_builder.rs
+++ b/src/sinks/amqp/request_builder.rs
@@ -15,6 +15,7 @@ use vector_common::{
     finalization::{EventFinalizers, Finalizable},
     request_metadata::RequestMetadata,
 };
+use vector_core::EstimatedJsonEncodedSizeOf;
 
 use super::{encoder::AmqpEncoder, service::AmqpRequest, sink::AmqpEvent};
 
@@ -23,6 +24,7 @@ pub(super) struct AmqpMetadata {
     routing_key: String,
     properties: BasicProperties,
     finalizers: EventFinalizers,
+    event_json_size: usize,
 }
 
 /// Build the request to send to `AMQP` by using the encoder to convert it into
@@ -59,6 +61,7 @@ impl RequestBuilder<AmqpEvent> for AmqpRequestBuilder {
             routing_key: input.routing_key,
             properties: input.properties,
             finalizers: input.event.take_finalizers(),
+            event_json_size: input.event.estimated_json_encoded_size_of(),
         };
 
         (metadata, builder, input.event)
@@ -78,6 +81,7 @@ impl RequestBuilder<AmqpEvent> for AmqpRequestBuilder {
             amqp_metadata.properties,
             amqp_metadata.finalizers,
             metadata,
+            amqp_metadata.event_json_size,
         )
     }
 }

--- a/src/sinks/amqp/service.rs
+++ b/src/sinks/amqp/service.rs
@@ -26,6 +26,7 @@ pub(super) struct AmqpRequest {
     properties: BasicProperties,
     finalizers: EventFinalizers,
     metadata: RequestMetadata,
+    event_json_size: usize,
 }
 
 impl AmqpRequest {
@@ -36,6 +37,7 @@ impl AmqpRequest {
         properties: BasicProperties,
         finalizers: EventFinalizers,
         metadata: RequestMetadata,
+        event_json_size: usize,
     ) -> Self {
         Self {
             body,
@@ -44,6 +46,7 @@ impl AmqpRequest {
             properties,
             finalizers,
             metadata,
+            event_json_size,
         }
     }
 }
@@ -63,6 +66,7 @@ impl MetaDescriptive for AmqpRequest {
 /// A successful response from `AMQP`.
 pub(super) struct AmqpResponse {
     byte_size: usize,
+    json_size: usize,
 }
 
 impl DriverResponse for AmqpResponse {
@@ -71,7 +75,7 @@ impl DriverResponse for AmqpResponse {
     }
 
     fn events_sent(&self) -> CountByteSize {
-        CountByteSize(1, self.byte_size)
+        CountByteSize(1, self.json_size)
     }
 
     fn bytes_sent(&self) -> Option<usize> {
@@ -128,14 +132,14 @@ impl Service<AmqpRequest> for AmqpService {
                 Ok(result) => match result.await {
                     Ok(lapin::publisher_confirm::Confirmation::Nack(_)) => {
                         warn!("Received Negative Acknowledgement from AMQP server.");
-                        Ok(AmqpResponse { byte_size })
+                        Ok(AmqpResponse {json_size: req.event_json_size, byte_size })
                     }
                     Err(error) => {
                         // TODO: In due course the caller could emit these on error.
                         emit!(AmqpAcknowledgementError { error: &error });
                         Err(AmqpError::AmqpAcknowledgementFailed { error })
                     }
-                    Ok(_) => Ok(AmqpResponse { byte_size }),
+                    Ok(_) => Ok(AmqpResponse { json_size: req.event_json_size, byte_size }),
                 },
                 Err(error) => {
                     // TODO: In due course the caller could emit these on error.

--- a/src/sinks/aws_kinesis/service.rs
+++ b/src/sinks/aws_kinesis/service.rs
@@ -72,7 +72,9 @@ where
 
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, requests: BatchKinesisRequest<R>) -> Self::Future {
-        let events_byte_size = requests.get_metadata().events_byte_size();
+        let events_byte_size = requests
+            .get_metadata()
+            .events_estimated_json_encoded_byte_size();
         let count = requests.get_metadata().event_count();
 
         let records = requests

--- a/src/sinks/aws_sqs/request_builder.rs
+++ b/src/sinks/aws_sqs/request_builder.rs
@@ -130,7 +130,7 @@ pub(crate) struct SendMessageEntry {
     pub message_deduplication_id: Option<String>,
     pub queue_url: String,
     finalizers: EventFinalizers,
-    metadata: RequestMetadata,
+    pub metadata: RequestMetadata,
 }
 
 impl ByteSizeOf for SendMessageEntry {

--- a/src/sinks/azure_blob/request_builder.rs
+++ b/src/sinks/azure_blob/request_builder.rs
@@ -3,7 +3,7 @@ use chrono::Utc;
 use codecs::encoding::Framer;
 use uuid::Uuid;
 use vector_common::request_metadata::RequestMetadata;
-use vector_core::ByteSizeOf;
+use vector_core::EstimatedJsonEncodedSizeOf;
 
 use crate::{
     codecs::{Encoder, Transformer},
@@ -51,7 +51,7 @@ impl RequestBuilder<(String, Vec<Event>)> for AzureBlobRequestOptions {
         let azure_metadata = AzureBlobMetadata {
             partition_key,
             count: events.len(),
-            byte_size: events.size_of(),
+            byte_size: events.estimated_json_encoded_size_of(),
             finalizers,
         };
 

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -85,7 +85,7 @@ impl DriverResponse for DatabendResponse {
     fn events_sent(&self) -> CountByteSize {
         CountByteSize(
             self.metadata.event_count(),
-            self.metadata.events_byte_size(),
+            self.metadata.events_estimated_json_encoded_byte_size(),
         )
     }
 

--- a/src/sinks/datadog/events/service.rs
+++ b/src/sinks/datadog/events/service.rs
@@ -90,7 +90,7 @@ impl Service<DatadogEventsRequest> for DatadogEventsService {
 
         Box::pin(async move {
             http_service.ready().await?;
-            let event_byte_size = req.get_metadata().events_byte_size();
+            let event_byte_size = req.get_metadata().events_estimated_json_encoded_byte_size();
             let http_response = http_service.call(req).await?;
             let event_status = if http_response.is_successful() {
                 EventStatus::Delivered

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -137,7 +137,9 @@ impl Service<LogApiRequest> for LogApiService {
         };
 
         let count = request.get_metadata().event_count();
-        let events_byte_size = request.get_metadata().events_byte_size();
+        let events_byte_size = request
+            .get_metadata()
+            .events_estimated_json_encoded_byte_size();
         let raw_byte_size = request.uncompressed_size;
 
         let mut http_request = http_request.header(CONTENT_LENGTH, request.body.len());

--- a/src/sinks/datadog/metrics/service.rs
+++ b/src/sinks/datadog/metrics/service.rs
@@ -182,7 +182,9 @@ impl Service<DatadogMetricsRequest> for DatadogMetricsService {
         let api_key = self.api_key.clone();
 
         Box::pin(async move {
-            let byte_size = request.get_metadata().events_byte_size();
+            let byte_size = request
+                .get_metadata()
+                .events_estimated_json_encoded_byte_size();
             let batch_size = request.get_metadata().event_count();
             let raw_byte_size = request.raw_bytes;
 

--- a/src/sinks/datadog/traces/service.rs
+++ b/src/sinks/datadog/traces/service.rs
@@ -146,7 +146,9 @@ impl Service<TraceApiRequest> for TraceApiService {
         let client = self.client.clone();
 
         Box::pin(async move {
-            let byte_size = request.get_metadata().events_byte_size();
+            let byte_size = request
+                .get_metadata()
+                .events_estimated_json_encoded_byte_size();
             let batch_size = request.get_metadata().event_count();
             let uncompressed_size = request.uncompressed_size;
             let http_request = request.into_http_request().context(BuildRequestSnafu)?;

--- a/src/sinks/datadog_archives.rs
+++ b/src/sinks/datadog_archives.rs
@@ -31,7 +31,7 @@ use vector_config::{configurable_component, NamedComponent};
 use vector_core::{
     config::AcknowledgementsConfig,
     event::{Event, EventFinalizers, Finalizable},
-    schema, ByteSizeOf,
+    schema, EstimatedJsonEncodedSizeOf,
 };
 use vrl::value::Kind;
 
@@ -816,7 +816,7 @@ impl RequestBuilder<(String, Vec<Event>)> for DatadogAzureRequestBuilder {
         let metadata = AzureBlobMetadata {
             partition_key,
             count: events.len(),
-            byte_size: events.size_of(),
+            byte_size: events.estimated_json_encoded_size_of(),
             finalizers,
         };
         let builder = RequestMetadataBuilder::from_events(&events);

--- a/src/sinks/elasticsearch/request_builder.rs
+++ b/src/sinks/elasticsearch/request_builder.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use vector_common::request_metadata::RequestMetadata;
-use vector_core::ByteSizeOf;
+use vector_core::EstimatedJsonEncodedSizeOf;
 
 use crate::{
     event::{EventFinalizers, Finalizable},
@@ -50,7 +50,7 @@ impl RequestBuilder<Vec<ProcessedEvent>> for ElasticsearchRequestBuilder {
     ) -> (Self::Metadata, RequestMetadataBuilder, Self::Events) {
         let events_byte_size = events
             .iter()
-            .map(|x| x.log.size_of())
+            .map(|x| x.log.estimated_json_encoded_size_of())
             .reduce(|a, b| a + b)
             .unwrap_or(0);
 

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -90,7 +90,9 @@ impl Service<KafkaRequest> for KafkaService {
         let this = self.clone();
 
         Box::pin(async move {
-            let event_byte_size = request.get_metadata().events_byte_size();
+            let event_byte_size = request
+                .get_metadata()
+                .events_estimated_json_encoded_byte_size();
 
             let mut record =
                 FutureRecord::to(&request.metadata.topic).payload(request.body.as_ref());

--- a/src/sinks/opendal_common.rs
+++ b/src/sinks/opendal_common.rs
@@ -25,7 +25,7 @@ use vector_core::{
     internal_event::CountByteSize,
     sink::StreamSink,
     stream::{BatcherSettings, DriverResponse},
-    ByteSizeOf,
+    EstimatedJsonEncodedSizeOf,
 };
 
 use crate::{
@@ -204,7 +204,7 @@ impl RequestBuilder<(String, Vec<Event>)> for OpenDalRequestBuilder {
         let opendal_metadata = OpenDalMetadata {
             partition_key,
             count: events.len(),
-            byte_size: events.size_of(),
+            byte_size: events.estimated_json_encoded_size_of(),
             finalizers,
         };
 

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -293,9 +293,10 @@ fn encode_event(
 
     // Errors are handled by `Encoder`.
     encoder.encode(event, &mut bytes).ok()?;
+    let byte_size = bytes.len();
     let value = bytes.freeze();
 
-    let event = EncodedEvent::new(RedisKvEntry { key, value }, event_byte_size);
+    let event = EncodedEvent::new(RedisKvEntry { key, value }, byte_size, event_byte_size);
     Some(event)
 }
 

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -100,7 +100,9 @@ impl Service<S3Request> for S3Service {
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, request: S3Request) -> Self::Future {
         let count = request.get_metadata().event_count();
-        let events_byte_size = request.get_metadata().events_byte_size();
+        let events_byte_size = request
+            .get_metadata()
+            .events_estimated_json_encoded_byte_size();
 
         let options = request.options;
 

--- a/src/sinks/splunk_hec/common/service.rs
+++ b/src/sinks/splunk_hec/common/service.rs
@@ -114,7 +114,7 @@ where
         let ack_slot = self.current_ack_slot.take();
 
         let events_count = req.get_metadata().event_count();
-        let events_byte_size = req.get_metadata().events_byte_size();
+        let events_byte_size = req.get_metadata().events_estimated_json_encoded_byte_size();
         let response = self.inner.call(req);
 
         Box::pin(async move {

--- a/src/sinks/statsd/service.rs
+++ b/src/sinks/statsd/service.rs
@@ -49,7 +49,7 @@ impl DriverResponse for StatsdResponse {
     fn events_sent(&self) -> CountByteSize {
         CountByteSize(
             self.metadata.event_count(),
-            self.metadata.events_byte_size(),
+            self.metadata.events_estimated_json_encoded_byte_size(),
         )
     }
 

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -184,7 +184,7 @@ impl SinkConfig for TestConfig {
                 VecBuffer::new(batch_settings.size),
                 batch_settings.timeout,
             )
-            .with_flat_map(|event| stream::iter(Some(Ok(EncodedEvent::new(event, 0)))))
+            .with_flat_map(|event| stream::iter(Some(Ok(EncodedEvent::new(event, 0, 0)))))
             .sink_map_err(|error| panic!("Fatal test sink error: {}", error));
         let healthcheck = future::ok(()).boxed();
 

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -362,6 +362,7 @@ pub struct EncodedBatch<I> {
     pub finalizers: EventFinalizers,
     pub count: usize,
     pub byte_size: usize,
+    pub json_byte_size: usize,
 }
 
 /// This is a batch construct that stores an set of event finalizers alongside the batch itself.
@@ -374,6 +375,7 @@ pub struct FinalizersBatch<B> {
     // could be smaller due to aggregated items (ie metrics).
     count: usize,
     byte_size: usize,
+    json_byte_size: usize,
 }
 
 impl<B: Batch> From<B> for FinalizersBatch<B> {
@@ -383,6 +385,7 @@ impl<B: Batch> From<B> for FinalizersBatch<B> {
             finalizers: Default::default(),
             count: 0,
             byte_size: 0,
+            json_byte_size: 0,
         }
     }
 }
@@ -402,18 +405,21 @@ impl<B: Batch> Batch for FinalizersBatch<B> {
             item,
             finalizers,
             byte_size,
+            json_byte_size,
         } = item;
         match self.inner.push(item) {
             PushResult::Ok(full) => {
                 self.finalizers.merge(finalizers);
                 self.count += 1;
                 self.byte_size += byte_size;
+                self.json_byte_size += json_byte_size;
                 PushResult::Ok(full)
             }
             PushResult::Overflow(item) => PushResult::Overflow(EncodedEvent {
                 item,
                 finalizers,
                 byte_size,
+                json_byte_size,
             }),
         }
     }
@@ -428,6 +434,7 @@ impl<B: Batch> Batch for FinalizersBatch<B> {
             finalizers: Default::default(),
             count: 0,
             byte_size: 0,
+            json_byte_size: 0,
         }
     }
 
@@ -437,6 +444,7 @@ impl<B: Batch> Batch for FinalizersBatch<B> {
             finalizers: self.finalizers,
             count: self.count,
             byte_size: self.byte_size,
+            json_byte_size: self.json_byte_size,
         }
     }
 

--- a/src/sinks/util/buffer/mod.rs
+++ b/src/sinks/util/buffer/mod.rs
@@ -179,7 +179,7 @@ mod test {
 
         buffered
             .sink_map_err(drop)
-            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -63,16 +63,18 @@ pub struct EncodedEvent<I> {
     pub item: I,
     pub finalizers: EventFinalizers,
     pub byte_size: usize,
+    pub json_byte_size: usize,
 }
 
 impl<I> EncodedEvent<I> {
     /// Create a trivial input with no metadata. This method will be
     /// removed when all sinks are converted.
-    pub fn new(item: I, byte_size: usize) -> Self {
+    pub fn new(item: I, byte_size: usize, json_byte_size: usize) -> Self {
         Self {
             item,
             finalizers: Default::default(),
             byte_size,
+            json_byte_size,
         }
     }
 
@@ -89,6 +91,7 @@ impl<I> EncodedEvent<I> {
             item: I::from(that.item),
             finalizers: that.finalizers,
             byte_size: that.byte_size,
+            json_byte_size: that.json_byte_size,
         }
     }
 
@@ -98,6 +101,7 @@ impl<I> EncodedEvent<I> {
             item: doit(self.item),
             finalizers: self.finalizers,
             byte_size: self.byte_size,
+            json_byte_size: self.json_byte_size,
         }
     }
 }

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -520,7 +520,7 @@ mod tests {
 
         let input = (0..20).map(|i| PartitionInnerBuffer::new(i, 0));
         sink.sink_map_err(drop)
-            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 

--- a/src/sinks/util/sink.rs
+++ b/src/sinks/util/sink.rs
@@ -426,7 +426,8 @@ where
             items,
             finalizers,
             count,
-            byte_size,
+            json_byte_size,
+            ..
         } = batch;
 
         let (tx, rx) = oneshot::channel();
@@ -449,7 +450,7 @@ where
                 finalizers.update_status(status);
                 match status {
                     EventStatus::Delivered => {
-                        events_sent.emit(CountByteSize(count, byte_size));
+                        events_sent.emit(CountByteSize(count, json_byte_size));
                         // TODO: Emit a BytesSent event here too
                     }
                     EventStatus::Rejected => {
@@ -621,6 +622,7 @@ mod tests {
             EncodedEvent {
                 item,
                 finalizers,
+                json_byte_size: 0,
                 byte_size: 0,
             }
         }
@@ -770,7 +772,7 @@ mod tests {
 
         buffered
             .sink_map_err(drop)
-            .send_all(&mut stream::iter(0..22).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(0..22).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 
@@ -806,7 +808,7 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert!(matches!(
-            buffered.start_send_unpin(EncodedEvent::new(0, 0)),
+            buffered.start_send_unpin(EncodedEvent::new(0, 0, 0)),
             Ok(())
         ));
         assert!(matches!(
@@ -814,7 +816,7 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert!(matches!(
-            buffered.start_send_unpin(EncodedEvent::new(1, 0)),
+            buffered.start_send_unpin(EncodedEvent::new(1, 0, 0)),
             Ok(())
         ));
 
@@ -845,7 +847,7 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert!(matches!(
-            buffered.start_send_unpin(EncodedEvent::new(0, 0)),
+            buffered.start_send_unpin(EncodedEvent::new(0, 0, 0)),
             Ok(())
         ));
         assert!(matches!(
@@ -853,7 +855,7 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert!(matches!(
-            buffered.start_send_unpin(EncodedEvent::new(1, 0)),
+            buffered.start_send_unpin(EncodedEvent::new(1, 0, 0)),
             Ok(())
         ));
 
@@ -887,7 +889,7 @@ mod tests {
         let sink = PartitionBatchSink::new(svc, VecBuffer::new(batch_settings.size), TIMEOUT);
 
         sink.sink_map_err(drop)
-            .send_all(&mut stream::iter(0..22).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(0..22).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 
@@ -920,7 +922,7 @@ mod tests {
 
         let input = vec![Partitions::A, Partitions::B];
         sink.sink_map_err(drop)
-            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 
@@ -947,7 +949,7 @@ mod tests {
 
         let input = vec![Partitions::A, Partitions::B, Partitions::A, Partitions::B];
         sink.sink_map_err(drop)
-            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 
@@ -984,7 +986,7 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert!(matches!(
-            sink.start_send_unpin(EncodedEvent::new(1, 0)),
+            sink.start_send_unpin(EncodedEvent::new(1, 0, 0)),
             Ok(())
         ));
         assert!(matches!(sink.poll_flush_unpin(&mut cx), Poll::Pending));
@@ -1024,6 +1026,7 @@ mod tests {
                 finalizers,
                 count: items,
                 byte_size: 1,
+                json_byte_size: 1,
             }
         };
 
@@ -1085,7 +1088,7 @@ mod tests {
 
         let input = (0..20).map(|i| (0, i)).chain((0..20).map(|i| (1, i)));
         sink.sink_map_err(drop)
-            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0))))
+            .send_all(&mut stream::iter(input).map(|item| Ok(EncodedEvent::new(item, 0, 0))))
             .await
             .unwrap();
 

--- a/src/sinks/util/socket_bytes_sink.rs
+++ b/src/sinks/util/socket_bytes_sink.rs
@@ -129,7 +129,7 @@ where
         let pinned = self.project();
         pinned.state.finalizers.push(item.finalizers);
         pinned.state.events_total += 1;
-        pinned.state.event_bytes += item.byte_size;
+        pinned.state.event_bytes += item.json_byte_size;
         pinned.state.bytes_total += item.item.len();
 
         let result = pinned.inner.start_send(item.item);

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -18,7 +18,7 @@ use tokio::{
 };
 use tokio_util::codec::Encoder;
 use vector_config::configurable_component;
-use vector_core::ByteSizeOf;
+use vector_core::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 
 use crate::{
     codecs::Transformer,
@@ -275,6 +275,8 @@ where
         let mut encoder = self.encoder.clone();
         let mut input = input.map(|mut event| {
             let byte_size = event.size_of();
+            let json_byte_size = event.estimated_json_encoded_size_of();
+
             let finalizers = event.metadata_mut().take_finalizers();
             self.transformer.transform(&mut event);
             let mut bytes = BytesMut::new();
@@ -286,9 +288,10 @@ where
                     item,
                     finalizers,
                     byte_size,
+                    json_byte_size,
                 }
             } else {
-                EncodedEvent::new(Bytes::new(), 0)
+                EncodedEvent::new(Bytes::new(), 0, 0)
             }
         });
 

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -7,7 +7,7 @@ use snafu::{ResultExt, Snafu};
 use tokio::{net::UnixStream, time::sleep};
 use tokio_util::codec::Encoder;
 use vector_config::configurable_component;
-use vector_core::ByteSizeOf;
+use vector_core::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 
 use crate::{
     codecs::Transformer,
@@ -151,6 +151,7 @@ where
         let mut input = input
             .map(|mut event| {
                 let byte_size = event.size_of();
+                let json_byte_size = event.estimated_json_encoded_size_of();
 
                 transformer.transform(&mut event);
 
@@ -164,9 +165,10 @@ where
                         item,
                         finalizers,
                         byte_size,
+                        json_byte_size,
                     }
                 } else {
-                    EncodedEvent::new(Bytes::new(), 0)
+                    EncodedEvent::new(Bytes::new(), 0, 0)
                 }
             })
             .peekable();

--- a/src/sinks/vector/service.rs
+++ b/src/sinks/vector/service.rs
@@ -104,7 +104,9 @@ impl Service<VectorRequest> for VectorService {
         let mut service = self.clone();
         let byte_size = list.request.encoded_len();
         let events_count = list.get_metadata().event_count();
-        let events_byte_size = list.get_metadata().events_byte_size();
+        let events_byte_size = list
+            .get_metadata()
+            .events_estimated_json_encoded_byte_size();
 
         let future = async move {
             service


### PR DESCRIPTION
This is a copy of #17465 but without the `JsonSize` wrapper. That PR introduced some performance regressions, so this is to see if the regressions are because of the wrapper, or because we are using the different metrics in various places.