### PR TITLE
chore(deps): Bump MSRV to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default-run = "vector"
 autobenches = false # our benchmarks are not runnable on their own either way
 # Minimum supported rust version
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 
 [[bin]]
 name = "vector"

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -167,7 +167,7 @@ impl Default for PrometheusExporterConfig {
     }
 }
 
-fn default_address() -> SocketAddr {
+const fn default_address() -> SocketAddr {
     use std::net::{IpAddr, Ipv4Addr};
 
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9598)

--- a/src/sinks/statsd/config.rs
+++ b/src/sinks/statsd/config.rs
@@ -99,7 +99,7 @@ impl Mode {
     }
 }
 
-fn default_address() -> SocketAddr {
+const fn default_address() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8125)
 }
 

--- a/src/sinks/util/service/net/udp.rs
+++ b/src/sinks/util/service/net/udp.rs
@@ -75,7 +75,7 @@ impl UdpConnector {
     }
 }
 
-fn find_bind_address(remote_addr: &SocketAddr) -> SocketAddr {
+const fn find_bind_address(remote_addr: &SocketAddr) -> SocketAddr {
     match remote_addr {
         SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
         SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -248,7 +248,7 @@ async fn udp_send(socket: &mut UdpSocket, buf: &[u8]) -> tokio::io::Result<()> {
     Ok(())
 }
 
-fn find_bind_address(remote_addr: &SocketAddr) -> SocketAddr {
+const fn find_bind_address(remote_addr: &SocketAddr) -> SocketAddr {
     match remote_addr {
         SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
         SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),


### PR DESCRIPTION
We have a couple of dependency updates that require it (clap and rmpv).

I'd still like to define an official MSRV support policy for Vector, but in absence of that,
I figured I'd bump to not block the dependency updates. The only real downside is users trying to
build Vector on systems where they only have access to older versions of Rust; which seems to be
fairly rare currently.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
