### PR TITLE
feat: Refactor dnstap to use 'OwnedValuePath's

### DIFF
--- a/benches/dnstap/mod.rs
+++ b/benches/dnstap/mod.rs
@@ -1,14 +1,10 @@
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use vector::{
-    event::LogEvent,
-    sources::dnstap::{schema::DnstapEventSchema, DnstapParser},
-};
+use vector::event::LogEvent;
+use vector::sources::dnstap::parser::DnstapParser;
 
 fn benchmark_query_parsing(c: &mut Criterion) {
     let mut event = LogEvent::default();
-    let schema = DnstapEventSchema::new();
-    let mut parser = DnstapParser::new(&schema, &mut event);
     let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcnoIAxACGAEiEAAAAAAAAA\
     AAAAAAAAAAAAAqECABBQJwlAAAAAAAAAAAADAw8+0CODVA7+zq9wVNMU3WNlI2kwIAAAABAAAAAAABCWZhY2Vib29rMQNjb\
     20AAAEAAQAAKQIAAACAAAAMAAoACOxjCAG9zVgzWgUDY29tAHgB";
@@ -19,7 +15,7 @@ fn benchmark_query_parsing(c: &mut Criterion) {
     group.bench_function("dns_query_parsing", |b| {
         b.iter_batched(
             || dnstap_data.clone(),
-            |dnstap_data| parser.parse_dnstap_data(Bytes::from(dnstap_data)).unwrap(),
+            |dnstap_data| DnstapParser::parse(&mut event, Bytes::from(dnstap_data)).unwrap(),
             BatchSize::SmallInput,
         )
     });
@@ -29,8 +25,6 @@ fn benchmark_query_parsing(c: &mut Criterion) {
 
 fn benchmark_update_parsing(c: &mut Criterion) {
     let mut event = LogEvent::default();
-    let schema = DnstapEventSchema::new();
-    let mut parser = DnstapParser::new(&schema, &mut event);
     let raw_dnstap_data = "ChVqYW1lcy1WaXJ0dWFsLU1hY2hpbmUSC0JJTkQgOS4xNi4zcmsIDhABGAEiBH8AAA\
     EqBH8AAAEwrG44AEC+iu73BU14gfofUh1wi6gAAAEAAAAAAAAHZXhhbXBsZQNjb20AAAYAAWC+iu73BW0agDwvch1wi6gAA\
     AEAAAAAAAAHZXhhbXBsZQNjb20AAAYAAXgB";
@@ -41,7 +35,7 @@ fn benchmark_update_parsing(c: &mut Criterion) {
     group.bench_function("dns_update_parsing", |b| {
         b.iter_batched(
             || dnstap_data.clone(),
-            |dnstap_data| parser.parse_dnstap_data(Bytes::from(dnstap_data)).unwrap(),
+            |dnstap_data| DnstapParser::parse(&mut event, Bytes::from(dnstap_data)).unwrap(),
             BatchSize::SmallInput,
         )
     });

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -7,7 +7,7 @@ use vector_common::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
 };
 use vector_config::configurable_component;
-use vrl::event_path;
+use vrl::path::PathPrefix;
 use vrl::value::{kind::Collection, Kind};
 
 use super::util::framestream::{build_framestream_unix_source, FrameHandler};
@@ -19,9 +19,9 @@ use crate::{
 };
 
 pub mod parser;
-pub use parser::{parse_dnstap_data, DnstapParser};
-
 pub mod schema;
+use crate::sources::dnstap::parser::DnstapParser;
+use crate::sources::dnstap::schema::DNSTAP_VALUE_PATHS;
 use dnsmsg_parser::{dns_message, dns_message_parser};
 use lookup::lookup_v2::OptionalValuePath;
 pub use schema::DnstapEventSchema;
@@ -109,19 +109,11 @@ impl DnstapConfig {
         "protobuf:dnstap.Dnstap".to_string() //content-type for framestream
     }
 
-    fn event_schema(timestamp_key: Option<&OwnedValuePath>) -> DnstapEventSchema {
-        let mut schema = DnstapEventSchema::new();
-        schema
-            .dnstap_root_data_schema_mut()
-            .set_timestamp(timestamp_key.cloned());
-        schema
-    }
-
     pub fn schema_definition(
         &self,
         log_namespace: LogNamespace,
     ) -> vector_core::schema::Definition {
-        let event_schema = Self::event_schema(log_schema().timestamp_key());
+        let event_schema = DnstapEventSchema;
 
         match log_namespace {
             LogNamespace::Legacy => {
@@ -205,7 +197,6 @@ pub struct DnstapFrameHandler {
     max_frame_length: usize,
     socket_path: PathBuf,
     content_type: String,
-    schema: DnstapEventSchema,
     raw_data_only: bool,
     multithreaded: bool,
     max_frame_handling_tasks: u32,
@@ -224,8 +215,6 @@ impl DnstapFrameHandler {
         let source_type_key = log_schema().source_type_key();
         let timestamp_key = log_schema().timestamp_key();
 
-        let schema = DnstapConfig::event_schema(timestamp_key);
-
         let host_key = config
             .host_key
             .clone()
@@ -235,7 +224,6 @@ impl DnstapFrameHandler {
             max_frame_length: config.max_frame_length,
             socket_path: config.socket_path.clone(),
             content_type: config.content_type(),
-            schema,
             raw_data_only: config.raw_data_only.unwrap_or(false),
             multithreaded: config.multithreaded.unwrap_or(false),
             max_frame_handling_tasks: config.max_frame_handling_tasks.unwrap_or(1000),
@@ -281,10 +269,10 @@ impl FrameHandler for DnstapFrameHandler {
 
         if self.raw_data_only {
             log_event.insert(
-                event_path!(self.schema.dnstap_root_data_schema().raw_data()),
+                (PathPrefix::Event, &DNSTAP_VALUE_PATHS.raw_data),
                 BASE64_STANDARD.encode(&frame),
             );
-        } else if let Err(err) = parse_dnstap_data(&self.schema, &mut log_event, frame) {
+        } else if let Err(err) = DnstapParser::parse(&mut log_event, frame) {
             emit!(DnstapParseError {
                 error: format!("Dnstap protobuf decode error {:?}.", err)
             });
@@ -408,7 +396,7 @@ mod tests {
         let mut event = Event::from(LogEvent::from(vrl::value::Value::from(json)));
         event.as_mut_log().insert("timestamp", chrono::Utc::now());
 
-        let definition = DnstapConfig::event_schema(Some(&owned_value_path!("timestamp")));
+        let definition = DnstapEventSchema;
         let schema = vector_core::schema::Definition::empty_legacy_namespace()
             .with_standard_vector_source_metadata();
 

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -33,7 +33,7 @@ use dnstap_proto::{
     message::Type as DnstapMessageType, Dnstap, Message as DnstapMessage, SocketFamily,
     SocketProtocol,
 };
-use lookup::lookup_v2::{OwnedValuePath, ValuePath};
+use lookup::lookup_v2::ValuePath;
 use lookup::PathPrefix;
 use vector_core::config::log_schema;
 
@@ -226,7 +226,6 @@ impl DnstapParser {
                 query_time_sec,
                 dnstap_message.query_time_nsec,
                 dnstap_message_type_id,
-                &DNSTAP_VALUE_PATHS.request_message,
                 dnstap_message.query_message.as_ref(),
                 &DNSTAP_MESSAGE_REQUEST_TYPE_IDS,
             );
@@ -239,7 +238,6 @@ impl DnstapParser {
                 response_time_sec,
                 dnstap_message.response_time_nsec,
                 dnstap_message_type_id,
-                &DNSTAP_VALUE_PATHS.request_message,
                 dnstap_message.response_message.as_ref(),
                 &DNSTAP_MESSAGE_RESPONSE_TYPE_IDS,
             );
@@ -352,7 +350,6 @@ impl DnstapParser {
         time_sec: u64,
         time_nsec: Option<u32>,
         dnstap_message_type_id: i32,
-        message_key: &'a OwnedValuePath,
         message: Option<&Vec<u8>>,
         type_ids: &HashSet<i32>,
     ) {
@@ -374,7 +371,12 @@ impl DnstapParser {
         }
 
         if message.is_none() {
-            DnstapParser::log_time(event, prefix.concat(message_key), time_in_nanosec, "ns");
+            DnstapParser::log_time(
+                event,
+                prefix.concat(&DNSTAP_VALUE_PATHS.request_message),
+                time_in_nanosec,
+                "ns",
+            );
         }
     }
 

--- a/src/sources/dnstap/schema.rs
+++ b/src/sources/dnstap/schema.rs
@@ -1,4 +1,5 @@
 use lookup::{owned_value_path, OwnedValuePath};
+use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 use vrl::btreemap;
 use vrl::value::{
@@ -7,151 +8,121 @@ use vrl::value::{
 };
 
 #[derive(Debug, Default, Clone)]
-pub struct DnstapEventSchema {
-    dnstap_root_data_schema: DnstapRootDataSchema,
-    dnstap_message_schema: DnstapMessageSchema,
-    dns_query_message_schema: DnsQueryMessageSchema,
-    dns_query_header_schema: DnsQueryHeaderSchema,
-    dns_update_message_schema: DnsUpdateMessageSchema,
-    dns_update_header_schema: DnsUpdateHeaderSchema,
-    dns_message_opt_pseudo_section_schema: DnsMessageOptPseudoSectionSchema,
-    dns_message_option_schema: DnsMessageOptionSchema,
-    dns_record_schema: DnsRecordSchema,
-    dns_query_question_schema: DnsQueryQuestionSchema,
-    dns_update_zone_info_schema: DnsUpdateZoneInfoSchema,
-}
+pub struct DnstapEventSchema;
 
 impl DnstapEventSchema {
     /// The message schema for the request and response message fields
     fn request_message_schema_definition(&self) -> Collection<Field> {
-        let mut result = BTreeMap::new();
+        let mut result: BTreeMap<Field, Kind> = BTreeMap::new();
         result.insert(
-            self.dns_query_message_schema().time().into(),
+            DNSTAP_VALUE_PATHS.time.to_string().into(),
             Kind::integer().or_undefined(),
         );
 
         result.insert(
-            self.dns_update_message_schema().time().into(),
+            DNSTAP_VALUE_PATHS.time.to_string().into(),
             Kind::integer().or_undefined(),
         );
         result.insert(
-            self.dns_query_message_schema().time_precision().into(),
+            DNSTAP_VALUE_PATHS.time_precision.to_string().into(),
             Kind::bytes().or_undefined(),
         );
         result.insert(
-            self.dns_update_message_schema().time_precision().into(),
+            DNSTAP_VALUE_PATHS.time_precision.to_string().into(),
             Kind::bytes().or_undefined(),
         );
         result.insert(
-            self.dns_query_message_schema().response_code().into(),
+            DNSTAP_VALUE_PATHS.response_code.to_string().into(),
             Kind::integer().or_undefined(),
         );
         result.insert(
-            self.dns_update_message_schema().response_code().into(),
+            DNSTAP_VALUE_PATHS.response_code.to_string().into(),
             Kind::integer().or_undefined(),
         );
         result.insert(
-            self.dns_query_message_schema().response().into(),
+            DNSTAP_VALUE_PATHS.response.to_string().into(),
             Kind::bytes().or_undefined(),
         );
         result.insert(
-            self.dns_update_message_schema().response().into(),
+            DNSTAP_VALUE_PATHS.response.to_string().into(),
             Kind::bytes().or_undefined(),
         );
 
-        if self.dns_query_message_schema().header() == self.dns_update_message_schema().header() {
-            // This branch will always be hit -
-            // we know that both headers are equal since they both pull the values from the common schema.
-            let mut schema = self.dns_query_header_schema().schema_definition();
-            schema.merge(self.dns_update_header_schema().schema_definition(), true);
+        let mut schema = DnsQueryHeaderSchema::schema_definition();
+        schema.merge(DnsUpdateHeaderSchema::schema_definition(), true);
 
-            result.insert(
-                self.dns_query_message_schema().header().into(),
-                Kind::object(schema).or_undefined(),
-            );
-        } else {
-            result.insert(
-                self.dns_query_message_schema().header().into(),
-                Kind::object(self.dns_query_header_schema().schema_definition()).or_undefined(),
-            );
-            result.insert(
-                self.dns_update_message_schema().header().into(),
-                Kind::object(self.dns_update_header_schema().schema_definition()).or_undefined(),
-            );
-        }
         result.insert(
-            self.dns_update_message_schema().zone_section().into(),
-            Kind::object(self.dns_update_zone_info_schema().schema_definition()).or_undefined(),
+            DNSTAP_VALUE_PATHS.header.to_string().into(),
+            Kind::object(schema).or_undefined(),
         );
 
         result.insert(
-            self.dns_query_message_schema().question_section().into(),
+            DNSTAP_VALUE_PATHS.zone_section.to_string().into(),
+            Kind::object(DnsUpdateZoneInfoSchema::schema_definition()).or_undefined(),
+        );
+
+        result.insert(
+            DNSTAP_VALUE_PATHS.question_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_query_question_schema().schema_definition(),
+                DnsQueryQuestionSchema::schema_definition(),
             )))
             .or_undefined(),
         );
 
         result.insert(
-            self.dns_query_message_schema().answer_section().into(),
+            DNSTAP_VALUE_PATHS.answer_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_record_schema().schema_definition(),
+                DnsRecordSchema::schema_definition(),
             )))
             .or_undefined(),
         );
 
         result.insert(
-            self.dns_query_message_schema().authority_section().into(),
+            DNSTAP_VALUE_PATHS.authority_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_record_schema().schema_definition(),
+                DnsRecordSchema::schema_definition(),
             )))
             .or_undefined(),
         );
 
         result.insert(
-            self.dns_query_message_schema().additional_section().into(),
+            DNSTAP_VALUE_PATHS.additional_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_record_schema().schema_definition(),
+                DnsRecordSchema::schema_definition(),
             )))
             .or_undefined(),
         );
 
         result.insert(
-            self.dns_query_message_schema().opt_pseudo_section().into(),
-            Kind::object(
-                self.dns_message_opt_pseudo_section_schema()
-                    .schema_definition(self.dns_message_option_schema()),
-            )
-            .or_undefined(),
+            DNSTAP_VALUE_PATHS.opt_pseudo_section.to_string().into(),
+            Kind::object(DnsMessageOptPseudoSectionSchema::schema_definition()).or_undefined(),
         );
 
         result.insert(
-            self.dns_query_message_schema().raw_data().into(),
+            DNSTAP_VALUE_PATHS.raw_data.to_string().into(),
             Kind::bytes().or_undefined(),
         );
 
         result.insert(
-            self.dns_update_message_schema()
-                .prerequisite_section()
-                .into(),
+            DNSTAP_VALUE_PATHS.prerequisite_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_record_schema().schema_definition(),
+                DnsRecordSchema::schema_definition(),
             )))
             .or_undefined(),
         );
 
         result.insert(
-            self.dns_update_message_schema().update_section().into(),
+            DNSTAP_VALUE_PATHS.update_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_record_schema().schema_definition(),
+                DnsRecordSchema::schema_definition(),
             )))
             .or_undefined(),
         );
 
         result.insert(
-            self.dns_update_message_schema().additional_section().into(),
+            DNSTAP_VALUE_PATHS.additional_section.to_string().into(),
             Kind::array(Collection::from_unknown(Kind::object(
-                self.dns_record_schema().schema_definition(),
+                DnsRecordSchema::schema_definition(),
             )))
             .or_undefined(),
         );
