### PR TITLE
chore: update VRL to version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ members = [
 ]
 
 [workspace.dependencies]
-vrl = { version = "0.5.0", features = ["cli", "test", "test_framework", "arbitrary"] }
+vrl = { version = "0.6.0", features = ["cli", "test", "test_framework", "arbitrary"] }
 
 [dependencies]
 vrl.workspace = true

--- a/website/cue/reference/remap/functions/encrypt.cue
+++ b/website/cue/reference/remap/functions/encrypt.cue
@@ -14,8 +14,14 @@ remap: functions: encrypt: {
 		* AES-192-OFB  (key = 24 bytes, iv = 16 bytes)
 		* AES-128-OFB (key = 16 bytes, iv = 16 bytes)
 		* AES-256-CTR (key = 32 bytes, iv = 16 bytes)
+		* AES-256-CTR-LE (key = 32 bytes, iv = 16 bytes)
+		* AES-256-CTR-BE (key = 32 bytes, iv = 16 bytes)
 		* AES-192-CTR (key = 24 bytes, iv = 16 bytes)
+		* AES-192-CTR-LE (key = 24 bytes, iv = 16 bytes)
+		* AES-192-CTR-BE (key = 24 bytes, iv = 16 bytes)
 		* AES-128-CTR (key = 16 bytes, iv = 16 bytes)
+		* AES-128-CTR-LE (key = 16 bytes, iv = 16 bytes)
+		* AES-128-CTR-BE (key = 16 bytes, iv = 16 bytes)
 		* AES-256-CBC-PKCS7 (key = 32 bytes, iv = 16 bytes)
 		* AES-192-CBC-PKCS7 (key = 24 bytes, iv = 16 bytes)
 		* AES-128-CBC-PKCS7 (key = 16 bytes, iv = 16 bytes)
@@ -28,6 +34,9 @@ remap: functions: encrypt: {
 		* AES-256-CBC-ISO10126 (key = 32 bytes, iv = 16 bytes)
 		* AES-192-CBC-ISO10126 (key = 24 bytes, iv = 16 bytes)
 		* AES-128-CBC-ISO10126 (key = 16 bytes, iv = 16 bytes)
+		* CHACHA20-POLY1305 (key = 32 bytes, iv = 12 bytes)
+		* XCHACHA20-POLY1305 (key = 32 bytes, iv = 24 bytes)
+		* XSALSA20-POLY1305 (key = 32 bytes, iv = 24 bytes)
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/parse_nginx_log.cue
+++ b/website/cue/reference/remap/functions/parse_nginx_log.cue
@@ -64,9 +64,6 @@ remap: functions: parse_nginx_log: {
 				user:        "alice"
 				timestamp:   "2021-04-01T12:02:31Z"
 				request:     "POST /not-found HTTP/1.1"
-				method:      "POST"
-				path:        "/not-found"
-				protocol:    "HTTP/1.1"
 				status:      404
 				size:        153
 				referer:     "http://localhost/somewhere"


### PR DESCRIPTION
This updates VRL from `0.5.0` to `0.6.0`.
Includes a breaking change: https://github.com/vectordotdev/vrl/pull/249.

