### PR TITLE
chore(docs): Clarify `bytes` framing for streams

### DIFF
--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -94,7 +94,7 @@ components: sources: [Name=string]: {
 								type: string: {
 									default: features.codecs.default_framing
 									enum: {
-										bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages or stream segments)."
+										bytes:               "Byte frames are passed through as-is according to the underlying I/O boundaries (e.g. split between messages, payloads, or streams)."
 										character_delimited: "Byte frames which are delimited by a chosen character."
 										length_delimited:    "Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length."
 										newline_delimited:   "Byte frames which are delimited by a newline character."


### PR DESCRIPTION
I'm not aware of any sources that separate "steam segments" so I updated the language a bit to
account for how the `tcp` mode of the `socket` source handles `bytes` framing.

Reference: https://github.com/vectordotdev/vector/issues/17136

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
