### PR TITLE
chore(ci): Add apt retries to cross builds

### DIFF
--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -o errexit
 
+echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 apt-get update
 apt-get install -y \
   apt-transport-https \


### PR DESCRIPTION
To see if this helps with flakey apt installs.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
