### PR TITLE
chore(codecs): Update syslog_loose to properly handle escapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
  "similar-asserts",
  "smallvec",
  "snafu",
- "syslog_loose",
+ "syslog_loose 0.19.0",
  "tokio",
  "tokio-util",
  "tracing 0.1.37",
@@ -8137,6 +8137,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syslog_loose"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf5252d1adec0a489a0225f867c1a7fd445e41674530a396d0629cff0c4b211"
+dependencies = [
+ "chrono",
+ "nom",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9830,7 +9840,7 @@ dependencies = [
  "sha3",
  "snafu",
  "strip-ansi-escapes",
- "syslog_loose",
+ "syslog_loose 0.18.0",
  "termcolor",
  "thiserror",
  "tracing 0.1.37",

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
 smallvec = { version = "1", default-features = false, features = ["union"] }
 snafu = { version = "0.7.5", default-features = false, features = ["futures"] }
-syslog_loose = { version = "0.18", default-features = false, optional = true }
+syslog_loose = { version = "0.19", default-features = false, optional = true }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tracing = { version = "0.1", default-features = false }
 vrl.workspace = true

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -5,7 +5,7 @@ use lookup::{event_path, owned_value_path, OwnedTargetPath, OwnedValuePath};
 use smallvec::{smallvec, SmallVec};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use syslog_loose::{IncompleteDate, Message, ProcId, Protocol};
+use syslog_loose::{IncompleteDate, Message, ProcId, Protocol, Variant};
 use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
 use vector_core::{
@@ -282,7 +282,7 @@ impl Deserializer for SyslogDeserializer {
             false => Cow::from(std::str::from_utf8(&bytes)?),
         };
         let line = line.trim();
-        let parsed = syslog_loose::parse_message_with_year_exact(line, resolve_year)?;
+        let parsed = syslog_loose::parse_message_with_year_exact(line, resolve_year, Variant::Either)?;
 
         let log = match (self.source, log_namespace) {
             (Some(source), LogNamespace::Vector) => {

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -282,7 +282,8 @@ impl Deserializer for SyslogDeserializer {
             false => Cow::from(std::str::from_utf8(&bytes)?),
         };
         let line = line.trim();
-        let parsed = syslog_loose::parse_message_with_year_exact(line, resolve_year, Variant::Either)?;
+        let parsed =
+            syslog_loose::parse_message_with_year_exact(line, resolve_year, Variant::Either)?;
 
         let log = match (self.source, log_namespace) {
             (Some(source), LogNamespace::Vector) => {


### PR DESCRIPTION
Syslog wasn't parsing escapes in the SD fields properly as per [this issue](https://github.com/StephenWakely/syslog-loose/issues/18).

That is now fixed in the Syslog parser, so this updates the library version. For the interested the PR that fixed it in the library is [this](https://github.com/StephenWakely/syslog-loose/pull/21).

This is also being updated in [VRL](https://github.com/vectordotdev/vrl/pull/353).