@@ -165,51 +136,15 @@ impl DnstapEventSchema {
         schema: vector_core::schema::Definition,
     ) -> vector_core::schema::Definition {
         schema
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().server_identity()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().server_version()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().extra()),
-                Kind::bytes(),
-                None,
-            )
-            .with_event_field(
-                &owned_value_path!(self.dnstap_root_data_schema().data_type_id()),
-                Kind::integer(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().data_type()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().error()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().raw_data()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().time()),
-                Kind::integer(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_root_data_schema().time_precision()),
-                Kind::bytes(),
-                None,
-            )
+            .optional_field(&DNSTAP_VALUE_PATHS.server_identity, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.server_version, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.extra, Kind::bytes(), None)
+            .with_event_field(&DNSTAP_VALUE_PATHS.data_type_id, Kind::integer(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.data_type, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.error, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.raw_data, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.time, Kind::integer(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.time_precision, Kind::bytes(), None)
     }
 
     /// Schema definition from the message.
@@ -218,58 +153,22 @@ impl DnstapEventSchema {
         schema: vector_core::schema::Definition,
     ) -> vector_core::schema::Definition {
         schema
+            .optional_field(&DNSTAP_VALUE_PATHS.socket_family, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.socket_protocol, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.query_address, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.query_port, Kind::integer(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.response_address, Kind::bytes(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.response_port, Kind::integer(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.query_zone, Kind::bytes(), None)
+            .with_event_field(&DNSTAP_VALUE_PATHS.message_type_id, Kind::integer(), None)
+            .optional_field(&DNSTAP_VALUE_PATHS.message_type, Kind::bytes(), None)
             .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().socket_family()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().socket_protocol()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().query_address()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().query_port()),
-                Kind::integer(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().response_address()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().response_port()),
-                Kind::integer(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().query_zone()),
-                Kind::bytes(),
-                None,
-            )
-            .with_event_field(
-                &owned_value_path!(self.dnstap_message_schema().dnstap_message_type_id()),
-                Kind::integer(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().dnstap_message_type()),
-                Kind::bytes(),
-                None,
-            )
-            .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().request_message()),
+                &DNSTAP_VALUE_PATHS.request_message,
                 Kind::object(self.request_message_schema_definition()),
                 None,
             )
             .optional_field(
-                &owned_value_path!(self.dnstap_message_schema().response_message()),
+                &DNSTAP_VALUE_PATHS.response_message,
                 Kind::object(self.request_message_schema_definition()),
                 None,
             )
@@ -282,391 +181,202 @@ impl DnstapEventSchema {
     ) -> vector_core::schema::Definition {
         self.root_schema_definition(self.message_schema_definition(schema))
     }
-
-    pub const fn dnstap_root_data_schema(&self) -> &DnstapRootDataSchema {
-        &self.dnstap_root_data_schema
-    }
-
-    pub const fn dnstap_message_schema(&self) -> &DnstapMessageSchema {
-        &self.dnstap_message_schema
-    }
-
-    pub const fn dns_query_message_schema(&self) -> &DnsQueryMessageSchema {
-        &self.dns_query_message_schema
-    }
-
-    pub const fn dns_query_header_schema(&self) -> &DnsQueryHeaderSchema {
-        &self.dns_query_header_schema
-    }
-
-    pub const fn dns_update_message_schema(&self) -> &DnsUpdateMessageSchema {
-        &self.dns_update_message_schema
-    }
-
-    pub const fn dns_update_header_schema(&self) -> &DnsUpdateHeaderSchema {
-        &self.dns_update_header_schema
-    }
-
-    pub const fn dns_message_opt_pseudo_section_schema(&self) -> &DnsMessageOptPseudoSectionSchema {
-        &self.dns_message_opt_pseudo_section_schema
-    }
-
-    pub const fn dns_message_option_schema(&self) -> &DnsMessageOptionSchema {
-        &self.dns_message_option_schema
-    }
-
-    pub const fn dns_record_schema(&self) -> &DnsRecordSchema {
-        &self.dns_record_schema
-    }
-
-    pub const fn dns_query_question_schema(&self) -> &DnsQueryQuestionSchema {
-        &self.dns_query_question_schema
-    }
-
-    pub const fn dns_update_zone_info_schema(&self) -> &DnsUpdateZoneInfoSchema {
-        &self.dns_update_zone_info_schema
-    }
-
-    pub fn dnstap_root_data_schema_mut(&mut self) -> &mut DnstapRootDataSchema {
-        &mut self.dnstap_root_data_schema
-    }
-
-    pub fn new() -> Self {
-        Self::default()
-    }
 }
 
