### PR TITLE
feat(component validation): validate `component_discarded_events_total` for sources

### DIFF
--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -181,6 +181,7 @@ pub struct RunnerMetrics {
     pub sent_bytes_total: u64, // a reciprocal for received_bytes_total
     pub sent_event_bytes_total: u64,
     pub sent_events_total: u64,
+    pub discarded_events_total: u64,
 }
 
 #[cfg(all(test, feature = "component-validation-tests"))]

--- a/src/components/validation/validators/component_spec/sources.rs
+++ b/src/components/validation/validators/component_spec/sources.rs
@@ -234,8 +234,6 @@ fn validate_component_discarded_events_total(
     telemetry_events: &[Event],
     runner_metrics: &RunnerMetrics,
 ) -> Result<Vec<String>, Vec<String>> {
-    // The reciprocal metric for sent_event_bytes is received_event_bytes,
-    // so the expected value is what the output runner received.
     let expected_dropped = runner_metrics.discarded_events_total;
 
     validate_bytes_total(

--- a/src/components/validation/validators/component_spec/sources.rs
+++ b/src/components/validation/validators/component_spec/sources.rs
@@ -14,6 +14,7 @@ pub enum SourceMetricType {
     ReceivedBytesTotal,
     SentEventsTotal,
     SentEventBytesTotal,
+    EventsDropped,
 }
 
 impl SourceMetricType {
@@ -24,6 +25,7 @@ impl SourceMetricType {
             SourceMetricType::ReceivedBytesTotal => "component_received_bytes_total",
             SourceMetricType::SentEventsTotal => "component_sent_events_total",
             SourceMetricType::SentEventBytesTotal => "component_sent_event_bytes_total",
+            SourceMetricType::EventsDropped => "component_discarded_events_total",
         }
     }
 }
@@ -47,6 +49,7 @@ pub fn validate_sources(
         validate_component_received_bytes_total,
         validate_component_sent_events_total,
         validate_component_sent_event_bytes_total,
+        validate_component_discarded_events_total,
     ];
 
     for v in validations.iter() {
@@ -224,5 +227,20 @@ fn validate_component_sent_event_bytes_total(
         telemetry_events,
         &SourceMetricType::SentEventBytesTotal,
         expected_bytes,
+    )
+}
+
+fn validate_component_discarded_events_total(
+    telemetry_events: &[Event],
+    runner_metrics: &RunnerMetrics,
+) -> Result<Vec<String>, Vec<String>> {
+    // The reciprocal metric for sent_event_bytes is received_event_bytes,
+    // so the expected value is what the output runner received.
+    let expected_dropped = runner_metrics.discarded_events_total;
+
+    validate_bytes_total(
+        telemetry_events,
+        &SourceMetricType::EventsDropped,
+        expected_dropped,
     )
 }

--- a/src/components/validation/validators/component_spec/sources.rs
+++ b/src/components/validation/validators/component_spec/sources.rs
@@ -14,7 +14,7 @@ pub enum SourceMetricType {
     ReceivedBytesTotal,
     SentEventsTotal,
     SentEventBytesTotal,
-    EventsDropped,
+    EventsDiscardedTotal,
 }
 
 impl SourceMetricType {
@@ -25,7 +25,7 @@ impl SourceMetricType {
             SourceMetricType::ReceivedBytesTotal => "component_received_bytes_total",
             SourceMetricType::SentEventsTotal => "component_sent_events_total",
             SourceMetricType::SentEventBytesTotal => "component_sent_event_bytes_total",
-            SourceMetricType::EventsDropped => "component_discarded_events_total",
+            SourceMetricType::EventsDiscardedTotal => "component_discarded_events_total",
         }
     }
 }
@@ -236,9 +236,9 @@ fn validate_component_discarded_events_total(
 ) -> Result<Vec<String>, Vec<String>> {
     let expected_dropped = runner_metrics.discarded_events_total;
 
-    validate_bytes_total(
+    validate_events_total(
         telemetry_events,
-        &SourceMetricType::EventsDropped,
+        &SourceMetricType::EventsDiscardedTotal,
         expected_dropped,
     )
 }


### PR DESCRIPTION
addresses: https://github.com/vectordotdev/vector/issues/16842

The note in https://github.com/vectordotdev/vector/pull/16935 , about it being challenging to validate this metric, is true in general. That comment was specific to validating it for sources, where the events are more or less only droppable when the stream closes unexpectedly on us. Which I have no idea right now how to trigger deterministically.

Validating that with sinks should _hopefully_ be a little easier as we could fail encoding etc.

Also a note, the code changed in this PR is altered significantly in https://github.com/vectordotdev/vector/pull/17980  ... posting this draft PR is mostly a tracking mechanism at this point.
