### PR TITLE
chore: Fix publish workflow for older OS images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -320,7 +320,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
+        # Workaround for older OS images
+        # https://github.com/actions/checkout/issues/758
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Resolves git submodule issue on older OS images.

Based on https://github.com/actions/checkout/issues/758#issuecomment-1097027361