### PR TITLE
fix(http_client source): adapt int test to use breaking change of dep

### DIFF
--- a/scripts/integration/http-client/compose.yaml
+++ b/scripts/integration/http-client/compose.yaml
@@ -11,7 +11,7 @@ services:
     image: docker.io/sigoden/dufs:${CONFIG_VERSION}
     command:
     - -a
-    - /@user:pass
+    - "user:pass@/"
     - --auth-method
     - basic
     - /data

--- a/scripts/integration/http-client/test.yaml
+++ b/scripts/integration/http-client/test.yaml
@@ -9,4 +9,4 @@ env:
   DUFS_HTTPS_ADDRESS: https://dufs-https:5000
 
 matrix:
-  version: [latest]
+  version: ["v0.34.1"]


### PR DESCRIPTION
- `dufs` a dep of the integration test, had a breaking change to the auth syntax
- pegged the version to a specific release since this component isn't tied to a specific service