### PR TITLE
docs: Add notes about `ingress_upstreaminfo` log format for `parse_nginx_log()` function

### DIFF
--- a/website/cue/reference/remap/functions/parse_nginx_log.cue
+++ b/website/cue/reference/remap/functions/parse_nginx_log.cue
@@ -3,8 +3,9 @@ package metadata
 remap: functions: parse_nginx_log: {
 	category:    "Parse"
 	description: """
-        Parses Nginx access and error log lines. Lines can be in [`combined`](\(urls.nginx_combined)), or [`error`](\(urls.nginx_error)) format.
-        """
+      Parses Nginx access and error log lines. Lines can be in [`combined`](\(urls.nginx_combined)),
+      [`ingress_upstreaminfo`](\(urls.nginx_ingress_upstreaminfo)) or [`error`](\(urls.nginx_error)) format.
+      """
 	notices: [
 		"""
 			Missing information in the log message may be indicated by `-`. These fields are omitted in the result.

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -376,6 +376,7 @@ urls: {
 	new_transform:                              "\(vector_repo)/issues/new?labels=type%3A+new+feature"
 	nginx:                                      "https://www.nginx.com/"
 	nginx_combined:                             "https://nginx.org/en/docs/http/ngx_http_log_module.html"
+	nginx_ingress_upstreaminfo:                 "https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/"
 	nginx_error:                                "https://github.com/nginx/nginx/blob/branches/stable-1.18/src/core/ngx_log.c#L102"
 	nginx_stub_status_module:                   "http://nginx.org/en/docs/http/ngx_http_stub_status_module.html"
 	nix:                                        "https://nixos.org/nix/"


### PR DESCRIPTION
Adds notes about recently added `ingress_upstreaminfo` log format for `parse_nginx_log()` function [VRL PR here](https://github.com/vectordotdev/vrl/pull/193)