### PR TITLE
fix(codecs): Add lossy option to JSON deserializer

### DIFF
--- a/lib/codecs/src/decoding/format/mod.rs
+++ b/lib/codecs/src/decoding/format/mod.rs
@@ -14,7 +14,7 @@ mod syslog;
 use ::bytes::Bytes;
 use dyn_clone::DynClone;
 pub use gelf::{GelfDeserializer, GelfDeserializerConfig};
-pub use json::{JsonDeserializer, JsonDeserializerConfig};
+pub use json::{JsonDeserializer, JsonDeserializerConfig, JsonDeserializerOptions};
 pub use native::{NativeDeserializer, NativeDeserializerConfig};
 pub use native_json::{NativeJsonDeserializer, NativeJsonDeserializerConfig};
 use smallvec::SmallVec;

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -9,8 +9,9 @@ use bytes::{Bytes, BytesMut};
 pub use error::StreamDecodingError;
 pub use format::{
     BoxedDeserializer, BytesDeserializer, BytesDeserializerConfig, GelfDeserializer,
-    GelfDeserializerConfig, JsonDeserializer, JsonDeserializerConfig, NativeDeserializer,
-    NativeDeserializerConfig, NativeJsonDeserializer, NativeJsonDeserializerConfig,
+    GelfDeserializerConfig, JsonDeserializer, JsonDeserializerConfig, JsonDeserializerOptions,
+    NativeDeserializer, NativeDeserializerConfig, NativeJsonDeserializer,
+    NativeJsonDeserializerConfig,
 };
 #[cfg(feature = "syslog")]
 pub use format::{SyslogDeserializer, SyslogDeserializerConfig};
