### PR TITLE
fix(demo gcp_pubsub internal_metrics source throttle transform): Fix `interval` fractional second parsing

### DIFF
--- a/lib/vector-config/src/external/serde_with.rs
+++ b/lib/vector-config/src/external/serde_with.rs
@@ -105,6 +105,35 @@ impl Configurable for serde_with::DurationSeconds<f64, serde_with::formats::Stri
     }
 }
 
+impl Configurable for serde_with::DurationSecondsWithFrac<f64, serde_with::formats::Strict> {
+    fn referenceable_name() -> Option<&'static str> {
+        // We're masking the type parameters here because we only deal with fractional seconds via this
+        // version, and handle whole seconds with `DurationSeconds<u64, Strict>`, which we
+        // expose as `serde_with::DurationSeconds`.
+        Some("serde_with::DurationFractionalSeconds")
+    }
+
+    fn metadata() -> Metadata {
+        let mut metadata = Metadata::default();
+        metadata.set_description("A span of time, in fractional seconds.");
+        metadata.add_custom_attribute(CustomAttribute::kv(
+            constants::DOCS_META_NUMERIC_TYPE,
+            NumberClass::FloatingPoint,
+        ));
+        metadata.add_custom_attribute(CustomAttribute::kv(
+            constants::DOCS_META_TYPE_UNIT,
+            "seconds",
+        ));
+        metadata
+    }
+
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        // This boils down to a number schema, but we just need to shuttle around the metadata so
+        // that we can call the relevant schema generation function.
+        Ok(generate_number_schema::<f64>())
+    }
+}
+
 impl Configurable for serde_with::DurationMilliSeconds<u64, serde_with::formats::Strict> {
     fn referenceable_name() -> Option<&'static str> {
         // We're masking the type parameters here because we only deal with whole milliseconds via this

--- a/lib/vector-config/src/external/serde_with.rs
+++ b/lib/vector-config/src/external/serde_with.rs
@@ -50,7 +50,7 @@ where
 impl Configurable for serde_with::DurationSeconds<u64, serde_with::formats::Strict> {
     fn referenceable_name() -> Option<&'static str> {
         // We're masking the type parameters here because we only deal with whole seconds via this
-        // version, and handle fractional seconds with `DurationSeconds<f64, Strict>`, which we
+        // version, and handle fractional seconds with `DurationSecondsWithFrac<f64, Strict>`, which we
         // expose as `serde_with::DurationFractionalSeconds`.
         Some("serde_with::DurationSeconds")
     }
@@ -73,35 +73,6 @@ impl Configurable for serde_with::DurationSeconds<u64, serde_with::formats::Stri
         // This boils down to a number schema, but we just need to shuttle around the metadata so
         // that we can call the relevant schema generation function.
         Ok(generate_number_schema::<u64>())
-    }
-}
-
-impl Configurable for serde_with::DurationSeconds<f64, serde_with::formats::Strict> {
-    fn referenceable_name() -> Option<&'static str> {
-        // We're masking the type parameters here because we only deal with fractional seconds via this
-        // version, and handle whole seconds with `DurationSeconds<u64, Strict>`, which we
-        // expose as `serde_with::DurationSeconds`.
-        Some("serde_with::DurationFractionalSeconds")
-    }
-
-    fn metadata() -> Metadata {
-        let mut metadata = Metadata::default();
-        metadata.set_description("A span of time, in fractional seconds.");
-        metadata.add_custom_attribute(CustomAttribute::kv(
-            constants::DOCS_META_NUMERIC_TYPE,
-            NumberClass::FloatingPoint,
-        ));
-        metadata.add_custom_attribute(CustomAttribute::kv(
-            constants::DOCS_META_TYPE_UNIT,
-            "seconds",
-        ));
-        metadata
-    }
-
-    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
-        // This boils down to a number schema, but we just need to shuttle around the metadata so
-        // that we can call the relevant schema generation function.
-        Ok(generate_number_schema::<f64>())
     }
 }
 

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -48,7 +48,7 @@ pub struct DemoLogsConfig {
     #[derivative(Default(value = "default_interval()"))]
     #[serde(default = "default_interval")]
     #[configurable(metadata(docs::examples = 1.0, docs::examples = 0.1, docs::examples = 0.01,))]
-    #[serde_as(as = "serde_with::DurationSeconds<f64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     pub interval: Duration,
 
     /// The total number of lines to output.

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -162,7 +162,7 @@ pub struct PubsubConfig {
     /// How often to poll the currently active streams to see if they
     /// are all busy and so open a new stream.
     #[serde(default = "default_poll_time")]
-    #[serde_as(as = "serde_with::DurationSeconds<f64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[configurable(metadata(docs::human_name = "Poll Time"))]
     pub poll_time_seconds: Duration,
 
@@ -184,7 +184,7 @@ pub struct PubsubConfig {
 
     /// The amount of time, in seconds, to wait between retry attempts after an error.
     #[serde(default = "default_retry_delay")]
-    #[serde_as(as = "serde_with::DurationSeconds<f64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[configurable(metadata(docs::human_name = "Retry Delay"))]
     pub retry_delay_secs: Duration,
 
@@ -198,7 +198,7 @@ pub struct PubsubConfig {
     /// before sending a keepalive request. If this is set larger than
     /// `60`, you may see periodic errors sent from the server.
     #[serde(default = "default_keepalive")]
-    #[serde_as(as = "serde_with::DurationSeconds<f64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[configurable(metadata(docs::human_name = "Keepalive"))]
     pub keepalive_secs: Duration,
 

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -26,7 +26,7 @@ use crate::{
 #[serde(deny_unknown_fields, default)]
 pub struct InternalMetricsConfig {
     /// The interval between metric gathering, in seconds.
-    #[serde_as(as = "serde_with::DurationSeconds<f64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[serde(default = "default_scrape_interval")]
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub scrape_interval_secs: Duration,

--- a/src/transforms/throttle.rs
+++ b/src/transforms/throttle.rs
@@ -30,7 +30,7 @@ pub struct ThrottleConfig {
     threshold: u32,
 
     /// The time window in which the configured `threshold` is applied, in seconds.
-    #[serde_as(as = "serde_with::DurationSeconds<f64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[configurable(metadata(docs::human_name = "Time Window"))]
     window_secs: Duration,
 


### PR DESCRIPTION
The demo logs source `interval` parameter examples imply that demo logs faster than 1/sec are possible by specifying a fractional value. However, the demo logs source incorrectly parses this value using serde's [DurationSeconds](https://docs.rs/serde_with/latest/serde_with/struct.DurationSeconds.html). This is incorrect - fractional second parts are coerced into a full-integer value based on rounding rules. So currently, `interval` values of >= 0.5 to 1 behave the same as `interval = 1`, while `interval` values of < 0.5 behave the same as `interval = 0`. The correct serde struct to use is [DurationSecondsWithFrac](https://docs.rs/serde_with/latest/serde_with/struct.DurationSecondsWithFrac.html).

(edit): This has since expanded to complete replacement of all usages of `DurationSeconds<f64, Strict>` with `DurationSecondsWithFrac<f64, Strict>`. This now also affects `gcp_pubsub` and `internal_metrics` sources, as well as the `throttle` transform.