### PR TITLE
enhancement(prometheus_scrape source): run requests in parallel with timeouts

### DIFF
--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -202,6 +202,14 @@ impl SourceConfig for HttpClientConfig {
             log_namespace,
         };
 
+        if self.target_timeout > self.interval {
+            warn!(
+                interval_secs = %self.interval.as_secs_f64(),
+                target_timeout_secs = %self.target_timeout.as_secs_f64(),
+                message = "Having a scrape timeout that exceeds the scrape interval can lead to excessive resource consumption.",
+            );
+        }
+
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -20,7 +20,8 @@ use crate::{
     sources::util::{
         http::HttpMethod,
         http_client::{
-            build_url, call, default_interval, GenericHttpClientInputs, HttpClientBuilder,
+            build_url, call, default_interval, default_target_timeout, GenericHttpClientInputs,
+            HttpClientBuilder,
         },
     },
     tls::{TlsConfig, TlsSettings},
@@ -57,6 +58,13 @@ pub struct HttpClientConfig {
     #[serde(rename = "scrape_interval_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub interval: Duration,
+
+    /// The timeout for each scrape request, in seconds.
+    #[serde(default = "default_target_timeout")]
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(rename = "scrape_target_timeout_secs")]
+    #[configurable(metadata(docs::human_name = "Scrape Target Timeout"))]
+    pub target_timeout: Duration,
 
     /// Custom parameters for the HTTP request query string.
     ///
@@ -153,6 +161,7 @@ impl Default for HttpClientConfig {
             endpoint: "http://localhost:9898/logs".to_string(),
             query: HashMap::new(),
             interval: default_interval(),
+            target_timeout: default_target_timeout(),
             decoding: default_decoding(),
             framing: default_framing_message_based(),
             headers: HashMap::new(),
@@ -196,6 +205,7 @@ impl SourceConfig for HttpClientConfig {
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,
+            target_timeout: self.target_timeout,
             headers: self.headers.clone(),
             content_type,
             auth: self.auth.clone(),

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -52,7 +52,9 @@ pub struct HttpClientConfig {
     #[configurable(metadata(docs::examples = "http://127.0.0.1:9898/logs"))]
     pub endpoint: String,
 
-    /// The interval between scrapes. Requests run concurrently.
+    /// The interval between scrapes. Requests are run concurrently so if a scrape takes longer
+    /// than the interval a new scrape will be started. This can take extra resources, set the timeout
+    /// to a value lower than the scrape interval to prevent this from happening.
     #[serde(default = "default_interval")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(rename = "scrape_interval_secs")]

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -52,18 +52,18 @@ pub struct HttpClientConfig {
     #[configurable(metadata(docs::examples = "http://127.0.0.1:9898/logs"))]
     pub endpoint: String,
 
-    /// The interval between calls.
+    /// The interval between scrapes. Requests run concurrently.
     #[serde(default = "default_interval")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(rename = "scrape_interval_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub interval: Duration,
 
-    /// The timeout for each scrape request, in seconds.
+    /// The timeout for each scrape request.
     #[serde(default = "default_target_timeout")]
-    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
-    #[serde(rename = "scrape_target_timeout_secs")]
-    #[configurable(metadata(docs::human_name = "Scrape Target Timeout"))]
+    #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
+    #[serde(rename = "scrape_timeout")]
+    #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
     pub target_timeout: Duration,
 
     /// Custom parameters for the HTTP request query string.

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -62,7 +62,7 @@ pub struct HttpClientConfig {
     /// The timeout for each scrape request.
     #[serde(default = "default_target_timeout")]
     #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
-    #[serde(rename = "scrape_timeout")]
+    #[serde(rename = "scrape_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
     pub target_timeout: Duration,
 

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -61,7 +61,7 @@ pub struct HttpClientConfig {
 
     /// The timeout for each scrape request, in seconds.
     #[serde(default = "default_target_timeout")]
-    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[serde(rename = "scrape_target_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Target Timeout"))]
     pub target_timeout: Duration,

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -20,8 +20,8 @@ use crate::{
     sources::util::{
         http::HttpMethod,
         http_client::{
-            build_url, call, default_interval, default_target_timeout, GenericHttpClientInputs,
-            HttpClientBuilder,
+            build_url, call, default_interval, default_target_timeout, warn_if_interval_too_low,
+            GenericHttpClientInputs, HttpClientBuilder,
         },
     },
     tls::{TlsConfig, TlsSettings},
@@ -202,13 +202,7 @@ impl SourceConfig for HttpClientConfig {
             log_namespace,
         };
 
-        if self.target_timeout > self.interval {
-            warn!(
-                interval_secs = %self.interval.as_secs_f64(),
-                target_timeout_secs = %self.target_timeout.as_secs_f64(),
-                message = "Having a scrape timeout that exceeds the scrape interval can lead to excessive resource consumption.",
-            );
-        }
+        warn_if_interval_too_low(self.target_timeout, self.interval);
 
         let inputs = GenericHttpClientInputs {
             urls,

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -20,7 +20,7 @@ use crate::{
     sources::util::{
         http::HttpMethod,
         http_client::{
-            build_url, call, default_interval, default_target_timeout, warn_if_interval_too_low,
+            build_url, call, default_interval, default_timeout, warn_if_interval_too_low,
             GenericHttpClientInputs, HttpClientBuilder,
         },
     },
@@ -60,11 +60,11 @@ pub struct HttpClientConfig {
     pub interval: Duration,
 
     /// The timeout for each scrape request.
-    #[serde(default = "default_target_timeout")]
+    #[serde(default = "default_timeout")]
     #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
     #[serde(rename = "scrape_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
-    pub target_timeout: Duration,
+    pub timeout: Duration,
 
     /// Custom parameters for the HTTP request query string.
     ///
@@ -161,7 +161,7 @@ impl Default for HttpClientConfig {
             endpoint: "http://localhost:9898/logs".to_string(),
             query: HashMap::new(),
             interval: default_interval(),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             decoding: default_decoding(),
             framing: default_framing_message_based(),
             headers: HashMap::new(),
@@ -202,12 +202,12 @@ impl SourceConfig for HttpClientConfig {
             log_namespace,
         };
 
-        warn_if_interval_too_low(self.target_timeout, self.interval);
+        warn_if_interval_too_low(self.timeout, self.interval);
 
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,
-            target_timeout: self.target_timeout,
+            timeout: self.timeout,
             headers: self.headers.clone(),
             content_type,
             auth: self.auth.clone(),

--- a/src/sources/http_client/integration_tests.rs
+++ b/src/sources/http_client/integration_tests.rs
@@ -19,7 +19,7 @@ use codecs::decoding::DeserializerConfig;
 use vector_core::config::log_schema;
 
 use super::{
-    tests::{run_compliance, INTERVAL},
+    tests::{run_compliance, INTERVAL, TIMEOUT},
     HttpClientConfig,
 };
 
@@ -53,6 +53,7 @@ async fn invalid_endpoint() {
     run_error(HttpClientConfig {
         endpoint: "http://nope".to_string(),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: default_decoding(),
         framing: default_framing_message_based(),
@@ -71,6 +72,7 @@ async fn collected_logs_bytes() {
     let events = run_compliance(HttpClientConfig {
         endpoint: format!("{}/logs/bytes", dufs_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Bytes,
         framing: default_framing_message_based(),
@@ -95,6 +97,7 @@ async fn collected_logs_json() {
     let events = run_compliance(HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),
@@ -119,6 +122,7 @@ async fn collected_metrics_native_json() {
     let events = run_compliance(HttpClientConfig {
         endpoint: format!("{}/metrics/native.json", dufs_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::NativeJson(Default::default()),
         framing: default_framing_message_based(),
@@ -148,6 +152,7 @@ async fn collected_trace_native_json() {
     let events = run_compliance(HttpClientConfig {
         endpoint: format!("{}/traces/native.json", dufs_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::NativeJson(Default::default()),
         framing: default_framing_message_based(),
@@ -172,6 +177,7 @@ async fn unauthorized_no_auth() {
     run_error(HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_auth_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),
@@ -190,6 +196,7 @@ async fn unauthorized_wrong_auth() {
     run_error(HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_auth_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),
@@ -211,6 +218,7 @@ async fn authorized() {
     run_compliance(HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_auth_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),
@@ -232,6 +240,7 @@ async fn tls_invalid_ca() {
     run_error(HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_https_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),
@@ -253,6 +262,7 @@ async fn tls_valid() {
     run_compliance(HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_https_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),
@@ -275,6 +285,7 @@ async fn shutdown() {
     let source = HttpClientConfig {
         endpoint: format!("{}/logs/json.json", dufs_address()),
         interval: INTERVAL,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: default_framing_message_based(),

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -16,7 +16,7 @@ use crate::test_util::{
 
 pub(crate) const INTERVAL: Duration = Duration::from_secs(1);
 
-pub(crate) const TARGET_TIMEOUT: Duration = Duration::from_secs(1);
+pub(crate) const TIMEOUT: Duration = Duration::from_secs(1);
 
 /// The happy path should yield at least one event and must emit the required internal events for sources.
 pub(crate) async fn run_compliance(config: HttpClientConfig) -> Vec<Event> {
@@ -49,7 +49,7 @@ async fn bytes_decoding() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
-        target_timeout: TARGET_TIMEOUT,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: default_decoding(),
         framing: default_framing_message_based(),
@@ -78,7 +78,7 @@ async fn json_decoding_newline_delimited() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
-        target_timeout: TARGET_TIMEOUT,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: FramingConfig::NewlineDelimited(Default::default()),
@@ -107,7 +107,7 @@ async fn json_decoding_character_delimited() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
-        target_timeout: TARGET_TIMEOUT,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig {
@@ -140,7 +140,7 @@ async fn request_query_applied() {
     let events = run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint?key1=val1", in_addr),
         interval: INTERVAL,
-        target_timeout: TARGET_TIMEOUT,
+        timeout: TIMEOUT,
         query: HashMap::from([
             ("key1".to_string(), vec!["val2".to_string()]),
             (
@@ -209,7 +209,7 @@ async fn headers_applied() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
-        target_timeout: TARGET_TIMEOUT,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: default_decoding(),
         framing: default_framing_message_based(),
@@ -241,7 +241,7 @@ async fn accept_header_override() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
-        target_timeout: TARGET_TIMEOUT,
+        timeout: TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Bytes,
         framing: default_framing_message_based(),

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -16,6 +16,8 @@ use crate::test_util::{
 
 pub(crate) const INTERVAL: Duration = Duration::from_secs(1);
 
+pub(crate) const TARGET_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// The happy path should yield at least one event and must emit the required internal events for sources.
 pub(crate) async fn run_compliance(config: HttpClientConfig) -> Vec<Event> {
     let events =
@@ -47,6 +49,7 @@ async fn bytes_decoding() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
+        target_timeout: TARGET_TIMEOUT,
         query: HashMap::new(),
         decoding: default_decoding(),
         framing: default_framing_message_based(),
@@ -75,6 +78,7 @@ async fn json_decoding_newline_delimited() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
+        target_timeout: TARGET_TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: FramingConfig::NewlineDelimited(Default::default()),
@@ -103,6 +107,7 @@ async fn json_decoding_character_delimited() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
+        target_timeout: TARGET_TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Json(Default::default()),
         framing: FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig {
@@ -135,6 +140,7 @@ async fn request_query_applied() {
     let events = run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint?key1=val1", in_addr),
         interval: INTERVAL,
+        target_timeout: TARGET_TIMEOUT,
         query: HashMap::from([
             ("key1".to_string(), vec!["val2".to_string()]),
             (
@@ -203,6 +209,7 @@ async fn headers_applied() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
+        target_timeout: TARGET_TIMEOUT,
         query: HashMap::new(),
         decoding: default_decoding(),
         framing: default_framing_message_based(),
@@ -234,6 +241,7 @@ async fn accept_header_override() {
     run_compliance(HttpClientConfig {
         endpoint: format!("http://{}/endpoint", in_addr),
         interval: INTERVAL,
+        target_timeout: TARGET_TIMEOUT,
         query: HashMap::new(),
         decoding: DeserializerConfig::Bytes,
         framing: default_framing_message_based(),

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -64,7 +64,7 @@ pub struct PrometheusScrapeConfig {
     /// The timeout for each scrape request.
     #[serde(default = "default_target_timeout")]
     #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
-    #[serde(rename = "scrape_timeout")]
+    #[serde(rename = "scrape_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
     target_timeout: Duration,
 

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -11,7 +11,7 @@ use vector_core::{config::LogNamespace, event::Event};
 
 use super::parser;
 use crate::sources::util::http::HttpMethod;
-use crate::sources::util::http_client::default_target_timeout;
+use crate::sources::util::http_client::{default_target_timeout, warn_if_interval_too_low};
 use crate::{
     config::{GenerateConfig, SourceConfig, SourceContext, SourceOutput},
     http::Auth,
@@ -152,13 +152,7 @@ impl SourceConfig for PrometheusScrapeConfig {
             endpoint_tag: self.endpoint_tag.clone(),
         };
 
-        if self.target_timeout > self.interval {
-            warn!(
-                interval_secs = %self.interval.as_secs_f64(),
-                target_timeout_secs = %self.target_timeout.as_secs_f64(),
-                message = "Having a scrape timeout that exceeds the scrape interval can lead to excessive resource consumption.",
-            );
-        }
+        warn_if_interval_too_low(self.target_timeout, self.interval);
 
         let inputs = GenericHttpClientInputs {
             urls,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -63,7 +63,7 @@ pub struct PrometheusScrapeConfig {
 
     /// The timeout for each scrape request, in seconds.
     #[serde(default = "default_target_timeout")]
-    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
     #[serde(rename = "scrape_target_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Target Timeout"))]
     target_timeout: Duration,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -773,6 +773,7 @@ mod integration_tests {
         let config = PrometheusScrapeConfig {
             endpoints: vec!["http://prometheus:9090/metrics".into()],
             interval: Duration::from_secs(1),
+            timeout: Duration::from_secs(1),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: false,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -11,7 +11,7 @@ use vector_core::{config::LogNamespace, event::Event};
 
 use super::parser;
 use crate::sources::util::http::HttpMethod;
-use crate::sources::util::http_client::{default_target_timeout, warn_if_interval_too_low};
+use crate::sources::util::http_client::{default_timeout, warn_if_interval_too_low};
 use crate::{
     config::{GenerateConfig, SourceConfig, SourceContext, SourceOutput},
     http::Auth,
@@ -62,11 +62,11 @@ pub struct PrometheusScrapeConfig {
     interval: Duration,
 
     /// The timeout for each scrape request.
-    #[serde(default = "default_target_timeout")]
+    #[serde(default = "default_timeout")]
     #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
     #[serde(rename = "scrape_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
-    target_timeout: Duration,
+    timeout: Duration,
 
     /// The tag name added to each event representing the scraped instance's `host:port`.
     ///
@@ -122,7 +122,7 @@ impl GenerateConfig for PrometheusScrapeConfig {
         toml::Value::try_from(Self {
             endpoints: vec!["http://localhost:9090/metrics".to_string()],
             interval: default_interval(),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: false,
@@ -152,12 +152,12 @@ impl SourceConfig for PrometheusScrapeConfig {
             endpoint_tag: self.endpoint_tag.clone(),
         };
 
-        warn_if_interval_too_low(self.target_timeout, self.interval);
+        warn_if_interval_too_low(self.timeout, self.interval);
 
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,
-            target_timeout: self.target_timeout,
+            timeout: self.timeout,
             headers: HashMap::new(),
             content_type: "text/plain".to_string(),
             auth: self.auth.clone(),
@@ -363,7 +363,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: true,
@@ -397,7 +397,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: true,
@@ -449,7 +449,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: false,
@@ -515,7 +515,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: true,
@@ -571,7 +571,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics?key1=val1", in_addr)],
             interval: Duration::from_secs(1),
-            target_timeout: default_target_timeout(),
+            timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
             honor_labels: false,
@@ -685,7 +685,7 @@ mod test {
                 honor_labels: false,
                 query: HashMap::new(),
                 interval: Duration::from_secs(1),
-                target_timeout: default_target_timeout(),
+                timeout: default_timeout(),
                 tls: None,
                 auth: None,
             },

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -54,7 +54,9 @@ pub struct PrometheusScrapeConfig {
     #[serde(alias = "hosts")]
     endpoints: Vec<String>,
 
-    /// The interval between scrapes. Requests run concurrently.
+    /// The interval between scrapes. Requests are run concurrently so if a scrape takes longer
+    /// than the interval a new scrape will be started. This can take extra resources, set the timeout
+    /// to a value lower than the scrape interval to prevent this from happening.
     #[serde(default = "default_interval")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(rename = "scrape_interval_secs")]

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -54,18 +54,18 @@ pub struct PrometheusScrapeConfig {
     #[serde(alias = "hosts")]
     endpoints: Vec<String>,
 
-    /// The interval between scrapes, in seconds.
+    /// The interval between scrapes. Requests run concurrently.
     #[serde(default = "default_interval")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(rename = "scrape_interval_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     interval: Duration,
 
-    /// The timeout for each scrape request, in seconds.
+    /// The timeout for each scrape request.
     #[serde(default = "default_target_timeout")]
     #[serde_as(as = "serde_with:: DurationSecondsWithFrac<f64>")]
-    #[serde(rename = "scrape_target_timeout_secs")]
-    #[configurable(metadata(docs::human_name = "Scrape Target Timeout"))]
+    #[serde(rename = "scrape_timeout")]
+    #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
     target_timeout: Duration,
 
     /// The tag name added to each event representing the scraped instance's `host:port`.

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -152,6 +152,14 @@ impl SourceConfig for PrometheusScrapeConfig {
             endpoint_tag: self.endpoint_tag.clone(),
         };
 
+        if self.target_timeout > self.interval {
+            warn!(
+                interval_secs = %self.interval.as_secs_f64(),
+                target_timeout_secs = %self.target_timeout.as_secs_f64(),
+                message = "Having a scrape timeout that exceeds the scrape interval can lead to excessive resource consumption.",
+            );
+        }
+
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -37,7 +37,7 @@ pub(crate) struct GenericHttpClientInputs {
     /// Interval between calls.
     pub interval: Duration,
     /// Timeout for the HTTP request.
-    pub target_timeout: Duration,
+    pub timeout: Duration,
     /// Map of Header+Value to apply to HTTP request.
     pub headers: HashMap<String, Vec<String>>,
     /// Content type of the HTTP request, determined by the source.
@@ -54,7 +54,7 @@ pub(crate) const fn default_interval() -> Duration {
 }
 
 /// The default timeout for the HTTP request if none is configured.
-pub(crate) const fn default_target_timeout() -> Duration {
+pub(crate) const fn default_timeout() -> Duration {
     Duration::from_secs(5)
 }
 
@@ -176,14 +176,14 @@ pub(crate) async fn call<
             }
 
             let start = Instant::now();
-            tokio::time::timeout(inputs.target_timeout, client.send(request))
+            tokio::time::timeout(inputs.timeout, client.send(request))
                 .then(move |result| async move {
                     match result {
                         Ok(Ok(response)) => Ok(response),
                         Ok(Err(error)) => Err(error.into()),
                         Err(_) => Err(format!(
                             "Timeout error: request exceeded {}s",
-                            inputs.target_timeout.as_secs_f64()
+                            inputs.timeout.as_secs_f64()
                         )
                         .into()),
                     }

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -108,6 +108,17 @@ pub(crate) fn build_url(uri: &Uri, query: &HashMap<String, Vec<String>>) -> Uri 
         .expect("Failed to build URI from parsed arguments")
 }
 
+/// Warns if the scrape timeout is greater than the scrape interval.
+pub(crate) fn warn_if_interval_too_low(timeout: Duration, interval: Duration) {
+    if timeout > interval {
+        warn!(
+            interval_secs = %interval.as_secs_f64(),
+            timeout_secs = %timeout.as_secs_f64(),
+            message = "Having a scrape timeout that exceeds the scrape interval can lead to excessive resource consumption.",
+        );
+    }
+}
+
 /// Calls one or more urls at an interval.
 ///   - The HTTP request is built per the options in provided generic inputs.
 ///   - The HTTP response is decoded/parsed into events by the specific context.

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -36,6 +36,8 @@ pub(crate) struct GenericHttpClientInputs {
     pub urls: Vec<Uri>,
     /// Interval between calls.
     pub interval: Duration,
+    /// Timeout for the HTTP request.
+    pub target_timeout: Duration,
     /// Map of Header+Value to apply to HTTP request.
     pub headers: HashMap<String, Vec<String>>,
     /// Content type of the HTTP request, determined by the source.
@@ -52,7 +54,9 @@ pub(crate) const fn default_interval() -> Duration {
 }
 
 /// The default timeout for the HTTP request if none is configured.
-const DEFAULT_TARGET_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const fn default_target_timeout() -> Duration {
+    Duration::from_secs(5)
+}
 
 /// Builds the context, allowing the source-specific implementation to leverage data from the
 /// config and the current HTTP request.
@@ -160,7 +164,7 @@ pub(crate) async fn call<
             }
 
             let start = Instant::now();
-            let timeout = std::cmp::min(DEFAULT_TARGET_TIMEOUT, inputs.interval);
+            let timeout = std::cmp::min(inputs.target_timeout, inputs.interval);
             tokio::time::timeout(timeout, client.send(request))
                 .then(move |result| async move {
                     match result {

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -121,15 +121,16 @@ pub(crate) async fn call<
     mut out: SourceSender,
     http_method: HttpMethod,
 ) -> Result<(), ()> {
+    // Building the HttpClient should not fail as it is just setting up the client with the
+    // proxy and tls settings.
+    let client =
+        HttpClient::new(inputs.tls.clone(), &inputs.proxy).expect("Building HTTP client failed");
     let mut stream = IntervalStream::new(tokio::time::interval(inputs.interval))
         .take_until(inputs.shutdown)
         .map(move |_| stream::iter(inputs.urls.clone()))
         .flatten()
         .map(move |url| {
-            // Building the HttpClient should not fail as it is just setting up the client with the
-            // proxy and tls settings.
-            let client = HttpClient::new(inputs.tls.clone(), &inputs.proxy)
-                .expect("Building HTTP client failed");
+            let client = client.clone();
             let endpoint = url.to_string();
 
             let context_builder = context_builder.clone();

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -165,15 +165,14 @@ pub(crate) async fn call<
             }
 
             let start = Instant::now();
-            let timeout = std::cmp::min(inputs.target_timeout, inputs.interval);
-            tokio::time::timeout(timeout, client.send(request))
+            tokio::time::timeout(inputs.target_timeout, client.send(request))
                 .then(move |result| async move {
                     match result {
                         Ok(Ok(response)) => Ok(response),
                         Ok(Err(error)) => Err(error.into()),
                         Err(_) => Err(format!(
                             "Timeout error: request exceeded {}s",
-                            timeout.as_secs_f32()
+                            inputs.target_timeout.as_secs_f64()
                         )
                         .into()),
                     }

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -309,10 +309,18 @@ base: components: sources: http_client: configuration: {
 		}
 	}
 	scrape_interval_secs: {
-		description: "The interval between calls."
+		description: "The interval between scrapes. Requests run concurrently."
 		required:    false
 		type: uint: {
 			default: 15
+			unit:    "seconds"
+		}
+	}
+	scrape_timeout: {
+		description: "The timeout for each scrape request."
+		required:    false
+		type: float: {
+			default: 5.0
 			unit:    "seconds"
 		}
 	}

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -316,7 +316,7 @@ base: components: sources: http_client: configuration: {
 			unit:    "seconds"
 		}
 	}
-	scrape_timeout: {
+	scrape_timeout_secs: {
 		description: "The timeout for each scrape request."
 		required:    false
 		type: float: {

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -309,8 +309,12 @@ base: components: sources: http_client: configuration: {
 		}
 	}
 	scrape_interval_secs: {
-		description: "The interval between scrapes. Requests run concurrently."
-		required:    false
+		description: """
+			The interval between scrapes. Requests are run concurrently so if a scrape takes longer
+			than the interval a new scrape will be started. This can take extra resources, set the timeout
+			to a value lower than the scrape interval to prevent this from happening.
+			"""
+		required: false
 		type: uint: {
 			default: 15
 			unit:    "seconds"

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -104,8 +104,12 @@ base: components: sources: prometheus_scrape: configuration: {
 		}
 	}
 	scrape_interval_secs: {
-		description: "The interval between scrapes. Requests run concurrently."
-		required:    false
+		description: """
+			The interval between scrapes. Requests are run concurrently so if a scrape takes longer
+			than the interval a new scrape will be started. This can take extra resources, set the timeout
+			to a value lower than the scrape interval to prevent this from happening.
+			"""
+		required: false
 		type: uint: {
 			default: 15
 			unit:    "seconds"

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -111,7 +111,7 @@ base: components: sources: prometheus_scrape: configuration: {
 			unit:    "seconds"
 		}
 	}
-	scrape_timeout: {
+	scrape_timeout_secs: {
 		description: "The timeout for each scrape request."
 		required:    false
 		type: float: {

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -104,10 +104,18 @@ base: components: sources: prometheus_scrape: configuration: {
 		}
 	}
 	scrape_interval_secs: {
-		description: "The interval between scrapes, in seconds."
+		description: "The interval between scrapes. Requests run concurrently."
 		required:    false
 		type: uint: {
 			default: 15
+			unit:    "seconds"
+		}
+	}
+	scrape_timeout: {
+		description: "The timeout for each scrape request."
+		required:    false
+		type: float: {
+			default: 5.0
 			unit:    "seconds"
 		}
 	}


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

fixes #14087 
fixes #14132 
fixes #17659

- [x] make target timeout configurable

this builds on what @wjordan did in https://github.com/vectordotdev/vector/pull/17660

### what's changed
- prometheus scrapes happen concurrently
- requests to targets can timeout
- the timeout can be configured (user facing change)
- small change in how the http was instantiated