### PR TITLE
fix(ci): fix upload test results to DD in int test workflows

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -165,6 +165,7 @@ Samsung
 Sega
 Segoe
 Shopify
+SIGINTs
 Simvalley
 Skype
 Skytex

--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -89,7 +89,12 @@ jobs:
           # First one requires more time, as we need to build the image from scratch
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh amqp
+          shell: bash
+          command: scripts/ci-integration-test.sh amqp
+
+      # Due to https://github.com/nick-fields/retry/issues/54 , we cannot use the retry GHA with uploading the test
+      # results to DD, because it requires the env var to be passed in. So we must do that in a separate step.
+      - run: ./scripts/upload-test-results.sh
 
       - name: appsignal
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-appsignal') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -97,7 +102,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh appsignal
+          shell: bash
+          command: scripts/ci-integration-test.sh appsignal
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: aws
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-aws') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -105,7 +113,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh aws
+          shell: bash
+          command: scripts/ci-integration-test.sh aws
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: axiom
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-axiom') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -113,7 +124,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh axiom
+          shell: bash
+          command: scripts/ci-integration-test.sh axiom
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: azure
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-azure') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -121,7 +135,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh azure
+          shell: bash
+          command: scripts/ci-integration-test.sh azure
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: clickhouse
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-clickhouse') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -129,7 +146,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh clickhouse
+          shell: bash
+          command: scripts/ci-integration-test.sh clickhouse
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: databend
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-databend') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -137,7 +157,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh databend
+          shell: bash
+          command: scripts/ci-integration-test.sh databend
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: datadog-agent
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-datadog-agent') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -145,7 +168,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh datadog-agent
+          shell: bash
+          command: scripts/ci-integration-test.sh datadog-agent
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: datadog-logs
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-datadog-logs') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -153,7 +179,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh datadog-logs
+          shell: bash
+          command: scripts/ci-integration-test.sh datadog-logs
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: datadog-metrics
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-datadog-metrics') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -161,7 +190,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh datadog-metrics
+          shell: bash
+          command: scripts/ci-integration-test.sh datadog-metrics
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: datadog-traces
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-datadog-traces') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -169,7 +201,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh datadog-traces
+          shell: bash
+          command: scripts/ci-integration-test.sh datadog-traces
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: dnstap
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-dnstap') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -177,7 +212,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh dnstap
+          shell: bash
+          command: scripts/ci-integration-test.sh dnstap
+
+      - run: ./scripts/upload-test-results.sh
 
       - run: docker image prune -af --filter=label!=vector-test-runner=true ; docker container prune -f
 
@@ -187,7 +225,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh docker-logs
+          shell: bash
+          command: scripts/ci-integration-test.sh docker-logs
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: elasticsearch
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-elasticsearch') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -195,7 +236,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh elasticsearch
+          shell: bash
+          command: scripts/ci-integration-test.sh elasticsearch
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: eventstoredb
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-eventstoredb') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -203,7 +247,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh eventstoredb
+          shell: bash
+          command: scripts/ci-integration-test.sh eventstoredb
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: fluent
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-fluent') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -211,7 +258,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh fluent
+          shell: bash
+          command: scripts/ci-integration-test.sh fluent
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: gcp
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-gcp') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -219,7 +269,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh gcp
+          shell: bash
+          command: scripts/ci-integration-test.sh gcp
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: humio
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-humio') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -227,7 +280,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh humio
+          shell: bash
+          command: scripts/ci-integration-test.sh humio
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: http-client
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-http-client') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -235,7 +291,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh http-client
+          shell: bash
+          command: scripts/ci-integration-test.sh http-client
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: influxdb
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-influxdb') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -243,7 +302,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh influxdb
+          shell: bash
+          command: scripts/ci-integration-test.sh influxdb
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: kafka
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-kafka') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -251,7 +313,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh kafka
+          shell: bash
+          command: scripts/ci-integration-test.sh kafka
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: logstash
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-logstash') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -259,7 +324,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh logstash
+          shell: bash
+          command: scripts/ci-integration-test.sh logstash
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: loki
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-loki') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -267,7 +335,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh loki
+          shell: bash
+          command: scripts/ci-integration-test.sh loki
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: mongodb
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-mongodb') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -275,7 +346,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh mongodb
+          shell: bash
+          command: scripts/ci-integration-test.sh mongodb
+
+      - run: ./scripts/upload-test-results.sh
 
       - run: docker image prune -af --filter=label!=vector-test-runner=true ; docker container prune -f
 
