### PR TITLE
fix(core): refactor the openssl provider option so it is usable

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,9 +195,9 @@ pub struct RootOpts {
     )]
     pub allocation_tracing_reporting_interval_ms: u64,
 
-    /// Load the OpenSSL legacy provider.
-    #[arg(long, env = "VECTOR_OPENSSL_LEGACY_PROVIDER", default_value = "true")]
-    pub openssl_legacy_provider: bool,
+    /// Set the OpenSSL implementation provider to use.
+    #[arg(long, env = "VECTOR_OPENSSL_PROVIDER", default_value = "legacy")]
+    pub openssl_provider: OpenSSLProvider,
 
     /// Disable probing and configuration of root certificate locations on the system for OpenSSL.
     ///
@@ -327,6 +327,27 @@ impl Color {
 pub enum LogFormat {
     Text,
     Json,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenSSLProvider {
+    Default,
+    Base,
+    FIPS,
+    Legacy,
+    Null,
+}
+
+impl OpenSSLProvider {
+    pub fn name(&self) -> &str {
+        match self {
+            OpenSSLProvider::Default => "default",
+            OpenSSLProvider::Base => "base",
+            OpenSSLProvider::FIPS => "fips",
+            OpenSSLProvider::Legacy => "legacy",
+            OpenSSLProvider::Null => "null",
+        }
+    }
 }
 
 pub fn handle_config_errors(errors: Vec<String>) -> exitcode::ExitCode {

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -113,9 +113,11 @@ cli: {
 			description: env_vars.VECTOR_NO_GRACEFUL_SHUTDOWN_LIMIT.description
 			env_var:     "VECTOR_NO_GRACEFUL_SHUTDOWN_LIMIT"
 		}
-		"openssl-legacy-provider": {
-			description: env_vars.VECTOR_OPENSSL_LEGACY_PROVIDER.description
-			env_var:     "VECTOR_OPENSSL_LEGACY_PROVIDER"
+		"openssl-provider": {
+			description: env_vars.VECTOR_OPENSSL_PROVIDER.description
+			default:     env_vars.VECTOR_OPENSSL_PROVIDER.type.string.default
+			enum:        env_vars.VECTOR_OPENSSL_PROVIDER.type.string.enum
+			env_var:     "VECTOR_OPENSSL_PROVIDER"
 		}
 		"openssl-no-probe": {
 			description: env_vars.VECTOR_OPENSSL_NO_PROBE.description
@@ -632,9 +634,18 @@ cli: {
 			description: "Never time out while waiting for graceful shutdown after SIGINT or SIGTERM received. This is useful when you would like for Vector to attempt to send data until terminated by a SIGKILL. Overrides/cannot be set with `--graceful-shutdown-limit-secs`."
 			type: bool: default: false
 		}
-		VECTOR_OPENSSL_LEGACY_PROVIDER: {
-			description: "Load the OpenSSL legacy provider."
-			type: bool: default: true
+		VECTOR_OPENSSL_PROVIDER: {
+			description: "Set the OpenSSL implementation provider to use."
+			type: string: {
+				default: "legacy"
+				enum: {
+					default: "The default provider contains all of the most commonly used algorithm implementations. This is the recommended provider."
+					base:    "The base provider contains algorithm implementations for encoding and decoding for OpenSSL keys."
+					fips:    "The FIPS provider contains algorithm implementations that have been validated according to the FIPS 140-2 standard."
+					legacy:  "The legacy provider contains algorithm implementations that are considered insecure, or are no longer in common use such as MD2 or RC4. This provider is deprecated and is not recommended. It is set as default for backwards compatibility."
+					null:    "The null provider contains no algorithms in it at all. This provider is useful for testing."
+				}
+			}
 		}
 		VECTOR_OPENSSL_NO_PROBE: {
 			description: """


### PR DESCRIPTION
While checking the OpenSSL legacy provider CLI option, I realized that it is actually not working.
Therefore, this PR re-implements the `--openssl-legacy-provider` (bool) into `--openssl-provider` (enum).

Previously, the option default was set to `true` and there was no way to switch it to `false` using the CLI argument because the arg action by default is `SetTrue`. The associated environment variable was the only way to turn the legacy provider on or off. To avoid a potentially non-intuitive falsey `--openssl-no-legacy-provider` boolean option, it is now re-implemented as an enum option with all the possible built-in OpenSSL 3.1 implementation providers.

The default was kept as `legacy` to remain consistent with the previous behavior.
When the legacy provider is fully deprecated, we can simply switch the default for this option to `default`.

Note that I decided to include _all_ of the built-in OpenSSL providers for completeness, but I'm not sure if the Vector team and users really need them all. Please let me know if you want to scope the list of available providers to a smaller list.

This is a breaking change for users using the `VECTOR_OPENSSL_LEGACY_PROVIDER=false` environment variable. This flag was released in Vector 0.32.0 (today) but not announced in the highlights. So I'm not sure to flag this as a breaking change or not. The migration step after this PR would be to use `VECTOR_OPENSSL_PROVIDER=default`.

OpenSSL 3.1 reference: <https://www.openssl.org/docs/man3.1/man7/crypto.html> (OPENSSL PROVIDERS)
