### PR TITLE
fix(vector source): Remove the 4MB default for requests

### DIFF
--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -181,7 +181,9 @@ impl SourceConfig for VectorConfig {
             acknowledgements,
             log_namespace,
         })
-        .accept_compressed(tonic::codec::CompressionEncoding::Gzip);
+        .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
+        // Tonic added a default of 4MB in 0.9. This replaces the old behavior.
+        .max_decoding_message_size(usize::MAX);
 
         let source =
             run_grpc_server(self.address, tls_settings, service, cx.shutdown).map_err(|error| {


### PR DESCRIPTION
This was added in tonic 0.9 but caused a regression in Vector behavior. I think ideally this would
be configurable, but I think in this case we can let users ask for it since the use-case for the
`vector` source/sink is primarily such that the operator controls both sides and doesn't need to
worry about DOS from misbehaving clients.

Fixes: https://github.com/vectordotdev/vector/issues/17926

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
