### PR TITLE
feat: replace LogEvent 'String's with '&OwnedTargetPath's

### DIFF
--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -1,7 +1,8 @@
-use lookup::lookup_v2::OptionalValuePath;
+use lookup::lookup_v2::{OptionalTargetPath, OptionalValuePath};
 use lookup::{OwnedTargetPath, OwnedValuePath};
 use once_cell::sync::{Lazy, OnceCell};
 use vector_config::configurable_component;
+use vrl::path::PathPrefix;
 
 static LOG_SCHEMA: OnceCell<LogSchema> = OnceCell::new();
 static LOG_SCHEMA_DEFAULT: Lazy<LogSchema> = Lazy::new(LogSchema::default);
@@ -49,24 +50,24 @@ pub struct LogSchema {
     ///
     /// This would be the field that holds the raw message, such as a raw log line.
     #[serde(default = "LogSchema::default_message_key")]
-    message_key: OptionalValuePath,
+    message_key: OptionalTargetPath,
 
     /// The name of the event field to treat as the event timestamp.
     #[serde(default = "LogSchema::default_timestamp_key")]
-    timestamp_key: OptionalValuePath,
+    timestamp_key: OptionalTargetPath,
 
     /// The name of the event field to treat as the host which sent the message.
     ///
     /// This field will generally represent a real host, or container, that generated the message,
     /// but is somewhat source-dependent.
     #[serde(default = "LogSchema::default_host_key")]
-    host_key: OptionalValuePath,
+    host_key: OptionalTargetPath,
 
     /// The name of the event field to set the source identifier in.
     ///
     /// This field will be set by the Vector source that the event was created in.
     #[serde(default = "LogSchema::default_source_type_key")]
-    source_type_key: OptionalValuePath,
+    source_type_key: OptionalTargetPath,
 
     /// The name of the event field to set the event metadata in.
     ///
@@ -89,20 +90,20 @@ impl Default for LogSchema {
 }
 
 impl LogSchema {
-    fn default_message_key() -> OptionalValuePath {
-        OptionalValuePath::new(MESSAGE)
+    fn default_message_key() -> OptionalTargetPath {
+        OptionalTargetPath::event(MESSAGE)
     }
 
-    fn default_timestamp_key() -> OptionalValuePath {
-        OptionalValuePath::new(TIMESTAMP)
+    fn default_timestamp_key() -> OptionalTargetPath {
+        OptionalTargetPath::event(TIMESTAMP)
     }
 
-    fn default_host_key() -> OptionalValuePath {
-        OptionalValuePath::new(HOST)
+    fn default_host_key() -> OptionalTargetPath {
+        OptionalTargetPath::event(HOST)
     }
 
-    fn default_source_type_key() -> OptionalValuePath {
-        OptionalValuePath::new(SOURCE_TYPE)
+    fn default_source_type_key() -> OptionalTargetPath {
+        OptionalTargetPath::event(SOURCE_TYPE)
     }
 
     fn default_metadata_key() -> OptionalValuePath {
@@ -110,7 +111,7 @@ impl LogSchema {
     }
 
     pub fn message_key(&self) -> Option<&OwnedValuePath> {
-        self.message_key.path.as_ref()
+        self.message_key.path.as_ref().map(|key| &key.path)
     }
 
     /// Returns an `OwnedTargetPath` of the message key.
@@ -119,39 +120,59 @@ impl LogSchema {
     /// This should only be used where the result will either be cached,
     /// or performance isn't critical, since this requires parsing / memory allocation.
     pub fn owned_message_path(&self) -> OwnedTargetPath {
-        OwnedTargetPath::event(self.message_key.clone().path.expect("valid message key"))
+        self.message_key
+            .path
+            .as_ref()
+            .expect("valid message key")
+            .clone()
     }
 
     pub fn timestamp_key(&self) -> Option<&OwnedValuePath> {
-        self.timestamp_key.path.as_ref()
+        self.timestamp_key.as_ref().map(|key| &key.path)
     }
 
     pub fn host_key(&self) -> Option<&OwnedValuePath> {
-        self.host_key.path.as_ref()
+        self.host_key.as_ref().map(|key| &key.path)
     }
 
     pub fn source_type_key(&self) -> Option<&OwnedValuePath> {
-        self.source_type_key.path.as_ref()
+        self.source_type_key.as_ref().map(|key| &key.path)
     }
 
     pub fn metadata_key(&self) -> Option<&OwnedValuePath> {
         self.metadata_key.path.as_ref()
     }
 
-    pub fn set_message_key(&mut self, path: Option<OwnedValuePath>) {
-        self.message_key = OptionalValuePath { path };
+    pub fn message_key_target_path(&self) -> Option<&OwnedTargetPath> {
+        self.message_key.as_ref()
     }
 
-    pub fn set_timestamp_key(&mut self, v: Option<OwnedValuePath>) {
-        self.timestamp_key = OptionalValuePath { path: v };
+    pub fn timestamp_key_target_path(&self) -> Option<&OwnedTargetPath> {
+        self.timestamp_key.as_ref()
+    }
+
+    pub fn host_key_target_path(&self) -> Option<&OwnedTargetPath> {
+        self.host_key.as_ref()
+    }
+
+    pub fn source_type_key_target_path(&self) -> Option<&OwnedTargetPath> {
+        self.source_type_key.as_ref()
+    }
+
+    pub fn set_message_key(&mut self, path: Option<OwnedValuePath>) {
+        self.message_key = OptionalTargetPath::from(PathPrefix::Event, path);
+    }
+
+    pub fn set_timestamp_key(&mut self, path: Option<OwnedValuePath>) {
+        self.timestamp_key = OptionalTargetPath::from(PathPrefix::Event, path);
     }
 
     pub fn set_host_key(&mut self, path: Option<OwnedValuePath>) {
-        self.host_key = OptionalValuePath { path };
+        self.host_key = OptionalTargetPath::from(PathPrefix::Event, path);
     }
 
     pub fn set_source_type_key(&mut self, path: Option<OwnedValuePath>) {
-        self.source_type_key = OptionalValuePath { path };
+        self.source_type_key = OptionalTargetPath::from(PathPrefix::Event, path);
     }
 
     pub fn set_metadata_key(&mut self, path: Option<OwnedValuePath>) {

--- a/lib/vector-core/src/config/log_schema.rs
+++ b/lib/vector-core/src/config/log_schema.rs
@@ -118,7 +118,7 @@ impl LogSchema {
     /// This parses the path and will panic if it is invalid.
     ///
     /// This should only be used where the result will either be cached,
-    /// or performance isn't critical, since this requires parsing / memory allocation.
+    /// or performance isn't critical, since this requires memory allocation.
     pub fn owned_message_path(&self) -> OwnedTargetPath {
         self.message_key
             .path

--- a/lib/vector-lookup/src/lookup_v2/optional_path.rs
+++ b/lib/vector-lookup/src/lookup_v2/optional_path.rs
@@ -1,5 +1,6 @@
 use vector_config::configurable_component;
 use vrl::owned_value_path;
+use vrl::path::PathPrefix;
 
 use crate::lookup_v2::PathParseError;
 use crate::{OwnedTargetPath, OwnedValuePath};
@@ -15,6 +16,25 @@ pub struct OptionalTargetPath {
 impl OptionalTargetPath {
     pub fn none() -> Self {
         Self { path: None }
+    }
+
+    pub fn event(path: &str) -> Self {
+        Self {
+            path: Some(OwnedTargetPath {
+                prefix: PathPrefix::Event,
+                path: owned_value_path!(path),
+            }),
+        }
+    }
+
+    pub fn from(prefix: PathPrefix, path: Option<OwnedValuePath>) -> Self {
+        Self {
+            path: path.map(|path| OwnedTargetPath { prefix, path }),
+        }
+    }
+
+    pub fn as_ref(&self) -> Option<&OwnedTargetPath> {
+        self.path.as_ref()
     }
 }
 

--- a/src/sinks/datadog/events/sink.rs
+++ b/src/sinks/datadog/events/sink.rs
@@ -58,25 +58,26 @@ async fn ensure_required_fields(event: Event) -> Option<Event> {
     if !log.contains("text") {
         let message_path = log
             .message_path()
-            .expect("message is required (make sure the \"message\" semantic meaning is set)");
-        log.rename_key(message_path.as_str(), event_path!("text"))
+            .expect("message is required (make sure the \"message\" semantic meaning is set)")
+            .clone();
+        log.rename_key(&message_path, event_path!("text"));
     }
 
     if !log.contains("host") {
-        if let Some(host_path) = log.host_path() {
-            log.rename_key(host_path.as_str(), event_path!("host"));
+        if let Some(host_path) = log.host_path().cloned().as_ref() {
+            log.rename_key(host_path, event_path!("host"));
         }
     }
 
     if !log.contains("date_happened") {
-        if let Some(timestamp_path) = log.timestamp_path() {
-            log.rename_key(timestamp_path.as_str(), "date_happened");
+        if let Some(timestamp_path) = log.timestamp_path().cloned().as_ref() {
+            log.rename_key(timestamp_path, "date_happened");
         }
     }
 
     if !log.contains("source_type_name") {
-        if let Some(source_type_path) = log.source_type_path() {
-            log.rename_key(source_type_path.as_str(), "source_type_name")
+        if let Some(source_type_path) = log.source_type_path().cloned().as_ref() {
+            log.rename_key(source_type_path, "source_type_name");
         }
     }
 

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -134,19 +134,21 @@ impl crate::sinks::util::encoding::Encoder<Vec<Event>> for JsonEncoding {
             let log = event.as_mut_log();
             let message_path = log
                 .message_path()
-                .expect("message is required (make sure the \"message\" semantic meaning is set)");
-            log.rename_key(message_path.as_str(), event_path!("message"));
+                .expect("message is required (make sure the \"message\" semantic meaning is set)")
+                .clone();
+            log.rename_key(&message_path, event_path!("message"));
 
-            if let Some(host_path) = log.host_path() {
-                log.rename_key(host_path.as_str(), event_path!("hostname"));
+            if let Some(host_path) = log.host_path().cloned().as_ref() {
+                log.rename_key(host_path, event_path!("hostname"));
             }
 
-            if let Some(Value::Timestamp(ts)) = log.remove(
-                log
+            let message_path = log
                 .timestamp_path()
-                .expect("timestamp is required (make sure the \"timestamp\" semantic meaning is set)")
-                .as_str()
-            ) {
+                .expect(
+                    "timestamp is required (make sure the \"timestamp\" semantic meaning is set)",
+                )
+                .clone();
+            if let Some(Value::Timestamp(ts)) = log.remove(&message_path) {
                 log.insert(
                     event_path!("timestamp"),
                     Value::Integer(ts.timestamp_millis()),

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -355,15 +355,12 @@ impl DataStreamConfig {
 
     /// If there is a `timestamp` field, rename it to the expected `@timestamp` for Elastic Common Schema.
     pub fn remap_timestamp(&self, log: &mut LogEvent) {
-        if let Some(timestamp_key) = log.timestamp_path() {
-            if timestamp_key == DATA_STREAM_TIMESTAMP_KEY {
+        if let Some(timestamp_key) = log.timestamp_path().cloned() {
+            if timestamp_key.to_string() == DATA_STREAM_TIMESTAMP_KEY {
                 return;
             }
 
-            log.rename_key(
-                timestamp_key.as_str(),
-                event_path!(DATA_STREAM_TIMESTAMP_KEY),
-            )
+            log.rename_key(&timestamp_key, event_path!(DATA_STREAM_TIMESTAMP_KEY));
         }
     }
 

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -253,12 +253,15 @@ impl HttpEventEncoder<PartitionInnerBuffer<serde_json::Value, PartitionKey>> for
 
         let line = log
             .message_path()
-            .and_then(|path| log.remove(path.as_str()))
+            .cloned()
+            .as_ref()
+            .and_then(|path| log.remove(path))
             .unwrap_or_else(|| String::from("").into());
 
         let timestamp: Value = log
             .timestamp_path()
-            .and_then(|path| log.remove(path.as_str()))
+            .cloned()
+            .and_then(|path| log.remove(&path))
             .unwrap_or_else(|| chrono::Utc::now().into());
 
         let mut map = serde_json::map::Map::new();

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -143,12 +143,12 @@ fn map_timestamp(mut events: EventArray) -> EventArray {
     match &mut events {
         EventArray::Logs(logs) => {
             for log in logs {
-                if let Some(path) = log.timestamp_path() {
-                    log.rename_key(path.as_str(), "@timestamp");
+                if let Some(path) = log.timestamp_path().cloned().as_ref() {
+                    log.rename_key(path, "@timestamp");
                 }
 
-                if let Some(path) = log.host_path() {
-                    log.rename_key(path.as_str(), "os.host");
+                if let Some(path) = log.host_path().cloned().as_ref() {
+                    log.rename_key(path, "os.host");
                 }
             }
         }


### PR DESCRIPTION
## Motivation
The lookup migration involves eliminating `String`s in favor of other types can convert to a `TargetPath`.
This part of https://github.com/vectordotdev/vector/issues/7070 and specifically https://github.com/vectordotdev/vector/issues/18059.

## Summary
* This PR focuses on `LogEvent` path lookups.
* Unifies the path retrieval API in `LogEvent`. Regardless of the log namespacing, a `&OwnedTargetPath` is returned.
* Supporting `Legacy` namespaces creates some friction: 
     * Existing `LogSchema` accessors still return the _value_ path. I also added new _target_ path accessors.
     * Eliminated string conversions and copies deep in the code. However, accessing paths later might require cloning the target path in some contexts.
     * When `Legacy` namespace code is deleted, these inefficiencies will go away.