### PR TITLE
chore(ci): exclude protobuf files from spell checking

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -48,6 +48,7 @@
 \.otf$
 \.p12$
 \.pattern$
+\.pb$
 \.pdf$
 \.pem$
 \.png$


### PR DESCRIPTION
Currently we have a couple warnings from the spell checker GHA for a couple .pb files, which are binary so we should ignore them.
