### PR TITLE
chore(ci): Update publish workflow test Ubuntu versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -286,11 +286,11 @@ jobs:
     strategy:
       matrix:
         container:
-          - ubuntu:14.04
           - ubuntu:16.04
           - ubuntu:18.04
           - ubuntu:20.04
           - ubuntu:22.04
+          - ubuntu:22.10
           - ubuntu:23.04
           - debian:10
           - debian:11


### PR DESCRIPTION
To currently supported versions.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
