### PR TITLE
retry check component docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,29 @@ jobs:
 
       - name: Check Component Docs
         if: needs.changes.outputs.source == 'true' || needs.changes.outputs.component_docs == 'true'
-        run: make check-component-docs
+        run: |
+          retry() {
+              MAX_N_RETRIES=5
+
+              output=0
+              command_to_retry="$@"
+
+              for n_retry in $(seq 1 $MAX_N_RETRIES)
+              do
+                  (eval "$command_to_retry")
+                  output=$?
+
+                  if [ "$output" = "0" ]; then
+                      return 0
+                  else
+                      echo "RETRY FAILURE: run #$(($n_retry)) failed ($MAX_N_RETRIES consecutive failures tolerated)"
+                  fi
+              done
+              echo "RETRY FAILURE: command failed $MAX_N_RETRIES consecutive times."
+
+              return $last_run_result
+          }
+          retry make check-component-docs
 
       - name: Check Rust Docs
         if: needs.changes.outputs.source == 'true'


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Adds retries to the docs step. This test step is known to be flaky due to ruby errors which are believed to be non-deterministic and not evident to debug.

Here is an example of a flake that stopped code from making it through the merge queue yesterday: https://github.com/vectordotdev/vector/actions/runs/5335644122/jobs/9669180792
