### PR TITLE
fix: make LogEvent index operator test only

### DIFF
--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -648,6 +648,7 @@ impl TryInto<serde_json::Value> for LogEvent {
     }
 }
 
+#[cfg(any(test, feature = "test"))]
 impl<T> std::ops::Index<T> for LogEvent
 where
     T: AsRef<str>,


### PR DESCRIPTION
Part of #18059