### PR TITLE
chore(log_to_metric transform): add missing Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -579,6 +579,7 @@ transforms-logs = [
   "transforms-aws_ec2_metadata",
   "transforms-dedupe",
   "transforms-filter",
+  "transforms-log_to_metric",
   "transforms-lua",
   "transforms-metric_to_log",
   "transforms-pipelines",
@@ -591,6 +592,7 @@ transforms-logs = [
 transforms-metrics = [
   "transforms-aggregate",
   "transforms-filter",
+  "transforms-log_to_metric",
   "transforms-lua",
   "transforms-metric_to_log",
   "transforms-pipelines",
@@ -603,6 +605,7 @@ transforms-aggregate = []
 transforms-aws_ec2_metadata = ["dep:arc-swap"]
 transforms-dedupe = ["dep:lru"]
 transforms-filter = []
+transforms-log_to_metric = []
 transforms-lua = ["dep:mlua", "vector-core/lua"]
 transforms-metric_to_log = []
 transforms-pipelines = ["transforms-filter", "transforms-route"]

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -76,6 +76,7 @@ mod journald;
 mod kafka;
 #[cfg(feature = "sources-kubernetes_logs")]
 mod kubernetes_logs;
+#[cfg(feature = "transforms-log_to_metric")]
 mod log_to_metric;
 mod logplex;
 #[cfg(feature = "sinks-loki")]
@@ -89,6 +90,7 @@ mod mongodb_metrics;
 #[cfg(feature = "sources-nginx_metrics")]
 mod nginx_metrics;
 mod open;
+#[cfg(feature = "transforms-log_to_metric")]
 mod parser;
 #[cfg(feature = "sources-postgresql_metrics")]
 mod postgresql_metrics;
@@ -213,6 +215,7 @@ pub(crate) use self::journald::*;
 pub(crate) use self::kafka::*;
 #[cfg(feature = "sources-kubernetes_logs")]
 pub(crate) use self::kubernetes_logs::*;
+#[cfg(feature = "transforms-log_to_metric")]
 pub(crate) use self::log_to_metric::*;
 #[cfg(feature = "sources-heroku_logs")]
 pub(crate) use self::logplex::*;
@@ -224,6 +227,7 @@ pub(crate) use self::lua::*;
 pub(crate) use self::metric_to_log::*;
 #[cfg(feature = "sources-nginx_metrics")]
 pub(crate) use self::nginx_metrics::*;
+#[cfg(feature = "transforms-log_to_metric")]
 pub(crate) use self::parser::*;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub(crate) use self::postgresql_metrics::*;

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -12,6 +12,7 @@ pub mod aws_ec2_metadata;
 pub mod dedupe;
 #[cfg(feature = "transforms-filter")]
 pub mod filter;
+#[cfg(feature = "transforms-log_to_metric")]
 pub mod log_to_metric;
 #[cfg(feature = "transforms-lua")]
 pub mod lua;


### PR DESCRIPTION
The `log_to_metric` transform was missing a corresponding Cargo feature. Therefore, when compiling Vector with a reduced set of features, this transform was always included even if not requested.

This is the only transform that was missing a Cargo feature.

I tested this by compiling Vector with different feature sets and verifying the resulting binary config schemas:
```
cargo build --no-default-features --features 'sources-exec sinks-console'
cargo build --no-default-features --features 'sources-exec transforms sinks-console'
cargo build --no-default-features --features 'sources-exec transforms-log_to_metric sinks-console'
```

Before this PR, the first build above would only include the `log_to_metric` transform, when I was expecting none. If I included a specific transform feature, it would be compiled together with the `log_to_metric` transform. With this PR, the `log_to_metric` transform is only included when expected according to Cargo feature selection.