### PR TITLE
fix: default to nullbyte delimiter for GELF #18008

### DIFF
--- a/src/codecs/encoding/config.rs
+++ b/src/codecs/encoding/config.rs
@@ -107,10 +107,12 @@ impl EncodingConfigWithFraming {
             (None, Serializer::Avro(_) | Serializer::Native(_)) => {
                 LengthDelimitedEncoder::new().into()
             }
+            (None, Serializer::Gelf(_)) => { 
+                CharacterDelimitedEncoder::new(0).into() 
+            }
             (
                 None,
                 Serializer::Csv(_)
-                | Serializer::Gelf(_)
                 | Serializer::Logfmt(_)
                 | Serializer::NativeJson(_)
                 | Serializer::RawMessage(_)


### PR DESCRIPTION
Changes the default message delimiter for GELF encoding from Newline to Null-Byte.

Apparently, Graylog ignores its own configuration option and always assumes Null-Bytes as delimiter for TCP transport. https://github.com/Graylog2/graylog2-server/issues/1240