### PR TITLE
chore(rust-doc): Add new Make command for CI builds

### DIFF
--- a/rust-doc/Makefile
+++ b/rust-doc/Makefile
@@ -1,3 +1,8 @@
+# Full docs build with all dependencies for local development
 docs:
+	../scripts/environment/install-protoc.sh ${HOME}/protoc
+	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs"
+# rust-doc.vector.dev specific build without the extra dependencies
+ci-docs-build:
 	../scripts/environment/install-protoc.sh ${HOME}/protoc
 	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs" --no-deps

--- a/rust-doc/Makefile
+++ b/rust-doc/Makefile
@@ -1,3 +1,3 @@
 docs:
 	../scripts/environment/install-protoc.sh ${HOME}/protoc
-	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs"
+	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs" --no-deps


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

With the migration to amplify by the websites team, we want to build the rust-doc just scoped to vector. While the migration is not complete, this has been built on amplify with the new `ci-docs-build` command. Leaving the original `docs` command in place for local development. 

Preview site can be found here: https://devin-ford-amplify-rust-doc.d1hoyoksbulg25.amplifyapp.com/vector/

**NOTE:** This change will **NOT** effect the current netlify deployment
