### PR TITLE
chore(datadog_traces sink): Add additional warning around APM stats for `peer.service`

### DIFF
--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -64,7 +64,18 @@ components: sinks: datadog_traces: {
 
 	support: {
 		requirements: []
-		warnings: ["APM stats are in Beta. Currently the sink does not support the Datadog Agent sampling feature. This must be disabled in the Agent in order for APM stats output from vector to be accurate."]
+		warnings: [
+			"""
+				Support for APM statistics is in beta.
+
+				Currently the sink does not support the Datadog Agent sampling feature. Sampling must be
+				disabled in the Agent in order for APM stats output from vector to be accurate.
+
+				Currently the sink does not calculate statistics aggregated across `peer.service`. Any
+				functionality in Datadog's APM product that depends on this aggregation will not
+				function correctly.
+				""",
+		]
 		notices: []
 	}
 


### PR DESCRIPTION
Tracking issue for enhancement: https://github.com/vectordotdev/vector/issues/17732

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
