### PR TITLE
fix(remap transform): log namespace should be used when splitting events from arrays

### DIFF
--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -50,6 +50,7 @@ pub struct TargetIter<T> {
     iter: std::vec::IntoIter<Value>,
     metadata: EventMetadata,
     _marker: PhantomData<T>,
+    log_namespace: LogNamespace,
 }
 
 fn create_log_event(value: Value, metadata: EventMetadata) -> LogEvent {
@@ -63,9 +64,12 @@ impl Iterator for TargetIter<LogEvent> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|v| {
-            match v {
-                value @ Value::Object(_) => LogEvent::from_parts(value, self.metadata.clone()),
-                value => create_log_event(value, self.metadata.clone()),
+            match self.log_namespace {
+                LogNamespace::Legacy => match v {
+                    value @ Value::Object(_) => LogEvent::from_parts(value, self.metadata.clone()),
+                    value => create_log_event(value, self.metadata.clone()),
+                },
+                LogNamespace::Vector => LogEvent::from_parts(v, self.metadata.clone()),
             }
             .into()
         })
@@ -142,6 +146,7 @@ impl VrlTarget {
                     iter: values.into_iter(),
                     metadata,
                     _marker: PhantomData,
+                    log_namespace,
                 }),
 
                 v => match log_namespace {
@@ -161,6 +166,7 @@ impl VrlTarget {
                     iter: values.into_iter(),
                     metadata,
                     _marker: PhantomData,
+                    log_namespace,
                 }),
 
                 v => TargetEvents::One(create_log_event(v, metadata).into()),


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/vectordotdev/vector/discussions/17889#discussioncomment-6796480

If a `remap` transform returns an array, the event is split into multiple events. In certain cases, the log namespace was not being used, which meant some values were being nested under a `message` field when it shouldn't be. This is now fixed.

