### PR TITLE
feat(socket source): Add inode number & peer creds to events

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -377,6 +377,7 @@ opentelemetry
 oss
 pacman
 pantech
+PASSCRED
 papertrail
 papertrailapp
 petabytes

--- a/src/sources/statsd/unix.rs
+++ b/src/sources/statsd/unix.rs
@@ -11,6 +11,7 @@ use crate::{
     codecs::Decoder,
     shutdown::ShutdownSignal,
     sources::{util::build_unix_stream_source, Source},
+    sources::util::unix::UnixSocketMetadataCollectTypes,
     SourceSender,
 };
 
@@ -38,6 +39,7 @@ pub fn statsd_unix(
     build_unix_stream_source(
         config.path,
         None,
+        UnixSocketMetadataCollectTypes::default(),
         decoder,
         |_events, _host| {},
         shutdown,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -32,6 +32,7 @@ use crate::{
     net,
     shutdown::ShutdownSignal,
     sources::util::net::{try_bind_udp_socket, SocketListenAddr, TcpNullAcker, TcpSource},
+    sources::util::unix::UnixSocketMetadataCollectTypes,
     tcp::TcpKeepaliveConfig,
     tls::{MaybeTlsSettings, TlsSourceConfig},
     SourceSender,
@@ -229,9 +230,14 @@ impl SourceConfig for SyslogConfig {
                     ),
                 );
 
+                let mut collect_metadata = UnixSocketMetadataCollectTypes::default();
+                // the peer_path is used as the default hostname for the record, so we must collect it.
+                collect_metadata.peer_path = true;
+
                 build_unix_stream_source(
                     path,
                     socket_file_mode,
+                    collect_metadata,
                     decoder,
                     move |events, socket_metadata| {
                         // handle_events expects to own its default hostname, so we must copy.

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -233,7 +233,13 @@ impl SourceConfig for SyslogConfig {
                     path,
                     socket_file_mode,
                     decoder,
-                    move |events, host| handle_events(events, &host_key, host, log_namespace),
+                    move |events, socket_metadata| {
+                        // handle_events expects to own its default hostname, so we must copy.
+                        let default_hostname = Some(
+                            Bytes::copy_from_slice(socket_metadata.peer_path_or_default().as_bytes())
+                        );
+                        handle_events(events, &host_key, default_hostname, log_namespace)
+                    },
                     cx.shutdown,
                     cx.out,
                 )

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -20,6 +20,18 @@ pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Resu
     Ok(())
 }
 
+/// This is a structure which represents what kind of metadata should be
+/// _collected_ by unix_stream.rs & unix_datagram.rs. I would do this with
+/// some kind of flags structure, but Rust doesn't have one, so I guess a
+/// struct-of-bools works.
+#[derive(Default, Copy, Clone, Debug)]
+pub struct UnixSocketMetadataCollectTypes {
+    /// Use getpeername(2) (on stream sockets) or read the struct sockaddr
+    /// argument from recvfrom(2) (on datagram sockets) to get the bound name
+    /// of the other half of the socket.
+    pub peer_path: bool,
+}
+
 /// This structure defines the various kinds of metadata we can
 /// collect off a connected unix-domain socket and expose as source fields.
 pub struct UnixSocketMetadata {

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -37,7 +37,7 @@ pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Resu
 /// This is a structure which represents what kind of metadata should be
 /// _collected_ by unix_stream.rs & unix_datagram.rs. I would do this with
 /// some kind of flags structure, but Rust doesn't have one, so I guess a
-/// struct-of-bools works.
+/// struct-of-booleans works.
 #[derive(Default, Copy, Clone, Debug)]
 pub struct UnixSocketMetadataCollectTypes {
     /// Use getpeername(2) (on stream sockets) or read the struct sockaddr
@@ -143,7 +143,7 @@ impl UnixSocketMetadata {
 
 /// Collects the device & inode number for a socket.
 pub async fn get_socket_inode<T : AsRawFd>(socket: &T) -> Result<SocketInode, Box<dyn std::error::Error>> {
-    // Get the socket file descriptor. This is the actual intgeger in use by the socket,
+    // Get the socket file descriptor. This is the actual integer in use by the socket,
     // not a dup(2) of it.
     let socket_fd = socket.as_raw_fd();
 
@@ -196,7 +196,7 @@ impl FromRawFd for NonClosingFile {
 
 impl Drop for NonClosingFile {
     fn drop(&mut self) {
-        // Saftey: we must never use self.file again. It's OK, we won't,
+        // Safety: we must never use self.file again. It's OK, we won't,
         // we only get dropped once.
         unsafe { ManuallyDrop::take(&mut self.file) }.into_raw_fd();
     }

--- a/src/sources/util/unix.rs
+++ b/src/sources/util/unix.rs
@@ -19,3 +19,21 @@ pub fn change_socket_permissions(path: &Path, perms: Option<u32>) -> crate::Resu
     }
     Ok(())
 }
+
+/// This structure defines the various kinds of metadata we can
+/// collect off a connected unix-domain socket and expose as source fields.
+pub struct UnixSocketMetadata {
+    /// The peer address of the socket, as returned from getpeername(2). This
+    /// will usually not be set (unless the connecting peer has explicitly
+    /// bound their socket to a path).
+    pub peer_path: Option<String>,
+}
+
+impl UnixSocketMetadata {
+    pub fn peer_path_or_default(&self) -> &str {
+        match &self.peer_path {
+            Some(path) => &path,
+            None => UNNAMED_SOCKET_HOST,
+        }
+    }
+}

--- a/src/sources/util/unix_datagram.rs
+++ b/src/sources/util/unix_datagram.rs
@@ -146,6 +146,14 @@ async fn get_socket_metadata(
     UnixSocketMetadata {
         peer_path: None, // Added later when a peer sends a message
         socket_inode,
+        // We can't implement peer_creds for datagram sockets, unfortunately, because of
+        // missing support in Rust std for ancillary messages. On many platforms, one can
+        // call something like getsockopt(SO_PASSCRED or LOCAL_CREDS) to ask that all
+        // datagrams get an associated ancillary message containing the peer credentials.
+        // Unfortunately, Rust std doesn't have a way of reading ancillary messages from
+        // sockets yet (see https://github.com/rust-lang/rust/issues/76915) and so tokio
+        // doesn't have this either.
+        peer_creds: None,
     }
 }
 

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -73,9 +73,7 @@ pub fn build_unix_stream_source(
             let socket_metadata = get_socket_metadata(&socket);
 
             let span = info_span!("connection");
-            if let Some(peer_path) = socket_metadata.peer_path.as_ref() {
-                span.record("peer_path", field::debug(peer_path));
-            }
+            span.record("peer_path", field::debug(socket_metadata.peer_path_or_default()));
 
             let handle_events = handle_events.clone();
 

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -1,6 +1,5 @@
 use std::{fs::remove_file, path::PathBuf, time::Duration};
 
-use bytes::Bytes;
 use codecs::StreamDecodingError;
 use futures::{FutureExt, StreamExt};
 use tokio::{
@@ -25,7 +24,7 @@ use crate::{
     },
     shutdown::ShutdownSignal,
     sources::util::change_socket_permissions,
-    sources::util::unix::UNNAMED_SOCKET_HOST,
+    sources::util::unix::UnixSocketMetadata,
     sources::Source,
     SourceSender,
 };
@@ -38,7 +37,7 @@ pub fn build_unix_stream_source(
     listen_path: PathBuf,
     socket_file_mode: Option<u32>,
     decoder: Decoder,
-    handle_events: impl Fn(&mut [Event], Option<Bytes>) + Clone + Send + Sync + 'static,
+    handle_events: impl Fn(&mut [Event], &UnixSocketMetadata) + Clone + Send + Sync + 'static,
     shutdown: ShutdownSignal,
     out: SourceSender,
 ) -> crate::Result<Source> {
@@ -71,24 +70,12 @@ pub fn build_unix_stream_source(
 
             let listen_path = listen_path.clone();
 
-            let span = info_span!("connection");
+            let socket_metadata = get_socket_metadata(&socket);
 
-            let received_from: Bytes = socket
-                .peer_addr()
-                .ok()
-                .and_then(|addr| {
-                    addr.as_pathname().map(|e| e.to_owned()).map({
-                        |path| {
-                            span.record("peer_path", &field::debug(&path));
-                            path.to_string_lossy().into_owned().into()
-                        }
-                    })
-                })
-                // In most cases, we'll be connecting to this socket from
-                // an unnamed socket (a socket not bound to a
-                // file). Instead of a filename, we'll surface a specific
-                // host value.
-                .unwrap_or_else(|| UNNAMED_SOCKET_HOST.into());
+            let span = info_span!("connection");
+            if let Some(peer_path) = socket_metadata.peer_path.as_ref() {
+                span.record("peer_path", field::debug(peer_path));
+            }
 
             let handle_events = handle_events.clone();
 
@@ -115,7 +102,7 @@ pub fn build_unix_stream_source(
                                     count: events.len(),
                                 });
 
-                                handle_events(&mut events, Some(received_from.clone()));
+                                handle_events(&mut events, &socket_metadata);
 
                                 let count = events.len();
                                 if (out.send_batch(events).await).is_err() {
@@ -161,4 +148,31 @@ pub fn build_unix_stream_source(
 
         Ok(())
     }))
+}
+
+// This method gets all the metadata we can about the socket. It unconditionally returns
+// a UnixSocketMetadata object containing everything we found out about it through various
+// system calls (which could be nothing - each of the _fields_ in UnixSocketMetadata is
+// an Optional).
+fn get_socket_metadata(socket: &tokio::net::UnixStream) -> UnixSocketMetadata {
+    // First thing to try - use getpeername(2) to see if the associated socket has a name.
+    let peer_path = socket
+        .peer_addr()
+        .map_err(|error| {
+            // Log & throw error away
+            debug!(message = "getpeername(2) failed.", %error);
+            ()
+        })
+        .ok()
+        .and_then(|addr| {
+            addr.as_pathname().map(|p| { p.to_owned() })
+        })
+        .map(|path| -> String {
+            path.to_string_lossy().into()
+        });
+
+
+    UnixSocketMetadata{
+        peer_path: peer_path,
+    }
 }

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -18,6 +18,37 @@ base: components: sources: socket: configuration: {
 		required:      false
 		type: uint: unit: "connections"
 	}
+	credentials_key: {
+		description: """
+			If set, on a stream socket, output events will contain information about
+			the UID/GID/PID of the process which connected to the socket. Note that
+			this information is subject to some race conditions and is not available
+			in all circumstances:
+
+			* If a process exits after connecting, and passes the socket on to a different
+			  process, (e.g. a child), the pid might now refer to a different process
+			  (or, on some platforms, might not be returned at all)
+			* If a process connects to this socket source, writes data, and immediately
+			  disconnects, it's possible Vector won't query the peer credentials before
+			  the other process disconnects; in this case, the data won't be available
+			  on some platforms.
+
+			Vector configurations should be prepared for this information to be absent,
+			incorrect, or only partially present; it's a best-guess only.
+
+			Peer credential information cannot currently be collected for datagram sockets,
+			and setting this key will simply produce a null object.
+
+			The key will be set with an object containing `"uid"`, `"gid"`, and `"pid"`
+			keys, or `null` if the information was not available.
+
+			By default, this key is not emitted. Set to `""` to explicitly suppress
+			this key.
+			"""
+		required: false
+		relevant_when: "mode = \"unix_datagram\" or mode = \"unix_stream\""
+		type: string: default: ""
+	}
 	decoding: {
 		description: "Configures how events are decoded from raw bytes."
 		required:    false
@@ -235,6 +266,24 @@ base: components: sources: socket: configuration: {
 			"""
 		required: false
 		type: string: default: "host"
+	}
+	inode_key: {
+		description: """
+			If set, output events will contain the device & inode number of the
+			socket under this key. For stream sockets, this will be a unique
+			identifier of each incoming connection; for datagram sockets, this
+			will be the same value for every incoming message (but can uniquely
+			identify this source).
+
+			The key will be set with an object containing `"dev"` and `"ino"` keys
+			representing the device & inode number of the socket.
+
+			By default, this key is not emitted. Set to `""` to explicitly suppress
+			this key.
+			"""
+		required: false
+		relevant_when: "mode = \"unix_datagram\" or mode = \"unix_stream\""
+		type: string: default: ""
 	}
 	keepalive: {
 		description:   "TCP keepalive settings for socket-based components."


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

This is the implementation of a couple of new pieces of data on Unix socket source, as discussed in https://github.com/vectordotdev/vector/issues/17671.

`inode_key`: If `inode_key` is set on the socket configuration, then we will look up the inode & device number for the socket, and attach a structure like `{"ino": 123 "dev": 456}` at the configured path. This is done through a call to `File::metadata` (which essentially calls `fstat(2)`) and should work on all unixy-platforms.

On a Unix stream socket, the combination of these two numbers uniquely identifies a particular connection, in the same way that a host & port number uniquely identifies a TCP connection. This can be used to group events by connection in reduce transforms, for instance. On a datagram socket, every event will have the same inode number (because one single socket in the server accepts messages from all the clients), so it's probably not especially useful, but I added it anyway for symmetry's sake. It does at least uniquely identify the socket source instance in this case.

`credentials_key`: If `credentials_key` is set on a socket, then we will use a call to Tokio's `::peer_creds()` on the socket to look up the UID, GID, and PID of the remote process. This only works for a stream socket, and it isn't guaranteed to be present on every event even then. For example, if a process connects to the socket, then passes the socket to a child process, and then exits, _before_ Vector gets a chance to call `::peer_creds()`, then at least on macOS (and probably elsewhere too), the pid isn't returned. So this data should probably be considered "best effort".

On datagram sockets, setting `credentials_key` will just emit the value as `null` always. It should in theory be possible to implement this for datagram sockets on most unix-alikes by looking at SCM_CREDS/SCM_CREDENTIALS type ancillary data messages, but Rust std, and also Tokio's mio, doesn't have any mechanism for receiving ancillary data. There's an open issue for adding this to std here - https://github.com/rust-lang/rust/issues/76915. I guess nothing stops this from being implemented in Tokio's mio before that, but in any case I didn't really need this feature. 

---

Finally, I noticed an unrelated bug. If you bind a client-side unix socket before connecting it to Vector, Vector is supposed to take the bound name of the client socket and put it in the host field. When doing this, it actually truncates the name by one character, at least on macOS. You can test this by setting up a Unix socket source and connecting to it with a bound socket in socat, like this: `socat STDIN UNIX:./vector_socket.sock,bind=./my_socket_name`.

Actually, Vector will report the hostname as `"./my_socket_nam"` in that case. I believe this is because this code in mio is expecting the sockaddr to be zero-terminated, but on macOS, it seems not to be: https://github.com/tokio-rs/mio/blob/c2f79f6969cccb6dc0452a3f360757d9e01290ce/src/sys/unix/uds/socketaddr.rs#L47

In any case, I haven't got around to reducing this down to a testcase and sending a patch to tokio yet, but perhaps it's something we should do.