### PR TITLE
fix(ci): Unlink python before `brew install`

### DIFF
--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -6,6 +6,10 @@ unset HOMEBREW_NO_INSTALL_FROM_API
 
 brew update
 
+# `brew install` attempts to upgrade python as a dependency but fails
+# https://github.com/actions/setup-python/issues/577
+brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+
 brew install ruby@2.7 coreutils cue-lang/tap/cue protobuf
 
 gem install bundler

--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -8,7 +8,7 @@ brew update
 
 # `brew install` attempts to upgrade python as a dependency but fails
 # https://github.com/actions/setup-python/issues/577
-brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
 
 brew install ruby@2.7 coreutils cue-lang/tap/cue protobuf
 


### PR DESCRIPTION
Otherwise it fails to update Python with:

```
==> Upgrading python@3.11
  3.11.4_1 -> 3.11.5

==> Pouring python@3.11--3.11.5.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.11

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.11
```

Example: https://github.com/vectordotdev/vector/actions/runs/5995416388/job/16258473755

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
