### PR TITLE
OPB-900: extract regex to be used as library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9269,6 +9269,7 @@ dependencies = [
  "vector-config",
  "vector-config-common",
  "vector-config-macros",
+ "vector-config-regex",
  "vector-core",
  "vector-lookup",
  "vector-vrl-functions",
@@ -9430,6 +9431,10 @@ dependencies = [
  "vector-config",
  "vector-config-common",
 ]
+
+[[package]]
+name = "vector-config-regex"
+version = "0.1.0"
 
 [[package]]
 name = "vector-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9435,6 +9435,10 @@ dependencies = [
 [[package]]
 name = "vector-config-regex"
 version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "vector-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ members = [
   "lib/vector-config",
   "lib/vector-config-common",
   "lib/vector-config-macros",
+  "lib/vector-config-regex",
   "lib/vector-core",
   "lib/vector-lookup",
   "lib/vector-vrl/cli",
@@ -132,6 +133,7 @@ vector-common = { path = "lib/vector-common" }
 vector-config = { path = "lib/vector-config" }
 vector-config-common = { path = "lib/vector-config-common" }
 vector-config-macros = { path = "lib/vector-config-macros" }
+vector-config-regex = { path = "lib/vector-config-regex" }
 vector-core = { path = "lib/vector-core", default-features = false, features = ["vrl"] }
 vector-vrl-functions = { path = "lib/vector-vrl/functions" }
 loki-logproto = { path = "lib/loki-logproto", optional = true }

--- a/lib/vector-config-regex/Cargo.toml
+++ b/lib/vector-config-regex/Cargo.toml
@@ -5,4 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["regex"]
+regex = ["dep:once_cell", "dep:regex"]
+
 [dependencies]
+once_cell = { version = "1", default-features = false, optional = true }
+regex = { version = "1.8.4", default-features = false, features = ["std", "perf"], optional = true }

--- a/lib/vector-config-regex/Cargo.toml
+++ b/lib/vector-config-regex/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "vector-config-regex"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/lib/vector-config-regex/Cargo.toml
+++ b/lib/vector-config-regex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vector-config-regex"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lib/vector-config-regex/LICENSE
+++ b/lib/vector-config-regex/LICENSE
@@ -1,0 +1,363 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/lib/vector-config-regex/src/environment_variable.rs
+++ b/lib/vector-config-regex/src/environment_variable.rs
@@ -1,0 +1,21 @@
+#[cfg(feature = "regex")]
+use once_cell::sync::Lazy;
+#[cfg(feature = "regex")]
+use regex::Regex;
+
+// Environment variable names can have any characters from the Portable Character Set other
+// than NUL.  However, for Vector's interpolation, we are closer to what a shell supports which
+// is solely of uppercase letters, digits, and the '_' (that is, the `[:word:]` regex class).
+// In addition to these characters, we allow `.` as this commonly appears in environment
+// variable names when they come from a Java properties file.
+//
+// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
+pub const RAW_REGEX: &str = r"(?x)
+\$\$|
+\$([[:word:].]+)|
+\$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}";
+
+#[cfg(feature = "regex")]
+pub static REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(RAW_REGEX).unwrap()
+});

--- a/lib/vector-config-regex/src/environment_variable.rs
+++ b/lib/vector-config-regex/src/environment_variable.rs
@@ -16,6 +16,4 @@ pub const RAW_REGEX: &str = r"(?x)
 \$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}";
 
 #[cfg(feature = "regex")]
-pub static REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(RAW_REGEX).unwrap()
-});
+pub static REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(RAW_REGEX).unwrap());

