### PR TITLE
chore: replace various string paths with actual paths

### DIFF
--- a/benches/event.rs
+++ b/benches/event.rs
@@ -44,8 +44,8 @@ fn benchmark_event_iterate(c: &mut Criterion) {
         b.iter_batched_ref(
             || {
                 let mut log = LogEvent::default();
-                log.insert(event_path!("key1", "nested1", "0"), Bytes::from("value1"));
-                log.insert(event_path!("key1", "nested1", "1"), Bytes::from("value2"));
+                log.insert(event_path!("key1", "nested1", 0), Bytes::from("value1"));
+                log.insert(event_path!("key1", "nested1", 1), Bytes::from("value2"));
                 log
             },
             |e| e.all_fields().unwrap().count(),

--- a/benches/event.rs
+++ b/benches/event.rs
@@ -83,7 +83,7 @@ fn benchmark_event_create(c: &mut Criterion) {
     group.bench_function("array", |b| {
         b.iter(|| {
             let mut log = LogEvent::default();
-            log.insert(event_path!("key1", "nested1", "0"), Bytes::from("value1"));
+            log.insert(event_path!("key1", "nested1", 0), Bytes::from("value1"));
             log.insert(event_path!("key1", "nested1", "1"), Bytes::from("value2"));
         })
     });

--- a/benches/event.rs
+++ b/benches/event.rs
@@ -84,7 +84,7 @@ fn benchmark_event_create(c: &mut Criterion) {
         b.iter(|| {
             let mut log = LogEvent::default();
             log.insert(event_path!("key1", "nested1", 0), Bytes::from("value1"));
-            log.insert(event_path!("key1", "nested1", "1"), Bytes::from("value2"));
+            log.insert(event_path!("key1", "nested1", 1), Bytes::from("value2"));
         })
     });
 }

--- a/benches/event.rs
+++ b/benches/event.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use criterion::{criterion_group, BatchSize, Criterion};
 use vector::event::LogEvent;
+use vrl::event_path;
 
 fn benchmark_event_iterate(c: &mut Criterion) {
     let mut group = c.benchmark_group("event/iterate");
@@ -9,9 +10,9 @@ fn benchmark_event_iterate(c: &mut Criterion) {
         b.iter_batched_ref(
             || {
                 let mut log = LogEvent::default();
-                log.insert("key1", Bytes::from("value1"));
-                log.insert("key2", Bytes::from("value2"));
-                log.insert("key3", Bytes::from("value3"));
+                log.insert(event_path!("key1"), Bytes::from("value1"));
+                log.insert(event_path!("key2"), Bytes::from("value2"));
+                log.insert(event_path!("key3"), Bytes::from("value3"));
                 log
             },
             |e| e.all_fields().unwrap().count(),
@@ -23,9 +24,15 @@ fn benchmark_event_iterate(c: &mut Criterion) {
         b.iter_batched_ref(
             || {
                 let mut log = LogEvent::default();
-                log.insert("key1.nested1.nested2", Bytes::from("value1"));
-                log.insert("key1.nested1.nested3", Bytes::from("value4"));
-                log.insert("key3", Bytes::from("value3"));
+                log.insert(
+                    event_path!("key1", "nested1", "nested2"),
+                    Bytes::from("value1"),
+                );
+                log.insert(
+                    event_path!("key1", "nested1", "nested3"),
+                    Bytes::from("value4"),
+                );
+                log.insert(event_path!("key3"), Bytes::from("value3"));
                 log
             },
             |e| e.all_fields().unwrap().count(),
@@ -37,8 +44,8 @@ fn benchmark_event_iterate(c: &mut Criterion) {
         b.iter_batched_ref(
             || {
                 let mut log = LogEvent::default();
-                log.insert("key1.nested1[0]", Bytes::from("value1"));
-                log.insert("key1.nested1[1]", Bytes::from("value2"));
+                log.insert(event_path!("key1", "nested1", "0"), Bytes::from("value1"));
+                log.insert(event_path!("key1", "nested1", "1"), Bytes::from("value2"));
                 log
             },
             |e| e.all_fields().unwrap().count(),
@@ -53,25 +60,31 @@ fn benchmark_event_create(c: &mut Criterion) {
     group.bench_function("single-level", |b| {
         b.iter(|| {
             let mut log = LogEvent::default();
-            log.insert("key1", Bytes::from("value1"));
-            log.insert("key2", Bytes::from("value2"));
-            log.insert("key3", Bytes::from("value3"));
+            log.insert(event_path!("key1"), Bytes::from("value1"));
+            log.insert(event_path!("key2"), Bytes::from("value2"));
+            log.insert(event_path!("key3"), Bytes::from("value3"));
         })
     });
 
     group.bench_function("nested-keys", |b| {
         b.iter(|| {
             let mut log = LogEvent::default();
-            log.insert("key1.nested1.nested2", Bytes::from("value1"));
-            log.insert("key1.nested1.nested3", Bytes::from("value4"));
-            log.insert("key3", Bytes::from("value3"));
+            log.insert(
+                event_path!("key1", "nested1", "nested2"),
+                Bytes::from("value1"),
+            );
+            log.insert(
+                event_path!("key1", "nested1", "nested3"),
+                Bytes::from("value4"),
+            );
+            log.insert(event_path!("key3"), Bytes::from("value3"));
         })
     });
     group.bench_function("array", |b| {
         b.iter(|| {
             let mut log = LogEvent::default();
-            log.insert("key1.nested1[0]", Bytes::from("value1"));
-            log.insert("key1.nested1[1]", Bytes::from("value2"));
+            log.insert(event_path!("key1", "nested1", "0"), Bytes::from("value1"));
+            log.insert(event_path!("key1", "nested1", "1"), Bytes::from("value2"));
         })
     });
 }

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -9,6 +9,7 @@ use vector::{
     test_util::collect_ready,
     transforms::{self, OutputBuffer, Transform},
 };
+use vrl::event_path;
 
 fn bench_add_fields(c: &mut Criterion) {
     let event = Event::from(LogEvent::default());
@@ -87,7 +88,7 @@ fn bench_field_filter(c: &mut Criterion) {
     let events = (0..num_events)
         .map(|i| {
             let mut event = LogEvent::default();
-            event.insert("the_field", (i % 10).to_string());
+            event.insert(event_path!("the_field"), (i % 10).to_string());
             Event::from(event)
         })
         .collect::<Vec<_>>();

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -12,6 +12,7 @@ use vector::{
     },
 };
 use vector_common::TimeZone;
+use vrl::event_path;
 use vrl::prelude::*;
 
 criterion_group!(
@@ -35,9 +36,9 @@ fn benchmark_remap(c: &mut Criterion) {
         let result = outputs.take_primary();
         let output_1 = result.first().unwrap().as_log();
 
-        debug_assert_eq!(output_1.get("foo").unwrap().to_string_lossy(), "bar");
-        debug_assert_eq!(output_1.get("bar").unwrap().to_string_lossy(), "baz");
-        debug_assert_eq!(output_1.get("copy").unwrap().to_string_lossy(), "buz");
+        debug_assert_eq!(output_1.get(event_path!("foo")).unwrap().to_string_lossy(), "bar");
+        debug_assert_eq!(output_1.get(event_path!("bar")).unwrap().to_string_lossy(), "baz");
+        debug_assert_eq!(output_1.get(event_path!("copy")).unwrap().to_string_lossy(), "buz");
 
         result
     };
@@ -67,7 +68,9 @@ fn benchmark_remap(c: &mut Criterion) {
 
         let event = {
             let mut event = Event::Log(LogEvent::from("augment me"));
-            event.as_mut_log().insert("copy_from", "buz".to_owned());
+            event
+                .as_mut_log()
+                .insert(event_path!("copy_from"), "buz".to_owned());
             event
         };
 
@@ -88,11 +91,11 @@ fn benchmark_remap(c: &mut Criterion) {
         let output_1 = result.first().unwrap().as_log();
 
         debug_assert_eq!(
-            output_1.get("foo").unwrap().to_string_lossy(),
+            output_1.get(event_path!("foo")).unwrap().to_string_lossy(),
             r#"{"key": "value"}"#
         );
         debug_assert_eq!(
-            output_1.get("bar").unwrap().to_string_lossy(),
+            output_1.get(event_path!("bar")).unwrap().to_string_lossy(),
             r#"{"key":"value"}"#
         );
 
@@ -141,10 +144,10 @@ fn benchmark_remap(c: &mut Criterion) {
             let result = outputs.take_primary();
             let output_1 = result.first().unwrap().as_log();
 
-            debug_assert_eq!(output_1.get("number").unwrap(), &Value::Integer(1234));
-            debug_assert_eq!(output_1.get("bool").unwrap(), &Value::Boolean(true));
+            debug_assert_eq!(output_1.get(event_path!("number")).unwrap(), &Value::Integer(1234));
+            debug_assert_eq!(output_1.get(event_path!("bool")).unwrap(), &Value::Boolean(true));
             debug_assert_eq!(
-                output_1.get("timestamp").unwrap(),
+                output_1.get(event_path!("timestamp")).unwrap(),
                 &Value::Timestamp(timestamp),
             );
 
@@ -176,7 +179,7 @@ fn benchmark_remap(c: &mut Criterion) {
             ("bool", "yes"),
             ("timestamp", "19/06/2019:17:20:49 -0400"),
         ] {
-            event.as_mut_log().insert(key, value.to_owned());
+            event.as_mut_log().insert(event_path!(key), value.to_owned());
         }
 
         let timestamp =

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -36,9 +36,18 @@ fn benchmark_remap(c: &mut Criterion) {
         let result = outputs.take_primary();
         let output_1 = result.first().unwrap().as_log();
 
-        debug_assert_eq!(output_1.get(event_path!("foo")).unwrap().to_string_lossy(), "bar");
-        debug_assert_eq!(output_1.get(event_path!("bar")).unwrap().to_string_lossy(), "baz");
-        debug_assert_eq!(output_1.get(event_path!("copy")).unwrap().to_string_lossy(), "buz");
+        debug_assert_eq!(
+            output_1.get(event_path!("foo")).unwrap().to_string_lossy(),
+            "bar"
+        );
+        debug_assert_eq!(
+            output_1.get(event_path!("bar")).unwrap().to_string_lossy(),
+            "baz"
+        );
+        debug_assert_eq!(
+            output_1.get(event_path!("copy")).unwrap().to_string_lossy(),
+            "buz"
+        );
 
         result
     };
@@ -144,8 +153,14 @@ fn benchmark_remap(c: &mut Criterion) {
             let result = outputs.take_primary();
             let output_1 = result.first().unwrap().as_log();
 
-            debug_assert_eq!(output_1.get(event_path!("number")).unwrap(), &Value::Integer(1234));
-            debug_assert_eq!(output_1.get(event_path!("bool")).unwrap(), &Value::Boolean(true));
+            debug_assert_eq!(
+                output_1.get(event_path!("number")).unwrap(),
+                &Value::Integer(1234)
+            );
+            debug_assert_eq!(
+                output_1.get(event_path!("bool")).unwrap(),
+                &Value::Boolean(true)
+            );
             debug_assert_eq!(
                 output_1.get(event_path!("timestamp")).unwrap(),
                 &Value::Timestamp(timestamp),

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -17,6 +17,7 @@ use vrl::value::kind::Collection;
 use vrl::value::{Kind, Value};
 
 use super::{default_lossy, Deserializer};
+use crate::gelf::GELF_TARGET_PATHS;
 use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
 /// On GELF decoding behavior:
@@ -123,11 +124,11 @@ impl GelfDeserializer {
             .into());
         }
 
-        log.insert(VERSION, parsed.version.to_string());
-        log.insert(HOST, parsed.host.to_string());
+        log.insert(&GELF_TARGET_PATHS.version, parsed.version.to_string());
+        log.insert(&GELF_TARGET_PATHS.host, parsed.host.to_string());
 
         if let Some(full_message) = &parsed.full_message {
-            log.insert(FULL_MESSAGE, full_message.to_string());
+            log.insert(&GELF_TARGET_PATHS.full_message, full_message.to_string());
         }
 
         if let Some(timestamp_key) = log_schema().timestamp_key_target_path() {
@@ -145,19 +146,19 @@ impl GelfDeserializer {
         }
 
         if let Some(level) = parsed.level {
-            log.insert(LEVEL, level);
+            log.insert(&GELF_TARGET_PATHS.level, level);
         }
         if let Some(facility) = &parsed.facility {
-            log.insert(FACILITY, facility.to_string());
+            log.insert(&GELF_TARGET_PATHS.facility, facility.to_string());
         }
         if let Some(line) = parsed.line {
             log.insert(
-                LINE,
+                &GELF_TARGET_PATHS.line,
                 Value::Float(ordered_float::NotNan::new(line).expect("JSON doesn't allow NaNs")),
             );
         }
         if let Some(file) = &parsed.file {
-            log.insert(FILE, file.to_string());
+            log.insert(&GELF_TARGET_PATHS.file, file.to_string());
         }
 
         if let Some(add) = &parsed.additional_fields {

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -2,10 +2,11 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
+use vrl::owned_value_path;
+use vrl::path::OwnedTargetPath;
 
 /// GELF Message fields. Definitions from <https://docs.graylog.org/docs/gelf>.
 pub mod gelf_fields {
-
     /// (not a field) The latest version of the GELF specification.
     pub const GELF_VERSION: &str = "1.1";
 
@@ -39,6 +40,30 @@ pub mod gelf_fields {
 
     // < Every field with an underscore (_) prefix will be treated as an additional field. >
 }
+
+/// GELF owned target paths.
+pub(crate) struct GelfTargetPaths {
+    pub version: OwnedTargetPath,
+    pub host: OwnedTargetPath,
+    pub full_message: OwnedTargetPath,
+    pub level: OwnedTargetPath,
+    pub facility: OwnedTargetPath,
+    pub line: OwnedTargetPath,
+    pub file: OwnedTargetPath,
+    pub short_message: OwnedTargetPath,
+}
+
+/// Lazily initialized singleton.
+pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTargetPaths {
+    version: OwnedTargetPath::event(owned_value_path!(gelf_fields::VERSION)),
+    host: OwnedTargetPath::event(owned_value_path!(gelf_fields::HOST)),
+    full_message: OwnedTargetPath::event(owned_value_path!(gelf_fields::FULL_MESSAGE)),
+    level: OwnedTargetPath::event(owned_value_path!(gelf_fields::LEVEL)),
+    facility: OwnedTargetPath::event(owned_value_path!(gelf_fields::FACILITY)),
+    line: OwnedTargetPath::event(owned_value_path!(gelf_fields::LINE)),
+    file: OwnedTargetPath::event(owned_value_path!(gelf_fields::FILE)),
+    short_message: OwnedTargetPath::event(owned_value_path!(gelf_fields::SHORT_MESSAGE)),
+});
 
 /// Regex for matching valid field names. Must contain only word chars, periods and dashes.
 /// Additional field names must also be prefixed with an `_` , however that is intentionally

--- a/lib/vector-core/benches/event/log_event.rs
+++ b/lib/vector-core/benches/event/log_event.rs
@@ -6,6 +6,14 @@ use criterion::{
 use lookup::event_path;
 use vector_core::event::LogEvent;
 
+fn default_log_event() -> LogEvent {
+    let mut log_event = LogEvent::default();
+    log_event.insert(event_path!("one"), 1);
+    log_event.insert(event_path!("two"), 2);
+    log_event.insert(event_path!("three"), 3);
+    log_event
+}
+
 fn rename_key_flat(c: &mut Criterion) {
     let mut group: BenchmarkGroup<WallTime> =
         c.benchmark_group("vector_core::event::log_event::LogEvent::rename_key_flat");
@@ -13,13 +21,7 @@ fn rename_key_flat(c: &mut Criterion) {
 
     group.bench_function("rename_flat_key (key is present)", move |b| {
         b.iter_batched(
-            || {
-                let mut log_event = LogEvent::default();
-                log_event.insert("one", 1);
-                log_event.insert("two", 2);
-                log_event.insert("three", 3);
-                log_event
-            },
+            default_log_event,
             |mut log_event| {
                 log_event.rename_key(event_path!("one"), event_path!("1"));
             },
@@ -29,13 +31,7 @@ fn rename_key_flat(c: &mut Criterion) {
 
     group.bench_function("rename_flat_key (key is NOT present)", move |b| {
         b.iter_batched(
-            || {
-                let mut log_event = LogEvent::default();
-                log_event.insert("one", 1);
-                log_event.insert("two", 2);
-                log_event.insert("three", 3);
-                log_event
-            },
+            default_log_event,
             |mut log_event| {
                 log_event.rename_key(event_path!("four"), event_path!("4"));
             },

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -457,6 +457,7 @@ impl LogEvent {
     }
 
     /// Merge all fields specified at `fields` from `incoming` to `current`.
+    /// Note that `fields` containing dots and other special characters will be treated as a single segment.
     pub fn merge(&mut self, mut incoming: LogEvent, fields: &[impl AsRef<str>]) {
         for field in fields {
             let field_path = event_path!(field.as_ref());

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -754,33 +754,31 @@ impl From<&tracing::Event<'_>> for LogEvent {
     }
 }
 
+/// Note that `tracing::field::Field` containing dots and other special characters will be treated as a single segment.
 impl tracing::field::Visit for LogEvent {
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.parse_path_and_insert(field.as_ref(), value.to_string())
-            .ok();
+        self.insert(event_path!(field.name()), value.to_string());
     }
 
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn Debug) {
-        self.parse_path_and_insert(field.as_ref(), format!("{value:?}"))
-            .ok();
+        self.insert(event_path!(field.name()), format!("{value:?}"));
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.parse_path_and_insert(field.as_ref(), value).ok();
+        self.insert(event_path!(field.name()), value);
     }
 
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        let field_path = event_path!(field.name());
         let converted: Result<i64, _> = value.try_into();
         match converted {
-            Ok(value) => self.parse_path_and_insert(field.as_ref(), value).ok(),
-            Err(_) => self
-                .parse_path_and_insert(field.as_ref(), value.to_string())
-                .ok(),
+            Ok(value) => self.insert(field_path, value),
+            Err(_) => self.insert(field_path, value.to_string()),
         };
     }
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.parse_path_and_insert(field.as_ref(), value).ok();
+        self.insert(event_path!(field.name()), value);
     }
 }
 

--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -115,13 +115,12 @@ fn log_operation_maintains_size() {
             match action {
                 Action::InsertFlat { key, value } => {
                     let new_value_sz = value.size_of();
-                    let old_value_sz = log_event
-                        .get((PathPrefix::Event, path!(key.as_str())))
-                        .map_or(0, ByteSizeOf::size_of);
+                    let target_path = (PathPrefix::Event, path!(key.as_str()));
+                    let old_value_sz = log_event.get(target_path).map_or(0, ByteSizeOf::size_of);
                     if !log_event.contains(key.as_str()) {
                         current_size += key.size_of();
                     }
-                    log_event.insert((PathPrefix::Event, path!(&key)), value);
+                    log_event.insert(target_path, value);
                     current_size -= old_value_sz;
                     current_size += new_value_sz;
                 }

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -91,8 +91,8 @@ impl TraceEvent {
         self.0.get_mut(key)
     }
 
-    pub fn contains(&self, key: impl AsRef<str>) -> bool {
-        self.0.contains(key.as_ref())
+    pub fn contains<'a>(&self, key: impl TargetPath<'a>) -> bool {
+        self.0.contains(key)
     }
 
     pub fn insert<'a>(

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -191,7 +191,7 @@ impl Transformer {
                             }
                         }
                         for (k, v) in unix_timestamps {
-                            log.insert(k.as_str(), v);
+                            log.insert(event_path!(k.as_str()), v);
                         }
                     } else {
                         // root is not an object

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -191,7 +191,7 @@ impl Transformer {
                             }
                         }
                         for (k, v) in unix_timestamps {
-                            log.insert(event_path!(k.as_str()), v);
+                            log.parse_path_and_insert(k, v).unwrap();
                         }
                     } else {
                         // root is not an object

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -15,6 +15,7 @@ use tokio::sync::{
     Mutex,
 };
 use uuid::Uuid;
+use vrl::event_path;
 
 pub use self::unit_test_components::{
     UnitTestSinkCheck, UnitTestSinkConfig, UnitTestSinkResult, UnitTestSourceConfig,
@@ -572,7 +573,7 @@ fn build_input_event(input: &TestInput) -> Result<Event, String> {
                             NotNan::new(*f).map_err(|_| "NaN value not supported".to_string())?,
                         ),
                     };
-                    event.insert(path.as_str(), value);
+                    event.insert(event_path!(path.as_str()), value);
                 }
                 Ok(event.into())
             } else {

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -15,7 +15,6 @@ use tokio::sync::{
     Mutex,
 };
 use uuid::Uuid;
-use vrl::event_path;
 
 pub use self::unit_test_components::{
     UnitTestSinkCheck, UnitTestSinkConfig, UnitTestSinkResult, UnitTestSourceConfig,
@@ -573,7 +572,9 @@ fn build_input_event(input: &TestInput) -> Result<Event, String> {
                             NotNan::new(*f).map_err(|_| "NaN value not supported".to_string())?,
                         ),
                     };
-                    event.insert(event_path!(path.as_str()), value);
+                    event
+                        .parse_path_and_insert(path, value)
+                        .map_err(|e| e.to_string())?;
                 }
                 Ok(event.into())
             } else {

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -188,10 +188,7 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
         let line = input_lines.next().unwrap();
         let mut event = LogEvent::from(line.clone());
         event.insert(
-            (
-                lookup::PathPrefix::Event,
-                log_schema().timestamp_key().unwrap(),
-            ),
+            log_schema().timestamp_key_target_path().unwrap(),
             now + offset,
         );
         events.push(Event::Log(event));

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -154,13 +154,7 @@ mod tests {
         let timestamp = Utc::now();
         let message = "event message";
         let mut event = LogEvent::from(message);
-        event.insert(
-            (
-                lookup::PathPrefix::Event,
-                log_schema().timestamp_key().unwrap(),
-            ),
-            timestamp,
-        );
+        event.insert(log_schema().timestamp_key_target_path().unwrap(), timestamp);
 
         let request = request_builder.build(event.into()).unwrap();
         assert_eq!(request.timestamp, timestamp.timestamp_millis());

--- a/src/sinks/azure_monitor_logs.rs
+++ b/src/sinks/azure_monitor_logs.rs
@@ -488,11 +488,13 @@ mod tests {
     fn insert_timestamp_kv(log: &mut LogEvent) -> (String, String) {
         let now = chrono::Utc::now();
 
-        let timestamp_key = log_schema().timestamp_key().unwrap();
         let timestamp_value = now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-        log.insert((PathPrefix::Event, timestamp_key), now);
+        log.insert(log_schema().timestamp_key_target_path().unwrap(), now);
 
-        (timestamp_key.to_string(), timestamp_value)
+        (
+            log_schema().timestamp_key().unwrap().to_string(),
+            timestamp_value,
+        )
     }
 
     #[test]

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -223,15 +223,13 @@ mod tests {
 #[cfg(test)]
 #[cfg(feature = "humio-integration-tests")]
 mod integration_tests {
-    use std::{collections::HashMap, convert::TryFrom};
-
     use chrono::{TimeZone, Utc};
     use futures::{future::ready, stream};
     use indoc::indoc;
     use serde::Deserialize;
     use serde_json::{json, Value as JsonValue};
+    use std::{collections::HashMap, convert::TryFrom};
     use tokio::time::Duration;
-    use vrl::path::PathPrefix;
 
     use super::*;
     use crate::{
@@ -263,10 +261,7 @@ mod integration_tests {
         let message = random_string(100);
         let host = "192.168.1.1".to_string();
         let mut event = LogEvent::from(message.clone());
-        event.insert(
-            (PathPrefix::Event, log_schema().host_key().unwrap()),
-            host.clone(),
-        );
+        event.insert(log_schema().host_key_target_path().unwrap(), host.clone());
 
         let ts = Utc.timestamp_nanos(Utc::now().timestamp_millis() * 1_000_000 + 132_456);
         event.insert(log_schema().timestamp_key_target_path().unwrap(), ts);

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -4,6 +4,7 @@ use bytes::{Bytes, BytesMut};
 use futures::SinkExt;
 use http::{Request, Uri};
 use indoc::indoc;
+use vrl::event_path;
 use vrl::path::OwnedValuePath;
 use vrl::value::Kind;
 
@@ -280,7 +281,7 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         }
 
         self.tags.replace("metric_type".to_string());
-        log.insert("metric_type", "logs");
+        log.insert(event_path!("metric_type"), "logs");
 
         // Timestamp
         let timestamp = encode_timestamp(match log.remove_timestamp() {

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -7,6 +7,7 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_config::configurable_component;
+use vrl::event_path;
 use vrl::value::{kind::Collection, Kind};
 
 use super::util::framestream::{build_framestream_unix_source, FrameHandler};
@@ -280,7 +281,7 @@ impl FrameHandler for DnstapFrameHandler {
 
         if self.raw_data_only {
             log_event.insert(
-                self.schema.dnstap_root_data_schema().raw_data(),
+                event_path!(self.schema.dnstap_root_data_schema().raw_data()),
                 BASE64_STANDARD.encode(&frame),
             );
         } else if let Err(err) = parse_dnstap_data(&self.schema, &mut log_event, frame) {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -23,7 +23,6 @@ use rdkafka::{
 use serde_with::serde_as;
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::FramedRead;
-use vrl::path::PathPrefix;
 
 use vector_common::finalizer::OrderedFinalizer;
 use vector_config::configurable_component;
@@ -604,11 +603,8 @@ impl ReceivedMessage {
                     );
                 }
                 LogNamespace::Legacy => {
-                    if let Some(source_type_key) = log_schema().source_type_key() {
-                        log.insert(
-                            (PathPrefix::Event, source_type_key),
-                            KafkaSourceConfig::NAME,
-                        );
+                    if let Some(source_type_key) = log_schema().source_type_key_target_path() {
+                        log.insert(source_type_key, KafkaSourceConfig::NAME);
                     }
                 }
             }
@@ -924,7 +920,7 @@ mod integration_test {
     use tokio::time::sleep;
     use vector_buffers::topology::channel::BufferReceiver;
     use vector_core::event::EventStatus;
-    use vrl::value;
+    use vrl::{event_path, value};
 
     use super::{test::*, *};
     use crate::{
@@ -1132,7 +1128,7 @@ mod integration_test {
         let recv = BufferReceiver::new(recv.into()).into_stream();
         let recv = recv.then(move |mut events| async move {
             events.iter_logs_mut().for_each(|log| {
-                log.insert("pipeline_id", id.to_string());
+                log.insert(event_path!("pipeline_id"), id.to_string());
             });
             sleep(delay).await;
             events.iter_events_mut().for_each(|mut event| {

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -9,7 +9,7 @@ use std::{
 use bytes::{Buf, Bytes, BytesMut};
 use codecs::{BytesDeserializerConfig, StreamDecodingError};
 use flate2::read::ZlibDecoder;
-use lookup::{event_path, metadata_path, owned_value_path, path, OwnedValuePath, PathPrefix};
+use lookup::{event_path, metadata_path, owned_value_path, path, OwnedValuePath};
 use smallvec::{smallvec, SmallVec};
 use snafu::{ResultExt, Snafu};
 use tokio_util::codec::Decoder;
@@ -232,9 +232,9 @@ impl TcpSource for LogstashSource {
                     log.insert(metadata_path!("vector", "ingest_timestamp"), now);
                 }
                 LogNamespace::Legacy => {
-                    if let Some(timestamp_key) = log_schema().timestamp_key() {
+                    if let Some(timestamp_key) = log_schema().timestamp_key_target_path() {
                         log.insert(
-                            (PathPrefix::Event, timestamp_key),
+                            timestamp_key,
                             log_timestamp.unwrap_or_else(|| Value::from(now)),
                         );
                     }

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -423,9 +423,7 @@ fn enrich_syslog_event(
             .get("timestamp")
             .and_then(|timestamp| timestamp.as_timestamp().cloned())
             .unwrap_or_else(Utc::now);
-        if let Some(timestamp_key) = log_schema().timestamp_key_target_path() {
-            log.insert(timestamp_key, timestamp);
-        }
+        log.maybe_insert(log_schema().timestamp_key_target_path(), timestamp);
     }
 
     trace!(

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -666,7 +666,7 @@ mod test {
             let mut log_event = LogEvent::from(frame);
 
             log_event.insert(
-                log_schema().source_type_key().unwrap().to_string().as_str(),
+                log_schema().source_type_key_target_path().unwrap(),
                 "framestream",
             );
             if let Some(host) = received_from {

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -273,16 +273,14 @@ mod test {
 #[cfg(feature = "sinks-vector")]
 #[cfg(test)]
 mod tests {
-    use vector_common::assert_event_data_eq;
-    use vector_core::config::log_schema;
-    use vrl::path::PathPrefix;
-
     use super::*;
     use crate::{
         config::{SinkConfig as _, SinkContext},
         sinks::vector::VectorConfig as SinkConfig,
         test_util, SourceSender,
     };
+    use vector_common::assert_event_data_eq;
+    use vector_core::config::log_schema;
 
     async fn run_test(vector_source_config_str: &str, addr: SocketAddr) {
         let config = format!(r#"address = "{}""#, addr);
@@ -306,11 +304,11 @@ mod tests {
         let (mut events, stream) = test_util::random_events_with_stream(100, 100, None);
         sink.run(stream).await.unwrap();
 
-        let source_type_key = log_schema().source_type_key().unwrap();
         for event in &mut events {
-            event
-                .as_mut_log()
-                .insert((PathPrefix::Event, source_type_key), "vector");
+            event.as_mut_log().insert(
+                log_schema().source_type_key_target_path().unwrap(),
+                "vector",
+            );
         }
 
         let output = test_util::collect_ready(rx).await;

--- a/src/template.rs
+++ b/src/template.rs
@@ -503,13 +503,9 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert(
-            (
-                lookup::PathPrefix::Event,
-                log_schema().timestamp_key().unwrap(),
-            ),
-            ts,
-        );
+        event
+            .as_mut_log()
+            .insert(log_schema().timestamp_key_target_path().unwrap(), ts);
 
         let template = Template::try_from("abcd-%F").unwrap();
 
@@ -524,13 +520,9 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert(
-            (
-                lookup::PathPrefix::Event,
-                log_schema().timestamp_key().unwrap(),
-            ),
-            ts,
-        );
+        event
+            .as_mut_log()
+            .insert(log_schema().timestamp_key_target_path().unwrap(), ts);
 
         let template = Template::try_from("abcd-%F_%T").unwrap();
 


### PR DESCRIPTION
## Motivation
This part of https://github.com/vectordotdev/vector/issues/7070 and specifically https://github.com/vectordotdev/vector/issues/18059.

## Summary
* Update (almost) all non-test code to instantiate paths.
   * Mostly used `find` and `sed` for this work. 
   * I manually edited some more complex usages.  
   * I will follow-up with another PR for those `.get` functions that take a dynamic string as argument (those need explicit parsing and error handling). 
* Found some places that can use the new log schema accessors.

Note: 
Currently we do not check for parsing errors. This PR doesn't change this behavior because it would take significant extra effort to refactor the code to propagate/handle parsing errors.