### PR TITLE
chore(dev): Install dd-rust-license-tool from crates.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ When deprecating functionality in Vector, see [DEPRECATION.md](DEPRECATION.md).
 
 When adding, modifying, or removing a dependency in Vector you may find that you need to update the
 inventory of third-party licenses maintained in `LICENSE-3rdparty.csv`. This file is generated using
-[rust-license-tool](https://github.com/DataDog/rust-license-tool.git) and can be updated using
+[dd-rust-license-tool](https://github.com/DataDog/rust-license-tool.git) and can be updated using
 `cargo vdev build licenses`.
 
 ## Next steps

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -124,7 +124,7 @@ Loosely, you'll need the following:
 - **To run `make test`:** Install [`cargo-nextest`](https://nexte.st/)
 - **To run integration tests:** Have `docker` available, or a real live version of that service. (Use `AUTOSPAWN=false`)
 - **To run `make check-component-features`:** Have `remarshal` installed.
-- **To run `make check-licenses` or `cargo vdev build licenses`:** Have `rust-license-tool` [installed](https://github.com/DataDog/rust-license-tool).
+- **To run `make check-licenses` or `cargo vdev build licenses`:** Have `dd-rust-license-tool` [installed](https://github.com/DataDog/rust-license-tool).
 - **To run `cargo vdev build component-docs`:** Have `cue` [installed](https://cuelang.org/docs/install/).
 
 If you find yourself needing to run something inside the Docker environment described above, that's totally fine, they won't collide or hurt each other. In this case, you'd just run `make environment-generate`.

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -17,8 +17,8 @@ fi
 if ! cargo deny --version >& /dev/null ; then
   rustup run stable cargo install cargo-deny --force --locked
 fi
-if ! rust-license-tool --help >& /dev/null ; then
-  cargo install --git https://github.com/DataDog/rust-license-tool
+if ! dd-rust-license-tool --help >& /dev/null ; then
+  rustup run stable cargo install dd-rust-license-tool --version 1.0.1 --force --locked
 fi
 
 # Currently fixing this to version 0.30 since version 0.31 has introduced

--- a/vdev/src/commands/build/licenses.rs
+++ b/vdev/src/commands/build/licenses.rs
@@ -9,6 +9,6 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec("rust-license-tool", ["write"], true)
+        app::exec("dd-rust-license-tool", ["write"], true)
     }
 }

--- a/vdev/src/commands/check/licenses.rs
+++ b/vdev/src/commands/check/licenses.rs
@@ -9,7 +9,7 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        app::exec("rust-license-tool", ["check"], true).map_err(|err| {
+        app::exec("dd-rust-license-tool", ["check"], true).map_err(|err| {
             info!("Run `cargo vdev build licenses` to regenerate the file");
             err
         })


### PR DESCRIPTION
And update vdev as well as the docs to use the new binary name.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>