### PR TITLE
Migrate LogSchema::message_key to new lookup code

### DIFF
--- a/benches/codecs/character_delimited_bytes.rs
+++ b/benches/codecs/character_delimited_bytes.rs
@@ -55,7 +55,7 @@ fn decoding(c: &mut Criterion) {
                                 .map(|ml| CharacterDelimitedDecoder::new_with_max_length(b'a', ml))
                                 .unwrap_or(CharacterDelimitedDecoder::new(b'a')),
                         );
-                        let deserializer = Deserializer::Bytes(BytesDeserializer::new());
+                        let deserializer = Deserializer::Bytes(BytesDeserializer {});
                         let decoder = vector::codecs::Decoder::new(framer, deserializer);
 
                         (Box::new(decoder), param.input.clone())

--- a/benches/codecs/newline_bytes.rs
+++ b/benches/codecs/newline_bytes.rs
@@ -53,7 +53,7 @@ fn decoding(c: &mut Criterion) {
                                 .map(|ml| NewlineDelimitedDecoder::new_with_max_length(ml))
                                 .unwrap_or(NewlineDelimitedDecoder::new()),
                         );
-                        let deserializer = Deserializer::Bytes(BytesDeserializer::new());
+                        let deserializer = Deserializer::Bytes(BytesDeserializer {});
                         let decoder = vector::codecs::Decoder::new(framer, deserializer);
 
                         (Box::new(decoder), param.input.clone())

--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use lookup::lookup_v2::parse_value_path;
 use lookup::OwnedTargetPath;
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
@@ -9,6 +8,7 @@ use vector_core::{
     event::{Event, LogEvent},
     schema,
 };
+use vrl::path::PathPrefix;
 use vrl::value::Kind;
 
 use super::Deserializer;
