### PR TITLE
fix: socket tcp port typedef

### DIFF
--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -262,7 +262,7 @@ impl SourceConfig for SocketConfig {
                         Self::NAME,
                         legacy_port_key,
                         &owned_value_path!("port"),
-                        Kind::bytes(),
+                        Kind::integer(),
                         None,
                     )
             }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -233,7 +233,7 @@ impl SourceConfig for SocketConfig {
                         Self::NAME,
                         legacy_port_key,
                         &owned_value_path!("port"),
-                        Kind::bytes(),
+                        Kind::integer(),
                         None,
                     )
                     .with_source_metadata(


### PR DESCRIPTION
The actual type of the port value on a tcp socket is a number, but the typedef was set to bytes (a string).