### PR TITLE
chore(ci): Re-add docker-compose installation

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -109,6 +109,12 @@ if ! [ -x "$(command -v docker)" ]; then
     usermod --append --groups docker ubuntu || true
 fi
 
+# docker-compose
+if ! [ -x "$(command -v docker-compose)" ]; then
+  curl -fsSL "https://github.com/docker/compose/releases/download/2.20.3/docker-compose-Linux-$(dpkg --print-architecture)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+fi
+
 bash scripts/environment/install-protoc.sh
 
 # Apt cleanup

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -111,7 +111,7 @@ fi
 
 # docker-compose
 if ! [ -x "$(command -v docker-compose)" ]; then
-  curl -fsSL "https://github.com/docker/compose/releases/download/2.20.3/docker-compose-linux-$(dpkg --print-architecture)" -o /usr/local/bin/docker-compose
+  curl -fsSL "https://github.com/docker/compose/releases/download/2.20.3/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
 fi
 

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -111,7 +111,7 @@ fi
 
 # docker-compose
 if ! [ -x "$(command -v docker-compose)" ]; then
-  curl -fsSL "https://github.com/docker/compose/releases/download/2.20.3/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
+  curl -fsSL "https://github.com/docker/compose/releases/download/v2.20.3/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
 fi
 

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -111,7 +111,7 @@ fi
 
 # docker-compose
 if ! [ -x "$(command -v docker-compose)" ]; then
-  curl -fsSL "https://github.com/docker/compose/releases/download/2.20.3/docker-compose-Linux-$(dpkg --print-architecture)" -o /usr/local/bin/docker-compose
+  curl -fsSL "https://github.com/docker/compose/releases/download/2.20.3/docker-compose-linux-$(dpkg --print-architecture)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
 fi
 


### PR DESCRIPTION
So that the bootstrap script installs docker-compose when used by scripts/environment/Dockerfile
(but not in CI which already has it).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
