### PR TITLE
chore: Upgrade aws-smithy and aws-sdk crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,17 @@ dependencies = [
 
 [[package]]
 name = "assert-json-diff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
+dependencies = [
+ "extend",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
@@ -641,19 +652,20 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.51.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a636c44c77fa18bdba56126a34d30cfe5538fe88f7d34988fa731fee143ddd"
+checksum = "3c3d1e2a1f1ab3ac6c4b884e37413eaa03eb9d901e4fc68ee8f5c1d49721680e"
 dependencies = [
+ "aws-credential-types",
  "aws-http",
  "aws-sdk-sso",
  "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
  "aws-smithy-json",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "hex",
@@ -668,13 +680,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-endpoint"
-version = "0.51.0"
+name = "aws-credential-types"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca8f374874f6459aaa88dc861d7f5d834ca1ff97668eae190e97266b5f6c3fb"
+checksum = "bb0696a0523a39a19087747e4dafda0362dc867531e3d72a3f195564c84e5e08"
 dependencies = [
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-types 0.54.4",
+ "tokio",
+ "tracing 0.1.37",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.54.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a4f935ab6a1919fbfd6102a80c4fccd9ff5f47f94ba154074afe1051903261"
+dependencies = [
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "http",
  "regex",
@@ -683,12 +708,13 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.51.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d41e19e779b73463f5f0c21b3aacc995f4ba783ab13a7ae9f5dfb159a551b4"
+checksum = "82976ca4e426ee9ca3ffcf919d9b2c8d14d0cd80d43cc02173737a8f07f28d4d"
 dependencies = [
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
+ "aws-credential-types",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -701,218 +727,246 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520b1ac14f0850d0d6a69136d15ba7702d41ee7f4014a5d2d1bf4a86e74f7a6b"
+checksum = "ca35aa6f343ca08847b0f1bbebf2cf8518e2d0e6db7409e410001113536d98cd"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89415e55b57044a09a7eb0a885c2d0af1aa7f95b373e0e898f71a28d7e7d10f9"
+checksum = "d4f8dbe7e86cb0c5999cb5911e052ec1e6e3f4abbbcb1333a63538b4aecdaa9b"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
  "aws-smithy-json",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-elasticsearch"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f4cc10278701dbc0d386ddd8cddfda2695eae7103a54eae11b981f28779ff2"
+checksum = "a26b30b456954c76df16bcc07b53c76416add85b5f17764e6051b8289572f7af"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
  "aws-smithy-json",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-firehose"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68310f9d7860b4fe73c58e5cec4d7a310a658d1a983fdf176eb35149939896a"
+checksum = "e5f8c3898ce8ad0ae8c81c340fdd30f0b12785ffbce242d3d9854e5196f81113"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
  "aws-smithy-json",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37766fdf50feab317b4f939b1c9ee58a2a1c51785974328ce84cff1eea7a1bb8"
+checksum = "f85f773996e276281696482efe866719d12e962041bb75f326f8375fb8ac574d"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
  "aws-smithy-json",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f08665c8e03aca8cb092ef01e617436ebfa977fddc1240e1b062488ab5d48a"
+checksum = "1533be023eeac69668eb718b1c48af7bd5e26305ed770553d2877ab1f7507b68"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-sigv4 0.51.0",
- "aws-smithy-async",
+ "aws-sigv4",
+ "aws-smithy-async 0.54.4",
  "aws-smithy-checksums",
- "aws-smithy-client",
- "aws-smithy-eventstream 0.51.0",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-eventstream 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json",
+ "aws-smithy-types 0.54.4",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "bytes-utils",
+ "fastrand",
  "http",
  "http-body",
+ "once_cell",
+ "percent-encoding",
+ "regex",
  "tokio-stream",
  "tower",
  "tracing 0.1.37",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26bb3d12238492cb12bde0de8486679b007daada21fdb110913b32a2a38275"
+checksum = "4b2afbc1dfbf260945ad1cc19a1d2109f588663b053ffd828faacb29b02c9260"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dcb1cb71aa8763b327542ead410424515cff0cde5b753eedd2917e09c63734"
+checksum = "ca0119bacf0c42f587506769390983223ba834e605f049babe514b2bd646dbb2"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
  "aws-smithy-json",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfcf584297c666f6b472d5368a78de3bc714b6e0a53d7fbf76c3e347c292ab1"
+checksum = "270b6a33969ebfcb193512fbd5e8ee5306888ad6c6d5d775cdbfb2d50d94de26"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
  "http",
+ "regex",
  "tower",
+ "tracing 0.1.37",
 ]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.51.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cbe7b2be9e185c1fbce27fc9c41c66b195b32d89aa099f98768d9544221308"
+checksum = "660a02a98ab1af83bd8d714afbab2d502ba9b18c49e7e4cddd6bf8837ff778cb"
 dependencies = [
- "aws-sigv4 0.51.0",
- "aws-smithy-eventstream 0.51.0",
- "aws-smithy-http 0.51.0",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-eventstream 0.54.4",
+ "aws-smithy-http 0.54.4",
  "aws-types",
  "http",
  "tracing 0.1.37",
@@ -920,31 +974,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.51.0"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ff4cff8c4a101962d593ba94e72cd83891aecd423f0c6e3146bff6fb92c9e3"
+checksum = "86529e7b64d902efea8fff52c1b2529368d04f90305cf632729e3713f6b57dc0"
 dependencies = [
- "aws-smithy-eventstream 0.51.0",
- "aws-smithy-http 0.51.0",
+ "aws-smithy-eventstream 0.54.4",
+ "aws-smithy-http 0.54.4",
  "bytes 1.4.0",
- "form_urlencoded",
- "hex",
- "http",
- "once_cell",
- "percent-encoding",
- "regex",
- "ring",
- "time",
- "tracing 0.1.37",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
-dependencies = [
- "aws-smithy-http 0.55.3",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -970,13 +1006,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-checksums"
-version = "0.51.0"
+name = "aws-smithy-async"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc227e36e346f45298288359f37123e1a92628d1cec6b11b5eb335553278bd9e"
+checksum = "63c712a28a4f2f2139759235c08bf98aca99d4fdf1b13c78c5f95613df0a5db9"
 dependencies = [
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3875fb4b28606a5368a048016a28c15707f2b21238d5b2e4a23198f590e92c4"
+dependencies = [
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
  "bytes 1.4.0",
  "crc32c",
  "crc32fast",
@@ -996,7 +1044,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 0.51.0",
  "aws-smithy-http 0.51.0",
  "aws-smithy-http-tower 0.51.0",
  "aws-smithy-types 0.51.0",
@@ -1005,8 +1053,33 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
  "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104ca17f56cde00a10207169697dfe9c6810db339d52fb352707e64875b30a44"
+dependencies = [
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-protocol-test",
+ "aws-smithy-types 0.54.4",
+ "bytes 1.4.0",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.1",
+ "hyper-tls",
+ "lazy_static",
+ "pin-project-lite",
+ "serde",
  "tokio",
  "tower",
  "tracing 0.1.37",
@@ -1016,39 +1089,20 @@ dependencies = [
 name = "aws-smithy-eventstream"
 version = "0.0.0-smithy-rs-head"
 dependencies = [
- "aws-smithy-types 0.0.0-smithy-rs-head",
+ "aws-smithy-types 0.54.4",
  "bytes 1.4.0",
  "crc32fast",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.51.0"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ea0df7161ce65b5c8ca6eb709a1a907376fa18226976e41c748ce02ccccf24"
+checksum = "ac250d8c0e42af0097a6837ffc5a6fb9f8ba4107bb53124c047c91bc2a58878f"
 dependencies = [
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "bytes 1.4.0",
  "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.0.0-smithy-rs-head"
-dependencies = [
- "aws-smithy-eventstream 0.0.0-smithy-rs-head",
- "aws-smithy-types 0.0.0-smithy-rs-head",
- "bytes 1.4.0",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing 0.1.37",
 ]
 
 [[package]]
@@ -1057,7 +1111,6 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
 dependencies = [
- "aws-smithy-eventstream 0.51.0",
  "aws-smithy-types 0.51.0",
  "bytes 1.4.0",
  "bytes-utils",
@@ -1075,30 +1128,9 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873f316f1833add0d3aa54ed1b0cd252ddd88c792a0cf839886400099971e844"
 dependencies = [
+ "aws-smithy-eventstream 0.0.0-smithy-rs-head",
  "aws-smithy-types 0.54.4",
- "bytes 1.4.0",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing 0.1.37",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
-dependencies = [
- "aws-smithy-types 0.55.3",
  "bytes 1.4.0",
  "bytes-utils",
  "futures-core",
@@ -1145,33 +1177,36 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.51.0"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8324ba98c8a94187723cc16c37aefa09504646ee65c3d2c3af495bab5ea701b"
+checksum = "4bd83ff2b79e9f729746fcc8ad798676b68fe6ea72986571569a5306a277a182"
 dependencies = [
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d1c9bcb35ce11055ec128dab2c66a7ed47e2dfff99883e32c21a1ab6d6bee6"
+dependencies = [
+ "assert-json-diff 1.1.0",
+ "http",
+ "pretty_assertions",
+ "regex",
+ "roxmltree 0.14.1",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.51.0"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83834ed2ff69ea6f6657baf205267dc2c0abe940703503a3e5d60ce23be3d306"
+checksum = "a2f0445dafe9d2cd50b44339ae3c3ed46549aad8ac696c52ad660b3e7ae8682b"
 dependencies = [
- "aws-smithy-types 0.51.0",
+ "aws-smithy-types 0.54.4",
  "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "0.0.0-smithy-rs-head"
-dependencies = [
- "base64-simd",
- "itoa",
- "num-integer",
- "ryu",
- "serde",
- "time",
 ]
 
 [[package]]
@@ -1189,21 +1224,6 @@ dependencies = [
 [[package]]
 name = "aws-smithy-types"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8161232eda10290f5136610a1eb9de56aceaccd70c963a26a260af20ac24794f"
-dependencies = [
- "base64-simd",
- "itoa",
- "num-integer",
- "ryu",
- "time",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
 dependencies = [
  "base64-simd",
  "itoa",
@@ -1214,27 +1234,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.51.0"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f83dd1fdf5d347fa30ae4ad30a9d1d42ce4cd74a93d94afa874646f94cd"
+checksum = "343ffe9a9bb3f542675f4df0e0d5933513d6ad038ca3907ad1767ba690a99684"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.51.0"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05701d32da168b44f7ee63147781aed8723e792cc131cb9b18363b5393f17f70"
+checksum = "f8f15b34253b68cde08e39b0627cc6101bcca64351229484b4743392c035d057"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.51.0",
- "aws-smithy-types 0.51.0",
+ "aws-credential-types",
+ "aws-smithy-async 0.54.4",
+ "aws-smithy-client 0.54.4",
+ "aws-smithy-http 0.54.4",
+ "aws-smithy-types 0.54.4",
  "http",
  "rustc_version 0.4.0",
  "tracing 0.1.37",
- "zeroize",
 ]
 
 [[package]]
@@ -1424,12 +1444,11 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64-simd"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
 dependencies = [
- "outref",
- "vsimd",
+ "simd-abstraction",
 ]
 
 [[package]]
@@ -2463,6 +2482,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote 1.0.28",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3141,18 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
+name = "extend"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "fakedata"
@@ -5732,10 +5773,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "outref"
-version = "0.5.1"
+name = "output_vt100"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "outref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "overload"
@@ -6149,6 +6199,18 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
 ]
 
 [[package]]
@@ -6936,6 +6998,15 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "roxmltree"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
@@ -7649,6 +7720,15 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "simd-abstraction"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
+dependencies = [
+ "outref",
+]
 
 [[package]]
 name = "similar"
@@ -9142,6 +9222,7 @@ dependencies = [
  "async-trait",
  "atty",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-cloudwatch",
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-elasticsearch",
@@ -9149,10 +9230,10 @@ dependencies = [
  "aws-sdk-kinesis",
  "aws-sdk-s3",
  "aws-sdk-sqs",
- "aws-sigv4 0.55.3",
- "aws-smithy-async",
- "aws-smithy-client",
- "aws-smithy-http 0.0.0-smithy-rs-head",
+ "aws-sigv4",
+ "aws-smithy-async 0.51.0",
+ "aws-smithy-client 0.51.0",
+ "aws-smithy-http 0.54.4",
  "aws-smithy-http-tower 0.54.4",
  "aws-smithy-types 0.51.0",
  "aws-types",
@@ -9421,7 +9502,7 @@ dependencies = [
 name = "vector-config"
 version = "0.1.0"
 dependencies = [
- "assert-json-diff",
+ "assert-json-diff 2.0.2",
  "chrono",
  "chrono-tz",
  "encoding_rs",
@@ -9682,7 +9763,7 @@ dependencies = [
  "quoted_printable",
  "rand 0.8.5",
  "regex",
- "roxmltree",
+ "roxmltree 0.18.0",
  "rust_decimal",
  "rustyline",
  "seahash",
@@ -9705,12 +9786,6 @@ dependencies = [
  "woothee",
  "zstd 0.12.3+zstd.1.5.2",
 ]
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -10197,7 +10272,7 @@ version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
 dependencies = [
- "assert-json-diff",
+ "assert-json-diff 2.0.2",
  "async-trait",
  "base64 0.21.2",
  "deadpool",
@@ -10252,6 +10327,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-client",
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.51.0",
  "aws-smithy-http 0.51.0",
  "aws-smithy-http-tower 0.51.0",
  "aws-smithy-types 0.51.0",
@@ -911,7 +911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cbe7b2be9e185c1fbce27fc9c41c66b195b32d89aa099f98768d9544221308"
 dependencies = [
  "aws-sigv4 0.51.0",
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.51.0",
  "aws-smithy-http 0.51.0",
  "aws-types",
  "http",
@@ -924,7 +924,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03ff4cff8c4a101962d593ba94e72cd83891aecd423f0c6e3146bff6fb92c9e3"
 dependencies = [
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.51.0",
  "aws-smithy-http 0.51.0",
  "bytes 1.4.0",
  "form_urlencoded",
@@ -1014,6 +1014,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
+version = "0.0.0-smithy-rs-head"
+dependencies = [
+ "aws-smithy-types 0.0.0-smithy-rs-head",
+ "bytes 1.4.0",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7ea0df7161ce65b5c8ca6eb709a1a907376fa18226976e41c748ce02ccccf24"
@@ -1025,11 +1034,30 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
+version = "0.0.0-smithy-rs-head"
+dependencies = [
+ "aws-smithy-eventstream 0.0.0-smithy-rs-head",
+ "aws-smithy-types 0.0.0-smithy-rs-head",
+ "bytes 1.4.0",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "aws-smithy-http"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
 dependencies = [
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.51.0",
  "aws-smithy-types 0.51.0",
  "bytes 1.4.0",
  "bytes-utils",
@@ -1132,6 +1160,18 @@ checksum = "83834ed2ff69ea6f6657baf205267dc2c0abe940703503a3e5d60ce23be3d306"
 dependencies = [
  "aws-smithy-types 0.51.0",
  "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.0.0-smithy-rs-head"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "serde",
+ "time",
 ]
 
 [[package]]
@@ -9112,7 +9152,7 @@ dependencies = [
  "aws-sigv4 0.55.3",
  "aws-smithy-async",
  "aws-smithy-client",
- "aws-smithy-http 0.51.0",
+ "aws-smithy-http 0.0.0-smithy-rs-head",
  "aws-smithy-http-tower 0.54.4",
  "aws-smithy-types 0.51.0",
  "aws-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-config"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -680,6 +681,7 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -691,6 +693,7 @@ dependencies = [
 [[package]]
 name = "aws-endpoint"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -703,6 +706,7 @@ dependencies = [
 [[package]]
 name = "aws-http"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -720,6 +724,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-cloudwatch"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -744,6 +749,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -766,6 +772,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-elasticsearch"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -788,6 +795,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-firehose"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -809,6 +817,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-kinesis"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -831,6 +840,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-s3"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -864,6 +874,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sqs"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -888,6 +899,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sso"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -910,6 +922,7 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sts"
 version = "0.24.0"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -934,6 +947,7 @@ dependencies = [
 [[package]]
 name = "aws-sig-auth"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -947,6 +961,7 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "0.54.2"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -966,6 +981,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-async"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -976,6 +992,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-checksums"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -995,6 +1012,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-client"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1019,6 +1037,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-eventstream"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-types",
  "bytes 1.4.0",
@@ -1028,6 +1047,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -1047,6 +1067,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http-tower"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1061,6 +1082,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-json"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -1068,6 +1090,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-protocol-test"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "assert-json-diff 1.1.0",
  "http",
@@ -1081,6 +1104,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-query"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -1089,6 +1113,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-types"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "base64-simd",
  "itoa",
@@ -1100,6 +1125,7 @@ dependencies = [
 [[package]]
 name = "aws-smithy-xml"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "xmlparser",
 ]
@@ -1107,6 +1133,7 @@ dependencies = [
 [[package]]
 name = "aws-types"
 version = "0.54.1"
+source = "git+https://github.com/vectordotdev/aws-sdk-rust?rev=3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670#3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,19 +653,17 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aws-config"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3d1e2a1f1ab3ac6c4b884e37413eaa03eb9d901e4fc68ee8f5c1d49721680e"
 dependencies = [
  "aws-credential-types",
  "aws-http",
  "aws-sdk-sso",
  "aws-sdk-sts",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "hex",
@@ -682,11 +680,9 @@ dependencies = [
 [[package]]
 name = "aws-credential-types"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0696a0523a39a19087747e4dafda0362dc867531e3d72a3f195564c84e5e08"
 dependencies = [
- "aws-smithy-async 0.54.4",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-types",
  "tokio",
  "tracing 0.1.37",
  "zeroize",
@@ -695,11 +691,9 @@ dependencies = [
 [[package]]
 name = "aws-endpoint"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4f935ab6a1919fbfd6102a80c4fccd9ff5f47f94ba154074afe1051903261"
 dependencies = [
- "aws-smithy-http 0.54.4",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "aws-types",
  "http",
  "regex",
@@ -709,12 +703,10 @@ dependencies = [
 [[package]]
 name = "aws-http"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82976ca4e426ee9ca3ffcf919d9b2c8d14d0cd80d43cc02173737a8f07f28d4d"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.54.4",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -728,20 +720,18 @@ dependencies = [
 [[package]]
 name = "aws-sdk-cloudwatch"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca35aa6f343ca08847b0f1bbebf2cf8518e2d0e6db7409e410001113536d98cd"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -754,19 +744,17 @@ dependencies = [
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f8dbe7e86cb0c5999cb5911e052ec1e6e3f4abbbcb1333a63538b4aecdaa9b"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -778,19 +766,17 @@ dependencies = [
 [[package]]
 name = "aws-sdk-elasticsearch"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26b30b456954c76df16bcc07b53c76416add85b5f17764e6051b8289572f7af"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -802,19 +788,17 @@ dependencies = [
 [[package]]
 name = "aws-sdk-firehose"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f8c3898ce8ad0ae8c81c340fdd30f0b12785ffbce242d3d9854e5196f81113"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -825,19 +809,17 @@ dependencies = [
 [[package]]
 name = "aws-sdk-kinesis"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85f773996e276281696482efe866719d12e962041bb75f326f8375fb8ac574d"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -849,22 +831,20 @@ dependencies = [
 [[package]]
 name = "aws-sdk-s3"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1533be023eeac69668eb718b1c48af7bd5e26305ed770553d2877ab1f7507b68"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-sigv4",
- "aws-smithy-async 0.54.4",
+ "aws-smithy-async",
  "aws-smithy-checksums",
- "aws-smithy-client 0.54.4",
- "aws-smithy-eventstream 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -884,20 +864,18 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sqs"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2afbc1dfbf260945ad1cc19a1d2109f588663b053ffd828faacb29b02c9260"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -910,19 +888,17 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sso"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0119bacf0c42f587506769390983223ba834e605f049babe514b2bd646dbb2"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-types",
  "bytes 1.4.0",
  "http",
@@ -934,20 +910,18 @@ dependencies = [
 [[package]]
 name = "aws-sdk-sts"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270b6a33969ebfcb193512fbd5e8ee5306888ad6c6d5d775cdbfb2d50d94de26"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-json",
  "aws-smithy-query",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.4.0",
@@ -960,13 +934,11 @@ dependencies = [
 [[package]]
 name = "aws-sig-auth"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660a02a98ab1af83bd8d714afbab2d502ba9b18c49e7e4cddd6bf8837ff778cb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
- "aws-smithy-eventstream 0.54.4",
- "aws-smithy-http 0.54.4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
  "aws-types",
  "http",
  "tracing 0.1.37",
@@ -975,11 +947,9 @@ dependencies = [
 [[package]]
 name = "aws-sigv4"
 version = "0.54.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86529e7b64d902efea8fff52c1b2529368d04f90305cf632729e3713f6b57dc0"
 dependencies = [
- "aws-smithy-eventstream 0.54.4",
- "aws-smithy-http 0.54.4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
  "bytes 1.4.0",
  "form_urlencoded",
  "hex",
@@ -995,21 +965,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3442b4c5d3fc39891a2e5e625735fba6b24694887d49c6518460fde98247a9"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c712a28a4f2f2139759235c08bf98aca99d4fdf1b13c78c5f95613df0a5db9"
+version = "0.54.1"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1019,12 +975,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3875fb4b28606a5368a048016a28c15707f2b21238d5b2e4a23198f590e92c4"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-http 0.54.4",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "bytes 1.4.0",
  "crc32c",
  "crc32fast",
@@ -1040,36 +994,13 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-async 0.51.0",
- "aws-smithy-http 0.51.0",
- "aws-smithy-http-tower 0.51.0",
- "aws-smithy-types 0.51.0",
- "bytes 1.4.0",
- "fastrand",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "tokio",
- "tower",
- "tracing 0.1.37",
-]
-
-[[package]]
-name = "aws-smithy-client"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104ca17f56cde00a10207169697dfe9c6810db339d52fb352707e64875b30a44"
-dependencies = [
- "aws-smithy-async 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
  "aws-smithy-protocol-test",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "bytes 1.4.0",
  "fastrand",
  "http",
@@ -1087,50 +1018,19 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.0.0-smithy-rs-head"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-types 0.54.4",
- "bytes 1.4.0",
- "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac250d8c0e42af0097a6837ffc5a6fb9f8ba4107bb53124c047c91bc2a58878f"
-dependencies = [
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "bytes 1.4.0",
  "crc32fast",
 ]
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-types 0.51.0",
- "bytes 1.4.0",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing 0.1.37",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.54.4"
-dependencies = [
- "aws-smithy-eventstream 0.0.0-smithy-rs-head",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
  "bytes 1.4.0",
  "bytes-utils",
  "futures-core",
@@ -1146,27 +1046,10 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c96d7bd35e7cf96aca1134b2f81b1b59ffe493f7c6539c051791cbbf7a42d3"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-http 0.51.0",
- "bytes 1.4.0",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tracing 0.1.37",
-]
-
-[[package]]
-name = "aws-smithy-http-tower"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38231d3f5dac9ac7976f44e12803add1385119ffca9e5f050d8e980733d164"
-dependencies = [
- "aws-smithy-http 0.54.4",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "bytes 1.4.0",
  "http",
  "http-body",
@@ -1177,18 +1060,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd83ff2b79e9f729746fcc8ad798676b68fe6ea72986571569a5306a277a182"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d1c9bcb35ce11055ec128dab2c66a7ed47e2dfff99883e32c21a1ab6d6bee6"
+version = "0.54.1"
 dependencies = [
  "assert-json-diff 1.1.0",
  "http",
@@ -1201,29 +1080,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f0445dafe9d2cd50b44339ae3c3ed46549aad8ac696c52ad660b3e7ae8682b"
+version = "0.54.1"
 dependencies = [
- "aws-smithy-types 0.54.4",
+ "aws-smithy-types",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
-dependencies = [
- "itoa",
- "num-integer",
- "ryu",
- "time",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "0.54.4"
+version = "0.54.1"
 dependencies = [
  "base64-simd",
  "itoa",
@@ -1234,9 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343ffe9a9bb3f542675f4df0e0d5933513d6ad038ca3907ad1767ba690a99684"
+version = "0.54.1"
 dependencies = [
  "xmlparser",
 ]
@@ -1244,14 +1107,12 @@ dependencies = [
 [[package]]
 name = "aws-types"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f15b34253b68cde08e39b0627cc6101bcca64351229484b4743392c035d057"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-async 0.54.4",
- "aws-smithy-client 0.54.4",
- "aws-smithy-http 0.54.4",
- "aws-smithy-types 0.54.4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "http",
  "rustc_version 0.4.0",
  "tracing 0.1.37",
@@ -9231,11 +9092,11 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "aws-sigv4",
- "aws-smithy-async 0.51.0",
- "aws-smithy-client 0.51.0",
- "aws-smithy-http 0.54.4",
- "aws-smithy-http-tower 0.54.4",
- "aws-smithy-types 0.51.0",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
  "aws-types",
  "axum",
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,16 +158,17 @@ metrics = "0.21.0"
 metrics-tracing-context = { version = "0.14.0", default-features = false }
 
 # AWS - Official SDK
-aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-sqs = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatch = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatchlogs = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-elasticsearch = {version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-firehose = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls"], optional = true }
-aws-types = { version = "0.51.0", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-sigv4 = { version = "0.55.3", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-s3 = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-sqs = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatch = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatchlogs = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-elasticsearch = {version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-firehose = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-kinesis = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
+aws-types = { version = "0.54.1", default-features = false, optional = true }
+aws-sigv4 = { version = "0.54.2", default-features = false, features = ["sign-http"], optional = true }
+aws-config = { version = "0.54.1", default-features = false, features = ["native-tls"], optional = true }
+aws-credential-types = { version = "0.54.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
 aws-smithy-async = { version = "0.51.0", default-features = false, optional = true }
 aws-smithy-client = { version = "0.51.0", default-features = false, features = ["client-hyper"], optional = true}
 aws-smithy-http = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-http", default-features = false, features = ["event-stream"], optional = true }
@@ -362,6 +363,8 @@ wiremock = "0.5.19"
 zstd = { version = "0.12.3", default-features = false }
 
 [patch.crates-io]
+aws-smithy-http = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-http" }
+aws-smithy-types = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-types" }
 # Removes dependency on `time` v0.1
 # https://github.com/chronotope/chrono/pull/578
 chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.26-no-default-time-1" }
@@ -435,6 +438,7 @@ api-client = [
 
 aws-core = [
   "aws-config",
+  "dep:aws-credential-types",
   "dep:aws-sigv4",
   "dep:aws-types",
   "dep:aws-smithy-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,8 @@ aws-sigv4 = { version = "0.55.3", default-features = false, features = ["sign-ht
 aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"], optional = true }
 aws-smithy-async = { version = "0.51.0", default-features = false, optional = true }
 aws-smithy-client = { version = "0.51.0", default-features = false, features = ["client-hyper"], optional = true}
-aws-smithy-http = { version = "0.51.0", default-features = false, features = ["event-stream"], optional = true }
+aws-smithy-http = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-http", default-features = false, features = ["event-stream"], optional = true }
+#aws-smithy-http = { version = "0.51.0", default-features = false, features = ["event-stream"], optional = true }
 aws-smithy-http-tower = { version = "0.54.4", default-features = false, optional = true }
 aws-smithy-types = { version = "0.51.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,23 +158,22 @@ metrics = "0.21.0"
 metrics-tracing-context = { version = "0.14.0", default-features = false }
 
 # AWS - Official SDK
-aws-sdk-s3 = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-sqs = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatch = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatchlogs = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-elasticsearch = {version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-firehose = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-kinesis = { version = "0.24.0", default-features = false, features = ["native-tls"], optional = true }
-aws-types = { version = "0.54.1", default-features = false, optional = true }
-aws-sigv4 = { version = "0.54.2", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "0.54.1", default-features = false, features = ["native-tls"], optional = true }
-aws-credential-types = { version = "0.54.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-smithy-async = { version = "0.51.0", default-features = false, optional = true }
-aws-smithy-client = { version = "0.51.0", default-features = false, features = ["client-hyper"], optional = true}
-aws-smithy-http = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-http", default-features = false, features = ["event-stream"], optional = true }
-#aws-smithy-http = { version = "0.51.0", default-features = false, features = ["event-stream"], optional = true }
-aws-smithy-http-tower = { version = "0.54.4", default-features = false, optional = true }
-aws-smithy-types = { version = "0.51.0", default-features = false, optional = true }
+aws-sdk-s3 = { path = "../../awslabs/aws-sdk-rust/sdk/s3", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-sqs = { path = "../../awslabs/aws-sdk-rust/sdk/sqs", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatch = { path = "../../awslabs/aws-sdk-rust/sdk/cloudwatch", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatchlogs = { path = "../../awslabs/aws-sdk-rust/sdk/cloudwatchlogs", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-elasticsearch = { path = "../../awslabs/aws-sdk-rust/sdk/elasticsearch", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-firehose = { path = "../../awslabs/aws-sdk-rust/sdk/firehose", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-kinesis = { path = "../../awslabs/aws-sdk-rust/sdk/kinesis", default-features = false, features = ["native-tls"], optional = true }
+aws-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-types", default-features = false, optional = true }
+aws-sigv4 = { path = "../../awslabs/aws-sdk-rust/sdk/aws-sigv4", default-features = false, features = ["sign-http"], optional = true }
+aws-config = { path = "../../awslabs/aws-sdk-rust/sdk/aws-config", default-features = false, features = ["native-tls"], optional = true }
+aws-credential-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-credential-types", default-features = false, features = ["hardcoded-credentials"], optional = true }
+aws-smithy-async = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-async", default-features = false, optional = true }
+aws-smithy-client = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-client", default-features = false, features = ["client-hyper"], optional = true}
+aws-smithy-http = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-http", default-features = false, features = ["event-stream"], optional = true }
+aws-smithy-http-tower = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-http-tower", default-features = false, optional = true }
+aws-smithy-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-types", default-features = false, optional = true }
 
 # Azure
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "b4544d4920fa3064eb921340054cd9cc130b7664", default-features = false, features = ["enable_reqwest"], optional = true }
@@ -363,8 +362,8 @@ wiremock = "0.5.19"
 zstd = { version = "0.12.3", default-features = false }
 
 [patch.crates-io]
-aws-smithy-http = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-http" }
-aws-smithy-types = { path = "../../awslabs/smithy-rs/rust-runtime/aws-smithy-types" }
+aws-smithy-http = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-http" }
+aws-smithy-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-types" }
 # Removes dependency on `time` v0.1
 # https://github.com/chronotope/chrono/pull/578
 chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.26-no-default-time-1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,22 +158,23 @@ metrics = "0.21.0"
 metrics-tracing-context = { version = "0.14.0", default-features = false }
 
 # AWS - Official SDK
-aws-sdk-s3 = { path = "../../awslabs/aws-sdk-rust/sdk/s3", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-sqs = { path = "../../awslabs/aws-sdk-rust/sdk/sqs", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatch = { path = "../../awslabs/aws-sdk-rust/sdk/cloudwatch", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-cloudwatchlogs = { path = "../../awslabs/aws-sdk-rust/sdk/cloudwatchlogs", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-elasticsearch = { path = "../../awslabs/aws-sdk-rust/sdk/elasticsearch", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-firehose = { path = "../../awslabs/aws-sdk-rust/sdk/firehose", default-features = false, features = ["native-tls"], optional = true }
-aws-sdk-kinesis = { path = "../../awslabs/aws-sdk-rust/sdk/kinesis", default-features = false, features = ["native-tls"], optional = true }
-aws-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-types", default-features = false, optional = true }
-aws-sigv4 = { path = "../../awslabs/aws-sdk-rust/sdk/aws-sigv4", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { path = "../../awslabs/aws-sdk-rust/sdk/aws-config", default-features = false, features = ["native-tls"], optional = true }
-aws-credential-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-credential-types", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-smithy-async = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-async", default-features = false, optional = true }
-aws-smithy-client = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-client", default-features = false, features = ["client-hyper"], optional = true}
-aws-smithy-http = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-http", default-features = false, features = ["event-stream"], optional = true }
-aws-smithy-http-tower = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-http-tower", default-features = false, optional = true }
-aws-smithy-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-types", default-features = false, optional = true }
+# depending on a fork to circumvent https://github.com/awslabs/aws-sdk-rust/issues/749
+aws-sdk-s3 = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-sqs = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatch = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-cloudwatchlogs = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-elasticsearch = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-firehose = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-sdk-kinesis = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-types = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, optional = true }
+aws-sigv4 = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["sign-http"], optional = true }
+aws-config = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["native-tls"], optional = true }
+aws-credential-types = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["hardcoded-credentials"], optional = true }
+aws-smithy-async = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, optional = true }
+aws-smithy-client = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["client-hyper"], optional = true}
+aws-smithy-http = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, features = ["event-stream"], optional = true }
+aws-smithy-http-tower = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, optional = true }
+aws-smithy-types = { git = "https://github.com/vectordotdev/aws-sdk-rust", rev = "3d6aefb7fcfced5fc2a7e761a87e4ddbda1ee670", default-features = false, optional = true }
 
 # Azure
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust.git", rev = "b4544d4920fa3064eb921340054cd9cc130b7664", default-features = false, features = ["enable_reqwest"], optional = true }
@@ -362,8 +363,6 @@ wiremock = "0.5.19"
 zstd = { version = "0.12.3", default-features = false }
 
 [patch.crates-io]
-aws-smithy-http = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-http" }
-aws-smithy-types = { path = "../../awslabs/aws-sdk-rust/sdk/aws-smithy-types" }
 # Removes dependency on `time` v0.1
 # https://github.com/chronotope/chrono/pull/578
 chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.26-no-default-time-1" }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -18,6 +18,7 @@ arc-swap,https://github.com/vorner/arc-swap,MIT OR Apache-2.0,Michal 'vorner' Va
 arr_macro,https://github.com/JoshMcguigan/arr_macro,MIT OR Apache-2.0,Josh Mcguigan
 arrayvec,https://github.com/bluss/arrayvec,MIT OR Apache-2.0,bluss
 ascii,https://github.com/tomprogrammer/rust-ascii,Apache-2.0  OR  MIT,"Thomas Bahn <thomas@thomas-bahn.net>, Torbjørn Birch Moltu <t.b.moltu@lyse.net>, Simon Sapin <simon.sapin@exyr.org>"
+assert-json-diff,https://github.com/davidpdrsn/assert-json-diff,MIT,David Pedersen <david.pdrsn@gmail.com>
 async-channel,https://github.com/smol-rs/async-channel,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-compat,https://github.com/smol-rs/async-compat,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 async-compression,https://github.com/Nemo157/async-compression,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>"
@@ -38,6 +39,7 @@ async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolna
 atomic-waker,https://github.com/stjepang/atomic-waker,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 atty,https://github.com/softprops/atty,MIT,softprops <d.tangren@gmail.com>
 aws-config,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
+aws-credential-types,https://github.com/awslabs/smithy-rs,Apache-2.0,AWS Rust SDK Team <aws-sdk-rust@amazon.com>
 aws-endpoint,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-http,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-sdk-cloudwatch,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
@@ -57,6 +59,7 @@ aws-smithy-eventstream,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust
 aws-smithy-http,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-smithy-http-tower,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-smithy-json,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, John DiSanti <jdisanti@amazon.com>"
+aws-smithy-protocol-test,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-smithy-query,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, John DiSanti <jdisanti@amazon.com>"
 aws-smithy-types,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-smithy-xml,https://github.com/awslabs/smithy-rs,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
@@ -138,6 +141,7 @@ crossterm,https://github.com/crossterm-rs/crossterm,MIT,T. Post
 crossterm_winapi,https://github.com/crossterm-rs/crossterm-winapi,MIT,T. Post
 crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 csv,https://github.com/BurntSushi/rust-csv,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <matthew@mastracci.com>
 ctr,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Developers
 cty,https://github.com/japaric/cty,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 curve25519-dalek,https://github.com/dalek-cryptography/curve25519-dalek,BSD-3-Clause,"Isis Lovecruft <isis@patternsinthevoid.net>, Henry de Valence <hdevalence@hdevalence.ca>"
@@ -151,6 +155,7 @@ der,https://github.com/RustCrypto/formats/tree/master/der,Apache-2.0 OR MIT,Rust
 derivative,https://github.com/mcarton/rust-derivative,MIT OR Apache-2.0,mcarton <cartonmartin+git@gmail.com>
 derive_arbitrary,https://github.com/rust-fuzz/arbitrary,MIT OR Apache-2.0,"The Rust-Fuzz Project Developers, Nick Fitzgerald <fitzgen@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>, Andre Bogus <bogusandre@gmail.com>, Corey Farwell <coreyf@rwell.org>"
 derive_more,https://github.com/JelteF/derive_more,MIT,Jelte Fennema <github-tech@jeltef.nl>
+diff,https://github.com/utkarshkukreti/diff.rs,MIT OR Apache-2.0,Utkarsh Kukreti <utkarshkukreti@gmail.com>
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 dirs,https://github.com/soc/dirs-rs,MIT OR Apache-2.0,Simon Ochsenreither <simon@ochsenreither.de>
 dirs-next,https://github.com/xdg-rs/dirs,MIT OR Apache-2.0,The @xdg-rs members
@@ -177,6 +182,7 @@ error-code,https://github.com/DoumanAsh/error-code,BSL-1.0,Douman <douman@gmx.se
 event-listener,https://github.com/smol-rs/event-listener,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 executor-trait,https://github.com/amqp-rs/executor-trait,Apache-2.0 OR MIT,Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
 exitcode,https://github.com/benwilber/exitcode,Apache-2.0,Ben Wilber <benwilber@gmail.com>
+extend,https://github.com/davidpdrsn/ext,MIT,David Pedersen <david.pdrsn@gmail.com>
 fakedata_generator,https://github.com/kevingimbel/fakedata_generator,MIT,Kevin Gimbel <hallo@kevingimbel.com>
 fallible-iterator,https://github.com/sfackler/rust-fallible-iterator,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>
 fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
@@ -351,6 +357,7 @@ openssl-macros,https://github.com/sfackler/rust-openssl,MIT OR Apache-2.0,The op
 openssl-probe,https://github.com/alexcrichton/openssl-probe,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 openssl-sys,https://github.com/sfackler/rust-openssl,MIT,"Alex Crichton <alex@alexcrichton.com>, Steven Fackler <sfackler@gmail.com>"
 ordered-float,https://github.com/reem/rust-ordered-float,MIT,"Jonathan Reem <jonathan.reem@gmail.com>, Matt Brubeck <mbrubeck@limpet.net>"
+output_vt100,https://github.com/Phundrak/output-vt100-rs,MIT,Phuntsok Drak-pa <phundrak@phundrak.fr>
 outref,https://github.com/Nugine/outref,MIT,The outref Authors
 overload,https://github.com/danaugrs/overload,MIT,Daniel Salvadori <danaugrs@gmail.com>
 pad,https://github.com/ogham/rust-pad,MIT,Ben S <ogham@bsago.me>
@@ -376,6 +383,7 @@ postgres-openssl,https://github.com/sfackler/rust-postgres,MIT OR Apache-2.0,Ste
 postgres-protocol,https://github.com/sfackler/rust-postgres,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>
 postgres-types,https://github.com/sfackler/rust-postgres,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
+pretty_assertions,https://github.com/rust-pretty-assertions/rust-pretty-assertions,MIT OR Apache-2.0,"Colin Kiegel <kiegel@gmx.de>, Florent Fayolle <florent.fayolle69@gmail.com>, Tom Milligan <code@tommilligan.net>"
 prettydiff,https://github.com/romankoblov/prettydiff,MIT,Roman Koblov <penpen938@me.com>
 prettytable-rs,https://github.com/phsym/prettytable-rs,BSD-3-Clause,Pierre-Henri Symoneaux
 proc-macro-crate,https://github.com/bkchr/proc-macro-crate,Apache-2.0 OR MIT,Bastian Köcher <git@kchr.de>
@@ -420,6 +428,7 @@ rmp,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail
 rmp-serde,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
 rmpv,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
 roaring,https://github.com/RoaringBitmap/roaring-rs,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Kerollmops <kero@meilisearch.com>"
+roxmltree,https://github.com/RazrFalcon/roxmltree,MIT OR Apache-2.0,Evgeniy Reizner <razrfalcon@gmail.com>
 roxmltree,https://github.com/RazrFalcon/roxmltree,MIT OR Apache-2.0,Yevhenii Reizner <razrfalcon@gmail.com>
 rust_decimal,https://github.com/paupino/rust-decimal,MIT,Paul Mason <paul@form1.co.nz>
 rustc-hash,https://github.com/rust-lang-nursery/rustc-hash,Apache-2.0 OR MIT,The Rust Project Developers
@@ -473,6 +482,7 @@ signal-hook,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vor
 signal-hook-registry,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>"
 signatory,https://github.com/iqlusioninc/crates/tree/main/signatory,Apache-2.0 OR MIT,Tony Arcieri <tony@iqlusion.io>
 signature,https://github.com/RustCrypto/traits/tree/master/signature,Apache-2.0 OR MIT,RustCrypto Developers
+simd-abstraction,https://github.com/Nugine/simd,MIT,The simd-abstraction Authors
 simpl,https://github.com/durch/simplerr,MIT,Drazen Urch <drazen@urch.eu>
 siphasher,https://github.com/jedisct1/rust-siphash,MIT OR Apache-2.0,Frank Denis <github@pureftpd.org>
 sketches-ddsketch,https://github.com/mheffner/rust-sketches-ddsketch,Apache-2.0,Mike Heffner <mikeh@fesnel.com>
@@ -571,7 +581,6 @@ valuable,https://github.com/tokio-rs/valuable,MIT,The valuable Authors
 vec_map,https://github.com/contain-rs/vec-map,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Jorge Aparicio <japaricious@gmail.com>, Alexis Beingessner <a.beingessner@gmail.com>, Brian Anderson <>, tbu- <>, Manish Goregaokar <>, Aaron Turon <aturon@mozilla.com>, Adolfo Ochagavía <>, Niko Matsakis <>, Steven Fackler <>, Chase Southwood <csouth3@illinois.edu>, Eduard Burtescu <>, Florian Wilkens <>, Félix Raimundo <>, Tibor Benke <>, Markus Siemens <markus@m-siemens.de>, Josh Branchaud <jbranchaud@gmail.com>, Huon Wilson <dbau.pp@gmail.com>, Corey Farwell <coref@rwell.org>, Aaron Liblong <>, Nick Cameron <nrc@ncameron.org>, Patrick Walton <pcwalton@mimiga.net>, Felix S Klock II <>, Andrew Paseltiner <apaseltiner@gmail.com>, Sean McArthur <sean.monstar@gmail.com>, Vadim Petrochenkov <>"
 void,https://github.com/reem/rust-void,MIT,Jonathan Reem <jonathan.reem@gmail.com>
 vrl,https://github.com/vectordotdev/vrl,MPL-2.0,Vector Contributors <vector@datadoghq.com>
-vsimd,https://github.com/Nugine/simd,MIT,The vsimd Authors
 vte,https://github.com/alacritty/vte,Apache-2.0 OR MIT,"Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>"
 vte_generate_state_changes,https://github.com/jwilm/vte,Apache-2.0 OR MIT,Christian Duerr <contact@christianduerr.com>
 wait-timeout,https://github.com/alexcrichton/wait-timeout,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
@@ -613,6 +622,7 @@ wyz,https://github.com/myrrlyn/wyz,MIT,myrrlyn <self@myrrlyn.dev>
 xml-rs,https://github.com/kornelski/xml-rs,MIT,Vladimir Matveev <vmatveev@citrine.cc>
 xmlparser,https://github.com/RazrFalcon/xmlparser,MIT OR Apache-2.0,Evgeniy Reizner <razrfalcon@gmail.com>
 yaml-rust,https://github.com/chyh1990/yaml-rust,MIT OR Apache-2.0,Yuheng Chen <yuhengchen@sensetime.com>
+yansi,https://github.com/SergioBenitez/yansi,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 zerocopy,https://fuchsia.googlesource.com/fuchsia/+/HEAD/src/lib/zerocopy,BSD-2-Clause,Joshua Liebow-Feeser <joshlf@google.com>
 zerocopy-derive,https://github.com/google/zerocopy,BSD-2-Clause,Joshua Liebow-Feeser <joshlf@google.com>
 zeroize,https://github.com/RustCrypto/utils/tree/master/zeroize,Apache-2.0 OR MIT,The RustCrypto Project Developers

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -9,7 +9,10 @@ use aws_config::{
     },
     sts::AssumeRoleProviderBuilder,
 };
-use aws_types::{credentials::SharedCredentialsProvider, region::Region, Credentials};
+use aws_credential_types::{
+    cache::CredentialsCache, provider::SharedCredentialsProvider, Credentials,
+};
+use aws_types::region::Region;
 use serde_with::serde_as;
 use vector_common::sensitive_string::SensitiveString;
 use vector_config::configurable_component;

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -168,6 +168,28 @@ fn default_profile() -> String {
 }
 
 impl AwsAuthentication {
+    pub async fn credentials_cache(&self) -> crate::Result<CredentialsCache> {
+        match self {
+            AwsAuthentication::Role {
+                load_timeout_secs, ..
+            }
+            | AwsAuthentication::Default {
+                load_timeout_secs, ..
+            } => {
+                let credentials_cache = CredentialsCache::lazy_builder()
+                    .load_timeout(
+                        load_timeout_secs
+                            .map(Duration::from_secs)
+                            .unwrap_or(DEFAULT_LOAD_TIMEOUT),
+                    )
+                    .into_credentials_cache();
+
+                Ok(credentials_cache)
+            }
+            _ => Ok(CredentialsCache::lazy()),
+        }
+    }
+
     pub async fn credentials_provider(
         &self,
         service_region: Region,
@@ -210,28 +232,20 @@ impl AwsAuthentication {
             }
             AwsAuthentication::Role {
                 assume_role,
-                load_timeout_secs,
                 imds,
                 region,
+                ..
             } => {
                 let auth_region = region.clone().map(Region::new).unwrap_or(service_region);
                 let provider = AssumeRoleProviderBuilder::new(assume_role)
                     .region(auth_region.clone())
-                    .build(
-                        default_credentials_provider(auth_region, *load_timeout_secs, *imds)
-                            .await?,
-                    );
+                    .build(default_credentials_provider(auth_region, *imds).await?);
 
                 Ok(SharedCredentialsProvider::new(provider))
             }
-            AwsAuthentication::Default {
-                load_timeout_secs,
-                imds,
-                region,
-            } => Ok(SharedCredentialsProvider::new(
+            AwsAuthentication::Default { imds, region, .. } => Ok(SharedCredentialsProvider::new(
                 default_credentials_provider(
                     region.clone().map(Region::new).unwrap_or(service_region),
-                    *load_timeout_secs,
                     *imds,
                 )
                 .await?,
@@ -252,7 +266,6 @@ impl AwsAuthentication {
 
 async fn default_credentials_provider(
     region: Region,
-    load_timeout_secs: Option<u64>,
     imds: ImdsAuthentication,
 ) -> crate::Result<SharedCredentialsProvider> {
     let client = imds::Client::builder()
@@ -262,16 +275,13 @@ async fn default_credentials_provider(
         .build()
         .await?;
 
-    let chain = DefaultCredentialsChain::builder()
+    let credentials_provider = DefaultCredentialsChain::builder()
         .region(region)
         .imds_client(client)
-        .load_timeout(
-            load_timeout_secs
-                .map(Duration::from_secs)
-                .unwrap_or(DEFAULT_LOAD_TIMEOUT),
-        );
+        .build()
+        .await;
 
-    Ok(SharedCredentialsProvider::new(chain.build().await))
+    Ok(SharedCredentialsProvider::new(credentials_provider))
 }
 
 #[cfg(test)]

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -258,7 +258,7 @@ where
             let body = {
                 let shared_bytes_sent = Arc::clone(&shared_bytes_sent);
 
-                body.map(move |body| {
+                body.map_immutable(move |body| {
                     let body = MeasuredBody::new(body, Arc::clone(&shared_bytes_sent));
                     SdkBody::from_dyn(BoxBody::new(body))
                 })

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -2,6 +2,7 @@
 pub mod auth;
 pub mod region;
 
+use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -11,22 +12,23 @@ use std::time::SystemTime;
 
 pub use auth::{AwsAuthentication, ImdsAuthentication};
 use aws_config::meta::region::ProvideRegion;
+use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
 use aws_sigv4::http_request::{SignableRequest, SigningSettings};
 use aws_sigv4::SigningParams;
 use aws_smithy_async::rt::sleep::TokioSleep;
 use aws_smithy_client::bounds::SmithyMiddleware;
 use aws_smithy_client::erase::{DynConnector, DynMiddleware};
 use aws_smithy_client::{Builder, SdkError};
-use aws_smithy_http::callback::BodyCallback;
-use aws_smithy_http::endpoint::Endpoint;
-use aws_smithy_http::event_stream::BoxError;
+use aws_smithy_http::body::{BoxBody, SdkBody};
 use aws_smithy_http::operation::{Request, Response};
 use aws_smithy_types::retry::RetryConfig;
-use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
 use aws_types::region::Region;
 use aws_types::SdkConfig;
 use bytes::Bytes;
+use http::HeaderMap;
+use http_body::Body;
 use once_cell::sync::OnceCell;
+use pin_project::pin_project;
 use regex::RegexSet;
 pub use region::RegionOrEndpoint;
 use tower::{Layer, Service, ServiceBuilder};
@@ -42,39 +44,46 @@ pub fn is_retriable_error<T>(error: &SdkError<T>) -> bool {
     match error {
         SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => true,
         SdkError::ConstructionFailure(_) => false,
-        SdkError::ResponseError { err: _, raw } | SdkError::ServiceError { err: _, raw } => {
-            // This header is a direct indication that we should retry the request. Eventually it'd
-            // be nice to actually schedule the retry after the given delay, but for now we just
-            // check that it contains a positive value.
-            let retry_header = raw.http().headers().get("x-amz-retry-after").is_some();
-
-            // Certain 400-level responses will contain an error code indicating that the request
-            // should be retried. Since we don't retry 400-level responses by default, we'll look
-            // for these specifically before falling back to more general heuristics. Because AWS
-            // services use a mix of XML and JSON response bodies and the AWS SDK doesn't give us
-            // a parsed representation, we resort to a simple string match.
-            //
-            // S3: RequestTimeout
-            // SQS: RequestExpired, ThrottlingException
-            // ECS: RequestExpired, ThrottlingException
-            // Kinesis: RequestExpired, ThrottlingException
-            // Cloudwatch: RequestExpired, ThrottlingException
-            //
-            // Now just look for those when it's a client_error
-            let re = RETRIABLE_CODES.get_or_init(|| {
-                RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException"])
-                    .expect("invalid regex")
-            });
-
-            let status = raw.http().status();
-            let response_body = String::from_utf8_lossy(raw.http().body().bytes().unwrap_or(&[]));
-
-            retry_header
-                || status.is_server_error()
-                || status == http::StatusCode::TOO_MANY_REQUESTS
-                || (status.is_client_error() && re.is_match(response_body.as_ref()))
+        SdkError::ResponseError(err) => check_response(err.raw()),
+        SdkError::ServiceError(err) => check_response(err.raw()),
+        _ => {
+            warn!("AWS returned unknown error, retrying request.");
+            true
         }
     }
+}
+
+fn check_response(res: &Response) -> bool {
+    // This header is a direct indication that we should retry the request. Eventually it'd
+    // be nice to actually schedule the retry after the given delay, but for now we just
+    // check that it contains a positive value.
+    let retry_header = res.http().headers().get("x-amz-retry-after").is_some();
+
+    // Certain 400-level responses will contain an error code indicating that the request
+    // should be retried. Since we don't retry 400-level responses by default, we'll look
+    // for these specifically before falling back to more general heuristics. Because AWS
+    // services use a mix of XML and JSON response bodies and the AWS SDK doesn't give us
+    // a parsed representation, we resort to a simple string match.
+    //
+    // S3: RequestTimeout
+    // SQS: RequestExpired, ThrottlingException
+    // ECS: RequestExpired, ThrottlingException
+    // Kinesis: RequestExpired, ThrottlingException
+    // Cloudwatch: RequestExpired, ThrottlingException
+    //
+    // Now just look for those when it's a client_error
+    let re = RETRIABLE_CODES.get_or_init(|| {
+        RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException"])
+            .expect("invalid regex")
+    });
+
+    let status = res.http().status();
+    let response_body = String::from_utf8_lossy(res.http().body().bytes().unwrap_or(&[]));
+
+    retry_header
+        || status.is_server_error()
+        || status == http::StatusCode::TOO_MANY_REQUESTS
+        || (status.is_client_error() && re.is_match(response_body.as_ref()))
 }
 
 pub trait ClientBuilder {
@@ -84,7 +93,7 @@ pub trait ClientBuilder {
 
     fn default_middleware() -> Self::DefaultMiddleware;
 
-    fn build(client: aws_smithy_client::Client, config: &aws_types::SdkConfig) -> Self::Client;
+    fn build(client: aws_smithy_client::Client, config: &SdkConfig) -> Self::Client;
 }
 
 pub async fn create_smithy_client<T: ClientBuilder>(
@@ -99,11 +108,11 @@ pub async fn create_smithy_client<T: ClientBuilder>(
     let connector = if proxy.enabled {
         let proxy = build_proxy_connector(tls_settings, proxy)?;
         let hyper_client = aws_smithy_client::hyper_ext::Adapter::builder().build(proxy);
-        aws_smithy_client::erase::DynConnector::new(hyper_client)
+        DynConnector::new(hyper_client)
     } else {
         let tls_connector = build_tls_connector(tls_settings)?;
         let hyper_client = aws_smithy_client::hyper_ext::Adapter::builder().build(tls_connector);
-        aws_smithy_client::erase::DynConnector::new(hyper_client)
+        DynConnector::new(hyper_client)
     };
 
     let middleware_builder = ServiceBuilder::new()
@@ -135,7 +144,7 @@ pub async fn resolve_region(region: Option<Region>) -> crate::Result<Region> {
 pub async fn create_client<T: ClientBuilder>(
     auth: &AwsAuthentication,
     region: Option<Region>,
-    endpoint: Option<Endpoint>,
+    endpoint: Option<String>,
     proxy: &ProxyConfig,
     tls_options: &Option<TlsConfig>,
     is_sink: bool,
@@ -148,12 +157,13 @@ pub async fn create_client<T: ClientBuilder>(
 
     // Build the configuration first.
     let mut config_builder = SdkConfig::builder()
+        .credentials_cache(auth.credentials_cache().await?)
         .credentials_provider(auth.credentials_provider(region.clone()).await?)
         .region(region.clone())
         .retry_config(retry_config.clone());
 
     if let Some(endpoint_override) = endpoint {
-        config_builder = config_builder.endpoint_resolver(endpoint_override);
+        config_builder = config_builder.endpoint_url(endpoint_override);
     }
 
     let config = config_builder.build();
@@ -230,23 +240,36 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: Request) -> Self::Future {
+    fn call(&mut self, req: Request) -> Self::Future {
         // Attach a body callback that will capture the bytes sent by interrogating the body chunks that get read as it
         // sends the request out over the wire. We'll read the shared atomic counter, which will contain the number of
         // bytes "read", aka the bytes it actually sent, if and only if we get back a successful response.
-        let maybe_bytes_sent = self.enabled.then(|| {
-            let (callback, shared_bytes_sent) = BodyCaptureCallback::new();
-            req.http_mut().body_mut().with_callback(Box::new(callback));
+        let (req, maybe_bytes_sent) = if self.enabled {
+            let shared_bytes_sent = Arc::new(AtomicUsize::new(0));
+            let (request, properties) = req.into_parts();
+            let (parts, body) = request.into_parts();
 
-            shared_bytes_sent
-        });
+            let body = {
+                let shared_bytes_sent = Arc::clone(&shared_bytes_sent);
+
+                body.map(move |body| {
+                    let body = MeasuredBody::new(body, Arc::clone(&shared_bytes_sent));
+                    SdkBody::from_dyn(BoxBody::new(body))
+                })
+            };
+
+            let req = Request::from_parts(http::Request::from_parts(parts, body), properties);
+
+            (req, Some(shared_bytes_sent))
+        } else {
+            (req, None)
+        };
 
         let region = self.region.clone();
         let fut = self.inner.call(req);
@@ -275,69 +298,48 @@ where
     }
 }
 
-struct BodyCaptureCallback {
-    bytes_sent: usize,
+#[pin_project]
+struct MeasuredBody {
+    #[pin]
+    inner: SdkBody,
     shared_bytes_sent: Arc<AtomicUsize>,
 }
 
-impl BodyCaptureCallback {
-    fn new() -> (Self, Arc<AtomicUsize>) {
-        let shared_bytes_sent = Arc::new(AtomicUsize::new(0));
-
-        (
-            Self {
-                bytes_sent: 0,
-                shared_bytes_sent: Arc::clone(&shared_bytes_sent),
-            },
+impl MeasuredBody {
+    fn new(body: SdkBody, shared_bytes_sent: Arc<AtomicUsize>) -> Self {
+        Self {
+            inner: body,
             shared_bytes_sent,
-        )
+        }
     }
 }
 
-impl BodyCallback for BodyCaptureCallback {
-    fn update(&mut self, bytes: &[u8]) -> Result<(), BoxError> {
-        // This gets called every time a chunk is read from the request body, which includes both static chunks and
-        // streaming bodies. Just add the chunk's length to our running tally.
-        self.bytes_sent += bytes.len();
-        Ok(())
+impl Body for MeasuredBody {
+    type Data = Bytes;
+    type Error = Box<dyn Error + Send + Sync>;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.project();
+
+        match this.inner.poll_data(cx) {
+            Poll::Ready(Some(Ok(data))) => {
+                this.shared_bytes_sent
+                    .fetch_add(data.len(), Ordering::Release);
+                Poll::Ready(Some(Ok(data)))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Pending => Poll::Pending,
+        }
     }
 
-    fn trailers(&self) -> Result<Option<headers::HeaderMap<headers::HeaderValue>>, BoxError> {
-        Ok(None)
-    }
-
-    fn make_new(&self) -> Box<dyn BodyCallback> {
-        // We technically don't use retries within the AWS side of the API clients, but we have to satisfy this trait
-        // method, because `aws_smithy_http` uses the retry layer from `tower`, which clones the request regardless
-        // before it even executes the first attempt... so there's no reason not to make it technically correct.
-        Box::new(Self {
-            bytes_sent: 0,
-            shared_bytes_sent: Arc::clone(&self.shared_bytes_sent),
-        })
-    }
-}
-
-impl Drop for BodyCaptureCallback {
-    fn drop(&mut self) {
-        // This is where we actually emit. We specifically emit here, and not in `trailers`, because despite the
-        // documentation that `trailers` is called after all chunks of the body are successfully read, `hyper` won't
-        // continue polling a body if it knows it's gotten all the available bytes i.e. it doesn't necessarily drive it
-        // until `poll_data` returns `None`. This means the only consistent place to know that the body is "done" is
-        // when it's dropped.
-        //
-        // We update our shared atomic counter with the total bytes sent that we accumulated, and it will read the
-        // atomic if the response indicates that the request was successful. Since we know the body will go out-of-scope
-        // before a response can possibly be generated, we know the atomic will in turn be updated before it is read.
-        //
-        // This design also copes with the fact that, technically, `aws_smithy_client` supports retries and could clone
-        // this callback for each copy of the request... which it already does at least once per request since the retry
-        // middleware has to clone the request before trying it. As requests are retried sequentially, only after the
-        // previous attempt failed, we know that we'll end up in a "last write wins" scenario, so this is still sound.
-        //
-        // In the future, we may track every single byte sent in order to generate "raw bytes over the wire, regardless
-        // of status" metrics, but right now, this is purely "how many bytes have we sent as part of _successful_
-        // sends?"
-        self.shared_bytes_sent
-            .store(self.bytes_sent, Ordering::Release);
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
     }
 }

--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -1,8 +1,4 @@
-use std::str::FromStr;
-
-use aws_smithy_http::endpoint::Endpoint;
 use aws_types::region::Region;
-use http::Uri;
 use vector_config::configurable_component;
 
 /// Configuration of the region/endpoint to use when interacting with an AWS service.
@@ -37,9 +33,8 @@ impl RegionOrEndpoint {
         }
     }
 
-    pub fn endpoint(&self) -> crate::Result<Option<Endpoint>> {
-        let uri = self.endpoint.as_deref().map(Uri::from_str).transpose()?;
-        Ok(uri.map(Endpoint::immutable))
+    pub fn endpoint(&self) -> Option<String> {
+        self.endpoint.clone()
     }
 
     pub fn region(&self) -> Option<Region> {

--- a/src/common/s3.rs
+++ b/src/common/s3.rs
@@ -12,6 +12,10 @@ impl ClientBuilder for S3ClientBuilder {
     }
 
     fn build(client: aws_smithy_client::Client, config: &aws_types::SdkConfig) -> Self::Client {
-        aws_sdk_s3::client::Client::with_config(client, config.into())
+        let config = aws_sdk_s3::config::Builder::from(config)
+            .force_path_style(true)
+            .build();
+
+        aws_sdk_s3::client::Client::with_config(client, config)
     }
 }

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -136,7 +136,7 @@ impl CloudwatchLogsSinkConfig {
         create_client::<CloudwatchLogsClientBuilder>(
             &self.auth,
             self.region.region(),
-            self.region.endpoint()?,
+            self.region.endpoint(),
             proxy,
             &self.tls,
             true,

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -1,12 +1,10 @@
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
-use aws_sdk_cloudwatchlogs::{Endpoint, Region};
+use aws_sdk_cloudwatchlogs::Region;
 use chrono::Duration;
 use codecs::TextSerializerConfig;
 use futures::{stream, StreamExt};
-use http::Uri;
 use similar_asserts::assert_eq;
 
 use super::*;
@@ -461,10 +459,7 @@ async fn cloudwatch_healthcheck() {
 async fn create_client_test() -> CloudwatchLogsClient {
     let auth = AwsAuthentication::test_auth();
     let region = Some(Region::new("localstack"));
-    let watchlogs_address = watchlogs_address();
-    let endpoint = Some(Endpoint::immutable(
-        Uri::from_str(&watchlogs_address).unwrap(),
-    ));
+    let endpoint = Some(watchlogs_address());
     let proxy = ProxyConfig::default();
 
     create_client::<CloudwatchLogsClientBuilder>(&auth, region, endpoint, &proxy, &None, true)

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -32,11 +32,13 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
     type Error = CloudwatchError;
     type Response = T;
 
+    // TODO this match may not be necessary given the logic in `is_retriable_error()`
     #[allow(clippy::cognitive_complexity)] // long, but just a hair over our limit
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
             CloudwatchError::Put(err) => {
-                if let SdkError::ServiceError { err, raw: _ } = err {
+                if let SdkError::ServiceError(inner) = err {
+                    let err = inner.err();
                     if let PutLogEventsErrorKind::ServiceUnavailableException(_) = err.kind {
                         return true;
                     }
@@ -44,7 +46,8 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
                 is_retriable_error(err)
             }
             CloudwatchError::Describe(err) => {
-                if let SdkError::ServiceError { err, raw: _ } = err {
+                if let SdkError::ServiceError(inner) = err {
+                    let err = inner.err();
                     if let DescribeLogStreamsErrorKind::ServiceUnavailableException(_) = err.kind {
                         return true;
                     }
@@ -52,7 +55,8 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
                 is_retriable_error(err)
             }
             CloudwatchError::CreateStream(err) => {
-                if let SdkError::ServiceError { err, raw: _ } = err {
+                if let SdkError::ServiceError(inner) = err {
+                    let err = inner.err();
                     if let CreateLogStreamErrorKind::ServiceUnavailableException(_) = err.kind {
                         return true;
                     }
@@ -66,7 +70,7 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
 
 #[cfg(test)]
 mod test {
-    use aws_sdk_cloudwatchlogs::error::{PutLogEventsError, PutLogEventsErrorKind};
+    use aws_sdk_cloudwatchlogs::error::PutLogEventsError;
     use aws_sdk_cloudwatchlogs::types::SdkError;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_http::operation::Response;
@@ -89,13 +93,10 @@ mod test {
         *http_response.status_mut() = http::StatusCode::BAD_REQUEST;
         let raw = Response::new(http_response);
 
-        let err = CloudwatchError::Put(SdkError::ServiceError {
-            err: PutLogEventsError::new(
-                PutLogEventsErrorKind::Unhandled(Box::new(meta_err.clone())),
-                meta_err,
-            ),
+        let err = CloudwatchError::Put(SdkError::service_error(
+            PutLogEventsError::unhandled(meta_err),
             raw,
-        });
+        ));
         assert!(retry_logic.is_retriable_error(&err));
     }
 }

--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -168,7 +168,7 @@ impl CloudWatchMetricsSinkConfig {
         create_client::<CloudwatchMetricsClientBuilder>(
             &self.auth,
             region,
-            self.region.endpoint()?,
+            self.region.endpoint(),
             proxy,
             &self.tls,
             true,

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -108,7 +108,7 @@ impl KinesisFirehoseSinkConfig {
         create_client::<KinesisFirehoseClientBuilder>(
             &self.base.auth,
             self.base.region.region(),
-            self.base.region.endpoint()?,
+            self.base.region.endpoint(),
             proxy,
             &self.base.tls,
             true,
@@ -173,8 +173,8 @@ impl RetryLogic for KinesisRetryLogic {
     type Response = KinesisResponse;
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        if let SdkError::ServiceError { err, raw: _ } = error {
-            if let PutRecordBatchErrorKind::ServiceUnavailableException(_) = err.kind {
+        if let SdkError::ServiceError(inner) = error {
+            if let PutRecordBatchErrorKind::ServiceUnavailableException(_) = inner.err().kind {
                 return true;
             }
         }

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -157,7 +157,7 @@ async fn ensure_elasticsearch_domain(domain_name: String) -> String {
                     .await
                     .unwrap(),
             )
-            .endpoint_url(test_region_endpoint().endpoint())
+            .endpoint_url(test_region_endpoint().endpoint().unwrap())
             .region(test_region_endpoint().region())
             .build(),
     );

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -138,7 +138,7 @@ async fn firehose_client() -> aws_sdk_firehose::Client {
     create_client::<KinesisFirehoseClientBuilder>(
         &auth,
         region_endpoint.region(),
-        region_endpoint.endpoint().unwrap(),
+        region_endpoint.endpoint(),
         &proxy,
         &None,
         true,
@@ -157,7 +157,7 @@ async fn ensure_elasticsearch_domain(domain_name: String) -> String {
                     .await
                     .unwrap(),
             )
-            .endpoint_resolver(test_region_endpoint().endpoint().unwrap().unwrap())
+            .endpoint_url(test_region_endpoint().endpoint())
             .region(test_region_endpoint().region())
             .build(),
     );

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -115,7 +115,7 @@ impl KinesisStreamsSinkConfig {
         create_client::<KinesisClientBuilder>(
             &self.base.auth,
             self.base.region.region(),
-            self.base.region.endpoint()?,
+            self.base.region.endpoint(),
             proxy,
             &self.base.tls,
             true,
@@ -180,14 +180,15 @@ impl RetryLogic for KinesisRetryLogic {
     type Response = KinesisResponse;
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        if let SdkError::ServiceError { err, raw: _ } = error {
+        if let SdkError::ServiceError(inner) = error {
             // Note that if the request partially fails (records sent to one
             // partition fail but the others do not, for example), Vector
             // does not retry. This line only covers a failure for the entire
             // request.
             //
             // https://github.com/vectordotdev/vector/issues/359
-            if let PutRecordsErrorKind::ProvisionedThroughputExceededException(_) = err.kind {
+            if let PutRecordsErrorKind::ProvisionedThroughputExceededException(_) = inner.err().kind
+            {
                 return true;
             }
         }

--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -174,7 +174,7 @@ async fn client() -> aws_sdk_kinesis::Client {
     create_client::<KinesisClientBuilder>(
         &auth,
         region.region(),
-        region.endpoint().unwrap(),
+        region.endpoint(),
         &proxy,
         &None,
         true,

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -414,7 +414,7 @@ async fn client() -> S3Client {
     create_client::<S3ClientBuilder>(
         &auth,
         region.region(),
-        region.endpoint().unwrap(),
+        region.endpoint(),
         &proxy,
         &tls_options,
         true,
@@ -471,7 +471,7 @@ async fn create_bucket(bucket: &str, object_lock_enabled: bool) {
     {
         Ok(_) => {}
         Err(err) => match err {
-            SdkError::ServiceError { err, raw: _ } => match err.kind {
+            SdkError::ServiceError(inner) => match &inner.err().kind {
                 CreateBucketErrorKind::BucketAlreadyOwnedByYou(_) => {}
                 err => panic!("Failed to create bucket: {:?}", err),
             },

--- a/src/sinks/aws_sqs/config.rs
+++ b/src/sinks/aws_sqs/config.rs
@@ -149,7 +149,7 @@ impl SqsSinkConfig {
         create_client::<SqsClientBuilder>(
             &self.auth,
             self.region.region(),
-            self.region.endpoint()?,
+            self.region.endpoint(),
             proxy,
             &self.tls,
             true,

--- a/src/sinks/aws_sqs/integration_tests.rs
+++ b/src/sinks/aws_sqs/integration_tests.rs
@@ -1,11 +1,9 @@
 #![cfg(all(test, feature = "aws-sqs-integration-tests"))]
 
 use std::collections::HashMap;
-use std::str::FromStr;
 
-use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient, Endpoint, Region};
+use aws_sdk_sqs::{model::QueueAttributeName, Client as SqsClient, Region};
 use codecs::TextSerializerConfig;
-use http::Uri;
 use tokio::time::{sleep, Duration};
 
 use super::{config::SqsSinkConfig, sink::SqsSink};
@@ -32,7 +30,7 @@ async fn create_test_client() -> SqsClient {
     create_client::<SqsClientBuilder>(
         &auth,
         Some(Region::new("localstack")),
-        Some(Endpoint::immutable(Uri::from_str(&endpoint).unwrap())),
+        Some(endpoint),
         &proxy,
         &None,
         true,

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use aws_types::credentials::SharedCredentialsProvider;
+use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_types::region::Region;
 use bytes::{Buf, Bytes};
 use http::{Response, StatusCode, Uri};

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use aws_types::credentials::SharedCredentialsProvider;
+use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_types::region::Region;
 use bytes::Bytes;
 use futures::future::BoxFuture;

--- a/src/sinks/prometheus/remote_write.rs
+++ b/src/sinks/prometheus/remote_write.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::sync::Arc;
 use std::task;
 
-use aws_types::credentials::SharedCredentialsProvider;
+use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_types::region::Region;
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, stream, FutureExt, SinkExt};

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -299,9 +299,7 @@ impl From<S3CannedAcl> for ObjectCannedAcl {
             S3CannedAcl::AuthenticatedRead => ObjectCannedAcl::AuthenticatedRead,
             S3CannedAcl::BucketOwnerRead => ObjectCannedAcl::BucketOwnerRead,
             S3CannedAcl::BucketOwnerFullControl => ObjectCannedAcl::BucketOwnerFullControl,
-            S3CannedAcl::LogDeliveryWrite => {
-                ObjectCannedAcl::Unknown("log-delivery-write".to_string())
-            }
+            S3CannedAcl::LogDeliveryWrite => ObjectCannedAcl::from("log-delivery-write"),
         }
     }
 }
@@ -340,7 +338,7 @@ pub fn build_healthcheck(bucket: String, client: S3Client) -> crate::Result<Heal
         match req {
             Ok(_) => Ok(()),
             Err(error) => Err(match error {
-                SdkError::ServiceError { err: _, raw } => match raw.http().status() {
+                SdkError::ServiceError(inner) => match inner.into_raw().http().status() {
                     StatusCode::FORBIDDEN => HealthcheckError::InvalidCredentials.into(),
                     StatusCode::NOT_FOUND => HealthcheckError::UnknownBucket { bucket }.into(),
                     status => HealthcheckError::UnknownStatus { status }.into(),
@@ -359,7 +357,7 @@ pub async fn create_service(
     proxy: &ProxyConfig,
     tls_options: &Option<TlsConfig>,
 ) -> crate::Result<S3Service> {
-    let endpoint = region.endpoint()?;
+    let endpoint = region.endpoint();
     let region = region.region();
     let client =
         create_client::<S3ClientBuilder>(auth, region.clone(), endpoint, proxy, tls_options, true)

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -228,10 +228,7 @@ impl AwsS3Config {
             .region()
             .ok_or(CreateSqsIngestorError::RegionMissing)?;
 
-        let endpoint = self
-            .region
-            .endpoint()
-            .map_err(|_| CreateSqsIngestorError::InvalidEndpoint)?;
+        let endpoint = self.region.endpoint();
 
         let s3_client = create_client::<S3ClientBuilder>(
             &self.auth,
@@ -925,7 +922,7 @@ mod integration_tests {
         create_client::<S3ClientBuilder>(
             &auth,
             region_endpoint.region(),
-            region_endpoint.endpoint().unwrap(),
+            region_endpoint.endpoint(),
             &proxy_config,
             &None,
             false,
@@ -944,7 +941,7 @@ mod integration_tests {
         create_client::<SqsClientBuilder>(
             &auth,
             region_endpoint.region(),
-            region_endpoint.endpoint().unwrap(),
+            region_endpoint.endpoint(),
             &proxy_config,
             &None,
             false,

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -162,7 +162,7 @@ impl AwsSqsConfig {
         create_client::<SqsClientBuilder>(
             &self.auth,
             self.region.region(),
-            self.region.endpoint()?,
+            self.region.endpoint(),
             &cx.proxy,
             &self.tls,
             false,

--- a/src/sources/aws_sqs/integration_tests.rs
+++ b/src/sources/aws_sqs/integration_tests.rs
@@ -1,12 +1,11 @@
 #![cfg(feature = "aws-sqs-integration-tests")]
 #![cfg(test)]
 
-use std::{collections::HashSet, str::FromStr, time::Duration};
+use std::{collections::HashSet, time::Duration};
 
-use aws_sdk_sqs::{output::CreateQueueOutput, Endpoint};
+use aws_sdk_sqs::output::CreateQueueOutput;
 use aws_types::region::Region;
 use futures::StreamExt;
-use http::Uri;
 use tokio::time::timeout;
 
 use crate::{
@@ -58,9 +57,7 @@ async fn get_sqs_client() -> aws_sdk_sqs::Client {
                 .await
                 .unwrap(),
         )
-        .endpoint_resolver(Endpoint::immutable(
-            Uri::from_str(sqs_address().as_str()).unwrap(),
-        ))
+        .endpoint_url(sqs_address())
         .region(Some(Region::new("us-east-1")))
         .build();
 

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -110,7 +110,7 @@ impl SqsSource {
             .visibility_timeout(self.visibility_timeout_secs as i32)
             // I think this should be a known attribute
             // https://github.com/awslabs/aws-sdk-rust/issues/411
-            .attribute_names(QueueAttributeName::Unknown(String::from("SentTimestamp")))
+            .attribute_names(QueueAttributeName::from("SentTimestamp"))
             .send()
             .await;
 


### PR DESCRIPTION
This PR changes the source of our AWS dependencies to track a fork to circumvent a currently unresolved bug upstream.

Smithy crates are upgraded to `0.54.x` and sdk crates are upgraded to `0.24.x`

Closes https://github.com/vectordotdev/vector/issues/17728