+/// Collection of owned value paths.
 #[derive(Debug, Clone)]
-pub struct DnstapRootDataSchema {
-    timestamp: Option<OwnedValuePath>,
+pub struct DnstapPaths {
+    // DnstapRootDataSchema
+    pub server_identity: OwnedValuePath,
+    pub server_version: OwnedValuePath,
+    pub extra: OwnedValuePath,
+    pub data_type: OwnedValuePath,
+    pub data_type_id: OwnedValuePath,
+    pub time: OwnedValuePath,
+    pub time_precision: OwnedValuePath,
+    pub error: OwnedValuePath,
+    pub raw_data: OwnedValuePath,
+
+    // DnstapMessageSchema
+    pub socket_family: OwnedValuePath,
+    pub socket_protocol: OwnedValuePath,
+    pub query_address: OwnedValuePath,
+    pub query_port: OwnedValuePath,
+    pub response_address: OwnedValuePath,
+    pub response_port: OwnedValuePath,
+    pub query_zone: OwnedValuePath,
+    pub message_type: OwnedValuePath,
+    pub message_type_id: OwnedValuePath,
+    pub request_message: OwnedValuePath,
+    pub response_message: OwnedValuePath,
+
+    // DnsQueryMessageSchema
+    pub response_code: OwnedValuePath,
+    pub response: OwnedValuePath,
+    pub header: OwnedValuePath,
+    pub question_section: OwnedValuePath,
+    pub answer_section: OwnedValuePath,
+    pub authority_section: OwnedValuePath,
+    pub additional_section: OwnedValuePath,
+    pub opt_pseudo_section: OwnedValuePath,
+
+    // DnsUpdateMessageSchema
+    pub zone_section: OwnedValuePath,
+    pub prerequisite_section: OwnedValuePath,
+    pub update_section: OwnedValuePath,
+
+    // DnsMessageHeaderCommonSchema
+    pub id: OwnedValuePath,
+    pub opcode: OwnedValuePath,
+    pub rcode: OwnedValuePath,
+    pub qr: OwnedValuePath,
+
+    // DnsQueryHeaderSchema
+    pub aa: OwnedValuePath,
+    pub tc: OwnedValuePath,
+    pub rd: OwnedValuePath,
+    pub ra: OwnedValuePath,
+    pub ad: OwnedValuePath,
+    pub cd: OwnedValuePath,
+    pub question_count: OwnedValuePath,
+    pub answer_count: OwnedValuePath,
+    pub authority_count: OwnedValuePath,
+    pub ar_count: OwnedValuePath,
+
+    // DnsUpdateHeaderSchema
+    pub zone_count: OwnedValuePath,
+    pub prerequisite_count: OwnedValuePath,
+    pub update_count: OwnedValuePath,
+    pub ad_count: OwnedValuePath,
+
+    // DnsMessageOptPseudoSectionSchema
+    pub extended_rcode: OwnedValuePath,
+    pub version: OwnedValuePath,
+    pub do_flag: OwnedValuePath,
+    pub udp_max_payload_size: OwnedValuePath,
+    pub options: OwnedValuePath,
+
+    // DnsMessageOptionSchema
+    pub opt_code: OwnedValuePath,
+    pub opt_name: OwnedValuePath,
+    pub opt_data: OwnedValuePath,
+
+    // DnsRecordSchema
+    pub domain_name: OwnedValuePath,
+    pub record_type: OwnedValuePath,
+    pub record_type_id: OwnedValuePath,
+    pub ttl: OwnedValuePath,
+    pub class: OwnedValuePath,
+    pub rdata: OwnedValuePath,
+    pub rdata_bytes: OwnedValuePath,
+
+    // DnsQueryQuestionSchema
+    pub question_type: OwnedValuePath,
+    pub question_type_id: OwnedValuePath,
+
+    // DnsUpdateZoneInfoSchema
+    pub zone_name: OwnedValuePath,
+    pub zone_class: OwnedValuePath,
+    pub zone_type: OwnedValuePath,
+    pub zone_type_id: OwnedValuePath,
 }
 
-impl Default for DnstapRootDataSchema {
-    fn default() -> Self {
-        Self {
-            timestamp: Some(owned_value_path!("timestamp")),
-        }
-    }
-}
-
-impl DnstapRootDataSchema {
-    pub const fn server_identity(&self) -> &'static str {
-        "serverId"
-    }
-
-    pub const fn server_version(&self) -> &'static str {
-        "serverVersion"
-    }
-
-    pub const fn extra(&self) -> &'static str {
-        "extraInfo"
-    }
-
-    pub const fn data_type(&self) -> &'static str {
-        "dataType"
-    }
-
-    pub const fn data_type_id(&self) -> &'static str {
-        "dataTypeId"
-    }
-
-    pub const fn timestamp(&self) -> Option<&OwnedValuePath> {
-        self.timestamp.as_ref()
-    }
-
-    pub const fn time(&self) -> &'static str {
-        "time"
-    }
-
-    pub const fn time_precision(&self) -> &'static str {
-        "timePrecision"
-    }
-
-    pub const fn error(&self) -> &'static str {
-        "error"
-    }
-
-    pub const fn raw_data(&self) -> &'static str {
-        "rawData"
-    }
-
-    pub fn set_timestamp(&mut self, val: Option<OwnedValuePath>) -> &mut Self {
-        self.timestamp = val;
-        self
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct DnstapMessageSchema;
-
-impl DnstapMessageSchema {
-    pub const fn socket_family(&self) -> &'static str {
-        "socketFamily"
-    }
-
-    pub const fn socket_protocol(&self) -> &'static str {
-        "socketProtocol"
-    }
-
-    pub const fn query_address(&self) -> &'static str {
-        "sourceAddress"
-    }
-
-    pub const fn query_port(&self) -> &'static str {
-        "sourcePort"
-    }
-
-    pub const fn response_address(&self) -> &'static str {
-        "responseAddress"
-    }
-
-    pub const fn response_port(&self) -> &'static str {
-        "responsePort"
-    }
-
-    pub const fn query_zone(&self) -> &'static str {
-        "queryZone"
-    }
-
-    pub const fn dnstap_message_type(&self) -> &'static str {
-        "messageType"
-    }
-
-    pub const fn dnstap_message_type_id(&self) -> &'static str {
-        "messageTypeId"
-    }
-
-    pub const fn request_message(&self) -> &'static str {
-        "requestData"
-    }
-
-    pub const fn response_message(&self) -> &'static str {
-        "responseData"
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct DnsMessageCommonSchema;
-
-impl DnsMessageCommonSchema {
-    pub const fn response_code() -> &'static str {
-        "fullRcode"
-    }
-
-    pub const fn response() -> &'static str {
-        "rcodeName"
-    }
-
-    pub const fn time() -> &'static str {
-        "time"
-    }
-
-    pub const fn time_precision() -> &'static str {
-        "timePrecision"
-    }
-
-    pub const fn raw_data() -> &'static str {
-        "rawData"
-    }
-
-    pub const fn header() -> &'static str {
-        "header"
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct DnsQueryMessageSchema;
-
-impl DnsQueryMessageSchema {
-    pub const fn response_code(&self) -> &'static str {
-        DnsMessageCommonSchema::response_code()
-    }
-
-    pub const fn response(&self) -> &'static str {
-        DnsMessageCommonSchema::response()
-    }
-
-    pub const fn time(&self) -> &'static str {
-        DnsMessageCommonSchema::time()
-    }
-
-    pub const fn time_precision(&self) -> &'static str {
-        DnsMessageCommonSchema::time_precision()
-    }
-
-    pub const fn raw_data(&self) -> &'static str {
-        DnsMessageCommonSchema::raw_data()
-    }
-
-    pub const fn header(&self) -> &'static str {
-        DnsMessageCommonSchema::header()
-    }
-
-    pub const fn question_section(&self) -> &'static str {
-        "question"
-    }
-
-    pub const fn answer_section(&self) -> &'static str {
-        "answers"
-    }
-
-    pub const fn authority_section(&self) -> &'static str {
-        "authority"
-    }
-
-    pub const fn additional_section(&self) -> &'static str {
-        "additional"
-    }
-
-    pub const fn opt_pseudo_section(&self) -> &'static str {
-        "opt"
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct DnsUpdateMessageSchema;
-
-impl DnsUpdateMessageSchema {
-    pub const fn response_code(&self) -> &'static str {
-        DnsMessageCommonSchema::response_code()
-    }
-
-    pub const fn response(&self) -> &'static str {
-        DnsMessageCommonSchema::response()
-    }
-
-    pub const fn time(&self) -> &'static str {
-        DnsMessageCommonSchema::time()
-    }
-
-    pub const fn time_precision(&self) -> &'static str {
-        DnsMessageCommonSchema::time_precision()
-    }
-
-    pub const fn raw_data(&self) -> &'static str {
-        DnsMessageCommonSchema::raw_data()
-    }
-
-    pub const fn header(&self) -> &'static str {
-        DnsMessageCommonSchema::header()
-    }
-
-    pub const fn zone_section(&self) -> &'static str {
-        "zone"
-    }
-
-    pub const fn prerequisite_section(&self) -> &'static str {
-        "prerequisite"
-    }
-
-    pub const fn update_section(&self) -> &'static str {
-        "update"
-    }
-
-    pub const fn additional_section(&self) -> &'static str {
-        "additional"
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct DnsMessageHeaderCommonSchema;
-
-impl DnsMessageHeaderCommonSchema {
-    pub const fn id() -> &'static str {
-        "id"
-    }
-
-    pub const fn opcode() -> &'static str {
-        "opcode"
-    }
-
-    pub const fn rcode() -> &'static str {
-        "rcode"
-    }
-
-    pub const fn qr() -> &'static str {
-        "qr"
-    }
-}
+/// Lazily initialized singleton.
+pub(crate) static DNSTAP_VALUE_PATHS: Lazy<DnstapPaths> = Lazy::new(|| DnstapPaths {
+    server_identity: owned_value_path!("serverId"),
+    server_version: owned_value_path!("serverVersion"),
+    extra: owned_value_path!("extraInfo"),
+    data_type: owned_value_path!("dataType"),
+    data_type_id: owned_value_path!("dataTypeId"),
+    time: owned_value_path!("time"),
+    time_precision: owned_value_path!("timePrecision"),
+    error: owned_value_path!("error"),
+    raw_data: owned_value_path!("rawData"),
+    socket_family: owned_value_path!("socketFamily"),
+    socket_protocol: owned_value_path!("socketProtocol"),
+    query_address: owned_value_path!("sourceAddress"),
+    query_port: owned_value_path!("sourcePort"),
+    response_address: owned_value_path!("responseAddress"),
+    response_port: owned_value_path!("responsePort"),
+    query_zone: owned_value_path!("queryZone"),
+    message_type: owned_value_path!("messageType"),
+    message_type_id: owned_value_path!("messageTypeId"),
+    request_message: owned_value_path!("requestData"),
+    response_message: owned_value_path!("responseData"),
+    response_code: owned_value_path!("fullRcode"),
+    response: owned_value_path!("rcodeName"),
+    header: owned_value_path!("header"),
+    question_section: owned_value_path!("question"),
+    answer_section: owned_value_path!("answers"),
+    authority_section: owned_value_path!("authority"),
+    additional_section: owned_value_path!("additional"),
+    opt_pseudo_section: owned_value_path!("opt"),
+    zone_section: owned_value_path!("zone"),
+    prerequisite_section: owned_value_path!("prerequisite"),
+    update_section: owned_value_path!("update"),
+    id: owned_value_path!("id"),
+    opcode: owned_value_path!("opcode"),
+    rcode: owned_value_path!("rcode"),
+    qr: owned_value_path!("qr"),
+    aa: owned_value_path!("aa"),
+    tc: owned_value_path!("tc"),
+    rd: owned_value_path!("rd"),
+    ra: owned_value_path!("ra"),
+    ad: owned_value_path!("ad"),
+    cd: owned_value_path!("cd"),
+    question_count: owned_value_path!("qdCount"),
+    answer_count: owned_value_path!("anCount"),
+    authority_count: owned_value_path!("nsCount"),
+    ar_count: owned_value_path!("arCount"),
+    zone_count: owned_value_path!("zoCount"),
+    prerequisite_count: owned_value_path!("prCount"),
+    update_count: owned_value_path!("upCount"),
+    ad_count: owned_value_path!("adCount"),
+    extended_rcode: owned_value_path!("extendedRcode"),
+    version: owned_value_path!("ednsVersion"),
+    do_flag: owned_value_path!("do"),
+    udp_max_payload_size: owned_value_path!("udpPayloadSize"),
+    options: owned_value_path!("options"),
+    opt_code: owned_value_path!("optCode"),
+    opt_name: owned_value_path!("optName"),
+    opt_data: owned_value_path!("optValue"),
+    record_type: owned_value_path!("recordType"),
+    record_type_id: owned_value_path!("recordTypeId"),
+    ttl: owned_value_path!("ttl"),
+    class: owned_value_path!("class"),
+    rdata: owned_value_path!("rData"),
+    rdata_bytes: owned_value_path!("rDataBytes"),
+    domain_name: owned_value_path!("domainName"),
+    question_type: owned_value_path!("questionType"),
+    question_type_id: owned_value_path!("questionTypeId"),
+    zone_name: owned_value_path!("zName"),
+    zone_class: owned_value_path!("zClass"),
+    zone_type: owned_value_path!("zType"),
+    zone_type_id: owned_value_path!("zTypeId"),
+});
 
 #[derive(Debug, Default, Clone)]
 pub struct DnsQueryHeaderSchema;
 
 impl DnsQueryHeaderSchema {
-    pub fn schema_definition(&self) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.id() => Kind::integer(),
-            self.opcode() => Kind::integer(),
-            self.rcode() => Kind::integer(),
-            self.qr() => Kind::integer(),
-            self.aa() => Kind::boolean(),
-            self.tc() => Kind::boolean(),
-            self.rd() => Kind::boolean(),
-            self.ra() => Kind::boolean(),
-            self.ad() => Kind::boolean(),
-            self.cd() => Kind::boolean(),
-            self.additional_count() => Kind::integer().or_undefined(),
-            self.question_count() => Kind::integer().or_undefined(),
-            self.answer_count() => Kind::integer().or_undefined(),
-            self.authority_count() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.id.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.opcode.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.rcode.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.qr.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.aa.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.tc.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.rd.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.ra.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.ad.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.cd.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.ar_count.to_string() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.question_count.to_string() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.answer_count.to_string() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.authority_count.to_string() => Kind::integer().or_undefined(),
         }
         .into()
