### PR TITLE
fix(tests): fix tests for the generate command

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -643,6 +643,11 @@ mod tests {
         );
     }
 
+    #[cfg(all(
+        feature = "sources-demo_logs",
+        feature = "transforms-remap",
+        feature = "sinks-console"
+    ))]
     #[test]
     fn generate_basic_yaml() {
         let opts = Opts {
@@ -695,6 +700,11 @@ mod tests {
         );
     }
 
+    #[cfg(all(
+        feature = "sources-demo_logs",
+        feature = "transforms-remap",
+        feature = "sinks-console"
+    ))]
     #[test]
     fn generate_basic_json() {
         let opts = Opts {


### PR DESCRIPTION
This quick PR adds missing conditional compilation features to the tests, which fail when any of the `demo_logs` source, the `remap` transform or the `console` sink are not compiled.

Fixes the following test panics when these features are not used:
```
---- generate::tests::generate_basic_yaml stdout ----
thread 'generate::tests::generate_basic_yaml' panicked at 'called `Result::unwrap()` on an `Err` value: ["failed to generate source 'demo_logs': component 'demo_logs' does not exist", "failed to generate transform 'remap': component 'remap' does not exist"]', src/generate.rs:656:68

---- generate::tests::generate_basic_json stdout ----
thread 'generate::tests::generate_basic_json' panicked at 'called `Result::unwrap()` on an `Err` value: ["failed to generate source 'demo_logs': component 'demo_logs' does not exist", "failed to generate transform 'remap': component 'remap' does not exist"]', src/generate.rs:708:68
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

EDIT: I think these were just forgotten in #18345 🙈 