### PR TITLE
chore(ci): Retry `make check-component-docs` check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,10 @@ jobs:
         run: make check-markdown
       - name: Check Component Docs
         if: needs.changes.outputs.source == 'true' || needs.changes.outputs.component_docs == 'true'
-        run: make check-component-docs
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          command: make check-component-docs
       - name: Check Rust Docs
         if: needs.changes.outputs.source == 'true'
         run: cd rust-doc && make docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           max_attempts: 3
+          timeout_seconds: 900
           command: make check-component-docs
       - name: Check Rust Docs
         if: needs.changes.outputs.source == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
         if: needs.changes.outputs.source == 'true' || needs.changes.outputs.component_docs == 'true'
         uses: nick-fields/retry@v2
         with:
-          max_attempts: 3
+          max_attempts: 10
           timeout_seconds: 900
           command: make check-component-docs
       - name: Check Rust Docs


### PR DESCRIPTION
This check seems to be flakey but we haven't been able to reliably reproduce. Just retry for now. In
the future we hope to rewrite this script into Rust.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
