### PR TITLE
feat(route transform): Add option to enable/disable unmatched output

### DIFF
--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -182,7 +182,7 @@ mod test {
 
         assert_eq!(
             serde_json::to_string(&config).unwrap(),
-            r#"{"route":{"first":{"type":"vrl","source":".message == \"hello world\"","runtime":"ast"}}}"#
+            r#"{"reroute_unmatched":true,"route":{"first":{"type":"vrl","source":".message == \"hello world\"","runtime":"ast"}}}"#
         );
     }
 

--- a/website/cue/reference/components/transforms/base/route.cue
+++ b/website/cue/reference/components/transforms/base/route.cue
@@ -1,20 +1,37 @@
 package metadata
 
-base: components: transforms: route: configuration: route: {
-	description: """
-		A table of route identifiers to logical conditions representing the filter of the route.
+base: components: transforms: route: configuration: {
+	reroute_unmatched: {
+		description: """
+			Reroutes unmatched events to a named output instead of silently discarding them.
 
-		Each route can then be referenced as an input by other components with the name
-		`<transform_name>.<route_id>`. If an event doesn’t match any route, it is sent to the
-		`<transform_name>._unmatched` output.
+			Normally, if an event doesn't match any defined route, it is sent to the `<transform_name>._unmatched`
+			output for further processing. In some cases, you may want to simply discard unmatched events and not
+			process them any further.
 
-		Both `_unmatched`, as well as `_default`, are reserved output names and thus cannot be used
-		as a route name.
-		"""
-	required: false
-	type: object: options: "*": {
-		description: "An individual route."
-		required:    true
-		type: condition: {}
+			In these cases, `reroute_unmatched` can be set to `false` to disable the `<transform_name>._unmatched`
+			output and instead silently discard any unmatched events.
+			"""
+		required: false
+		type: bool: default: true
+	}
+	route: {
+		description: """
+			A table of route identifiers to logical conditions representing the filter of the route.
+
+			Each route can then be referenced as an input by other components with the name
+			`<transform_name>.<route_id>`. If an event doesn’t match any route, and if `reroute_unmatched`
+			is set to `true` (the default), it is sent to the `<transform_name>._unmatched` output.
+			Otherwise, the unmatched event is instead silently discarded.
+
+			Both `_unmatched`, as well as `_default`, are reserved output names and thus cannot be used
+			as a route name.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: "An individual route."
+			required:    true
+			type: condition: {}
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a new boolean option `reroute_unmatched` to the `route` transform.

It is inspired on the `reroute_dropped` option in the `remap` transform, allowing the user to control if they want or not the `<transform_name>._unmatched` output to be created and used. For backwards compatibility, this new option defaults to `true`.

Users that are not interested in processing unmatched events can use this option to avoid the following warning on Vector startup, and also to remove the unnecessary `_unmatched` output in `vector top`:
```
WARN vector::config::loading: Transform "route._unmatched" has no consumers
```

An example issue benefiting from this option is #15865 (closed). In that issue, the solution to eliminate the warning was simply to route the `_unmatched` output to a blackhole sink. This creates an unnecessary sink and noise in `vector top`.

Another example are these cases where the routing conditions are full-covering and guaranteed to always match.

In that same issue there is a reference to an RFC about the subject of handling discarded events (#14708). Let me know if you prefer not to merge this PR in favour of completing that RFC and its implementation in the future. Nonetheless, I still see value in the option implemented in this PR because it streamlines the amount of outputs created in the pipeline.