### PR TITLE
chore(observability): Fix a couple typos with the registered event cache

### DIFF
--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -1,6 +1,6 @@
 mod bytes_received;
 mod bytes_sent;
-mod cached_event;
+pub mod cached_event;
 pub mod component_events_dropped;
 mod events_received;
 mod events_sent;
@@ -254,7 +254,7 @@ macro_rules! registered_event {
 
                 fn register(
                     $tags_name: $tags,
-                ) -> <TaggedEventsSent as super::RegisterInternalEvent>::Handle {
+                ) -> <Self as $crate::internal_event::RegisterInternalEvent>::Handle {
                     $register_body
                 }
             })?


### PR DESCRIPTION
Without these, the cache cannot be used for types outside of `vector-common`.