### PR TITLE
fix(ci): don't continue on errors in unit-mac test

### DIFF
--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -5,9 +5,6 @@ on:
 
 jobs:
   unit-mac:
-    # Full CI suites for this platform were only recently introduced.
-    # Some failures are permitted until we can properly correct them.
-    continue-on-error: true
     runs-on: macos-11
     env:
       CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Previously this job was a required check for merging into master. With the merge queue it isn't required and this job option is resulting in failures of this job to not fail out of the merge queue.