### PR TITLE
chore(observability): Have `tower_limit` use configured log level

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -378,7 +378,7 @@ fn get_log_levels(default: &str) -> String {
                 format!("codec={}", level),
                 format!("vrl={}", level),
                 format!("file_source={}", level),
-                "tower_limit=trace".to_owned(),
+                format!("tower_limit={}", level),
                 format!("rdkafka={}", level),
                 format!("buffers={}", level),
                 format!("lapin={}", level),


### PR DESCRIPTION
I wasn't able to trigger this message on 0.30.0 so it may not even be relevant anymore, but at least
use the configured log level.

Closes: #1391

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
