### PR TITLE
fix(dev): fix Rust toolchain check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ build-graphql-schema: ## Generate the `schema.json` for Vector's GraphQL API
 .PHONY: check-build-tools
 check-build-tools:
 ifneq ($(ENVIRONMENT), true)
-ifeq (, $(shell command -v cargo))
+ifeq ($(shell command -v cargo >/dev/null || echo not-found), not-found)
 	$(error "Please install Rust: https://www.rust-lang.org/tools/install")
 endif
 endif


### PR DESCRIPTION
This is a small follow up fix to my previous PR: #18112
Apologies as I didn't notice it before. On my Debian machine, the issue described does not happen 🙈.

The `make` command inside of the Vector environment image optimizes `$(shell ...)` such that if the command to run is simple enough, it will just call it directly without using a shell. The problem is that the `command` command used to check if the Rust toolchain is installed is a shell builtin and, when optimized, `make` invocations that use the `check-build-tools` target emit the following error:

    make: command: Command not found

This commit fixes the issue by using a redirect, and thus forcing `make` to use the shell.

Ref: https://stackoverflow.com/a/12991757

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
