### PR TITLE
docs: remove aggregator beta warning

### DIFF
--- a/website/content/en/docs/setup/deployment/roles.md
+++ b/website/content/en/docs/setup/deployment/roles.md
@@ -8,13 +8,6 @@ aliases: ["/docs/setup/deployment/strategies"]
 
 Vector is an end-to-end data pipeline designed to collect, process, and route data. This means that Vector serves all roles in building your pipeline. You can deploy it as an [agent](#agent), [sidecar](#sidecar), or [aggregator](#aggregator). You combine these roles to form [topologies]. In this section, we'll cover each role in detail and help you understand when to use each.
 
-{{< warning title="Aggregator role in public beta" >}}
-Helm support for the [aggregator] role is currently in public beta. We're currently seeking beta testers. If interested, please [join our chat][chat] and let us know.
-
-[aggregator]: /docs/setup/deployment/roles/#aggregator
-[chat]: https://chat.vector.dev
-{{< /warning >}}
-
 {{< roles >}}
 
 You can install the Vector as an Aggregator on Kubernetes using Helm. For more information about getting started with the Aggregator role, see the [Helm install docs][helm].


### PR DESCRIPTION
According to https://discord.com/channels/742820443487993987/1040011926563983441/1040016552243761162, this warning isn't relevant anymore

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
