### PR TITLE
fix(observability): add all events that are being encoded

### DIFF
--- a/lib/vector-common/src/request_metadata.rs
+++ b/lib/vector-common/src/request_metadata.rs
@@ -61,7 +61,7 @@ impl GroupedCountByteSize {
     /// Returns a `HashMap` of tags => event counts for when we are tracking by tags.
     /// Returns `None` if we are not tracking by tags.
     #[must_use]
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test"))]
     pub fn sizes(&self) -> Option<&HashMap<TaggedEventsSent, CountByteSize>> {
         match self {
             Self::Tagged { sizes } => Some(sizes),
@@ -71,8 +71,8 @@ impl GroupedCountByteSize {
 
     /// Returns a single count for when we are not tracking by tags.
     #[must_use]
-    #[cfg(test)]
-    fn size(&self) -> Option<CountByteSize> {
+    #[cfg(any(test, feature = "test"))]
+    pub fn size(&self) -> Option<CountByteSize> {
         match self {
             Self::Tagged { .. } => None,
             Self::Untagged { size } => Some(*size),


### PR DESCRIPTION
Fixes #18265

The `Encoder` implementation for batches of Events for the tuple Encoder `(Transformer, crate::codecs::Encoder<Framer>)` was only counting the first event in the batch.

This fixes the issue to ensure all events are counted and adds tests to ensure it is correct. I have also tested manually with the AWS S3 sink.

Affected sinks are:

- WebHDFS
- GCP Cloud Storage
- AWS S3
- Azure Blob Storage
- Azure Monitor Logs
- Databend
- Clickhouse 
- Datadog Logs
