### PR TITLE
enhancement(kubernetes_logs source): add container_start_time to k8s_logs

### DIFF
--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -716,6 +716,11 @@ async fn metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap()
             .is_empty());
         assert_eq!(val["kubernetes"]["container_image"], BUSYBOX_IMAGE);
+        assert!(
+            val["kubernetes"]["container_start_time"].is_string(),
+            "{:?}[container_start_time] is not a string",
+            val["kubernetes"]
+        );
 
         // Request to stop the flow.
         FlowControlCommand::Terminate

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -266,6 +266,18 @@ base: components: sources: kubernetes_logs: configuration: {
 					examples: [".k8s.container_name", "k8s.container_name", ""]
 				}
 			}
+			container_start_time: {
+				description: """
+					Event field for the Container's start time.
+
+					Set to `""` to suppress this key.
+					"""
+				required: false
+				type: string: {
+					default: ".kubernetes.container_start_time"
+					examples: [".k8s.container_start_time", "k8s.container_start_time", ""]
+				}
+			}
 			pod_annotations: {
 				description: """
 					Event field for the Pod's annotations.

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -96,6 +96,15 @@ components: sources: kubernetes_logs: {
 					examples: ["busybox@sha256:1e7b63c09af457b93c17d25ef4e6aee96b5bb95f087840cffd7c4bb2fe8ae5c6"]
 				}
 			}
+			"kubernetes.container_start_time": {
+				description: "Container start time"
+				required:    false
+				common:      true
+				type: string: {
+					default: null
+					examples: ["2023-01-01T10:10:10Z"]
+				}
+			}
 			"kubernetes.container_name": {
 				description: "Container name."
 				required:    false


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

This adds the container start time to the `kubernetes_logs` source. While `container_id` helps distinguish between different instances of the same container, it does not clarify the time-order of these container. Often, we want to be able to look at the logs

My understanding (not confirmed, but based on my understanding of kubernetes) is that this field may not be filled in before the container starts. This means some early log lines may have chance of missing this label. If this is actually the case, its still useful to use the existence of log lines with both the `container_id` and `start_time` label to associate container instances with their start time
