### PR TITLE
chore: update `rustls-webpki` due to security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7365,8 +7365,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.101.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+source = "git+https://github.com/rustls/webpki?tag=v/0.101.4#d7f6aa4d2138de89cec1daf1d07e7d3263f7d9b6"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7364,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7365,7 +7365,8 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.101.4"
-source = "git+https://github.com/rustls/webpki?tag=v/0.101.4#d7f6aa4d2138de89cec1daf1d07e7d3263f7d9b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,6 +394,10 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl", tag = "openssl-sys-v0.9.91_3.0.0" }
 openssl-src = { git = "https://github.com/vectordotdev/openssl-src-rs", tag = "release-300-force-engine_3.1.2" }
 
+# https://rustsec.org/advisories/RUSTSEC-2023-0052.html
+webpki = { package = "rustls-webpki", git = "https://github.com/rustls/webpki", tag = "v/0.101.4"}
+
+
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
 default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "component-validation-runner"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,9 +394,6 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl", tag = "openssl-sys-v0.9.91_3.0.0" }
 openssl-src = { git = "https://github.com/vectordotdev/openssl-src-rs", tag = "release-300-force-engine_3.1.2" }
 
-# https://rustsec.org/advisories/RUSTSEC-2023-0052.html
-webpki = { package = "rustls-webpki", git = "https://github.com/rustls/webpki", tag = "v/0.101.4"}
-
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,6 @@ license-files = [
 
 [advisories]
 ignore = [
-  # requires our dependencies to migrate to `rustls-webpki`S
-  "RUSTSEC-2023-0052.html"
+  # requires our dependencies to migrate to `rustls-webpki`
+  "RUSTSEC-2023-0052"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -38,4 +38,6 @@ license-files = [
 
 [advisories]
 ignore = [
+  # requires our dependencies to migrate to `rustls-webpki`S
+  "RUSTSEC-2023-0052.html"
 ]


### PR DESCRIPTION
There are 2 relevant advisories here:
- https://rustsec.org/advisories/RUSTSEC-2023-0053.html
  - This was fixed by upgrading `rustls-webpki` to `0.101.4`
-  https://rustsec.org/advisories/RUSTSEC-2023-0052.html
   - This requires migration from `webpki` to `rustls-webpki`. It was added to the `ignore` section of `deny.toml` until dependencies can be updated

