### PR TITLE
feat: add metadata support to `set_semantic_meaning`

### DIFF
--- a/lib/vector-vrl/functions/src/set_semantic_meaning.rs
+++ b/lib/vector-vrl/functions/src/set_semantic_meaning.rs
@@ -68,8 +68,6 @@ impl Function for SetSemanticMeaning {
             .expect("meaning not bytes")
             .into_owned();
 
-        // let path = query.path().clone();
-
         let path = if let Some(path) = query.external_path() {
             path
         } else {

--- a/lib/vector-vrl/functions/src/set_semantic_meaning.rs
+++ b/lib/vector-vrl/functions/src/set_semantic_meaning.rs
@@ -73,19 +73,23 @@ impl Function for SetSemanticMeaning {
         } else {
             // Semantic meaning can only be assigned to external fields.
             let mut labels = vec![Label::primary(
-                "the target of this semantic meaning is non-external",
+                "this path must point to an event or metadata",
                 span,
             )];
 
             if let Some(variable) = query.as_variable() {
                 labels.push(Label::context(
-                    format!("maybe you meant \".{}\"?", variable.ident()),
+                    format!(
+                        "maybe you meant \".{}\" or \"%{}\"?",
+                        variable.ident(),
+                        variable.ident()
+                    ),
                     span,
                 ));
             }
 
             let error = ExpressionError::Error {
-                message: "semantic meaning defined for non-external target".to_owned(),
+                message: "semantic meaning is not valid for local variables".to_owned(),
                 labels,
                 notes: vec![],
             };

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -9,7 +9,7 @@ use std::{
 
 use codecs::MetricTagValues;
 use lookup::lookup_v2::{parse_value_path, ValuePath};
-use lookup::{metadata_path, owned_value_path, path, OwnedTargetPath, PathPrefix};
+use lookup::{metadata_path, owned_value_path, path, PathPrefix};
 use snafu::{ResultExt, Snafu};
 use vector_common::TimeZone;
 use vector_config::configurable_component;
@@ -274,7 +274,7 @@ impl TransformConfig for RemapConfig {
                     // Apply any semantic meanings set in the VRL program
                     for (id, path) in meaning {
                         // currently only event paths are supported
-                        new_type_def = new_type_def.with_meaning(OwnedTargetPath::event(path), &id);
+                        new_type_def = new_type_def.with_meaning(path, &id);
                     }
                     new_type_def
                 })


### PR DESCRIPTION
The `set_semantic_meaning` function didn't support setting meanings that point to metadata. This will be needed when log namespacing is enabled.