### PR TITLE
fix(sample transform): Use metadata when log namespacing is enabled

### DIFF
--- a/src/transforms/sample.rs
+++ b/src/transforms/sample.rs
@@ -1,6 +1,7 @@
 use vector_config::configurable_component;
-use vector_core::config::LogNamespace;
-use vrl::event_path;
+use vector_core::config::{LegacyKey, LogNamespace};
+use vrl::value::Kind;
+use vrl::{event_path, owned_value_path};
 
 use crate::{
     conditions::{AnyCondition, Condition},
@@ -85,7 +86,18 @@ impl TransformConfig for SampleConfig {
             DataType::Log | DataType::Trace,
             input_definitions
                 .iter()
-                .map(|(output, definition)| (output.clone(), definition.clone()))
+                .map(|(output, definition)| {
+                    (
+                        output.clone(),
+                        definition.clone().with_source_metadata(
+                            SampleConfig::NAME,
+                            Some(LegacyKey::Overwrite(owned_value_path!("sample_rate"))),
+                            &owned_value_path!("sample_rate"),
+                            Kind::bytes(),
+                            None,
+                        ),
+                    )
+                })
                 .collect(),
         )]
     }
@@ -153,10 +165,16 @@ impl FunctionTransform for Sample {
         if num % self.rate == 0 {
             match event {
                 Event::Log(ref mut event) => {
-                    event.insert(event_path!("sample_rate"), self.rate.to_string())
+                    event.namespace().insert_source_metadata(
+                        SampleConfig::NAME,
+                        event,
+                        Some(LegacyKey::Overwrite(vrl::path!("sample_rate"))),
+                        vrl::path!("sample_rate"),
+                        self.rate.to_string(),
+                    );
                 }
                 Event::Trace(ref mut event) => {
-                    event.insert(event_path!("sample_rate"), self.rate.to_string())
+                    event.insert(event_path!("sample_rate"), self.rate.to_string());
                 }
                 Event::Metric(_) => panic!("component can never receive metric events"),
             };


### PR DESCRIPTION
closes: https://github.com/vectordotdev/vector/issues/18215

The `sample` transform adds a `sample_rate` field to the event. When log namespacing is enabled, this should be moved to the event metadata so it doesn't override fields on the event itself. 