### PR TITLE
feat: Migrate `LogSchema` `source_type_key` to new lookup code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,6 @@ members = [
 
 [workspace.dependencies]
 vrl = { version = "0.5.0", features = ["cli", "test", "test_framework", "arbitrary"] }
-#vrl = { path = "../vrl", features = ["cli", "test", "test_framework", "arbitrary"] }
 
 [dependencies]
 vrl.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ members = [
 
 [workspace.dependencies]
 vrl = { version = "0.5.0", features = ["cli", "test", "test_framework", "arbitrary"] }
+#vrl = { path = "../vrl", features = ["cli", "test", "test_framework", "arbitrary"] }
 
 [dependencies]
 vrl.workspace = true

--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -208,7 +208,7 @@ impl ResourceLog {
 
         log_namespace.insert_vector_metadata(
             &mut log,
-            Some(log_schema().source_type_key()),
+            log_schema().source_type_key(),
             path!("source_type"),
             Bytes::from_static(SOURCE_NAME.as_bytes()),
         );

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -1,6 +1,7 @@
-use lookup::lookup_v2::{parse_target_path, OptionalValuePath};
-use lookup::{owned_value_path, OwnedTargetPath, OwnedValuePath};
+use lookup::lookup_v2::{OptionalValuePath};
+use lookup::{OwnedTargetPath, OwnedValuePath};
 use once_cell::sync::{Lazy, OnceCell};
+use vrl::path::parse_target_path;
 use vector_config::configurable_component;
 
 static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
@@ -60,7 +61,7 @@ pub struct LogSchema {
     ///
     /// This field will be set by the Vector source that the event was created in.
     #[serde(default = "LogSchema::default_source_type_key")]
-    source_type_key: String,
+    source_type_key: OptionalValuePath,
 
     /// The name of the event field to set the event metadata in.
     ///
@@ -88,17 +89,15 @@ impl LogSchema {
     }
 
     fn default_timestamp_key() -> OptionalValuePath {
-        OptionalValuePath {
-            path: Some(owned_value_path!("timestamp")),
-        }
+        OptionalValuePath::new("timestamp")
     }
 
     fn default_host_key() -> String {
         String::from("host")
     }
 
-    fn default_source_type_key() -> String {
-        String::from("source_type")
+    fn default_source_type_key() -> OptionalValuePath {
+        OptionalValuePath::new("source_type")
     }
 
     fn default_metadata_key() -> String {
@@ -126,8 +125,8 @@ impl LogSchema {
         &self.host_key
     }
 
-    pub fn source_type_key(&self) -> &str {
-        &self.source_type_key
+    pub fn source_type_key(&self) -> Option<&OwnedValuePath> {
+        self.source_type_key.path.as_ref()
     }
 
     pub fn metadata_key(&self) -> &str {
@@ -146,8 +145,8 @@ impl LogSchema {
         self.host_key = v;
     }
 
-    pub fn set_source_type_key(&mut self, v: String) {
-        self.source_type_key = v;
+    pub fn set_source_type_key(&mut self, path: Option<OwnedValuePath>) {
+        self.source_type_key = OptionalValuePath { path };
     }
 
     pub fn set_metadata_key(&mut self, v: String) {
@@ -191,7 +190,7 @@ impl LogSchema {
             {
                 errors.push("conflicting values for 'log_schema.source_type_key' found".to_owned());
             } else {
-                self.set_source_type_key(other.source_type_key().to_string());
+                self.set_source_type_key(other.source_type_key().cloned());
             }
             if self.metadata_key() != LOG_SCHEMA_DEFAULT.metadata_key()
                 && self.metadata_key() != other.metadata_key()

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -1,8 +1,8 @@
-use lookup::lookup_v2::{OptionalValuePath};
+use lookup::lookup_v2::OptionalValuePath;
 use lookup::{OwnedTargetPath, OwnedValuePath};
 use once_cell::sync::{Lazy, OnceCell};
-use vrl::path::parse_target_path;
 use vector_config::configurable_component;
+use vrl::path::parse_target_path;
 
 static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
 static LOG_SCHEMA_DEFAULT: Lazy<LogSchema> = Lazy::new(LogSchema::default);

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -476,7 +476,7 @@ impl LogNamespace {
     ) {
         self.insert_vector_metadata(
             log,
-            Some(log_schema().source_type_key()),
+            log_schema().source_type_key(),
             path!("source_type"),
             Bytes::from_static(source_name.as_bytes()),
         );

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -551,14 +551,15 @@ mod test {
     use chrono::Utc;
     use lookup::{event_path, owned_value_path, OwnedTargetPath};
     use vector_common::btreemap;
+    use vrl::path::OwnedValuePath;
     use vrl::value::Kind;
 
     #[test]
     fn test_insert_standard_vector_source_metadata() {
-        let nested_path = "a.b.c.d";
+        let nested_path = "a.b.c.d".to_string();
 
         let mut schema = LogSchema::default();
-        schema.set_source_type_key(nested_path.to_owned());
+        schema.set_source_type_key(Some(OwnedValuePath::try_from(nested_path).unwrap()));
         init_log_schema(schema, false);
 
         let namespace = LogNamespace::Legacy;

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -466,10 +466,10 @@ impl LogEvent {
     /// or from the `source_type` key set on the "Global Log Schema" (Legacy namespace).
     // TODO: This can eventually return a `&TargetOwnedPath` once Semantic meaning and the
     //   "Global Log Schema" are updated to the new path lookup code
-    pub fn source_type_path(&self) -> &'static str {
+    pub fn source_type_path(&self) -> Option<String> {
         match self.namespace() {
-            LogNamespace::Vector => "%vector.source_type",
-            LogNamespace::Legacy => log_schema().source_type_key(),
+            LogNamespace::Vector => Some("%vector.source_type".to_string()),
+            LogNamespace::Legacy => log_schema().source_type_key().map(ToString::to_string),
         }
     }
 
@@ -514,7 +514,9 @@ impl LogEvent {
     pub fn get_source_type(&self) -> Option<&Value> {
         match self.namespace() {
             LogNamespace::Vector => self.get(metadata_path!("vector", "source_type")),
-            LogNamespace::Legacy => self.get((PathPrefix::Event, log_schema().source_type_key())),
+            LogNamespace::Legacy => log_schema()
+                .source_type_key()
+                .and_then(|key| self.get((PathPrefix::Event, key))),
         }
     }
 }

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::config::{log_schema, LegacyKey, LogNamespace};
-use lookup::lookup_v2::{parse_value_path, TargetPath};
+use lookup::lookup_v2::TargetPath;
 use lookup::{owned_value_path, OwnedTargetPath, OwnedValuePath, PathPrefix};
 use vrl::value::{kind::Collection, Kind};
 
@@ -144,9 +144,7 @@ impl Definition {
     #[must_use]
     pub fn with_standard_vector_source_metadata(self) -> Self {
         self.with_vector_metadata(
-            parse_value_path(log_schema().source_type_key())
-                .ok()
-                .as_ref(),
+            log_schema().source_type_key(),
             &owned_value_path!("source_type"),
             Kind::bytes(),
             None,

--- a/lib/vector-lookup/src/lookup_v2/optional_path.rs
+++ b/lib/vector-lookup/src/lookup_v2/optional_path.rs
@@ -1,5 +1,5 @@
-use vrl::owned_value_path;
 use vector_config::configurable_component;
+use vrl::owned_value_path;
 
 use crate::lookup_v2::PathParseError;
 use crate::{OwnedTargetPath, OwnedValuePath};
@@ -59,7 +59,9 @@ impl OptionalValuePath {
     }
 
     pub fn new(path: &str) -> Self {
-        Self { path: Some(owned_value_path!(path)) }
+        Self {
+            path: Some(owned_value_path!(path)),
+        }
     }
 }
 

--- a/lib/vector-lookup/src/lookup_v2/optional_path.rs
+++ b/lib/vector-lookup/src/lookup_v2/optional_path.rs
@@ -1,3 +1,4 @@
+use vrl::owned_value_path;
 use vector_config::configurable_component;
 
 use crate::lookup_v2::PathParseError;
@@ -55,6 +56,10 @@ pub struct OptionalValuePath {
 impl OptionalValuePath {
     pub fn none() -> Self {
         Self { path: None }
+    }
+
+    pub fn new(path: &str) -> Self {
+        Self { path: Some(owned_value_path!(path)) }
     }
 }
 

--- a/src/sinks/datadog/events/sink.rs
+++ b/src/sinks/datadog/events/sink.rs
@@ -75,7 +75,9 @@ async fn ensure_required_fields(event: Event) -> Option<Event> {
     }
 
     if !log.contains("source_type_name") {
-        log.rename_key(log.source_type_path(), "source_type_name")
+        if let Some(source_type_path) = log.source_type_path() {
+            log.rename_key(source_type_path.as_str(), "source_type_name")
+        }
     }
 
     Some(Event::from(log))

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -206,7 +206,9 @@ impl SinkConfig for InfluxDbLogsConfig {
         let source_type_key = self
             .source_type_key
             .clone()
-            .and_then(|k| k.path).or(log_schema().source_type_key().cloned()).unwrap();
+            .and_then(|k| k.path)
+            .or(log_schema().source_type_key().cloned())
+            .unwrap();
 
         let sink = InfluxDbLogsSink {
             uri,
@@ -281,7 +283,7 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
             self.tags.replace(source_type_path);
         }
 
-        if let Some(source_type_key) =  log_schema().source_type_key() {
+        if let Some(source_type_key) = log_schema().source_type_key() {
             log.rename_key(
                 (PathPrefix::Event, source_type_key),
                 (PathPrefix::Event, &self.source_type_key),

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -280,12 +280,9 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         }
 
         if let Some(source_type_path) = log.source_type_path() {
-            self.tags.replace(source_type_path);
-        }
-
-        if let Some(source_type_key) = log_schema().source_type_key() {
+            self.tags.replace(source_type_path.clone());
             log.rename_key(
-                (PathPrefix::Event, source_type_key),
+                (PathPrefix::Event, source_type_path.as_str()),
                 (PathPrefix::Event, &self.source_type_key),
             );
         }

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -282,7 +282,7 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         if let Some(source_type_path) = log.source_type_path() {
             self.tags.replace(source_type_path.clone());
             log.rename_key(
-                (PathPrefix::Event, source_type_path.as_str()),
+                source_type_path.as_str(),
                 (PathPrefix::Event, &self.source_type_key),
             );
         }

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -713,7 +713,10 @@ mod integration_test {
         trace!("{:?}", log);
         assert_eq!(log[log_schema().message_key()], "my message".into());
         assert_eq!(log["routing"], routing_key.into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "amqp".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "amqp".into()
+        );
         let log_ts = log[log_schema().timestamp_key().unwrap().to_string()]
             .as_timestamp()
             .unwrap();

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -278,7 +278,7 @@ fn populate_event(
 
     log_namespace.insert_vector_metadata(
         log,
-        Some(log_schema().source_type_key()),
+        log_schema().source_type_key(),
         path!("source_type"),
         Bytes::from_static(AmqpSourceConfig::NAME.as_bytes()),
     );
@@ -713,7 +713,7 @@ mod integration_test {
         trace!("{:?}", log);
         assert_eq!(log[log_schema().message_key()], "my message".into());
         assert_eq!(log["routing"], routing_key.into());
-        assert_eq!(log[log_schema().source_type_key()], "amqp".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "amqp".into());
         let log_ts = log[log_schema().timestamp_key().unwrap().to_string()]
             .as_timestamp()
             .unwrap();

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -93,7 +93,7 @@ pub(super) async fn firehose(
                         if let Event::Log(ref mut log) = event {
                             log_namespace.insert_vector_metadata(
                                 log,
-                                Some(log_schema().source_type_key()),
+                                log_schema().source_type_key(),
                                 path!("source_type"),
                                 Bytes::from_static(AwsKinesisFirehoseConfig::NAME.as_bytes()),
                             );

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -691,7 +691,7 @@ fn handle_single_log(
 
     log_namespace.insert_vector_metadata(
         log,
-        Some(log_schema().source_type_key()),
+        log_schema().source_type_key(),
         path!("source_type"),
         Bytes::from_static(AwsS3Config::NAME.as_bytes()),
     );

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -334,7 +334,8 @@ impl DatadogAgentSource {
                     .expect("static regex always compiles"),
             },
             log_schema_host_key: log_schema().host_key(),
-            log_schema_source_type_key: log_schema().source_type_key(),
+            log_schema_source_type_key: log_schema().source_type_key()
+                .map_or("", |key| Box::leak(key.to_string().into_boxed_str())),
             decoder,
             protocol,
             logs_schema_definition: Arc::new(logs_schema_definition),

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -334,7 +334,8 @@ impl DatadogAgentSource {
                     .expect("static regex always compiles"),
             },
             log_schema_host_key: log_schema().host_key(),
-            log_schema_source_type_key: log_schema().source_type_key()
+            log_schema_source_type_key: log_schema()
+                .source_type_key()
                 .map_or("", |key| Box::leak(key.to_string().into_boxed_str())),
             decoder,
             protocol,

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -284,7 +284,7 @@ pub struct ApiKeyQueryParams {
 pub(crate) struct DatadogAgentSource {
     pub(crate) api_key_extractor: ApiKeyExtractor,
     pub(crate) log_schema_host_key: &'static str,
-    pub(crate) log_schema_source_type_key: &'static str,
+    pub(crate) log_schema_source_type_key: String,
     pub(crate) log_namespace: LogNamespace,
     pub(crate) decoder: Decoder,
     protocol: &'static str,
@@ -336,7 +336,7 @@ impl DatadogAgentSource {
             log_schema_host_key: log_schema().host_key(),
             log_schema_source_type_key: log_schema()
                 .source_type_key()
-                .map_or("", |key| Box::leak(key.to_string().into_boxed_str())),
+                .map_or("".to_string(), |key| key.to_string()),
             decoder,
             protocol,
             logs_schema_definition: Arc::new(logs_schema_definition),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -238,7 +238,7 @@ async fn full_payload_v1() {
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert!(event.metadata().datadog_api_key().is_none());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 event.metadata().schema_definition(),
                 &test_logs_schema_definition()
@@ -300,7 +300,7 @@ async fn full_payload_v2() {
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert!(event.metadata().datadog_api_key().is_none());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 event.metadata().schema_definition(),
                 &test_logs_schema_definition()
@@ -362,7 +362,7 @@ async fn no_api_key() {
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert!(event.metadata().datadog_api_key().is_none());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 event.metadata().schema_definition(),
                 &test_logs_schema_definition()
@@ -423,7 +423,7 @@ async fn api_key_in_url() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"
@@ -488,7 +488,7 @@ async fn api_key_in_query_params() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"
@@ -559,7 +559,7 @@ async fn api_key_in_header() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"
@@ -706,7 +706,7 @@ async fn ignores_api_key() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert!(event.metadata().datadog_api_key().is_none());
             assert_eq!(
                 event.metadata().schema_definition(),
@@ -1398,7 +1398,7 @@ async fn split_outputs() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key()], "datadog_agent".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -238,7 +238,10 @@ async fn full_payload_v1() {
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert!(event.metadata().datadog_api_key().is_none());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 event.metadata().schema_definition(),
                 &test_logs_schema_definition()
@@ -300,7 +303,10 @@ async fn full_payload_v2() {
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert!(event.metadata().datadog_api_key().is_none());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 event.metadata().schema_definition(),
                 &test_logs_schema_definition()
@@ -362,7 +368,10 @@ async fn no_api_key() {
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert!(event.metadata().datadog_api_key().is_none());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 event.metadata().schema_definition(),
                 &test_logs_schema_definition()
@@ -423,7 +432,10 @@ async fn api_key_in_url() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"
@@ -488,7 +500,10 @@ async fn api_key_in_query_params() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"
@@ -559,7 +574,10 @@ async fn api_key_in_header() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"
@@ -706,7 +724,10 @@ async fn ignores_api_key() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert!(event.metadata().datadog_api_key().is_none());
             assert_eq!(
                 event.metadata().schema_definition(),
@@ -1398,7 +1419,10 @@ async fn split_outputs() {
             assert_eq!(log["service"], "vector".into());
             assert_eq!(log["ddsource"], "curl".into());
             assert_eq!(log["ddtags"], "one,two,three".into());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "datadog_agent".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "datadog_agent".into()
+            );
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
                 "12345678abcdefgh12345678abcdefgh"

--- a/src/sources/datadog_agent/traces.rs
+++ b/src/sources/datadog_agent/traces.rs
@@ -142,7 +142,7 @@ fn handle_dd_trace_payload_v1(
                     .set_datadog_api_key(Arc::clone(k));
             }
             trace_event.insert(
-                source.log_schema_source_type_key,
+                source.log_schema_source_type_key.as_str(),
                 Bytes::from("datadog_agent"),
             );
             trace_event.insert("payload_version", "v2".to_string());
@@ -255,7 +255,7 @@ fn handle_dd_trace_payload_v0(
                 trace_event.insert("language_name", lang.clone());
             }
             trace_event.insert(
-                source.log_schema_source_type_key,
+                source.log_schema_source_type_key.as_str(),
                 Bytes::from("datadog_agent"),
             );
             trace_event.insert("payload_version", "v1".to_string());

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -212,7 +212,7 @@ pub struct DnstapFrameHandler {
     socket_send_buffer_size: Option<usize>,
     host_key: Option<OwnedValuePath>,
     timestamp_key: Option<OwnedValuePath>,
-    source_type_key: String,
+    source_type_key: Option<OwnedValuePath>,
     bytes_received: Registered<BytesReceived>,
     log_namespace: LogNamespace,
 }
@@ -242,7 +242,7 @@ impl DnstapFrameHandler {
             socket_send_buffer_size: config.socket_send_buffer_size,
             host_key,
             timestamp_key: timestamp_key.cloned(),
-            source_type_key: source_type_key.to_string(),
+            source_type_key: source_type_key.cloned(),
             bytes_received: register!(BytesReceived::from(Protocol::from("protobuf"))),
             log_namespace,
         }
@@ -307,7 +307,7 @@ impl FrameHandler for DnstapFrameHandler {
 
         self.log_namespace.insert_vector_metadata(
             &mut log_event,
-            Some(self.source_type_key()),
+            self.source_type_key(),
             path!("source_type"),
             DnstapConfig::NAME,
         );
@@ -343,8 +343,8 @@ impl FrameHandler for DnstapFrameHandler {
         &self.host_key
     }
 
-    fn source_type_key(&self) -> &str {
-        self.source_type_key.as_str()
+    fn source_type_key(&self) -> Option<&OwnedValuePath> {
+        self.source_type_key.as_ref()
     }
 
     fn timestamp_key(&self) -> Option<&OwnedValuePath> {

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -14,8 +14,7 @@ use chrono::{DateTime, FixedOffset, Local, ParseError, Utc};
 use codecs::{BytesDeserializer, BytesDeserializerConfig};
 use futures::{Stream, StreamExt};
 use lookup::{
-    lookup_v2::{OptionalValuePath},
-    metadata_path, owned_value_path, path, OwnedValuePath, PathPrefix,
+    lookup_v2::OptionalValuePath, metadata_path, owned_value_path, path, OwnedValuePath, PathPrefix,
 };
 use once_cell::sync::Lazy;
 use serde_with::serde_as;

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, FixedOffset, Local, ParseError, Utc};
 use codecs::{BytesDeserializer, BytesDeserializerConfig};
 use futures::{Stream, StreamExt};
 use lookup::{
-    lookup_v2::{parse_value_path, OptionalValuePath},
+    lookup_v2::{OptionalValuePath},
     metadata_path, owned_value_path, path, OwnedValuePath, PathPrefix,
 };
 use once_cell::sync::Lazy;
@@ -338,9 +338,7 @@ impl SourceConfig for DockerLogsConfig {
                 Some("timestamp"),
             )
             .with_vector_metadata(
-                parse_value_path(log_schema().source_type_key())
-                    .ok()
-                    .as_ref(),
+                log_schema().source_type_key(),
                 &owned_value_path!("source_type"),
                 Kind::bytes(),
                 None,
@@ -1119,7 +1117,7 @@ impl ContainerLogInfo {
 
         log_namespace.insert_vector_metadata(
             &mut log,
-            Some(log_schema().source_type_key()),
+            log_schema().source_type_key(),
             path!("source_type"),
             Bytes::from_static(DockerLogsConfig::NAME.as_bytes()),
         );

--- a/src/sources/docker_logs/tests.rs
+++ b/src/sources/docker_logs/tests.rs
@@ -447,7 +447,7 @@ mod integration_tests {
             assert!(log.get(format!("label.{}", label).as_str()).is_some());
             assert_eq!(events[0].as_log()[&NAME], name.into());
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 DockerLogsConfig::NAME.into()
             );
         })
@@ -654,7 +654,7 @@ mod integration_tests {
             assert!(log.get(format!("label.{}", label).as_str()).is_some());
             assert_eq!(events[0].as_log()[&NAME], name.into());
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 DockerLogsConfig::NAME.into()
             );
         })
@@ -795,7 +795,7 @@ mod integration_tests {
                 .is_some());
             assert_eq!(events[0].as_log()[&NAME], name.into());
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 DockerLogsConfig::NAME.into()
             );
         })

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -761,7 +761,10 @@ mod tests {
         assert_eq!(log[PID_KEY], (8888_i64).into());
         assert_eq!(log[COMMAND_KEY], config.command.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "exec".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "exec".into()
+        );
         assert!(log
             .get((
                 lookup::PathPrefix::Event,
@@ -842,7 +845,10 @@ mod tests {
         assert_eq!(log[PID_KEY], (8888_i64).into());
         assert_eq!(log[COMMAND_KEY], config.command.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "exec".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "exec".into()
+        );
         assert!(log
             .get((
                 lookup::PathPrefix::Event,
@@ -1041,7 +1047,10 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log[COMMAND_KEY], config.command.clone().into());
             assert_eq!(log[STREAM_KEY], STDOUT.into());
-            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "exec".into());
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                "exec".into()
+            );
             assert_eq!(log[log_schema().message_key()], "Hello World!".into());
             assert_eq!(log[log_schema().host_key()], "Some.Machine".into());
             assert!(log.get(PID_KEY).is_some());

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -761,7 +761,7 @@ mod tests {
         assert_eq!(log[PID_KEY], (8888_i64).into());
         assert_eq!(log[COMMAND_KEY], config.command.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key()], "exec".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "exec".into());
         assert!(log
             .get((
                 lookup::PathPrefix::Event,
@@ -842,7 +842,7 @@ mod tests {
         assert_eq!(log[PID_KEY], (8888_i64).into());
         assert_eq!(log[COMMAND_KEY], config.command.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key()], "exec".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "exec".into());
         assert!(log
             .get((
                 lookup::PathPrefix::Event,
@@ -1041,7 +1041,7 @@ mod tests {
             let log = event.as_log();
             assert_eq!(log[COMMAND_KEY], config.command.clone().into());
             assert_eq!(log[STREAM_KEY], STDOUT.into());
-            assert_eq!(log[log_schema().source_type_key()], "exec".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "exec".into());
             assert_eq!(log[log_schema().message_key()], "Hello World!".into());
             assert_eq!(log[log_schema().host_key()], "Some.Machine".into());
             assert!(log.get(PID_KEY).is_some());

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -751,7 +751,7 @@ fn create_event(
 
     log_namespace.insert_vector_metadata(
         &mut event,
-        Some(log_schema().source_type_key()),
+        log_schema().source_type_key(),
         path!("source_type"),
         Bytes::from_static(FileConfig::NAME.as_bytes()),
     );
@@ -1037,7 +1037,7 @@ mod tests {
         assert_eq!(log["host"], "Some.Machine".into());
         assert_eq!(log["offset"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key()], "file".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "file".into());
         assert!(log[log_schema().timestamp_key().unwrap().to_string()].is_timestamp());
     }
 
@@ -1059,7 +1059,7 @@ mod tests {
         assert_eq!(log["hostname"], "Some.Machine".into());
         assert_eq!(log["off"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key()], "file".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "file".into());
         assert!(log[log_schema().timestamp_key().unwrap().to_string()].is_timestamp());
     }
 
@@ -1466,7 +1466,7 @@ mod tests {
                     log_schema().host_key().to_string(),
                     log_schema().message_key().to_string(),
                     log_schema().timestamp_key().unwrap().to_string(),
-                    log_schema().source_type_key().to_string()
+                    log_schema().source_type_key().unwrap().to_string()
                 ]
                 .into_iter()
                 .collect::<HashSet<_>>()

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1037,7 +1037,10 @@ mod tests {
         assert_eq!(log["host"], "Some.Machine".into());
         assert_eq!(log["offset"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "file".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "file".into()
+        );
         assert!(log[log_schema().timestamp_key().unwrap().to_string()].is_timestamp());
     }
 
@@ -1059,7 +1062,10 @@ mod tests {
         assert_eq!(log["hostname"], "Some.Machine".into());
         assert_eq!(log["off"], 0.into());
         assert_eq!(log[log_schema().message_key()], "hello world".into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "file".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "file".into()
+        );
         assert!(log[log_schema().timestamp_key().unwrap().to_string()].is_timestamp());
     }
 

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -587,7 +587,7 @@ impl From<FluentEvent<'_>> for LogEvent {
 
         log_namespace.insert_vector_metadata(
             &mut log,
-            Some(log_schema().source_type_key()),
+            log_schema().source_type_key(),
             path!("source_type"),
             Bytes::from_static(FluentConfig::NAME.as_bytes()),
         );
@@ -665,7 +665,7 @@ mod tests {
         Event::Log(LogEvent::from(BTreeMap::from([
             (String::from("message"), Value::from(name)),
             (
-                String::from(log_schema().source_type_key()),
+                log_schema().source_type_key().unwrap().to_string(),
                 Value::from(FluentConfig::NAME),
             ),
             (String::from("tag"), Value::from("tag.name")),

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -531,7 +531,7 @@ mod tests {
                     .into()
             );
             assert_eq!(log[&log_schema().host_key()], "host".into());
-            assert_eq!(log[log_schema().source_type_key()], "heroku_logs".into());
+            assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
             assert_eq!(log["appname"], "lumberjack-store".into());
             assert_eq!(log["absent"], Value::Null);
         }).await;
@@ -614,7 +614,7 @@ mod tests {
                 .into()
         );
         assert_eq!(log[log_schema().host_key()], "host".into());
-        assert_eq!(log[log_schema().source_type_key()], "heroku_logs".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
     }
 
     #[test]
@@ -634,7 +634,7 @@ mod tests {
                 log_schema().timestamp_key().unwrap()
             ))
             .is_some());
-        assert_eq!(log[log_schema().source_type_key()], "heroku_logs".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
     }
 
     #[test]
@@ -653,7 +653,7 @@ mod tests {
                 .into()
         );
         assert_eq!(log[log_schema().host_key()], "host".into());
-        assert_eq!(log[log_schema().source_type_key()], "heroku_logs".into());
+        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
     }
 
     #[test]

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -614,7 +614,10 @@ mod tests {
                 .into()
         );
         assert_eq!(log[log_schema().host_key()], "host".into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "heroku_logs".into()
+        );
     }
 
     #[test]
@@ -634,7 +637,10 @@ mod tests {
                 log_schema().timestamp_key().unwrap()
             ))
             .is_some());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "heroku_logs".into()
+        );
     }
 
     #[test]
@@ -653,7 +659,10 @@ mod tests {
                 .into()
         );
         assert_eq!(log[log_schema().host_key()], "host".into());
-        assert_eq!(log[log_schema().source_type_key().unwrap().to_string()], "heroku_logs".into());
+        assert_eq!(
+            log[log_schema().source_type_key().unwrap().to_string()],
+            "heroku_logs".into()
+        );
     }
 
     #[test]

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -328,16 +328,20 @@ impl http_client::HttpClientContext for HttpClientContext {
                     );
                 }
                 Event::Metric(ref mut metric) => {
-                    metric.replace_tag(
-                        log_schema().source_type_key().to_string(),
-                        HttpClientConfig::NAME.to_string(),
-                    );
+                    if let Some(source_type_key) = log_schema().source_type_key() {
+                        metric.replace_tag(
+                            source_type_key.to_string(),
+                            HttpClientConfig::NAME.to_string(),
+                        );
+                    }
                 }
                 Event::Trace(ref mut trace) => {
-                    trace.insert(
-                        log_schema().source_type_key(),
-                        Bytes::from(HttpClientConfig::NAME),
-                    );
+                    if let Some(source_type_key) = log_schema().source_type_key() {
+                        trace.insert(
+                            source_type_key.to_string(),
+                            Bytes::from(HttpClientConfig::NAME),
+                        );
+                    }
                 }
             }
         }

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -136,7 +136,7 @@ async fn collected_metrics_native_json() {
         metric
             .tags()
             .unwrap()
-            .get(log_schema().source_type_key())
+            .get(log_schema().source_type_key().unwrap().to_string().as_str())
             .map(AsRef::as_ref),
         Some(HttpClientConfig::NAME)
     );
@@ -161,7 +161,7 @@ async fn collected_trace_native_json() {
 
     let trace = events[0].as_trace();
     assert_eq!(
-        trace.as_map()[log_schema().source_type_key()],
+        trace.as_map()[log_schema().source_type_key().unwrap().to_string()],
         HttpClientConfig::NAME.into()
     );
 }

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -161,7 +161,7 @@ async fn collected_trace_native_json() {
 
     let trace = events[0].as_trace();
     assert_eq!(
-        trace.as_map()[log_schema().source_type_key().unwrap().to_string()],
+        trace.as_map()[log_schema().source_type_key().unwrap().to_string().as_str()],
         HttpClientConfig::NAME.into()
     );
 }

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -84,7 +84,7 @@ async fn collected_logs_bytes() {
     // panics if not log event
     let log = events[0].as_log();
     assert_eq!(
-        log[log_schema().source_type_key()],
+        log[log_schema().source_type_key().unwrap().to_string()],
         HttpClientConfig::NAME.into()
     );
 }
@@ -108,7 +108,7 @@ async fn collected_logs_json() {
     // panics if not log event
     let log = events[0].as_log();
     assert_eq!(
-        log[log_schema().source_type_key()],
+        log[log_schema().source_type_key().unwrap().to_string()],
         HttpClientConfig::NAME.into()
     );
 }

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -959,11 +959,13 @@ mod tests {
             ))
             .is_some());
 
-        let source_type_key_value = log.get((lookup::PathPrefix::Event, log_schema().source_type_key().unwrap())).unwrap();
-        assert_eq!(
-            source_type_key_value.to_string(),
-            SimpleHttpConfig::NAME
-        );
+        let source_type_key_value = log
+            .get((
+                lookup::PathPrefix::Event,
+                log_schema().source_type_key().unwrap(),
+            ))
+            .unwrap();
+        assert_eq!(source_type_key_value.to_string(), SimpleHttpConfig::NAME);
         assert_eq!(log["http_path"], "/".into());
     }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -964,8 +964,8 @@ mod tests {
                 lookup::PathPrefix::Event,
                 log_schema().source_type_key().unwrap(),
             ))
-            .unwrap();
-        assert_eq!(source_type_key_value.to_string(), SimpleHttpConfig::NAME);
+            .unwrap().as_str().unwrap();
+        assert_eq!(source_type_key_value, SimpleHttpConfig::NAME);
         assert_eq!(log["http_path"], "/".into());
     }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -662,7 +662,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                log[log_schema().source_type_key()],
+                log[log_schema().source_type_key().unwrap().to_string()],
                 SimpleHttpConfig::NAME.into()
             );
             assert_eq!(log["http_path"], "/".into());
@@ -958,9 +958,11 @@ mod tests {
                 log_schema().timestamp_key().unwrap()
             ))
             .is_some());
+
+        let source_type_key_value = log.get((lookup::PathPrefix::Event, log_schema().source_type_key().unwrap())).unwrap();
         assert_eq!(
-            log[log_schema().source_type_key()],
-            SimpleHttpConfig::NAME.into()
+            source_type_key_value.to_string(),
+            SimpleHttpConfig::NAME
         );
         assert_eq!(log["http_path"], "/".into());
     }
@@ -1131,7 +1133,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                log[log_schema().source_type_key()],
+                log[log_schema().source_type_key().unwrap().to_string()],
                 SimpleHttpConfig::NAME.into()
             );
         }
@@ -1184,7 +1186,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                log[log_schema().source_type_key()],
+                log[log_schema().source_type_key().unwrap().to_string()],
                 SimpleHttpConfig::NAME.into()
             );
         }
@@ -1200,7 +1202,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                log[log_schema().source_type_key()],
+                log[log_schema().source_type_key().unwrap().to_string()],
                 SimpleHttpConfig::NAME.into()
             );
         }

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -964,7 +964,9 @@ mod tests {
                 lookup::PathPrefix::Event,
                 log_schema().source_type_key().unwrap(),
             ))
-            .unwrap().as_str().unwrap();
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(source_type_key_value, SimpleHttpConfig::NAME);
         assert_eq!(log["http_path"], "/".into());
     }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -756,7 +756,7 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
     // Add source type.
     log_namespace.insert_vector_metadata(
         log,
-        Some(log_schema().source_type_key()),
+        log_schema().source_type_key(),
         path!("source_type"),
         JournaldConfig::NAME,
     );
@@ -1165,7 +1165,7 @@ mod tests {
             Value::Bytes("System Initialization".into())
         );
         assert_eq!(
-            received[0].as_log()[log_schema().source_type_key()],
+            received[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
             "journald".into()
         );
         assert_eq!(timestamp(&received[0]), value_ts(1578529839, 140001000));

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -23,6 +23,7 @@ use rdkafka::{
 use serde_with::serde_as;
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::FramedRead;
+use vrl::path::PathPrefix;
 
 use vector_common::finalizer::OrderedFinalizer;
 use vector_config::configurable_component;
@@ -602,7 +603,9 @@ impl ReceivedMessage {
                     );
                 }
                 LogNamespace::Legacy => {
-                    log.insert(log_schema().source_type_key(), KafkaSourceConfig::NAME);
+                    if let Some(source_type_key) = log_schema().source_type_key() {
+                        log.insert((PathPrefix::Event, source_type_key), KafkaSourceConfig::NAME);
+                    }
                 }
             }
 
@@ -1054,7 +1057,7 @@ mod integration_test {
                     format!("{} {}", KEY, i).into()
                 );
                 assert_eq!(
-                    event.as_log()[log_schema().source_type_key()],
+                    event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                     "kafka".into()
                 );
                 assert_eq!(

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -604,7 +604,10 @@ impl ReceivedMessage {
                 }
                 LogNamespace::Legacy => {
                     if let Some(source_type_key) = log_schema().source_type_key() {
-                        log.insert((PathPrefix::Event, source_type_key), KafkaSourceConfig::NAME);
+                        log.insert(
+                            (PathPrefix::Event, source_type_key),
+                            KafkaSourceConfig::NAME,
+                        );
                     }
                 }
             }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -910,7 +910,7 @@ fn create_event(
 
     log_namespace.insert_vector_metadata(
         &mut log,
-        Some(log_schema().source_type_key()),
+        log_schema().source_type_key(),
         path!("source_type"),
         Bytes::from(Config::NAME),
     );

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -209,7 +209,7 @@ impl TcpSource for LogstashSource {
 
             self.log_namespace.insert_vector_metadata(
                 log,
-                Some(log_schema().source_type_key()),
+                log_schema().source_type_key(),
                 path!("source_type"),
                 Bytes::from_static(LogstashConfig::NAME.as_bytes()),
             );

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -256,7 +256,7 @@ impl InputHandler {
                         if let Event::Log(ref mut log) = event {
                             self.log_namespace.insert_vector_metadata(
                                 log,
-                                Some(log_schema().source_type_key()),
+                                log_schema().source_type_key(),
                                 path!("source_type"),
                                 Bytes::from(RedisSourceConfig::NAME),
                             );
@@ -482,7 +482,7 @@ mod integration_test {
         for event in events {
             assert_eq!(event.as_log()[log_schema().message_key()], text.into());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 RedisSourceConfig::NAME.into()
             );
         }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -497,7 +497,7 @@ mod test {
 
             let event = rx.next().await.unwrap();
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
         })
@@ -1121,7 +1121,7 @@ mod test {
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
         })
@@ -1327,7 +1327,7 @@ mod test {
                 "test".into()
             );
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
             assert_eq!(events[0].as_log()["host"], UNNAMED_SOCKET_HOST.into());
@@ -1419,7 +1419,7 @@ mod test {
                 "foo\nbar".into()
             );
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
         })
@@ -1506,7 +1506,7 @@ mod test {
                 "test".into()
             );
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
         })
@@ -1546,12 +1546,12 @@ mod test {
             assert_eq!(events.len(), 2);
             assert_eq!(events[0].as_log()[log_schema().message_key()], "foo".into());
             assert_eq!(
-                events[0].as_log()[log_schema().source_type_key()],
+                events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
             assert_eq!(events[1].as_log()[log_schema().message_key()], "bar".into());
             assert_eq!(
-                events[1].as_log()[log_schema().source_type_key()],
+                events[1].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
         })

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1567,7 +1567,10 @@ mod tests {
                 log_schema().timestamp_key().unwrap()
             ))
             .is_some());
-        assert_eq!(event[log_schema().source_type_key().unwrap().to_string()], "splunk_hec".into());
+        assert_eq!(
+            event[log_schema().source_type_key().unwrap().to_string()],
+            "splunk_hec".into()
+        );
         assert!(event.metadata().splunk_hec_token().is_none());
     }
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -661,7 +661,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         // Add source type
         self.log_namespace.insert_vector_metadata(
             &mut log,
-            Some(log_schema().source_type_key()),
+            log_schema().source_type_key(),
             lookup::path!("source_type"),
             SplunkConfig::NAME,
         );
@@ -1420,7 +1420,7 @@ mod tests {
             ))
             .is_some());
         assert_eq!(
-            event.as_log()[log_schema().source_type_key()],
+            event.as_log()[log_schema().source_type_key().unwrap().to_string()],
             "splunk_hec".into()
         );
         assert!(event.metadata().splunk_hec_token().is_none());
@@ -1447,7 +1447,7 @@ mod tests {
             ))
             .is_some());
         assert_eq!(
-            event.as_log()[log_schema().source_type_key()],
+            event.as_log()[log_schema().source_type_key().unwrap().to_string()],
             "splunk_hec".into()
         );
         assert!(event.metadata().splunk_hec_token().is_none());
@@ -1478,7 +1478,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
             assert!(event.metadata().splunk_hec_token().is_none());
@@ -1506,7 +1506,7 @@ mod tests {
             ))
             .is_some());
         assert_eq!(
-            event.as_log()[log_schema().source_type_key()],
+            event.as_log()[log_schema().source_type_key().unwrap().to_string()],
             "splunk_hec".into()
         );
         assert!(event.metadata().splunk_hec_token().is_none());
@@ -1537,7 +1537,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
             assert!(event.metadata().splunk_hec_token().is_none());
@@ -1567,7 +1567,7 @@ mod tests {
                 log_schema().timestamp_key().unwrap()
             ))
             .is_some());
-        assert_eq!(event[log_schema().source_type_key()], "splunk_hec".into());
+        assert_eq!(event[log_schema().source_type_key().unwrap().to_string()], "splunk_hec".into());
         assert!(event.metadata().splunk_hec_token().is_none());
     }
 
@@ -1608,7 +1608,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
             assert!(event.metadata().splunk_hec_token().is_none());
@@ -1635,7 +1635,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
             assert!(event.metadata().splunk_hec_token().is_none());
@@ -1874,7 +1874,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
             assert_eq!(
@@ -1951,7 +1951,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
         })
@@ -1981,7 +1981,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
         })
@@ -2009,7 +2009,7 @@ mod tests {
                 ))
                 .is_some());
             assert_eq!(
-                event.as_log()[log_schema().source_type_key()],
+                event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "splunk_hec".into()
             );
         })
@@ -2038,7 +2038,7 @@ mod tests {
         assert_eq!(event.as_log()["bool"], true.into());
         assert!(event.as_log().get((lookup::PathPrefix::Event, log_schema().timestamp_key().unwrap())).is_some());
         assert_eq!(
-            event.as_log()[log_schema().source_type_key()],
+            event.as_log()[log_schema().source_type_key().unwrap().to_string()],
             "splunk_hec".into()
         );
     }).await;

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -811,7 +811,10 @@ mod test {
                     .single()
                     .expect("invalid timestamp"),
             );
-            expected.insert(log_schema().source_type_key(), "syslog");
+            expected.insert((
+                                PathPrefix::Event,
+                                log_schema().source_type_key().unwrap(),
+                            ), "syslog");
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
 
@@ -863,7 +866,10 @@ mod test {
             );
             expected.insert(log_schema().host_key(), "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
-            expected.insert(log_schema().source_type_key(), "syslog");
+            expected.insert((
+                                PathPrefix::Event,
+                                log_schema().source_type_key().unwrap(),
+                            ), "syslog");
             expected.insert("severity", "notice");
             expected.insert("facility", "user");
             expected.insert("version", 1);
@@ -1003,7 +1009,10 @@ mod test {
                 expected_date,
             );
             expected.insert(log_schema().host_key(), "74794bfb6795");
-            expected.insert(log_schema().source_type_key(), "syslog");
+            expected.insert((
+                                PathPrefix::Event,
+                                log_schema().source_type_key().unwrap(),
+                            ), "syslog");
             expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "notice");
             expected.insert("facility", "user");
@@ -1048,7 +1057,10 @@ mod test {
                 ),
                 expected_date,
             );
