### PR TITLE
fix(distribution): Use yaml instead of toml file

### DIFF
--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -79,7 +79,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{_bindir}/*
 %{_unitdir}/vector.service
-%config(noreplace) %{_sysconfdir}/%{_name}/vector.toml
+%config(noreplace) %{_sysconfdir}/%{_name}/vector.yaml
 %config(noreplace) %{_sysconfdir}/default/vector
 %config %{_sysconfdir}/%{_name}/examples/*
 %dir %{_sharedstatedir}/%{_name}


### PR DESCRIPTION
Since YAML is the default now

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