@@ -285,7 +359,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh nats
+          shell: bash
+          command: scripts/ci-integration-test.sh nats
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: nginx
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-nginx') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -293,7 +370,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh nginx
+          shell: bash
+          command: scripts/ci-integration-test.sh nginx
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: opentelemetry
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-opentelemetry') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -301,7 +381,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh opentelemetry
+          shell: bash
+          command: scripts/ci-integration-test.sh opentelemetry
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: postgres
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-postgres') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -309,7 +392,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh postgres
+          shell: bash
+          command: scripts/ci-integration-test.sh postgres
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: prometheus
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-prometheus') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -317,7 +403,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh prometheus
+          shell: bash
+          command: scripts/ci-integration-test.sh prometheus
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: pulsar
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-pulsar') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -325,7 +414,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh pulsar
+          shell: bash
+          command: scripts/ci-integration-test.sh pulsar
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: redis
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-redis') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -333,7 +425,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh redis
+          shell: bash
+          command: scripts/ci-integration-test.sh redis
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: shutdown
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-shutdown') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -341,7 +436,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh shutdown
+          shell: bash
+          command: scripts/ci-integration-test.sh shutdown
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: splunk
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-splunk') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -349,7 +447,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh splunk
+          shell: bash
+          command: scripts/ci-integration-test.sh splunk
+
+      - run: ./scripts/upload-test-results.sh
 
       - name: webhdfs
         if: ${{ contains(github.event.comment.body, '/ci-run-integration-webhdfs') || contains(github.event.comment.body, '/ci-run-all') }}
@@ -357,7 +458,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh webhdfs
+          shell: bash
+          command: scripts/ci-integration-test.sh webhdfs
+
+      - run: ./scripts/upload-test-results.sh
 
   update-pr-status:
     name: Signal result to PR

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -101,7 +101,12 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh amqp
+          shell: bash
+          command: scripts/ci-integration-test.sh amqp
+
+      # Due to https://github.com/nick-fields/retry/issues/54 , we cannot use the retry GHA with uploading the test
+      # results to DD, because it requires the env var to be passed in. So we must do that in a separate step.
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.appsignal == 'true' }}
         name: appsignal
@@ -109,7 +114,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  appsignal
+          shell: bash
+          command: scripts/ci-integration-test.sh  appsignal
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.aws == 'true' }}
         name: aws
@@ -117,7 +125,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  aws
+          shell: bash
+          command: scripts/ci-integration-test.sh  aws
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.axiom == 'true' }}
         name: axiom
@@ -125,7 +136,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  axiom
+          shell: bash
+          command: scripts/ci-integration-test.sh  axiom
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.azure == 'true' }}
         name: azure
@@ -133,7 +147,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  azure
+          shell: bash
+          command: scripts/ci-integration-test.sh  azure
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.clickhouse == 'true' }}
         name: clickhouse
@@ -141,7 +158,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  clickhouse
+          shell: bash
+          command: scripts/ci-integration-test.sh  clickhouse
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.databend == 'true' }}
         name: databend
@@ -149,7 +169,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  databend
+          shell: bash
+          command: scripts/ci-integration-test.sh  databend
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
         name: datadog-agent
@@ -157,7 +180,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  datadog-agent
+          shell: bash
+          command: scripts/ci-integration-test.sh  datadog-agent
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
         name: datadog-logs
@@ -165,7 +191,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  datadog-logs
+          shell: bash
+          command: scripts/ci-integration-test.sh  datadog-logs
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
         name: datadog-metrics
@@ -173,7 +202,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  datadog-metrics
+          shell: bash
+          command: scripts/ci-integration-test.sh  datadog-metrics
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
         name: datadog-traces
@@ -181,7 +213,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  datadog-traces
+          shell: bash
+          command: scripts/ci-integration-test.sh  datadog-traces
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.dnstap == 'true' }}
         name: dnstap
@@ -189,7 +224,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  dnstap
+          shell: bash
+          command: scripts/ci-integration-test.sh  dnstap
+
+      - run: ./scripts/upload-test-results.sh
 
       - run: docker image prune -af --filter=label!=vector-test-runner=true ; docker container prune -f
 
@@ -199,7 +237,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  docker-logs
+          shell: bash
+          command: scripts/ci-integration-test.sh  docker-logs
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.elasticsearch == 'true' }}
         name: elasticsearch
