### PR TITLE
chore(core): Expose shutdown errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "strum",
- "syn 2.0.27",
+ "syn 2.0.28",
  "thiserror",
 ]
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -141,7 +141,9 @@ impl ApplicationConfig {
                 }
                 Err(e) => {
                     error!("An error occurred that Vector couldn't handle: {}.", e);
-                    _ = self.graceful_crash_sender.send(ShutdownError::ApiFailed);
+                    _ = self
+                        .graceful_crash_sender
+                        .send(ShutdownError::ApiFailed(e.to_string()));
                     None
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,11 +139,12 @@ impl ApplicationConfig {
 
                     Some(api_server)
                 }
-                Err(e) => {
-                    error!("An error occurred that Vector couldn't handle: {}.", e);
+                Err(error) => {
+                    let error = error.to_string();
+                    error!("An error occurred that Vector couldn't handle: {}.", error);
                     _ = self
                         .graceful_crash_sender
-                        .send(ShutdownError::ApiFailed(e.to_string()));
+                        .send(ShutdownError::ApiFailed { error });
                     None
                 }
             }

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -134,7 +134,7 @@ async fn query_backend(
     loop {
         tokio::select! {
             biased;
-            Ok(signal::SignalTo::Shutdown | signal::SignalTo::Quit) = signal_rx.recv() => {
+            Ok(signal::SignalTo::Shutdown(_) | signal::SignalTo::Quit) = signal_rx.recv() => {
                 drop(command);
                 return Err("Secret retrieval was interrupted.".into());
             }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -30,11 +30,11 @@ pub enum ShutdownError {
     /// Reload failed, and then failed to restore the previous config
     ReloadFailedToRestore,
     /// Source task died during execution
-    SourceAborted(ComponentKey),
+    SourceAborted(ComponentKey, String),
     /// Transform task died during execution
-    TransformAborted(ComponentKey),
+    TransformAborted(ComponentKey, String),
     /// Sink task died during execution
-    SinkAborted(ComponentKey),
+    SinkAborted(ComponentKey, String),
 }
 
 /// Convenience struct for app setup handling.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -26,7 +26,9 @@ pub enum SignalTo {
 #[derive(Clone, Debug)]
 pub enum ShutdownError {
     /// The API failed to start
-    ApiFailed, // TODO: Hand off the failure error here
+    // For future work: It would be nice if we could keep the actual errors in here, but
+    // `crate::Error` doesn't implement `Clone`, and adding `DynClone` for errors is tricky.
+    ApiFailed(String),
     /// Reload failed, and then failed to restore the previous config
     ReloadFailedToRestore,
     /// Source task died during execution

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -18,9 +18,19 @@ pub enum SignalTo {
     /// Signal to reload config from the filesystem.
     ReloadFromDisk,
     /// Signal to shutdown process.
-    Shutdown,
+    Shutdown(Option<ShutdownError>),
     /// Shutdown process immediately.
     Quit,
+}
+
+#[derive(Clone, Debug)]
+pub enum ShutdownError {
+    /// The API failed to start
+    ApiFailed, // TODO: Hand off the failure error here
+    /// Reload failed, and then failed to restore the previous config
+    ReloadFailedToRestore,
+    /// FIXME
+    HandledError,
 }
 
 /// Convenience struct for app setup handling.
@@ -153,11 +163,11 @@ fn os_signals(runtime: &Runtime) -> impl Stream<Item = SignalTo> {
                 let signal = tokio::select! {
                     _ = sigint.recv() => {
                         info!(message = "Signal received.", signal = "SIGINT");
-                        SignalTo::Shutdown
+                        SignalTo::Shutdown(None)
                     },
                     _ = sigterm.recv() => {
                         info!(message = "Signal received.", signal = "SIGTERM");
-                        SignalTo::Shutdown
+                        SignalTo::Shutdown(None)
                     } ,
                     _ = sigquit.recv() => {
                         info!(message = "Signal received.", signal = "SIGQUIT");

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -29,8 +29,12 @@ pub enum ShutdownError {
     ApiFailed, // TODO: Hand off the failure error here
     /// Reload failed, and then failed to restore the previous config
     ReloadFailedToRestore,
-    /// FIXME
-    HandledError,
+    /// Source task died during execution
+    SourceAborted,
+    /// Transform task died during execution
+    TransformAborted,
+    /// Sink task died during execution
+    SinkAborted,
 }
 
 /// Convenience struct for app setup handling.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -3,7 +3,7 @@
 use tokio::{runtime::Runtime, sync::broadcast};
 use tokio_stream::{Stream, StreamExt};
 
-use super::config::ConfigBuilder;
+use super::config::{ComponentKey, ConfigBuilder};
 
 pub type ShutdownTx = broadcast::Sender<()>;
 pub type SignalTx = broadcast::Sender<SignalTo>;
@@ -30,11 +30,11 @@ pub enum ShutdownError {
     /// Reload failed, and then failed to restore the previous config
     ReloadFailedToRestore,
     /// Source task died during execution
-    SourceAborted,
+    SourceAborted(ComponentKey),
     /// Transform task died during execution
-    TransformAborted,
+    TransformAborted(ComponentKey),
     /// Sink task died during execution
-    SinkAborted,
+    SinkAborted(ComponentKey),
 }
 
 /// Convenience struct for app setup handling.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+use snafu::Snafu;
 use tokio::{runtime::Runtime, sync::broadcast};
 use tokio_stream::{Stream, StreamExt};
 
@@ -23,20 +24,20 @@ pub enum SignalTo {
     Quit,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Snafu)]
 pub enum ShutdownError {
-    /// The API failed to start
     // For future work: It would be nice if we could keep the actual errors in here, but
     // `crate::Error` doesn't implement `Clone`, and adding `DynClone` for errors is tricky.
-    ApiFailed(String),
-    /// Reload failed, and then failed to restore the previous config
+    #[snafu(display("The API failed to start: {error}"))]
+    ApiFailed { error: String },
+    #[snafu(display("Reload failed, and then failed to restore the previous config"))]
     ReloadFailedToRestore,
-    /// Source task died during execution
-    SourceAborted(ComponentKey, String),
-    /// Transform task died during execution
-    TransformAborted(ComponentKey, String),
-    /// Sink task died during execution
-    SinkAborted(ComponentKey, String),
+    #[snafu(display(r#"The task for source "{key}" died during execution: {error}"#))]
+    SourceAborted { key: ComponentKey, error: String },
+    #[snafu(display(r#"The task for transform "{key}" died during execution: {error}"#))]
+    TransformAborted { key: ComponentKey, error: String },
+    #[snafu(display(r#"The task for sink "{key}" died during execution: {error}"#))]
+    SinkAborted { key: ComponentKey, error: String },
 }
 
 /// Convenience struct for app setup handling.

--- a/src/sinks/datadog/traces/apm_stats/integration_tests.rs
+++ b/src/sinks/datadog/traces/apm_stats/integration_tests.rs
@@ -16,6 +16,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::{
     config::ConfigBuilder,
+    signal::ShutdownError,
     sinks::datadog::traces::{apm_stats::StatsPayload, DatadogTracesConfig},
     sources::datadog_agent::DatadogAgentConfig,
     test_util::{start_topology, trace_init},
@@ -322,8 +323,8 @@ fn validate_stats(agent_stats: &StatsPayload, vector_stats: &StatsPayload) {
 async fn start_vector() -> (
     RunningTopology,
     (
-        tokio::sync::mpsc::UnboundedSender<()>,
-        tokio::sync::mpsc::UnboundedReceiver<()>,
+        tokio::sync::mpsc::UnboundedSender<ShutdownError>,
+        tokio::sync::mpsc::UnboundedReceiver<ShutdownError>,
     ),
 ) {
     let dd_agent_address = format!("0.0.0.0:{}", vector_receive_port());

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -53,7 +53,7 @@ pub async fn tap(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitC
     loop {
         tokio::select! {
             biased;
-            Ok(SignalTo::Shutdown | SignalTo::Quit) = signal_rx.recv() => break,
+            Ok(SignalTo::Shutdown(_) | SignalTo::Quit) = signal_rx.recv() => break,
             status = run(subscription_url.clone(), opts, outputs_patterns.clone(), formatter.clone()) => {
                 if status == exitcode::UNAVAILABLE || status == exitcode::TEMPFAIL && !opts.no_reconnect {
                     #[allow(clippy::print_stderr)]

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -41,6 +41,7 @@ use zstd::Decoder as ZstdDecoder;
 
 use crate::{
     config::{Config, ConfigDiff, GenerateConfig},
+    signal::ShutdownError,
     topology::{self, RunningTopology},
     trace,
 };
@@ -683,8 +684,8 @@ pub async fn start_topology(
 ) -> (
     RunningTopology,
     (
-        tokio::sync::mpsc::UnboundedSender<()>,
-        tokio::sync::mpsc::UnboundedReceiver<()>,
+        tokio::sync::mpsc::UnboundedSender<ShutdownError>,
+        tokio::sync::mpsc::UnboundedReceiver<ShutdownError>,
     ),
 ) {
     config.healthchecks.set_require_healthy(require_healthy);

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -16,7 +16,7 @@ use crate::internal_events::{
     VectorConfigLoadError, VectorRecoveryError, VectorReloadError, VectorReloaded,
 };
 
-use crate::{config, topology::RunningTopology};
+use crate::{config, signal::ShutdownError, topology::RunningTopology};
 
 #[derive(Clone, Debug)]
 pub struct SharedTopologyController(Arc<Mutex<TopologyController>>);
@@ -54,12 +54,13 @@ impl std::fmt::Debug for TopologyController {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum ReloadOutcome {
     NoConfig,
     MissingApiKey,
     Success,
     RolledBack,
-    FatalError,
+    FatalError(ShutdownError),
 }
 
 impl TopologyController {
@@ -104,7 +105,6 @@ impl TopologyController {
             }
         } else if self.api_server.is_none() {
             use crate::internal_events::ApiStarted;
-            use crate::topology::ReloadOutcome::FatalError;
             use std::sync::atomic::AtomicBool;
             use tokio::runtime::Handle;
 
@@ -126,7 +126,7 @@ impl TopologyController {
                 }
                 Err(e) => {
                     error!("An error occurred that Vector couldn't handle: {}.", e);
-                    return FatalError;
+                    return ReloadOutcome::FatalError(ShutdownError::ApiFailed);
                 }
             }
         }
@@ -152,7 +152,7 @@ impl TopologyController {
             Err(()) => {
                 emit!(VectorReloadError);
                 emit!(VectorRecoveryError);
-                ReloadOutcome::FatalError
+                ReloadOutcome::FatalError(ShutdownError::ReloadFailedToRestore)
             }
         }
     }

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -126,7 +126,7 @@ impl TopologyController {
                 }
                 Err(e) => {
                     error!("An error occurred that Vector couldn't handle: {}.", e);
-                    return ReloadOutcome::FatalError(ShutdownError::ApiFailed);
+                    return ReloadOutcome::FatalError(ShutdownError::ApiFailed(e.to_string()));
                 }
             }
         }

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -124,9 +124,10 @@ impl TopologyController {
 
                     Some(api_server)
                 }
-                Err(e) => {
-                    error!("An error occurred that Vector couldn't handle: {}.", e);
-                    return ReloadOutcome::FatalError(ShutdownError::ApiFailed(e.to_string()));
+                Err(error) => {
+                    let error = error.to_string();
+                    error!("An error occurred that Vector couldn't handle: {}.", error);
+                    return ReloadOutcome::FatalError(ShutdownError::ApiFailed { error });
                 }
             }
         }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -156,7 +156,7 @@ pub(super) fn take_healthchecks(
 async fn handle_errors(
     task: impl Future<Output = TaskResult>,
     abort_tx: mpsc::UnboundedSender<ShutdownError>,
-    error: ShutdownError,
+    error: impl FnOnce(String) -> ShutdownError,
 ) -> TaskResult {
     AssertUnwindSafe(task)
         .catch_unwind()
@@ -165,7 +165,7 @@ async fn handle_errors(
         .and_then(|res| res)
         .map_err(|e| {
             error!("An error occurred that Vector couldn't handle: {}.", e);
-            _ = abort_tx.send(error);
+            _ = abort_tx.send(error(e.to_string()));
             e
         })
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -156,6 +156,7 @@ pub(super) fn take_healthchecks(
 async fn handle_errors(
     task: impl Future<Output = TaskResult>,
     abort_tx: mpsc::UnboundedSender<ShutdownError>,
+    error: ShutdownError,
 ) -> TaskResult {
     AssertUnwindSafe(task)
         .catch_unwind()
@@ -164,7 +165,7 @@ async fn handle_errors(
         .and_then(|res| res)
         .map_err(|e| {
             error!("An error occurred that Vector couldn't handle: {}.", e);
-            _ = abort_tx.send(ShutdownError::HandledError);
+            _ = abort_tx.send(error);
             e
         })
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -34,6 +34,7 @@ use vector_buffers::topology::channel::{BufferReceiverStream, BufferSender};
 use crate::{
     config::{ComponentKey, Config, ConfigDiff, Inputs, OutputId},
     event::EventArray,
+    signal::ShutdownError,
     topology::{builder::Pieces, task::Task},
 };
 
@@ -80,7 +81,10 @@ pub async fn start_validated(
     mut pieces: Pieces,
 ) -> Option<(
     RunningTopology,
-    (mpsc::UnboundedSender<()>, mpsc::UnboundedReceiver<()>),
+    (
+        mpsc::UnboundedSender<ShutdownError>,
+        mpsc::UnboundedReceiver<ShutdownError>,
+    ),
 )> {
     let (abort_tx, abort_rx) = mpsc::unbounded_channel();
 
@@ -151,7 +155,7 @@ pub(super) fn take_healthchecks(
 
 async fn handle_errors(
     task: impl Future<Output = TaskResult>,
-    abort_tx: mpsc::UnboundedSender<()>,
+    abort_tx: mpsc::UnboundedSender<ShutdownError>,
 ) -> TaskResult {
     AssertUnwindSafe(task)
         .catch_unwind()
@@ -160,7 +164,7 @@ async fn handle_errors(
         .and_then(|res| res)
         .map_err(|e| {
             error!("An error occurred that Vector couldn't handle: {}.", e);
-            _ = abort_tx.send(());
+            _ = abort_tx.send(ShutdownError::HandledError);
             e
         })
 }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -20,6 +20,7 @@ use crate::{
     config::{ComponentKey, Config, ConfigDiff, HealthcheckOptions, Inputs, OutputId, Resource},
     event::EventArray,
     shutdown::SourceShutdownCoordinator,
+    signal::ShutdownError,
     spawn_named,
     topology::{
         build_or_log_errors, builder,
@@ -42,14 +43,14 @@ pub struct RunningTopology {
     shutdown_coordinator: SourceShutdownCoordinator,
     detach_triggers: HashMap<ComponentKey, DisabledTrigger>,
     pub(crate) config: Config,
-    abort_tx: mpsc::UnboundedSender<()>,
+    abort_tx: mpsc::UnboundedSender<ShutdownError>,
     watch: (WatchTx, WatchRx),
     pub(crate) running: Arc<AtomicBool>,
     graceful_shutdown_duration: Option<Duration>,
 }
 
 impl RunningTopology {
-    pub fn new(config: Config, abort_tx: mpsc::UnboundedSender<()>) -> Self {
+    pub fn new(config: Config, abort_tx: mpsc::UnboundedSender<ShutdownError>) -> Self {
         Self {
             inputs: HashMap::new(),
             inputs_tap_metadata: HashMap::new(),

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -856,8 +856,12 @@ impl RunningTopology {
         }
 
         let task_name = format!(">> {} ({})", task.typetag(), task.id());
-        let task = handle_errors(task, self.abort_tx.clone(), ShutdownError::SinkAborted)
-            .instrument(task_span);
+        let task = handle_errors(
+            task,
+            self.abort_tx.clone(),
+            ShutdownError::SinkAborted(key.clone()),
+        )
+        .instrument(task_span);
         let spawned = spawn_named(task, task_name.as_ref());
         if let Some(previous) = self.tasks.insert(key.clone(), spawned) {
             drop(previous); // detach and forget
@@ -894,8 +898,12 @@ impl RunningTopology {
         }
 
         let task_name = format!(">> {} ({}) >>", task.typetag(), task.id());
-        let task = handle_errors(task, self.abort_tx.clone(), ShutdownError::TransformAborted)
-            .instrument(task_span);
+        let task = handle_errors(
+            task,
+            self.abort_tx.clone(),
+            ShutdownError::TransformAborted(key.clone()),
+        )
+        .instrument(task_span);
         let spawned = spawn_named(task, task_name.as_ref());
         if let Some(previous) = self.tasks.insert(key.clone(), spawned) {
             drop(previous); // detach and forget
@@ -933,8 +941,12 @@ impl RunningTopology {
         }
 
         let task_name = format!("{} ({}) >>", task.typetag(), task.id());
-        let task = handle_errors(task, self.abort_tx.clone(), ShutdownError::SourceAborted)
-            .instrument(task_span.clone());
+        let task = handle_errors(
+            task,
+            self.abort_tx.clone(),
+            ShutdownError::SourceAborted(key.clone()),
+        )
+        .instrument(task_span.clone());
         let spawned = spawn_named(task, task_name.as_ref());
         if let Some(previous) = self.tasks.insert(key.clone(), spawned) {
             drop(previous); // detach and forget
@@ -948,7 +960,7 @@ impl RunningTopology {
         let source_task = handle_errors(
             source_task,
             self.abort_tx.clone(),
-            ShutdownError::SourceAborted,
+            ShutdownError::SourceAborted(key.clone()),
         )
         .instrument(task_span);
         self.source_tasks

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -859,7 +859,7 @@ impl RunningTopology {
         let task = {
             let key = key.clone();
             handle_errors(task, self.abort_tx.clone(), |error| {
-                ShutdownError::SinkAborted(key, error)
+                ShutdownError::SinkAborted { key, error }
             })
         }
         .instrument(task_span);
@@ -902,7 +902,7 @@ impl RunningTopology {
         let task = {
             let key = key.clone();
             handle_errors(task, self.abort_tx.clone(), |error| {
-                ShutdownError::TransformAborted(key, error)
+                ShutdownError::TransformAborted { key, error }
             })
         }
         .instrument(task_span);
@@ -946,7 +946,7 @@ impl RunningTopology {
         let task = {
             let key = key.clone();
             handle_errors(task, self.abort_tx.clone(), |error| {
-                ShutdownError::SourceAborted(key, error)
+                ShutdownError::SourceAborted { key, error }
             })
         }
         .instrument(task_span.clone());
@@ -963,7 +963,7 @@ impl RunningTopology {
         let source_task = {
             let key = key.clone();
             handle_errors(source_task, self.abort_tx.clone(), |error| {
-                ShutdownError::SourceAborted(key, error)
+                ShutdownError::SourceAborted { key, error }
             })
         }
         .instrument(task_span);


### PR DESCRIPTION
When components need to shut down the topology, the only information that exists between the Vector application finishing and starting the shutdown handling is simply a flag about what kind of shutdown signal happened. This change extends those types to expose, where possible, error messages and component names involved.