### PR TITLE
enhancement(kubernetes_logs source): Expose `oldest_first`

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -205,7 +205,11 @@ pub struct FileConfig {
     #[serde(default)]
     pub multiline: Option<MultilineConfig>,
 
-    /// An approximate limit on the amount of data read from a single file at a given time.
+    /// Max amount of bytes to read from a single file before switching over to the next file.
+    /// **Note:** This does not apply when `oldest_first` is `true.
+    ///
+    /// This allows distributing the reads more or less evenly across
+    /// the files.
     #[serde(default = "default_max_read_bytes")]
     #[configurable(metadata(docs::type_unit = "bytes"))]
     pub max_read_bytes: usize,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -163,8 +163,8 @@ pub struct Config {
     #[configurable(metadata(docs::human_name = "Ignore Files Older Than"))]
     ignore_older_secs: Option<u64>,
 
-    /// Max amount of bytes to read from a single file before switching over
-    /// to the next file.
+    /// Max amount of bytes to read from a single file before switching over to the next file.
+    /// **Note:** This does not apply when `oldest_first` is `true.
     ///
     /// This allows distributing the reads more or less evenly across
     /// the files.

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -228,8 +228,14 @@ base: components: sources: file: configuration: {
 		}
 	}
 	max_read_bytes: {
-		description: "An approximate limit on the amount of data read from a single file at a given time."
-		required:    false
+		description: """
+			Max amount of bytes to read from a single file before switching over to the next file.
+			**Note:** This does not apply when `oldest_first` is `true.
+
+			This allows distributing the reads more or less evenly across
+			the files.
+			"""
+		required: false
 		type: uint: {
 			default: 2048
 			unit:    "bytes"

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -165,8 +165,8 @@ base: components: sources: kubernetes_logs: configuration: {
 	}
 	max_read_bytes: {
 		description: """
-			Max amount of bytes to read from a single file before switching over
-			to the next file.
+			Max amount of bytes to read from a single file before switching over to the next file.
+			**Note:** This does not apply when `oldest_first` is `true.
 
 			This allows distributing the reads more or less evenly across
 			the files.

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -209,6 +209,11 @@ base: components: sources: kubernetes_logs: configuration: {
 			}
 		}
 	}
+	oldest_first: {
+		description: "Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files."
+		required:    false
+		type: bool: default: true
+	}
 	pod_annotation_fields: {
 		description: "Configuration for how the events are enriched with Pod metadata."
 		required:    false


### PR DESCRIPTION
In response to https://github.com/vectordotdev/vector/issues/18088#issuecomment-1690491190

Might close: https://github.com/vectordotdev/vector/issues/18088

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
