### PR TITLE
chore(releasing): Add 0.32.0 highlight for legacy OpenSSL provider deprecation

### DIFF
--- a/website/content/en/highlights/2023-08-15-0-32-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-08-15-0-32-0-upgrade-guide.md
@@ -12,10 +12,11 @@ badges:
 Vector's 0.32.0 release includes **deprecations**:
 
 1. [VRL `to_timestamp` function](#deprecated-to-timestamp)
+2. [Deprecation of legacy OpenSSL providers](#legacy-openssl)
 
 and **potentially impactful changes**:
 
-1. [Upgrade of OpenSSL from 1.1.1 to 3.1](#openssl-upgrade)
+1. [Upgrade of OpenSSL from 1.1.1 to 3.1.2](#openssl-upgrade)
 
 We cover them below to help you upgrade quickly:
 
@@ -33,9 +34,18 @@ The `to_timestamp` function in VRL was deprecated. Instead, the following functi
 This removes some confusion that existed around "magic formats" that the `to_timestamp` had by
 requiring string timestamp formats to be specified explicitly.
 
+#### Deprecation of legacy OpenSSL providers {#legacy-openssl}
+
+With the upgrade to OpenSSL 3.1.2, the [legacy algorithm
+provider](https://github.com/openssl/openssl/blob/openssl-3.1.2/README-PROVIDERS.md#the-legacy-provider)
+was deprecated. The default will be switched in a future version to [default
+provider](https://github.com/openssl/openssl/blob/openssl-3.1.2/README-PROVIDERS.md#the-default-provider).
+You can opt into this behavior now by setting the environment variable
+`VECTOR_OPENSSL_LEGACY_PROVIDER=false`.
+
 ### Potentially impactful changes
 
-#### Upgrade of OpenSSL from 1.1.1 to 3.1.0 {#openssl-upgrade}
+#### Upgrade of OpenSSL from 1.1.1 to 3.1.2 {#openssl-upgrade}
 
 As part of moving off of OpenSSL 1.1.1 before it becomes [end-of-life in
 September](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/), Vector has upgraded the version


### PR DESCRIPTION
I forgot to do this prior to the release
(https://github.com/vectordotdev/vector/pull/17669#discussion_r1289029219).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
