### PR TITLE
chore: Update `smp` to its latest released version

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -232,7 +232,7 @@ jobs:
           export REPLICAS="10"
           export TOTAL_SAMPLES="600"
           export P_VALUE="0.1"
-          export SMP_CRATE_VERSION="0.9.1"
+          export SMP_CRATE_VERSION="0.10.0"
           export LADING_VERSION="0.12.0"
 
           echo "warmup seconds: ${WARMUP_SECONDS}"
@@ -499,7 +499,6 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job submit \
-            --use-curta \
             --lading-version ${{ needs.compute-metadata.outputs.lading-version }} \
             --total-samples ${{ needs.compute-metadata.outputs.total-samples }} \
             --warmup-seconds ${{ needs.compute-metadata.outputs.warmup-seconds }} \
@@ -529,7 +528,6 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job status \
-            --use-curta \
             --wait \
             --wait-delay-seconds 60 \
             --wait-timeout-minutes 90 \
@@ -542,7 +540,6 @@ jobs:
         run: |
           chmod +x ${{ runner.temp }}/bin/smp
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job cancel \
-            --use-curta \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Check status, cancelled
@@ -623,7 +620,6 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job result \
-            --use-curta \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - name: Check status, cancelled
@@ -715,7 +711,6 @@ jobs:
           chmod +x ${{ runner.temp }}/bin/smp
 
           ${{ runner.temp }}/bin/smp --team-id ${{ secrets.SINGLE_MACHINE_PERFORMANCE_TEAM_ID }} job sync \
-            --use-curta \
             --submission-metadata ${{ runner.temp }}/submission-metadata \
             --output-path "${{ runner.temp }}/outputs"
 


### PR DESCRIPTION
This commit updates the smp binary to its latest release, removing a legacy flow with no user-facing change. Peer to
https://github.com/DataDog/datadog-agent/pull/18725. I have not opted to update lading in this PR as the jump from 0.12 to 0.18 is rather large, despite the branch name. 

REF SMP-673

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