@@ -207,7 +248,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  elasticsearch
+          shell: bash
+          command: scripts/ci-integration-test.sh  elasticsearch
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.eventstoredb == 'true' }}
         name: eventstoredb
@@ -215,7 +259,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  eventstoredb
+          shell: bash
+          command: scripts/ci-integration-test.sh  eventstoredb
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.fluent == 'true' }}
         name: fluent
@@ -223,7 +270,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  fluent
+          shell: bash
+          command: scripts/ci-integration-test.sh  fluent
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.gcp == 'true' }}
         name: gcp
@@ -231,7 +281,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  gcp
+          shell: bash
+          command: scripts/ci-integration-test.sh  gcp
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.humio == 'true' }}
         name: humio
@@ -239,7 +292,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  humio
+          shell: bash
+          command: scripts/ci-integration-test.sh  humio
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.http-client == 'true' }}
         name: http-client
@@ -247,7 +303,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  http-client
+          shell: bash
+          command: scripts/ci-integration-test.sh  http-client
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.influxdb == 'true' }}
         name: influxdb
@@ -255,7 +314,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  influxdb
+          shell: bash
+          command: scripts/ci-integration-test.sh  influxdb
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.kafka == 'true' }}
         name: kafka
@@ -263,7 +325,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  kafka
+          shell: bash
+          command: scripts/ci-integration-test.sh  kafka
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.logstash == 'true' }}
         name: logstash
@@ -271,7 +336,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  logstash
+          shell: bash
+          command: scripts/ci-integration-test.sh  logstash
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.loki == 'true' }}
         name: loki
@@ -279,7 +347,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  loki
+          shell: bash
+          command: scripts/ci-integration-test.sh  loki
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.mongodb == 'true' }}
         name: mongodb
@@ -287,7 +358,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  mongodb
+          shell: bash
+          command: scripts/ci-integration-test.sh  mongodb
+
+      - run: ./scripts/upload-test-results.sh
 
       - run: docker image prune -af --filter=label!=vector-test-runner=true ; docker container prune -f
 
@@ -297,7 +371,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  nats
+          shell: bash
+          command: scripts/ci-integration-test.sh  nats
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.nginx == 'true' }}
         name: nginx
@@ -305,7 +382,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  nginx
+          shell: bash
+          command: scripts/ci-integration-test.sh  nginx
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.opentelemetry == 'true' }}
         name: opentelemetry
@@ -313,7 +393,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  opentelemetry
+          shell: bash
+          command: scripts/ci-integration-test.sh  opentelemetry
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.postgres == 'true' }}
         name: postgres
@@ -321,7 +404,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  postgres
+          shell: bash
+          command: scripts/ci-integration-test.sh  postgres
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.prometheus == 'true' }}
         name: prometheus
@@ -329,7 +415,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  prometheus
+          shell: bash
+          command: scripts/ci-integration-test.sh  prometheus
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.pulsar == 'true' }}
         name: pulsar
@@ -337,7 +426,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  pulsar
+          shell: bash
+          command: scripts/ci-integration-test.sh  pulsar
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.redis == 'true' }}
         name: redis
@@ -345,7 +437,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  redis
+          shell: bash
+          command: scripts/ci-integration-test.sh  redis
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' }}
         name: shutdown
@@ -353,7 +448,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  shutdown
+          shell: bash
+          command: scripts/ci-integration-test.sh  shutdown
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.splunk == 'true' }}
         name: splunk
@@ -361,7 +459,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  splunk
+          shell: bash
+          command: scripts/ci-integration-test.sh  splunk
+
+      - run: ./scripts/upload-test-results.sh
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.webhdfs == 'true' }}
         name: webhdfs
@@ -369,7 +470,10 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: bash scripts/ci-integration-test.sh  webhdfs
+          shell: bash
+          command: scripts/ci-integration-test.sh  webhdfs
+
+      - run: ./scripts/upload-test-results.sh
 
   integration-test-suite:
     name: Integration Test Suite

--- a/scripts/ci-integration-test.sh
+++ b/scripts/ci-integration-test.sh
@@ -26,5 +26,4 @@ sleep 30
 cargo vdev -v int test --retries 2 -a "${INTEGRATION}"
 RET=$?
 cargo vdev -v int stop -a "${INTEGRATION}"
-./scripts/upload-test-results.sh
 exit $RET


### PR DESCRIPTION
The upload to DD in integration test workflows was broken because the retry GHA used, does not allow forwarding env vars to the shell that executes the command to retry.