### PR TITLE
chore(deps): Remove an unneeded advisory ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,9 +38,4 @@ license-files = [
 
 [advisories]
 ignore = [
-    # The NATS official Rust clients are vulnerable to MitM when using TLS
-    #
-    # Will be resolved when we switch to `async_nats` crate
-    # https://github.com/vectordotdev/vector/pull/15533
-    "RUSTSEC-2023-0029",
 ]


### PR DESCRIPTION
Resolved by https://github.com/vectordotdev/vector/pull/18165

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
