### PR TITLE
fix(vdev): Add `--features` with default features for vdev test

### DIFF
--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -38,13 +38,14 @@ impl Cli {
         let runner = get_agent_test_runner(self.container)?;
 
         let mut args = vec!["--workspace".to_string()];
-        if let Some(extra_args) = &self.args {
-            args.extend(extra_args.clone());
 
-            if !(self.container || extra_args.contains(&"--features".to_string())) {
-                let features = platform::default_features();
-                args.extend(["--features".to_string(), features.to_string()]);
-            }
+        if let Some(mut extra_args) = self.args {
+            args.append(&mut extra_args);
+        }
+
+        if !args.contains(&"--features".to_string()) {
+            let features = platform::default_features();
+            args.extend(["--features".to_string(), features.to_string()]);
         }
 
         runner.test(


### PR DESCRIPTION
Whenever `features` are not provided. Matches `make test` behavior.

Fixes: #17975

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
