### PR TITLE
chore(config): Update field labels for the rest of the sources and transforms fields

### DIFF
--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -41,7 +41,7 @@ impl NoProxyInterceptor {
 ///
 /// Configure to proxy traffic through an HTTP(S) proxy when making external requests.
 ///
-/// Similar to common proxy configuration convention, users can set different proxies
+/// Similar to common proxy configuration convention, you can set different proxies
 /// to use based on the type of traffic being proxied, as well as set specific hosts that
 /// should not be proxied.
 #[configurable_component]

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -66,6 +66,7 @@ pub struct Config {
     /// The maximum amount of time to wait for the next additional line, in milliseconds.
     ///
     /// Once this timeout is reached, the buffered message is guaranteed to be flushed, even if incomplete.
+    #[configurable(metadata(docs::human_name = "Timeout"))]
     pub timeout: Duration,
 }
 

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -66,7 +66,6 @@ pub struct Config {
     /// The maximum amount of time to wait for the next additional line, in milliseconds.
     ///
     /// Once this timeout is reached, the buffered message is guaranteed to be flushed, even if incomplete.
-    #[configurable(metadata(docs::human_name = "Timeout"))]
     pub timeout: Duration,
 }
 

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -45,6 +45,7 @@ pub struct AwsSqsConfig {
     #[serde(default = "default_poll_secs")]
     #[derivative(Default(value = "default_poll_secs()"))]
     #[configurable(metadata(docs::type_unit = "seconds"))]
+    #[configurable(metadata(docs::human_name = "Poll Wait Time"))]
     pub poll_secs: u32,
 
     /// The visibility timeout to use for messages, in seconds.

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -151,6 +151,7 @@ pub struct DockerLogsConfig {
     /// The amount of time to wait before retrying after an error.
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(default = "default_retry_backoff_secs")]
+    #[configurable(metadata(docs::human_name = "Retry Backoff"))]
     retry_backoff_secs: Duration,
 
     /// Multiline aggregation configuration.

--- a/src/sources/eventstoredb_metrics/mod.rs
+++ b/src/sources/eventstoredb_metrics/mod.rs
@@ -41,6 +41,7 @@ pub struct EventStoreDbConfig {
     /// The interval between scrapes, in seconds.
     #[serde(default = "default_scrape_interval_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     scrape_interval_secs: Duration,
 
     /// Overrides the default namespace for the metrics emitted by the source.

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -56,7 +56,7 @@ pub struct ExecConfig {
     #[configurable(derived)]
     pub streaming: Option<StreamingConfig>,
 
-    /// The command to be run, plus any arguments required.
+    /// The command to run, plus any arguments required.
     #[configurable(metadata(docs::examples = "echo", docs::examples = "Hello World!"))]
     pub command: Vec<String>,
 
@@ -119,6 +119,7 @@ pub struct StreamingConfig {
 
     /// The amount of time, in seconds, before rerunning a streaming command that exited.
     #[serde(default = "default_respawn_interval_secs")]
+    #[configurable(metadata(docs::human_name = "Respawn Interval"))]
     respawn_interval_secs: u64,
 }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -222,7 +222,7 @@ pub struct FileConfig {
     #[configurable(metadata(docs::examples = 0))]
     #[configurable(metadata(docs::examples = 5))]
     #[configurable(metadata(docs::examples = 60))]
-    #[configurable(metadata(docs::human_name = "Remove After"))]
+    #[configurable(metadata(docs::human_name = "Wait Time Before Removing File"))]
     pub remove_after_secs: Option<u64>,
 
     /// String sequence used to separate one file line from another.

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -214,7 +214,7 @@ pub struct FileConfig {
     #[serde(default)]
     pub oldest_first: bool,
 
-    /// Timeout, in seconds, from reaching `EOF` after which the file is removed from the filesystem, unless new data is written in the meantime.
+    /// After reaching EOF, the number of seconds to wait before removing the file, unless new data is written.
     ///
     /// If not specified, files are not removed.
     #[serde(alias = "remove_after", default)]

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -121,6 +121,7 @@ pub struct FileConfig {
     #[serde(alias = "ignore_older", default)]
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::examples = 600))]
+    #[configurable(metadata(docs::human_name = "Ignore Older Files"))]
     pub ignore_older_secs: Option<u64>,
 
     /// The maximum size of a line before it is discarded.
@@ -149,6 +150,7 @@ pub struct FileConfig {
     /// [global_data_dir]: https://vector.dev/docs/reference/configuration/global-options/#data_dir
     #[serde(default)]
     #[configurable(metadata(docs::examples = "/var/local/lib/vector/"))]
+    #[configurable(metadata(docs::human_name = "Data Directory"))]
     pub data_dir: Option<PathBuf>,
 
     /// Enables adding the file offset to each event and sets the name of the log field used.
@@ -160,7 +162,7 @@ pub struct FileConfig {
     #[configurable(metadata(docs::examples = "offset"))]
     pub offset_key: Option<OptionalValuePath>,
 
-    /// Delay between file discovery calls.
+    /// The delay between file discovery calls.
     ///
     /// This controls the interval at which files are searched. A higher value results in greater
     /// chances of some short-lived files being missed between searches, but a lower value increases
@@ -171,6 +173,7 @@ pub struct FileConfig {
     )]
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
     #[configurable(metadata(docs::type_unit = "milliseconds"))]
+    #[configurable(metadata(docs::human_name = "Glob Minimum Cooldown"))]
     pub glob_minimum_cooldown_ms: Duration,
 
     #[configurable(derived)]
@@ -211,7 +214,7 @@ pub struct FileConfig {
     #[serde(default)]
     pub oldest_first: bool,
 
-    /// Timeout from reaching `EOF` after which the file is removed from the filesystem, unless new data is written in the meantime.
+    /// Timeout, in seconds, from reaching `EOF` after which the file is removed from the filesystem, unless new data is written in the meantime.
     ///
     /// If not specified, files are not removed.
     #[serde(alias = "remove_after", default)]
@@ -219,6 +222,7 @@ pub struct FileConfig {
     #[configurable(metadata(docs::examples = 0))]
     #[configurable(metadata(docs::examples = 5))]
     #[configurable(metadata(docs::examples = 60))]
+    #[configurable(metadata(docs::human_name = "Remove After"))]
     pub remove_after_secs: Option<u64>,
 
     /// String sequence used to separate one file line from another.

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -38,6 +38,7 @@ pub struct FileDescriptorSourceConfig {
 
     /// The file descriptor number to read from.
     #[configurable(metadata(docs::examples = 10))]
+    #[configurable(metadata(docs::human_name = "File Descriptor Number"))]
     pub fd: u32,
 
     /// The namespace to use for logs. This overrides the global setting.

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -93,6 +93,7 @@ pub struct HostMetricsConfig {
     /// The interval between metric gathering, in seconds.
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(default = "default_scrape_interval")]
+    #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub scrape_interval_secs: Duration,
 
     /// The list of host metric collector services to use.
@@ -136,7 +137,7 @@ pub struct HostMetricsConfig {
 pub struct CGroupsConfig {
     /// The number of levels of the cgroups hierarchy for which to report metrics.
     ///
-    /// A value of `1` means just the root or named cgroup.
+    /// A value of `1` means the root or named cgroup.
     #[derivative(Default(value = "default_levels()"))]
     #[serde(default = "default_levels")]
     #[configurable(metadata(docs::examples = 1))]
@@ -157,6 +158,7 @@ pub struct CGroupsConfig {
     /// Base cgroup directory, for testing use only
     #[serde(skip_serializing)]
     #[configurable(metadata(docs::hidden))]
+    #[configurable(metadata(docs::human_name = "Base Directory"))]
     base_dir: Option<PathBuf>,
 }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -81,7 +81,7 @@ pub struct SimpleHttpConfig {
 
     /// The expected encoding of received data.
     ///
-    /// Note: For `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
+    /// For `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
     #[serde(default)]
     encoding: Option<Encoding>,
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -28,6 +28,7 @@ pub struct InternalMetricsConfig {
     /// The interval between metric gathering, in seconds.
     #[serde_as(as = "serde_with::DurationSeconds<f64>")]
     #[serde(default = "default_scrape_interval")]
+    #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub scrape_interval_secs: Duration,
 
     #[configurable(derived)]

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -152,6 +152,7 @@ pub struct JournaldConfig {
     /// permissions to this directory.
     #[serde(default)]
     #[configurable(metadata(docs::examples = "/var/lib/vector"))]
+    #[configurable(metadata(docs::human_name = "Data Directory"))]
     pub data_dir: Option<PathBuf>,
 
     /// The systemd journal is read in batches, and a checkpoint is set at the end of each batch.

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -143,6 +143,7 @@ pub struct Config {
     /// By default, the global `data_dir` option is used. Make sure the running user has write
     /// permissions to this directory.
     #[configurable(metadata(docs::examples = "/var/local/lib/vector/"))]
+    #[configurable(metadata(docs::human_name = "Data Directory"))]
     data_dir: Option<PathBuf>,
 
     #[configurable(derived)]
@@ -157,6 +158,7 @@ pub struct Config {
 
     /// A list of glob patterns to exclude from reading the files.
     #[configurable(metadata(docs::examples = "**/exclude/**"))]
+
     exclude_paths_glob_patterns: Vec<PathBuf>,
 
     #[configurable(derived)]
@@ -167,6 +169,7 @@ pub struct Config {
     #[serde(default)]
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::examples = 600))]
+    #[configurable(metadata(docs::human_name = "Ignore Older Files"))]
     ignore_older_secs: Option<u64>,
 
     /// Max amount of bytes to read from a single file before switching over
@@ -198,6 +201,7 @@ pub struct Config {
     /// in the underlying file server, so setting it too low may introduce
     /// a significant overhead.
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Glob Minimum Cooldown"))]
     glob_minimum_cooldown_ms: Duration,
 
     /// Overrides the name of the log field used to add the ingestion timestamp to each event.
@@ -229,6 +233,7 @@ pub struct Config {
     /// removed. If relevant metadata has been removed, the log is forwarded un-enriched and a
     /// warning is emitted.
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Delay Deletion"))]
     delay_deletion_ms: Duration,
 
     /// The namespace to use for logs. This overrides the global setting.

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -168,7 +168,7 @@ pub struct Config {
     #[serde(default)]
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::examples = 600))]
-    #[configurable(metadata(docs::human_name = "Ignore Older Files"))]
+    #[configurable(metadata(docs::human_name = "Ignore Files Older Than"))]
     ignore_older_secs: Option<u64>,
 
     /// Max amount of bytes to read from a single file before switching over

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -158,7 +158,6 @@ pub struct Config {
 
     /// A list of glob patterns to exclude from reading the files.
     #[configurable(metadata(docs::examples = "**/exclude/**"))]
-
     exclude_paths_glob_patterns: Vec<PathBuf>,
 
     #[configurable(derived)]

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -89,6 +89,7 @@ pub struct MongoDbMetricsConfig {
     /// The interval between scrapes, in seconds.
     #[serde(default = "default_scrape_interval_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     scrape_interval_secs: Duration,
 
     /// Overrides the default namespace for the metrics emitted by the source.

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -74,6 +74,7 @@ pub struct NginxMetricsConfig {
     /// The interval between scrapes.
     #[serde(default = "default_scrape_interval_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     scrape_interval_secs: Duration,
 
     /// Overrides the default namespace for the metrics emitted by the source.

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -159,6 +159,7 @@ pub struct PostgresqlMetricsConfig {
     /// The interval between scrapes.
     #[serde(default = "default_scrape_interval_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     scrape_interval_secs: Duration,
 
     /// Overrides the default namespace for the metrics emitted by the source.

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -33,6 +33,7 @@ pub struct TcpConfig {
     /// The timeout before a connection is forcefully closed during shutdown.
     #[serde(default = "default_shutdown_timeout_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Shutdown Timeout"))]
     shutdown_timeout_secs: Duration,
 
     /// Overrides the name of the log field used to add the peer host to each event.

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -74,7 +74,7 @@ pub struct SplunkConfig {
     #[configurable(deprecated = "This option has been deprecated, use `valid_tokens` instead.")]
     token: Option<SensitiveString>,
 
-    /// Optional list of valid authorization tokens.
+    /// A list of valid authorization tokens.
     ///
     /// If supplied, incoming requests must supply one of these tokens in the `Authorization` header, just as a client
     /// would if it was communicating with the Splunk HEC endpoint directly.

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -99,6 +99,7 @@ pub struct TcpConfig {
     /// The timeout before a connection is forcefully closed during shutdown.
     #[serde(default = "default_shutdown_timeout_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Shutdown Timeout"))]
     shutdown_timeout_secs: Duration,
 
     /// The size of the receive buffer used for each connection.

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -117,7 +117,7 @@ pub enum Mode {
 
         /// Unix file mode bits to be applied to the unix socket file as its designated file permissions.
         ///
-        /// Note: The file mode value can be specified in any numeric format supported by your configuration
+        /// The file mode value can be specified in any numeric format supported by your configuration
         /// language, but it is most intuitive to use an octal number.
         socket_file_mode: Option<u32>,
     },

--- a/src/sources/util/http/auth.rs
+++ b/src/sources/util/http/auth.rs
@@ -11,7 +11,7 @@ use warp::http::HeaderMap;
 ))]
 use super::error::ErrorMessage;
 
-/// HTTP Basic authentication configuration.
+/// HTTP basic authentication configuration.
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct HttpSourceAuthConfig {

--- a/src/sources/util/http/auth.rs
+++ b/src/sources/util/http/auth.rs
@@ -11,7 +11,7 @@ use warp::http::HeaderMap;
 ))]
 use super::error::ErrorMessage;
 
-/// HTTP basic authentication configuration.
+/// HTTP Basic authentication configuration.
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct HttpSourceAuthConfig {

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     SourceSender,
 };
 
-/// Marker type for the version two of the configuration for the `vector` source.
+/// Marker type for version two of the configuration for the `vector` source.
 #[configurable_component]
 #[derive(Clone, Debug)]
 enum VectorConfigVersion {

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -39,7 +39,7 @@ pub struct LuaConfigV1 {
     config: v1::LuaConfig,
 }
 
-/// Marker type for the version two of the configuration for the `lua` transform.
+/// Marker type for version two of the configuration for the `lua` transform.
 #[configurable_component]
 #[derive(Clone, Debug)]
 enum V2 {

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -21,7 +21,7 @@ enum BuildError {
     InvalidLua { source: mlua::Error },
 }
 
-/// Configuration for the version one of the `lua` transform.
+/// Configuration for version one of the `lua` transform.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -68,6 +68,7 @@ pub struct LuaConfig {
     /// If not specified, the modules are looked up in the configuration directories.
     #[serde(default = "default_config_paths")]
     #[configurable(metadata(docs::examples = "/etc/vector/lua"))]
+    #[configurable(metadata(docs::human_name = "Search Directories"))]
     search_dirs: Vec<PathBuf>,
 
     #[configurable(derived)]
@@ -156,6 +157,7 @@ struct HooksConfig {
 struct TimerConfig {
     /// The interval to execute the handler, in seconds.
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[configurable(metadata(docs::human_name = "Interval"))]
     interval_seconds: Duration,
 
     /// The handler function which is called when the timer ticks.

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -118,7 +118,7 @@ base: components: sinks: configuration: {
 
 			Configure to proxy traffic through an HTTP(S) proxy when making external requests.
 
-			Similar to common proxy configuration convention, users can set different proxies
+			Similar to common proxy configuration convention, you can set different proxies
 			to use based on the type of traffic being proxied, as well as set specific hosts that
 			should not be proxied.
 			"""

--- a/website/cue/reference/components/base/sources.cue
+++ b/website/cue/reference/components/base/sources.cue
@@ -6,7 +6,7 @@ base: components: sources: configuration: proxy: {
 
 		Configure to proxy traffic through an HTTP(S) proxy when making external requests.
 
-		Similar to common proxy configuration convention, users can set different proxies
+		Similar to common proxy configuration convention, you can set different proxies
 		to use based on the type of traffic being proxied, as well as set specific hosts that
 		should not be proxied.
 		"""

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -2,7 +2,7 @@ package metadata
 
 base: components: sources: exec: configuration: {
 	command: {
-		description: "The command to be run, plus any arguments required."
+		description: "The command to run, plus any arguments required."
 		required:    true
 		type: array: items: type: string: examples: ["echo", "Hello World!"]
 	}

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -144,7 +144,7 @@ base: components: sources: file: configuration: {
 	}
 	glob_minimum_cooldown_ms: {
 		description: """
-			Delay between file discovery calls.
+			The delay between file discovery calls.
 
 			This controls the interval at which files are searched. A higher value results in greater
 			chances of some short-lived files being missed between searches, but a lower value increases
@@ -336,7 +336,7 @@ base: components: sources: file: configuration: {
 	}
 	remove_after_secs: {
 		description: """
-			Timeout from reaching `EOF` after which the file is removed from the filesystem, unless new data is written in the meantime.
+			After reaching EOF, the number of seconds to wait before removing the file, unless new data is written.
 
 			If not specified, files are not removed.
 			"""

--- a/website/cue/reference/components/sources/base/host_metrics.cue
+++ b/website/cue/reference/components/sources/base/host_metrics.cue
@@ -54,7 +54,7 @@ base: components: sources: host_metrics: configuration: {
 				description: """
 					The number of levels of the cgroups hierarchy for which to report metrics.
 
-					A value of `1` means just the root or named cgroup.
+					A value of `1` means the root or named cgroup.
 					"""
 				required: false
 				type: uint: {

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -97,7 +97,7 @@ base: components: sources: http: configuration: {
 		description: """
 			The expected encoding of received data.
 
-			Note: For `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
+			For `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
 			"""
 		required: false
 		type: string: enum: {

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -97,7 +97,7 @@ base: components: sources: http_server: configuration: {
 		description: """
 			The expected encoding of received data.
 
-			Note: For `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
+			For `json` and `ndjson` encodings, the fields of the JSON objects are output as separate fields.
 			"""
 		required: false
 		type: string: enum: {

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -193,7 +193,7 @@ base: components: sources: splunk_hec: configuration: {
 	}
 	valid_tokens: {
 		description: """
-			Optional list of valid authorization tokens.
+			A list of valid authorization tokens.
 
 			If supplied, incoming requests must supply one of these tokens in the `Authorization` header, just as a client
 			would if it was communicating with the Splunk HEC endpoint directly.

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -87,7 +87,7 @@ base: components: sources: syslog: configuration: {
 		description: """
 			Unix file mode bits to be applied to the unix socket file as its designated file permissions.
 
-			Note: The file mode value can be specified in any numeric format supported by your configuration
+			The file mode value can be specified in any numeric format supported by your configuration
 			language, but it is most intuitive to use an octal number.
 			"""
 		relevant_when: "mode = \"unix\""

--- a/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/base/aws_ec2_metadata.cue
@@ -25,7 +25,7 @@ base: components: transforms: aws_ec2_metadata: configuration: {
 
 			Configure to proxy traffic through an HTTP(S) proxy when making external requests.
 
-			Similar to common proxy configuration convention, users can set different proxies
+			Similar to common proxy configuration convention, you can set different proxies
 			to use based on the type of traffic being proxied, as well as set specific hosts that
 			should not be proxied.
 			"""


### PR DESCRIPTION
This PR updates the rest of the sources and transforms' field labels that needs a human_name label. Related to https://github.com/vectordotdev/vector/pull/17517.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
