### PR TITLE
chore(CI): Update `smp` to version 0.9.1

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -232,7 +232,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.9.0"
+          export SMP_CRATE_VERSION="0.9.1"
           export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"


### PR DESCRIPTION
The `smp` 0.9.1 release fixes a backwards compatibility bug. This addresses the failure observed after updating Vector's SMP deploy: https://github.com/vectordotdev/vector/actions/runs/5535572306/jobs/10127326812