### PR TITLE
fix(dev): Unfeature flag internal_events::parser

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -90,7 +90,6 @@ mod mongodb_metrics;
 #[cfg(feature = "sources-nginx_metrics")]
 mod nginx_metrics;
 mod open;
-#[cfg(feature = "transforms-log_to_metric")]
 mod parser;
 #[cfg(feature = "sources-postgresql_metrics")]
 mod postgresql_metrics;
@@ -227,7 +226,6 @@ pub(crate) use self::lua::*;
 pub(crate) use self::metric_to_log::*;
 #[cfg(feature = "sources-nginx_metrics")]
 pub(crate) use self::nginx_metrics::*;
-#[cfg(feature = "transforms-log_to_metric")]
 pub(crate) use self::parser::*;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub(crate) use self::postgresql_metrics::*;


### PR DESCRIPTION
Was overeargerly flagged in https://github.com/vectordotdev/vector/pull/18308 which caused CI
failures in the nightly Component Features workflow.

See: https://github.com/vectordotdev/vector/actions/runs/5908210923/attempts/1

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
