### PR TITLE
fix(syslog source, docs): Fix docs for `host` field for syslog source

### DIFF
--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -59,7 +59,13 @@ components: sources: syslog: {
 					examples: ["app-name"]
 				}
 			}
-			host: fields._local_host
+			host: {
+				description: "The hostname extracted from the Syslog line."
+				required:    true
+				type: string: {
+					examples: ["my.host.com"]
+				}
+			}
 			hostname: {
 				description: "The hostname extracted from the Syslog line. (`host` is also this value if it exists in the log.)"
 				required:    true

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -60,7 +60,7 @@ components: sources: syslog: {
 				}
 			}
 			host: {
-				description: "The hostname extracted from the Syslog line."
+				description: "The hostname extracted from the Syslog message. If no hostname can be extracted from the Syslog message, the IP address of the peer is used instead."
 				required:    true
 				type: string: {
 					examples: ["my.host.com"]

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -60,14 +60,14 @@ components: sources: syslog: {
 				}
 			}
 			host: {
-				description: "The hostname extracted from the Syslog message. If no hostname can be extracted from the Syslog message, the IP address of the peer is used instead."
+				description: "Same as `hostname` if that field is set, or the IP address of the peer otherwise."
 				required:    true
 				type: string: {
-					examples: ["my.host.com"]
+					examples: ["my.host.com", "127.0.0.1"]
 				}
 			}
 			hostname: {
-				description: "The hostname extracted from the Syslog line. (`host` is also this value if it exists in the log.)"
+				description: "The `hostname` field extracted from the Syslog line. If a `hostname` field is found, `host` is also set to this value."
 				required:    true
 				type: string: {
 					examples: ["my.host.com"]


### PR DESCRIPTION
It is incorrectly documented as using `gethostname` on the host receiving the data, but actually
extracts the host from the log message itself.

Closes: #18371

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