-    }
-
-    pub const fn id(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::id()
-    }
-
-    pub const fn opcode(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::opcode()
-    }
-
-    pub const fn rcode(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::rcode()
-    }
-
-    pub const fn qr(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::qr()
-    }
-
-    pub const fn aa(&self) -> &'static str {
-        "aa"
-    }
-
-    pub const fn tc(&self) -> &'static str {
-        "tc"
-    }
-
-    pub const fn rd(&self) -> &'static str {
-        "rd"
-    }
-
-    pub const fn ra(&self) -> &'static str {
-        "ra"
-    }
-
-    pub const fn ad(&self) -> &'static str {
-        "ad"
-    }
-
-    pub const fn cd(&self) -> &'static str {
-        "cd"
-    }
-
-    pub const fn question_count(&self) -> &'static str {
-        "qdCount"
-    }
-
-    pub const fn answer_count(&self) -> &'static str {
-        "anCount"
-    }
-
-    pub const fn authority_count(&self) -> &'static str {
-        "nsCount"
-    }
-
-    pub const fn additional_count(&self) -> &'static str {
-        "arCount"
     }
 }
 
@@ -674,50 +384,18 @@ impl DnsQueryHeaderSchema {
 pub struct DnsUpdateHeaderSchema;
 
 impl DnsUpdateHeaderSchema {
-    pub fn schema_definition(&self) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.id() => Kind::integer(),
-            self.opcode() => Kind::integer(),
-            self.rcode() => Kind::integer(),
-            self.qr() => Kind::integer(),
-            self.zone_count() => Kind::integer().or_undefined(),
-            self.prerequisite_count() => Kind::integer().or_undefined(),
-            self.update_count() => Kind::integer().or_undefined(),
-            self.additional_count() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.id.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.opcode.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.rcode.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.qr.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.zone_count.to_string() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.prerequisite_count.to_string() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.update_count.to_string() => Kind::integer().or_undefined(),
+            DNSTAP_VALUE_PATHS.ad_count.to_string() => Kind::integer().or_undefined(),
         }
         .into()
-    }
-
-    pub const fn id(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::id()
-    }
-
-    pub const fn opcode(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::opcode()
-    }
-
-    pub const fn rcode(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::rcode()
-    }
-
-    pub const fn qr(&self) -> &'static str {
-        DnsMessageHeaderCommonSchema::qr()
-    }
-
-    pub const fn zone_count(&self) -> &'static str {
-        "zoCount"
-    }
-
-    pub const fn prerequisite_count(&self) -> &'static str {
-        "prCount"
-    }
-
-    pub const fn update_count(&self) -> &'static str {
-        "upCount"
-    }
-
-    pub const fn additional_count(&self) -> &'static str {
-        "adCount"
     }
 }
 
