### PR TITLE
fix(sinks): Add missing component span for sink building

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -541,14 +541,7 @@ impl<'a> Builder<'a> {
                     BufferType::Memory { .. } => "memory",
                     BufferType::DiskV2 { .. } => "disk",
                 };
-                let buffer_span = error_span!(
-                    "sink",
-                    component_kind = "sink",
-                    component_id = %key.id(),
-                    component_type = typetag,
-                    component_name = %key.id(),
-                    buffer_type,
-                );
+                let buffer_span = error_span!("sink", buffer_type);
                 let buffer = sink
                     .buffer
                     .build(

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -512,6 +512,16 @@ impl<'a> Builder<'a> {
             let typetag = sink.inner.get_component_name();
             let input_type = sink.inner.input().data_type();
 
+            let span = error_span!(
+                "sink",
+                component_kind = "sink",
+                component_id = %key.id(),
+                component_type = %sink.inner.get_component_name(),
+                // maintained for compatibility
+                component_name = %key.id(),
+            );
+            let _entered_span = span.enter();
+
             // At this point, we've validated that all transforms are valid, including any
             // transform that mutates the schema provided by their sources. We can now validate the
             // schema expectations of each individual sink.


### PR DESCRIPTION
We have one for sources and transforms, but evidentially didn't for sinks.

Closes: #17763

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
