### PR TITLE
fix(deps): load default and legacy openssl providers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,7 +62,7 @@ pub struct Application {
     pub require_healthy: Option<bool>,
     pub config: ApplicationConfig,
     pub signals: SignalPair,
-    pub openssl_legacy_provider: Option<Provider>,
+    pub openssl_providers: Option<Vec<Provider>>,
 }
 
 impl ApplicationConfig {
@@ -196,11 +196,10 @@ impl Application {
             debug!(message = "Disabled probing and configuration of root certificate locations on the system for OpenSSL.");
         }
 
-        let openssl_legacy_provider = opts
+        let openssl_providers = opts
             .root
             .openssl_legacy_provider
-            .then(load_openssl_legacy_provider)
-            .flatten();
+            .then(load_openssl_legacy_providers);
 
         let runtime = build_runtime(opts.root.threads, "vector-worker")?;
 
@@ -222,7 +221,7 @@ impl Application {
                 require_healthy: opts.root.require_healthy,
                 config,
                 signals,
-                openssl_legacy_provider,
+                openssl_providers,
             },
         ))
     }
@@ -239,7 +238,7 @@ impl Application {
             require_healthy,
             config,
             signals,
-            openssl_legacy_provider,
+            openssl_providers,
         } = self;
 
         let topology_controller = SharedTopologyController::new(TopologyController {
@@ -257,7 +256,7 @@ impl Application {
             graceful_crash_receiver: config.graceful_crash_receiver,
             signals,
             topology_controller,
-            openssl_legacy_provider,
+            openssl_providers,
         })
     }
 }
@@ -267,7 +266,7 @@ pub struct StartedApplication {
     pub graceful_crash_receiver: mpsc::UnboundedReceiver<ShutdownError>,
     pub signals: SignalPair,
     pub topology_controller: SharedTopologyController,
-    pub openssl_legacy_provider: Option<Provider>,
+    pub openssl_providers: Option<Vec<Provider>>,
 }
 
 impl StartedApplication {
@@ -281,7 +280,7 @@ impl StartedApplication {
             graceful_crash_receiver,
             signals,
             topology_controller,
-            openssl_legacy_provider,
+            openssl_providers,
         } = self;
 
         let mut graceful_crash = UnboundedReceiverStream::new(graceful_crash_receiver);
@@ -313,7 +312,7 @@ impl StartedApplication {
             signal,
             signal_rx,
             topology_controller,
-            openssl_legacy_provider,
+            openssl_providers,
         }
     }
 }
@@ -368,7 +367,7 @@ pub struct FinishedApplication {
     pub signal: SignalTo,
     pub signal_rx: SignalRx,
     pub topology_controller: SharedTopologyController,
-    pub openssl_legacy_provider: Option<Provider>,
+    pub openssl_providers: Option<Vec<Provider>>,
 }
 
 impl FinishedApplication {
@@ -377,7 +376,7 @@ impl FinishedApplication {
             signal,
             signal_rx,
             topology_controller,
-            openssl_legacy_provider,
+            openssl_providers,
         } = self;
 
         // At this point, we'll have the only reference to the shared topology controller and can
@@ -392,7 +391,7 @@ impl FinishedApplication {
             SignalTo::Quit => Self::quit(),
             _ => unreachable!(),
         };
-        drop(openssl_legacy_provider);
+        drop(openssl_providers);
         status
     }
 
@@ -571,13 +570,15 @@ pub fn init_logging(color: bool, format: LogFormat, log_level: &str, rate: u64) 
 ///
 /// The returned [Provider] must stay in scope for the entire lifetime of the application, as it
 /// will be unloaded when it is dropped.
-pub fn load_openssl_legacy_provider() -> Option<Provider> {
+pub fn load_openssl_legacy_providers() -> Vec<Provider> {
     warn!(message = "DEPRECATED The openssl legacy provider provides algorithms and key sizes no longer recommended for use.");
-    Provider::try_load(None, "legacy", true)
-        .map(|provider| {
-            info!(message = "Loaded openssl legacy provider.");
-            provider
-        })
-        .map_err(|error| error!(message = "Failed to load openssl legacy provider.", %error))
-        .ok()
+    ["legacy", "default"].into_iter().filter_map(|provider_name| {
+        Provider::try_load(None, provider_name, true)
+            .map(|provider| {
+                info!(message = "Loaded openssl provider.", provider = provider_name);
+                provider
+            })
+            .map_err(|error| error!(message = "Failed to load openssl provider.", provider = provider_name, %error))
+            .ok()
+    }).collect()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,7 +196,15 @@ pub struct RootOpts {
     pub allocation_tracing_reporting_interval_ms: u64,
 
     /// Load the OpenSSL legacy provider.
-    #[arg(long, env = "VECTOR_OPENSSL_LEGACY_PROVIDER", default_value = "true")]
+    #[arg(
+        long,
+        env = "VECTOR_OPENSSL_LEGACY_PROVIDER",
+        default_value = "true",
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        action = ArgAction::Set
+    )]
     pub openssl_legacy_provider: bool,
 
     /// Disable probing and configuration of root certificate locations on the system for OpenSSL.


### PR DESCRIPTION
The OpenSSL documentation is unclear about whether or not the default provider remains loaded when calling `try_load` with `retain_fallbacks=true`. We now explicitly load the default provider to be safe.

This also fixes the `--openssl-legacy-provider` cli arg, which could previously only be set to true.

The following now work
```
vector --openssl-legacy-provider
vector --openssl-legacy-provider=true
vector --openssl-legacy-provider=false
VECTOR_OPENSSL_LEGACY_PROVIDER=true ./target/debug/vector
VECTOR_OPENSSL_LEGACY_PROVIDER=false ./target/debug/vector
```
But the below still result in an error
```
vector --openssl-legacy-provider true
vector --openssl-legacy-provider false
```

In the future, we will refactor this to allow the user to specify a list of providers to load (https://github.com/vectordotdev/vector/pull/18261).