### PR TITLE
feat(dev): add `ENVIRONMENT_AUTOPULL` override to Makefile

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -49,6 +49,7 @@ authsvc
 autobenches
 AUTOBUILD
 AUTODESPAWN
+AUTOPULL
 autodiscovered
 autodiscovery
 autogen

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ export ENVIRONMENT_UPSTREAM ?= docker.io/timberio/vector-dev:sha-3eadc96742a3375
 # Override to disable building the container, having it pull from the GitHub packages repo instead
 # TODO: Disable this by default. Blocked by `docker pull` from GitHub Packages requiring authenticated login
 export ENVIRONMENT_AUTOBUILD ?= true
+# Override to disable force pulling the image, leaving the container tool to pull it only when necessary instead
+export ENVIRONMENT_AUTOPULL ?= true
 # Override this when appropriate to disable a TTY being available in commands with `ENVIRONMENT=true`
 export ENVIRONMENT_TTY ?= true
 
@@ -144,8 +146,9 @@ define ENVIRONMENT_PREPARE
 		--file scripts/environment/Dockerfile \
 		.
 endef
-else
+else ifeq ($(ENVIRONMENT_AUTOPULL), true)
 define ENVIRONMENT_PREPARE
+	@echo "Pulling the environment image. (ENVIRONMENT_AUTOPULL=true)"
 	$(CONTAINER_TOOL) pull $(ENVIRONMENT_UPSTREAM)
 endef
 endif


### PR DESCRIPTION
This commits adds an override to disable force pulling the environment image, leaving the container tool to pull it only when necessary instead.

Before this change, every time `make environment ENVIRONMENT_AUTOBUILD=false` is executed, it would force pull the image in `ENVIRONMENT_UPSTREAM` even if the image already exists locally. This is not efficient when the value in `ENVIRONMENT_UPSTREAM` is a static/fixed tag.

With the new override, the environment can be started very quickly when the image exists locally:

    make environment ENVIRONMENT_AUTOBUILD=false ENVIRONMENT_AUTOPULL=false

The default value for `ENVIRONMENT_AUTOPULL` is `true` to preserve the current behavior.
