### PR TITLE
chore(enrichment): avoid importing vector-common in enrichment module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,7 +2904,6 @@ dependencies = [
  "arc-swap",
  "chrono",
  "dyn-clone",
- "vector-common",
  "vrl",
 ]
 

--- a/lib/enrichment/Cargo.toml
+++ b/lib/enrichment/Cargo.toml
@@ -7,7 +7,9 @@ publish = false
 
 [dependencies]
 arc-swap = { version = "1.6.0", default-features = false }
-dyn-clone = { version = "1.0.11", default-features = false }
 chrono = { version = "0.4.19", default-features = false }
-vector-common = { path = "../vector-common", default-features = false, features = [ "btreemap", "conversion", "serde" ] }
-vrl = { version = "0.4.0", default-features = false, features = ["diagnostic"] }
+dyn-clone = { version = "1.0.11", default-features = false }
+vrl = { version = "0.4.0", default-features = false, features = [
+  "compiler",
+  "diagnostic",
+] }

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -191,9 +191,9 @@ impl FunctionExpression for FindEnrichmentTableRecordsFn {
 
 #[cfg(test)]
 mod tests {
-    use vector_common::TimeZone;
     use vrl::compiler::state::RuntimeState;
     use vrl::compiler::TargetValue;
+    use vrl::compiler::TimeZone;
     use vrl::value;
     use vrl::value::Secrets;
 

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -183,7 +183,7 @@ impl FunctionExpression for GetEnrichmentTableRecordFn {
 
 #[cfg(test)]
 mod tests {
-    use vector_common::TimeZone;
+    use vrl::compiler::prelude::TimeZone;
     use vrl::compiler::state::RuntimeState;
     use vrl::compiler::TargetValue;
     use vrl::value;


### PR DESCRIPTION
We need to use enrichment tables in `vrl-wasm` and pulling vector-common is not needed so better not using it.
