### PR TITLE
fix(codecs): Move protobuf codec options under a `protobuf` key

### DIFF
--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -100,12 +100,6 @@ base: components: sources: amqp: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -138,12 +132,6 @@ base: components: sources: amqp: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -158,6 +146,23 @@ base: components: sources: amqp: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -103,12 +103,6 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -141,12 +135,6 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -161,6 +149,23 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -198,12 +198,6 @@ base: components: sources: aws_s3: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -236,12 +230,6 @@ base: components: sources: aws_s3: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -256,6 +244,23 @@ base: components: sources: aws_s3: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -193,12 +193,6 @@ base: components: sources: aws_sqs: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -231,12 +225,6 @@ base: components: sources: aws_sqs: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -251,6 +239,23 @@ base: components: sources: aws_sqs: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -85,12 +85,6 @@ base: components: sources: datadog_agent: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -123,12 +117,6 @@ base: components: sources: datadog_agent: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -143,6 +131,23 @@ base: components: sources: datadog_agent: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -64,12 +64,6 @@ base: components: sources: demo_logs: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -102,12 +96,6 @@ base: components: sources: demo_logs: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -122,6 +110,23 @@ base: components: sources: demo_logs: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -60,12 +60,6 @@ base: components: sources: exec: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -98,12 +92,6 @@ base: components: sources: exec: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -118,6 +106,23 @@ base: components: sources: exec: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -55,12 +55,6 @@ base: components: sources: file_descriptor: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -93,12 +87,6 @@ base: components: sources: file_descriptor: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -113,6 +101,23 @@ base: components: sources: file_descriptor: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -131,12 +131,6 @@ base: components: sources: gcp_pubsub: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -169,12 +163,6 @@ base: components: sources: gcp_pubsub: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -189,6 +177,23 @@ base: components: sources: gcp_pubsub: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -97,12 +97,6 @@ base: components: sources: heroku_logs: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -135,12 +129,6 @@ base: components: sources: heroku_logs: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -155,6 +143,23 @@ base: components: sources: heroku_logs: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -98,12 +98,6 @@ base: components: sources: http: configuration: {
 						"""
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -136,12 +130,6 @@ base: components: sources: http: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -156,6 +144,23 @@ base: components: sources: http: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -97,12 +97,6 @@ base: components: sources: http_client: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -135,12 +129,6 @@ base: components: sources: http_client: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -155,6 +143,23 @@ base: components: sources: http_client: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -98,12 +98,6 @@ base: components: sources: http_server: configuration: {
 						"""
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -136,12 +130,6 @@ base: components: sources: http_server: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -156,6 +144,23 @@ base: components: sources: http_server: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -109,12 +109,6 @@ base: components: sources: kafka: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -147,12 +141,6 @@ base: components: sources: kafka: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -167,6 +155,23 @@ base: components: sources: kafka: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -152,12 +152,6 @@ base: components: sources: nats: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -190,12 +184,6 @@ base: components: sources: nats: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -210,6 +198,23 @@ base: components: sources: nats: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -70,12 +70,6 @@ base: components: sources: redis: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -108,12 +102,6 @@ base: components: sources: redis: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -128,6 +116,23 @@ base: components: sources: redis: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -72,12 +72,6 @@ base: components: sources: socket: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -110,12 +104,6 @@ base: components: sources: socket: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -130,6 +118,23 @@ base: components: sources: socket: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -55,12 +55,6 @@ base: components: sources: stdin: configuration: {
 					}
 				}
 			}
-			desc_file: {
-				description:   "Path to desc file"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			gelf: {
 				description:   "GELF-specific decoding options."
 				relevant_when: "codec = \"gelf\""
@@ -93,12 +87,6 @@ base: components: sources: stdin: configuration: {
 					type: bool: default: true
 				}
 			}
-			message_type: {
-				description:   "message type. e.g package.message"
-				relevant_when: "codec = \"protobuf\""
-				required:      true
-				type: string: {}
-			}
 			native_json: {
 				description:   "Vector's native JSON-specific decoding options."
 				relevant_when: "codec = \"native_json\""
@@ -113,6 +101,23 @@ base: components: sources: stdin: configuration: {
 						"""
 					required: false
 					type: bool: default: true
+				}
+			}
+			protobuf: {
+				description:   "Protobuf-specific decoding options."
+				relevant_when: "codec = \"protobuf\""
+				required:      false
+				type: object: options: {
+					desc_file: {
+						description: "Path to desc file"
+						required:    false
+						type: string: default: ""
+					}
+					message_type: {
+						description: "message type. e.g package.message"
+						required:    false
+						type: string: default: ""
+					}
 				}
 			}
 			syslog: {


### PR DESCRIPTION
Follow up to https://github.com/vectordotdev/vector/pull/18019#discussion_r1278192502

The option "namespacing" is per: https://github.com/vectordotdev/vector/blob/master/docs/specs/configuration.md#polymorphism

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
