### PR TITLE
Update VRL to `0.5.0`

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -411,6 +411,7 @@ timespan
 timestamped
 tzdata
 ubuntu
+upstreaminfo
 useragents
 usergroups
 userguide

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "clipboard-win"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
 dependencies = [
  "error-code",
  "str-buf",
@@ -2605,13 +2605,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
+checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.28",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2732,14 +2732,14 @@ dependencies = [
 
 [[package]]
 name = "dns-lookup"
-version = "1.0.8"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+checksum = "8f332aa79f9e9de741ac013237294ef42ce2e9c6394dc7d766725812f1238812"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2 0.4.9",
- "winapi",
+ "socket2 0.5.3",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4510,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -4523,7 +4523,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.2",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -4532,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 
 [[package]]
 name = "lapin"
@@ -6469,9 +6469,9 @@ dependencies = [
 
 [[package]]
 name = "quoted_printable"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24039f627d8285853cc90dcddf8c1ebfaa91f834566948872b225b9a28ed1b6"
+checksum = "79ec282e887b434b68c18fe5c121d38e72a5cf35119b59e54ec5b992ea9c8eb0"
 
 [[package]]
 name = "radium"
@@ -7122,11 +7122,11 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.2",
  "cfg-if",
  "clipboard-win",
  "libc",
@@ -9071,6 +9071,7 @@ dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -9627,9 +9628,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vrl"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6236fdfaaa956af732a73630b8a8b43ef75e0a42fed6b94cf3c1c19c99daca5"
+checksum = "ee149a42aa313d18cf7a7e6b54e06df03b4a0e6e5dd42a2b8b6d5eeb98d582c1"
 dependencies = [
  "aes",
  "ansi_term",
@@ -9640,6 +9641,7 @@ dependencies = [
  "bytes 1.4.0",
  "cbc",
  "cfb-mode",
+ "cfg-if",
  "charset",
  "chrono",
  "chrono-tz",
@@ -9653,14 +9655,13 @@ dependencies = [
  "dyn-clone",
  "exitcode",
  "flate2",
- "getrandom 0.2.10",
  "grok",
  "hex",
  "hmac",
  "hostname",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "indoc",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lalrpop",
  "lalrpop-util",
  "md-5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,12 @@ members = [
   "vdev",
 ]
 
+[workspace.dependencies]
+vrl = { version = "0.5.0", features = ["cli", "test", "test_framework", "arbitrary"] }
+
 [dependencies]
+vrl.workspace = true
+
 # Internal libs
 codecs = { path = "lib/codecs", default-features = false }
 dnsmsg-parser = { path = "lib/dnsmsg-parser", optional = true }
@@ -226,9 +231,6 @@ tui = { version = "0.19.0", optional = true, default-features = false, features 
 
 hex = { version = "0.4.3", default-features = false, optional = true }
 sha2 = { version = "0.10.7", default-features = false, optional = true }
-
-# VRL Lang
-vrl = { package = "vrl", version = "0.4.0", features = ["cli", "test"] }
 
 # External libs
 arc-swap = { version = "1.6", default-features = false, optional = true }

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -25,7 +25,7 @@ snafu = { version = "0.7.4", default-features = false, features = ["futures"] }
 syslog_loose = { version = "0.18", default-features = false, optional = true }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tracing = { version = "0.1", default-features = false }
-vrl = { version = "0.4.0", default-features = false, features = ["value"] }
+vrl.workspace = true
 vector-common = { path = "../vector-common", default-features = false }
 vector-config = { path = "../vector-config", default-features = false }
 vector-config-common = { path = "../vector-config-common", default-features = false }

--- a/lib/enrichment/Cargo.toml
+++ b/lib/enrichment/Cargo.toml
@@ -9,7 +9,4 @@ publish = false
 arc-swap = { version = "1.6.0", default-features = false }
 chrono = { version = "0.4.19", default-features = false }
 dyn-clone = { version = "1.0.11", default-features = false }
-vrl = { version = "0.4.0", default-features = false, features = [
-  "compiler",
-  "diagnostic",
-] }
+vrl.workspace = true

--- a/lib/opentelemetry-proto/Cargo.toml
+++ b/lib/opentelemetry-proto/Cargo.toml
@@ -17,5 +17,5 @@ lookup = { package = "vector-lookup", path = "../vector-lookup", default-feature
 ordered-float = { version = "3.7.0", default-features = false }
 prost = { version = "0.11", default-features = false, features = ["std"] }
 tonic = { version = "0.9", default-features = false, features = ["codegen", "gzip", "prost", "tls", "tls-roots", "transport"] }
-vrl = { version = "0.4.0", default-features = false, features = ["value"] }
+vrl.workspace = true
 vector-core = { path = "../vector-core", default-features = false }

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -62,7 +62,7 @@ snafu = { version = "0.7", optional = true }
 stream-cancel = { version = "0.8.1", default-features = false }
 tokio = { version = "1.28.2", default-features = false, features = ["macros", "time"] }
 tracing = { version = "0.1.34", default-features = false }
-vrl = { version = "0.4.0", default-features = false, features = ["value", "core", "compiler"] }
+vrl.workspace = true
 vector-config = { path = "../vector-config" }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -26,7 +26,7 @@ snafu = { version = "0.7.4", default-features = false }
 toml = { version = "0.7.5", default-features = false }
 tracing = { version = "0.1.34", default-features = false }
 url = { version = "2.4.0", default-features = false, features = ["serde"] }
-vrl = { version = "0.4.0", default-features = false, features = ["compiler"] }
+vrl.workspace = true
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
 

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -65,7 +65,7 @@ vector-common = { path = "../vector-common" }
 vector-config = { path = "../vector-config" }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
-vrl = { version = "0.4.0" }
+vrl.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2.9.1"
@@ -94,7 +94,7 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt", "ansi", "registry"] }
 vector-common = { path = "../vector-common", default-features = false, features = ["test"] }
-vrl = { version = "0.4.0", default-features = false, features = ["value", "arbitrary", "lua"] }
+vrl.workspace = true
 
 [features]
 api = ["dep:async-graphql"]

--- a/lib/vector-lookup/Cargo.toml
+++ b/lib/vector-lookup/Cargo.toml
@@ -10,4 +10,4 @@ license = "MPL-2.0"
 serde = { version = "1.0.164", default-features = false, features = ["derive", "alloc"] }
 vector-config = { path = "../vector-config" }
 vector-config-macros = { path = "../vector-config-macros" }
-vrl = { version = "0.4.0", default-features = false, features = ["path"] }
+vrl.workspace = true

--- a/lib/vector-vrl/cli/Cargo.toml
+++ b/lib/vector-vrl/cli/Cargo.toml
@@ -9,4 +9,4 @@ license = "MPL-2.0"
 [dependencies]
 clap = { version = "4.1.14", features = ["derive"] }
 vector-vrl-functions = { path = "../functions" }
-vrl = { version = "0.4.0", default-features = false, features = ["stdlib", "cli"] }
+vrl.workspace = true

--- a/lib/vector-vrl/functions/Cargo.toml
+++ b/lib/vector-vrl/functions/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 license = "MPL-2.0"
 
 [dependencies]
-vrl = { version = "0.4.0", default-features = false, features = ["compiler", "path", "diagnostic"] }
+vrl.workspace = true

--- a/lib/vector-vrl/tests/Cargo.toml
+++ b/lib/vector-vrl/tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 enrichment = { path = "../../enrichment" }
-vrl = { version = "0.4.0", features = ["test_framework"]}
+vrl.workspace = true
 vector-vrl-functions = { path = "../../vector-vrl/functions" }
 
 ansi_term = "0.12"

--- a/lib/vector-vrl/web-playground/Cargo.toml
+++ b/lib/vector-vrl/web-playground/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-vrl = { version = "0.4.0", default-features = false, features = ["value", "stdlib"] }
+vrl.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.5"
 gloo-utils = { version = "0.1", features = ["serde"] }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -241,7 +241,7 @@ impl TransformConfig for RemapConfig {
             .compile_vrl_program(enrichment_tables, merged_definition)
             .map(|(program, _, _, external_context)| {
                 (
-                    program.final_type_state(),
+                    program.final_type_info().state,
                     external_context
                         .get_custom::<MeaningList>()
                         .cloned()

--- a/website/cue/reference/remap/functions/format_timestamp.cue
+++ b/website/cue/reference/remap/functions/format_timestamp.cue
@@ -19,6 +19,12 @@ remap: functions: format_timestamp: {
 			required:    true
 			type: ["string"]
 		},
+		{
+			name:        "timezone"
+			description: "The timezone to use when formatting the timestamp. The uses the TZ identifier, or 'local'"
+			required:    false
+			type: ["string"]
+		},
 	]
 	internal_failure_reasons: []
 	return: types: ["string"]

--- a/website/cue/reference/remap/functions/from_unix_timestamp.cue
+++ b/website/cue/reference/remap/functions/from_unix_timestamp.cue
@@ -43,14 +43,14 @@ remap: functions: from_unix_timestamp: {
 		{
 			title: "Convert from a Unix timestamp (milliseconds)"
 			source: #"""
-				from_unix_timestamp(5000, unit: "milliseconds")
+				from_unix_timestamp!(5000, unit: "milliseconds")
 				"""#
 			return: "1970-01-01T00:00:05Z"
 		},
 		{
 			title: "Convert from a Unix timestamp (nanoseconds)"
 			source: #"""
-				from_unix_timestamp(5000, unit: "nanoseconds")
+				from_unix_timestamp!(5000, unit: "nanoseconds")
 				"""#
 			return: "1970-01-01T00:00:00.000005Z"
 		},

--- a/website/cue/reference/remap/functions/from_unix_timestamp.cue
+++ b/website/cue/reference/remap/functions/from_unix_timestamp.cue
@@ -1,0 +1,58 @@
+package metadata
+
+remap: functions: from_unix_timestamp: {
+	category:    "Convert"
+	description: """
+		Converts the `value` integer from a [Unix timestamp](\(urls.unix_timestamp)) to a VRL `timestamp`.
+
+		Converts from the number of seconds since the Unix epoch by default, but milliseconds or nanoseconds can also be
+		specified by `unit`.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The Unix timestamp to convert."
+			required:    true
+			type: ["timestamp"]
+		},
+		{
+			name:        "unit"
+			description: "The time unit."
+			type: ["string"]
+			required: false
+			enum: {
+				seconds:      "Express Unix time in seconds"
+				milliseconds: "Express Unix time in milliseconds"
+				nanoseconds:  "Express Unix time in nanoseconds"
+			}
+			default: "seconds"
+		},
+	]
+	internal_failure_reasons: []
+	return: types: ["timestamp"]
+
+	examples: [
+		{
+			title: "Convert from a Unix timestamp (seconds)"
+			source: #"""
+				from_unix_timestamp!(5)
+				"""#
+			return: "1970-01-01T00:00:05Z"
+		},
+		{
+			title: "Convert from a Unix timestamp (milliseconds)"
+			source: #"""
+				from_unix_timestamp(5000, unit: "milliseconds")
+				"""#
+			return: "1970-01-01T00:00:05Z"
+		},
+		{
+			title: "Convert from a Unix timestamp (nanoseconds)"
+			source: #"""
+				from_unix_timestamp(5000, unit: "nanoseconds")
+				"""#
+			return: "1970-01-01T00:00:00.000005Z"
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/from_unix_timestamp.cue
+++ b/website/cue/reference/remap/functions/from_unix_timestamp.cue
@@ -14,7 +14,7 @@ remap: functions: from_unix_timestamp: {
 			name:        "value"
 			description: "The Unix timestamp to convert."
 			required:    true
-			type: ["timestamp"]
+			type: ["integer"]
 		},
 		{
 			name:        "unit"

--- a/website/cue/reference/remap/functions/parse_nginx_log.cue
+++ b/website/cue/reference/remap/functions/parse_nginx_log.cue
@@ -37,6 +37,7 @@ remap: functions: parse_nginx_log: {
 			enum: {
 				"combined": "Nginx combined format"
 				"error":    "Default Nginx error format"
+				"ingress_upstreaminfo": "Provides detailed upstream information (Nginx Ingress Controller)"
 			}
 			type: ["string"]
 		},

--- a/website/cue/reference/remap/functions/parse_nginx_log.cue
+++ b/website/cue/reference/remap/functions/parse_nginx_log.cue
@@ -35,8 +35,8 @@ remap: functions: parse_nginx_log: {
 			description: "The format to use for parsing the log."
 			required:    true
 			enum: {
-				"combined": "Nginx combined format"
-				"error":    "Default Nginx error format"
+				"combined":             "Nginx combined format"
+				"error":                "Default Nginx error format"
 				"ingress_upstreaminfo": "Provides detailed upstream information (Nginx Ingress Controller)"
 			}
 			type: ["string"]


### PR DESCRIPTION
This updates VRL: `0.4.0` -> `0.5.0`

I'm also trying out the newish "workspace" dependencies, so the VRL version is only specified a single time.

VRL changes can be viewed here: https://github.com/vectordotdev/vrl/blob/main/CHANGELOG.md