### PR TITLE
fix(vector sink): Add DataLoss error code as non-retryable

### DIFF
--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -253,7 +253,6 @@ impl RetryLogic for VectorGrpcRetryLogic {
                     | OutOfRange
                     | Unimplemented
                     | Unauthenticated
-                    | Internal
                     | DataLoss
             ),
             _ => true,

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -253,6 +253,8 @@ impl RetryLogic for VectorGrpcRetryLogic {
                     | OutOfRange
                     | Unimplemented
                     | Unauthenticated
+                    | Internal
+                    | DataLoss
             ),
             _ => true,
         }


### PR DESCRIPTION
Fixes #17895 as discussed in #17873. The Vector source propagates downstream non-retryable errors as either DataLoss or Internal GRPC error codes. However, these error codes are not treated as non-retryable by the corresponding upstream Vector sink, leading to a delivery retry loop.

(update): Only treating DataLoss as non-retryable. As explained by @dsmith3197 in a commit review - Internal errors occur when At least one event in the batch had a transient error in delivery and DataLoss errors occur when At least one event in the batch had a permanent failure or rejection, with Internal taking precedence over Dataloss. With that in mind, we'll want to retry for Internal, but not DataLoss.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
