### PR TITLE
chore(deps): Drop patch to use custom `chrono` repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,7 +1965,8 @@ dependencies = [
 [[package]]
 name = "chrono"
 version = "0.4.30"
-source = "git+https://github.com/vectordotdev/chrono.git?tag=v0.4.30-no-default-time-1#f59d4df9fc887bba7365e8bc39eb9ab3f3f5750c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,9 +379,6 @@ wiremock = "0.5.19"
 zstd = { version = "0.12.4", default-features = false }
 
 [patch.crates-io]
-# Removes dependency on `time` v0.1
-# https://github.com/chronotope/chrono/pull/578
-chrono = { git = "https://github.com/vectordotdev/chrono.git", tag = "v0.4.30-no-default-time-1" }
 # The upgrade for `tokio-util` >= 0.6.9 is blocked on https://github.com/vectordotdev/vector/issues/11257.
 tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-util-0.7.8-framed-read-continue-on-error" }
 nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/musl" }


### PR DESCRIPTION
We had set up a custom `chrono` repo to be able to use the crate without enabling the `oldtime` feature, which in turn pulled in the `time` crate that was the subject of a vulnerability issue. With the latest `chrono` release, it no longer depends on the `time` crate, so the patch is no longer needed.