### PR TITLE
chore(docs): Add spec for `listen` option

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -84,6 +84,22 @@ representing multiple endpoints. If a component uses multiple options to
 automatically build the endpoint, then the `endpoint(s)` option MUST
 override that process.
 
+#### `listen`
+
+When a component listens for incoming connections, it SHOULD expose a `listen` option that takes
+a `string` representing an address with `<protocol>:<address>`.
+
+Options for `protocol` are:
+
+- `unix+stream`, where `address` should be a file path
+- `unix+datagram`, where `address` should be a file path
+- `unix`, same as `unix+stream`
+- `tcp`, where `address` should be `<host>:<port>`
+- `udp`, where `address` should be `<host>:<port>`
+
+Components MAY have a default protocol. For example, a `statsd` component may default the protocol
+to `udp` and only require the `<host>:<port>` to bind to.
+
 ## Instrumentation
 
 **Extends the [Instrumentation Specification].**

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -86,7 +86,7 @@ override that process.
 
 #### `listen`
 
-When a component listens for incoming connections, it SHOULD expose a `listen` option that takes
+When a component listens for incoming connections, it SHOULD expose a `listen` configuration option that takes
 a `string` representing an address with `<protocol>:<address>`.
 
 Options for `protocol` are:


### PR DESCRIPTION
Creating partially as a strawman to push this conversation forward.

In https://github.com/vectordotdev/vector/pull/8858#discussion_r695992243 we attempted to codify the option name to use for addresses on which Vector components listen on. We couldn't come to a consensus then, so the change was backed out. Here I reintroduce a proposal. I considered both `bind` and `listen` and decided in `listen` mostly due to the fact that it seems to match more with socket terminology where `bind` just allocates the address and `listen` actually starts passively listening for clients (and then `accept` accepts a new connection).

Some prior art from other tools to consider:

* FluentD: `bind` and `port`
* Nginx: `listen`
* Apache HTTPD: `listen`
* OpenTelemetry Collector: `endpoint` for both binding and transmitting
* Fluent-Bit: `listen`
* Logstash: `host` and `port`
* Filebeat: `listen_address` and `listen_port`
* Telegraf: `service_address`

Closes: https://github.com/vectordotdev/vector/issues/8877