@@ -725,40 +403,17 @@ impl DnsUpdateHeaderSchema {
 pub struct DnsMessageOptPseudoSectionSchema;
 
 impl DnsMessageOptPseudoSectionSchema {
-    pub fn schema_definition(
-        &self,
-        dns_message_option_schema: &DnsMessageOptionSchema,
-    ) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.extended_rcode() => Kind::integer(),
-            self.version() => Kind::integer(),
-            self.do_flag() => Kind::boolean(),
-            self.udp_max_payload_size() => Kind::integer(),
-            self.options() => Kind::array(
-                Collection::from_unknown(Kind::object(dns_message_option_schema.schema_definition()))
+            DNSTAP_VALUE_PATHS.extended_rcode.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.version.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.do_flag.to_string() => Kind::boolean(),
+            DNSTAP_VALUE_PATHS.udp_max_payload_size.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.options.to_string() => Kind::array(
+                Collection::from_unknown(Kind::object(DnsMessageOptionSchema::schema_definition()))
             ).or_undefined(),
         }
         .into()
-    }
-
-    pub const fn extended_rcode(&self) -> &'static str {
-        "extendedRcode"
-    }
-
-    pub const fn version(&self) -> &'static str {
-        "ednsVersion"
-    }
-
-    pub const fn do_flag(&self) -> &'static str {
-        "do"
-    }
-
-    pub const fn udp_max_payload_size(&self) -> &'static str {
-        "udpPayloadSize"
-    }
-
-    pub const fn options(&self) -> &'static str {
-        "options"
     }
 }
 
