### PR TITLE
enhancement(csv codec): added additional csv encoding options

### DIFF
--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -78,17 +78,38 @@ pub enum QuoteStyle {
     Never,
 }
 
+const fn default_delimiter() -> u8 {
+    b','
+}
+
+const fn default_escape() -> u8 {
+    b','
+}
+
+const fn default_double_quote() -> bool {
+    true
+}
+
 /// Config used to build a `CsvSerializer`.
 #[crate::configurable_component]
 #[derive(Debug, Clone)]
 pub struct CsvSerializerOptions {
     /// The field delimiter to use when writing CSV.
+    #[serde(
+        default = "default_delimiter",
+        with = "vector_core::serde::ascii_char",
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
     pub delimiter: u8,
 
     /// Enable double quote escapes.
     ///
     /// This is enabled by default, but it may be disabled. When disabled, quotes in
     /// field data are escaped instead of doubled.
+    #[serde(
+        default = "default_double_quote",
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
     pub double_quote: bool,
 
     /// The escape character to use when writing CSV.
@@ -97,9 +118,18 @@ pub struct CsvSerializerOptions {
     /// like \ (instead of escaping quotes by doubling them).
     ///
     /// To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+    #[serde(
+        default = "default_escape",
+        with = "vector_core::serde::ascii_char",
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
     pub escape: u8,
 
     /// The quoting style to use when writing CSV data.
+    #[serde(
+        default,
+        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+    )]
     pub quote_style: QuoteStyle,
 
     /// Configures the fields that will be encoded, as well as the order in which they
@@ -112,20 +142,8 @@ pub struct CsvSerializerOptions {
     pub fields: Vec<ConfigTargetPath>,
 }
 
-impl Default for CsvSerializerOptions {
-    fn default() -> CsvSerializerOptions {
-        CsvSerializerOptions {
-            delimiter: b',',
-            double_quote: true,
-            escape: b'"',
-            quote_style: QuoteStyle::Necessary,
-            fields: vec![],
-        }
-    }
-}
-
 impl CsvSerializerOptions {
-    const fn csv_quote_style(&self) -> csv::QuoteStyle {
+    fn csv_quote_style(&self) -> csv::QuoteStyle {
         match self.quote_style {
             QuoteStyle::Always => csv::QuoteStyle::Always,
             QuoteStyle::NonNumeric => csv::QuoteStyle::NonNumeric,

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -28,16 +28,7 @@ impl CsvSerializerConfig {
         if self.csv.fields.is_empty() {
             Err("At least one CSV field must be specified".into())
         } else {
-            let opts = CsvSerializerOptions {
-                delimiter: self.csv.delimiter,
-                escape: self.csv.escape,
-                double_quote: self.csv.double_quote,
-                quote_style: self.csv.quote_style,
-                fields: self.csv.fields.clone(),
-            };
-            let config = CsvSerializerConfig::new(opts);
-
-            Ok(CsvSerializer::new(config))
+            Ok(CsvSerializer::new(self.clone()))
         }
     }
 
@@ -92,7 +83,7 @@ const fn default_double_quote() -> bool {
 
 /// Config used to build a `CsvSerializer`.
 #[crate::configurable_component]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CsvSerializerOptions {
     /// The field delimiter to use when writing CSV.
     #[serde(


### PR DESCRIPTION
Closes #17261

This will be a Draft for now since I potentially found a bug in the existing implementation. This commit so far includes the discussed config changes which I happily accept critique for since I am quite new to rust. Furthermore it contains additional tests like `correct_quoting` which might be surface a bug in the current implementation?

To fix this behavior I asked [here](https://github.com/BurntSushi/rust-csv/issues/331) for en enhancement in the respective csv lib. Opinions on that are appreciated as well