### PR TITLE
chore: tidy `encode_input` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ lapin = { version = "2.3.1", default-features = false, features = ["native-tls"]
 # API
 async-graphql = { version = "6.0.0", default-features = false, optional = true, features = ["chrono", "playground"] }
 async-graphql-warp = { version = "6.0.0", default-features = false, optional = true }
-itertools = { version = "0.11.0", default-features = false, optional = true }
+itertools = { version = "0.11.0", default-features = false }
 
 # API client
 crossterm = { version = "0.26.1", default-features = false, features = ["event-stream"], optional = true }
@@ -436,7 +436,6 @@ api = [
   "dep:async-graphql",
   "dep:async-graphql-warp",
   "dep:base64",
-  "dep:itertools",
   "vector-core/api",
 ]
 


### PR DESCRIPTION
Ref #18265 

This refactors the `encode_input` function to use `itertools` to determine the last item in the list to encode. It's a slightly tidier pattern that removes the duplicate code