### PR TITLE
chore(deps): Upgrade debian usages to use bookworm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -294,6 +294,7 @@ jobs:
           - ubuntu:23.04
           - debian:10
           - debian:11
+          - debian:12
     container:
       image: ${{ matrix.container }}
     steps:

--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-slim AS builder
+FROM docker.io/debian:bookworm-slim AS builder
 
 WORKDIR /vector
 
@@ -7,7 +7,7 @@ RUN dpkg -i vector_*_"$(dpkg --print-architecture)".deb
 
 RUN mkdir -p /var/lib/vector
 
-FROM docker.io/debian:bullseye-slim
+FROM docker.io/debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
 

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-slim AS builder
+FROM docker.io/debian:bookworm-slim AS builder
 
 WORKDIR /vector
 

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # TARGET
 #
-FROM docker.io/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dedea30abcd8f584b23d583ec6dadc7
+FROM docker.io/debian:bookworm-slim@sha256:01bd742e2c269abf94e2fefb47b08b5b61c9a880b993417d23a1d0bd9fa60dc4
 RUN apt-get update && apt-get dist-upgrade -y && apt-get -y --no-install-recommends install zlib1g ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=lading /usr/bin/lading /usr/local/bin/lading
 COPY --from=builder /vector/vector /usr/local/bin/vector

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -9,8 +9,19 @@ apt-get install -y \
   gnupg \
   wget
 
+# we need LLVM >= 3.9 for onig_sys/bindgen
+
+cat <<-EOF > /etc/apt/sources.list.d/llvm.list
+deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
+deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
+EOF
+
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+
+apt-get update
+
 # needed by onig_sys
 apt-get install -y \
-      libclang1-14 \
-      llvm-14 \
+      libclang1-9 \
+      llvm-9 \
       unzip

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -9,19 +9,8 @@ apt-get install -y \
   gnupg \
   wget
 
-# we need LLVM >= 3.9 for onig_sys/bindgen
-
-cat <<-EOF > /etc/apt/sources.list.d/llvm.list
-deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
-deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
-EOF
-
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
-
-apt-get update
-
 # needed by onig_sys
 apt-get install -y \
-      libclang1-9 \
-      llvm-9 \
+      libclang1-14 \
+      llvm-14 \
       unzip

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_VERSION
-FROM docker.io/rust:${RUST_VERSION}-slim-bullseye
+FROM docker.io/rust:${RUST_VERSION}-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     curl \
     g++ \
-    libclang1-14 \
+    libclang1 \
     libsasl2-dev \
     libssl-dev \
-    llvm-14 \
+    llvm \
     pkg-config \
     zlib1g-dev \
     unzip \

--- a/scripts/integration/Dockerfile
+++ b/scripts/integration/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     curl \
     g++ \
-    libclang1-9 \
+    libclang1-14 \
     libsasl2-dev \
     libssl-dev \
-    llvm-9 \
+    llvm-14 \
     pkg-config \
     zlib1g-dev \
     unzip \

--- a/tests/data/dnstap/Dockerfile
+++ b/tests/data/dnstap/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:bullseye
+FROM docker.io/library/debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_VERSION
-ARG DEBIAN_RELEASE=bullseye
+ARG DEBIAN_RELEASE=bookworm
 # Features required for both Agent and Aggregator Helm chart configurations
 ARG FEATURES=api,api-client,sources-datadog_agent,sources-fluent,sources-host_metrics,sources-internal_metrics,sources-kubernetes_logs,sources-logstash,sources-splunk_hec,sources-statsd,sources-syslog,sources-vector,sinks-console,sinks-prometheus,sinks-vector
 


### PR DESCRIPTION
Released in June. Prompted by https://github.com/vectordotdev/vector/issues/16673#issuecomment-1645602002

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
