### PR TITLE
chore: stop ignoring topology test

### DIFF
--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -598,7 +598,6 @@ async fn topology_swap_sink() {
     assert_eq!(vec![event1], res2);
 }
 
-#[ignore] // TODO: issue #2186
 #[tokio::test]
 async fn topology_swap_transform_is_atomic() {
     trace_init();


### PR DESCRIPTION
This is passing consistently for me locally, so hopefully we can stop ignoring it.

Closes #2186 

