### PR TITLE
feature(enterprise): configurable app name

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -984,6 +984,7 @@ skywalking
 slashin
 slf
 slideover
+slugified
 smallvec
 smartphone
 Smol

--- a/src/app.rs
+++ b/src/app.rs
@@ -535,6 +535,18 @@ fn build_enterprise(
     config: &mut Config,
     config_paths: Vec<ConfigPath>,
 ) -> Result<Option<EnterpriseReporter<BoxFuture<'static, ()>>>, ExitCode> {
+    use crate::ENTERPRISE_ENABLED;
+
+    ENTERPRISE_ENABLED
+        .set(
+            config
+                .enterprise
+                .as_ref()
+                .map(|e| e.enabled)
+                .unwrap_or_default(),
+        )
+        .expect("double initialization of enterprise enabled flag");
+
     match EnterpriseMetadata::try_from(&*config) {
         Ok(metadata) => {
             let enterprise = EnterpriseReporter::new();

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -235,15 +235,27 @@ pub trait SinkConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync
 
 dyn_clone::clone_trait_object!(SinkConfig);
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct SinkContext {
     pub healthcheck: SinkHealthcheckOptions,
     pub globals: GlobalOptions,
     pub proxy: ProxyConfig,
     pub schema: schema::Options,
+    pub app_name: String,
+    pub app_name_slug: String,
+}
 
-    #[cfg(feature = "enterprise")]
-    pub enterprise_enabled: bool,
+impl Default for SinkContext {
+    fn default() -> Self {
+        Self {
+            healthcheck: Default::default(),
+            globals: Default::default(),
+            proxy: Default::default(),
+            schema: Default::default(),
+            app_name: crate::get_app_name().to_string(),
+            app_name_slug: crate::get_slugified_app_name(),
+        }
+    }
 }
 
 impl SinkContext {

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -243,7 +243,7 @@ pub struct SinkContext {
     pub schema: schema::Options,
 
     #[cfg(feature = "enterprise")]
-    pub enterprise_in_use: bool,
+    pub enterprise_enabled: bool,
 }
 
 impl SinkContext {

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -241,6 +241,9 @@ pub struct SinkContext {
     pub globals: GlobalOptions,
     pub proxy: ProxyConfig,
     pub schema: schema::Options,
+
+    #[cfg(feature = "enterprise")]
+    pub enterprise_in_use: bool,
 }
 
 impl SinkContext {

--- a/src/http.rs
+++ b/src/http.rs
@@ -82,9 +82,10 @@ where
         let proxy_connector = build_proxy_connector(tls_settings.into(), proxy_config)?;
         let client = client_builder.build(proxy_connector.clone());
 
+        let app_name = crate::get_app_name();
         let version = crate::get_version();
-        let user_agent = HeaderValue::from_str(&format!("Vector/{}", version))
-            .expect("Invalid header value for version!");
+        let user_agent = HeaderValue::from_str(&format!("{}/{}", app_name, version))
+            .expect("Invalid header value for user-agent!");
 
         Ok(HttpClient {
             client,

--- a/src/http.rs
+++ b/src/http.rs
@@ -82,7 +82,12 @@ where
         let proxy_connector = build_proxy_connector(tls_settings.into(), proxy_config)?;
         let client = client_builder.build(proxy_connector.clone());
 
-        let app_name = crate::get_app_name();
+        let app_name = crate::get_app_name(
+            // TODO: correctly set this field.
+            // Note that Vector Enterprise is deprecated so the effort does not seem worthwhile.
+            #[cfg(feature = "enterprise")]
+            false,
+        );
         let version = crate::get_version();
         let user_agent = HeaderValue::from_str(&format!("{}/{}", app_name, version))
             .expect("Invalid header value for user-agent!");

--- a/src/http.rs
+++ b/src/http.rs
@@ -82,12 +82,7 @@ where
         let proxy_connector = build_proxy_connector(tls_settings.into(), proxy_config)?;
         let client = client_builder.build(proxy_connector.clone());
 
-        let app_name = crate::get_app_name(
-            // TODO: correctly set this field.
-            // Note that Vector Enterprise is deprecated so the effort does not seem worthwhile.
-            #[cfg(feature = "enterprise")]
-            false,
-        );
+        let app_name = crate::get_app_name();
         let version = crate::get_version();
         let user_agent = HeaderValue::from_str(&format!("{}/{}", app_name, version))
             .expect("Invalid header value for user-agent!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,11 +124,11 @@ pub use source_sender::SourceSender;
 pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
+static APP_NAME_SLUG: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
 /// Flag denoting whether or not enterprise features are enabled.
 #[cfg(feature = "enterprise")]
 pub static ENTERPRISE_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-
-static APP_NAME_SLUG: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
 /// The name used to identify this Vector application.
 ///
@@ -138,10 +138,7 @@ pub fn get_app_name() -> &'static str {
     #[cfg(not(feature = "enterprise"))]
     let app_name = "Vector";
     #[cfg(feature = "enterprise")]
-    let app_name = if *ENTERPRISE_ENABLED
-        .get()
-        .unwrap_or(&false)
-    {
+    let app_name = if *ENTERPRISE_ENABLED.get().unwrap_or(&false) {
         "Vector Enterprise"
     } else {
         "Vector"
@@ -154,7 +151,9 @@ pub fn get_app_name() -> &'static str {
 ///
 /// Defaults to "vector".
 pub fn get_slugified_app_name() -> String {
-    APP_NAME_SLUG.get_or_init(|| get_app_name().to_lowercase().replace(' ', "-")).clone()
+    APP_NAME_SLUG
+        .get_or_init(|| get_app_name().to_lowercase().replace(' ', "-"))
+        .clone()
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,14 @@ pub use source_sender::SourceSender;
 pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
+/// The name used to identify this Vector service.
+///
+/// This can be set at compile-time through the VECTOR_APP_NAME env variable.
+/// Defaults to "vector".
+pub fn get_app_name() -> &'static str {
+    option_env!("VECTOR_APP_NAME").unwrap_or("vector")
+}
+
 /// The current version of Vector in simplified format.
 /// `<version-number>-nightly`.
 pub fn vector_version() -> impl std::fmt::Display {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,29 @@ pub use vector_core::{event, metrics, schema, tcp, tls};
 ///
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
 /// Defaults to "Vector".
-pub fn get_app_name() -> &'static str {
-    option_env!("VECTOR_APP_NAME").unwrap_or("Vector")
+pub fn get_app_name(#[cfg(feature = "enterprise")] enterprise_in_use: bool) -> &'static str {
+    #[cfg(not(feature = "enterprise"))]
+    let default_app_name = "Vector";
+    #[cfg(feature = "enterprise")]
+    let default_app_name = if enterprise_in_use {
+        "Vector Enterprise"
+    } else {
+        "Vector"
+    };
+
+    option_env!("VECTOR_APP_NAME").unwrap_or(default_app_name)
+}
+
+/// Returns a sluggified version of the name used to identify this Vector application.
+///
+/// Defaults to "vector".
+pub fn get_sluggified_app_name(#[cfg(feature = "enterprise")] enterprise_in_use: bool) -> String {
+    get_app_name(
+        #[cfg(feature = "enterprise")]
+        enterprise_in_use,
+    )
+    .to_lowercase()
+    .replace(' ', "-")
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub use source_sender::SourceSender;
 pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
-/// The name used to identify this Vector service.
+/// The name used to identify this Vector application.
 ///
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
 /// Defaults to "vector".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,33 +124,35 @@ pub use source_sender::SourceSender;
 pub use vector_common::{shutdown, Error, Result};
 pub use vector_core::{event, metrics, schema, tcp, tls};
 
+/// Flag denoting whether or not enterprise features are enabled.
+#[cfg(feature = "enterprise")]
+pub static ENTERPRISE_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
 /// The name used to identify this Vector application.
 ///
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
 /// Defaults to "Vector".
-pub fn get_app_name(#[cfg(feature = "enterprise")] enterprise_enabled: bool) -> &'static str {
+pub fn get_app_name() -> &'static str {
     #[cfg(not(feature = "enterprise"))]
-    let default_app_name = "Vector";
+    let app_name = DEFAULT_APP_NAME;
     #[cfg(feature = "enterprise")]
-    let default_app_name = if enterprise_enabled {
+    let app_name = if *ENTERPRISE_ENABLED
+        .get()
+        .unwrap_or(&false)
+    {
         "Vector Enterprise"
     } else {
         "Vector"
     };
 
-    option_env!("VECTOR_APP_NAME").unwrap_or(default_app_name)
+    option_env!("VECTOR_APP_NAME").unwrap_or(app_name)
 }
 
 /// Returns a slugified version of the name used to identify this Vector application.
 ///
 /// Defaults to "vector".
-pub fn get_slugified_app_name(#[cfg(feature = "enterprise")] enterprise_enabled: bool) -> String {
-    get_app_name(
-        #[cfg(feature = "enterprise")]
-        enterprise_enabled,
-    )
-    .to_lowercase()
-    .replace(' ', "-")
+pub fn get_slugified_app_name() -> String {
+   get_app_name().to_lowercase().replace(' ', "-")
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub use vector_core::{event, metrics, schema, tcp, tls};
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
 /// Defaults to "vector".
 pub fn get_app_name() -> &'static str {
-    option_env!("VECTOR_APP_NAME").unwrap_or("vector")
+    option_env!("VECTOR_APP_NAME").unwrap_or("Vector")
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@ pub use vector_core::{event, metrics, schema, tcp, tls};
 #[cfg(feature = "enterprise")]
 pub static ENTERPRISE_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
+static APP_NAME_SLUG: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
 /// The name used to identify this Vector application.
 ///
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
@@ -152,7 +154,7 @@ pub fn get_app_name() -> &'static str {
 ///
 /// Defaults to "vector".
 pub fn get_slugified_app_name() -> String {
-   get_app_name().to_lowercase().replace(' ', "-")
+    APP_NAME_SLUG.get_or_init(|| get_app_name().to_lowercase().replace(' ', "-")).clone()
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub use vector_core::{event, metrics, schema, tcp, tls};
 /// The name used to identify this Vector application.
 ///
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
-/// Defaults to "vector".
+/// Defaults to "Vector".
 pub fn get_app_name() -> &'static str {
     option_env!("VECTOR_APP_NAME").unwrap_or("Vector")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub static ENTERPRISE_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::
 /// Defaults to "Vector".
 pub fn get_app_name() -> &'static str {
     #[cfg(not(feature = "enterprise"))]
-    let app_name = DEFAULT_APP_NAME;
+    let app_name = "Vector";
     #[cfg(feature = "enterprise")]
     let app_name = if *ENTERPRISE_ENABLED
         .get()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,11 +128,11 @@ pub use vector_core::{event, metrics, schema, tcp, tls};
 ///
 /// This can be set at compile-time through the VECTOR_APP_NAME env variable.
 /// Defaults to "Vector".
-pub fn get_app_name(#[cfg(feature = "enterprise")] enterprise_in_use: bool) -> &'static str {
+pub fn get_app_name(#[cfg(feature = "enterprise")] enterprise_enabled: bool) -> &'static str {
     #[cfg(not(feature = "enterprise"))]
     let default_app_name = "Vector";
     #[cfg(feature = "enterprise")]
-    let default_app_name = if enterprise_in_use {
+    let default_app_name = if enterprise_enabled {
         "Vector Enterprise"
     } else {
         "Vector"
@@ -141,13 +141,13 @@ pub fn get_app_name(#[cfg(feature = "enterprise")] enterprise_in_use: bool) -> &
     option_env!("VECTOR_APP_NAME").unwrap_or(default_app_name)
 }
 
-/// Returns a sluggified version of the name used to identify this Vector application.
+/// Returns a slugified version of the name used to identify this Vector application.
 ///
 /// Defaults to "vector".
-pub fn get_sluggified_app_name(#[cfg(feature = "enterprise")] enterprise_in_use: bool) -> String {
+pub fn get_slugified_app_name(#[cfg(feature = "enterprise")] enterprise_enabled: bool) -> String {
     get_app_name(
         #[cfg(feature = "enterprise")]
-        enterprise_in_use,
+        enterprise_enabled,
     )
     .to_lowercase()
     .replace(' ', "-")

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -114,7 +114,11 @@ impl DatadogLogsConfig {
         self.get_uri().scheme_str().unwrap_or("http").to_string()
     }
 
-    pub fn build_processor(&self, client: HttpClient) -> crate::Result<VectorSink> {
+    pub fn build_processor(
+        &self,
+        client: HttpClient,
+        dd_evp_origin: String,
+    ) -> crate::Result<VectorSink> {
         let default_api_key: Arc<str> = Arc::from(self.dd_common.default_api_key.inner());
         let request_limits = self.request.tower.unwrap_with(&Default::default());
 
@@ -133,6 +137,7 @@ impl DatadogLogsConfig {
                 client,
                 self.get_uri(),
                 self.request.headers.clone(),
+                dd_evp_origin,
             )?);
 
         let encoding = self.encoding.clone();
@@ -169,7 +174,11 @@ impl SinkConfig for DatadogLogsConfig {
             .dd_common
             .build_healthcheck(client.clone(), self.region.as_ref())?;
 
-        let sink = self.build_processor(client)?;
+        let sluggified_app_name = crate::get_sluggified_app_name(
+            #[cfg(feature = "enterprise")]
+            cx.enterprise_in_use,
+        );
+        let sink = self.build_processor(client, sluggified_app_name)?;
 
         Ok((sink, healthcheck))
     }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -174,11 +174,11 @@ impl SinkConfig for DatadogLogsConfig {
             .dd_common
             .build_healthcheck(client.clone(), self.region.as_ref())?;
 
-        let sluggified_app_name = crate::get_sluggified_app_name(
+        let slugified_app_name = crate::get_slugified_app_name(
             #[cfg(feature = "enterprise")]
-            cx.enterprise_in_use,
+            cx.enterprise_enabled,
         );
-        let sink = self.build_processor(client, sluggified_app_name)?;
+        let sink = self.build_processor(client, slugified_app_name)?;
 
         Ok((sink, healthcheck))
     }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -174,11 +174,7 @@ impl SinkConfig for DatadogLogsConfig {
             .dd_common
             .build_healthcheck(client.clone(), self.region.as_ref())?;
 
-        let slugified_app_name = crate::get_slugified_app_name(
-            #[cfg(feature = "enterprise")]
-            cx.enterprise_enabled,
-        );
-        let sink = self.build_processor(client, slugified_app_name)?;
+        let sink = self.build_processor(client, cx.app_name_slug)?;
 
         Ok((sink, healthcheck))
     }

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -111,7 +111,7 @@ impl LogApiService {
             (CONTENT_TYPE.to_string(), "application/json".to_string()),
             (
                 "DD-EVP-ORIGIN".to_string(),
-                crate::get_app_name().to_lowercase(),
+                crate::get_app_name().to_lowercase().replace(" ", "_"),
             ),
             ("DD-EVP-ORIGIN-VERSION".to_string(), crate::get_version()),
         ]

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -106,6 +106,7 @@ impl LogApiService {
     ) -> crate::Result<Self> {
         let user_provided_headers = validate_headers(&headers)?;
 
+        // Note that these headers cannot be overriden by the user.
         let default_headers = &[
             (CONTENT_TYPE.to_string(), "application/json".to_string()),
             (
@@ -156,12 +157,11 @@ impl Service<LogApiRequest> for LogApiService {
         let mut http_request = http_request.header(CONTENT_LENGTH, request.body.len());
 
         if let Some(headers) = http_request.headers_mut() {
-            for (name, value) in &self.default_headers {
-                headers.insert(name, value.clone());
-            }
-
             for (name, value) in &self.user_provided_headers {
                 // Replace rather than append to any existing header values
+                headers.insert(name, value.clone());
+            }
+            for (name, value) in &self.default_headers {
                 headers.insert(name, value.clone());
             }
         }

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -128,7 +128,7 @@ impl Service<LogApiRequest> for LogApiService {
         let mut client = self.client.clone();
         let http_request = Request::post(&self.uri)
             .header(CONTENT_TYPE, "application/json")
-            .header("DD-EVP-ORIGIN", "vector")
+            .header("DD-EVP-ORIGIN", crate::get_app_name())
             .header("DD-EVP-ORIGIN-VERSION", crate::get_version())
             .header("DD-API-KEY", request.api_key.to_string());
 

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -103,16 +103,14 @@ impl LogApiService {
         client: HttpClient,
         uri: Uri,
         headers: IndexMap<String, String>,
+        dd_evp_origin: String,
     ) -> crate::Result<Self> {
         let user_provided_headers = validate_headers(&headers)?;
 
         // Note that these headers cannot be overriden by the user.
         let default_headers = &[
             (CONTENT_TYPE.to_string(), "application/json".to_string()),
-            (
-                "DD-EVP-ORIGIN".to_string(),
-                crate::get_app_name().to_lowercase().replace(' ', "_"),
-            ),
+            ("DD-EVP-ORIGIN".to_string(), dd_evp_origin),
             ("DD-EVP-ORIGIN-VERSION".to_string(), crate::get_version()),
         ]
         .into_iter()

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -111,13 +111,13 @@ impl LogApiService {
             (CONTENT_TYPE.to_string(), "application/json".to_string()),
             (
                 "DD-EVP-ORIGIN".to_string(),
-                crate::get_app_name().to_lowercase().replace(" ", "_"),
+                crate::get_app_name().to_lowercase().replace(' ', "_"),
             ),
             ("DD-EVP-ORIGIN-VERSION".to_string(), crate::get_version()),
         ]
         .into_iter()
         .collect();
-        let default_headers = validate_headers(&default_headers)?;
+        let default_headers = validate_headers(default_headers)?;
 
         Ok(Self {
             client,

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -402,14 +402,12 @@ async fn enterprise_headers_v1() {
 }
 
 async fn enterprise_headers_inner(api_status: ApiStatus) {
-    let (mut config, cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
+    let (mut config, mut cx) = load_sink::<DatadogLogsConfig>(indoc! {r#"
             default_api_key = "atoken"
             compression = "none"
-
-            [request]
-            headers.DD-EVP-ORIGIN = "vector-enterprise"
         "#})
     .unwrap();
+    cx.enterprise_in_use = true;
 
     let addr = next_addr();
     // Swap out the endpoint so we can force send it to our local server

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -407,7 +407,7 @@ async fn enterprise_headers_inner(api_status: ApiStatus) {
             compression = "none"
         "#})
     .unwrap();
-    cx.enterprise_in_use = true;
+    cx.enterprise_enabled = true;
 
     let addr = next_addr();
     // Swap out the endpoint so we can force send it to our local server

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -407,7 +407,8 @@ async fn enterprise_headers_inner(api_status: ApiStatus) {
             compression = "none"
         "#})
     .unwrap();
-    cx.enterprise_enabled = true;
+    cx.app_name = "Vector Enterprise".to_string();
+    cx.app_name_slug = "vector-enterprise".to_string();
 
     let addr = next_addr();
     // Swap out the endpoint so we can force send it to our local server

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -568,6 +568,14 @@ impl<'a> Builder<'a> {
                 globals: self.config.global.clone(),
                 proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
                 schema: self.config.schema,
+
+                #[cfg(feature = "enterprise")]
+                enterprise_in_use: self
+                    .config
+                    .enterprise
+                    .as_ref()
+                    .map(|e| e.enabled)
+                    .unwrap_or_default(),
             };
 
             let (sink, healthcheck) = match sink.inner.build(cx).await {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -570,7 +570,7 @@ impl<'a> Builder<'a> {
                 schema: self.config.schema,
 
                 #[cfg(feature = "enterprise")]
-                enterprise_in_use: self
+                enterprise_enabled: self
                     .config
                     .enterprise
                     .as_ref()

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -568,14 +568,8 @@ impl<'a> Builder<'a> {
                 globals: self.config.global.clone(),
                 proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
                 schema: self.config.schema,
-
-                #[cfg(feature = "enterprise")]
-                enterprise_enabled: self
-                    .config
-                    .enterprise
-                    .as_ref()
-                    .map(|e| e.enabled)
-                    .unwrap_or_default(),
+                app_name: crate::get_app_name().to_string(),
+                app_name_slug: crate::get_slugified_app_name(),
             };
 
             let (sink, healthcheck) = match sink.inner.build(cx).await {


### PR DESCRIPTION
Allow the Vector "app" name, which is used for the `User-Agent` and `DD-EVP-ORIGIN` headers, to be configurable at compilation time.

Also fixed `DD-EVP-ORIGIN` header value for when enterprise features are enabled. It was previously only set to `vector-enterprise` for the datadog internal logs sink. It is now set to `vector-enterprise` for all datadog logs sinks.