### PR TITLE
chore(CI): Single Machine Performance: turn off consignor

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -530,7 +530,6 @@ jobs:
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
             --use-curta \
-            --use-consignor \
             --wait \
             --wait-delay-seconds 60 \
             --wait-timeout-minutes 90 \
@@ -625,7 +624,6 @@ jobs:
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job result \
             --use-curta \
-            --use-consignor \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Check status, cancelled
@@ -718,7 +716,6 @@ jobs:
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job sync \
             --use-curta \
-            --use-consignor \
             --submission-metadata ${{ runner.temp }}/submission-metadata \
             --output-path "${{ runner.temp }}/outputs"
 


### PR DESCRIPTION
Fall back to the legacy Single Machine Performance analysis workers. It turns out we don't have as much runtime on consignor as we thought, and we would like to let it soak in the SMP dogfood cluster for a while.