### PR TITLE
fix(ci): add comment trigger filter for regression workflow concurrency group

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,7 +34,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.merge_group.head_sha || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.event.merge_group.head_sha || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Noticed that when the Comment Trigger workflow was initiated on a different PR than mine, it cancelled my in progress run. The k8s workflow correctly handles this but it was missing from Regression workflow. This appears to be the only one missing it.