### PR TITLE
chore(deps): Update tokio-util fork to 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8527,8 +8527,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
-source = "git+https://github.com/vectordotdev/tokio?branch=tokio-util-0.7.4-framed-read-continue-on-error#53a17f257b599a9d18bd75249de98d0b6fc28cfa"
+version = "0.7.8"
+source = "git+https://github.com/vectordotdev/tokio?branch=tokio-util-0.7.8-framed-read-continue-on-error#3747655f8f0443e13fe20da3f613ea65c23347c2"
 dependencies = [
  "bytes 1.4.0",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,7 +376,7 @@ zstd = { version = "0.12.4", default-features = false }
 # https://github.com/chronotope/chrono/pull/578
 chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.26-no-default-time-1" }
 # The upgrade for `tokio-util` >= 0.6.9 is blocked on https://github.com/vectordotdev/vector/issues/11257.
-tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-util-0.7.4-framed-read-continue-on-error" }
+tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-util-0.7.8-framed-read-continue-on-error" }
 nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/musl" }
 # The `heim` crates depend on `ntapi` 0.3.7 on Windows, but that version has an
 # unaligned access bug fixed in the following revision.


### PR DESCRIPTION
Prompted by https://github.com/vectordotdev/vector/issues/11257#issuecomment-1649238963

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
