### PR TITLE
fix(observability): don't increment component_errors_total for `HttpClient` warning

### DIFF
--- a/src/internal_events/http_client.rs
+++ b/src/internal_events/http_client.rs
@@ -80,11 +80,6 @@ impl<'a> InternalEvent for GotHttpWarning<'a> {
             stage = error_stage::PROCESSING,
             internal_log_rate_limit = true,
         );
-        counter!(
-            "component_errors_total", 1,
-            "error_type" => error_type::REQUEST_FAILED,
-            "stage" => error_stage::PROCESSING,
-        );
         counter!("http_client_errors_total", 1, "error_kind" => self.error.to_string());
         histogram!("http_client_rtt_seconds", self.roundtrip);
         histogram!("http_client_error_rtt_seconds", self.roundtrip, "error_kind" => self.error.to_string());

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -413,7 +413,8 @@ where
                 .service(http_client);
 
             // Any errors raised in `http_client.call` results in a `GotHttpWarning` event being emitted
-            // in `HttpClient::send`.
+            // in `HttpClient::send`. This does not result in incremeneting `component_errors_total` however,
+            // because that is incremented by the driver when retries have been exhausted.
             let response = decompression_service.call(request).await?;
 
             if response.status().is_success() {

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -413,7 +413,7 @@ where
                 .service(http_client);
 
             // Any errors raised in `http_client.call` results in a `GotHttpWarning` event being emitted
-            // in `HttpClient::send`. This does not result in incremeneting `component_errors_total` however,
+            // in `HttpClient::send`. This does not result in incrementing `component_errors_total` however,
             // because that is incremented by the driver when retries have been exhausted.
             let response = decompression_service.call(request).await?;
 


### PR DESCRIPTION
There is some history around this code. It appears that originally this internal metric was named with an `Error` suffix, and that at some point there was a change to emit this internal metric because of that suffix. When in reality, this condition should generally be retried by the upstream.