### PR TITLE
feat(metrics): add 'container_name' to emitted 'kubernetes_logs' metrics

### DIFF
--- a/src/internal_events/kubernetes_logs.rs
+++ b/src/internal_events/kubernetes_logs.rs
@@ -19,6 +19,7 @@ pub struct KubernetesLogsEventsReceived<'a> {
 pub struct KubernetesLogsPodInfo {
     pub name: String,
     pub namespace: String,
+    pub container_name: String
 }
 
 impl InternalEvent for KubernetesLogsEventsReceived<'_> {
@@ -33,9 +34,10 @@ impl InternalEvent for KubernetesLogsEventsReceived<'_> {
             Some(pod_info) => {
                 let pod_name = pod_info.name;
                 let pod_namespace = pod_info.namespace;
+                let container_name: String = pod_info.container_name;
 
-                counter!("component_received_events_total", 1, "pod_name" => pod_name.clone(), "pod_namespace" => pod_namespace.clone());
-                counter!("component_received_event_bytes_total", self.byte_size.get() as u64, "pod_name" => pod_name, "pod_namespace" => pod_namespace);
+                counter!("component_received_events_total", 1, "pod_name" => pod_name.clone(), "pod_namespace" => pod_namespace.clone(), "container_name" => container_name.clone());
+                counter!("component_received_event_bytes_total", self.byte_size.get() as u64, "pod_name" => pod_name, "pod_namespace" => pod_namespace, "container_name" => container_name);
             }
             None => {
                 counter!("component_received_events_total", 1);

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -804,6 +804,7 @@ impl Source {
                 pod_info: file_info.as_ref().map(|info| KubernetesLogsPodInfo {
                     name: info.pod_name.to_owned(),
                     namespace: info.pod_namespace.to_owned(),
+                    container_name: info.container_name.to_owned()
                 }),
             });
 


### PR DESCRIPTION
# Description

This PR enriches the following metrics emitted from the `Kubernetes_Logs` with the `container_name`:
1. `component_received_events_total`
2. `component_received_event_bytes_total`

This will allow for queried metrics to be distinguished by pod/container especially when there is more than one container to a pod.