--- a/lib/vector-config-regex/src/lib.rs
+++ b/lib/vector-config-regex/src/lib.rs
@@ -1,0 +1,21 @@
+// Environment variable names can have any characters from the Portable Character Set other
+// than NUL.  However, for Vector's interpolation, we are closer to what a shell supports which
+// is solely of uppercase letters, digits, and the '_' (that is, the `[:word:]` regex class).
+// In addition to these characters, we allow `.` as this commonly appears in environment
+// variable names when they come from a Java properties file.
+//
+// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
+pub const ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX: &str = r"(?x)
+\$\$|
+\$([[:word:].]+)|
+\$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}";
+
+
+// The following regex aims to extract a pair of strings, the first being the secret backend name
+// and the second being the secret key. Here are some matching & non-matching examples:
+// - "SECRET[backend.secret_name]" will match and capture "backend" and "secret_name"
+// - "SECRET[backend.secret.name]" will match and capture "backend" and "secret.name"
+// - "SECRET[backend..secret.name]" will match and capture "backend" and ".secret.name"
+// - "SECRET[secret_name]" will not match
+// - "SECRET[.secret.name]" will not match
+pub const SECRET_COLLECTOR_REGEX: &str = r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]";

--- a/lib/vector-config-regex/src/lib.rs
+++ b/lib/vector-config-regex/src/lib.rs
@@ -1,21 +1,2 @@
-// Environment variable names can have any characters from the Portable Character Set other
-// than NUL.  However, for Vector's interpolation, we are closer to what a shell supports which
-// is solely of uppercase letters, digits, and the '_' (that is, the `[:word:]` regex class).
-// In addition to these characters, we allow `.` as this commonly appears in environment
-// variable names when they come from a Java properties file.
-//
-// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
-pub const ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX: &str = r"(?x)
-\$\$|
-\$([[:word:].]+)|
-\$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}";
-
-
-// The following regex aims to extract a pair of strings, the first being the secret backend name
-// and the second being the secret key. Here are some matching & non-matching examples:
-// - "SECRET[backend.secret_name]" will match and capture "backend" and "secret_name"
-// - "SECRET[backend.secret.name]" will match and capture "backend" and "secret.name"
-// - "SECRET[backend..secret.name]" will match and capture "backend" and ".secret.name"
-// - "SECRET[secret_name]" will not match
-// - "SECRET[.secret.name]" will not match
-pub const SECRET_COLLECTOR_REGEX: &str = r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]";
+pub mod environment_variable;
+pub mod secret;

--- a/lib/vector-config-regex/src/secret.rs
+++ b/lib/vector-config-regex/src/secret.rs
@@ -1,0 +1,16 @@
+#[cfg(feature = "regex")]
+use once_cell::sync::Lazy;
+#[cfg(feature = "regex")]
+use regex::Regex;
+
+// The following regex aims to extract a pair of strings, the first being the secret backend name
+// and the second being the secret key. Here are some matching & non-matching examples:
+// - "SECRET[backend.secret_name]" will match and capture "backend" and "secret_name"
+// - "SECRET[backend.secret.name]" will match and capture "backend" and "secret.name"
+// - "SECRET[backend..secret.name]" will match and capture "backend" and ".secret.name"
+// - "SECRET[secret_name]" will not match
+// - "SECRET[.secret.name]" will not match
+pub const RAW_REGEX: &str = r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]";
+
+#[cfg(feature = "regex")]
+pub static REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(RAW_REGEX).unwrap());

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -19,6 +19,7 @@ pub use loader::*;
 pub use secret::*;
 pub use source::*;
 use vector_config::NamedComponent;
+pub use vector_config_regex::secret::REGEX as COLLECTOR;
 
 use super::{
     builder::ConfigBuilder, format, validation, vars, Config, ConfigPath, Format, FormatHint,

--- a/src/config/loading/secret.rs
+++ b/src/config/loading/secret.rs
@@ -27,7 +27,7 @@ use crate::{
 // - "SECRET[secret_name]" will not match
 // - "SECRET[.secret.name]" will not match
 pub static COLLECTOR: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"SECRET\[([[:word:]]+)\.([[:word:].]+)\]").unwrap());
