### PR TITLE
chore(deps): Drop use of `hashlink` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3615,16 +3615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0761a1b9491c4f2e3d66aa0f62d0fba0af9a0e2852e4d48ea506632a4b56e6aa"
-dependencies = [
- "hashbrown 0.13.2",
- "serde",
-]
-
-[[package]]
 name = "hdrhistogram"
 version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9071,8 +9061,8 @@ dependencies = [
  "directories 5.0.1",
  "dunce",
  "glob",
- "hashlink",
  "hex",
+ "indexmap",
  "indicatif",
  "itertools",
  "log",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -20,8 +20,8 @@ directories = "5.0.1"
 # remove this when stabilized https://doc.rust-lang.org/stable/std/path/fn.absolute.html
 dunce = "1.0.4"
 glob = { version = "0.3.1", default-features = false }
-hashlink = { version = "0.8.2", features = ["serde_impl"] }
 hex = "0.4.3"
+indexmap = { version = "1.9", default-features = false, features = ["serde"] }
 indicatif = { version = "0.17.5", features = ["improved_unicode"] }
 itertools = "0.10.5"
 log = "0.4.18"

--- a/vdev/src/testing/config.rs
+++ b/vdev/src/testing/config.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use anyhow::{bail, Context, Result};
-use hashlink::LinkedHashMap;
+use indexmap::IndexMap;
 use itertools::{self, Itertools};
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
@@ -98,7 +98,7 @@ pub struct IntegrationTestConfig {
     #[serde(default)]
     pub env: Environment,
     /// The matrix of environment configurations values.
-    matrix: LinkedHashMap<String, Vec<String>>,
+    matrix: IndexMap<String, Vec<String>>,
     /// Configuration specific to the compose services.
     #[serde(default)]
     pub runner: IntegrationRunnerConfig,
@@ -140,7 +140,7 @@ impl IntegrationTestConfig {
         Ok(config)
     }
 
-    pub fn environments(&self) -> LinkedHashMap<String, Environment> {
+    pub fn environments(&self) -> IndexMap<String, Environment> {
         self.matrix
             .values()
             .multi_cartesian_product()


### PR DESCRIPTION
The version bump to `hashlink` is causing an issue for licensing, and we more commonly use the equivalent `indexmap` crate already, so just move the usage in `vdev` to that crate.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
