### PR TITLE
feat: panic if the condition return type is not a boolean

### DIFF
--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -113,12 +113,7 @@ impl Conditional for Vrl {
         let result = result
             .map(|value| match value {
                 Value::Boolean(boolean) => boolean,
-                _ => {
-                    emit!(VrlConditionExecutionError {
-                        error: "VRL condition did not return a boolean type"
-                    });
-                    false
-                }
+                _ => panic!("VRL condition did not return a boolean type"),
             })
             .unwrap_or_else(|err| {
                 emit!(VrlConditionExecutionError {

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -113,7 +113,12 @@ impl Conditional for Vrl {
         let result = result
             .map(|value| match value {
                 Value::Boolean(boolean) => boolean,
-                _ => false,
+                _ => {
+                    emit!(VrlConditionExecutionError {
+                        error: "VRL condition did not return a boolean type"
+                    });
+                    false
+                }
             })
             .unwrap_or_else(|err| {
                 emit!(VrlConditionExecutionError {


### PR DESCRIPTION
Follow-up for https://github.com/vectordotdev/vector/issues/17175. This is a quick fix to avoid shallowing the error completely, ideally we would refactor the `check` to return an error.
