### PR TITLE
fix(docker source): do not emit component error for out of order logs

### DIFF
--- a/src/internal_events/docker_logs.rs
+++ b/src/internal_events/docker_logs.rs
@@ -186,28 +186,3 @@ impl InternalEvent for DockerLogsLoggingDriverUnsupportedError<'_> {
         counter!("logging_driver_errors_total", 1);
     }
 }
-
-#[derive(Debug)]
-pub struct DockerLogsReceivedOutOfOrderError<'a> {
-    pub timestamp_str: &'a str,
-    pub container_id: &'a str,
-}
-
-impl InternalEvent for DockerLogsReceivedOutOfOrderError<'_> {
-    fn emit(self) {
-        error!(
-            message = "Received out of order log message.",
-            error_type = error_type::CONDITION_FAILED,
-            stage = error_stage::RECEIVING,
-            container_id = ?self.container_id,
-            timestamp = ?self.timestamp_str,
-            internal_log_rate_limit = true,
-        );
-        counter!(
-            "component_errors_total", 1,
-            "error_type" => error_type::CONDITION_FAILED,
-            "stage" => error_stage::RECEIVING,
-            "container_id" => self.container_id.to_owned(),
-        );
-    }
-}

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -37,8 +37,7 @@ use crate::{
         DockerLogsCommunicationError, DockerLogsContainerEventReceived,
         DockerLogsContainerMetadataFetchError, DockerLogsContainerUnwatch,
         DockerLogsContainerWatch, DockerLogsEventsReceived,
-        DockerLogsLoggingDriverUnsupportedError, DockerLogsReceivedOutOfOrderError,
-        DockerLogsTimestampParseError, StreamClosedError,
+        DockerLogsLoggingDriverUnsupportedError, DockerLogsTimestampParseError, StreamClosedError,
     },
     line_agg::{self, LineAgg},
     shutdown::ShutdownSignal,
@@ -995,7 +994,7 @@ impl ContainerLogInfo {
         let timestamp = match DateTime::parse_from_rfc3339(timestamp_str) {
             Ok(timestamp) => {
                 // Timestamp check. This is included to avoid processing the same log multiple times, which can
-                // occur when a container changes generations, and to avoid processing logs with timestamps before 
+                // occur when a container changes generations, and to avoid processing logs with timestamps before
                 // the created timestamp.
                 match self.last_log.as_ref() {
                     Some(&(last, gen)) => {

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -793,7 +793,7 @@ impl EventStreamBuilder {
                 error = v.as_ref().err().cloned();
                 ready(v.is_ok())
             })
-            .filter_map(|v| ready(v.unwrap()))
+            .filter_map(|v| ready(v.ok().flatten()))
             .take_until(self.shutdown.clone());
 
         let events_stream: Box<dyn Stream<Item = LogEvent> + Unpin + Send> =
@@ -994,25 +994,38 @@ impl ContainerLogInfo {
         let timestamp_str = splitter.next()?;
         let timestamp = match DateTime::parse_from_rfc3339(timestamp_str) {
             Ok(timestamp) => {
-                // Timestamp check
+                // Timestamp check. This is included to avoid processing the same log multiple times, which can
+                // occur when a container changes generations, and to avoid processing logs with timestamps before 
+                // the created timestamp.
                 match self.last_log.as_ref() {
-                    // Received log has not already been processed.
-                    Some(&(ref last, gen))
-                        if *last < timestamp || (*last == timestamp && gen == self.generation) =>
-                    {
-                        // noop
+                    Some(&(last, gen)) => {
+                        if last < timestamp || (last == timestamp && gen == self.generation) {
+                            // Noop - log received in order.
+                        } else {
+                            // Docker returns logs in order.
+                            // If we reach this state, this log is from a previous generation of the container.
+                            // It was already processed, so we can safely skip it.
+                            trace!(
+                                message = "Received log from previous container generation.",
+                                log_timestamp = %timestamp_str,
+                                last_log_timestamp = %last,
+                            );
+                            return None;
+                        }
                     }
-                    // Received log is after the time the container was created.
-                    None if self.created <= timestamp.with_timezone(&Utc) => {
-                        // noop
-                    }
-                    // Received log is older than the previously received entry.
-                    _ => {
-                        emit!(DockerLogsReceivedOutOfOrderError {
-                            container_id: self.id.as_str(),
-                            timestamp_str,
-                        });
-                        return None;
+                    None => {
+                        if self.created < timestamp.with_timezone(&Utc) {
+                            // Noop - first log to process.
+                        } else {
+                            // Received a log with a timestamp before that provided to the Docker API.
+                            // This should not happen, but if it does, we can just ignore these logs.
+                            trace!(
+                                message = "Received log from before created timestamp.",
+                                log_timestamp = %timestamp_str,
+                                created_timestamp = %self.created
+                            );
+                            return None;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes https://github.com/vectordotdev/vector/issues/17747

We mistakenly began treating this as an error in https://github.com/vectordotdev/vector/pull/14449