### PR TITLE
chore: Revert all submodule introductions to fix CI

### DIFF
--- a/.github/audit.yml
+++ b/.github/audit.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/audit.yml
+++ b/.github/audit.yml
@@ -11,7 +11,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v1
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -119,8 +119,6 @@ jobs:
       k8s: ${{ steps.filter.outputs.k8s }}
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: "recursive"
 
     - uses: dorny/paths-filter@v2
       id: filter
@@ -214,8 +212,6 @@ jobs:
       webhdfs: ${{ steps.filter.outputs.webhdfs }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       # creates a yaml file that contains the filters for each integration,
       # extracted from the output of the `vdev int ci-paths` command, which

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,13 +28,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Cache Cargo registry + index
         uses: actions/cache@v3

--- a/.github/workflows/compilation-timings.yml
+++ b/.github/workflows/compilation-timings.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: cargo clean
@@ -35,8 +33,6 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: cargo clean
@@ -48,8 +44,6 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: cargo clean
@@ -61,8 +55,6 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: cargo clean
@@ -76,8 +68,6 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh
       - run: cargo clean

--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -26,13 +26,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: bash scripts/environment/prepare.sh

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -39,13 +39,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/cache@v3
         name: Cache Cargo registry + index

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -34,13 +34,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.2.0

--- a/.github/workflows/gardener_remove_waiting_author.yml
+++ b/.github/workflows/gardener_remove_waiting_author.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: "meta: awaiting author"

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -28,13 +28,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - run: pip3 install awscli --upgrade --user
       - env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,13 +54,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - run: sudo npm -g install @datadog/datadog-ci
 

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -88,13 +88,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/cache@v3
         with:
@@ -208,13 +205,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -28,13 +28,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/cache@v3
         name: Cache Cargo registry + index

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - run: cargo install cargo-msrv --version 0.15.1
       - run: cargo msrv verify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Generate publish metadata
         id: generate-publish-metadata
         run: make ci-generate-publish-metadata
@@ -57,7 +56,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Ubuntu-specific)
         run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - name: Bootstrap runner environment (generic)
@@ -83,7 +81,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Ubuntu-specific)
         run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - name: Bootstrap runner environment (generic)
@@ -109,7 +106,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Ubuntu-specific)
         run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - name: Bootstrap runner environment (generic)
@@ -137,7 +133,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Ubuntu-specific)
         run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - name: Bootstrap runner environment (generic)
@@ -165,7 +160,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Ubuntu-specific)
         run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - name: Bootstrap runner environment (generic)
@@ -193,7 +187,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Ubuntu-specific)
         run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
       - name: Bootstrap runner environment (generic)
@@ -221,7 +214,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (macOS-specific)
         run: bash scripts/environment/bootstrap-macos-10.sh
       - name: Build Vector
@@ -252,7 +244,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Bootstrap runner environment (Windows-specific)
         run: .\scripts\environment\bootstrap-windows-2019.ps1
       - name: Install Wix
@@ -320,7 +311,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:
@@ -377,7 +367,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:
@@ -405,7 +394,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Download staged package artifacts (x86_64-apple-darwin)
         uses: actions/download-artifact@v3
         with:
@@ -436,7 +424,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Login to DockerHub
         uses: docker/login-action@v2.1.0
         with:
@@ -512,7 +499,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Download staged package artifacts (aarch64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:
@@ -584,7 +570,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Download staged package artifacts (aarch64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:
@@ -645,7 +630,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Publish update to Homebrew tap
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PACKAGE_PUBLISHER_TOKEN }}
@@ -671,7 +655,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-          submodules: "recursive"
       - name: Download staged package artifacts (aarch64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -320,11 +320,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git_ref }}
-        # Workaround for older OS images
-        # https://github.com/actions/checkout/issues/758
-      - name: Checkout submodules
-        run: |
-          git submodule update --init --recursive
+          submodules: "recursive"
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -48,8 +48,6 @@ jobs:
       comment_valid: ${{ steps.comment.outputs.isTeamMember }}
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: "recursive"
 
     - name: Collect file changes
       id: changes
@@ -131,7 +129,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1000
-          submodules: "recursive"
 
       # If triggered by issue comment, the event payload doesn't directly contain the head and base sha from the PR.
       # But, we can retrieve this info from some commands.
@@ -290,8 +287,6 @@ jobs:
       - uses: colpal/actions-clean@v1
 
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/checkout@v3
         with:
@@ -330,8 +325,6 @@ jobs:
       - uses: colpal/actions-clean@v1
 
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/checkout@v3
         with:
@@ -482,7 +475,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.compute-metadata.outputs.comparison-sha }}
-          submodules: "recursive"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.2.0
@@ -602,8 +594,6 @@ jobs:
       - compute-metadata
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.2.0
@@ -695,7 +685,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.compute-metadata.outputs.comparison-sha }}
-          submodules: "recursive"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.2.0

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -292,7 +292,6 @@ jobs:
         with:
           ref: ${{ needs.compute-metadata.outputs.baseline-sha }}
           path: baseline-vector
-          submodules: "recursive"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -330,7 +329,6 @@ jobs:
         with:
           ref: ${{ needs.compute-metadata.outputs.comparison-sha }}
           path: comparison-vector
-          submodules: "recursive"
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           # check-version needs tags
           fetch-depth: 0 # fetch everything
-          submodules: "recursive"
 
       - uses: actions/cache@v3
         name: Cache Cargo registry + index

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -32,13 +32,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - uses: actions/cache@v3
         name: Cache Cargo registry + index

--- a/.github/workflows/unit_windows.yml
+++ b/.github/workflows/unit_windows.yml
@@ -35,13 +35,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: "recursive"
 
       - name: Checkout branch
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - run: .\scripts\environment\bootstrap-windows-2019.ps1
       - run: make test


### PR DESCRIPTION
- Revert "chore: Fix publish workflow for older OS images (#17787)"
- Revert "chore: Add submodules to all checkouts (#17770)"
- Revert "chore: Download submodules in the CI checkouts (#17760)"
