### PR TITLE
chore(ci): group azure and prost crates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
+    groups:
+      azure:
+        patterns:
+        - "azure_*"
+      prost:
+        patterns:
+        - "prost"
+        - "prost-*"
   - package-ecosystem: "docker"
     directory: "/distribution/docker/"
     schedule:


### PR DESCRIPTION
This tells dependabot that we want the `azure_*` and `prost` crates to be grouped into a single PR.

Docs for the settings are [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).