### PR TITLE
fix(docs, syslog source): Correct docs for `syslog_ip`

### DIFF
--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -103,7 +103,7 @@ components: sources: syslog: {
 				}
 			}
 			source_ip: {
-				description: "The upstream hostname. In the case where `mode` = `\"unix\"` the socket path will be used. (`host` is also this value if `hostname` does not exist in the log.)"
+				description: "The IP address of the client. In the case where `mode` = `\"unix\"` the socket path will be used."
 				required:    true
 				type: string: {
 					examples: ["127.0.0.1"]


### PR DESCRIPTION
For UDP/TCP connections it will contain the IP address of the connection client. There is no
fallback to `hostname` that I can see (nor could I get it to fallback during testing).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