@@ -766,25 +421,13 @@ impl DnsMessageOptPseudoSectionSchema {
 pub struct DnsMessageOptionSchema;
 
 impl DnsMessageOptionSchema {
-    pub fn schema_definition(&self) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.opt_code() => Kind::integer(),
-            self.opt_name() => Kind::bytes(),
-            self.opt_data() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.opt_code.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.opt_name.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.opt_data.to_string() => Kind::bytes(),
         }
         .into()
-    }
-
-    pub const fn opt_code(&self) -> &'static str {
-        "optCode"
-    }
-
-    pub const fn opt_name(&self) -> &'static str {
-        "optName"
-    }
-
-    pub const fn opt_data(&self) -> &'static str {
-        "optValue"
     }
 }
 
@@ -792,45 +435,17 @@ impl DnsMessageOptionSchema {
 pub struct DnsRecordSchema;
 
 impl DnsRecordSchema {
-    pub fn schema_definition(&self) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.name() => Kind::bytes(),
-            self.record_type() => Kind::bytes().or_undefined(),
-            self.record_type_id() => Kind::integer(),
-            self.ttl() => Kind::integer(),
-            self.class() => Kind::bytes(),
-            self.rdata() => Kind::bytes(),
-            self.rdata_bytes() => Kind::bytes().or_undefined(),
+            DNSTAP_VALUE_PATHS.domain_name.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.record_type.to_string() => Kind::bytes().or_undefined(),
+            DNSTAP_VALUE_PATHS.record_type_id.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.ttl.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.class.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.rdata.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.rdata_bytes.to_string() => Kind::bytes().or_undefined(),
         }
         .into()
-    }
-
-    pub const fn name(&self) -> &'static str {
-        "domainName"
-    }
-
-    pub const fn record_type(&self) -> &'static str {
-        "recordType"
-    }
-
-    pub const fn record_type_id(&self) -> &'static str {
-        "recordTypeId"
-    }
-
-    pub const fn ttl(&self) -> &'static str {
-        "ttl"
-    }
-
-    pub const fn class(&self) -> &'static str {
-        "class"
-    }
-
-    pub const fn rdata(&self) -> &'static str {
-        "rData"
-    }
-
-    pub const fn rdata_bytes(&self) -> &'static str {
-        "rDataBytes"
     }
 }
 
