### PR TITLE
fix(docs): remove '---\n' prefix from toYaml config example generator

### DIFF
--- a/website/scripts/create-config-examples.js
+++ b/website/scripts/create-config-examples.js
@@ -99,7 +99,7 @@ const toToml = (obj) => {
 
 // Convert object to YAML string
 const toYaml = (obj) => {
-  return `---\n${YAML.stringify(obj)}`;
+  return `${YAML.stringify(obj)}`;
 }
 
 // Convert object to JSON string (indented)


### PR DESCRIPTION
This prefix is only defined for yaml examples and is inconsistent with other examples.