### PR TITLE
chore(datadog_logs sink)!: Use `endpoint` config setting consistent with the other datadog_ sinks.

### DIFF
--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -36,13 +36,13 @@ pub(crate) fn default_site() -> String {
 pub struct DatadogCommonConfig {
     /// The endpoint to send observability data to.
     ///
-    /// The endpoint must contain an HTTP scheme, and may specify a
-    /// hostname or IP address and port.
+    /// The endpoint must contain an HTTP scheme, and may specify a hostname or IP
+    /// address and port. The path must be specified if expected by the downstream.
     ///
     /// If set, overrides the `site` option.
     #[configurable(metadata(docs::advanced))]
-    #[configurable(metadata(docs::examples = "http://127.0.0.1:8080"))]
-    #[configurable(metadata(docs::examples = "http://example.com:12345"))]
+    #[configurable(metadata(docs::examples = "http://127.0.0.1:8080/api/v2/logs"))]
+    #[configurable(metadata(docs::examples = "http://example.com:12345/api/beta/sketches"))]
     #[serde(default)]
     pub endpoint: Option<String>,
 

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -37,12 +37,13 @@ pub struct DatadogCommonConfig {
     /// The endpoint to send observability data to.
     ///
     /// The endpoint must contain an HTTP scheme, and may specify a hostname or IP
-    /// address and port. The path must be specified if expected by the downstream.
+    /// address and port. The API path should NOT be specified as this is handled by
+    /// the sink.
     ///
     /// If set, overrides the `site` option.
     #[configurable(metadata(docs::advanced))]
-    #[configurable(metadata(docs::examples = "http://127.0.0.1:8080/api/v2/logs"))]
-    #[configurable(metadata(docs::examples = "http://example.com:12345/api/beta/sketches"))]
+    #[configurable(metadata(docs::examples = "http://127.0.0.1:8080"))]
+    #[configurable(metadata(docs::examples = "http://example.com:12345"))]
     #[serde(default)]
     pub endpoint: Option<String>,
 

--- a/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
@@ -2,12 +2,16 @@
 date: "2023-09-26"
 title: "0.33 Upgrade Guide"
 description: "An upgrade guide that addresses breaking changes in 0.33.0"
-authors: ["spencergilbert"]
+authors: ["spencergilbert", "neuronull"]
 release: "0.33.0"
 hide_on_release_notes: false
 badges:
   type: breaking change
 ---
+
+Vector's 0.33.0 release includes **breaking changes**:
+
+1. [Behavior of the `datadog_logs` sink's `endpoint` setting](#datadog-logs-endpoint)
 
 Vector's 0.33.0 release includes **deprecations**:
 
@@ -16,6 +20,20 @@ Vector's 0.33.0 release includes **deprecations**:
 We cover them below to help you upgrade quickly:
 
 ## Upgrade guide
+
+### Breaking changes
+
+#### Behavior of the `datadog_logs` sink's `endpoint` setting {#datadog-logs-endpoint}
+
+The `endpoint` configuration setting is common to each of the Datadog sinks. Before this
+change, when `endpoint` was set, the logs sink took the provided endpoint as the complete
+URL (including API path) to use for posting HTTP requests. This behavior is inconsistent
+with the other Datadog sinks, which use the `endpoint` as a base URL that the API path
+(eg. "/api/v2/logs"), is appended to.
+
+With this release, the `datadog_logs` sink's behavior is now consistent with the other
+Datadog sinks for the `endpoint` setting.
+
 
 ### Deprecations
 

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -44,12 +44,13 @@ base: components: sinks: datadog_events: configuration: {
 			The endpoint to send observability data to.
 
 			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
-			address and port. The path must be specified if expected by the downstream.
+			address and port. The API path should NOT be specified as this is handled by
+			the sink.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
+		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 	}
 	region: {
 		deprecated:         true

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -43,13 +43,13 @@ base: components: sinks: datadog_events: configuration: {
 		description: """
 			The endpoint to send observability data to.
 
-			The endpoint must contain an HTTP scheme, and may specify a
-			hostname or IP address and port.
+			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
+			address and port. The path must be specified if expected by the downstream.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
+		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
 	}
 	region: {
 		deprecated:         true

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -129,12 +129,13 @@ base: components: sinks: datadog_logs: configuration: {
 			The endpoint to send observability data to.
 
 			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
-			address and port. The path must be specified if expected by the downstream.
+			address and port. The API path should NOT be specified as this is handled by
+			the sink.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
+		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 	}
 	region: {
 		deprecated:         true

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -128,13 +128,13 @@ base: components: sinks: datadog_logs: configuration: {
 		description: """
 			The endpoint to send observability data to.
 
-			The endpoint must contain an HTTP scheme, and may specify a
-			hostname or IP address and port.
+			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
+			address and port. The path must be specified if expected by the downstream.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
+		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
 	}
 	region: {
 		deprecated:         true

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -85,13 +85,13 @@ base: components: sinks: datadog_metrics: configuration: {
 		description: """
 			The endpoint to send observability data to.
 
-			The endpoint must contain an HTTP scheme, and may specify a
-			hostname or IP address and port.
+			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
+			address and port. The path must be specified if expected by the downstream.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
+		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
 	}
 	region: {
 		deprecated:         true

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -86,12 +86,13 @@ base: components: sinks: datadog_metrics: configuration: {
 			The endpoint to send observability data to.
 
 			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
-			address and port. The path must be specified if expected by the downstream.
+			address and port. The API path should NOT be specified as this is handled by
+			the sink.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
+		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 	}
 	region: {
 		deprecated:         true

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -104,13 +104,13 @@ base: components: sinks: datadog_traces: configuration: {
 		description: """
 			The endpoint to send observability data to.
 
-			The endpoint must contain an HTTP scheme, and may specify a
-			hostname or IP address and port.
+			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
+			address and port. The path must be specified if expected by the downstream.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
+		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
 	}
 	request: {
 		description: """

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -105,12 +105,13 @@ base: components: sinks: datadog_traces: configuration: {
 			The endpoint to send observability data to.
 
 			The endpoint must contain an HTTP scheme, and may specify a hostname or IP
-			address and port. The path must be specified if expected by the downstream.
+			address and port. The API path should NOT be specified as this is handled by
+			the sink.
 
 			If set, overrides the `site` option.
 			"""
 		required: false
-		type: string: examples: ["http://127.0.0.1:8080/api/v2/logs", "http://example.com:12345/api/beta/sketches"]
+		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 	}
 	request: {
 		description: """


### PR DESCRIPTION
If an endpoint is specified for the datadog sink configs, we don't automatically append the path based on event types so it needs to be specified by the user.

This is in contrast to the other datadog sinks, which use the endpoint setting as a base url.

This PR updates the behavior of the logs sink to be consistent with the rest.

Note this is is a breaking change for users however it is an uncommon setting and is mainly useful in testing environments.