@@ -25,7 +25,7 @@ impl BytesDeserializerConfig {
 
     /// Build the `BytesDeserializer` from this configuration.
     pub fn build(&self) -> BytesDeserializer {
-        BytesDeserializer::new()
+        BytesDeserializer {}
     }
 
     /// Return the type of event build by this deserializer.
@@ -37,7 +37,7 @@ impl BytesDeserializerConfig {
     pub fn schema_definition(&self, log_namespace: LogNamespace) -> schema::Definition {
         match log_namespace {
             LogNamespace::Legacy => schema::Definition::empty_legacy_namespace().with_event_field(
-                &parse_value_path(log_schema().message_key()).expect("valid message key"),
+                log_schema().message_key().expect("valid message key"),
                 Kind::bytes(),
                 Some("message"),
             ),
@@ -54,32 +54,18 @@ impl BytesDeserializerConfig {
 /// This deserializer can be considered as the no-op action for input where no
 /// further decoding has been specified.
 #[derive(Debug, Clone)]
-pub struct BytesDeserializer {
-    // Only used with the "Legacy" namespace. The "Vector" namespace decodes the data at the root of the event.
-    log_schema_message_key: &'static str,
-}
-
-impl Default for BytesDeserializer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+pub struct BytesDeserializer {}
 
 impl BytesDeserializer {
-    /// Creates a new `BytesDeserializer`.
-    pub fn new() -> Self {
-        Self {
-            log_schema_message_key: log_schema().message_key(),
-        }
-    }
-
     /// Deserializes the given bytes, which will always produce a single `LogEvent`.
     pub fn parse_single(&self, bytes: Bytes, log_namespace: LogNamespace) -> LogEvent {
         match log_namespace {
             LogNamespace::Vector => log_namespace.new_log_from_data(bytes),
             LogNamespace::Legacy => {
                 let mut log = LogEvent::default();
-                log.insert(self.log_schema_message_key, bytes);
+                if let Some(message_key) = log_schema().message_key() {
+                    log.insert((PathPrefix::Event, message_key), bytes);
+                }
                 log
             }
         }
@@ -107,7 +93,7 @@ mod tests {
     #[test]
     fn deserialize_bytes_legacy_namespace() {
         let input = Bytes::from("foo");
-        let deserializer = BytesDeserializer::new();
+        let deserializer = BytesDeserializer {};
 
         let events = deserializer.parse(input, LogNamespace::Legacy).unwrap();
         let mut events = events.into_iter();
@@ -115,7 +101,10 @@ mod tests {
         {
             let event = events.next().unwrap();
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "foo".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "foo".into()
+            );
         }
 
         assert_eq!(events.next(), None);
@@ -124,7 +113,7 @@ mod tests {
     #[test]
     fn deserialize_bytes_vector_namespace() {
         let input = Bytes::from("foo");
-        let deserializer = BytesDeserializer::new();
+        let deserializer = BytesDeserializer {};
 
         let events = deserializer.parse(input, LogNamespace::Vector).unwrap();
         assert_eq!(events.len(), 1);

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -293,7 +293,7 @@ mod tests {
             Some(&Value::Bytes(Bytes::from_static(b"example.org")))
         );
         assert_eq!(
-            log.get(log_schema().message_key()),
+            log.get((PathPrefix::Event, log_schema().message_key().unwrap())),
             Some(&Value::Bytes(Bytes::from_static(
                 b"A short message that helps you identify what is going on"
             )))
@@ -348,7 +348,7 @@ mod tests {
             let events = deserialize_gelf_input(&input).unwrap();
             assert_eq!(events.len(), 1);
             let log = events[0].as_log();
-            assert!(log.contains(log_schema().message_key()));
+            assert!(log.contains((PathPrefix::Event, log_schema().message_key().unwrap())));
         }
 
         // filter out id

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -1,7 +1,6 @@
 use bytes::Bytes;
 use chrono::{DateTime, Datelike, Utc};
 use derivative::Derivative;
-use lookup::lookup_v2::parse_value_path;
 use lookup::{event_path, owned_value_path, OwnedTargetPath, OwnedValuePath, PathPrefix};
 use smallvec::{smallvec, SmallVec};
 use std::borrow::Cow;
@@ -71,7 +70,7 @@ impl SyslogDeserializerConfig {
                     // The `message` field is always defined. If parsing fails, the entire body becomes the
                     // message.
                     .with_event_field(
-                        &parse_value_path(log_schema().message_key()).expect("valid message key"),
+                        log_schema().message_key().expect("valid message key"),
                         Kind::bytes(),
                         Some("message"),
                     );
@@ -429,7 +428,9 @@ fn insert_fields_from_syslog(
 ) {
     match log_namespace {
         LogNamespace::Legacy => {
-            log.insert(event_path!(log_schema().message_key()), parsed.msg);
+            if let Some(message_key) = log_schema().message_key() {
+                log.insert((PathPrefix::Event, message_key), parsed.msg);
+            }
         }
         LogNamespace::Vector => {
             log.insert(event_path!("message"), parsed.msg);
@@ -500,7 +501,10 @@ mod tests {
 
         let events = deserializer.parse(input, LogNamespace::Legacy).unwrap();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].as_log()[log_schema().message_key()], "MSG".into());
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+            "MSG".into()
+        );
         assert!(
             events[0].as_log()[log_schema().timestamp_key().unwrap().to_string()].is_timestamp()
         );
@@ -522,8 +526,8 @@ mod tests {
 
     fn init() {
         let mut schema = LogSchema::default();
-        schema.set_message_key("legacy_message".to_string());
-        schema.set_message_key("legacy_timestamp".to_string());
+        schema.set_message_key(Some(owned_value_path!("legacy_message")));
+        schema.set_message_key(Some(owned_value_path!("legacy_timestamp")));
         init_log_schema(schema, false);
     }
 }

--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -7,6 +7,7 @@ use vector_core::{
     config::{log_schema, LegacyKey, LogNamespace},
     event::{Event, LogEvent},
 };
+use vrl::path::PathPrefix;
 use vrl::value::Value;
 
 use super::proto::{
@@ -94,7 +95,9 @@ impl ResourceLog {
             LogNamespace::Legacy => {
                 let mut log = LogEvent::default();
                 if let Some(v) = self.log_record.body.and_then(|av| av.value) {
-                    log.insert(log_schema().message_key(), v);
+                    if let Some(message_key) = log_schema().message_key() {
+                        log.insert((PathPrefix::Event, message_key), v);
+                    }
                 }
                 log
             }

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -150,7 +150,10 @@ impl LogEvent {
     /// valid for `LogNamespace::Legacy`
     pub fn from_str_legacy(msg: impl Into<String>) -> Self {
         let mut log = LogEvent::default();
-        log.insert(log_schema().message_key(), msg.into());
+        if let Some(message_key) = log_schema().message_key() {
+            log.insert((PathPrefix::Event, message_key), msg.into());
+        }
+
         if let Some(timestamp_key) = log_schema().timestamp_key() {
             log.insert((PathPrefix::Event, timestamp_key), Utc::now());
         }
@@ -436,7 +439,7 @@ impl LogEvent {
     pub fn message_path(&self) -> Option<String> {
         match self.namespace() {
             LogNamespace::Vector => self.find_key_by_meaning("message"),
-            LogNamespace::Legacy => Some(log_schema().message_key().to_owned()),
+            LogNamespace::Legacy => log_schema().message_key().map(ToString::to_string),
         }
     }
 
@@ -478,7 +481,9 @@ impl LogEvent {
     pub fn get_message(&self) -> Option<&Value> {
         match self.namespace() {
             LogNamespace::Vector => self.get_by_meaning("message"),
-            LogNamespace::Legacy => self.get((PathPrefix::Event, log_schema().message_key())),
+            LogNamespace::Legacy => log_schema()
+                .message_key()
+                .and_then(|key| self.get((PathPrefix::Event, key))),
         }
     }
 
@@ -548,8 +553,10 @@ mod test_utils {
     impl From<Bytes> for LogEvent {
         fn from(message: Bytes) -> Self {
             let mut log = LogEvent::default();
+            if let Some(message_key) = log_schema().message_key() {
+                log.insert((PathPrefix::Event, message_key), message);
+            }
 
-            log.insert(log_schema().message_key(), message);
             if let Some(timestamp_key) = log_schema().timestamp_key() {
                 log.insert((PathPrefix::Event, timestamp_key), Utc::now());
             }

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -52,6 +52,14 @@ pub struct TargetIter<T> {
     _marker: PhantomData<T>,
 }
 
+fn create_log_event(metadata: EventMetadata, value: Value) -> LogEvent {
+    let mut log = LogEvent::new_with_metadata(metadata);
+    if let Some(message_key) = log_schema().message_key() {
+        log.insert((PathPrefix::Event, message_key), value);
+    }
+    log
+}
+
 impl Iterator for TargetIter<LogEvent> {
     type Item = Event;
 
@@ -59,11 +67,7 @@ impl Iterator for TargetIter<LogEvent> {
         self.iter.next().map(|v| {
             match v {
                 value @ Value::Object(_) => LogEvent::from_parts(value, self.metadata.clone()),
-                value => {
-                    let mut log = LogEvent::new_with_metadata(self.metadata.clone());
-                    log.insert(log_schema().message_key(), value);
-                    log
-                }
+                value => create_log_event(self.metadata.clone(), value),
             }
             .into()
         })
@@ -79,11 +83,7 @@ impl Iterator for TargetIter<TraceEvent> {
                 value @ Value::Object(_) => {
                     TraceEvent::from(LogEvent::from_parts(value, self.metadata.clone()))
                 }
-                value => {
-                    let mut log = LogEvent::new_with_metadata(self.metadata.clone());
-                    log.insert(log_schema().message_key(), value);
-                    TraceEvent::from(log)
-                }
+                value => TraceEvent::from(create_log_event(self.metadata.clone(), value)),
             }
             .into()
         })
@@ -150,11 +150,7 @@ impl VrlTarget {
                     LogNamespace::Vector => {
                         TargetEvents::One(LogEvent::from_parts(v, metadata).into())
                     }
-                    LogNamespace::Legacy => {
-                        let mut log = LogEvent::new_with_metadata(metadata);
-                        log.insert(log_schema().message_key(), v);
-                        TargetEvents::One(log.into())
-                    }
+                    LogNamespace::Legacy => TargetEvents::One(create_log_event(metadata, v).into()),
                 },
             },
             VrlTarget::Trace(value, metadata) => match value {
@@ -169,11 +165,7 @@ impl VrlTarget {
                     _marker: PhantomData,
                 }),
 
-                v => {
-                    let mut log = LogEvent::new_with_metadata(metadata);
-                    log.insert(log_schema().message_key(), v);
-                    TargetEvents::One(log.into())
-                }
+                v => TargetEvents::One(create_log_event(metadata, v).into()),
             },
             VrlTarget::Metric { metric, .. } => TargetEvents::One(Event::Metric(metric)),
         }
@@ -202,22 +194,24 @@ fn move_field_definitions_into_message(mut definition: Definition) -> Definition
     message.remove_array();
 
     if !message.is_never() {
-        // We need to add the given message type to a field called `message`
-        // in the event.
-        let message = Kind::object(Collection::from(BTreeMap::from([(
-            log_schema().message_key().into(),
-            message,
-        )])));
+        if let Some(message_key) = log_schema().message_key() {
+            // We need to add the given message type to a field called `message`
+            // in the event.
+            let message = Kind::object(Collection::from(BTreeMap::from([(
+                message_key.to_string().into(),
+                message,
+            )])));
 
-        definition.event_kind_mut().remove_bytes();
-        definition.event_kind_mut().remove_integer();
-        definition.event_kind_mut().remove_float();
-        definition.event_kind_mut().remove_boolean();
-        definition.event_kind_mut().remove_timestamp();
-        definition.event_kind_mut().remove_regex();
-        definition.event_kind_mut().remove_null();
+            definition.event_kind_mut().remove_bytes();
+            definition.event_kind_mut().remove_integer();
+            definition.event_kind_mut().remove_float();
+            definition.event_kind_mut().remove_boolean();
+            definition.event_kind_mut().remove_timestamp();
+            definition.event_kind_mut().remove_regex();
+            definition.event_kind_mut().remove_null();
 
-        *definition.event_kind_mut() = definition.event_kind().union(message);
+            *definition.event_kind_mut() = definition.event_kind().union(message);
+        }
     }
 
     definition

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -14,7 +14,7 @@ use super::Definition;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Requirement {
     /// Semantic meanings configured for this requirement.
-    meaning: BTreeMap<&'static str, SemanticMeaning>,
+    meaning: BTreeMap<String, SemanticMeaning>,
 }
 
 /// The semantic meaning of an event.
@@ -52,7 +52,7 @@ impl Requirement {
 
     /// Add a restriction to the schema.
     #[must_use]
-    pub fn required_meaning(mut self, meaning: &'static str, kind: Kind) -> Self {
+    pub fn required_meaning(mut self, meaning: impl Into<String>, kind: Kind) -> Self {
         self.insert_meaning(meaning, kind, false);
         self
     }
@@ -63,14 +63,14 @@ impl Requirement {
     /// specified meaning defined, but invalid for that meaning to be defined, but its [`Kind`] not
     /// matching the configured expectation.
     #[must_use]
-    pub fn optional_meaning(mut self, meaning: &'static str, kind: Kind) -> Self {
+    pub fn optional_meaning(mut self, meaning: impl Into<String>, kind: Kind) -> Self {
         self.insert_meaning(meaning, kind, true);
         self
     }
 
-    fn insert_meaning(&mut self, identifier: &'static str, kind: Kind, optional: bool) {
+    fn insert_meaning(&mut self, identifier: impl Into<String>, kind: Kind, optional: bool) {
         let meaning = SemanticMeaning { kind, optional };
-        self.meaning.insert(identifier, meaning);
+        self.meaning.insert(identifier.into(), meaning);
     }
 
     /// Validate the provided [`Definition`] against the current requirement.
@@ -97,7 +97,10 @@ impl Requirement {
             // Check if we're dealing with an invalid meaning, meaning the definition has a single
             // meaning identifier pointing to multiple paths.
             if let Some(paths) = definition.invalid_meaning(identifier).cloned() {
-                errors.push(ValidationError::MeaningDuplicate { identifier, paths });
+                errors.push(ValidationError::MeaningDuplicate {
+                    identifier: identifier.clone(),
+                    paths,
+                });
                 continue;
             }
 
@@ -118,14 +121,16 @@ impl Requirement {
                         // The semantic meaning kind does not match the expected
                         // kind, so we can't use it in the sink.
                         errors.push(ValidationError::MeaningKind {
-                            identifier,
+                            identifier: identifier.clone(),
                             want: req_meaning.kind.clone(),
                             got: definition_kind,
                         });
                     }
                 }
                 None if !req_meaning.optional => {
-                    errors.push(ValidationError::MeaningMissing { identifier });
+                    errors.push(ValidationError::MeaningMissing {
+                        identifier: identifier.clone(),
+                    });
                 }
                 _ => {}
             }
@@ -176,18 +181,18 @@ impl std::fmt::Display for ValidationErrors {
 #[allow(clippy::enum_variant_names)]
 pub enum ValidationError {
     /// A required semantic meaning is missing.
-    MeaningMissing { identifier: &'static str },
+    MeaningMissing { identifier: String },
 
     /// A semantic meaning has an invalid `[Kind]`.
     MeaningKind {
-        identifier: &'static str,
+        identifier: String,
         want: Kind,
         got: Kind,
     },
 
     /// A semantic meaning is pointing to multiple paths.
     MeaningDuplicate {
-        identifier: &'static str,
+        identifier: String,
         paths: BTreeSet<OwnedTargetPath>,
     },
 }
@@ -301,7 +306,9 @@ mod tests {
                 TestCase {
                     requirement: Requirement::empty().required_meaning("foo", Kind::any()),
                     definition: Definition::default_for_namespace(&[LogNamespace::Vector].into()),
-                    errors: vec![ValidationError::MeaningMissing { identifier: "foo" }],
+                    errors: vec![ValidationError::MeaningMissing {
+                        identifier: "foo".into(),
+                    }],
                 },
             ),
             (
@@ -312,8 +319,12 @@ mod tests {
                         .required_meaning("bar", Kind::any()),
                     definition: Definition::default_for_namespace(&[LogNamespace::Vector].into()),
                     errors: vec![
-                        ValidationError::MeaningMissing { identifier: "bar" },
-                        ValidationError::MeaningMissing { identifier: "foo" },
+                        ValidationError::MeaningMissing {
+                            identifier: "bar".into(),
+                        },
+                        ValidationError::MeaningMissing {
+                            identifier: "foo".into(),
+                        },
                     ],
                 },
             ),
@@ -332,7 +343,9 @@ mod tests {
                         .optional_meaning("foo", Kind::any())
                         .required_meaning("bar", Kind::any()),
                     definition: Definition::default_for_namespace(&[LogNamespace::Vector].into()),
-                    errors: vec![ValidationError::MeaningMissing { identifier: "bar" }],
+                    errors: vec![ValidationError::MeaningMissing {
+                        identifier: "bar".into(),
+                    }],
                 },
             ),
             (
@@ -342,7 +355,7 @@ mod tests {
                     definition: Definition::default_for_namespace(&[LogNamespace::Vector].into())
                         .with_event_field(&owned_value_path!("foo"), Kind::integer(), Some("foo")),
                     errors: vec![ValidationError::MeaningKind {
-                        identifier: "foo",
+                        identifier: "foo".into(),
                         want: Kind::boolean(),
                         got: Kind::integer(),
                     }],
@@ -355,7 +368,7 @@ mod tests {
                     definition: Definition::default_for_namespace(&[LogNamespace::Vector].into())
                         .with_event_field(&owned_value_path!("foo"), Kind::integer(), Some("foo")),
                     errors: vec![ValidationError::MeaningKind {
-                        identifier: "foo",
+                        identifier: "foo".into(),
                         want: Kind::boolean(),
                         got: Kind::integer(),
                     }],
@@ -376,7 +389,7 @@ mod tests {
                                 ),
                         ),
                     errors: vec![ValidationError::MeaningDuplicate {
-                        identifier: "foo",
+                        identifier: "foo".into(),
                         paths: BTreeSet::from([
                             parse_target_path("foo").unwrap(),
                             parse_target_path("bar").unwrap(),

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -27,7 +27,7 @@ impl Default for Decoder {
     fn default() -> Self {
         Self {
             framer: Framer::NewlineDelimited(NewlineDelimitedDecoder::new()),
-            deserializer: Deserializer::Bytes(BytesDeserializer::new()),
+            deserializer: Deserializer::Bytes(BytesDeserializer {}),
             log_namespace: LogNamespace::Legacy,
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -849,7 +849,7 @@ mod tests {
         );
         assert_eq!(
             "message",
-            config.global.log_schema.message_key().to_string()
+            config.global.log_schema.message_key().unwrap().to_string()
         );
         assert_eq!(
             "timestamp",
@@ -886,7 +886,10 @@ mod tests {
             "this",
             config.global.log_schema.host_key().unwrap().to_string()
         );
-        assert_eq!("that", config.global.log_schema.message_key().to_string());
+        assert_eq!(
+            "that",
+            config.global.log_schema.message_key().unwrap().to_string()
+        );
         assert_eq!(
             "then",
             config

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -556,36 +556,37 @@ mod tests {
             lines_from_file(directory.join("errors-2019-29-07.log")),
         ];
 
+        let message_key = log_schema().message_key().unwrap().to_string();
         assert_eq!(
-            input[0].as_log()[log_schema().message_key()],
+            input[0].as_log()[&message_key],
             From::<&str>::from(&output[0][0])
         );
         assert_eq!(
-            input[1].as_log()[log_schema().message_key()],
+            input[1].as_log()[&message_key],
             From::<&str>::from(&output[1][0])
         );
         assert_eq!(
-            input[2].as_log()[log_schema().message_key()],
+            input[2].as_log()[&message_key],
             From::<&str>::from(&output[0][1])
         );
         assert_eq!(
-            input[3].as_log()[log_schema().message_key()],
+            input[3].as_log()[&message_key],
             From::<&str>::from(&output[3][0])
         );
         assert_eq!(
-            input[4].as_log()[log_schema().message_key()],
+            input[4].as_log()[&message_key],
             From::<&str>::from(&output[2][0])
         );
         assert_eq!(
-            input[5].as_log()[log_schema().message_key()],
+            input[5].as_log()[&message_key],
             From::<&str>::from(&output[2][1])
         );
         assert_eq!(
-            input[6].as_log()[log_schema().message_key()],
+            input[6].as_log()[&message_key],
             From::<&str>::from(&output[4][0])
         );
         assert_eq!(
-            input[7].as_log()[log_schema().message_key()],
+            input[7].as_log()[message_key],
             From::<&str>::from(&output[5][0])
         );
     }

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -6,7 +6,7 @@ use http::{Request, Uri};
 use indoc::indoc;
 use vrl::value::Kind;
 
-use lookup::lookup_v2::{parse_value_path, OptionalValuePath};
+use lookup::lookup_v2::OptionalValuePath;
 use lookup::{OwnedValuePath, PathPrefix};
 use vector_config::configurable_component;
 use vector_core::config::log_schema;
@@ -198,7 +198,9 @@ impl SinkConfig for InfluxDbLogsConfig {
             .clone()
             .and_then(|k| k.path)
             .unwrap_or_else(|| {
-                parse_value_path(log_schema().message_key())
+                log_schema()
+                    .message_key()
+                    .cloned()
                     .expect("global log_schema.message_key to be valid path")
             });
 

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -10,6 +10,7 @@ use vector_core::{
     config::LogNamespace,
     event::{BatchNotifier, BatchStatus, Event, LogEvent},
 };
+use vrl::path::PathPrefix;
 use vrl::value::{kind::Collection, Kind};
 
 use super::config::{LokiConfig, OutOfOrderAction};
@@ -327,7 +328,7 @@ async fn many_streams() {
         let index = (i % 5) * 2;
         let message = lines[index]
             .as_log()
-            .get(log_schema().message_key())
+            .get((PathPrefix::Event, log_schema().message_key().unwrap()))
             .unwrap()
             .to_string_lossy();
         assert_eq!(output, &message);
@@ -337,7 +338,7 @@ async fn many_streams() {
         let index = ((i % 5) * 2) + 1;
         let message = lines[index]
             .as_log()
-            .get(log_schema().message_key())
+            .get((PathPrefix::Event, log_schema().message_key().unwrap()))
             .unwrap()
             .to_string_lossy();
         assert_eq!(output, &message);
@@ -384,7 +385,7 @@ async fn interpolate_stream_key() {
     for (i, output) in outputs.iter().enumerate() {
         let message = lines[i]
             .as_log()
-            .get(log_schema().message_key())
+            .get((PathPrefix::Event, log_schema().message_key().unwrap()))
             .unwrap()
             .to_string_lossy();
         assert_eq!(output, &message);
@@ -637,7 +638,7 @@ async fn test_out_of_order_events(
         assert_eq!(
             &expected[i]
                 .as_log()
-                .get(log_schema().message_key())
+                .get((PathPrefix::Event, log_schema().message_key().unwrap()))
                 .unwrap()
                 .to_string_lossy(),
             output,

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -429,7 +429,7 @@ mod tests {
         .item
         .value;
         let map: HashMap<String, String> = serde_json::from_slice(&result[..]).unwrap();
-        assert_eq!(msg, map[&log_schema().message_key().to_string()]);
+        assert_eq!(msg, map[&log_schema().message_key().unwrap().to_string()]);
     }
 
     #[test]

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -152,7 +152,9 @@ fn splunk_encode_log_event_json() {
     assert_eq!(event.get("key").unwrap(), &serde_json::Value::from("value"));
     assert_eq!(event.get("int_val").unwrap(), &serde_json::Value::from(123));
     assert_eq!(
-        event.get(&log_schema().message_key().to_string()).unwrap(),
+        event
+            .get(&log_schema().message_key().unwrap().to_string())
+            .unwrap(),
         &serde_json::Value::from("hello world")
     );
     assert!(event

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -521,10 +521,13 @@ mod tests {
 
         let output = receiver.await;
         assert_eq!(lines.len(), output.len());
-        let message_key = crate::config::log_schema().message_key();
+        let message_key = crate::config::log_schema()
+            .message_key()
+            .expect("global log_schema.message_key to be valid path")
+            .to_string();
         for (source, received) in lines.iter().zip(output) {
             let json = serde_json::from_str::<JsonValue>(&received).expect("Invalid JSON");
-            let received = json.get(message_key).unwrap().as_str().unwrap();
+            let received = json.get(message_key.as_str()).unwrap().as_str().unwrap();
             assert_eq!(source, received);
         }
     }

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -711,7 +711,10 @@ mod integration_test {
 
         let log = events[0].as_log();
         trace!("{:?}", log);
-        assert_eq!(log[log_schema().message_key()], "my message".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "my message".into()
+        );
         assert_eq!(log["routing"], routing_key.into());
         assert_eq!(
             log[log_schema().source_type_key().unwrap().to_string()],

--- a/src/sources/aws_sqs/integration_tests.rs
+++ b/src/sources/aws_sqs/integration_tests.rs
@@ -7,6 +7,7 @@ use aws_sdk_sqs::output::CreateQueueOutput;
 use aws_types::region::Region;
 use futures::StreamExt;
 use tokio::time::timeout;
+use vrl::path::PathPrefix;
 
 use crate::{
     aws::{auth::AwsAuthentication, region::RegionOrEndpoint},
@@ -109,7 +110,7 @@ pub(crate) async fn test() {
         for event in events {
             let message = event
                 .as_log()
-                .get(log_schema().message_key())
+                .get((PathPrefix::Event, log_schema().message_key().unwrap()))
                 .unwrap()
                 .to_string_lossy();
             if !expected_messages.remove(message.as_ref()) {

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -222,6 +222,7 @@ mod tests {
     use crate::codecs::DecodingConfig;
     use chrono::SecondsFormat;
     use lookup::path;
+    use vrl::path::PathPrefix;
 
     use super::*;
     use crate::config::{log_schema, SourceConfig};
@@ -312,7 +313,7 @@ mod tests {
             events[0]
                 .clone()
                 .as_log()
-                .get(log_schema().message_key())
+                .get((PathPrefix::Event, log_schema().message_key().unwrap()))
                 .unwrap()
                 .to_string_lossy(),
             message

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -85,7 +85,7 @@ fn test_decode_log_body() {
         let api_key = None;
         let decoder = crate::codecs::Decoder::new(
             Framer::Bytes(BytesDecoder::new()),
-            Deserializer::Bytes(BytesDeserializer::new()),
+            Deserializer::Bytes(BytesDeserializer {}),
         );
 
         let source = DatadogAgentSource::new(

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -399,7 +399,7 @@ mod tests {
 
     #[tokio::test]
     async fn shuffle_demo_logs_copies_lines() {
-        let message_key = log_schema().message_key();
+        let message_key = log_schema().message_key().unwrap().to_string();
         let mut rx = runit(
             r#"format = "shuffle"
                lines = ["one", "two", "three", "four"]
@@ -439,7 +439,7 @@ mod tests {
 
     #[tokio::test]
     async fn shuffle_demo_logs_adds_sequence() {
-        let message_key = log_schema().message_key();
+        let message_key = log_schema().message_key().unwrap().to_string();
         let mut rx = runit(
             r#"format = "shuffle"
                lines = ["one", "two"]
@@ -539,7 +539,7 @@ mod tests {
 
     #[tokio::test]
     async fn json_format_generates_output() {
-        let message_key = log_schema().message_key();
+        let message_key = log_schema().message_key().unwrap().to_string();
         let mut rx = runit(
             r#"format = "json"
             count = 5"#,

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -127,14 +127,15 @@ impl DnstapConfig {
                 let schema = vector_core::schema::Definition::empty_legacy_namespace();
 
                 if self.raw_data_only.unwrap_or(false) {
-                    schema.with_event_field(
-                        &owned_value_path!(log_schema().message_key()),
-                        Kind::bytes(),
-                        Some("message"),
-                    )
-                } else {
-                    event_schema.schema_definition(schema)
+                    if let Some(message_key) = log_schema().message_key() {
+                        return schema.with_event_field(
+                            message_key,
+                            Kind::bytes(),
+                            Some("message"),
+                        );
+                    }
                 }
+                event_schema.schema_definition(schema)
             }
             LogNamespace::Vector => {
                 let schema = vector_core::schema::Definition::new_with_default_metadata(

--- a/src/sources/docker_logs/tests.rs
+++ b/src/sources/docker_logs/tests.rs
@@ -279,7 +279,7 @@ mod integration_tests {
         // Wait for before message
         let events = collect_n(out, 1).await;
         assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
             "before".into()
         );
 
@@ -346,7 +346,7 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 message.into()
             );
         })
@@ -440,7 +440,10 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             let log = events[0].as_log();
-            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                message.into()
+            );
             assert_eq!(log[CONTAINER], id.into());
             assert!(log.get(CREATED_AT).is_some());
             assert_eq!(log[IMAGE], "busybox".into());
@@ -479,15 +482,10 @@ mod integration_tests {
             let definition = schema_definitions.unwrap();
 
             definition.assert_valid_for_event(&events[0]);
-            assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
-                message.into()
-            );
+            let message_key = log_schema().message_key().unwrap().to_string();
+            assert_eq!(events[0].as_log()[&message_key], message.into());
             definition.assert_valid_for_event(&events[1]);
-            assert_eq!(
-                events[1].as_log()[log_schema().message_key()],
-                message.into()
-            );
+            assert_eq!(events[1].as_log()[message_key], message.into());
         })
         .await;
     }
@@ -521,7 +519,7 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 message.into()
             );
         })
@@ -567,18 +565,13 @@ mod integration_tests {
             assert_eq!(events.len(), 2);
 
             let definition = schema_definitions.unwrap();
-
             definition.assert_valid_for_event(&events[0]);
-            assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
-                will_be_read.into()
-            );
+
+            let message_key = log_schema().message_key().unwrap().to_string();
+            assert_eq!(events[0].as_log()[&message_key], will_be_read.into());
 
             definition.assert_valid_for_event(&events[1]);
-            assert_eq!(
-                events[1].as_log()[log_schema().message_key()],
-                will_be_read.into()
-            );
+            assert_eq!(events[1].as_log()[message_key], will_be_read.into());
         })
         .await;
     }
@@ -613,7 +606,7 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 message.into()
             );
         })
@@ -647,7 +640,10 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             let log = events[0].as_log();
-            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                message.into()
+            );
             assert_eq!(log[CONTAINER], id.into());
             assert!(log.get(CREATED_AT).is_some());
             assert_eq!(log[IMAGE], "busybox".into());
@@ -692,7 +688,7 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 message.into()
             );
         })
@@ -782,7 +778,10 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             let log = events[0].as_log();
-            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                message.into()
+            );
             assert_eq!(log[CONTAINER], id.into());
             assert!(log.get(CREATED_AT).is_some());
             assert_eq!(log[IMAGE], "busybox".into());
@@ -831,7 +830,10 @@ mod integration_tests {
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
             let log = events[0].as_log();
-            assert_eq!(log[log_schema().message_key()], message.into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                message.into()
+            );
         })
         .await;
     }
@@ -968,7 +970,7 @@ mod integration_tests {
 
                     event
                         .into_log()
-                        .remove(crate::config::log_schema().message_key())
+                        .remove((PathPrefix::Event, log_schema().message_key().unwrap()))
                         .unwrap()
                         .to_string_lossy()
                         .into_owned()

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -766,7 +766,10 @@ mod tests {
         assert_eq!(log[STREAM_KEY], STDOUT.into());
         assert_eq!(log[PID_KEY], (8888_i64).into());
         assert_eq!(log[COMMAND_KEY], config.command.into());
-        assert_eq!(log[log_schema().message_key()], "hello world".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "hello world".into()
+        );
         assert_eq!(
             log[log_schema().source_type_key().unwrap().to_string()],
             "exec".into()
@@ -853,7 +856,10 @@ mod tests {
         assert_eq!(log[STREAM_KEY], STDOUT.into());
         assert_eq!(log[PID_KEY], (8888_i64).into());
         assert_eq!(log[COMMAND_KEY], config.command.into());
-        assert_eq!(log[log_schema().message_key()], "hello world".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "hello world".into()
+        );
         assert_eq!(
             log[log_schema().source_type_key().unwrap().to_string()],
             "exec".into()
@@ -964,7 +970,7 @@ mod tests {
             assert_eq!(events.len(), 1);
             let log = events[0].as_log();
             assert_eq!(
-                log[log_schema().message_key()],
+                log[log_schema().message_key().unwrap().to_string()],
                 Bytes::from("hello world").into()
             );
             assert_eq!(origin, STDOUT);
@@ -976,7 +982,7 @@ mod tests {
             assert_eq!(events.len(), 1);
             let log = events[0].as_log();
             assert_eq!(
-                log[log_schema().message_key()],
+                log[log_schema().message_key().unwrap().to_string()],
                 Bytes::from("hello rocket 🚀").into()
             );
             assert_eq!(origin, STDOUT);
@@ -1060,7 +1066,10 @@ mod tests {
                 log[log_schema().source_type_key().unwrap().to_string()],
                 "exec".into()
             );
-            assert_eq!(log[log_schema().message_key()], "Hello World!".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "Hello World!".into()
+            );
             assert_eq!(
                 log[log_schema().host_key().unwrap().to_string().as_str()],
                 "Some.Machine".into()
@@ -1122,14 +1131,20 @@ mod tests {
 
         if let Poll::Ready(Some(event)) = futures::poll!(rx.next()) {
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "signal received".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "signal received".into()
+            );
         } else {
             panic!("Expected to receive event");
         }
 
         if let Poll::Ready(Some(event)) = futures::poll!(rx.next()) {
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "slept".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "slept".into()
+            );
         } else {
             panic!("Expected to receive event");
         }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -746,7 +746,7 @@ fn create_event(
     meta: &EventMetadata,
     log_namespace: LogNamespace,
 ) -> LogEvent {
-    let deserializer = BytesDeserializer::new();
+    let deserializer = BytesDeserializer {};
     let mut event = deserializer.parse_single(line, log_namespace);
 
     log_namespace.insert_vector_metadata(
@@ -1036,7 +1036,10 @@ mod tests {
         assert_eq!(log["file"], "some_file.rs".into());
         assert_eq!(log["host"], "Some.Machine".into());
         assert_eq!(log["offset"], 0.into());
-        assert_eq!(log[log_schema().message_key()], "hello world".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "hello world".into()
+        );
         assert_eq!(
             log[log_schema().source_type_key().unwrap().to_string()],
             "file".into()
@@ -1061,7 +1064,10 @@ mod tests {
         assert_eq!(log["file_path"], "some_file.rs".into());
         assert_eq!(log["hostname"], "Some.Machine".into());
         assert_eq!(log["off"], 0.into());
-        assert_eq!(log[log_schema().message_key()], "hello world".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "hello world".into()
+        );
         assert_eq!(
             log[log_schema().source_type_key().unwrap().to_string()],
             "file".into()
@@ -1154,7 +1160,8 @@ mod tests {
         let mut goodbye_i = 0;
 
         for event in received {
-            let line = event.as_log()[log_schema().message_key()].to_string_lossy();
+            let line =
+                event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
             if line.starts_with("hello") {
                 assert_eq!(line, format!("hello {}", hello_i));
                 assert_eq!(
@@ -1248,7 +1255,8 @@ mod tests {
                 path.to_str().unwrap()
             );
 
-            let line = event.as_log()[log_schema().message_key()].to_string_lossy();
+            let line =
+                event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
 
             if pre_trunc {
                 assert_eq!(line, format!("pretrunc {}", i));
@@ -1309,7 +1317,8 @@ mod tests {
                 path.to_str().unwrap()
             );
 
-            let line = event.as_log()[log_schema().message_key()].to_string_lossy();
+            let line =
+                event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
 
             if pre_rot {
                 assert_eq!(line, format!("prerot {}", i));
@@ -1362,7 +1371,8 @@ mod tests {
         let mut is = [0; 3];
 
         for event in received {
-            let line = event.as_log()[log_schema().message_key()].to_string_lossy();
+            let line =
+                event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
             let mut split = line.split(' ');
             let file = split.next().unwrap().parse::<usize>().unwrap();
             assert_ne!(file, 4);
@@ -1470,7 +1480,7 @@ mod tests {
                         .expect("file key to exist")
                         .to_string(),
                     log_schema().host_key().unwrap().to_string(),
-                    log_schema().message_key().to_string(),
+                    log_schema().message_key().unwrap().to_string(),
                     log_schema().timestamp_key().unwrap().to_string(),
                     log_schema().source_type_key().unwrap().to_string()
                 ]
@@ -1752,12 +1762,16 @@ mod tests {
         let before_lines = received
             .iter()
             .filter(|event| event.as_log()["file"].to_string_lossy().ends_with("before"))
-            .map(|event| event.as_log()[log_schema().message_key()].to_string_lossy())
+            .map(|event| {
+                event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy()
+            })
             .collect::<Vec<_>>();
         let after_lines = received
             .iter()
             .filter(|event| event.as_log()["file"].to_string_lossy().ends_with("after"))
-            .map(|event| event.as_log()[log_schema().message_key()].to_string_lossy())
+            .map(|event| {
+                event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy()
+            })
             .collect::<Vec<_>>();
         assert_eq!(before_lines, vec!["second line"]);
         assert_eq!(after_lines, vec!["_first line", "_second line"]);
@@ -2323,7 +2337,7 @@ mod tests {
             .into_iter()
             .map(Event::into_log)
             .map(|log| {
-                log[log_schema().message_key()]
+                log[log_schema().message_key().unwrap().to_string()]
                     .to_string_lossy()
                     .into_owned()
             })
@@ -2334,7 +2348,7 @@ mod tests {
         received
             .into_iter()
             .map(Event::into_log)
-            .map(|log| log[log_schema().message_key()].clone())
+            .map(|log| log[log_schema().message_key().unwrap().to_string()].clone())
             .collect()
     }
 }

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -143,19 +143,16 @@ mod tests {
             config.build(context).await.unwrap().await.unwrap();
 
             let event = stream.next().await;
+            let message_key = log_schema().message_key().unwrap().to_string();
             assert_eq!(
                 Some("hello world".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()]
-                    .to_string_lossy()
-                    .into_owned())
+                event.map(|event| event.as_log()[&message_key].to_string_lossy().into_owned())
             );
 
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world again".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()]
-                    .to_string_lossy()
-                    .into_owned())
+                event.map(|event| event.as_log()[message_key].to_string_lossy().into_owned())
             );
 
             let event = stream.next().await;

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -142,17 +142,21 @@ mod tests {
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()]
-                    .to_string_lossy()
-                    .into_owned())
+                event.map(
+                    |event| event.as_log()[log_schema().message_key().unwrap().to_string()]
+                        .to_string_lossy()
+                        .into_owned()
+                )
             );
 
             let event = stream.next().await;
             assert_eq!(
                 Some("hello world again".into()),
-                event.map(|event| event.as_log()[log_schema().message_key()]
-                    .to_string_lossy()
-                    .into_owned())
+                event.map(
+                    |event| event.as_log()[log_schema().message_key().unwrap().to_string()]
+                        .to_string_lossy()
+                        .into_owned()
+                )
             );
 
             let event = stream.next().await;

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -521,7 +521,7 @@ mod tests {
             let log = event.as_log();
 
             assert_eq!(
-                log[log_schema().message_key()],
+                log[log_schema().message_key().unwrap().to_string()],
                 r#"at=info method=GET path="/cart_link" host=lumberjack-store.timber.io request_id=05726858-c44e-4f94-9a20-37df73be9006 fwd="73.75.38.87" dyno=web.1 connect=1ms service=22ms status=304 bytes=656 protocol=http"#.into()
             );
             assert_eq!(
@@ -606,7 +606,10 @@ mod tests {
         let events = super::line_to_events(Default::default(), log_namespace, body.into());
         let log = events[0].as_log();
 
-        assert_eq!(log[log_schema().message_key()], "foo bar baz".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "foo bar baz".into()
+        );
         assert_eq!(
             log[log_schema().timestamp_key().unwrap().to_string()],
             "2020-01-08T22:33:57.353034+00:00"
@@ -632,7 +635,7 @@ mod tests {
         let log = events[0].as_log();
 
         assert_eq!(
-            log[log_schema().message_key()],
+            log[log_schema().message_key().unwrap().to_string()],
             "what am i doing here".into()
         );
         assert!(log
@@ -654,7 +657,10 @@ mod tests {
         let events = super::line_to_events(Default::default(), log_namespace, body.into());
         let log = events[0].as_log();
 
-        assert_eq!(log[log_schema().message_key()], "i'm not that long".into());
+        assert_eq!(
+            log[log_schema().message_key().unwrap().to_string()],
+            "i'm not that long".into()
+        );
         assert_eq!(
             log[log_schema().timestamp_key().unwrap().to_string()],
             "2020-01-08T22:33:57.353034+00:00"

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -654,7 +654,10 @@ mod tests {
         {
             let event = events.remove(0);
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "test body".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "test body".into()
+            );
             assert!(log
                 .get((
                     lookup::PathPrefix::Event,
@@ -671,7 +674,10 @@ mod tests {
         {
             let event = events.remove(0);
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "test body 2".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "test body 2".into()
+            );
             assert_event_metadata(log).await;
         }
     }
@@ -703,13 +709,19 @@ mod tests {
         {
             let event = events.remove(0);
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "test body".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "test body".into()
+            );
             assert_event_metadata(log).await;
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "test body 2".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "test body 2".into()
+            );
             assert_event_metadata(log).await;
         }
     }
@@ -742,7 +754,10 @@ mod tests {
         {
             let event = events.remove(0);
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "foo\nbar".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "foo\nbar".into()
+            );
             assert_event_metadata(log).await;
         }
     }
@@ -1094,7 +1109,10 @@ mod tests {
         {
             let event = events.remove(0);
             let log = event.as_log();
-            assert_eq!(log[log_schema().message_key()], "test body".into());
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                "test body".into()
+            );
             assert_event_metadata(log).await;
         }
     }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -784,7 +784,9 @@ fn create_log_event_from_record(
             let mut log = LogEvent::from_iter(record).with_batch_notifier_option(batch);
 
             if let Some(message) = log.remove(MESSAGE) {
-                log.insert(log_schema().message_key(), message);
+                if let Some(message_key) = log_schema().message_key() {
+                    log.insert((PathPrefix::Event, message_key), message);
+                }
             }
 
             log
@@ -1487,7 +1489,7 @@ mod tests {
     }
 
     fn message(event: &Event) -> Value {
-        event.as_log()[log_schema().message_key()].clone()
+        event.as_log()[log_schema().message_key().unwrap().to_string()].clone()
     }
 
     fn timestamp(event: &Event) -> Value {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1052,7 +1052,7 @@ mod integration_test {
         for (i, event) in events.into_iter().enumerate() {
             if let LogNamespace::Legacy = log_namespace {
                 assert_eq!(
-                    event.as_log()[log_schema().message_key()],
+                    event.as_log()[log_schema().message_key().unwrap().to_string()],
                     format!("{} {:03}", TEXT, i).into()
                 );
                 assert_eq!(

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -897,7 +897,7 @@ fn create_event(
     ingestion_timestamp_field: Option<&OwnedTargetPath>,
     log_namespace: LogNamespace,
 ) -> Event {
-    let deserializer = BytesDeserializer::new();
+    let deserializer = BytesDeserializer {};
     let mut log = deserializer.parse_single(line, log_namespace);
 
     log_namespace.insert_source_metadata(

--- a/src/sources/kubernetes_logs/partial_events_merger.rs
+++ b/src/sources/kubernetes_logs/partial_events_merger.rs
@@ -19,7 +19,10 @@ pub fn build(enabled: bool, log_namespace: LogNamespace) -> PartialEventsMerger 
     let reducer = if enabled {
         let key = match log_namespace {
             LogNamespace::Vector => ".".to_string(),
-            LogNamespace::Legacy => log_schema().message_key().to_string(),
+            LogNamespace::Legacy => log_schema()
+                .message_key()
+                .expect("global log_schema.message_key to be valid path")
+                .to_string(),
         };
 
         // Merge the message field of each event by concatenating it, with a space delimiter.

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -390,7 +390,10 @@ mod integration_tests {
         .await;
 
         println!("Received event  {:?}", events[0].as_log());
-        assert_eq!(events[0].as_log()[log_schema().message_key()], msg.into());
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+            msg.into()
+        );
         Ok(())
     }
 

--- a/src/sources/opentelemetry/integration_tests.rs
+++ b/src/sources/opentelemetry/integration_tests.rs
@@ -89,8 +89,8 @@ async fn receive_logs_legacy_namespace() {
         let events = collect_n(logs_output, 2).await;
         assert_eq!(events.len(), 2);
         assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
-            events[1].as_log()[log_schema().message_key()]
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()]
         );
     })
     .await;

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -251,7 +251,7 @@ impl SourceConfig for OpentelemetryConfig {
                 schema_definition.with_meaning(OwnedTargetPath::event_root(), "message")
             }
             LogNamespace::Legacy => {
-                schema_definition.with_meaning(log_schema().owned_message_path(), "message")
+                schema_definition.with_meaning(log_schema().owned_legacy_message_path(), "message")
             }
         };
 

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -354,9 +354,18 @@ mod integration_test {
 
         let events = run_and_assert_source_compliance_n(config, 3, &SOURCE_TAGS).await;
 
-        assert_eq!(events[0].as_log()[log_schema().message_key()], "3".into());
-        assert_eq!(events[1].as_log()[log_schema().message_key()], "2".into());
-        assert_eq!(events[2].as_log()[log_schema().message_key()], "1".into());
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+            "3".into()
+        );
+        assert_eq!(
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()],
+            "2".into()
+        );
+        assert_eq!(
+            events[2].as_log()[log_schema().message_key().unwrap().to_string()],
+            "1".into()
+        );
     }
 
     #[tokio::test]
@@ -427,9 +436,18 @@ mod integration_test {
 
         let events = run_and_assert_source_compliance_n(config, 3, &SOURCE_TAGS).await;
 
-        assert_eq!(events[0].as_log()[log_schema().message_key()], "1".into());
-        assert_eq!(events[1].as_log()[log_schema().message_key()], "2".into());
-        assert_eq!(events[2].as_log()[log_schema().message_key()], "3".into());
+        assert_eq!(
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+            "1".into()
+        );
+        assert_eq!(
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()],
+            "2".into()
+        );
+        assert_eq!(
+            events[2].as_log()[log_schema().message_key().unwrap().to_string()],
+            "3".into()
+        );
     }
 
     #[tokio::test]
@@ -480,7 +498,10 @@ mod integration_test {
         assert_eq!(events.len(), 10000);
 
         for event in events {
-            assert_eq!(event.as_log()[log_schema().message_key()], text.into());
+            assert_eq!(
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
+                text.into()
+            );
             assert_eq!(
                 event.as_log()[log_schema().source_type_key().unwrap().to_string()],
                 RedisSourceConfig::NAME.into()

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -472,8 +472,14 @@ mod test {
             let events = collect_n(rx, 2).await;
 
             assert_eq!(events.len(), 2);
-            assert_eq!(events[0].as_log()[log_schema().message_key()], "foo".into());
-            assert_eq!(events[1].as_log()[log_schema().message_key()], "bar".into());
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+                "foo".into()
+            );
+            assert_eq!(
+                events[1].as_log()[log_schema().message_key().unwrap().to_string()],
+                "bar".into()
+            );
         })
         .await;
     }
@@ -531,11 +537,14 @@ mod test {
             send_lines(addr, lines.into_iter()).await.unwrap();
 
             let event = rx.next().await.unwrap();
-            assert_eq!(event.as_log()[log_schema().message_key()], "short".into());
+            assert_eq!(
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
+                "short".into()
+            );
 
             let event = rx.next().await.unwrap();
             assert_eq!(
-                event.as_log()[log_schema().message_key()],
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
                 "more short".into()
             );
         })
@@ -585,7 +594,7 @@ mod test {
 
             let event = rx.next().await.unwrap();
             assert_eq!(
-                event.as_log()[log_schema().message_key()],
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
                 "one line".into()
             );
 
@@ -597,7 +606,7 @@ mod test {
 
             let event = rx.next().await.unwrap();
             assert_eq!(
-                event.as_log()[log_schema().message_key()],
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
                 "another line".into()
             );
 
@@ -703,7 +712,10 @@ mod test {
                 .unwrap();
 
             let event = rx.next().await.unwrap();
-            assert_eq!(event.as_log()[log_schema().message_key()], "test".into());
+            assert_eq!(
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
+                "test".into()
+            );
 
             // Now signal to the Source to shut down.
             let deadline = Instant::now() + Duration::from_secs(10);
@@ -781,10 +793,10 @@ mod test {
             .collect::<Vec<_>>();
         assert_eq!(100, events.len());
 
-        let message_key = log_schema().message_key();
+        let message_key = log_schema().message_key().unwrap().to_string();
         let expected_message = message.clone().into();
         for event in events.into_iter().flat_map(EventContainer::into_events) {
-            assert_eq!(event.as_log()[message_key], expected_message);
+            assert_eq!(event.as_log()[message_key.as_str()], expected_message);
         }
 
         // Now trigger shutdown on the source and ensure that it shuts down before or at the
@@ -956,7 +968,7 @@ mod test {
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test".into()
             );
         })
@@ -973,7 +985,7 @@ mod test {
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "foo\nbar".into()
             );
         })
@@ -990,11 +1002,11 @@ mod test {
             let events = collect_n(rx, 2).await;
 
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test".into()
             );
             assert_eq!(
-                events[1].as_log()[log_schema().message_key()],
+                events[1].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test2".into()
             );
         })
@@ -1021,11 +1033,11 @@ mod test {
 
             let events = collect_n(rx, 2).await;
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "short line".into()
             );
             assert_eq!(
-                events[1].as_log()[log_schema().message_key()],
+                events[1].as_log()[log_schema().message_key().unwrap().to_string()],
                 "a short un".into()
             );
         })
@@ -1057,11 +1069,11 @@ mod test {
 
             let events = collect_n(rx, 2).await;
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test with".into()
             );
             assert_eq!(
-                events[1].as_log()[log_schema().message_key()],
+                events[1].as_log()[log_schema().message_key().unwrap().to_string()],
                 "short one".into()
             );
         })
@@ -1142,7 +1154,7 @@ mod test {
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test".into()
             );
 
@@ -1183,7 +1195,10 @@ mod test {
             let events = collect_n(rx, 100).await;
             assert_eq!(100, events.len());
             for event in events {
-                assert_eq!(event.as_log()[log_schema().message_key()], "test".into());
+                assert_eq!(
+                    event.as_log()[log_schema().message_key().unwrap().to_string()],
+                    "test".into()
+                );
             }
 
             let deadline = Instant::now() + Duration::from_secs(10);
@@ -1268,11 +1283,11 @@ mod test {
 
         assert_eq!(2, events.len());
         assert_eq!(
-            events[0].as_log()[log_schema().message_key()],
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
             "test".into()
         );
         assert_eq!(
-            events[1].as_log()[log_schema().message_key()],
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()],
             "test2".into()
         );
     }
@@ -1323,7 +1338,7 @@ mod test {
 
             assert_eq!(events.len(), 1);
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test".into()
             );
             assert_eq!(
@@ -1415,7 +1430,7 @@ mod test {
 
             assert_eq!(events.len(), 1);
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "foo\nbar".into()
             );
             assert_eq!(
@@ -1502,7 +1517,7 @@ mod test {
 
             assert_eq!(1, events.len());
             assert_eq!(
-                events[0].as_log()[log_schema().message_key()],
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
                 "test".into()
             );
             assert_eq!(
@@ -1544,12 +1559,18 @@ mod test {
             let events = collect_n(rx, 2).await;
 
             assert_eq!(events.len(), 2);
-            assert_eq!(events[0].as_log()[log_schema().message_key()], "foo".into());
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+                "foo".into()
+            );
             assert_eq!(
                 events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()
             );
-            assert_eq!(events[1].as_log()[log_schema().message_key()], "bar".into());
+            assert_eq!(
+                events[1].as_log()[log_schema().message_key().unwrap().to_string()],
+                "bar".into()
+            );
             assert_eq!(
                 events[1].as_log()[log_schema().source_type_key().unwrap().to_string()],
                 "socket".into()

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -854,11 +854,11 @@ mod test {
         send_control_frame(&mut sock_sink, create_control_frame(ControlHeader::Stop)).await;
 
         assert_eq!(
-            events[0].as_log()[&log_schema().message_key()],
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
             "hello".into(),
         );
         assert_eq!(
-            events[1].as_log()[&log_schema().message_key()],
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()],
             "world".into(),
         );
 
@@ -903,12 +903,13 @@ mod test {
         //5 - send STOP frame
         send_control_frame(&mut sock_sink, create_control_frame(ControlHeader::Stop)).await;
 
+        let message_key = log_schema().message_key().unwrap().to_string();
         assert!(events
             .iter()
-            .any(|e| e.as_log()[&log_schema().message_key()] == "hello".into()));
+            .any(|e| e.as_log()[&message_key] == "hello".into()));
         assert!(events
             .iter()
-            .any(|e| e.as_log()[&log_schema().message_key()] == "world".into()));
+            .any(|e| e.as_log()[&message_key] == "world".into()));
 
         drop(sock_stream); //explicitly drop the stream so we don't get warnings about not using it
 
@@ -1025,11 +1026,11 @@ mod test {
         send_control_frame(&mut sock_sink, create_control_frame(ControlHeader::Stop)).await;
 
         assert_eq!(
-            events[0].as_log()[&log_schema().message_key()],
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
             "hello".into(),
         );
         assert_eq!(
-            events[1].as_log()[&log_schema().message_key()],
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()],
             "world".into(),
         );
 
@@ -1065,11 +1066,11 @@ mod test {
         send_control_frame(&mut sock_sink, create_control_frame(ControlHeader::Stop)).await;
 
         assert_eq!(
-            events[0].as_log()[&log_schema().message_key()],
+            events[0].as_log()[log_schema().message_key().unwrap().to_string()],
             "hello".into(),
         );
         assert_eq!(
-            events[1].as_log()[&log_schema().message_key()],
+            events[1].as_log()[log_schema().message_key().unwrap().to_string()],
             "world".into(),
         );
 

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -29,6 +29,7 @@ use tokio::{
 use vector_buffers::{BufferConfig, BufferType, WhenFull};
 use vector_common::config::ComponentKey;
 use vector_core::config::OutputId;
+use vrl::path::PathPrefix;
 
 mod backpressure;
 mod compliance;
@@ -67,9 +68,10 @@ fn basic_config_with_sink_failing_healthcheck() -> Config {
 }
 
 fn into_message(event: Event) -> String {
+    let message_key = crate::config::log_schema().message_key().unwrap();
     event
         .as_log()
-        .get(crate::config::log_schema().message_key())
+        .get((PathPrefix::Event, message_key))
         .unwrap()
         .to_string_lossy()
         .into_owned()
@@ -120,7 +122,10 @@ async fn topology_shutdown_while_active() {
         .flat_map(EventArray::into_events)
     {
         assert_eq!(
-            event.as_log()[&crate::config::log_schema().message_key()],
+            event.as_log()[&crate::config::log_schema()
+                .message_key()
+                .unwrap()
+                .to_string()],
             "test transformed".to_owned().into()
         );
     }

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -103,7 +103,10 @@ fn default_cache_config() -> CacheConfig {
 //   structure can vary significantly. This should probably either become a required field
 //   in the future, or maybe the "semantic meaning" can be utilized here.
 fn default_match_fields() -> Vec<String> {
-    let mut fields = vec![log_schema().message_key().into()];
+    let mut fields = vec![];
+    if let Some(message_key) = log_schema().message_key() {
+        fields.push(message_key.to_string());
+    }
     if let Some(host_key) = log_schema().host_key() {
         fields.push(host_key.to_string());
     }


### PR DESCRIPTION
## Motivation
This part of https://github.com/vectordotdev/vector/issues/13033.

## Summary
* `LogSchema::message_key` is now an `OptionalValuePath`.
* To avoid hacky `String` to `&'static str` conversions, I changed the `Requirement::meaning` key type to `String`.
