### PR TITLE
chore(ci): Set HOMEBREW_NO_INSTALL_FROM_API in CI

### DIFF
--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 set -e -o verbose
 
+# https://github.com/Homebrew/homebrew-cask/issues/150323
+unset HOMEBREW_NO_INSTALL_FROM_API
+
 brew update
 
 brew install ruby@2.7 coreutils cue-lang/tap/cue protobuf


### PR DESCRIPTION
We seem to be hitting https://github.com/Homebrew/homebrew-cask/issues/150323 which recommends this
workaround.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
