### PR TITLE
chore(deps): Swap tui crate for ratatui

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -869,6 +869,7 @@ qwe
 raboof
 rande
 RANDFILE
+ratatui
 rawconfig
 rawstring
 rdkafka

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,22 +2473,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
@@ -6822,6 +6806,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
+dependencies = [
+ "bitflags 2.3.2",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "paste",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9057,19 +9056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9440,7 +9426,7 @@ dependencies = [
  "colored",
  "console-subscriber",
  "criterion",
- "crossterm 0.26.1",
+ "crossterm",
  "csv",
  "derivative",
  "dirs-next",
@@ -9519,6 +9505,7 @@ dependencies = [
  "quickcheck",
  "rand 0.8.5",
  "rand_distr",
+ "ratatui",
  "rdkafka",
  "redis",
  "regex",
@@ -9567,7 +9554,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tower",
  "trust-dns-proto 0.22.0",
- "tui",
  "typetag",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,7 @@ itertools = { version = "0.11.0", default-features = false, optional = true }
 crossterm = { version = "0.26.1", default-features = false, features = ["event-stream"], optional = true }
 num-format = { version = "0.4.4", default-features = false, features = ["with-num-bigint"], optional = true }
 number_prefix = { version = "0.4.0", default-features = false, features = ["std"], optional = true }
-tui = { version = "0.19.0", optional = true, default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.22.0", optional = true, default-features = false, features = ["crossterm"] }
 
 # Datadog Pipelines
 
@@ -443,7 +443,7 @@ api-client = [
   "dep:crossterm",
   "dep:num-format",
   "dep:number_prefix",
-  "dep:tui",
+  "dep:ratatui",
   "vector-core/api",
   "dep:vector-api-client",
 ]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -422,6 +422,7 @@ rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Proj
 rand_distr,https://github.com/rust-random/rand,MIT OR Apache-2.0,The Rand Project Developers
 rand_hc,https://github.com/rust-random/rand,MIT OR Apache-2.0,The Rand Project Developers
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
+ratatui,https://github.com/tui-rs-revival/ratatui,MIT,"Florian Dehau <work@fdehau.com>, The Ratatui Developers"
 raw-cpuid,https://github.com/gz/rust-cpuid,MIT,Gerd Zellweger <mail@gerdzellweger.com>
 raw-window-handle,https://github.com/rust-windowing/raw-window-handle,MIT OR Apache-2.0 OR Zlib,Osspial <osspial@gmail.com>
 rdkafka,https://github.com/fede1024/rust-rdkafka,MIT,Federico Giraud <giraud.federico@gmail.com>
@@ -568,7 +569,6 @@ treediff,https://github.com/Byron/treediff-rs,MIT OR Apache-2.0,Sebastian Thiel 
 trust-dns-proto,https://github.com/bluejekyll/trust-dns,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 trust-dns-resolver,https://github.com/bluejekyll/trust-dns,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
-tui,https://github.com/fdehau/tui-rs,MIT,Florian Dehau <work@fdehau.com>
 tungstenite,https://github.com/snapview/tungstenite-rs,MIT OR Apache-2.0,"Alexey Galakhov, Daniel Abramov"
 twox-hash,https://github.com/shepmaster/twox-hash,MIT,Jake Goulding <jake.goulding@gmail.com>
 typed-builder,https://github.com/idanarye/rust-typed-builder,MIT OR Apache-2.0,"IdanArye <idanarye@gmail.com>, Chris Morgan <me@chrismorgan.info>"

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -9,16 +9,16 @@ use crossterm::{
 };
 use num_format::{Locale, ToFormattedString};
 use number_prefix::NumberPrefix;
-use std::io::stdout;
-use tokio::sync::oneshot;
-use tui::{
+use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
     Frame, Terminal,
 };
+use std::io::stdout;
+use tokio::sync::oneshot;
 
 use super::{
     events::capture_key_press,
@@ -180,7 +180,7 @@ impl<'a> Widgets<'a> {
         ];
         text.extend(connection_status.as_ui_spans());
 
-        let text = vec![Spans::from(text)];
+        let text = vec![Line::from(text)];
 
         let block = Block::default().borders(Borders::ALL).title(Span::styled(
             self.title,
@@ -260,7 +260,7 @@ impl<'a> Widgets<'a> {
                         .into_iter()
                         .map(Cell::from)
                         .collect::<Vec<_>>();
-                    data[1] = Cell::from(id.as_ref());
+                    data[1] = Cell::from(id.as_str());
                     data[5] = Cell::from(sent_events_metric);
                     items.push(Row::new(data).style(Style::default()));
                 }
@@ -312,7 +312,7 @@ impl<'a> Widgets<'a> {
 
     /// Renders a box showing instructions on how to exit from `vector top`.
     fn quit_box<B: Backend>(&self, f: &mut Frame<B>, area: Rect) {
-        let text = vec![Spans::from("To quit, press ESC or 'q'")];
+        let text = vec![Line::from("To quit, press ESC or 'q'")];
 
         let block = Block::default()
             .borders(Borders::ALL)

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -1,11 +1,11 @@
 use std::collections::{BTreeMap, HashMap};
 
 use chrono::{DateTime, Local};
-use tokio::sync::mpsc;
-use tui::{
+use ratatui::{
     style::{Color, Style},
     text::Span,
 };
+use tokio::sync::mpsc;
 use vector_core::internal_event::DEFAULT_OUTPUT;
 
 use crate::config::ComponentKey;


### PR DESCRIPTION
The `tui` crate is unmaintained and points to `ratatui` as the mantained fork.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