-            expected.insert(log_schema().source_type_key(), "syslog");
+            expected.insert((
+                                PathPrefix::Event,
+                                log_schema().source_type_key().unwrap(),
+                            ), "syslog");
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "info");
@@ -1085,7 +1097,10 @@ mod test {
                     .and_then(|t| t.with_nanosecond(605_850 * 1000))
                     .expect("invalid timestamp"),
             );
-            expected.insert(log_schema().source_type_key(), "syslog");
+            expected.insert((
+                                PathPrefix::Event,
+                                log_schema().source_type_key().unwrap(),
+                            ), "syslog");
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "info");

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -811,10 +811,10 @@ mod test {
                     .single()
                     .expect("invalid timestamp"),
             );
-            expected.insert((
-                                PathPrefix::Event,
-                                log_schema().source_type_key().unwrap(),
-                            ), "syslog");
+            expected.insert(
+                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                "syslog",
+            );
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
 
@@ -866,10 +866,10 @@ mod test {
             );
             expected.insert(log_schema().host_key(), "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
-            expected.insert((
-                                PathPrefix::Event,
-                                log_schema().source_type_key().unwrap(),
-                            ), "syslog");
+            expected.insert(
+                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                "syslog",
+            );
             expected.insert("severity", "notice");
             expected.insert("facility", "user");
             expected.insert("version", 1);
@@ -1009,10 +1009,10 @@ mod test {
                 expected_date,
             );
             expected.insert(log_schema().host_key(), "74794bfb6795");
-            expected.insert((
-                                PathPrefix::Event,
-                                log_schema().source_type_key().unwrap(),
-                            ), "syslog");
+            expected.insert(
+                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                "syslog",
+            );
             expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "notice");
             expected.insert("facility", "user");
