### PR TITLE
feat(dev): decouple syslog source and codec features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,6 +476,9 @@ gcp = ["dep:base64", "dep:goauth", "dep:smpl_jwt"]
 enrichment-tables = ["enrichment-tables-geoip"]
 enrichment-tables-geoip = ["dep:maxminddb"]
 
+# Codecs
+codecs-syslog = ["codecs/syslog"]
+
 # Sources
 sources = ["sources-logs", "sources-metrics"]
 sources-logs = [
@@ -559,7 +562,7 @@ sources-socket = ["sources-utils-net", "tokio-util/net"]
 sources-splunk_hec = ["dep:roaring"]
 sources-statsd = ["sources-utils-net", "tokio-util/net"]
 sources-stdin = ["tokio-util/io"]
-sources-syslog = ["codecs/syslog", "sources-utils-net", "tokio-util/net"]
+sources-syslog = ["codecs-syslog", "sources-utils-net", "tokio-util/net"]
 sources-utils-http = ["dep:snap", "sources-utils-http-auth", "sources-utils-http-encoding", "sources-utils-http-error", "sources-utils-http-prelude"]
 sources-utils-http-auth = ["sources-utils-http-error"]
 sources-utils-http-encoding = ["dep:snap", "sources-utils-http-error"]

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -146,7 +146,7 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         // TODO: We need to create an Avro serializer because, certainly, for any source decoding
         // the data as Avro, we can't possibly send anything else without the source just
         // immediately barfing.
-        #[cfg(feature = "sources-syslog")]
+        #[cfg(feature = "codecs-syslog")]
         DeserializerConfig::Syslog { .. } => SerializerConfig::Logfmt,
         DeserializerConfig::Native => SerializerConfig::Native,
         DeserializerConfig::NativeJson { .. } => SerializerConfig::NativeJson,

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1658,7 +1658,7 @@ fn test_config_outputs() {
                 ]),
             },
         ),
-        #[cfg(feature = "sources-syslog")]
+        #[cfg(feature = "codecs-syslog")]
         (
             "syslog / single output",
             TestCase {
@@ -1733,7 +1733,7 @@ fn test_config_outputs() {
                 )]),
             },
         ),
-        #[cfg(feature = "sources-syslog")]
+        #[cfg(feature = "codecs-syslog")]
         (
             "syslog / multiple output",
             TestCase {


### PR DESCRIPTION
This PR adds a new `codecs-syslog` feature to Vector mapped to the `codecs/syslog` package feature.

This allows for code requiring the `syslog` _codec_ to not depend on the `syslog` _source_ anymore and instead depend on the `syslog` codec directly. For example, it is now possible to compile any source with `syslog` codec support using `codecs-syslog` without having to compile the `syslog` source with it.

A concrete example is the following build configuration, which does not work without this PR:
```
cargo build --no-default-features --features 'sources-stdin sources-exec codecs-syslog sinks-console'
```
This will build a Vector with `stdin` and `exec` sources with `syslog` codec support, without needing the `syslog` source.

I tested building and ran testing of the affected compoenents, but given that this PR adds a Cargo feature and changes compilation conditionals, a CI component feature check should be triggered to validate that nothing else breaks.