### PR TITLE
chore(website): Update chat.vector.dev redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,7 +42,7 @@ force = true
 
 [[redirects]]
 from = "https://chat.vector.dev/*"
-to = "https://discord.gg/dX3bdkF"
+to = "https://discord.gg/ptvgXhUF2m"
 status = 302
 force = true
 


### PR DESCRIPTION
To drop people into #support rather than #development since we get a lot of users asking support
questions in #development.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
