### PR TITLE
chore: Warn about missing `const` for functions in `codecs` lib

### DIFF
--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -24,12 +24,12 @@ impl BytesDeserializerConfig {
     }
 
     /// Build the `BytesDeserializer` from this configuration.
-    pub fn build(&self) -> BytesDeserializer {
+    pub const fn build(&self) -> BytesDeserializer {
         BytesDeserializer
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::Log
     }
 

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -40,19 +40,19 @@ pub struct GelfDeserializerConfig {
 
 impl GelfDeserializerConfig {
     /// Creates a new `GelfDeserializerConfig`.
-    pub fn new(options: GelfDeserializerOptions) -> Self {
+    pub const fn new(options: GelfDeserializerOptions) -> Self {
         Self { gelf: options }
     }
 
     /// Build the `GelfDeserializer` from this configuration.
-    pub fn build(&self) -> GelfDeserializer {
+    pub const fn build(&self) -> GelfDeserializer {
         GelfDeserializer {
             lossy: self.gelf.lossy,
         }
     }
 
     /// Return the type of event built by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::Log
     }
 
@@ -106,7 +106,7 @@ pub struct GelfDeserializer {
 
 impl GelfDeserializer {
     /// Create a new `GelfDeserializer`.
-    pub fn new(lossy: bool) -> GelfDeserializer {
+    pub const fn new(lossy: bool) -> GelfDeserializer {
         GelfDeserializer { lossy }
     }
 

--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -26,7 +26,7 @@ pub struct JsonDeserializerConfig {
 
 impl JsonDeserializerConfig {
     /// Creates a new `JsonDeserializerConfig`.
-    pub fn new(options: JsonDeserializerOptions) -> Self {
+    pub const fn new(options: JsonDeserializerOptions) -> Self {
         Self { json: options }
     }
 
@@ -36,7 +36,7 @@ impl JsonDeserializerConfig {
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::Log
     }
 
@@ -93,7 +93,7 @@ pub struct JsonDeserializer {
 
 impl JsonDeserializer {
     /// Creates a new `JsonDeserializer`.
-    pub fn new(lossy: bool) -> Self {
+    pub const fn new(lossy: bool) -> Self {
         Self { lossy }
     }
 }

--- a/lib/codecs/src/decoding/format/native.rs
+++ b/lib/codecs/src/decoding/format/native.rs
@@ -18,12 +18,12 @@ pub struct NativeDeserializerConfig;
 
 impl NativeDeserializerConfig {
     /// Build the `NativeDeserializer` from this configuration.
-    pub fn build(&self) -> NativeDeserializer {
+    pub const fn build(&self) -> NativeDeserializer {
         NativeDeserializer
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::all()
     }
 

--- a/lib/codecs/src/decoding/format/native_json.rs
+++ b/lib/codecs/src/decoding/format/native_json.rs
@@ -23,21 +23,21 @@ pub struct NativeJsonDeserializerConfig {
 
 impl NativeJsonDeserializerConfig {
     /// Creates a new `NativeJsonDeserializerConfig`.
-    pub fn new(options: NativeJsonDeserializerOptions) -> Self {
+    pub const fn new(options: NativeJsonDeserializerOptions) -> Self {
         Self {
             native_json: options,
         }
     }
 
     /// Build the `NativeJsonDeserializer` from this configuration.
-    pub fn build(&self) -> NativeJsonDeserializer {
+    pub const fn build(&self) -> NativeJsonDeserializer {
         NativeJsonDeserializer {
             lossy: self.native_json.lossy,
         }
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::all()
     }
 

--- a/lib/codecs/src/decoding/format/protobuf.rs
+++ b/lib/codecs/src/decoding/format/protobuf.rs
@@ -38,7 +38,7 @@ impl ProtobufDeserializerConfig {
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::Log
     }
 
@@ -87,7 +87,7 @@ pub struct ProtobufDeserializer {
 
 impl ProtobufDeserializer {
     /// Creates a new `ProtobufDeserializer`.
-    pub fn new(message_descriptor: MessageDescriptor) -> Self {
+    pub const fn new(message_descriptor: MessageDescriptor) -> Self {
         Self { message_descriptor }
     }
 

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -34,7 +34,7 @@ pub struct SyslogDeserializerConfig {
 
 impl SyslogDeserializerConfig {
     /// Creates a new `SyslogDeserializerConfig`.
-    pub fn new(options: SyslogDeserializerOptions) -> Self {
+    pub const fn new(options: SyslogDeserializerOptions) -> Self {
         Self {
             source: None,
             syslog: options,
@@ -58,7 +58,7 @@ impl SyslogDeserializerConfig {
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         DataType::Log
     }
 

--- a/lib/codecs/src/decoding/framing/character_delimited.rs
+++ b/lib/codecs/src/decoding/framing/character_delimited.rs
@@ -53,7 +53,7 @@ pub struct CharacterDelimitedDecoderOptions {
 
 impl CharacterDelimitedDecoderOptions {
     /// Create a `CharacterDelimitedDecoderOptions` with a delimiter and optional max_length.
-    pub fn new(delimiter: u8, max_length: Option<usize>) -> Self {
+    pub const fn new(delimiter: u8, max_length: Option<usize>) -> Self {
         Self {
             delimiter,
             max_length,

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -309,7 +309,7 @@ impl DeserializerConfig {
     }
 
     /// Return the type of event build by this deserializer.
-    pub fn output_type(&self) -> DataType {
+    pub const fn output_type(&self) -> DataType {
         match self {
             DeserializerConfig::Bytes => BytesDeserializerConfig.output_type(),
             DeserializerConfig::Json(config) => config.output_type(),

--- a/lib/codecs/src/encoding/format/avro.rs
+++ b/lib/codecs/src/encoding/format/avro.rs
@@ -28,7 +28,7 @@ impl AvroSerializerConfig {
     }
 
     /// The data type of events that are accepted by `AvroSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::Log
     }
 

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -58,7 +58,7 @@ impl CsvSerializerConfig {
     }
 
     /// The data type of events that are accepted by `CsvSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::Log
     }
 
@@ -166,7 +166,7 @@ impl Default for CsvSerializerOptions {
 }
 
 impl CsvSerializerOptions {
-    fn csv_quote_style(&self) -> csv_core::QuoteStyle {
+    const fn csv_quote_style(&self) -> csv_core::QuoteStyle {
         match self.quote_style {
             QuoteStyle::Always => csv_core::QuoteStyle::Always,
             QuoteStyle::Necessary => csv_core::QuoteStyle::Necessary,

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -53,12 +53,12 @@ impl GelfSerializerConfig {
     }
 
     /// Build the `GelfSerializer` from this configuration.
-    pub fn build(&self) -> GelfSerializer {
+    pub const fn build(&self) -> GelfSerializer {
         GelfSerializer::new()
     }
 
     /// The data type of events that are accepted by `GelfSerializer`.
-    pub fn input_type() -> DataType {
+    pub const fn input_type() -> DataType {
         DataType::Log
     }
 
@@ -77,7 +77,7 @@ pub struct GelfSerializer;
 
 impl GelfSerializer {
     /// Creates a new `GelfSerializer`.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         GelfSerializer
     }
 

--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -31,7 +31,7 @@ impl JsonSerializerConfig {
     }
 
     /// The data type of events that are accepted by `JsonSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::all()
     }
 

--- a/lib/codecs/src/encoding/format/logfmt.rs
+++ b/lib/codecs/src/encoding/format/logfmt.rs
@@ -20,7 +20,7 @@ impl LogfmtSerializerConfig {
     }
 
     /// The data type of events that are accepted by `LogfmtSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::Log
     }
 

--- a/lib/codecs/src/encoding/format/native.rs
+++ b/lib/codecs/src/encoding/format/native.rs
@@ -19,7 +19,7 @@ impl NativeSerializerConfig {
     }
 
     /// The data type of events that are accepted by `NativeSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::all()
     }
 

--- a/lib/codecs/src/encoding/format/native_json.rs
+++ b/lib/codecs/src/encoding/format/native_json.rs
@@ -14,7 +14,7 @@ impl NativeJsonSerializerConfig {
     }
 
     /// The data type of events that are accepted by `NativeJsonSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::all()
     }
 

--- a/lib/codecs/src/encoding/format/raw_message.rs
+++ b/lib/codecs/src/encoding/format/raw_message.rs
@@ -20,7 +20,7 @@ impl RawMessageSerializerConfig {
     }
 
     /// The data type of events that are accepted by `RawMessageSerializer`.
-    pub fn input_type(&self) -> DataType {
+    pub const fn input_type(&self) -> DataType {
         DataType::Log
     }
 

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -319,7 +319,7 @@ impl SerializerConfig {
     }
 
     /// Return an appropriate default framer for the given serializer.
-    pub fn default_stream_framing(&self) -> FramingConfig {
+    pub const fn default_stream_framing(&self) -> FramingConfig {
         match self {
             // TODO: Technically, Avro messages are supposed to be framed[1] as a vector of
             // length-delimited buffers -- `len` as big-endian 32-bit unsigned integer, followed by
@@ -405,7 +405,7 @@ pub enum Serializer {
 
 impl Serializer {
     /// Check if the serializer supports encoding an event to JSON via `Serializer::to_json_value`.
-    pub fn supports_json(&self) -> bool {
+    pub const fn supports_json(&self) -> bool {
         match self {
             Serializer::Json(_) | Serializer::NativeJson(_) | Serializer::Gelf(_) => true,
             Serializer::Avro(_)

--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![deny(clippy::missing_const_for_fn)]
 
 pub mod decoding;
 pub mod encoding;


### PR DESCRIPTION
Is this worth doing in more libs? Unfortunately, `cargo clippy --fix` does not appear to correct these so it's a lot of manual tweaking. Hypothetically these could lead to code quality improvements, but the "fat" LTO should take care of that.