### PR TITLE
fix(ci): Drop docker-compose from bootstrap install

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -23,14 +23,13 @@ apt install --yes \
 apt upgrade --yes
 
 # Deps
-apt install --yes \
+apt install --yes --no-install-recommends \
     awscli \
     build-essential \
     ca-certificates \
     cmake \
     cmark-gfm \
     curl \
-    docker-compose \
     gawk \
     gnupg2 \
     gnupg-agent \


### PR DESCRIPTION
It seems like it might be causing `docker-ce` to be uninstalled.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