@@ -243,7 +244,11 @@ pub enum DeserializerConfig {
     /// Decodes the raw bytes as [JSON][json].
     ///
     /// [json]: https://www.json.org/
-    Json,
+    Json {
+        /// Options for the JSON deserializer.
+        #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
+        json: JsonDeserializerOptions,
+    },
 
     #[cfg(feature = "syslog")]
     /// Decodes the raw bytes as a Syslog message.
@@ -284,8 +289,8 @@ impl From<BytesDeserializerConfig> for DeserializerConfig {
 }
 
 impl From<JsonDeserializerConfig> for DeserializerConfig {
-    fn from(_: JsonDeserializerConfig) -> Self {
-        Self::Json
+    fn from(config: JsonDeserializerConfig) -> Self {
+        Self::Json { json: config.json }
     }
 }
 
@@ -307,7 +312,9 @@ impl DeserializerConfig {
     pub fn build(&self) -> Deserializer {
         match self {
             DeserializerConfig::Bytes => Deserializer::Bytes(BytesDeserializerConfig.build()),
-            DeserializerConfig::Json => Deserializer::Json(JsonDeserializerConfig.build()),
+            DeserializerConfig::Json { json } => {
+                Deserializer::Json(JsonDeserializerConfig::new_with_options(json.clone()).build())
+            }
             #[cfg(feature = "syslog")]
             DeserializerConfig::Syslog => {
                 Deserializer::Syslog(SyslogDeserializerConfig::default().build())
@@ -325,7 +332,7 @@ impl DeserializerConfig {
         match self {
             DeserializerConfig::Native => FramingConfig::LengthDelimited,
             DeserializerConfig::Bytes
-            | DeserializerConfig::Json
+            | DeserializerConfig::Json { .. }
             | DeserializerConfig::Gelf
             | DeserializerConfig::NativeJson => FramingConfig::NewlineDelimited {
                 newline_delimited: Default::default(),
@@ -341,7 +348,9 @@ impl DeserializerConfig {
     pub fn output_type(&self) -> DataType {
         match self {
             DeserializerConfig::Bytes => BytesDeserializerConfig.output_type(),
-            DeserializerConfig::Json => JsonDeserializerConfig.output_type(),
+            DeserializerConfig::Json { json } => {
+                JsonDeserializerConfig::new_with_options(json.clone()).output_type()
+            }
             #[cfg(feature = "syslog")]
             DeserializerConfig::Syslog => SyslogDeserializerConfig::default().output_type(),
             DeserializerConfig::Native => NativeDeserializerConfig.output_type(),
@@ -354,7 +363,10 @@ impl DeserializerConfig {
     pub fn schema_definition(&self, log_namespace: LogNamespace) -> schema::Definition {
         match self {
             DeserializerConfig::Bytes => BytesDeserializerConfig.schema_definition(log_namespace),
-            DeserializerConfig::Json => JsonDeserializerConfig.schema_definition(log_namespace),
+            DeserializerConfig::Json { json } => {
+                JsonDeserializerConfig::new_with_options(json.clone())
+                    .schema_definition(log_namespace)
+            }
             #[cfg(feature = "syslog")]
             DeserializerConfig::Syslog => {
                 SyslogDeserializerConfig::default().schema_definition(log_namespace)
@@ -371,12 +383,12 @@ impl DeserializerConfig {
     pub const fn content_type(&self, framer: &FramingConfig) -> &'static str {
         match (&self, framer) {
             (
-                DeserializerConfig::Json | DeserializerConfig::NativeJson,
+                DeserializerConfig::Json { .. } | DeserializerConfig::NativeJson,
                 FramingConfig::NewlineDelimited { .. },
             ) => "application/x-ndjson",
             (
                 DeserializerConfig::Gelf
-                | DeserializerConfig::Json
+                | DeserializerConfig::Json { .. }
                 | DeserializerConfig::NativeJson,
                 FramingConfig::CharacterDelimited {
                     character_delimited:
@@ -388,7 +400,7 @@ impl DeserializerConfig {
             ) => "application/json",
             (DeserializerConfig::Native, _) => "application/octet-stream",
             (
-                DeserializerConfig::Json
+                DeserializerConfig::Json { .. }
                 | DeserializerConfig::NativeJson
                 | DeserializerConfig::Bytes
                 | DeserializerConfig::Gelf,

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -141,7 +141,9 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         // "bytes" can be a top-level field and we aren't implicitly decoding everything into the
         // `message` field... but it's close enough for now.
         DeserializerConfig::Bytes => SerializerConfig::Text(TextSerializerConfig::default()),
-        DeserializerConfig::Json => SerializerConfig::Json(JsonSerializerConfig::default()),
+        DeserializerConfig::Json { .. } => {
+            SerializerConfig::Json(JsonSerializerConfig::default())
+        }
         // TODO: We need to create an Avro serializer because, certainly, for any source decoding
         // the data as Avro, we can't possibly send anything else without the source just
         // immediately barfing.
@@ -184,7 +186,9 @@ fn serializer_config_to_deserializer(config: &SerializerConfig) -> decoding::Des
         SerializerConfig::Avro { .. } => todo!(),
         SerializerConfig::Csv { .. } => todo!(),
         SerializerConfig::Gelf => DeserializerConfig::Gelf,
-        SerializerConfig::Json(_) => DeserializerConfig::Json,
+        SerializerConfig::Json(_) => DeserializerConfig::Json {
+            json: Default::default(),
+        },
         SerializerConfig::Logfmt => todo!(),
         SerializerConfig::Native => DeserializerConfig::Native,
         SerializerConfig::NativeJson => DeserializerConfig::NativeJson,

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1595,7 +1595,9 @@ fn test_config_outputs() {
         (
             "json / single output",
             TestCase {
-                decoding: DeserializerConfig::Json,
+                decoding: DeserializerConfig::Json {
+                    json: Default::default(),
+                },
                 multiple_outputs: false,
                 want: HashMap::from([(
                     None,
@@ -1620,7 +1622,9 @@ fn test_config_outputs() {
         (
             "json / multiple output",
             TestCase {
-                decoding: DeserializerConfig::Json,
+                decoding: DeserializerConfig::Json {
+                    json: Default::default(),
+                },
                 multiple_outputs: true,
                 want: HashMap::from([
                     (

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -235,7 +235,9 @@ impl ValidatableComponent for HttpClientConfig {
         let config = Self {
             endpoint: uri.to_string(),
             interval: Duration::from_secs(1),
-            decoding: DeserializerConfig::Json,
+            decoding: DeserializerConfig::Json {
+                json: Default::default(),
+            },
             ..Default::default()
         };
 

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -78,7 +78,9 @@ async fn json_decoding_newline_delimited() {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
         query: HashMap::new(),
-        decoding: DeserializerConfig::Json,
+        decoding: DeserializerConfig::Json {
+            json: Default::default(),
+        },
         framing: FramingConfig::NewlineDelimited {
             newline_delimited: NewlineDelimitedDecoderOptions::default(),
         },
@@ -108,7 +110,9 @@ async fn json_decoding_character_delimited() {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
         query: HashMap::new(),
-        decoding: DeserializerConfig::Json,
+        decoding: DeserializerConfig::Json {
+            json: Default::default(),
+        },
         framing: FramingConfig::CharacterDelimited {
             character_delimited: CharacterDelimitedDecoderOptions {
                 delimiter: b',',
@@ -146,7 +150,9 @@ async fn request_query_applied() {
                 vec!["val1".to_string(), "val2".to_string()],
             ),
         ]),
-        decoding: DeserializerConfig::Json,
+        decoding: DeserializerConfig::Json {
+            json: Default::default(),
+        },
         framing: default_framing_message_based(),
         headers: HashMap::new(),
         method: HttpMethod::Get,

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -256,7 +256,9 @@ impl_generate_config_from_default!(SimpleHttpConfig);
 impl ValidatableComponent for SimpleHttpConfig {
     fn validation_configuration() -> ValidationConfiguration {
         let config = Self {
-            decoding: Some(DeserializerConfig::Json),
+            decoding: Some(DeserializerConfig::Json {
+                json: Default::default(),
+            }),
             ..Default::default()
         };
 


### PR DESCRIPTION
Add `decoding.codec.json.lossy` option, as descried in https://github.com/vectordotdev/vector/issues/16406.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
