### PR TITLE
feat: Migrate LogSchema::metadata key to new lookup code

### DIFF
--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -73,7 +73,7 @@ pub struct LogSchema {
     /// Generally, this field will be set by Vector to hold event-specific metadata, such as
     /// annotations by the `remap` transform when an error or abort is encountered.
     #[serde(default = "LogSchema::default_metadata_key")]
-    metadata_key: String,
+    metadata_key: OptionalValuePath,
 }
 
 impl Default for LogSchema {
@@ -105,8 +105,8 @@ impl LogSchema {
         OptionalValuePath::new(SOURCE_TYPE)
     }
 
-    fn default_metadata_key() -> String {
-        String::from(METADATA)
+    fn default_metadata_key() -> OptionalValuePath {
+        OptionalValuePath::new(METADATA)
     }
 
     pub fn message_key(&self) -> Option<&OwnedValuePath> {
@@ -134,8 +134,8 @@ impl LogSchema {
         self.source_type_key.path.as_ref()
     }
 
-    pub fn metadata_key(&self) -> &str {
-        &self.metadata_key
+    pub fn metadata_key(&self) -> Option<&OwnedValuePath> {
+        self.metadata_key.path.as_ref()
     }
 
     pub fn set_message_key(&mut self, path: Option<OwnedValuePath>) {
@@ -154,8 +154,8 @@ impl LogSchema {
         self.source_type_key = OptionalValuePath { path };
     }
 
-    pub fn set_metadata_key(&mut self, v: String) {
-        self.metadata_key = v;
+    pub fn set_metadata_key(&mut self, path: Option<OwnedValuePath>) {
+        self.metadata_key = OptionalValuePath { path };
     }
 
     /// Merge two `LogSchema` instances together.
@@ -202,7 +202,7 @@ impl LogSchema {
             {
                 errors.push("conflicting values for 'log_schema.metadata_key' found".to_owned());
             } else {
-                self.set_metadata_key(other.metadata_key().to_string());
+                self.set_metadata_key(other.metadata_key().cloned());
             }
         }
 

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -6,6 +6,10 @@ use vector_config::configurable_component;
 static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
 static LOG_SCHEMA_DEFAULT: Lazy<LogSchema> = Lazy::new(LogSchema::default);
 
+const MESSAGE: &str = "message";
+const TIMESTAMP: &str = "timestamp";
+const HOST: &str = "host";
+const SOURCE_TYPE: &str = "source_type";
 const METADATA: &str = "metadata";
 
 /// Loads Log Schema from configurations and sets global schema. Once this is

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -6,10 +6,6 @@ use vector_config::configurable_component;
 static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
 static LOG_SCHEMA_DEFAULT: Lazy<LogSchema> = Lazy::new(LogSchema::default);
 
-const MESSAGE: &str = "message";
-const TIMESTAMP: &str = "timestamp";
-const HOST: &str = "host";
-const SOURCE_TYPE: &str = "source_type";
 const METADATA: &str = "metadata";
 
 /// Loads Log Schema from configurations and sets global schema. Once this is

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -348,6 +348,8 @@ impl LogEvent {
         }
     }
 
+    // TODO Refactor: change the `value` argument to function to avoid unnecessary value instantiations.
+    // https://github.com/vectordotdev/vector/issues/18059
     pub fn maybe_insert(
         &mut self,
         prefix: PathPrefix,

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -348,8 +348,6 @@ impl LogEvent {
         }
     }
 
-    // TODO Refactor: change the `value` argument to function to avoid unnecessary value instantiations.
-    // https://github.com/vectordotdev/vector/issues/18059
     pub fn maybe_insert(
         &mut self,
         prefix: PathPrefix,

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -86,7 +86,7 @@ impl TraceEvent {
     }
 
     // TODO This should eventually use TargetPath for the `key` parameter.
-    // https://github.com/vectordotdev/vector/issues/7070
+    // https://github.com/vectordotdev/vector/issues/18059
     pub fn insert(
         &mut self,
         key: impl AsRef<str>,
@@ -96,7 +96,7 @@ impl TraceEvent {
     }
 
     // TODO Audit code and use this if possible.
-    // https://github.com/vectordotdev/vector/issues/7070
+    // https://github.com/vectordotdev/vector/issues/18059
     pub fn maybe_insert<'a, F: FnOnce() -> Value>(
         &mut self,
         prefix: PathPrefix,

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -19,6 +19,8 @@ use vrl::compiler::runtime::{Runtime, Terminate};
 use vrl::compiler::state::ExternalEnv;
 use vrl::compiler::{CompileConfig, ExpressionError, Function, Program, TypeState, VrlRuntime};
 use vrl::diagnostic::{DiagnosticMessage, Formatter, Note};
+use vrl::path;
+use vrl::path::ValuePath;
 use vrl::value::{Kind, Value};
 
 use crate::config::OutputId;
@@ -450,11 +452,12 @@ where
         match event {
             Event::Log(ref mut log) => match log.namespace() {
                 LogNamespace::Legacy => {
-                    log.maybe_insert(
-                        PathPrefix::Event,
-                        log_schema().metadata_key(),
-                        self.dropped_data(reason, error),
-                    );
+                    if let Some(metadata_key) = log_schema().metadata_key() {
+                        log.insert(
+                            (PathPrefix::Event, metadata_key.concat(path!("dropped"))),
+                            self.dropped_data(reason, error),
+                        );
+                    }
                 }
                 LogNamespace::Vector => {
                     log.insert(

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -7,8 +7,7 @@ use std::{
 };
 
 use codecs::MetricTagValues;
-use lookup::lookup_v2::ValuePath;
-use lookup::{metadata_path, owned_value_path, path, PathPrefix};
+use lookup::{metadata_path, owned_value_path, PathPrefix};
 use snafu::{ResultExt, Snafu};
 use vector_common::TimeZone;
 use vector_config::configurable_component;
@@ -451,12 +450,11 @@ where
         match event {
             Event::Log(ref mut log) => match log.namespace() {
                 LogNamespace::Legacy => {
-                    if let Some(metadata_key) = log_schema().metadata_key() {
-                        log.insert(
-                            (PathPrefix::Event, metadata_key.concat(path!("dropped"))),
-                            self.dropped_data(reason, error),
-                        );
-                    }
+                    log.maybe_insert(
+                        PathPrefix::Event,
+                        log_schema().metadata_key(),
+                        self.dropped_data(reason, error),
+                    );
                 }
                 LogNamespace::Vector => {
                     log.insert(

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -486,9 +486,9 @@ where
                 }
             }
             Event::Trace(ref mut trace) => {
-                if let Some(metadata_key) = log_schema().metadata_key() {
-                    trace.insert(metadata_key.to_string(), self.dropped_data(reason, error));
-                }
+                trace.maybe_insert(PathPrefix::Event, log_schema().metadata_key(), || {
+                    self.dropped_data(reason, error).into()
+                });
             }
         }
     }


### PR DESCRIPTION
## Motivation
This part of https://github.com/vectordotdev/vector/issues/13033 and https://github.com/vectordotdev/vector/issues/7070.

## Summary
* Change the `metadata_key` type to `OptionalValuePath`.
* This completes the LogSchema changes.