### PR TITLE
chore(ci): Remove path filter that runs all integration tests

### DIFF
--- a/vdev/src/commands/integration/ci_paths.rs
+++ b/vdev/src/commands/integration/ci_paths.rs
@@ -11,9 +11,8 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(&self) -> Result<()> {
-        // changes to vector-core should test all integrations
+        // placeholder for changes that should run all integration tests
         println!("all-int:");
-        println!("- \"lib/vector-core/**\"");
 
         // paths for each integration are defined in their respective config files.
         for (integration, config) in IntegrationTestConfig::collect_all()? {


### PR DESCRIPTION
Currently this causes all integration tests to run on common dependabot changes to
`lib/vector-core/Cargo.toml` even though those changes are likely to be very low risk. These tests
also fail due to dependabot not having access to secrets but that is being addressed separately; the
primary argument in this PR is that the tests aren't needed in the PR, just the merge queue, for changes to `Cargo.toml` due to the low risk.

I had originally just wanted to exclude only `lib/vector-core/Cargo.toml` but this wasn't possible
due to a lack of support by the paths-filter action
(https://github.com/dorny/paths-filter/issues/106). Upon reflection, I think it is is unlikely that
core changes will cause integration test failures that don't also cause other test failures so my
proposal is that we just rely on the merge queue to catch that scenario. If we find it to be the
contrary, we can add it back.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
