### PR TITLE
chore(CI): Add missing `--use-consignor` flag on `smp` call

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -530,6 +530,7 @@ jobs:
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
             --use-curta \
+            --use-consignor \
             --wait \
             --wait-delay-seconds 60 \
             --wait-timeout-minutes 90 \


### PR DESCRIPTION
The `smp` status wait command was missing the `--use-consignor` flag. This caused it to wait for our EC2-hosted Analysis Worker to complete. Subsequent steps read the lambda hosted result (`consignor`), which may still be processing. Adding this flag corrects this synchronization bug.