### PR TITLE
fix: use `rstest` in `generate` command tests (vs wrong usage of `proptest`)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -403,6 +403,7 @@ rootfs
 roundrobin
 rpmbuild
 rpms
+rstest
 rsyslog
 rsyslogd
 servlet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7054,6 +7054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "relative-path"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+
+[[package]]
 name = "rend"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7229,6 +7235,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
 dependencies = [
  "xmlparser",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures 0.3.28",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.29",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -9549,6 +9584,7 @@ dependencies = [
  "rmp-serde",
  "rmpv",
  "roaring",
+ "rstest",
  "seahash",
  "semver 1.0.18",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,6 +367,7 @@ proptest = "1.2"
 quickcheck = "1.0.3"
 lookup = { package = "vector-lookup", path = "lib/vector-lookup", features = ["test"] }
 reqwest = { version = "0.11", features = ["json"] }
+rstest = {version = "0.18.2"}
 tempfile = "3.6.0"
 test-generator = "0.3.1"
 tokio = { version = "1.32.0", features = ["test-util"] }

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -74,16 +74,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::*;
-
-    impl Arbitrary for Format {
-        type Parameters = ();
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            prop_oneof![Just(Format::Toml), Just(Format::Json), Just(Format::Yaml),].boxed()
-        }
-
-        type Strategy = BoxedStrategy<Self>;
-    }
 
     /// This test ensures the logic to guess file format from the file path
     /// works correctly.

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -392,7 +392,7 @@ fn write_config(filepath: &Path, body: &str) -> Result<(), crate::Error> {
 mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
-    use proptest::prelude::*;
+    use rstest::rstest;
 
     fn generate_and_deserialize(expression: String, format: Format) {
         let opts = Opts {
@@ -410,20 +410,22 @@ mod tests {
         }
     }
 
-    proptest! {
-        #[test]
-        fn generate_all(format in any::<Format>()) {
-            for name in SourceDescription::types() {
-                generate_and_deserialize(format!("{}//", name), format);
-            }
+    #[rstest]
+    #[case(Format::Toml)]
+    #[case(Format::Json)]
+    #[case(Format::Yaml)]
+    #[test]
+    fn generate_all(#[case] format: Format) {
+        for name in SourceDescription::types() {
+            generate_and_deserialize(format!("{}//", name), format);
+        }
 
-            for name in TransformDescription::types() {
-                generate_and_deserialize(format!("/{}/", name), format);
-            }
+        for name in TransformDescription::types() {
+            generate_and_deserialize(format!("/{}/", name), format);
+        }
 
-            for name in SinkDescription::types() {
-                generate_and_deserialize(format!("//{}", name), format);
-            }
+        for name in SinkDescription::types() {
+            generate_and_deserialize(format!("//{}", name), format);
         }
     }
 


### PR DESCRIPTION
### Bug
Fix a test bug introduced by https://github.com/vectordotdev/vector/pull/18345.
Basically, the `generate_all` test runs multiple times vs the desired behavior which is one time for each possible enum value.

### Fix
The test cases should run only once per enum value. 
I didn't find a way to configure `proptest` to do just that and `rstest` looks like a great candidate for this use case.