+    Lazy::new(|| Regex::new(vector_config_regex::SECRET_COLLECTOR_REGEX).unwrap());
 
 /// Helper type for specifically deserializing secrets backends.
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/config/loading/secret.rs
+++ b/src/config/loading/secret.rs
@@ -97,18 +97,20 @@ impl Loader<SecretBackendLoader> for SecretBackendLoader {
 }
 
 fn collect_secret_keys(input: &str, keys: &mut HashMap<String, HashSet<String>>) {
-    vector_config_regex::secret::REGEX.captures_iter(input).for_each(|cap| {
-        if let (Some(backend), Some(key)) = (cap.get(1), cap.get(2)) {
-            if let Some(keys) = keys.get_mut(backend.as_str()) {
-                keys.insert(key.as_str().to_string());
-            } else {
-                keys.insert(
-                    backend.as_str().to_string(),
-                    HashSet::from_iter(std::iter::once(key.as_str().to_string())),
-                );
+    vector_config_regex::secret::REGEX
+        .captures_iter(input)
+        .for_each(|cap| {
+            if let (Some(backend), Some(key)) = (cap.get(1), cap.get(2)) {
+                if let Some(keys) = keys.get_mut(backend.as_str()) {
+                    keys.insert(key.as_str().to_string());
+                } else {
+                    keys.insert(
+                        backend.as_str().to_string(),
+                        HashSet::from_iter(std::iter::once(key.as_str().to_string())),
+                    );
+                }
             }
-        }
-    });
+        });
 }
 
 pub fn interpolate(input: &str, secrets: &HashMap<String, String>) -> Result<String, Vec<String>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,7 +61,8 @@ pub use transform::{
 };
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
-pub use vars::{interpolate, ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX};
+pub use vector_config_regex::environment_variable::REGEX as ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX;
+pub use vars::interpolate;
 pub use vector_core::config::{
     init_log_schema, log_schema, proxy::ProxyConfig, LogSchema, OutputId,
 };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,8 +61,8 @@ pub use transform::{
 };
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
-pub use vector_config_regex::environment_variable::REGEX as ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX;
 pub use vars::interpolate;
+pub use vector_config_regex::environment_variable::REGEX as ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX;
 pub use vector_core::config::{
     init_log_schema, log_schema, proxy::ProxyConfig, LogSchema, OutputId,
 };

--- a/src/config/vars.rs
+++ b/src/config/vars.rs
@@ -1,18 +1,8 @@
 use std::collections::HashMap;
 
-use once_cell::sync::Lazy;
-use regex::{Captures, Regex};
+use regex::Captures;
 
-// Environment variable names can have any characters from the Portable Character Set other
-// than NUL.  However, for Vector's interpolation, we are closer to what a shell supports which
-// is solely of uppercase letters, digits, and the '_' (that is, the `[:word:]` regex class).
-// In addition to these characters, we allow `.` as this commonly appears in environment
-// variable names when they come from a Java properties file.
-//
-// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
-pub static ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(vector_config_regex::ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX).unwrap()
-});
+use vector_config_regex::environment_variable::REGEX;
 
 /// (result, warnings)
 pub fn interpolate(
@@ -22,7 +12,7 @@ pub fn interpolate(
     let mut errors = Vec::new();
     let mut warnings = Vec::new();
 
-    let interpolated = ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX
+    let interpolated = REGEX
         .replace_all(input, |caps: &Captures<'_>| {
             let flags = caps.get(3).map(|m| m.as_str()).unwrap_or_default();
             let def_or_err = caps.get(4).map(|m| m.as_str()).unwrap_or_default();

--- a/src/config/vars.rs
+++ b/src/config/vars.rs
@@ -11,13 +11,7 @@ use regex::{Captures, Regex};
 //
 // https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
 pub static ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r"(?x)
-        \$\$|
-        \$([[:word:].]+)|
-        \$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}",
-    )
-    .unwrap()
+    Regex::new(vector_config_regex::ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX).unwrap()
 });
 
 /// (result, warnings)


### PR DESCRIPTION
Right now, we need to use the regexes for detecting environment variables and secrets in a DD product. With this modification, we can only import the regexes without importing vector entirely (and have version conflicts).

https://datadoghq.atlassian.net/browse/OPB-900