### PR TITLE
fix(gcp service): retry on unauthorized

### DIFF
--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -152,6 +152,7 @@ impl RetryLogic for GcsRetryLogic {
         let status = response.inner.status();
 
         match status {
+            StatusCode::UNAUTHORIZED => RetryAction::Retry("unauthorized".into()),
             StatusCode::TOO_MANY_REQUESTS => RetryAction::Retry("too many requests".into()),
             StatusCode::NOT_IMPLEMENTED => {
                 RetryAction::DontRetry("endpoint not implemented".into())


### PR DESCRIPTION
Fixes #18432 
Ref #10870

This updates the GCP sinks so that Vector will retry the request on an unauthorized response (401).

A user reported that GCP was sending 401s after a time even when a correct token was being sent. The user tested a custom build that had this fix and that has completely resolved their issue. 

I don't understand why GCP would be sending a 401 and why resending the request puts GCP right. Without fully understanding what is going on, I am slightly concerned that this could be covering a deeper issue. But it does fix the immediate issue, so unless this is causing a regression in some way I think it is worth pushing this through.