### PR TITLE
chore(ci): fix comment author validation

### DIFF
--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -59,13 +59,23 @@ jobs:
           || contains(github.event.comment.body, '/ci-run-regression')
       )
     steps:
-      - name: Validate issue comment
+      - name: Get PR comment author
         id: comment
         uses: tspascoal/get-user-teams-membership@v2
         with:
           username: ${{ github.actor }}
           team: 'Vector'
           GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
+
+      - name: Validate author membership
+        env:
+          isTeamMember: ${{ steps.comment.outputs.isTeamMember }}
+        run: |
+          if [ "${{ steps.comment.outputs.isTeamMember }}" = "false" ] ; then
+            exit 1
+          else
+            exit 0
+          fi
 
   cli:
     needs: validate

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -68,14 +68,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
 
       - name: Validate author membership
-        env:
-          isTeamMember: ${{ steps.comment.outputs.isTeamMember }}
-        run: |
-          if [ "${{ steps.comment.outputs.isTeamMember }}" = "false" ] ; then
-            exit 1
-          else
-            exit 0
-          fi
+        if: steps.comment.outputs.isTeamMember == 'false'
+        run: exit 1
 
   cli:
     needs: validate

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -85,13 +85,6 @@ jobs:
     needs: cross-linux
     if: needs.cross-linux.result == 'success' && github.event_name == 'issue_comment'
     steps:
-      - name: Validate issue comment
-        uses: tspascoal/get-user-teams-membership@v2
-        with:
-          username: ${{ github.actor }}
-          team: 'Vector'
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
-
       - name: (PR comment) Get PR branch
         uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch

--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -55,14 +55,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
 
       - name: Validate author membership
-        env:
-          isTeamMember: ${{ steps.comment.outputs.isTeamMember }}
-        run: |
-          if [ "${{ steps.comment.outputs.isTeamMember }}" = "false" ] ; then
-            exit 1
-          else
-            exit 0
-          fi
+        if: steps.comment.outputs.isTeamMember == 'false'
+        run: exit 1
 
       - name: (PR comment) Get PR branch
         uses: xt0rted/pull-request-comment-branch@v2

--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -46,13 +46,23 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/ci-run-integration') || contains(github.event.comment.body, '/ci-run-all')
     steps:
-      - name: Validate issue comment
-        if: github.event_name == 'issue_comment'
+      - name: Get PR comment author
+        id: comment
         uses: tspascoal/get-user-teams-membership@v2
         with:
           username: ${{ github.actor }}
           team: 'Vector'
           GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
+
+      - name: Validate author membership
+        env:
+          isTeamMember: ${{ steps.comment.outputs.isTeamMember }}
+        run: |
+          if [ "${{ steps.comment.outputs.isTeamMember }}" = "false" ] ; then
+            exit 1
+          else
+            exit 0
+          fi
 
       - name: (PR comment) Get PR branch
         uses: xt0rted/pull-request-comment-branch@v2

--- a/.github/workflows/unit_windows.yml
+++ b/.github/workflows/unit_windows.yml
@@ -8,14 +8,6 @@ jobs:
   test-windows:
     runs-on: [windows, windows-2019-8core]
     steps:
-      - name: Validate issue comment
-        if: github.event_name == 'issue_comment'
-        uses: tspascoal/get-user-teams-membership@v2
-        with:
-          username: ${{ github.actor }}
-          team: 'Vector'
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
-
       - name: (PR comment) Get PR branch
         if: ${{ github.event_name == 'issue_comment' }}
         uses: xt0rted/pull-request-comment-branch@v2


### PR DESCRIPTION
The PR comment author membership was being detected but that wasn't being used to validate if the workflow(s) should proceed.
