### PR TITLE
fix(dev): fix error in `make` when `cargo` is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ export AWS_ACCESS_KEY_ID ?= "dummy"
 export AWS_SECRET_ACCESS_KEY ?= "dummy"
 
 # Set version
-export VERSION ?= $(shell cargo vdev version)
+export VERSION ?= $(shell command -v cargo >/dev/null && cargo vdev version || echo unknown)
 
 # Set if you are on the CI and actually want the things to happen. (Non-CI users should never set this.)
 export CI ?= false


### PR DESCRIPTION
This PR fixes the following "no such file" errors when using `make environment` on a system without `cargo` installed:
```
$ make environment ENVIRONMENT_AUTOBUILD=false
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
make: cargo: No such file or directory
docker pull docker.io/timberio/vector-dev:sha-3eadc96742a33754a5859203b58249f6a806972a
make: cargo: No such file or directory
sha-3eadc96742a33754a5859203b58249f6a806972a: Pulling from timberio/vector-dev
Digest: sha256:23310245d469f0ae911da8de0be9a8d091e4df9f69a2591e9ab8df95405ceffc
Status: Image is up to date for timberio/vector-dev:sha-3eadc96742a33754a5859203b58249f6a806972a
docker.io/timberio/vector-dev:sha-3eadc96742a33754a5859203b58249f6a806972a
Entering environment...
```

It should be not necessary for a local machine to have `cargo` or Rust installed locally (the point of `make environnment`).

The problem is in the Makefile, where `VERSION` is assigned from the result of `cargo vdev version`. This PR fixes the issue by checking if `cargo` is available in the `PATH` first, or simply assign the value `unknown` if not.