### PR TITLE
chore(deps): Update fork of rust-openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5851,8 +5851,8 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.91"
-source = "git+https://github.com/vectordotdev/rust-openssl?tag=openssl-sys-v0.9.91_3.0.0#c3a8b494e0a8ab88db692c239d30c903353b56a3"
+version = "0.9.92"
+source = "git+https://github.com/vectordotdev/rust-openssl?tag=openssl-sys-v0.9.92_3.0.0#109e24197321dd167420413b5231f6a644088935"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,7 +391,7 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 # The current `openssl-sys` crate will vendor the OpenSSL sources via
 # `openssl-src` at version 1.1.1*, but we want version 3.1.*. Bring in forked
 # version of that crate with the appropriate dependency patched in.
-openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl", tag = "openssl-sys-v0.9.91_3.0.0" }
+openssl-sys = { git = "https://github.com/vectordotdev/rust-openssl", tag = "openssl-sys-v0.9.92_3.0.0" }
 openssl-src = { git = "https://github.com/vectordotdev/openssl-src-rs", tag = "release-300-force-engine_3.1.2" }
 
 


### PR DESCRIPTION
To include changes from latest release.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
