### PR TITLE
chore(ci): Bump up OSX runners for release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,7 +203,7 @@ jobs:
 
   build-x86_64-apple-darwin-packages:
     name: Build Vector for x86_64-apple-darwin (.tar.gz)
-    runs-on: macos-11
+    runs-on: macos-latest-xl
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}


### PR DESCRIPTION
Currently the longest build job at 2 hours; the second longest is an hour.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
