### PR TITLE
fix(sinks): spike out encoding events before batching

### DIFF
--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -1,11 +1,20 @@
-use std::io;
+use std::{fmt, io, num::NonZeroUsize, sync::Arc};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use chrono::Utc;
 use codecs::encoding::Framer;
+use futures::StreamExt;
+use futures_util::stream::BoxStream;
+use tokio_util::codec::Encoder as _;
+use tower::Service;
 use uuid::Uuid;
-use vector_common::request_metadata::RequestMetadata;
-use vector_core::event::Finalizable;
+use vector_common::request_metadata::{GroupedCountByteSize, RequestMetadata};
+use vector_core::{
+    event::Finalizable,
+    partition::Partitioner,
+    stream::{BatcherSettings, DriverResponse},
+    ByteSizeOf,
+};
 
 use crate::{
     codecs::{Encoder, Transformer},
@@ -13,15 +22,170 @@ use crate::{
     sinks::{
         s3_common::{
             config::S3Options,
-            partitioner::S3PartitionKey,
+            partitioner::{S3KeyPartitioner, S3PartitionKey},
             service::{S3Metadata, S3Request},
         },
         util::{
             metadata::RequestMetadataBuilder, request_builder::EncodeResult, Compression,
-            RequestBuilder,
+            RequestBuilder, SinkBuilderExt,
         },
     },
 };
+
+struct NewS3Sink<Svc> {
+    service: Svc,
+    partitioner: S3KeyPartitioner,
+    transformer: Transformer,
+    framer: Framer,
+    serializer: codecs::encoding::Serializer,
+    batcher_settings: BatcherSettings,
+    options: S3RequestOptions,
+}
+
+struct EncodedEvent {
+    inner: Event,
+    encoded: BytesMut,
+}
+
+// hack to reuse this trait for encoded size
+impl ByteSizeOf for EncodedEvent {
+    fn size_of(&self) -> usize {
+        self.allocated_bytes()
+    }
+
+    fn allocated_bytes(&self) -> usize {
+        self.encoded.len()
+    }
+}
+
+struct WrappedPartitioner(S3KeyPartitioner);
+
+impl Partitioner for WrappedPartitioner {
+    type Item = EncodedEvent;
+    type Key = Option<S3PartitionKey>;
+
+    fn partition(&self, item: &Self::Item) -> Self::Key {
+        self.0.partition(&item.inner)
+    }
+}
+
+impl<Svc> NewS3Sink<Svc>
+where
+    Svc: Service<S3Request> + Send + 'static,
+    Svc::Future: Send + 'static,
+    Svc::Response: DriverResponse + Send + 'static,
+    Svc::Error: fmt::Debug + Into<crate::Error> + Send,
+{
+    async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let transformer = self.transformer;
+        let mut serializer = self.serializer;
+        let partitioner = WrappedPartitioner(self.partitioner);
+        let service = self.service;
+        let framer = Arc::new(self.framer);
+        let batcher_settings = self.batcher_settings;
+        let options = Arc::new(self.options);
+
+        let combined_encoder = Arc::new(Encoder::<Framer>::new(
+            framer.as_ref().clone(),
+            serializer.clone(),
+        ));
+
+        let builder_limit = NonZeroUsize::new(64);
+
+        input
+            .map(|event| {
+                let mut to_encode = event.clone();
+                transformer.transform(&mut to_encode);
+
+                let mut encoded = BytesMut::new();
+                serializer.encode(to_encode, &mut encoded).unwrap();
+
+                EncodedEvent {
+                    inner: event,
+                    encoded,
+                }
+            })
+            .batched_partitioned(partitioner, batcher_settings)
+            .filter_map(|(key, batch)| async move { key.map(move |k| (k, batch)) })
+            .concurrent_map(builder_limit, move |(partition_key, encoded_events)| {
+                let framer = Arc::clone(&framer);
+                let combined_encoder = Arc::clone(&combined_encoder);
+                let options = Arc::clone(&options);
+
+                Box::pin(async move {
+                    // This is silly because we really just need the prefix, delimiter, and suffix. Oh well.
+                    let mut framer = framer.as_ref().clone();
+
+                    let mut grouped_sizes = GroupedCountByteSize::new_tagged();
+                    let mut events = Vec::with_capacity(encoded_events.len());
+                    let mut encoded = Vec::with_capacity(encoded_events.len());
+                    for e in encoded_events {
+                        grouped_sizes.add_event(&e.inner, e.encoded.len().into());
+                        events.push(e.inner);
+                        encoded.push(e.encoded);
+                    }
+
+                    // TODO: this doesn't include framing, is that right?
+                    let events_encoded_size = encoded.iter().map(BytesMut::len).sum::<usize>();
+
+                    let finalizers = events.take_finalizers();
+                    let s3_key_prefix = partition_key.key_prefix.clone();
+
+                    let metadata = S3Metadata {
+                        partition_key,
+                        s3_key: s3_key_prefix,
+                        finalizers,
+                    };
+
+                    // TODO: not doing compression yet
+                    let mut payload = BytesMut::new();
+                    payload.extend_from_slice(combined_encoder.batch_prefix());
+                    let mut remaining = encoded.len();
+                    for buf in encoded {
+                        payload.extend_from_slice(buf.as_ref());
+                        remaining -= 1;
+                        if remaining > 0 {
+                            // write the frame delimiter
+                            framer.encode((), &mut payload).expect("framing to bytes");
+                        }
+                    }
+                    payload.extend_from_slice(combined_encoder.batch_suffix());
+
+                    let request_metadata = RequestMetadata::new(
+                        events.len(),
+                        events_encoded_size,
+                        payload.len(),
+                        // TODO: same since no compression yet
+                        payload.len(),
+                        // TODO: just using encoded size here, not sure if we still need to estimate?
+                        grouped_sizes,
+                    );
+
+                    options.build_request(
+                        metadata,
+                        request_metadata,
+                        EncodeResult::uncompressed(payload.freeze()),
+                    )
+                })
+            })
+            .into_driver(service)
+            .run()
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl<Svc> vector_core::sink::StreamSink<Event> for NewS3Sink<Svc>
+where
+    Svc: Service<S3Request> + Send + 'static,
+    Svc::Future: Send + 'static,
+    Svc::Response: DriverResponse + Send + 'static,
+    Svc::Error: fmt::Debug + Into<crate::Error> + Send,
+{
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        self.run_inner(input).await
+    }
+}
 
 #[derive(Clone)]
 pub struct S3RequestOptions {

--- a/src/sinks/s3_common/partitioner.rs
+++ b/src/sinks/s3_common/partitioner.rs
@@ -18,13 +18,8 @@ impl S3KeyPartitioner {
     ) -> Self {
         Self(key_prefix_template, ssekms_key_id_template)
     }
-}
 
-impl Partitioner for S3KeyPartitioner {
-    type Item = Event;
-    type Key = Option<S3PartitionKey>;
-
-    fn partition(&self, item: &Self::Item) -> Self::Key {
+    pub fn partition(&self, item: &Event) -> Option<S3PartitionKey> {
         let key_prefix = self
             .0
             .render_string(item)
@@ -54,5 +49,14 @@ impl Partitioner for S3KeyPartitioner {
             key_prefix,
             ssekms_key_id,
         })
+    }
+}
+
+impl Partitioner for S3KeyPartitioner {
+    type Item = Event;
+    type Key = Option<S3PartitionKey>;
+
+    fn partition(&self, item: &Self::Item) -> Self::Key {
+        self.partition(item)
     }
 }


### PR DESCRIPTION
**DO NOT MERGE**: This is still missing at least a few important features.

# The problem

Vector currently does batching by using the in-memory size of events (via the `ByteSizeOf` trait), regardless of the encoding that the sink will actually use to write out those events. This is potentially useful if you care about managing Vector's memory use (though somewhat indirect), but surprisingly inaccurate if you're trying to affect the size of the sink's actual output.

For example, a simple config of `demo_logs` with `json` formatting piped into the `aws_s3` sink will result in 4MB objects (uncompressed) despite a batch size setting of 10MB. Metrics can have a large swing in the other direction due to struct field names not taking up any space in memory, but being a meaningful part of a JSON payload, for example. In general, the issue is heavily data-dependent, but there is very significant impact in many straightforward use cases.

# How it works today

The flow of the `aws_s3` and many similar sinks is roughly as follows:

1. The `PartitionedBatcher` turns the input stream of `Event`s into a stream of `(Key, Vec<Event>)`, using the provided batch settings and `ByteSizeOf` to calculate the size of each event. 
2. We concurrently map those incoming batches into actual requests via the `RequestBuilder` trait:
	1. Metadata is split out from the events themselves
	2. The events are encoded all at once into the request payload (kind of, see below)
	3. The full request is built from the metadata and the payload

The encoding stage in step 2.2 is somewhat complex, and we actually serialize each event into a new byte buffer before actually writing it to the final payload. This appears to be done primarily so that we can track the actual number of bytes being written for instrumentation purposes. 

# This PR

In this spike we experiment with pulling parts of the encoding stage up in the pipeline, before the partitioner, so that we can use the actual correct encoded size to build batches accurately (i.e. relative to what we will output, not the in-memory size). This doesn't fit into the current trait structure (e.g. `RequestBuilder`), so there's some messiness in the implementation that we could clean up if we decide this is a viable path forward.

To do this, we take a bit of a shortcut in that we keep both the original event and the encoded version together (the new `EncodedEvent`) and pass them along the pipeline for a while. This is probably not optimal from a memory-use perspective, but limited the amount of rework that needed to be done to prove the concept. An interesting alternative would be to precompute only what is needed downstream (e.g. partition keys, keys for tagging metrics, other semantically meaningful fields for request building) and pass that along instead of the full original event.

The main thing missing from the current implementation is compression, due to some very thorny compiler errors that popped up when I tried to add it. These issues were likely due to the relatively complex state of the spike (lots of nested async and chaining), and shouldn't prove to be a problem if we choose to move forward and properly factor the code.

# Open questions

1. How big of a deal is this? From one angle, it seems to be a serious correctness issue that needs to be addressed. On the other hand, it's not clear what, if any, guarantees we make about batching configuration and request sizes. The best argument that this is a serious bug is sinks like Datadog Logs not being able to respect hard limits on the target API, causing errors for users. Does that mean we need to fix this at all costs for all sinks?
2. Is there any performance impact from moving event encoding out of a concurrent stage? Would we need to take additional steps to encode chunks of events concurrently prior to batching? Related to the previous question, what kind of hit is acceptable?
3. We calculate a lot of different numbers about events flowing through a sink (e.g. byte size of events, estimated JSON size of events, pre-compression request size, post-compression request size), but which ones are important? Do we care about the in-memory size of events flowing through sinks despite the fact that they don't really represent the data in the way the user sees it (i.e. encoded)? Why do we estimate the JSON size of events at all, and should we replace use of that with the actual encoded size, or is there something special about JSON that we always want it even if we end up using a different encoding?
4. How much overlap is there here with `IncrementalRequestBuilder`? It seems designed to be able to split requests that are too large, which could be enough to solve for hard API failures like Datadog Logs, but does not seem like it'd help at all with use cases like S3 objects being too small. If we do make a larger change, should it replace this version as well?