### PR TITLE
chore: Remove links to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Vector**][docs.installation].
 
 * [**Community**][urls.vector_community] - [chat][urls.vector_chat], [calendar][urls.vector_calendar], [@vectordotdev][urls.vector_twitter]
 * [**Releases**][urls.vector_releases]
-* [**Roadmap**][urls.vector_roadmap] - [vote on new features][urls.vote_feature]
 * **Policies** - [Code of Conduct][urls.vector_code_of_conduct], [Privacy][urls.vector_privacy_policy], [Releases][urls.vector_releases_policy], [Security][urls.vector_security_policy], [Versioning][urls.vector_versioning_policy]
 
 ## Comparisons
@@ -221,7 +220,6 @@ Vector is an end-to-end, unified, open data platform.
 [urls.vector_release_policy]: https://github.com/vectordotdev/vector/blob/master/RELEASING.md
 [urls.vector_releases]: https://vector.dev/releases/
 [urls.vector_releases_policy]: https://github.com/vectordotdev/vector/blob/master/RELEASES.md
-[urls.vector_roadmap]: https://roadmap.vector.dev
 [urls.vector_security_policy]: https://github.com/vectordotdev/vector/security/policy
 [urls.vector_test_harness]: https://github.com/vectordotdev/vector-test-harness/
 [urls.vector_twitter]: https://twitter.com/vectordotdev

--- a/netlify.toml
+++ b/netlify.toml
@@ -53,12 +53,6 @@ status = 302
 force = true
 
 [[redirects]]
-from = "https://roadmap.vector.dev/*"
-to = "https://airtable.com/shriTZW5LeOE4cIyJ"
-status = 302
-force = true
-
-[[redirects]]
 from = "https://sh.vector.dev/*"
 to = "http://sh.vector.dev.s3-website-us-east-1.amazonaws.com/:splat"
 status = 200

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -586,7 +586,6 @@ urls: {
 	vector_remap_transform:                     "/docs/reference/configuration/transforms/remap/"
 	vector_remap_transform_multiple:            "/docs/reference/configuration/transforms/remap/#emitting-multiple-log-events"
 	vector_repo:                                "\(github)/vectordotdev/vector"
-	vector_roadmap:                             "https://roadmap.vector.dev"
 	vector_roles:                               "/docs/setup/deployment/roles"
 	vector_route_transform:                     "/docs/reference/configuration/transforms/route"
 	vector_rpm_source_files:                    "\(vector_repo)/tree/master/distribution/rpm"


### PR DESCRIPTION
Discovered by https://github.com/vectordotdev/vector/issues/17547#issuecomment-1570289321

We dropped the public roadmap as it seemed to be doing more harm than good as it proved not to be
terribly accurate as priorities shift.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
