### PR TITLE
feat: Begin publishing armv7hl rpm packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -749,3 +749,16 @@ jobs:
           release: "any-version"
           republish: "true"
           file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7.rpm"
+      - name: Push armv7hl-gnu RPM
+        id: push-rpm-armv7hl-gnu
+        uses: cloudsmith-io/action@v0.5.3
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "rpm"
+          owner: "timber"
+          repo: ${{ env.CLOUDSMITH_REPO }}
+          distro: "any-distro"
+          release: "any-version"
+          republish: "true"
+          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7hl.rpm"

--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,7 @@ package-aarch64-unknown-linux-musl-all: package-aarch64-unknown-linux-musl # Bui
 package-aarch64-unknown-linux-gnu-all: package-aarch64-unknown-linux-gnu package-deb-aarch64 package-rpm-aarch64 # Build all aarch64 GNU packages
 
 .PHONY: package-armv7-unknown-linux-gnueabihf-all
-package-armv7-unknown-linux-gnueabihf-all: package-armv7-unknown-linux-gnueabihf package-deb-armv7-gnu package-rpm-armv7-gnu  # Build all armv7-unknown-linux-gnueabihf MUSL packages
+package-armv7-unknown-linux-gnueabihf-all: package-armv7-unknown-linux-gnueabihf package-deb-armv7-gnu package-rpm-armv7hl-gnu package-rpm-armv7-gnu  # Build all armv7-unknown-linux-gnueabihf MUSL packages
 
 .PHONY: package-x86_64-unknown-linux-gnu
 package-x86_64-unknown-linux-gnu: target/artifacts/vector-${VERSION}-x86_64-unknown-linux-gnu.tar.gz ## Build an archive suitable for the `x86_64-unknown-linux-gnu` triple.
@@ -579,6 +579,10 @@ package-rpm-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 rpm 
 .PHONY: package-rpm-armv7-gnu
 package-rpm-armv7-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7-unknown-linux-gnueabihf rpm package
 	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
+
+.PHONY: package-rpm-armv7hl-gnu
+package-rpm-armv7hl-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7hl-unknown-linux-gnueabihf rpm package
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf -e ARCH=armv7hl -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
 
 ##@ Releasing
 

--- a/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
@@ -1,0 +1,26 @@
+---
+date: "2023-09-26"
+title: "0.33 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.33.0"
+authors: ["spencergilbert"]
+release: "0.33.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.33.0 release includes **deprecations**:
+
+1. [Renaming the `armv7` rpm package](#armv7-rename)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Deprecations
+
+#### Renaming the `armv7` rpm package {#armv7-rename}
+
+The `armv7` rpm package, `vector-<version>-1.armv7.rpm`, is now published as
+`vector-<version>-1.armv7hl.rpm` to better follow rpm guidelines. The `armv7`
+package will be no longer be published beginning in the 0.34.0 release.


### PR DESCRIPTION
- feat: Begin publishing armv7hl rpm packages
- docs: Add 0.33.0 upgrade guide

Following [discussion and discovery](https://datadoghq.atlassian.net/browse/AP-2268) this PR begins the deprecation process for the `armv7` rpm package and replaces it with an `armv7hl` package.

Based on cloudsmith numbers, this package is very unused (less than 10 downloads per package, less than 20 in the last 25 versions).

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
