### PR TITLE
fix(http_client source): remove utf8 lossy conversion

### DIFF
--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -307,8 +307,7 @@ impl http_client::HttpClientContext for HttpClientContext {
     fn on_response(&mut self, _url: &Uri, _header: &Parts, body: &Bytes) -> Option<Vec<Event>> {
         // get the body into a byte array
         let mut buf = BytesMut::new();
-        let body = String::from_utf8_lossy(body);
-        buf.extend_from_slice(body.as_bytes());
+        buf.extend_from_slice(body);
 
         let events = self.decode_events(&mut buf);
 


### PR DESCRIPTION
Fixes: https://github.com/vectordotdev/vector/issues/16814

This change is a now a no-op thanks to https://github.com/vectordotdev/vector/pull/17628 and https://github.com/vectordotdev/vector/pull/17688.
