### PR TITLE
Bump `chrono` to 0.4.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,8 +1958,8 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
-source = "git+https://github.com/vectordotdev/chrono.git?tag=v0.4.26-no-default-time-1#d44a3b100183d68f8a3e3cb431fcc4a47152a0a3"
+version = "0.4.27"
+source = "git+https://github.com/vectordotdev/chrono.git?tag=v0.4.27-no-default-time-1#15dc0b73a0f70d50b742208c4edf57def45ea2a8"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1967,7 +1967,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,7 @@ bloomy  = { version = "1.2.0", default-features = false, optional = true }
 bollard = { version = "0.14.0", default-features = false, features = ["ssl", "chrono"], optional = true }
 bytes = { version = "1.4.0", default-features = false, features = ["serde"] }
 bytesize = { version = "1.3.0", default-features = false }
-chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.27", default-features = false, features = ["serde"] }
 cidr-utils = { version = "0.5.10", default-features = false }
 clap = { version = "4.4.1", default-features = false, features = ["derive", "error-context", "env", "help", "std", "string", "usage", "wrap_help"] }
 colored = { version = "2.0.4", default-features = false }
@@ -382,7 +382,7 @@ zstd = { version = "0.12.4", default-features = false }
 [patch.crates-io]
 # Removes dependency on `time` v0.1
 # https://github.com/chronotope/chrono/pull/578
-chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.26-no-default-time-1" }
+chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.27-no-default-time-1" }
 # The upgrade for `tokio-util` >= 0.6.9 is blocked on https://github.com/vectordotdev/vector/issues/11257.
 tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-util-0.7.8-framed-read-continue-on-error" }
 nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/musl" }

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, Utc};
 use derivative::Derivative;
 use lookup::{event_path, owned_value_path};
 use serde::{Deserialize, Serialize};
@@ -138,7 +138,7 @@ impl GelfDeserializer {
                     f64::fract(timestamp) as u32,
                 )
                 .expect("invalid timestamp");
-                log.insert(timestamp_key, DateTime::<Utc>::from_utc(naive, Utc));
+                log.insert(timestamp_key, naive.and_utc());
                 // per GELF spec- add timestamp if not provided
             } else {
                 log.insert(timestamp_key, Utc::now());
@@ -239,7 +239,7 @@ impl Deserializer for GelfDeserializer {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use chrono::{DateTime, NaiveDateTime, Utc};
+    use chrono::NaiveDateTime;
     use lookup::event_path;
     use serde_json::json;
     use similar_asserts::assert_eq;
@@ -304,10 +304,7 @@ mod tests {
         );
         // Vector does not use the nanos
         let naive = NaiveDateTime::from_timestamp_opt(1385053862, 0).expect("invalid timestamp");
-        assert_eq!(
-            log.get(TIMESTAMP),
-            Some(&Value::Timestamp(DateTime::<Utc>::from_utc(naive, Utc)))
-        );
+        assert_eq!(log.get(TIMESTAMP), Some(&Value::Timestamp(naive.and_utc())));
         assert_eq!(log.get(LEVEL), Some(&Value::Integer(1)));
         assert_eq!(
             log.get(FACILITY),

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -243,7 +243,7 @@ mod tests {
     use crate::encoding::SerializerConfig;
 
     use super::*;
-    use chrono::{DateTime, NaiveDateTime, Utc};
+    use chrono::NaiveDateTime;
     use vector_core::event::{Event, EventMetadata};
     use vrl::btreemap;
     use vrl::value::Value;
@@ -347,7 +347,7 @@ mod tests {
         {
             let naive_dt =
                 NaiveDateTime::parse_from_str("1970-01-01 00:00:00.1", "%Y-%m-%d %H:%M:%S%.f");
-            let dt = DateTime::<Utc>::from_utc(naive_dt.unwrap(), Utc);
+            let dt = naive_dt.unwrap().and_utc();
 
             let event_fields = btreemap! {
                 VERSION => "1.1",
@@ -365,7 +365,7 @@ mod tests {
         {
             let naive_dt =
                 NaiveDateTime::parse_from_str("1970-01-01 00:00:00.0", "%Y-%m-%d %H:%M:%S%.f");
-            let dt = DateTime::<Utc>::from_utc(naive_dt.unwrap(), Utc);
+            let dt = naive_dt.unwrap().and_utc();
 
             let event_fields = btreemap! {
                 VERSION => "1.1",

--- a/lib/vector-core/src/event/test/common.rs
+++ b/lib/vector-core/src/event/test/common.rs
@@ -55,10 +55,9 @@ fn datetime(g: &mut Gen) -> DateTime<Utc> {
     // are. We just sort of arbitrarily restrict things.
     let secs = i64::arbitrary(g) % 32_000;
     let nanosecs = u32::arbitrary(g) % 32_000;
-    DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp_opt(secs, nanosecs).expect("invalid timestamp"),
-        Utc,
-    )
+    NaiveDateTime::from_timestamp_opt(secs, nanosecs)
+        .expect("invalid timestamp")
+        .and_utc()
 }
 
 impl Arbitrary for Event {

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::NaiveDateTime;
 use codecs::decoding::{DeserializerConfig, FramingConfig};
 use derivative::Derivative;
 use futures::{stream, stream::FuturesUnordered, FutureExt, Stream, StreamExt, TryFutureExt};
@@ -673,11 +673,9 @@ impl PubsubSource {
             "gcp_pubsub",
             &message.data,
             message.publish_time.map(|dt| {
-                DateTime::from_utc(
-                    NaiveDateTime::from_timestamp_opt(dt.seconds, dt.nanos as u32)
-                        .expect("invalid timestamp"),
-                    Utc,
-                )
+                NaiveDateTime::from_timestamp_opt(dt.seconds, dt.nanos as u32)
+                    .expect("invalid timestamp")
+                    .and_utc()
             }),
             batch,
             log_namespace,
@@ -840,6 +838,7 @@ mod integration_tests {
     use std::collections::{BTreeMap, HashSet};
 
     use base64::prelude::{Engine as _, BASE64_STANDARD};
+    use chrono::{DateTime, Utc};
     use futures::{Stream, StreamExt};
     use http::method::Method;
     use hyper::{Request, StatusCode};
@@ -1003,10 +1002,9 @@ mod integration_tests {
     fn now_trunc() -> DateTime<Utc> {
         let start = Utc::now().timestamp();
         // Truncate the milliseconds portion, the hard way.
-        DateTime::<Utc>::from_utc(
-            NaiveDateTime::from_timestamp_opt(start, 0).expect("invalid timestamp"),
-            Utc,
-        )
+        NaiveDateTime::from_timestamp_opt(start, 0)
+            .expect("invalid timestamp")
+            .and_utc()
     }
 
     struct Tester {


### PR DESCRIPTION
I thought this would trigger a load of "[this could be a `const fn`](https://rust-lang.github.io/rust-clippy/master/#/missing_const_for_fn)" clippy errors due to a number of `chrono` functions now being `const`, but I guess that lint isn't turned on in libs. Subject for another PR perhaps.

Ref: https://github.com/chronotope/chrono/releases/tag/v0.4.27