### PR TITLE
fix(core): don't show warning about max allocation groups if tracing not enabled

### DIFF
--- a/src/internal_telemetry/allocations/mod.rs
+++ b/src/internal_telemetry/allocations/mod.rs
@@ -21,11 +21,16 @@ pub(crate) use self::allocator::{
 };
 
 const NUM_GROUPS: usize = 128;
+
 // Allocations are not tracked during startup.
 // We use the Relaxed ordering for both stores and loads of this atomic as no other threads exist when
 // this code is running, and all future threads will have a happens-after relationship with
 // this thread -- the main thread -- ensuring that they see the latest value of TRACK_ALLOCATIONS.
 pub static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+
+pub fn is_allocation_tracing_enabled() -> bool {
+    TRACK_ALLOCATIONS.load(Ordering::Acquire)
+}
 
 /// Track allocations and deallocations separately.
 struct GroupMemStatsStorage {
@@ -207,6 +212,6 @@ pub fn acquire_allocation_group_id(
     // TODO: Technically, `NUM_GROUPS` is lower (128) than the upper bound for the
     // `AllocationGroupId::register` call itself (253), so we can hardcode `NUM_GROUPS` here knowing
     // it's the lower of the two values and will trigger first.. but this may not always be true.
-    info!("Maximum number of registrable allocation group IDs reached ({}). Allocations for component '{}' will be attributed to the root allocation group.", NUM_GROUPS, component_id);
+    warn!("Maximum number of registrable allocation group IDs reached ({}). Allocations for component '{}' will be attributed to the root allocation group.", NUM_GROUPS, component_id);
     AllocationGroupId::ROOT
 }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -839,7 +839,7 @@ impl RunningTopology {
 
         let task_span = span.or_current();
         #[cfg(feature = "allocation-tracing")]
-        {
+        if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
                 "sink".to_string(),
@@ -882,7 +882,7 @@ impl RunningTopology {
 
         let task_span = span.or_current();
         #[cfg(feature = "allocation-tracing")]
-        {
+        if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
                 "transform".to_string(),
@@ -925,7 +925,7 @@ impl RunningTopology {
 
         let task_span = span.or_current();
         #[cfg(feature = "allocation-tracing")]
-        {
+        if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
                 "source".to_string(),


### PR DESCRIPTION
This PR ensures that allocation groups are not created/attached to components unless allocation tracing itself is enabled at runtime. Prior to this PR, it would always create/attach them so long as allocation tracing support itself was compiled in. This has the side effect of emitting warnings about exhausting allocation group IDs for configurations with many components (> 128) even when allocation tracing wasn't being used.

We've also made the log message emit at the warning level, rather than the info level, to highlight this fact more prominently.

Fixes #18480.