### PR TITLE
chore(ci): move component features check out of merge queue

### DIFF
--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -17,24 +17,9 @@ on:
     - cron: '0 0 * * 2-6'
 
 jobs:
-  check-component-features-schedule:
-    # use free tier on the schedule
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
-
-      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
-      - run: bash scripts/environment/prepare.sh
-      - run: echo "::add-matcher::.github/matchers/rust.json"
-      - run: make check-component-features
-
-  check-component-features-comment:
-    # expedite results when running on demand
-    runs-on: [linux, ubuntu-20.04-8core]
+  check-component-features:
+    # use free tier on schedule and 8 core to expedite results on demand invocation
+    runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || fromJSON('["linux", "ubuntu-20.04-8core"]') }}
     if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
     steps:
       - name: (PR comment) Get PR branch

--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -1,35 +1,28 @@
+# Component Features - Linux
+#
+# Validates that each component feature compiles
+#
+# Runs on:
+#  - scheduled UTC midnight Tues-Sat
+#  - on PR comment (see comment-trigger.yml)
+#  - on demand from github actions UI
+
 name: Component Features - Linux
 
 on:
   workflow_call:
+  workflow_dispatch:
+  schedule:
+    # At midnight UTC Tue-Sat
+    - cron: '0 0 * * 2-6'
 
 jobs:
-  check-component-features:
-    runs-on: [linux, ubuntu-20.04-8core]
+  check-component-features-schedule:
+    # use free tier on the schedule
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
     steps:
-      - name: (PR comment) Get PR branch
-        if: ${{ github.event_name == 'issue_comment' }}
-        uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-
-      - name: (PR comment) Set latest commit status as pending
-        uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: ${{ github.event_name == 'issue_comment' }}
-        with:
-          sha: ${{ steps.comment-branch.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          context: Component Features - Linux
-          status: pending
-
-      - name: (PR comment) Checkout PR branch
-        if: ${{ github.event_name == 'issue_comment' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
-
       - name: Checkout branch
-        if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
         with:
           submodules: "recursive"
@@ -39,9 +32,36 @@ jobs:
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make check-component-features
 
+  check-component-features-comment:
+    # expedite results when running on demand
+    runs-on: [linux, ubuntu-20.04-8core]
+    if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: (PR comment) Get PR branch
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: (PR comment) Set latest commit status as pending
+        uses: myrotvorets/set-commit-status-action@v1.1.7
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          context: Component Features - Linux
+          status: pending
+
+      - name: (PR comment) Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          submodules: "recursive"
+
+      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - run: make check-component-features
+
       - name: (PR comment) Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@v1.1.7
-        if: always() && github.event_name == 'issue_comment'
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -38,10 +38,12 @@ jobs:
     if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
     steps:
       - name: (PR comment) Get PR branch
+        if: ${{ github.event_name == 'issue_comment' }}
         uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
 
       - name: (PR comment) Set latest commit status as pending
+        if: ${{ github.event_name == 'issue_comment' }}
         uses: myrotvorets/set-commit-status-action@v1.1.7
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
@@ -61,6 +63,7 @@ jobs:
       - run: make check-component-features
 
       - name: (PR comment) Set latest commit status as ${{ job.status }}
+        if: ${{ github.event_name == 'issue_comment' }}
         uses: myrotvorets/set-commit-status-action@v1.1.7
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}

--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -38,12 +38,12 @@ jobs:
     if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
     steps:
       - name: (PR comment) Get PR branch
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: github.event_name == 'issue_comment'
         uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
 
       - name: (PR comment) Set latest commit status as pending
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: github.event_name == 'issue_comment'
         uses: myrotvorets/set-commit-status-action@v1.1.7
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
@@ -52,9 +52,16 @@ jobs:
           status: pending
 
       - name: (PR comment) Checkout PR branch
+        if: github.event_name == 'issue_comment'
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
+          submodules: "recursive"
+
+      - name: Checkout branch
+        if: github.event_name != 'issue_comment'
+        uses: actions/checkout@v3
+        with:
           submodules: "recursive"
 
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -63,7 +70,7 @@ jobs:
       - run: make check-component-features
 
       - name: (PR comment) Set latest commit status as ${{ job.status }}
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: always() && github.event_name == 'issue_comment'
         uses: myrotvorets/set-commit-status-action@v1.1.7
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}

--- a/.github/workflows/master_merge_queue.yml
+++ b/.github/workflows/master_merge_queue.yml
@@ -74,12 +74,6 @@ jobs:
     needs: changes
     secrets: inherit
 
-  check-component-features:
-    if: needs.changes.outputs.source == 'true'
-    uses: ./.github/workflows/component_features.yml
-    needs: changes
-    secrets: inherit
-
   cross-linux:
     # We run cross checks when dependencies change to ensure they still build.
     # This helps us avoid adopting dependencies that aren't compatible with other architectures.
@@ -117,7 +111,6 @@ jobs:
       - test-misc
       - test-environment
       - check-msrv
-      - check-component-features
       - cross-linux
       - unit-mac
       - unit-windows


### PR DESCRIPTION
Moves the most costly (both $ and time) status check out of the merge queue into a fixed schedule.
The workflow can still be run on demand by a PR comment, or from the GHA UI.