### PR TITLE
docs: Fix "Bring your own toolbox" in `DEVELOPING.md`

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -121,6 +121,7 @@ To build Vector on your own host will require a fairly complete development envi
 Loosely, you'll need the following:
 
 - **To build Vector:** Have working Rustup, Protobuf tools, C++/C build tools (LLVM, GCC, or MSVC), Python, and Perl, `make` (the GNU one preferably), `bash`, `cmake`, `GNU coreutils`, and `autotools`.
+- **To run `make test`:** Install [`cargo-nextest`](https://nexte.st/)
 - **To run integration tests:** Have `docker` available, or a real live version of that service. (Use `AUTOSPAWN=false`)
 - **To run `make check-component-features`:** Have `remarshal` installed.
 - **To run `make check-licenses` or `cargo vdev build licenses`:** Have `rust-license-tool` [installed](https://github.com/DataDog/rust-license-tool).
@@ -141,19 +142,19 @@ cargo build
 make build-dev
 # Validate your test pass
 cargo test sources::example
-make test scope="sources::example"
+make test SCOPE="sources::example"
 # Validate tests (that do not require other services) pass
 cargo test
 make test
 # Validate your tests pass (starting required services in Docker)
-make test-integration scope="sources::example"
+make test-integration SCOPE="sources::example"
 # Validate your tests pass against a live service.
-make test-integration scope="sources::example" autospawn=false
+make test-integration SCOPE="sources::example" autospawn=false
 cargo test --features docker sources::example
 # Validate all tests pass (starting required services in Docker)
 make test-integration
 # Run your benchmarks
-make bench scope="transforms::example"
+make bench SCOPE="transforms::example"
 cargo bench transforms::example
 # Format your code before pushing!
 make fmt


### PR DESCRIPTION
There were a couple of small things I ran into while getting my development environment working, and I thought I'd update the docs to reflect them:

  - `cargo-nextest` is neede for some of the `make` targets
  - `SCOPE` needs to be capitalised when running tests, or it is silently ignored