### PR TITLE
fix(sinks/gcp/pubsub.rs): remove pubsub log only restriction

### DIFF
--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -330,7 +330,7 @@ mod integration_tests {
             let data = messages[i].message.decode_data();
             let data = serde_json::to_value(data).unwrap();
             //let expected = serde_json::to_value(input[i].as_metric());
-            let expected = serde_json::to_value(input[i].as_log().all_fields().unwrap()).unwrap();
+            let expected = serde_json::to_value(input[i].as_metric()).unwrap();
             assert_eq!(data, expected);
         }
     }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -144,7 +144,7 @@ impl SinkConfig for PubsubConfig {
     }
 
     fn input(&self) -> Input {
-        Input::new(self.encoding.config().input_type() & DataType::Log)
+        Input::new(self.encoding.config().input_type() )
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -469,5 +469,4 @@ mod integration_tests {
         timestamp: String,
         message: String,
     }
-
 }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -329,7 +329,6 @@ mod integration_tests {
         for i in 0..input.len() {
             let data = messages[i].message.decode_data();
             let data = serde_json::to_value(data).unwrap();
-            //let expected = serde_json::to_value(input[i].as_metric());
             let expected = serde_json::to_value(input[i].as_metric()).unwrap();
             assert_eq!(data, expected);
         }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -334,6 +334,7 @@ mod integration_tests {
             assert_eq!(data, expected);
         }
     }
+    
     #[tokio::test]
     async fn publish_events() {
         trace_init();


### PR DESCRIPTION
Looks like the pubsub sink was restricted to logs only as part of a wide change, but does not need to be. This simply removes that restiction.  