### PR TITLE
chore(ci): check for team membership on secret-requiring int tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
     name: Detect user team membership
     runs-on: ubuntu-latest
     outputs:
-      IS_TEAM_MEMBER: ${{ jobs.author.outputs.isTeamMember }}
+      IS_TEAM_MEMBER: ${{ steps.author.outputs.isTeamMember }}
     steps:
       - name: Get PR author
         if: github.event_name == 'pull_request'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,10 +46,25 @@ jobs:
       int_tests: true
     secrets: inherit
 
+  detect-user:
+    name: Detect user team membership
+    runs-on: ubuntu-latest
+    outputs:
+      IS_TEAM_MEMBER: ${{ jobs.author.outputs.isTeamMember }}
+    steps:
+      - name: Get PR author
+        if: github.event_name == 'pull_request'
+        id: author
+        uses: tspascoal/get-user-teams-membership@v2
+        with:
+          username: ${{ github.actor }}
+          team: 'Vector'
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_ORG }}
+
   integration-tests:
     name: Integration Tests
     runs-on: [linux, ubuntu-20.04-4core]
-    needs: changes
+    needs: [changes, detect-user]
     if: always() && (
       github.event_name == 'merge_group' || (
           needs.changes.outputs.all-int == 'true'
@@ -103,7 +118,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh amqp
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.appsignal == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.appsignal == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: appsignal
         uses: nick-fields/retry@v2
         with:
@@ -119,7 +135,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  aws
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.axiom == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.axiom == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: axiom
         uses: nick-fields/retry@v2
         with:
@@ -143,7 +160,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  clickhouse
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.databend == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.databend == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: databend
         uses: nick-fields/retry@v2
         with:
@@ -151,7 +169,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  databend
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: datadog-agent
         uses: nick-fields/retry@v2
         with:
@@ -159,7 +178,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  datadog-agent
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: datadog-logs
         uses: nick-fields/retry@v2
         with:
@@ -167,7 +187,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  datadog-logs
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: datadog-metrics
         uses: nick-fields/retry@v2
         with:
@@ -175,7 +196,8 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  datadog-metrics
 
-      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true' }}
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+          (github.event_name != 'pull_request' || needs.detect-user.outputs.IS_TEAM_MEMBER == 'true')
         name: datadog-traces
         uses: nick-fields/retry@v2
         with:


### PR DESCRIPTION
- Incidentally this is a nice-to-have in general.

- However with the recent merge queue changes, it has become necessary because previously, all status checks would run on external contributor PRs, and the force merge because secret-requiring int tests was ok. But there is no option to force add to merge queue, it's just force merge to the protected branch.

- Thus, for the `pull_request` trigger, we need to skip the integration tests that require secrets.

- On contributor PRs that touch those integrations, team members can either run them locally after checking out the branch, or trigger them by comment on the PR.