### PR TITLE
fix(debian platform): Remove `conf-files` directive for `cargo-deb`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ debug = true
 name = "vector"
 section = "admin"
 maintainer-scripts = "distribution/debian/scripts/"
-conf-files = ["/etc/vector/vector.toml", "/etc/default/vector"]
 assets = [
   ["target/release/vector", "/usr/bin/", "755"],
   ["config/vector.toml", "/etc/vector/vector.toml", "644"],


### PR DESCRIPTION
Apparently `cargo-deb` is including an extra newline in the generated `conffiles` file which causes a bug when used with Uyuni/SUSE Manager (https://github.com/vectordotdev/vector/issues/18439). I opened an issue upstream, https://github.com/kornelski/cargo-deb/issues/110, but observed that we only have conffiles in `/etc` and so don't actually need to include a `conffiles` control file. Per the Debian docs:

> dh_installdeb(1) automatically flags any files under the /etc directory as conffiles, so if your program only has conffiles there you do not need to specify them in this file. For most package types, the only place conffiles should ever be is under /etc, and so this file doesn't need to exist.

Closes: https://github.com/vectordotdev/vector/issues/18439

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
