### PR TITLE
chore(platform: arm): Add scaffolding for arm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,12 @@ start = false
 # libc requirements are defined by `cross`
 # https://github.com/rust-embedded/cross#supported-targets
 # Though, it seems like aarch64 libc is actually 2.18 and not 2.19
+[package.metadata.deb.variants.arm-unknown-linux-gnueabihf]
+depends = "libc6 (>= 2.15)"
+
+[package.metadata.deb.variants.arm-unknown-linux-musleabihf]
+depends = ""
+
 [package.metadata.deb.variants.armv7-unknown-linux-gnueabihf]
 depends = "libc6 (>= 2.15)"
 
@@ -421,6 +427,8 @@ target-aarch64-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "r
 target-aarch64-unknown-linux-musl = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
 target-armv7-unknown-linux-gnueabihf = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
 target-armv7-unknown-linux-musleabihf = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "enterprise"]
+target-arm-unknown-linux-gnueabihf = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
+target-arm-unknown-linux-musleabihf = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "enterprise"]
 target-x86_64-unknown-linux-gnu = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
 target-x86_64-unknown-linux-musl = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
 # Does not currently build

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,14 @@ build-armv7-unknown-linux-gnueabihf: target/armv7-unknown-linux-gnueabihf/releas
 build-armv7-unknown-linux-musleabihf: target/armv7-unknown-linux-musleabihf/release/vector ## Build a release binary for the armv7-unknown-linux-musleabihf triple.
 	@echo "Output to ${<}"
 
+.PHONY: build-arm-unknown-linux-gnueabihf
+build-arm-unknown-linux-gnueabihf: target/arm-unknown-linux-gnueabihf/release/vector ## Build a release binary for the arm-unknown-linux-gnueabihf triple.
+	@echo "Output to ${<}"
+
+.PHONY: build-arm-unknown-linux-musleabihf
+build-arm-unknown-linux-musleabihf: target/arm-unknown-linux-musleabihf/release/vector ## Build a release binary for the arm-unknown-linux-musleabihf triple.
+	@echo "Output to ${<}"
+
 .PHONY: build-graphql-schema
 build-graphql-schema: ## Generate the `schema.json` for Vector's GraphQL API
 	${MAYBE_ENVIRONMENT_EXEC} cargo run --bin graphql-schema --no-default-features --features=default-no-api-client
@@ -520,6 +528,9 @@ package-aarch64-unknown-linux-gnu-all: package-aarch64-unknown-linux-gnu package
 .PHONY: package-armv7-unknown-linux-gnueabihf-all
 package-armv7-unknown-linux-gnueabihf-all: package-armv7-unknown-linux-gnueabihf package-deb-armv7-gnu package-rpm-armv7hl-gnu package-rpm-armv7-gnu  # Build all armv7-unknown-linux-gnueabihf MUSL packages
 
+.PHONY: package-arm-unknown-linux-gnueabihf-all
+package-arm-unknown-linux-gnueabihf-all: package-arm-unknown-linux-gnueabihf package-deb-arm-gnu package-rpm-armhl-gnu package-rpm-arm-gnu  # Build all arm-unknown-linux-gnueabihf MUSL packages
+
 .PHONY: package-x86_64-unknown-linux-gnu
 package-x86_64-unknown-linux-gnu: target/artifacts/vector-${VERSION}-x86_64-unknown-linux-gnu.tar.gz ## Build an archive suitable for the `x86_64-unknown-linux-gnu` triple.
 	@echo "Output to ${<}."
@@ -542,6 +553,14 @@ package-armv7-unknown-linux-gnueabihf: target/artifacts/vector-${VERSION}-armv7-
 
 .PHONY: package-armv7-unknown-linux-musleabihf
 package-armv7-unknown-linux-musleabihf: target/artifacts/vector-${VERSION}-armv7-unknown-linux-musleabihf.tar.gz ## Build an archive suitable for the `armv7-unknown-linux-musleabihf triple.
+	@echo "Output to ${<}."
+
+.PHONY: package-arm-unknown-linux-gnueabihf
+package-arm-unknown-linux-gnueabihf: target/artifacts/vector-${VERSION}-arm-unknown-linux-gnueabihf.tar.gz ## Build an archive suitable for the `arm-unknown-linux-gnueabihf` triple.
+	@echo "Output to ${<}."
+
+.PHONY: package-arm-unknown-linux-musleabihf
+package-arm-unknown-linux-musleabihf: target/artifacts/vector-${VERSION}-arm-unknown-linux-musleabihf.tar.gz ## Build an archive suitable for the `arm-unknown-linux-musleabihf triple.
 	@echo "Output to ${<}."
 
 # debs

--- a/scripts/cross/arm-unknown-linux-gnueabihf.dockerfile
+++ b/scripts/cross/arm-unknown-linux-gnueabihf.dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/cross-rs/arm-unknown-linux-gnueabihf:0.2.5
+
+COPY scripts/cross/bootstrap-ubuntu.sh scripts/environment/install-protoc.sh /
+RUN /bootstrap-ubuntu.sh && bash /install-protoc.sh

--- a/scripts/cross/arm-unknown-linux-musleabihf.dockerfile
+++ b/scripts/cross/arm-unknown-linux-musleabihf.dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/cross-rs/arm-unknown-linux-musleabihf:0.2.5
+
+COPY scripts/cross/bootstrap-ubuntu.sh scripts/environment/install-protoc.sh /
+RUN /bootstrap-ubuntu.sh && bash /install-protoc.sh
+
+# Stick `libstdc++` somewhere it can be found other than it's normal location, otherwise we end up using the wrong version
+# of _other_ libraries, which ultimately just breaks linking. We'll set `/lib/native-libs` as a search path in `.cargo/config.toml`.
+RUN mkdir -p /lib/native-libs && cp /usr/local/arm-linux-musleabihf/lib/libstdc++.a /lib/native-libs/


### PR DESCRIPTION
Currently failing due to it not finding `protoc` in the path in the cross image, but I'm not sure why since it is in there when I `docker exec` in. Opening this as a draft in case anyone else wants to pick up the torch.