### PR TITLE
fix(opentelemetry source): Remove the 4MB default for gRPC request decoding

### DIFF
--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -138,7 +138,10 @@ impl SourceConfig for OpentelemetryConfig {
             log_namespace,
             events_received: events_received.clone(),
         })
-        .accept_compressed(tonic::codec::CompressionEncoding::Gzip);
+        .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
+        // Tonic added a default of 4MB in 0.9. This replaces the old behavior.
+        .max_decoding_message_size(usize::MAX);
+
         let grpc_source = run_grpc_server(
             self.grpc.address,
             grpc_tls_settings,


### PR DESCRIPTION
addresses: https://github.com/vectordotdev/vector/issues/17926

This is the same fix applied to the `vector` source in https://github.com/vectordotdev/vector/pull/18186 . The `opentelemetry` source needs the same explicit max decoding size fix.