@@ -1057,10 +1057,10 @@ mod test {
                 ),
                 expected_date,
             );
-            expected.insert((
-                                PathPrefix::Event,
-                                log_schema().source_type_key().unwrap(),
-                            ), "syslog");
+            expected.insert(
+                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                "syslog",
+            );
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "info");
@@ -1097,10 +1097,10 @@ mod test {
                     .and_then(|t| t.with_nanosecond(605_850 * 1000))
                     .expect("invalid timestamp"),
             );
-            expected.insert((
-                                PathPrefix::Event,
-                                log_schema().source_type_key().unwrap(),
-                            ), "syslog");
+            expected.insert(
+                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                "syslog",
+            );
             expected.insert("host", "74794bfb6795");
             expected.insert("hostname", "74794bfb6795");
             expected.insert("severity", "info");

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -603,8 +603,8 @@ mod test {
         time::{Duration, Instant},
     };
     use tokio_util::codec::{length_delimited, Framed};
-    use vrl::path::PathPrefix;
     use vector_core::config::{LegacyKey, LogNamespace};
+    use vrl::path::PathPrefix;
 
     use super::{
         build_framestream_unix_source, spawn_event_handling_tasks, ControlField, ControlHeader,
@@ -666,7 +666,10 @@ mod test {
         fn handle_event(&self, received_from: Option<Bytes>, frame: Bytes) -> Option<Event> {
             let mut log_event = LogEvent::from(frame);
 
-            log_event.insert((PathPrefix::Event, log_schema().source_type_key().unwrap()), "framestream");
+            log_event.insert(
+                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                "framestream",
+            );
             if let Some(host) = received_from {
                 self.log_namespace.insert_source_metadata(
                     "framestream",

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -604,7 +604,6 @@ mod test {
     };
     use tokio_util::codec::{length_delimited, Framed};
     use vector_core::config::{LegacyKey, LogNamespace};
-    use vrl::path::PathPrefix;
 
     use super::{
         build_framestream_unix_source, spawn_event_handling_tasks, ControlField, ControlHeader,
@@ -667,7 +666,7 @@ mod test {
             let mut log_event = LogEvent::from(frame);
 
             log_event.insert(
-                (PathPrefix::Event, log_schema().source_type_key().unwrap()),
+                log_schema().source_type_key().unwrap().to_string().as_str(),
                 "framestream",
             );
             if let Some(host) = received_from {

--- a/src/sources/util/message_decoding.rs
+++ b/src/sources/util/message_decoding.rs
@@ -33,7 +33,7 @@ pub fn decode_message<'a>(
                 if let Event::Log(ref mut log) = event {
                     log_namespace.insert_vector_metadata(
                         log,
-                        Some(schema.source_type_key()),
+                        schema.source_type_key(),
                         path!("source_type"),
                         Bytes::from(source_type),
                     );

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -273,6 +273,7 @@ mod test {
 #[cfg(feature = "sinks-vector")]
 #[cfg(test)]
 mod tests {
+    use vrl::path::PathPrefix;
     use vector_common::assert_event_data_eq;
     use vector_core::config::log_schema;
 
@@ -305,10 +306,11 @@ mod tests {
         let (mut events, stream) = test_util::random_events_with_stream(100, 100, None);
         sink.run(stream).await.unwrap();
 
+        let source_type_key = log_schema().source_type_key().unwrap();
         for event in &mut events {
             event
                 .as_mut_log()
-                .insert(log_schema().source_type_key(), "vector");
+                .insert((PathPrefix::Event, source_type_key), "vector");
         }
 
         let output = test_util::collect_ready(rx).await;

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -273,9 +273,9 @@ mod test {
 #[cfg(feature = "sinks-vector")]
 #[cfg(test)]
 mod tests {
-    use vrl::path::PathPrefix;
     use vector_common::assert_event_data_eq;
     use vector_core::config::log_schema;
+    use vrl::path::PathPrefix;
 
     use super::*;
     use crate::{


### PR DESCRIPTION
This part of https://github.com/vectordotdev/vector/issues/13033.

Tried this with a config where `source_type_key` is:
* `""` --> no source entry
* not defined --> same as above
* `"foo"` --> `"foo":"demo_logs"`
* `"foo.bar"` --> `"foo":{"bar":"demo_logs"}`
* `"foo.."` --> `Configuration error. error=Invalid field path "foo.."`

The config:
```
data_dir = "/Users/pavlos.rontidis/my_tests/vector"

[log_schema]
source_type_key = "foo"

[sources.source0]
format = "json"
type = "demo_logs"

[sinks.sink0]
inputs = ["source0"]
target = "stdout"
type = "console"

[sinks.sink0.encoding]
codec = "json"
```