### PR TITLE
chore: Install script supports Apple ARM with Rosetta

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,9 +1,7 @@
 abcd
 abcdefghijklm
 abcdefghijklmnopqrstuvwxyzand
-abced
 abortable
-acb
 ack'ing
 acking
 Acq
@@ -37,7 +35,6 @@ ARNOTAREALIDD
 arshiyasolei
 asdf
 asdfasdf
-ASMS
 assertverify
 Asterix
 asynk
@@ -140,7 +137,6 @@ casttype
 castvalue
 cbe
 CBOR
-cbs
 cddl
 cdeab
 cdylib
@@ -304,7 +300,6 @@ ebfcee
 edenhill
 edns
 eeyun
-efg
 efgh
 Elhage
 emca
@@ -325,7 +320,6 @@ ENVARS
 envsubst
 EOIG
 EOL'ed
-Erfxl
 Err'ing
 errorf
 Errorsfor
@@ -469,7 +463,6 @@ hannes
 Hashbang
 hashbrown
 hashindex
-hashlink
 hashring
 hashset
 hashsum
@@ -778,6 +771,7 @@ NQTP
 nresamples
 nullishness
 numbackends
+oahd
 oap
 OKD
 omfwd
@@ -821,6 +815,7 @@ pathgen
 peekable
 PEMS
 pgmajfault
+pgrep
 PII
 Pitbull
 pkc
@@ -1053,7 +1048,6 @@ supertrait
 suser
 sustainability
 svalue
-Sya
 sysfs
 sysinit
 syslogng
@@ -1114,7 +1108,6 @@ Tomola
 tonydanza
 toolbars
 toolchains
-TOOLSDIRECTORY
 toolset
 toor
 topdir

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -152,6 +152,16 @@ install_from_archive() {
         x86_64-*linux*-musl)
             _archive_arch="x86_64-unknown-linux-musl"
             ;;
+        aarch64-apple-darwin)
+            # This if statement can be removed when Vector publishes aarch64-apple-darwin builds
+            if /usr/bin/pgrep oahd >/dev/null 2>&1; then
+                echo "Rosetta is installed, installing x86_64-apple-darwin archive"
+                _archive_arch="x86_64-apple-darwin"
+            else
+                echo "Builds for Apple Silicon are not published today, please install Rosetta"
+                err "unsupported arch: $_arch"
+            fi
+            ;;
         aarch64-*linux*)
             _archive_arch="aarch64-unknown-linux-musl"
             ;;


### PR DESCRIPTION
Adds support to the install script for installing x86 builds of Vector on aarch64-apple-darwin when Rosetta is installed.