### PR TITLE
chore(deps): Bump OpenSSL base version to 3.1.*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9579,7 +9579,6 @@ dependencies = [
  "opendal",
  "openssl",
  "openssl-probe",
- "openssl-src",
  "opentelemetry-proto",
  "ordered-float 3.7.0",
  "paste",
@@ -10684,3 +10683,8 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "openssl-sys"
+version = "0.9.88"
+source = "git+https://github.com/vectordotdev/rust-openssl.git?tag=openssl-sys-v0.9.88+3.0.0#c20d6c72fdc78e70b2a608719a261bc31002dab7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,11 +1853,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -5850,9 +5851,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.0+1.1.1t"
+version = "300.1.3+3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
 dependencies = [
  "cc",
 ]
@@ -5860,8 +5861,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys"
 version = "0.9.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+source = "git+https://github.com/vectordotdev/rust-openssl.git?tag=openssl-sys-v0.9.91+3.0.0#c3a8b494e0a8ab88db692c239d30c903353b56a3"
 dependencies = [
  "cc",
  "libc",
@@ -10683,8 +10683,3 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "openssl-sys"
-version = "0.9.88"
-source = "git+https://github.com/vectordotdev/rust-openssl.git?tag=openssl-sys-v0.9.88+3.0.0#c20d6c72fdc78e70b2a608719a261bc31002dab7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,8 +5852,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "openssl-src"
 version = "300.1.3+3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
+source = "git+https://github.com/vectordotdev/openssl-src-rs.git?tag=release-300-force-engine+3.1.2#98b1172bcef15358ad7bbf4baa3a3aa59d831e81"
 dependencies = [
  "cc",
 ]
@@ -9579,6 +9578,7 @@ dependencies = [
  "opendal",
  "openssl",
  "openssl-probe",
+ "openssl-src",
  "opentelemetry-proto",
  "ordered-float 3.7.0",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,7 @@ nix = { version = "0.26.2", default-features = false, features = ["socket", "sig
 [build-dependencies]
 prost-build = { version = "0.11", default-features = false, optional = true }
 tonic-build = { version = "0.9", default-features = false, features = ["transport", "prost"], optional = true }
+openssl-src = { version = "300", default-features = false, features = ["force-engine", "legacy"] }
 
 [dev-dependencies]
 approx = "0.5.1"
@@ -384,6 +385,7 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 # `openssl-src` at version 1.1.1*, but we want version 3.0.*. Bring in forked
 # version of that crate with the appropriate dependency patched in.
 openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl.git", tag = "openssl-sys-v0.9.91+3.0.0" }
+openssl-src = { git = "https://github.com/vectordotdev/openssl-src-rs.git", tag = "release-300-force-engine+3.1.2"}
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,7 +382,7 @@ nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/mus
 # unaligned access bug fixed in the following revision.
 ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e38e5f154e6011dc9b270da6" }
 # The current `openssl-sys` crate will vendor the OpenSSL sources via
-# `openssl-src` at version 1.1.1*, but we want version 3.0.*. Bring in forked
+# `openssl-src` at version 1.1.1*, but we want version 3.1.*. Bring in forked
 # version of that crate with the appropriate dependency patched in.
 openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl.git", tag = "openssl-sys-v0.9.91+3.0.0" }
 openssl-src = { git = "https://github.com/vectordotdev/openssl-src-rs.git", tag = "release-300-force-engine+3.1.2"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,7 +383,7 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 # The current `openssl-sys` crate will vendor the OpenSSL sources via
 # `openssl-src` at version 1.1.1*, but we want version 3.0.*. Bring in forked
 # version of that crate with the appropriate dependency patched in.
-openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl.git", tag = "openssl-sys-v0.9.88+3.0.0" }
+openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl.git", tag = "openssl-sys-v0.9.91+3.0.0" }
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,6 @@ nix = { version = "0.26.2", default-features = false, features = ["socket", "sig
 [build-dependencies]
 prost-build = { version = "0.11", default-features = false, optional = true }
 tonic-build = { version = "0.9", default-features = false, features = ["transport", "prost"], optional = true }
-openssl-src = { version = "111", default-features = false, features = ["force-engine"] }
 
 [dev-dependencies]
 approx = "0.5.1"
@@ -381,6 +380,10 @@ nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/mus
 # The `heim` crates depend on `ntapi` 0.3.7 on Windows, but that version has an
 # unaligned access bug fixed in the following revision.
 ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e38e5f154e6011dc9b270da6" }
+# The current `openssl-sys` crate will vendor the OpenSSL sources via
+# `openssl-src` at version 1.1.1*, but we want version 3.0.*. Bring in forked
+# version of that crate with the appropriate dependency patched in.
+openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl.git", tag = "openssl-sys-v0.9.88+3.0.0" }
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -630,6 +630,7 @@ mod test {
 
     #[test]
     fn from_options_pkcs12() {
+        let _provider = openssl::provider::Provider::try_load(None, "legacy", true).unwrap();
         let options = TlsConfig {
             crt_file: Some(TEST_PKCS12_PATH.into()),
             key_pass: Some("NOPASS".into()),

--- a/scripts/cross/bootstrap-centos.sh
+++ b/scripts/cross/bootstrap-centos.sh
@@ -3,5 +3,7 @@ set -o errexit
 
 yum install -y unzip centos-release-scl
 yum install -y llvm-toolset-7
+
+# needed to compile openssl
 yum install -y perl-IPC-Cmd
 

--- a/scripts/cross/bootstrap-centos.sh
+++ b/scripts/cross/bootstrap-centos.sh
@@ -3,3 +3,5 @@ set -o errexit
 
 yum install -y unzip centos-release-scl
 yum install -y llvm-toolset-7
+yum install -y perl-IPC-Cmd
+

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -7,8 +7,7 @@ apt-get update
 apt-get install -y \
   apt-transport-https \
   gnupg \
-  wget \
-  libipc-cmd-perl
+  wget 
 
 # we need LLVM >= 3.9 for onig_sys/bindgen
 

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -7,7 +7,8 @@ apt-get update
 apt-get install -y \
   apt-transport-https \
   gnupg \
-  wget
+  wget \
+  libipc-cmd-perl
 
 # we need LLVM >= 3.9 for onig_sys/bindgen
 

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -7,7 +7,7 @@ apt-get update
 apt-get install -y \
   apt-transport-https \
   gnupg \
-  wget 
+  wget
 
 # we need LLVM >= 3.9 for onig_sys/bindgen
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -544,7 +544,7 @@ pub fn init_logging(color: bool, format: LogFormat, log_level: &str, rate: u64) 
     info!(message = "Log level is enabled.", level = ?level);
 }
 
-/// Loads the legacy OpenSSL provider.
+/// Load the legacy OpenSSL provider.
 ///
 /// The returned [Provider] must stay in scope for the entire lifetime of the application, as it
 /// will be unloaded when it is dropped.

--- a/src/app.rs
+++ b/src/app.rs
@@ -549,6 +549,7 @@ pub fn init_logging(color: bool, format: LogFormat, log_level: &str, rate: u64) 
 /// The returned [Provider] must stay in scope for the entire lifetime of the application, as it
 /// will be unloaded when it is dropped.
 pub fn load_openssl_legacy_provider() -> Option<Provider> {
+    warn!(message = "DEPRECATED The openssl legacy provider provides algorithms and key sizes no longer recommended for use.");
     Provider::try_load(None, "legacy", true)
         .map(|provider| {
             info!(message = "Loaded openssl legacy provider.");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,7 +195,7 @@ pub struct RootOpts {
     )]
     pub allocation_tracing_reporting_interval_ms: u64,
 
-    /// Enable the OpenSSL legacy provider.
+    /// Load the OpenSSL legacy provider.
     #[arg(long, env = "VECTOR_OPENSSL_LEGACY_PROVIDER", default_value = "false")]
     pub openssl_legacy_provider: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,6 +194,10 @@ pub struct RootOpts {
         default_value = "5000"
     )]
     pub allocation_tracing_reporting_interval_ms: u64,
+
+    /// Enable the OpenSSL legacy provider.
+    #[arg(long, env = "VECTOR_OPENSSL_LEGACY_PROVIDER", default_value = "false")]
+    pub openssl_legacy_provider: bool,
 }
 
 impl RootOpts {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,7 +196,7 @@ pub struct RootOpts {
     pub allocation_tracing_reporting_interval_ms: u64,
 
     /// Load the OpenSSL legacy provider.
-    #[arg(long, env = "VECTOR_OPENSSL_LEGACY_PROVIDER", default_value = "false")]
+    #[arg(long, env = "VECTOR_OPENSSL_LEGACY_PROVIDER", default_value = "true")]
     pub openssl_legacy_provider: bool,
 }
 


### PR DESCRIPTION
Vector currently vendors the OpenSSL library. Since the current vendored sources in `openssl-src` are pinned at version 1.1.1* by `openssl-sys`, this change pulls in a fork of that crate that pins the sources to version 3.1.*. This will move all uses of OpenSSL in Vector over to version 3.1.

For backwards compatibility, the "legacy" provider is loaded when the `VECTOR_OPENSSL_LEGACY_PROVIDER` environment variable is set or the `--openssl-legacy-provider` cli arg is provided. This is similar to what[ Node.js does](https://nodejs.org/en/blog/release/v17.0.0).

We have confirmed that this successfully cross compiles.