### PR TITLE
fix: propagate config build error instead of panicking

### DIFF
--- a/lib/codecs/src/decoding/format/protobuf.rs
+++ b/lib/codecs/src/decoding/format/protobuf.rs
@@ -31,9 +31,8 @@ pub struct ProtobufDeserializerConfig {
 
 impl ProtobufDeserializerConfig {
     /// Build the `ProtobufDeserializer` from this configuration.
-    pub fn build(&self) -> ProtobufDeserializer {
-        // TODO return a Result instead.
-        ProtobufDeserializer::try_from(self).unwrap()
+    pub fn build(&self) -> vector_common::Result<ProtobufDeserializer> {
+        ProtobufDeserializer::try_from(self)
     }
 
     /// Return the type of event build by this deserializer.

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -277,16 +277,18 @@ impl From<NativeJsonDeserializerConfig> for DeserializerConfig {
 
 impl DeserializerConfig {
     /// Build the `Deserializer` from this configuration.
-    pub fn build(&self) -> Deserializer {
+    pub fn build(&self) -> vector_common::Result<Deserializer> {
         match self {
-            DeserializerConfig::Bytes => Deserializer::Bytes(BytesDeserializerConfig.build()),
-            DeserializerConfig::Json(config) => Deserializer::Json(config.build()),
-            DeserializerConfig::Protobuf(config) => Deserializer::Protobuf(config.build()),
+            DeserializerConfig::Bytes => Ok(Deserializer::Bytes(BytesDeserializerConfig.build())),
+            DeserializerConfig::Json(config) => Ok(Deserializer::Json(config.build())),
+            DeserializerConfig::Protobuf(config) => Ok(Deserializer::Protobuf(config.build()?)),
             #[cfg(feature = "syslog")]
-            DeserializerConfig::Syslog(config) => Deserializer::Syslog(config.build()),
-            DeserializerConfig::Native => Deserializer::Native(NativeDeserializerConfig.build()),
-            DeserializerConfig::NativeJson(config) => Deserializer::NativeJson(config.build()),
-            DeserializerConfig::Gelf(config) => Deserializer::Gelf(config.build()),
+            DeserializerConfig::Syslog(config) => Ok(Deserializer::Syslog(config.build())),
+            DeserializerConfig::Native => {
+                Ok(Deserializer::Native(NativeDeserializerConfig.build()))
+            }
+            DeserializerConfig::NativeJson(config) => Ok(Deserializer::NativeJson(config.build())),
+            DeserializerConfig::Gelf(config) => Ok(Deserializer::Gelf(config.build())),
         }
     }
 

--- a/src/codecs/decoding/config.rs
+++ b/src/codecs/decoding/config.rs
@@ -41,13 +41,13 @@ impl DecodingConfig {
     }
 
     /// Builds a `Decoder` from the provided configuration.
-    pub fn build(&self) -> Decoder {
+    pub fn build(&self) -> vector_common::Result<Decoder> {
         // Build the framer.
         let framer = self.framing.build();
 
         // Build the deserializer.
-        let deserializer = self.decoding.build();
+        let deserializer = self.decoding.build()?;
 
-        Decoder::new(framer, deserializer).with_log_namespace(self.log_namespace)
+        Ok(Decoder::new(framer, deserializer).with_log_namespace(self.log_namespace))
     }
 }

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -191,7 +191,7 @@ impl Runner {
         }
     }
 
-    pub async fn run_validation(self) -> Result<Vec<RunnerResults>, String> {
+    pub async fn run_validation(self) -> Result<Vec<RunnerResults>, vector_common::Error> {
         // Initialize our test environment.
         initialize_test_environment();
 
@@ -413,7 +413,7 @@ fn build_external_resource(
     configuration: &ValidationConfiguration,
     input_task_coordinator: &TaskCoordinator<Configuring>,
     output_task_coordinator: &TaskCoordinator<Configuring>,
-) -> Result<(RunnerInput, RunnerOutput, Option<Encoder<encoding::Framer>>), String> {
+) -> Result<(RunnerInput, RunnerOutput, Option<Encoder<encoding::Framer>>), vector_common::Error> {
     let component_type = configuration.component_type();
     let maybe_external_resource = configuration.external_resource();
     let maybe_encoder = maybe_external_resource
@@ -448,9 +448,7 @@ fn build_external_resource(
             let (tx, rx) = mpsc::channel(1024);
             let resource =
                 maybe_external_resource.expect("a sink must always have an external resource");
-            resource
-                .spawn_as_output(tx, output_task_coordinator)
-                .map_err(|e| e.to_string())?;
+            resource.spawn_as_output(tx, output_task_coordinator)?;
 
             Ok((
                 RunnerInput::Controlled,

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -251,7 +251,7 @@ impl Runner {
                 &self.configuration,
                 &input_task_coordinator,
                 &output_task_coordinator,
-            );
+            )?;
             let input_tx = runner_input.into_sender(controlled_edges.input);
             let output_rx = runner_output.into_receiver(controlled_edges.output);
             debug!("External resource (if any) and controlled edges built and spawned.");
@@ -413,7 +413,7 @@ fn build_external_resource(
     configuration: &ValidationConfiguration,
     input_task_coordinator: &TaskCoordinator<Configuring>,
     output_task_coordinator: &TaskCoordinator<Configuring>,
-) -> (RunnerInput, RunnerOutput, Option<Encoder<encoding::Framer>>) {
+) -> Result<(RunnerInput, RunnerOutput, Option<Encoder<encoding::Framer>>), String> {
     let component_type = configuration.component_type();
     let maybe_external_resource = configuration.external_resource();
     let maybe_encoder = maybe_external_resource
@@ -430,15 +430,15 @@ fn build_external_resource(
                 maybe_external_resource.expect("a source must always have an external resource");
             resource.spawn_as_input(rx, input_task_coordinator);
 
-            (
+            Ok((
                 RunnerInput::External(tx),
                 RunnerOutput::Controlled,
                 maybe_encoder,
-            )
+            ))
         }
         ComponentType::Transform => {
             // Transforms have no external resources.
-            (RunnerInput::Controlled, RunnerOutput::Controlled, None)
+            Ok((RunnerInput::Controlled, RunnerOutput::Controlled, None))
         }
         ComponentType::Sink => {
             // As an external resource for a sink, we create a channel that the validation runner
@@ -448,13 +448,15 @@ fn build_external_resource(
             let (tx, rx) = mpsc::channel(1024);
             let resource =
                 maybe_external_resource.expect("a sink must always have an external resource");
-            resource.spawn_as_output(tx, output_task_coordinator);
+            resource
+                .spawn_as_output(tx, output_task_coordinator)
+                .map_err(|e| e.to_string())?;
 
-            (
+            Ok((
                 RunnerInput::Controlled,
                 RunnerOutput::External(rx),
                 maybe_encoder,
-            )
+            ))
         }
     }
 }

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -143,7 +143,8 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         let log_namespace = cx.log_namespace(self.log_namespace);
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
 
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
 

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -241,7 +241,8 @@ impl AwsS3Config {
         .await?;
 
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
 
         match self.sqs {
             Some(ref sqs) => {

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -111,7 +111,8 @@ impl SourceConfig for AwsSqsConfig {
 
         let client = self.build_client(&cx).await?;
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
 
         Ok(Box::pin(

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -245,7 +245,8 @@ mod tests {
                 config.decoding,
                 LogNamespace::Vector,
             )
-            .build(),
+            .build()
+            .unwrap(),
             "aws_sqs",
             b"test",
             Some(now),
@@ -297,7 +298,8 @@ mod tests {
                 config.decoding,
                 LogNamespace::Legacy,
             )
-            .build(),
+            .build()
+            .unwrap(),
             "aws_sqs",
             b"test",
             Some(now),

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -156,7 +156,8 @@ impl SourceConfig for DatadogAgentConfig {
             .clone();
 
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
 
         let tls = MaybeTlsSettings::from_config(&self.tls, true)?;
         let source = DatadogAgentSource::new(

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -292,7 +292,8 @@ impl SourceConfig for DemoLogsConfig {
 
         self.format.validate()?;
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
         Ok(Box::pin(demo_logs_source(
             self.interval,
             self.count,
@@ -361,7 +362,8 @@ mod tests {
                 default_decoding(),
                 LogNamespace::Legacy,
             )
-            .build();
+            .build()
+            .unwrap();
             demo_logs_source(
                 config.interval,
                 config.count,

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -234,7 +234,7 @@ impl SourceConfig for ExecConfig {
             .clone()
             .unwrap_or_else(|| self.decoding.default_stream_framing());
         let decoder =
-            DecodingConfig::new(framing, self.decoding.clone(), LogNamespace::Legacy).build();
+            DecodingConfig::new(framing, self.decoding.clone(), LogNamespace::Legacy).build()?;
 
         match &self.mode {
             Mode::Scheduled => {

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -62,7 +62,7 @@ pub trait FileDescriptorConfig: NamedComponent {
         let framing = self
             .framing()
             .unwrap_or_else(|| decoding.default_stream_framing());
-        let decoder = DecodingConfig::new(framing, decoding, log_namespace).build();
+        let decoder = DecodingConfig::new(framing, decoding, log_namespace).build()?;
 
         let (sender, receiver) = mpsc::channel(1024);
 

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -314,7 +314,7 @@ impl SourceConfig for PubsubConfig {
                 self.decoding.clone(),
                 log_namespace,
             )
-            .build(),
+            .build()?,
             acknowledgements: cx.do_acknowledgements(self.acknowledgements),
             shutdown: cx.shutdown,
             out: cx.out,

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -163,7 +163,8 @@ impl SourceConfig for LogplexConfig {
         let log_namespace = cx.log_namespace(self.log_namespace);
 
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
 
         let source = LogplexSource {
             query_parameters: self.query_parameters.clone(),

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -194,7 +194,7 @@ impl SourceConfig for HttpClientConfig {
         let log_namespace = cx.log_namespace(self.log_namespace);
 
         // build the decoder
-        let decoder = self.get_decoding_config(Some(log_namespace)).build();
+        let decoder = self.get_decoding_config(Some(log_namespace)).build()?;
 
         let content_type = self.decoding.content_type(&self.framing).to_string();
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -314,7 +314,7 @@ fn remove_duplicates(mut list: Vec<String>, list_name: &str) -> Vec<String> {
 #[typetag::serde(name = "http_server")]
 impl SourceConfig for SimpleHttpConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let decoder = self.get_decoding_config()?.build();
+        let decoder = self.get_decoding_config()?.build()?;
         let log_namespace = cx.log_namespace(self.log_namespace);
 
         let source = SimpleHttpSource {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1159,7 +1159,8 @@ mod integration_test {
             config.decoding.clone(),
             log_namespace,
         )
-        .build();
+        .build()
+        .unwrap();
 
         tokio::spawn(kafka_source(
             config,

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -296,7 +296,8 @@ impl SourceConfig for KafkaSourceConfig {
 
         let consumer = create_consumer(self)?;
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
 
         Ok(Box::pin(kafka_source(

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -122,7 +122,8 @@ impl SourceConfig for NatsSourceConfig {
         let log_namespace = cx.log_namespace(self.log_namespace);
         let (connection, subscription) = create_subscription(self).await?;
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
 
         Ok(Box::pin(nats_source(
             self.clone(),

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -374,7 +374,8 @@ mod integration_tests {
                 conf.decoding.clone(),
                 LogNamespace::Legacy,
             )
-            .build();
+            .build()
+            .unwrap();
             tokio::spawn(nats_source(
                 conf.clone(),
                 nc,

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -169,7 +169,8 @@ impl SourceConfig for RedisSourceConfig {
         let client = redis::Client::open(self.url.as_str()).context(ClientSnafu {})?;
         let connection_info = ConnectionInfo::from(client.get_connection_info());
         let decoder =
-            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace).build();
+            DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
+                .build()?;
 
         let bytes_received = register!(BytesReceived::from(Protocol::from(
             connection_info.protocol

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -124,7 +124,7 @@ impl SourceConfig for SocketConfig {
                     decoding,
                     log_namespace,
                 )
-                .build();
+                .build()?;
 
                 let tcp = tcp::RawTcpSource::new(config.clone(), decoder, log_namespace);
                 let tls_config = config.tls().as_ref().map(|tls| tls.tls_config.clone());
@@ -156,7 +156,7 @@ impl SourceConfig for SocketConfig {
                     config.decoding().clone(),
                     log_namespace,
                 )
-                .build();
+                .build()?;
                 Ok(udp::udp(
                     config,
                     decoder,
@@ -176,7 +176,7 @@ impl SourceConfig for SocketConfig {
                     config.decoding.clone(),
                     log_namespace,
                 )
-                .build();
+                .build()?;
 
                 unix::unix_datagram(config, decoder, cx.shutdown, cx.out, log_namespace)
             }
@@ -193,7 +193,7 @@ impl SourceConfig for SocketConfig {
                     decoding,
                     log_namespace,
                 )
-                .build();
+                .build()?;
 
                 unix::unix_stream(config, decoder, cx.shutdown, cx.out, log_namespace)
             }


### PR DESCRIPTION
## Motivation
fixes: https://github.com/vectordotdev/vector/issues/18110

## Summary
Propagate an error up the stack instead of panicking at deserializer instantiation.