### PR TITLE
chore(ci): reduce runner sizing to 4 core and free tier

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-cli:
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cross-linux:
     name: Cross - ${{ matrix.target }}
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,8 +40,8 @@ env:
 
 jobs:
   test-integration:
-    runs-on: [linux, ubuntu-20.04-8core]
-    timeout-minutes: 30
+    runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 40
     if: inputs.if || github.event_name == 'workflow_dispatch'
     steps:
       - name: (PR comment) Get PR branch

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -53,7 +53,7 @@ jobs:
 
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: [linux, ubuntu-20.04-4core]
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.k8s == 'true'
     # cargo-deb requires a release build, but we don't need optimizations for tests
@@ -126,7 +126,7 @@ jobs:
   # See https://github.community/t/feature-request-and-use-case-example-to-allow-matrix-in-if-s/126067
   compute-k8s-test-plan:
     name: Compute K8s test plan
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-latest
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.k8s == 'true'
     outputs:
@@ -187,7 +187,7 @@ jobs:
 
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: [linux, ubuntu-20.04-4core]
     needs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-misc:
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: [linux, ubuntu-20.04-4core]
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check-msrv:
-    runs-on: [ubuntu-20.04]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -280,7 +280,7 @@ jobs:
 
   build-baseline:
     name: Build baseline Vector container
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: [linux, ubuntu-20.04-4core]
     needs:
       - compute-metadata
     steps:
@@ -318,7 +318,7 @@ jobs:
 
   build-comparison:
     name: Build comparison Vector container
-    runs-on: [linux, soak-builder]
+    runs-on: [linux, ubuntu-20.04core]
     needs:
       - compute-metadata
     steps:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -318,7 +318,7 @@ jobs:
 
   build-comparison:
     name: Build comparison Vector container
-    runs-on: [linux, ubuntu-20.04core]
+    runs-on: [linux, ubuntu-20.04-4core]
     needs:
       - compute-metadata
     steps:


### PR DESCRIPTION
- In order to reduce CI costs, experiments were run on each of the altered workflows to understand the duration (and thus impact to DX) and changes in cost.
- The two cases of concern are what checks are run on each PR commit and in the merge queue:
    - in the merge queue- there was a trivial change in runtime. This is because the bottleneck workflow is the mac unit test, which takes about 1 hour to run. All runner-size-reduced workflows in this PR that are in the merge queue, still run within that time frame.
    - on each PR commit- this PR does not affect this case. However, a sister PR (#17724) does, because that PR fundamentally changes the integration test workflow to introduce the runner there, and so in that PR, we reduced to 4 core. That change adds 3 minutes of duration to the integration tests, which is trivial (and integration tests only run on some PR pushes, if that PR touches integrations).
- Thus the empirically anticipated outcome is a ~20% reduction in cost with a none-to-trivial increase in duration.