### PR TITLE
fix(external docs): Document intentional label on component_discarded_events_total

### DIFF
--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -420,7 +420,12 @@ components: sources: internal_metrics: {
 			description:       "The number of events dropped by this component."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags:              _component_tags & {
+				intentional: {
+					description: "True if the events were discarded intentionally, like a `filter` transform, or false if due to an error."
+					required:    true
+				}
+			}
 		}
 		component_errors_total: {
 			description:       "The total number of errors encountered by this component."


### PR DESCRIPTION
Noticed by https://github.com/vectordotdev/vector/discussions/18615#discussioncomment-7063705

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
