### PR TITLE
chore(ci): remove kinetic as it's no longer supported

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -290,7 +290,6 @@ jobs:
           - ubuntu:18.04
           - ubuntu:20.04
           - ubuntu:22.04
-          - ubuntu:22.10
           - ubuntu:23.04
           - debian:10
           - debian:11


### PR DESCRIPTION
Ubuntu 22.10 is [no longer supported](https://ubuntu.com/about/release-cycle), which is now breaking the nightly builds. 

This removes 22.10 from the `deb-verify` job.