### PR TITLE
fix(install.sh): Correctly `shift` all parsed arguments

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -76,9 +76,11 @@ main() {
                 ;;
             --no-modify-path)
                 modify_path=no
+                shift
                 ;;
             -y)
                 prompt=no
+                shift
                 ;;
             *)
                 ;;


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Closes #17681 

Without `shift`ing the other possible input arguments, the `--prefix` argument will set the `prefix` incorrectly. When using [the official Docker example](https://vector.dev/docs/setup/installation/#installation-script), arguments of `-y --prefix` will result in the following error:

```
mkdir: unrecognized option '--prefix'
```

...as `"$2"` is `--prefix`, because `-y` was never `shift`ed out.

Adding a `shift` to the other arguments correctly removes them from the argument list when parsed.