### PR TITLE
chore(CI): Switch regression detector to new API and analysis service

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -244,6 +244,7 @@ compiletime
 coredns
 corejs
 coreutils
+curta
 daemonset
 databend
 datacenter

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -229,7 +229,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.7.3"
+          export SMP_CRATE_VERSION="0.9.0"
           export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"
@@ -456,6 +456,8 @@ jobs:
       - compute-metadata
       - upload-baseline-image-to-ecr
       - upload-comparison-image-to-ecr
+    env:
+      SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
     steps:
       - name: Check status, in-progress
         env:
@@ -496,6 +498,7 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job submit \
+            --use-curta \
             --lading-version ${{ needs.compute-metadata.outputs.lading-version }} \
             --total-samples ${{ needs.compute-metadata.outputs.total-samples }} \
             --warmup-seconds ${{ needs.compute-metadata.outputs.warmup-seconds }} \
@@ -525,6 +528,7 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
+            --use-curta \
             --wait \
             --wait-delay-seconds 60 \
             --wait-timeout-minutes 90 \
@@ -537,6 +541,7 @@ jobs:
         run: |
           chmod +x ${{ runner.temp }}/bin/smp
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job cancel \
+            --use-curta \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Check status, cancelled
@@ -590,6 +595,8 @@ jobs:
     needs:
       - submit-job
       - compute-metadata
+    env:
+      SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
     steps:
       - uses: actions/checkout@v3
 
@@ -617,6 +624,8 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job result \
+            --use-curta \
+            --use-consignor \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Check status, cancelled
@@ -666,6 +675,8 @@ jobs:
     needs:
       - submit-job
       - compute-metadata
+    env:
+      SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
     steps:
       - name: Check status, in-progress
         env:
@@ -708,6 +719,8 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job sync \
+            --use-curta \
+            --use-consignor \
             --submission-metadata ${{ runner.temp }}/submission-metadata \
             --output-path "${{ runner.temp }}/outputs"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -37,6 +37,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.merge_group.head_sha || github.sha }}
   cancel-in-progress: true
 
+env:
+  SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
+
 jobs:
 
   # Only run this workflow if files changed in areas that could possibly introduce a regression
@@ -456,8 +459,6 @@ jobs:
       - compute-metadata
       - upload-baseline-image-to-ecr
       - upload-comparison-image-to-ecr
-    env:
-      SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
     steps:
       - name: Check status, in-progress
         env:
@@ -595,8 +596,6 @@ jobs:
     needs:
       - submit-job
       - compute-metadata
-    env:
-      SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
     steps:
       - uses: actions/checkout@v3
 
@@ -675,8 +674,6 @@ jobs:
     needs:
       - submit-job
       - compute-metadata
-    env:
-      SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
     steps:
       - name: Check status, in-progress
         env:


### PR DESCRIPTION
This should be a transparent change. If you notice any issues, please ping us in #single-machine-performance. We'll also be keeping a close eye on things after this is merged.

## Single Machine Performance API (`curta`)

The Single Machine Performance team has built an API to interact with the regression detector system. This will allow us to maintain reliability while continuing to evolve the system. This is enabled with the `--use-curta` flag, which will become the default in an upcoming release.

The curta API uses a unique URI for each team. This isn't secret - all endpoints have authorization - but we'd prefer it not be public. The URI for Vector is in SMP-617. The `smp` binary can read this from the `SINGLE_MACHINE_PERFORMANCE_API` environment variable or the `--api-base` flag.

## Lambda Analysis Worker (`consignor`)

We have also changed how the analysis worker is deployed so it can run on-demand for incoming requests. This improves analysis speed while reducing our operational workload. This is set using the `--use-consignor` flag, which will also become the default in a future release.
