### PR TITLE
docs: Editorial edits for updated component descriptions

### DIFF
--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -20,11 +20,11 @@ use super::{default_lossy, Deserializer};
 use crate::gelf::GELF_TARGET_PATHS;
 use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
-/// On GELF decoding behavior:
-///   Graylog has a relaxed decoding algorithm. It is much more lenient than the spec would
-///   suggest. A more strict approach is used here to maintain backwards compatibility
-///   in the event that the behavior needs to be changed to be more relaxed, so that prior versions
-///   still works with the new relaxed decoding algorithm.
+// On GELF decoding behavior:
+//   Graylog has a relaxed decoding. They are much more lenient than the spec would
+//   suggest. We've elected to take a more strict approach to maintain backwards compatibility
+//   in the event that we need to change the behavior to be more relaxed, so that prior versions
+//   of vector will still work with the new relaxed decoding.
 
 /// Config used to build a `GelfDeserializer`.
 #[configurable_component]

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -21,10 +21,10 @@ use crate::gelf::GELF_TARGET_PATHS;
 use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
 /// On GELF decoding behavior:
-///   Graylog has a relaxed decoding. They are much more lenient than the spec would
-///   suggest. We've elected to take a more strict approach to maintain backwards compatibility
-///   in the event that we need to change the behavior to be more relaxed, so that prior versions
-///   of vector will still work with the new relaxed decoding.
+///   Graylog has a relaxed decoding algorithm. It is much more lenient than the spec would
+///   suggest. A more strict approach is used here to maintain backwards compatibility
+///   in the event that the behavior needs to be changed to be more relaxed, so that prior versions
+///   still works with the new relaxed decoding algorithm.
 
 /// Config used to build a `GelfDeserializer`.
 #[configurable_component]

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -216,7 +216,7 @@ pub enum DeserializerConfig {
     /// [rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
     Syslog(SyslogDeserializerConfig),
 
-    /// Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+    /// Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
     ///
     /// This codec is **[experimental][experimental]**.
     ///
@@ -224,7 +224,7 @@ pub enum DeserializerConfig {
     /// [experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
     Native,
 
-    /// Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+    /// Decodes the raw bytes as [native JSON format][vector_native_json].
     ///
     /// This codec is **[experimental][experimental]**.
     ///

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -15,11 +15,11 @@ use vector_core::{
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum QuoteStyle {
-    /// This puts quotes around every field. Always.
+    /// This always puts quotes around every field.
     Always,
 
     /// This puts quotes around fields only when necessary.
-    /// They are necessary when fields contain a quote, delimiter or record terminator.
+    /// They are necessary when fields contain a quote, delimiter, or record terminator.
     /// Quotes are also necessary when writing an empty record
     /// (which is indistinguishable from a record with one empty field).
     #[default]
@@ -27,10 +27,10 @@ pub enum QuoteStyle {
 
     /// This puts quotes around all fields that are non-numeric.
     /// Namely, when writing a field that does not parse as a valid float or integer,
-    /// then quotes will be used even if they aren’t strictly necessary.
+    /// then quotes are used even if they aren't strictly necessary.
     NonNumeric,
 
-    /// This never writes quotes, even if it would produce invalid CSV data.
+    /// This never writes quotes, even if it produces invalid CSV data.
     Never,
 }
 
@@ -97,7 +97,7 @@ pub struct CsvSerializerOptions {
     /// In some variants of CSV, quotes are escaped using a special escape character
     /// like \ (instead of escaping quotes by doubling them).
     ///
-    /// To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+    /// To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
     #[serde(
         default = "default_escape",
         with = "vector_core::serde::ascii_char",

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -15,22 +15,22 @@ use vector_core::{
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum QuoteStyle {
-    /// This always puts quotes around every field.
+    /// Always puts quotes around every field.
     Always,
 
-    /// This puts quotes around fields only when necessary.
+    /// Puts quotes around fields only when necessary.
     /// They are necessary when fields contain a quote, delimiter, or record terminator.
     /// Quotes are also necessary when writing an empty record
     /// (which is indistinguishable from a record with one empty field).
     #[default]
     Necessary,
 
-    /// This puts quotes around all fields that are non-numeric.
+    /// Puts quotes around all fields that are non-numeric.
     /// Namely, when writing a field that does not parse as a valid float or integer,
     /// then quotes are used even if they aren't strictly necessary.
     NonNumeric,
 
-    /// This never writes quotes, even if it produces invalid CSV data.
+    /// Never writes quotes, even if it produces invalid CSV data.
     Never,
 }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -206,7 +206,7 @@ pub struct FileConfig {
     pub multiline: Option<MultilineConfig>,
 
     /// Max amount of bytes to read from a single file before switching over to the next file.
-    /// **Note:** This does not apply when `oldest_first` is `true.
+    /// **Note:** This does not apply when `oldest_first` is `true`.
     ///
     /// This allows distributing the reads more or less evenly across
     /// the files.
@@ -214,7 +214,7 @@ pub struct FileConfig {
     #[configurable(metadata(docs::type_unit = "bytes"))]
     pub max_read_bytes: usize,
 
-    /// Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files.
+    /// Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from more recent files.
     #[serde(default)]
     pub oldest_first: bool,
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -164,14 +164,14 @@ pub struct Config {
     ignore_older_secs: Option<u64>,
 
     /// Max amount of bytes to read from a single file before switching over to the next file.
-    /// **Note:** This does not apply when `oldest_first` is `true.
+    /// **Note:** This does not apply when `oldest_first` is `true`.
     ///
     /// This allows distributing the reads more or less evenly across
     /// the files.
     #[configurable(metadata(docs::type_unit = "bytes"))]
     max_read_bytes: usize,
 
-    /// Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files.
+    /// Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from more recent files.
     #[serde(default = "default_oldest_first")]
     pub oldest_first: bool,
 

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -158,7 +158,7 @@ base: components: sinks: amqp: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -187,18 +187,18 @@ base: components: sinks: amqp: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -329,7 +329,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -358,18 +358,18 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -308,7 +308,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -337,18 +337,18 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -308,7 +308,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -337,18 +337,18 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -417,7 +417,7 @@ base: components: sinks: aws_s3: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -446,18 +446,18 @@ base: components: sinks: aws_s3: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -244,7 +244,7 @@ base: components: sinks: aws_sns: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -273,18 +273,18 @@ base: components: sinks: aws_sns: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -244,7 +244,7 @@ base: components: sinks: aws_sqs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -273,18 +273,18 @@ base: components: sinks: aws_sqs: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -271,7 +271,7 @@ base: components: sinks: azure_blob: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -300,18 +300,18 @@ base: components: sinks: azure_blob: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -142,7 +142,7 @@ base: components: sinks: console: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -171,18 +171,18 @@ base: components: sinks: console: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -187,7 +187,7 @@ base: components: sinks: databend: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -216,18 +216,18 @@ base: components: sinks: databend: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -162,7 +162,7 @@ base: components: sinks: file: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -191,18 +191,18 @@ base: components: sinks: file: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -211,7 +211,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -240,18 +240,18 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -295,7 +295,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -324,18 +324,18 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -209,7 +209,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -238,18 +238,18 @@ base: components: sinks: gcp_pubsub: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -250,7 +250,7 @@ base: components: sinks: http: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -279,18 +279,18 @@ base: components: sinks: http: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -203,7 +203,7 @@ base: components: sinks: humio_logs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -232,18 +232,18 @@ base: components: sinks: humio_logs: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -197,7 +197,7 @@ base: components: sinks: kafka: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -226,18 +226,18 @@ base: components: sinks: kafka: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -254,7 +254,7 @@ base: components: sinks: loki: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -283,18 +283,18 @@ base: components: sinks: loki: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -242,7 +242,7 @@ base: components: sinks: nats: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -271,18 +271,18 @@ base: components: sinks: nats: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -142,7 +142,7 @@ base: components: sinks: papertrail: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -171,18 +171,18 @@ base: components: sinks: papertrail: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -236,7 +236,7 @@ base: components: sinks: pulsar: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -265,18 +265,18 @@ base: components: sinks: pulsar: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -195,7 +195,7 @@ base: components: sinks: redis: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -224,18 +224,18 @@ base: components: sinks: redis: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -154,7 +154,7 @@ base: components: sinks: socket: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -183,18 +183,18 @@ base: components: sinks: socket: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -253,7 +253,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -282,18 +282,18 @@ base: components: sinks: splunk_hec_logs: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -203,7 +203,7 @@ base: components: sinks: webhdfs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -232,18 +232,18 @@ base: components: sinks: webhdfs: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -189,7 +189,7 @@ base: components: sinks: websocket: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this `double_quotes` needs to be disabled as well otherwise it is ignored
+																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
 																"""
 						required: false
 						type: uint: default: 34
@@ -218,18 +218,18 @@ base: components: sinks: websocket: configuration: {
 						type: string: {
 							default: "necessary"
 							enum: {
-								always: "This puts quotes around every field. Always."
+								always: "Always puts quotes around every field."
 								necessary: """
-																			This puts quotes around fields only when necessary.
-																			They are necessary when fields contain a quote, delimiter or record terminator.
+																			Puts quotes around fields only when necessary.
+																			They are necessary when fields contain a quote, delimiter, or record terminator.
 																			Quotes are also necessary when writing an empty record
 																			(which is indistinguishable from a record with one empty field).
 																			"""
-								never: "This never writes quotes, even if it would produce invalid CSV data."
+								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
-																			This puts quotes around all fields that are non-numeric.
+																			Puts quotes around all fields that are non-numeric.
 																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes will be used even if they aren’t strictly necessary.
+																			then quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -68,7 +68,7 @@ base: components: sources: amqp: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -76,7 +76,7 @@ base: components: sources: amqp: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -71,7 +71,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -79,7 +79,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -166,7 +166,7 @@ base: components: sources: aws_s3: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -174,7 +174,7 @@ base: components: sources: aws_s3: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -161,7 +161,7 @@ base: components: sources: aws_sqs: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -169,7 +169,7 @@ base: components: sources: aws_sqs: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -53,7 +53,7 @@ base: components: sources: datadog_agent: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -61,7 +61,7 @@ base: components: sources: datadog_agent: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -32,7 +32,7 @@ base: components: sources: demo_logs: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -40,7 +40,7 @@ base: components: sources: demo_logs: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -33,7 +33,7 @@ base: components: sources: exec: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -41,7 +41,7 @@ base: components: sources: exec: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -230,7 +230,7 @@ base: components: sources: file: configuration: {
 	max_read_bytes: {
 		description: """
 			Max amount of bytes to read from a single file before switching over to the next file.
-			**Note:** This does not apply when `oldest_first` is `true.
+			**Note:** This does not apply when `oldest_first` is `true`.
 
 			This allows distributing the reads more or less evenly across
 			the files.
@@ -325,7 +325,7 @@ base: components: sources: file: configuration: {
 		]
 	}
 	oldest_first: {
-		description: "Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files."
+		description: "Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from more recent files."
 		required:    false
 		type: bool: default: false
 	}

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -23,7 +23,7 @@ base: components: sources: file_descriptor: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -31,7 +31,7 @@ base: components: sources: file_descriptor: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -99,7 +99,7 @@ base: components: sources: gcp_pubsub: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -107,7 +107,7 @@ base: components: sources: gcp_pubsub: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -65,7 +65,7 @@ base: components: sources: heroku_logs: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -73,7 +73,7 @@ base: components: sources: heroku_logs: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -67,7 +67,7 @@ base: components: sources: http: configuration: {
 						[json]: https://www.json.org/
 						"""
 					native: """
-						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+						Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 						This codec is **[experimental][experimental]**.
 
@@ -75,7 +75,7 @@ base: components: sources: http: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					native_json: """
-						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+						Decodes the raw bytes as [native JSON format][vector_native_json].
 
 						This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -65,7 +65,7 @@ base: components: sources: http_client: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -73,7 +73,7 @@ base: components: sources: http_client: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -67,7 +67,7 @@ base: components: sources: http_server: configuration: {
 						[json]: https://www.json.org/
 						"""
 					native: """
-						Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+						Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 						This codec is **[experimental][experimental]**.
 
@@ -75,7 +75,7 @@ base: components: sources: http_server: configuration: {
 						[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 						"""
 					native_json: """
-						Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+						Decodes the raw bytes as [native JSON format][vector_native_json].
 
 						This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -77,7 +77,7 @@ base: components: sources: kafka: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -85,7 +85,7 @@ base: components: sources: kafka: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -166,7 +166,7 @@ base: components: sources: kubernetes_logs: configuration: {
 	max_read_bytes: {
 		description: """
 			Max amount of bytes to read from a single file before switching over to the next file.
-			**Note:** This does not apply when `oldest_first` is `true.
+			**Note:** This does not apply when `oldest_first` is `true`.
 
 			This allows distributing the reads more or less evenly across
 			the files.
@@ -210,7 +210,7 @@ base: components: sources: kubernetes_logs: configuration: {
 		}
 	}
 	oldest_first: {
-		description: "Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from younger files."
+		description: "Instead of balancing read capacity fairly across all watched files, prioritize draining the oldest files before moving on to read data from more recent files."
 		required:    false
 		type: bool: default: true
 	}

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -120,7 +120,7 @@ base: components: sources: nats: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -128,7 +128,7 @@ base: components: sources: nats: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -38,7 +38,7 @@ base: components: sources: redis: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -46,7 +46,7 @@ base: components: sources: redis: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -40,7 +40,7 @@ base: components: sources: socket: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -48,7 +48,7 @@ base: components: sources: socket: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -23,7 +23,7 @@ base: components: sources: stdin: configuration: {
 															[json]: https://www.json.org/
 															"""
 						native: """
-															Decodes the raw bytes as Vector’s [native Protocol Buffers format][vector_native_protobuf].
+															Decodes the raw bytes as [native Protocol Buffers format][vector_native_protobuf].
 
 															This codec is **[experimental][experimental]**.
 
@@ -31,7 +31,7 @@ base: components: sources: stdin: configuration: {
 															[experimental]: https://vector.dev/highlights/2022-03-31-native-event-codecs
 															"""
 						native_json: """
-															Decodes the raw bytes as Vector’s [native JSON format][vector_native_json].
+															Decodes the raw bytes as [native JSON format][vector_native_json].
 
 															This codec is **[experimental][experimental]**.
 


### PR DESCRIPTION
This PR makes editorial edits for updated component descriptions and removes use of "Vector".

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
