### PR TITLE
docs: add PGO information

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -53,6 +53,7 @@ Enot
 Evercoss
 Explay
 FAQs
+FDO
 FQDNs
 Fabro
 Figma

--- a/website/content/en/docs/administration/tuning/_index.md
+++ b/website/content/en/docs/administration/tuning/_index.md
@@ -7,3 +7,7 @@ tags: ["tuning", "rust", "performance"]
 Vector is written in [Rust] and therefore doesn't include a runtime or a virtual machine. There are no special service-level steps you need to undertake to improve performance as Vector takes full advantage of all system resources by default and without any adjustments.
 
 [rust]: https://rust-lang.org
+
+## Pages
+
+{{< pages >}}

--- a/website/content/en/docs/administration/tuning/pgo.md
+++ b/website/content/en/docs/administration/tuning/pgo.md
@@ -1,0 +1,31 @@
+---
+title: Profile-Guided Optimization
+description: How to optimize Vector performance with Profile-Guided Optimization
+short: PGO
+weight: 3
+tags: ["pgo", "tuning", "rust", "performance"]
+---
+
+Profile-Guided Optimization (PGO) is a compiler optimization technique where a program is optimized based on the runtime profile.
+
+According to the [tests], we see improvements of up to 15% more processed log events per second on some Vector workloads. The performance benefits depend on your typical workload - you can get better or worse results.
+
+More information about PGO in Vector you can read in the corresponding GitHub [issue].
+
+### How to build Vector with PGO?
+
+There are two major kinds of PGO: Instrumentation and Sampling (also known as AutoFDO). In this guide, is described the Instrumentation PGO with Vector. In this guide we use [cargo-pgo] for building Vector with PGO.
+
+* Install [cargo-pgo].
+* Check out Vector sources.
+* Go to the Vector sources directory and run `cargo pgo build`. It will build the instrumented Vector version.
+* Run instrumented Vector on your test load like `cargo pgo run -- -- -c vector.toml` and wait for some time to collect enough information from your workload. Usually, waiting several minutes is enough (but your case can be different).
+* Stop Vector instance. The profile data will be generated in the `target/pgo-profiles` directory.
+* Run `cargo pgo optimize`. It will build Vector with PGO optimization.
+
+A more detailed guide on how to apply PGO is in the Rust [documentation].
+
+[tests]: https://github.com/vectordotdev/vector/issues/15631#issue-1502073978
+[issue]: https://github.com/vectordotdev/vector/issues/15631
+[documentation]: https://doc.rust-lang.org/rustc/profile-guided-optimization.html
+[cargo-pgo]: https://github.com/Kobzol/cargo-pgo

--- a/website/content/en/docs/administration/tuning/pgo.md
+++ b/website/content/en/docs/administration/tuning/pgo.md
@@ -17,8 +17,8 @@ More information about PGO in Vector you can read in the corresponding GitHub [i
 There are two major kinds of PGO: Instrumentation and Sampling (also known as AutoFDO). In this guide, is described the Instrumentation PGO with Vector. In this guide we use [cargo-pgo] for building Vector with PGO.
 
 * Install [cargo-pgo].
-* Check out Vector sources.
-* Go to the Vector sources directory and run `cargo pgo build`. It will build the instrumented Vector version.
+* Check out the Vector repository.
+* Go to the Vector source directory and run `cargo pgo build`. It will build the instrumented Vector version.
 * Run instrumented Vector on your test load like `cargo pgo run -- -- -c vector.toml` and wait for some time to collect enough information from your workload. Usually, waiting several minutes is enough (but your case can be different).
 * Stop Vector instance. The profile data will be generated in the `target/pgo-profiles` directory.
 * Run `cargo pgo optimize`. It will build Vector with PGO optimization.


### PR DESCRIPTION
Adds PGO documentation as discussed in https://github.com/vectordotdev/vector/issues/15631#issuecomment-1542411520

Feel free to suggest changes to the layout/wording/etc. As an example, I used a similar page from the ClickHouse documentation: https://clickhouse.com/docs/en/operations/optimizing-performance/profile-guided-optimization . Putted the page to this place as @jszwedko suggested in https://github.com/vectordotdev/vector/issues/15631#issuecomment-1683075569 .