### PR TITLE
feat(codecs): add lossy option to `gelf`, `native_json`, and `syslog` deserializers

### DIFF
--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -1,9 +1,11 @@
 use bytes::Bytes;
 use chrono::{DateTime, NaiveDateTime, Utc};
+use derivative::Derivative;
 use lookup::{event_path, owned_value_path, PathPrefix};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use std::collections::HashMap;
+use vector_config::configurable_component;
 use vector_core::config::LogNamespace;
 use vector_core::{
     config::{log_schema, DataType},
@@ -14,7 +16,7 @@ use vector_core::{
 use vrl::value::kind::Collection;
 use vrl::value::{Kind, Value};
 
-use super::Deserializer;
+use super::{default_lossy, Deserializer};
 use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
 /// On GELF decoding behavior:
@@ -25,12 +27,26 @@ use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
 /// Config used to build a `GelfDeserializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct GelfDeserializerConfig;
+pub struct GelfDeserializerConfig {
+    #[serde(
+        default,
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
+    /// GELF-specific decoding options.
+    pub gelf: GelfDeserializerOptions,
+}
 
 impl GelfDeserializerConfig {
+    /// Creates a new `GelfDeserializerConfig`.
+    pub fn new(options: GelfDeserializerOptions) -> Self {
+        Self { gelf: options }
+    }
+
     /// Build the `GelfDeserializer` from this configuration.
     pub fn build(&self) -> GelfDeserializer {
-        GelfDeserializer::default()
+        GelfDeserializer {
+            lossy: self.gelf.lossy,
+        }
     }
 
     /// Return the type of event built by this deserializer.
@@ -60,21 +76,36 @@ impl GelfDeserializerConfig {
     }
 }
 
-/// Deserializer that builds an `Event` from a byte frame containing a GELF log
-/// message.
-#[derive(Debug, Clone)]
-pub struct GelfDeserializer;
+/// GELF-specific decoding options.
+#[configurable_component]
+#[derive(Debug, Clone, PartialEq, Eq, Derivative)]
+#[derivative(Default)]
+pub struct GelfDeserializerOptions {
+    /// Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+    ///
+    /// When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+    ///
+    /// [U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+    #[serde(
+        default = "default_lossy",
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
+    #[derivative(Default(value = "default_lossy()"))]
+    pub lossy: bool,
+}
 
-impl Default for GelfDeserializer {
-    fn default() -> Self {
-        Self::new()
-    }
+/// Deserializer that builds an `Event` from a byte frame containing a GELF log message.
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Default)]
+pub struct GelfDeserializer {
+    #[derivative(Default(value = "default_lossy()"))]
+    lossy: bool,
 }
 
 impl GelfDeserializer {
-    /// Create a new GelfDeserializer
-    pub fn new() -> GelfDeserializer {
-        GelfDeserializer
+    /// Create a new `GelfDeserializer`.
+    pub fn new(lossy: bool) -> GelfDeserializer {
+        GelfDeserializer { lossy }
     }
 
     /// Builds a LogEvent from the parsed GelfMessage.
@@ -195,10 +226,10 @@ impl Deserializer for GelfDeserializer {
         bytes: Bytes,
         _log_namespace: LogNamespace,
     ) -> vector_common::Result<SmallVec<[Event; 1]>> {
-        let line = std::str::from_utf8(&bytes)?;
-        let line = line.trim();
-
-        let parsed: GelfMessage = serde_json::from_str(line)?;
+        let parsed: GelfMessage = match self.lossy {
+            true => serde_json::from_str(&String::from_utf8_lossy(&bytes)),
+            false => serde_json::from_slice(&bytes),
+        }?;
         let event = self.message_to_event(&parsed)?;
 
         Ok(smallvec![event])
@@ -220,7 +251,7 @@ mod tests {
     fn deserialize_gelf_input(
         input: &serde_json::Value,
     ) -> vector_common::Result<SmallVec<[Event; 1]>> {
-        let config = GelfDeserializerConfig;
+        let config = GelfDeserializerConfig::default();
         let deserializer = config.build();
         let buffer = Bytes::from(serde_json::to_vec(&input).unwrap());
         deserializer.parse(buffer, LogNamespace::Legacy)

--- a/lib/codecs/src/decoding/format/mod.rs
+++ b/lib/codecs/src/decoding/format/mod.rs
@@ -13,17 +13,19 @@ mod syslog;
 
 use ::bytes::Bytes;
 use dyn_clone::DynClone;
-pub use gelf::{GelfDeserializer, GelfDeserializerConfig};
+pub use gelf::{GelfDeserializer, GelfDeserializerConfig, GelfDeserializerOptions};
 pub use json::{JsonDeserializer, JsonDeserializerConfig, JsonDeserializerOptions};
 pub use native::{NativeDeserializer, NativeDeserializerConfig};
-pub use native_json::{NativeJsonDeserializer, NativeJsonDeserializerConfig};
+pub use native_json::{
+    NativeJsonDeserializer, NativeJsonDeserializerConfig, NativeJsonDeserializerOptions,
+};
 use smallvec::SmallVec;
+#[cfg(feature = "syslog")]
+pub use syslog::{SyslogDeserializer, SyslogDeserializerConfig, SyslogDeserializerOptions};
 use vector_core::config::LogNamespace;
 use vector_core::event::Event;
 
 pub use self::bytes::{BytesDeserializer, BytesDeserializerConfig};
-#[cfg(feature = "syslog")]
-pub use self::syslog::{SyslogDeserializer, SyslogDeserializerConfig};
 
 /// Parse structured events from bytes.
 pub trait Deserializer: DynClone + Send + Sync {
@@ -44,3 +46,8 @@ dyn_clone::clone_trait_object!(Deserializer);
 
 /// A `Box` containing a `Deserializer`.
 pub type BoxedDeserializer = Box<dyn Deserializer>;
+
+/// Default value for the UTF-8 lossy option.
+const fn default_lossy() -> bool {
+    true
+}

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -1,11 +1,14 @@
 use bytes::Bytes;
 use chrono::{DateTime, Datelike, Utc};
+use derivative::Derivative;
 use lookup::lookup_v2::parse_value_path;
 use lookup::{event_path, owned_value_path, OwnedTargetPath, OwnedValuePath, PathPrefix};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use syslog_loose::{IncompleteDate, Message, ProcId, Protocol};
+use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 use vector_core::{
     config::{log_schema, DataType},
@@ -14,25 +17,39 @@ use vector_core::{
 };
 use vrl::value::{kind::Collection, Kind};
 
-use super::Deserializer;
+use super::{default_lossy, Deserializer};
 
 /// Config used to build a `SyslogDeserializer`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct SyslogDeserializerConfig {
     source: Option<&'static str>,
+    /// Syslog-specific decoding options.
+    pub syslog: SyslogDeserializerOptions,
 }
 
 impl SyslogDeserializerConfig {
+    /// Creates a new `SyslogDeserializerConfig`.
+    pub fn new(options: SyslogDeserializerOptions) -> Self {
+        Self {
+            source: None,
+            syslog: options,
+        }
+    }
+
     /// Create the `SyslogDeserializer` from the given source name.
     pub fn from_source(source: &'static str) -> Self {
         Self {
             source: Some(source),
+            ..Default::default()
         }
     }
 
     /// Build the `SyslogDeserializer` from this configuration.
     pub const fn build(&self) -> SyslogDeserializer {
-        SyslogDeserializer { source: None }
+        SyslogDeserializer {
+            source: self.source,
+            lossy: self.syslog.lossy,
+        }
     }
 
     /// Return the type of event build by this deserializer.
@@ -218,14 +235,35 @@ impl SyslogDeserializerConfig {
     }
 }
 
+/// Syslog-specific decoding options.
+#[configurable_component]
+#[derive(Debug, Clone, PartialEq, Eq, Derivative)]
+#[derivative(Default)]
+pub struct SyslogDeserializerOptions {
+    /// Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+    ///
+    /// When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+    ///
+    /// [U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+    #[serde(
+        default = "default_lossy",
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
+    #[derivative(Default(value = "default_lossy()"))]
+    pub lossy: bool,
+}
+
 /// Deserializer that builds an `Event` from a byte frame containing a syslog
 /// message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Default)]
 pub struct SyslogDeserializer {
     /// The syslog source needs it's own syslog deserializer separate from the
     /// syslog codec since it needs to handle the structured of the decoded data
     /// differently when using the Vector lognamespace.
     pub source: Option<&'static str>,
+    #[derivative(Default(value = "default_lossy()"))]
+    lossy: bool,
 }
 
 impl Deserializer for SyslogDeserializer {
@@ -234,7 +272,10 @@ impl Deserializer for SyslogDeserializer {
         bytes: Bytes,
         log_namespace: LogNamespace,
     ) -> vector_common::Result<SmallVec<[Event; 1]>> {
-        let line = std::str::from_utf8(&bytes)?;
+        let line: Cow<str> = match self.lossy {
+            true => String::from_utf8_lossy(&bytes),
+            false => Cow::from(std::str::from_utf8(&bytes)?),
+        };
         let line = line.trim();
         let parsed = syslog_loose::parse_message_with_year_exact(line, resolve_year)?;
 
@@ -449,7 +490,7 @@ mod tests {
 
         let input =
             Bytes::from("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - MSG");
-        let deserializer = SyslogDeserializer { source: None };
+        let deserializer = SyslogDeserializer::default();
 
         let events = deserializer.parse(input, LogNamespace::Legacy).unwrap();
         assert_eq!(events.len(), 1);
@@ -465,7 +506,7 @@ mod tests {
 
         let input =
             Bytes::from("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - MSG");
-        let deserializer = SyslogDeserializer { source: None };
+        let deserializer = SyslogDeserializer::default();
 
         let events = deserializer.parse(input, LogNamespace::Vector).unwrap();
         assert_eq!(events.len(), 1);

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -9,12 +9,12 @@ use bytes::{Bytes, BytesMut};
 pub use error::StreamDecodingError;
 pub use format::{
     BoxedDeserializer, BytesDeserializer, BytesDeserializerConfig, GelfDeserializer,
-    GelfDeserializerConfig, JsonDeserializer, JsonDeserializerConfig, JsonDeserializerOptions,
-    NativeDeserializer, NativeDeserializerConfig, NativeJsonDeserializer,
-    NativeJsonDeserializerConfig,
+    GelfDeserializerConfig, GelfDeserializerOptions, JsonDeserializer, JsonDeserializerConfig,
+    JsonDeserializerOptions, NativeDeserializer, NativeDeserializerConfig, NativeJsonDeserializer,
+    NativeJsonDeserializerConfig, NativeJsonDeserializerOptions,
 };
 #[cfg(feature = "syslog")]
-pub use format::{SyslogDeserializer, SyslogDeserializerConfig};
+pub use format::{SyslogDeserializer, SyslogDeserializerConfig, SyslogDeserializerOptions};
 pub use framing::{
     BoxedFramer, BoxedFramingError, BytesDecoder, BytesDecoderConfig, CharacterDelimitedDecoder,
     CharacterDelimitedDecoderConfig, CharacterDelimitedDecoderOptions, FramingError,
@@ -245,7 +245,7 @@ pub enum DeserializerConfig {
     ///
     /// [json]: https://www.json.org/
     Json {
-        /// Options for the JSON deserializer.
+        /// JSON-specific decoding options.
         #[serde(
             default,
             skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
@@ -261,7 +261,14 @@ pub enum DeserializerConfig {
     ///
     /// [rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
     /// [rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
-    Syslog,
+    Syslog {
+        /// Syslog-specific decoding options.
+        #[serde(
+            default,
+            skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        )]
+        syslog: SyslogDeserializerOptions,
+    },
 
     /// Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
     ///
@@ -277,12 +284,26 @@ pub enum DeserializerConfig {
     ///
     /// [vector_native_json]: https://github.com/vectordotdev/vector/blob/master/lib/codecs/tests/data/native_encoding/schema.cue
     /// [experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
-    NativeJson,
+    NativeJson {
+        /// Vector's native JSON-specific decoding options.
+        #[serde(
+            default,
+            skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        )]
+        native_json: NativeJsonDeserializerOptions,
+    },
 
     /// Decodes the raw bytes as a [GELF][gelf] message.
     ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
-    Gelf,
+    Gelf {
+        /// Gelf-specific decoding options.
+        #[serde(
+            default,
+            skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        )]
+        gelf: GelfDeserializerOptions,
+    },
 }
 
 impl From<BytesDeserializerConfig> for DeserializerConfig {
@@ -299,14 +320,16 @@ impl From<JsonDeserializerConfig> for DeserializerConfig {
 
 #[cfg(feature = "syslog")]
 impl From<SyslogDeserializerConfig> for DeserializerConfig {
-    fn from(_: SyslogDeserializerConfig) -> Self {
-        Self::Syslog
+    fn from(config: SyslogDeserializerConfig) -> Self {
+        Self::Syslog {
+            syslog: config.syslog,
+        }
     }
 }
 
 impl From<GelfDeserializerConfig> for DeserializerConfig {
-    fn from(_: GelfDeserializerConfig) -> Self {
-        Self::Gelf
+    fn from(config: GelfDeserializerConfig) -> Self {
+        Self::Gelf { gelf: config.gelf }
     }
 }
 
@@ -319,14 +342,16 @@ impl DeserializerConfig {
                 Deserializer::Json(JsonDeserializerConfig::new(json.clone()).build())
             }
             #[cfg(feature = "syslog")]
-            DeserializerConfig::Syslog => {
-                Deserializer::Syslog(SyslogDeserializerConfig::default().build())
+            DeserializerConfig::Syslog { syslog } => {
+                Deserializer::Syslog(SyslogDeserializerConfig::new(syslog.clone()).build())
             }
             DeserializerConfig::Native => Deserializer::Native(NativeDeserializerConfig.build()),
-            DeserializerConfig::NativeJson => {
-                Deserializer::NativeJson(NativeJsonDeserializerConfig.build())
+            DeserializerConfig::NativeJson { native_json } => Deserializer::NativeJson(
+                NativeJsonDeserializerConfig::new(native_json.clone()).build(),
+            ),
+            DeserializerConfig::Gelf { gelf } => {
+                Deserializer::Gelf(GelfDeserializerConfig::new(gelf.clone()).build())
             }
-            DeserializerConfig::Gelf => Deserializer::Gelf(GelfDeserializerConfig.build()),
         }
     }
 
@@ -336,12 +361,12 @@ impl DeserializerConfig {
             DeserializerConfig::Native => FramingConfig::LengthDelimited,
             DeserializerConfig::Bytes
             | DeserializerConfig::Json { .. }
-            | DeserializerConfig::Gelf
-            | DeserializerConfig::NativeJson => FramingConfig::NewlineDelimited {
+            | DeserializerConfig::Gelf { .. }
+            | DeserializerConfig::NativeJson { .. } => FramingConfig::NewlineDelimited {
                 newline_delimited: Default::default(),
             },
             #[cfg(feature = "syslog")]
-            DeserializerConfig::Syslog => FramingConfig::NewlineDelimited {
+            DeserializerConfig::Syslog { .. } => FramingConfig::NewlineDelimited {
                 newline_delimited: Default::default(),
             },
         }
@@ -355,10 +380,16 @@ impl DeserializerConfig {
                 JsonDeserializerConfig::new(json.clone()).output_type()
             }
             #[cfg(feature = "syslog")]
-            DeserializerConfig::Syslog => SyslogDeserializerConfig::default().output_type(),
+            DeserializerConfig::Syslog { syslog } => {
+                SyslogDeserializerConfig::new(syslog.clone()).output_type()
+            }
             DeserializerConfig::Native => NativeDeserializerConfig.output_type(),
-            DeserializerConfig::NativeJson => NativeJsonDeserializerConfig.output_type(),
-            DeserializerConfig::Gelf => GelfDeserializerConfig.output_type(),
+            DeserializerConfig::NativeJson { native_json } => {
+                NativeJsonDeserializerConfig::new(native_json.clone()).output_type()
+            }
+            DeserializerConfig::Gelf { gelf } => {
+                GelfDeserializerConfig::new(gelf.clone()).output_type()
+            }
         }
     }
 
@@ -370,14 +401,17 @@ impl DeserializerConfig {
                 JsonDeserializerConfig::new(json.clone()).schema_definition(log_namespace)
             }
             #[cfg(feature = "syslog")]
-            DeserializerConfig::Syslog => {
-                SyslogDeserializerConfig::default().schema_definition(log_namespace)
+            DeserializerConfig::Syslog { syslog } => {
+                SyslogDeserializerConfig::new(syslog.clone()).schema_definition(log_namespace)
             }
             DeserializerConfig::Native => NativeDeserializerConfig.schema_definition(log_namespace),
-            DeserializerConfig::NativeJson => {
-                NativeJsonDeserializerConfig.schema_definition(log_namespace)
+            DeserializerConfig::NativeJson { native_json } => {
+                NativeJsonDeserializerConfig::new(native_json.clone())
+                    .schema_definition(log_namespace)
             }
-            DeserializerConfig::Gelf => GelfDeserializerConfig.schema_definition(log_namespace),
+            DeserializerConfig::Gelf { gelf } => {
+                GelfDeserializerConfig::new(gelf.clone()).schema_definition(log_namespace)
+            }
         }
     }
 
@@ -385,13 +419,13 @@ impl DeserializerConfig {
     pub const fn content_type(&self, framer: &FramingConfig) -> &'static str {
         match (&self, framer) {
             (
-                DeserializerConfig::Json { .. } | DeserializerConfig::NativeJson,
+                DeserializerConfig::Json { .. } | DeserializerConfig::NativeJson { .. },
                 FramingConfig::NewlineDelimited { .. },
             ) => "application/x-ndjson",
             (
-                DeserializerConfig::Gelf
+                DeserializerConfig::Gelf { .. }
                 | DeserializerConfig::Json { .. }
-                | DeserializerConfig::NativeJson,
+                | DeserializerConfig::NativeJson { .. },
                 FramingConfig::CharacterDelimited {
                     character_delimited:
                         CharacterDelimitedDecoderOptions {
@@ -403,13 +437,13 @@ impl DeserializerConfig {
             (DeserializerConfig::Native, _) => "application/octet-stream",
             (
                 DeserializerConfig::Json { .. }
-                | DeserializerConfig::NativeJson
+                | DeserializerConfig::NativeJson { .. }
                 | DeserializerConfig::Bytes
-                | DeserializerConfig::Gelf,
+                | DeserializerConfig::Gelf { .. },
                 _,
             ) => "text/plain",
             #[cfg(feature = "syslog")]
-            (DeserializerConfig::Syslog, _) => "text/plain",
+            (DeserializerConfig::Syslog { .. }, _) => "text/plain",
         }
     }
 }

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -297,7 +297,7 @@ pub enum DeserializerConfig {
     ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
     Gelf {
-        /// Gelf-specific decoding options.
+        /// GELF-specific decoding options.
         #[serde(
             default,
             skip_serializing_if = "vector_core::serde::skip_serializing_if_default"

--- a/lib/codecs/tests/native.rs
+++ b/lib/codecs/tests/native.rs
@@ -27,7 +27,7 @@ fn roundtrip_current_native_json_fixtures() {
     roundtrip_fixtures(
         "json",
         "",
-        &NativeJsonDeserializerConfig.build(),
+        &NativeJsonDeserializerConfig::default().build(),
         &mut NativeJsonSerializerConfig.build(),
         false,
     );
@@ -51,7 +51,7 @@ fn reserialize_pre_v24_native_json_fixtures() {
     roundtrip_fixtures(
         "json",
         "pre-v24",
-        &NativeJsonDeserializerConfig.build(),
+        &NativeJsonDeserializerConfig::default().build(),
         &mut NativeJsonSerializerConfig.build(),
         true,
     );
@@ -100,7 +100,7 @@ fn pre_v24_native_decoding_matches() {
 fn rebuild_json_fixtures() {
     rebuild_fixtures(
         "json",
-        &NativeJsonDeserializerConfig.build(),
+        &NativeJsonDeserializerConfig::default().build(),
         &mut NativeJsonSerializerConfig.build(),
     );
 }
@@ -134,7 +134,7 @@ fn fixtures_match(suffix: &str) {
 /// This test ensures we can load the serialized binaries binary and that they match across
 /// protocols.
 fn decoding_matches(suffix: &str) {
-    let json_deserializer = NativeJsonDeserializerConfig.build();
+    let json_deserializer = NativeJsonDeserializerConfig::default().build();
     let proto_deserializer = NativeDeserializerConfig.build();
 
     let json_entries = list_fixtures("json", suffix);

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -146,10 +146,10 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         // the data as Avro, we can't possibly send anything else without the source just
         // immediately barfing.
         #[cfg(feature = "sources-syslog")]
-        DeserializerConfig::Syslog => SerializerConfig::Logfmt,
+        DeserializerConfig::Syslog { .. } => SerializerConfig::Logfmt,
         DeserializerConfig::Native => SerializerConfig::Native,
-        DeserializerConfig::NativeJson => SerializerConfig::NativeJson,
-        DeserializerConfig::Gelf => SerializerConfig::Gelf,
+        DeserializerConfig::NativeJson { .. } => SerializerConfig::NativeJson,
+        DeserializerConfig::Gelf { .. } => SerializerConfig::Gelf,
     };
 
     serializer_config
@@ -183,13 +183,17 @@ fn serializer_config_to_deserializer(config: &SerializerConfig) -> decoding::Des
     let deserializer_config = match config {
         SerializerConfig::Avro { .. } => todo!(),
         SerializerConfig::Csv { .. } => todo!(),
-        SerializerConfig::Gelf => DeserializerConfig::Gelf,
+        SerializerConfig::Gelf => DeserializerConfig::Gelf {
+            gelf: Default::default(),
+        },
         SerializerConfig::Json(_) => DeserializerConfig::Json {
             json: Default::default(),
         },
         SerializerConfig::Logfmt => todo!(),
         SerializerConfig::Native => DeserializerConfig::Native,
-        SerializerConfig::NativeJson => DeserializerConfig::NativeJson,
+        SerializerConfig::NativeJson => DeserializerConfig::NativeJson {
+            native_json: Default::default(),
+        },
         SerializerConfig::RawMessage | SerializerConfig::Text(_) => DeserializerConfig::Bytes,
     };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1314,6 +1314,7 @@ mod resource_tests {
     proptest! {
         #[test]
         fn valid(addr: IpAddr, port1 in specport(), port2 in specport()) {
+            prop_assume!(port1 != port2);
             let components = vec![
                 ("sink_0", vec![tcp(addr, 0)]),
                 ("sink_1", vec![tcp(addr, port1)]),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1666,7 +1666,9 @@ fn test_config_outputs() {
         (
             "syslog / single output",
             TestCase {
-                decoding: DeserializerConfig::Syslog,
+                decoding: DeserializerConfig::Syslog {
+                    syslog: Default::default(),
+                },
                 multiple_outputs: false,
                 want: HashMap::from([(
                     None,
@@ -1741,7 +1743,9 @@ fn test_config_outputs() {
         (
             "syslog / multiple output",
             TestCase {
-                decoding: DeserializerConfig::Syslog,
+                decoding: DeserializerConfig::Syslog {
+                    syslog: Default::default(),
+                },
                 multiple_outputs: true,
                 want: HashMap::from([
                     (

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -122,7 +122,9 @@ async fn collected_metrics_native_json() {
         endpoint: format!("{}/metrics/native.json", dufs_address()),
         interval: INTERVAL,
         query: HashMap::new(),
-        decoding: DeserializerConfig::NativeJson,
+        decoding: DeserializerConfig::NativeJson {
+            native_json: Default::default(),
+        },
         framing: default_framing_message_based(),
         headers: HashMap::new(),
         method: HttpMethod::Get,
@@ -151,7 +153,9 @@ async fn collected_trace_native_json() {
         endpoint: format!("{}/traces/native.json", dufs_address()),
         interval: INTERVAL,
         query: HashMap::new(),
-        decoding: DeserializerConfig::NativeJson,
+        decoding: DeserializerConfig::NativeJson {
+            native_json: Default::default(),
+        },
         framing: default_framing_message_based(),
         headers: HashMap::new(),
         method: HttpMethod::Get,

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -96,7 +96,7 @@ base: components: sources: amqp: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -95,13 +95,61 @@ base: components: sources: amqp: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -99,7 +99,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -98,13 +98,61 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -185,7 +185,7 @@ base: components: sources: aws_s3: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -184,13 +184,61 @@ base: components: sources: aws_s3: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -180,7 +180,7 @@ base: components: sources: aws_sqs: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -179,13 +179,61 @@ base: components: sources: aws_sqs: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -80,13 +80,61 @@ base: components: sources: datadog_agent: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -81,7 +81,7 @@ base: components: sources: datadog_agent: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -59,13 +59,61 @@ base: components: sources: demo_logs: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -60,7 +60,7 @@ base: components: sources: demo_logs: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -55,13 +55,61 @@ base: components: sources: exec: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -56,7 +56,7 @@ base: components: sources: exec: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -51,7 +51,7 @@ base: components: sources: file_descriptor: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -50,13 +50,61 @@ base: components: sources: file_descriptor: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -126,13 +126,61 @@ base: components: sources: gcp_pubsub: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -127,7 +127,7 @@ base: components: sources: gcp_pubsub: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -93,7 +93,7 @@ base: components: sources: heroku_logs: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -92,13 +92,61 @@ base: components: sources: heroku_logs: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -93,13 +93,61 @@ base: components: sources: http: configuration: {
 						"""
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -94,7 +94,7 @@ base: components: sources: http: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -93,7 +93,7 @@ base: components: sources: http_client: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -92,13 +92,61 @@ base: components: sources: http_client: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -93,13 +93,61 @@ base: components: sources: http_server: configuration: {
 						"""
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -94,7 +94,7 @@ base: components: sources: http_server: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -104,13 +104,61 @@ base: components: sources: kafka: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -105,7 +105,7 @@ base: components: sources: kafka: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -147,13 +147,61 @@ base: components: sources: nats: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -148,7 +148,7 @@ base: components: sources: nats: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -66,7 +66,7 @@ base: components: sources: redis: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -65,13 +65,61 @@ base: components: sources: redis: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -67,13 +67,61 @@ base: components: sources: socket: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -68,7 +68,7 @@ base: components: sources: socket: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -51,7 +51,7 @@ base: components: sources: stdin: configuration: {
 				}
 			}
 			gelf: {
-				description:   "Gelf-specific decoding options."
+				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
 				required:      false
 				type: object: options: lossy: {

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -50,13 +50,61 @@ base: components: sources: stdin: configuration: {
 					}
 				}
 			}
+			gelf: {
+				description:   "Gelf-specific decoding options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
 			json: {
-				description:   "Options for the JSON deserializer."
+				description:   "JSON-specific decoding options."
 				relevant_when: "codec = \"json\""
 				required:      false
 				type: object: options: lossy: {
 					description: """
-						Determines whether or not to replace invalid UTF-8 sequences instead of returning an error.
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			native_json: {
+				description:   "Vector's native JSON-specific decoding options."
+				relevant_when: "codec = \"native_json\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
+
+						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+
+						[U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
+						"""
+					required: false
+					type: bool: default: true
+				}
+			}
+			syslog: {
+				description:   "Syslog-specific decoding options."
+				relevant_when: "codec = \"syslog\""
+				required:      false
+				type: object: options: lossy: {
+					description: """
+						Determines whether or not to replace invalid UTF-8 sequences instead of failing.
 
 						When true, invalid UTF-8 sequences are replaced with the [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
 


### PR DESCRIPTION
Adds a `lossy` option to the relevant deserializers.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
