### PR TITLE
feat: add support for `external_id` in AWS assume role

### DIFF
--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -424,7 +424,7 @@ mod tests {
             auth.load_timeout_secs = 10
         "#,
         )
-            .unwrap();
+        .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::Role { .. }));
     }
@@ -548,7 +548,7 @@ mod tests {
             auth.external_id = "id"
         "#,
         )
-            .unwrap();
+        .unwrap();
 
         match config.auth {
             AwsAuthentication::AccessKey {

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -497,37 +497,6 @@ mod tests {
     }
 
     #[test]
-    fn parsing_both_external_id() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.assume_role = "auth.root"
-            external_id = "id"
-            auth.external_id = "auth.id"
-            auth.load_timeout_secs = 10
-            auth.region = "us-west-2"
-        "#,
-        )
-            .unwrap();
-
-        match config.auth {
-            AwsAuthentication::Role {
-                assume_role,
-                external_id,
-                load_timeout_secs,
-                imds,
-                region,
-            } => {
-                assert_eq!(&assume_role, "auth.root");
-                assert_eq!(external_id.unwrap(), "auth.id");
-                assert_eq!(load_timeout_secs, Some(10));
-                assert!(matches!(imds, ImdsAuthentication { .. }));
-                assert_eq!(region.unwrap(), "us-west-2");
-            }
-            _ => panic!(),
-        }
-    }
-
-    #[test]
     fn parsing_static() {
         let config = toml::from_str::<ComponentConfig>(
             r#"

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -50,6 +50,15 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -50,6 +50,15 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -50,6 +50,15 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -50,6 +50,15 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -125,6 +125,15 @@ base: components: sinks: aws_s3: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -50,6 +50,15 @@ base: components: sinks: aws_sqs: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -76,6 +76,16 @@ base: components: sinks: elasticsearch: configuration: {
 				required:      true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description:   "Configuration for authenticating with AWS through IMDS."
 				relevant_when: "strategy = \"aws\""

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -53,6 +53,16 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				required:      true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description:   "Configuration for authenticating with AWS through IMDS."
 				relevant_when: "strategy = \"aws\""

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -45,6 +45,15 @@ base: components: sources: aws_s3: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -45,6 +45,15 @@ base: components: sources: aws_sqs: configuration: {
 				required:    true
 				type: string: examples: ["/my/aws/credentials"]
 			}
+			external_id: {
+				description: """
+					The optional unique external ID in conjunction with role to assume.
+
+					[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+					"""
+				required: false
+				type: string: examples: ["randomEXAMPLEidString"]
+			}
 			imds: {
 				description: "Configuration for authenticating with AWS through IMDS."
 				required:    false


### PR DESCRIPTION
aws assume role did not have support for specifying external id which is quintessential for security concerned consumers.

P.S. [contributing guidelines](https://github.com/vectordotdev/vector/blob/44be37843c0599abb64073fe737ce146e30b3aa5/CONTRIBUTING.md) is empty, help me if I'm missing anything. 

Closes: https://github.com/vectordotdev/vector/issues/17739