### PR TITLE
feat: Refactor 'event.get()' to use path types

### DIFF
--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -27,7 +27,13 @@ impl Discriminant {
     pub fn from_log_event(event: &LogEvent, discriminant_fields: &[impl AsRef<str>]) -> Self {
         let values: Vec<Option<Value>> = discriminant_fields
             .iter()
-            .map(|discriminant_field| event.get(discriminant_field.as_ref()).cloned())
+            .map(|discriminant_field| {
+                event
+                    .parse_path_and_get_value(discriminant_field.as_ref())
+                    .ok()
+                    .flatten()
+                    .cloned()
+            })
             .collect();
         Self { values }
     }

--- a/lib/vector-core/src/event/trace.rs
+++ b/lib/vector-core/src/event/trace.rs
@@ -7,6 +7,7 @@ use vector_common::{
     internal_event::TaggedEventsSent, json_size::JsonSize, request_metadata::GetEventCountTags,
     EventDataEq,
 };
+use vrl::path::PathParseError;
 
 use super::{
     BatchNotifier, EstimatedJsonEncodedSizeOf, EventFinalizer, EventFinalizers, EventMetadata,
@@ -71,13 +72,23 @@ impl TraceEvent {
         self.0.as_map().expect("inner value must be a map")
     }
 
+    /// Parse the specified `path` and if there are no parsing errors, attempt to get a reference to a value.
+    /// # Errors
+    /// Will return an error if path parsing failed.
+    pub fn parse_path_and_get_value(
+        &self,
+        path: impl AsRef<str>,
+    ) -> Result<Option<&Value>, PathParseError> {
+        self.0.parse_path_and_get_value(path)
+    }
+
     #[allow(clippy::needless_pass_by_value)] // TargetPath is always a reference
     pub fn get<'a>(&self, key: impl TargetPath<'a>) -> Option<&Value> {
         self.0.get(key)
     }
 
-    pub fn get_mut(&mut self, key: impl AsRef<str>) -> Option<&mut Value> {
-        self.0.get_mut(key.as_ref())
+    pub fn get_mut<'a>(&mut self, key: impl TargetPath<'a>) -> Option<&mut Value> {
+        self.0.get_mut(key)
     }
 
     pub fn contains(&self, key: impl AsRef<str>) -> bool {

--- a/src/api/schema/events/trace.rs
+++ b/src/api/schema/events/trace.rs
@@ -1,5 +1,6 @@
 use async_graphql::Object;
 use vector_common::encode_logfmt;
+use vrl::event_path;
 
 use super::EventEncodingType;
 use crate::{event, topology::TapOutput};
@@ -48,7 +49,7 @@ impl Trace {
 
     /// Get JSON field data on the trace event, by field name
     async fn json(&self, field: String) -> Option<String> {
-        self.event.get(field.as_str()).map(|field| {
+        self.event.get(event_path!(field.as_str())).map(|field| {
             serde_json::to_string(field)
                 .expect("JSON serialization of log event field failed. Please report.")
         })

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -75,7 +75,12 @@ impl Filter<LogEvent> for EventFilter {
                 any_string_match("tags", move |value| value == field)
             }
             Field::Default(f) | Field::Facet(f) | Field::Reserved(f) => {
-                Run::boxed(move |log: &LogEvent| log.get(f.as_str()).is_some())
+                Run::boxed(move |log: &LogEvent| {
+                    log.parse_path_and_get_value(f.as_str())
+                        .ok()
+                        .flatten()
+                        .is_some()
+                })
             }
         }
     }
@@ -165,8 +170,11 @@ impl Filter<LogEvent> for EventFilter {
         match field {
             // Facets are compared numerically if the value is numeric, or as strings otherwise.
             Field::Facet(f) => {
-                Run::boxed(
-                    move |log: &LogEvent| match (log.get(f.as_str()), &comparison_value) {
+                Run::boxed(move |log: &LogEvent| {
+                    match (
+                        log.parse_path_and_get_value(f.as_str()).ok().flatten(),
+                        &comparison_value,
+                    ) {
                         // Integers.
                         (Some(Value::Integer(lhs)), ComparisonValue::Integer(rhs)) => {
                             match comparator {
@@ -227,8 +235,8 @@ impl Filter<LogEvent> for EventFilter {
                             }
                         }
                         _ => false,
-                    },
-                )
+                    }
+                })
             }
             // Tag values need extracting by "key:value" to be compared.
             Field::Tag(tag) => any_string_match("tags", move |value| match value.split_once(':') {
@@ -266,9 +274,11 @@ where
 {
     let field = field.into();
 
-    Run::boxed(move |log: &LogEvent| match log.get(field.as_str()) {
-        Some(Value::Bytes(v)) => func(String::from_utf8_lossy(v)),
-        _ => false,
+    Run::boxed(move |log: &LogEvent| {
+        match log.parse_path_and_get_value(field.as_str()).ok().flatten() {
+            Some(Value::Bytes(v)) => func(String::from_utf8_lossy(v)),
+            _ => false,
+        }
     })
 }
 
@@ -281,9 +291,11 @@ where
 {
     let field = field.into();
 
-    Run::boxed(move |log: &LogEvent| match log.get(field.as_str()) {
-        Some(Value::Array(values)) => func(values),
-        _ => false,
+    Run::boxed(move |log: &LogEvent| {
+        match log.parse_path_and_get_value(field.as_str()).ok().flatten() {
+            Some(Value::Array(values)) => func(values),
+            _ => false,
+        }
     })
 }
 

--- a/src/sinks/datadog/traces/apm_stats/aggregation.rs
+++ b/src/sinks/datadog/traces/apm_stats/aggregation.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use chrono::Utc;
+use vrl::event_path;
 
 use super::{
     bucket::Bucket, ClientStatsBucket, ClientStatsPayload, PartitionKey,
@@ -179,7 +180,7 @@ impl Aggregator {
     pub(crate) fn handle_trace(&mut self, partition_key: &PartitionKey, trace: &TraceEvent) {
         // Based on https://github.com/DataDog/datadog-agent/blob/cfa750c7412faa98e87a015f8ee670e5828bbe7f/pkg/trace/stats/concentrator.go#L148-L184
 
-        let spans = match trace.get("spans") {
+        let spans = match trace.get(event_path!("spans")) {
             Some(Value::Array(v)) => v.iter().filter_map(|s| s.as_object()).collect(),
             _ => vec![],
         };
@@ -189,16 +190,16 @@ impl Aggregator {
             env: partition_key.env.clone().unwrap_or_default(),
             hostname: partition_key.hostname.clone().unwrap_or_default(),
             version: trace
-                .get("app_version")
+                .get(event_path!("app_version"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             container_id: trace
-                .get("container_id")
+                .get(event_path!("container_id"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
         };
         let synthetics = trace
-            .get("origin")
+            .get(event_path!("origin"))
             .map(|v| v.to_string_lossy().starts_with(TAG_SYNTHETICS))
             .unwrap_or(false);
 

--- a/src/sinks/datadog/traces/request_builder.rs
+++ b/src/sinks/datadog/traces/request_builder.rs
@@ -10,6 +10,7 @@ use prost::Message;
 use snafu::Snafu;
 use vector_common::request_metadata::RequestMetadata;
 use vector_core::event::{EventFinalizers, Finalizable};
+use vrl::event_path;
 
 use super::{
     apm_stats::{compute_apm_stats, Aggregator},
@@ -283,7 +284,7 @@ impl DatadogTracesEncoder {
 
     fn vector_trace_into_dd_tracer_payload(trace: &TraceEvent) -> dd_proto::TracerPayload {
         let tags = trace
-            .get("tags")
+            .get(event_path!("tags"))
             .and_then(|m| m.as_object())
             .map(|m| {
                 m.iter()
@@ -292,7 +293,7 @@ impl DatadogTracesEncoder {
             })
             .unwrap_or_default();
 
-        let spans = match trace.get("spans") {
+        let spans = match trace.get(event_path!("spans")) {
             Some(Value::Array(v)) => v
                 .iter()
                 .filter_map(|s| s.as_object().map(DatadogTracesEncoder::convert_span))
@@ -302,7 +303,7 @@ impl DatadogTracesEncoder {
 
         let chunk = dd_proto::TraceChunk {
             priority: trace
-                .get("priority")
+                .get(event_path!("priority"))
                 .and_then(|v| v.as_integer().map(|v| v as i32))
                 // This should not happen for Datadog originated traces, but in case this field is not populated
                 // we default to 1 (https://github.com/DataDog/datadog-agent/blob/eac2327/pkg/trace/sampler/sampler.go#L54-L55),
@@ -310,11 +311,11 @@ impl DatadogTracesEncoder {
                 // https://github.com/DataDog/datadog-agent/blob/3ea2eb4/pkg/trace/api/otlp.go#L309.
                 .unwrap_or(1i32),
             origin: trace
-                .get("origin")
+                .get(event_path!("origin"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             dropped_trace: trace
-                .get("dropped")
+                .get(event_path!("dropped"))
                 .and_then(|v| v.as_boolean())
                 .unwrap_or(false),
             spans,
@@ -323,37 +324,37 @@ impl DatadogTracesEncoder {
 
         dd_proto::TracerPayload {
             container_id: trace
-                .get("container_id")
+                .get(event_path!("container_id"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             language_name: trace
-                .get("language_name")
+                .get(event_path!("language_name"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             language_version: trace
-                .get("language_version")
+                .get(event_path!("language_version"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             tracer_version: trace
-                .get("tracer_version")
+                .get(event_path!("tracer_version"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             runtime_id: trace
-                .get("runtime_id")
+                .get(event_path!("runtime_id"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             chunks: vec![chunk],
             tags,
             env: trace
-                .get("env")
+                .get(event_path!("env"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             hostname: trace
-                .get("hostname")
+                .get(event_path!("hostname"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             app_version: trace
-                .get("app_version")
+                .get(event_path!("app_version"))
                 .map(|v| v.to_string_lossy().into_owned())
                 .unwrap_or_default(),
         }

--- a/src/sinks/datadog/traces/sink.rs
+++ b/src/sinks/datadog/traces/sink.rs
@@ -7,6 +7,7 @@ use futures_util::{
 };
 use tokio::sync::oneshot::{channel, Sender};
 use tower::Service;
+use vrl::event_path;
 use vrl::path::PathPrefix;
 
 use vector_core::{
@@ -54,19 +55,21 @@ impl Partitioner for EventPartitioner {
             }
             Event::Trace(t) => PartitionKey {
                 api_key: item.metadata().datadog_api_key(),
-                env: t.get("env").map(|s| s.to_string_lossy().into_owned()),
+                env: t
+                    .get(event_path!("env"))
+                    .map(|s| s.to_string_lossy().into_owned()),
                 hostname: log_schema().host_key().and_then(|key| {
                     t.get((PathPrefix::Event, key))
                         .map(|s| s.to_string_lossy().into_owned())
                 }),
                 agent_version: t
-                    .get("agent_version")
+                    .get(event_path!("agent_version"))
                     .map(|s| s.to_string_lossy().into_owned()),
                 target_tps: t
-                    .get("target_tps")
+                    .get(event_path!("target_tps"))
                     .and_then(|tps| tps.as_integer().map(Into::into)),
                 error_tps: t
-                    .get("error_tps")
+                    .get(event_path!("error_tps"))
                     .and_then(|tps| tps.as_integer().map(Into::into)),
             },
         }

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -443,7 +443,9 @@ impl DataStreamConfig {
         let (dtype, dataset, namespace) = if !self.auto_routing {
             (self.dtype(log)?, self.dataset(log)?, self.namespace(log)?)
         } else {
-            let data_stream = log.get(event_path!("data_stream")).and_then(|ds| ds.as_object());
+            let data_stream = log
+                .get(event_path!("data_stream"))
+                .and_then(|ds| ds.as_object());
             let dtype = data_stream
                 .and_then(|ds| ds.get("type"))
                 .map(|value| value.to_string_lossy().into_owned())

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -443,7 +443,7 @@ impl DataStreamConfig {
         let (dtype, dataset, namespace) = if !self.auto_routing {
             (self.dtype(log)?, self.dataset(log)?, self.namespace(log)?)
         } else {
-            let data_stream = log.get("data_stream").and_then(|ds| ds.as_object());
+            let data_stream = log.get(event_path!("data_stream")).and_then(|ds| ds.as_object());
             let dtype = data_stream
                 .and_then(|ds| ds.get("type"))
                 .map(|value| value.to_string_lossy().into_owned())

--- a/src/sinks/new_relic/model.rs
+++ b/src/sinks/new_relic/model.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, convert::TryFrom, fmt::Debug, time::SystemTime};
 use chrono::{DateTime, Utc};
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
+use vrl::event_path;
 
 use super::NewRelicSinkError;
 use crate::event::{Event, MetricValue, Value};
@@ -117,7 +118,7 @@ impl TryFrom<Vec<Event>> for EventsApiModel {
                     event_model.insert(k, v.clone());
                 }
 
-                if let Some(message) = log.get("message") {
+                if let Some(message) = log.get(event_path!("message")) {
                     let message = message.to_string_lossy().replace("\\\"", "\"");
                     // If message contains a JSON string, parse it and insert all fields into self
                     if let serde_json::Result::Ok(json_map) =
@@ -189,7 +190,7 @@ impl TryFrom<Vec<Event>> for LogsApiModel {
                 for (k, v) in log.convert_to_fields() {
                     log_model.insert(k, v.clone());
                 }
-                if log.get("message").is_none() {
+                if log.get(event_path!("message")).is_none() {
                     log_model.insert(
                         "message".to_owned(),
                         Value::from("log from vector".to_owned()),

--- a/src/sources/datadog_agent/traces.rs
+++ b/src/sources/datadog_agent/traces.rs
@@ -146,16 +146,16 @@ fn handle_dd_trace_payload_v1(
                 &source.log_schema_source_type_key,
                 Bytes::from("datadog_agent"),
             );
-            trace_event.insert("payload_version", "v2".to_string());
+            trace_event.insert(event_path!("payload_version"), "v2".to_string());
             trace_event.insert(&source.log_schema_host_key, hostname.clone());
-            trace_event.insert("env", env.clone());
-            trace_event.insert("agent_version", agent_version.clone());
-            trace_event.insert("target_tps", target_tps);
-            trace_event.insert("error_tps", error_tps);
-            if let Some(Value::Object(span_tags)) = trace_event.get_mut("tags") {
+            trace_event.insert(event_path!("env"), env.clone());
+            trace_event.insert(event_path!("agent_version"), agent_version.clone());
+            trace_event.insert(event_path!("target_tps"), target_tps);
+            trace_event.insert(event_path!("error_tps"), error_tps);
+            if let Some(Value::Object(span_tags)) = trace_event.get_mut(event_path!("tags")) {
                 span_tags.extend(tags.clone());
             } else {
-                trace_event.insert("tags", Value::from(tags.clone()));
+                trace_event.insert(event_path!("tags"), Value::from(tags.clone()));
             }
             Event::Trace(trace_event)
         })

--- a/src/template.rs
+++ b/src/template.rs
@@ -167,13 +167,17 @@ impl Template {
                 Part::Reference(key) => {
                     out.push_str(
                         &match event {
-                            EventRef::Log(log) => log.get(&**key).map(Value::to_string_lossy),
+                            EventRef::Log(log) => log
+                                .parse_path_and_get_value(key)
+                                .ok()
+                                .and_then(|v| v.map(Value::to_string_lossy)),
                             EventRef::Metric(metric) => {
                                 render_metric_field(key, metric).map(Cow::Borrowed)
                             }
-                            EventRef::Trace(trace) => {
-                                trace.get(key.as_str()).map(Value::to_string_lossy)
-                            }
+                            EventRef::Trace(trace) => trace
+                                .parse_path_and_get_value(key)
+                                .ok()
+                                .and_then(|v| v.map(Value::to_string_lossy)),
                         }
                         .unwrap_or_else(|| {
                             missing_keys.push(key.to_owned());

--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -130,8 +130,14 @@ impl FunctionTransform for Sample {
             .key_field
             .as_ref()
             .and_then(|key_field| match &event {
-                Event::Log(event) => event.get(key_field.as_str()),
-                Event::Trace(event) => event.get(key_field.as_str()),
+                Event::Log(event) => event
+                    .parse_path_and_get_value(key_field.as_str())
+                    .ok()
+                    .flatten(),
+                Event::Trace(event) => event
+                    .parse_path_and_get_value(key_field.as_str())
+                    .ok()
+                    .flatten(),
                 Event::Metric(_) => panic!("component can never receive metric events"),
             })
             .map(|v| v.to_string_lossy());


### PR DESCRIPTION
## Motivation
This part of https://github.com/vectordotdev/vector/issues/7070.

## Summary
* All `event.get(...)` calls outside of test code should use path types instead of strings.
* For dynamic string values, I used `parse_target_path`. 

An important note here: Currently we do not propagate parsing errors, we just return `None` instead. This PR doesn't change this behavior because it would take significant extra effort to refactor the code to propagate/handle parsing errors.