@@ -838,30 +453,14 @@ impl DnsRecordSchema {
 pub struct DnsQueryQuestionSchema;
 
 impl DnsQueryQuestionSchema {
-    pub fn schema_definition(&self) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.class() => Kind::bytes(),
-            self.name() => Kind::bytes(),
-            self.question_type() => Kind::bytes(),
-            self.question_type_id() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.class.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.domain_name.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.question_type.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.question_type_id.to_string() => Kind::integer(),
         }
         .into()
-    }
-
-    pub const fn name(&self) -> &'static str {
-        "domainName"
-    }
-
-    pub const fn question_type(&self) -> &'static str {
-        "questionType"
-    }
-
-    pub const fn question_type_id(&self) -> &'static str {
-        "questionTypeId"
-    }
-
-    pub const fn class(&self) -> &'static str {
-        "class"
     }
 }
 
@@ -869,29 +468,13 @@ impl DnsQueryQuestionSchema {
 pub struct DnsUpdateZoneInfoSchema;
 
 impl DnsUpdateZoneInfoSchema {
-    pub fn schema_definition(&self) -> Collection<Field> {
+    pub fn schema_definition() -> Collection<Field> {
         btreemap! {
-            self.zone_name() => Kind::bytes(),
-            self.zone_type() => Kind::bytes().or_undefined(),
-            self.zone_type_id() => Kind::integer(),
-            self.zone_class() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.zone_name.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.zone_type.to_string() => Kind::bytes().or_undefined(),
+            DNSTAP_VALUE_PATHS.zone_type_id.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.zone_class.to_string() => Kind::bytes(),
         }
         .into()
-    }
-
-    pub const fn zone_name(&self) -> &'static str {
-        "zName"
-    }
-
-    pub const fn zone_class(&self) -> &'static str {
-        "zClass"
-    }
-
-    pub const fn zone_type(&self) -> &'static str {
-        "zType"
-    }
-
-    pub const fn zone_type_id(&self) -> &'static str {
-        "zTypeId"
     }
 }


### PR DESCRIPTION
## Motivation
This is part of #18059.


## Description
* Now using `OwnedValuePath`s instead of `&str`.
* Removed a lot unnecessary `strcut`s and accessors. Deleted a lot of dead code. 
* Made the parser stateless. 
* Now recursively building paths on the go.
