### PR TITLE
fix(config)!: fix concurrency default & docs

### DIFF
--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -15,7 +15,7 @@ use tower::{
 use vector_config::configurable_component;
 
 pub use crate::sinks::util::service::{
-    concurrency::{concurrency_is_none, Concurrency},
+    concurrency::{concurrency_is_adaptive, Concurrency},
     health::{HealthConfig, HealthLogic, HealthService},
     map::Map,
 };
@@ -93,7 +93,7 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
 pub struct TowerRequestConfig {
     #[configurable(derived)]
     #[serde(default = "default_concurrency")]
-    #[serde(skip_serializing_if = "concurrency_is_none")]
+    #[serde(skip_serializing_if = "concurrency_is_adaptive")]
     pub concurrency: Concurrency,
 
     /// The time a request can take before being aborted.
@@ -144,7 +144,7 @@ pub struct TowerRequestConfig {
 }
 
 const fn default_concurrency() -> Concurrency {
-    Concurrency::None
+    Concurrency::Adaptive
 }
 
 const fn default_timeout_secs() -> Option<u64> {

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -457,7 +457,7 @@ mod tests {
         toml::from_str::<TowerRequestConfig>(&toml).expect("Default config failed");
 
         let cfg = toml::from_str::<TowerRequestConfig>("").expect("Empty config failed");
-        assert_eq!(cfg.concurrency, Concurrency::None);
+        assert_eq!(cfg.concurrency, Concurrency::Adaptive);
 
         let cfg = toml::from_str::<TowerRequestConfig>("concurrency = 10")
             .expect("Fixed concurrency failed");

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -17,6 +17,9 @@ use serde::{
 };
 
 /// Configuration for outbound request concurrency.
+///
+/// This can be set either to one of the below enum values or to a uint, which denotes
+/// a fixed amount of concurrency limit.
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 pub enum Concurrency {
     /// A fixed concurrency of 1.
@@ -48,28 +51,29 @@ impl Serialize for Concurrency {
 
 impl Default for Concurrency {
     fn default() -> Self {
-        Self::None
+        Self::Adaptive
     }
 }
 
 impl Concurrency {
-    pub const fn if_none(self, other: Self) -> Self {
+    const fn if_adaptive(self, other: Self) -> Self {
         match self {
-            Self::None => other,
+            Self::Adaptive => other,
             _ => self,
         }
     }
 
-    pub const fn parse_concurrency(&self, default: Self) -> Option<usize> {
-        match self.if_none(default) {
-            Concurrency::None | Concurrency::Adaptive => None,
+    pub const fn parse_concurrency(&self, other: Self) -> Option<usize> {
+        match self.if_adaptive(other) {
+            Concurrency::None => Some(1),
+            Concurrency::Adaptive => None,
             Concurrency::Fixed(limit) => Some(limit),
         }
     }
 }
 
-pub const fn concurrency_is_none(concurrency: &Concurrency) -> bool {
-    matches!(concurrency, Concurrency::None)
+pub const fn concurrency_is_adaptive(concurrency: &Concurrency) -> bool {
+    matches!(concurrency, Concurrency::Adaptive)
 }
 
 impl<'de> Deserialize<'de> for Concurrency {
@@ -93,7 +97,7 @@ impl<'de> Deserialize<'de> for Concurrency {
                 } else if value == "none" {
                     Ok(Concurrency::None)
                 } else {
-                    Err(de::Error::unknown_variant(value, &["adaptive"]))
+                    Err(de::Error::unknown_variant(value, &["adaptive", "none"]))
                 }
             }
 
@@ -132,8 +136,16 @@ impl Configurable for Concurrency {
 
     fn metadata() -> Metadata {
         let mut metadata = Metadata::default();
-        metadata.set_description("Configuration for outbound request concurrency.");
+        metadata.set_description(
+            r#"Configuration for outbound request concurrency.
+
+This can be set either to one of the below enum values or to a uint, which denotes
+a fixed amount of concurrency limit."#,
+        );
         metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
+        metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", "none"));
+        metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", "adaptive"));
+        metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", 128));
         metadata
     }
 

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -19,7 +19,7 @@ use serde::{
 /// Configuration for outbound request concurrency.
 ///
 /// This can be set either to one of the below enum values or to a uint, which denotes
-/// a fixed amount of concurrency limit.
+/// a fixed concurrency limit.
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 pub enum Concurrency {
     /// A fixed concurrency of 1.
@@ -140,7 +140,7 @@ impl Configurable for Concurrency {
             r#"Configuration for outbound request concurrency.
 
 This can be set either to one of the below enum values or to a uint, which denotes
-a fixed amount of concurrency limit."#,
+a fixed concurrency limit."#,
         );
         metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
         metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", "none"));

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -18,7 +18,7 @@ use serde::{
 
 /// Configuration for outbound request concurrency.
 ///
-/// This can be set either to one of the below enum values or to a uint, which denotes
+/// This can be set either to one of the below enum values or to a positive integer, which denotes
 /// a fixed concurrency limit.
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 pub enum Concurrency {
@@ -139,7 +139,7 @@ impl Configurable for Concurrency {
         metadata.set_description(
             r#"Configuration for outbound request concurrency.
 
-This can be set either to one of the below enum values or to a uint, which denotes
+This can be set either to one of the below enum values or to a positive integer, which denotes
 a fixed concurrency limit."#,
         );
         metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -143,9 +143,6 @@ This can be set either to one of the below enum values or to a uint, which denot
 a fixed concurrency limit."#,
         );
         metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
-        metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", "none"));
-        metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", "adaptive"));
-        metadata.add_custom_attribute(CustomAttribute::kv("docs::examples", 128));
         metadata
     }
 

--- a/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
@@ -98,5 +98,5 @@ be overriden by setting the `VECTOR_THREADS` environment variable.
 Explicitly setting `request.concurrency = "none"` in a sink configuration now properly configures
 the sink to have a fixed concurrency limit of 1, as was stated in the documentation. Previously, the
 above configuration would result in the sink using adaptive request concurrency. The default setting
-remains to be adaptive request concurrency.
+remains unchanged (adaptive request concurrency).
 

--- a/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-09-26-0-33-0-upgrade-guide.md
@@ -18,11 +18,12 @@ and **deprecations**:
 
 1. [Default config location change](#default-config-location-change)
 1. [Renaming the `armv7` rpm package](#armv7-rename)
-2. [Metadata field in the Vector protobuf definition](#vector-proto-metadata)
+1. [Metadata field in the Vector protobuf definition](#vector-proto-metadata)
 
 and **potentially impactful changes**:
 
 1. [Async runtime default number of worker threads](#runtime-worker-threads)
+1. [Setting `request.concurrency = "none"`](#request-concurrency)
 
 We cover them below to help you upgrade quickly:
 
@@ -91,3 +92,11 @@ has limited quotas, but note this change may impact performance.
 
 The number of worker threads used can be seen by enabling debug logging, and the value can
 be overriden by setting the `VECTOR_THREADS` environment variable.
+
+#### Setting `request.concurrency = "none"` {#request-concurrency}
+
+Explicitly setting `request.concurrency = "none"` in a sink configuration now properly configures
+the sink to have a fixed concurrency limit of 1, as was stated in the documentation. Previously, the
+above configuration would result in the sink using adaptive request concurrency. The default setting
+remains to be adaptive request concurrency.
+

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -202,7 +202,7 @@ base: components: sinks: appsignal: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -220,9 +220,8 @@ base: components: sinks: appsignal: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -198,11 +198,16 @@ base: components: sinks: appsignal: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -215,8 +220,9 @@ base: components: sinks: appsignal: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -201,7 +201,7 @@ base: components: sinks: appsignal: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -531,9 +531,8 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -512,7 +512,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -513,7 +513,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -509,11 +509,16 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -526,8 +531,9 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -289,7 +289,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -286,11 +286,16 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -303,8 +308,9 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -308,9 +308,8 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -290,7 +290,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -484,7 +484,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -480,11 +480,16 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -497,8 +502,9 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -502,9 +502,8 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -483,7 +483,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -511,9 +511,8 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -489,11 +489,16 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -506,8 +511,9 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -493,7 +493,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -492,7 +492,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -726,11 +726,16 @@ base: components: sinks: aws_s3: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -743,8 +748,9 @@ base: components: sinks: aws_s3: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -748,9 +748,8 @@ base: components: sinks: aws_s3: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -729,7 +729,7 @@ base: components: sinks: aws_s3: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -730,7 +730,7 @@ base: components: sinks: aws_s3: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -441,7 +441,7 @@ base: components: sinks: aws_sns: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -437,11 +437,16 @@ base: components: sinks: aws_sns: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -454,8 +459,9 @@ base: components: sinks: aws_sns: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -440,7 +440,7 @@ base: components: sinks: aws_sns: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -459,9 +459,8 @@ base: components: sinks: aws_sns: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -445,7 +445,7 @@ base: components: sinks: aws_sqs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -446,7 +446,7 @@ base: components: sinks: aws_sqs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -464,9 +464,8 @@ base: components: sinks: aws_sqs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -442,11 +442,16 @@ base: components: sinks: aws_sqs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -459,8 +464,9 @@ base: components: sinks: aws_sqs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -140,7 +140,7 @@ base: components: sinks: axiom: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -158,9 +158,8 @@ base: components: sinks: axiom: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -136,11 +136,16 @@ base: components: sinks: axiom: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -153,8 +158,9 @@ base: components: sinks: axiom: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -139,7 +139,7 @@ base: components: sinks: axiom: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -478,7 +478,7 @@ base: components: sinks: azure_blob: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -477,7 +477,7 @@ base: components: sinks: azure_blob: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -496,9 +496,8 @@ base: components: sinks: azure_blob: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -474,11 +474,16 @@ base: components: sinks: azure_blob: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -491,8 +496,9 @@ base: components: sinks: azure_blob: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -216,9 +216,8 @@ base: components: sinks: azure_monitor_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -194,11 +194,16 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -211,8 +216,9 @@ base: components: sinks: azure_monitor_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -198,7 +198,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -197,7 +197,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -251,7 +251,7 @@ base: components: sinks: clickhouse: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -247,11 +247,16 @@ base: components: sinks: clickhouse: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -264,8 +269,9 @@ base: components: sinks: clickhouse: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -250,7 +250,7 @@ base: components: sinks: clickhouse: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -269,9 +269,8 @@ base: components: sinks: clickhouse: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -372,9 +372,8 @@ base: components: sinks: databend: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -353,7 +353,7 @@ base: components: sinks: databend: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -350,11 +350,16 @@ base: components: sinks: databend: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -367,8 +372,9 @@ base: components: sinks: databend: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -354,7 +354,7 @@ base: components: sinks: databend: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -136,7 +136,7 @@ base: components: sinks: datadog_events: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -154,9 +154,8 @@ base: components: sinks: datadog_events: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -132,11 +132,16 @@ base: components: sinks: datadog_events: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -149,8 +154,9 @@ base: components: sinks: datadog_events: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -135,7 +135,7 @@ base: components: sinks: datadog_events: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -213,11 +213,16 @@ base: components: sinks: datadog_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -230,8 +235,9 @@ base: components: sinks: datadog_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -235,9 +235,8 @@ base: components: sinks: datadog_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -216,7 +216,7 @@ base: components: sinks: datadog_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -217,7 +217,7 @@ base: components: sinks: datadog_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -178,7 +178,7 @@ base: components: sinks: datadog_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -196,9 +196,8 @@ base: components: sinks: datadog_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -174,11 +174,16 @@ base: components: sinks: datadog_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -191,8 +196,9 @@ base: components: sinks: datadog_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -177,7 +177,7 @@ base: components: sinks: datadog_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -186,7 +186,7 @@ base: components: sinks: datadog_traces: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -187,7 +187,7 @@ base: components: sinks: datadog_traces: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -205,9 +205,8 @@ base: components: sinks: datadog_traces: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -183,11 +183,16 @@ base: components: sinks: datadog_traces: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -200,8 +205,9 @@ base: components: sinks: datadog_traces: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -621,9 +621,8 @@ base: components: sinks: elasticsearch: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -603,7 +603,7 @@ base: components: sinks: elasticsearch: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -602,7 +602,7 @@ base: components: sinks: elasticsearch: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -599,11 +599,16 @@ base: components: sinks: elasticsearch: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -616,8 +621,9 @@ base: components: sinks: elasticsearch: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -401,7 +401,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -398,11 +398,16 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -415,8 +420,9 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -420,9 +420,8 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -402,7 +402,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -560,7 +560,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -579,9 +579,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -557,11 +557,16 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -574,8 +579,9 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -561,7 +561,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -389,11 +389,16 @@ base: components: sinks: gcp_pubsub: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -406,8 +411,9 @@ base: components: sinks: gcp_pubsub: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -393,7 +393,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -411,9 +411,8 @@ base: components: sinks: gcp_pubsub: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -392,7 +392,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -243,7 +243,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -240,11 +240,16 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -257,8 +262,9 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -262,9 +262,8 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -244,7 +244,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -182,11 +182,16 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -199,8 +204,9 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -204,9 +204,8 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -186,7 +186,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -185,7 +185,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -174,7 +174,7 @@ base: components: sinks: greptimedb: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -192,9 +192,8 @@ base: components: sinks: greptimedb: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -170,11 +170,16 @@ base: components: sinks: greptimedb: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -187,8 +192,9 @@ base: components: sinks: greptimedb: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -173,7 +173,7 @@ base: components: sinks: greptimedb: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -167,7 +167,7 @@ base: components: sinks: honeycomb: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -185,9 +185,8 @@ base: components: sinks: honeycomb: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -166,7 +166,7 @@ base: components: sinks: honeycomb: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -163,11 +163,16 @@ base: components: sinks: honeycomb: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -180,8 +185,9 @@ base: components: sinks: honeycomb: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -499,7 +499,7 @@ base: components: sinks: http: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -496,11 +496,16 @@ base: components: sinks: http: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -513,8 +518,9 @@ base: components: sinks: http: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -500,7 +500,7 @@ base: components: sinks: http: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -518,9 +518,8 @@ base: components: sinks: http: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			headers: {

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -455,9 +455,8 @@ base: components: sinks: humio_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -436,7 +436,7 @@ base: components: sinks: humio_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -433,11 +433,16 @@ base: components: sinks: humio_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -450,8 +455,9 @@ base: components: sinks: humio_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -437,7 +437,7 @@ base: components: sinks: humio_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -269,7 +269,7 @@ base: components: sinks: humio_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -265,11 +265,16 @@ base: components: sinks: humio_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -282,8 +287,9 @@ base: components: sinks: humio_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -287,9 +287,8 @@ base: components: sinks: humio_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -268,7 +268,7 @@ base: components: sinks: humio_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -246,7 +246,7 @@ base: components: sinks: influxdb_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -247,7 +247,7 @@ base: components: sinks: influxdb_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -265,9 +265,8 @@ base: components: sinks: influxdb_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -243,11 +243,16 @@ base: components: sinks: influxdb_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -260,8 +265,9 @@ base: components: sinks: influxdb_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -223,9 +223,8 @@ base: components: sinks: influxdb_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -201,11 +201,16 @@ base: components: sinks: influxdb_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -218,8 +223,9 @@ base: components: sinks: influxdb_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -205,7 +205,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -204,7 +204,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -228,9 +228,8 @@ base: components: sinks: logdna: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -209,7 +209,7 @@ base: components: sinks: logdna: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -206,11 +206,16 @@ base: components: sinks: logdna: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -223,8 +228,9 @@ base: components: sinks: logdna: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -210,7 +210,7 @@ base: components: sinks: logdna: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -521,9 +521,8 @@ base: components: sinks: loki: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -499,11 +499,16 @@ base: components: sinks: loki: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -516,8 +521,9 @@ base: components: sinks: loki: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -502,7 +502,7 @@ base: components: sinks: loki: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -503,7 +503,7 @@ base: components: sinks: loki: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -206,11 +206,16 @@ base: components: sinks: mezmo: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -223,8 +228,9 @@ base: components: sinks: mezmo: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -209,7 +209,7 @@ base: components: sinks: mezmo: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -210,7 +210,7 @@ base: components: sinks: mezmo: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -228,9 +228,8 @@ base: components: sinks: mezmo: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -403,7 +403,7 @@ base: components: sinks: nats: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -422,9 +422,8 @@ base: components: sinks: nats: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -404,7 +404,7 @@ base: components: sinks: nats: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -400,11 +400,16 @@ base: components: sinks: nats: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -417,8 +422,9 @@ base: components: sinks: nats: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -212,11 +212,16 @@ base: components: sinks: new_relic: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -229,8 +234,9 @@ base: components: sinks: new_relic: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -216,7 +216,7 @@ base: components: sinks: new_relic: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -215,7 +215,7 @@ base: components: sinks: new_relic: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -234,9 +234,8 @@ base: components: sinks: new_relic: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -354,7 +354,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -350,11 +350,16 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -367,8 +372,9 @@ base: components: sinks: prometheus_remote_write: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -353,7 +353,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -372,9 +372,8 @@ base: components: sinks: prometheus_remote_write: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -415,9 +415,8 @@ base: components: sinks: redis: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -396,7 +396,7 @@ base: components: sinks: redis: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -393,11 +393,16 @@ base: components: sinks: redis: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -410,8 +415,9 @@ base: components: sinks: redis: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -397,7 +397,7 @@ base: components: sinks: redis: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -176,7 +176,7 @@ base: components: sinks: sematext_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -195,9 +195,8 @@ base: components: sinks: sematext_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -173,11 +173,16 @@ base: components: sinks: sematext_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -190,8 +195,9 @@ base: components: sinks: sematext_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -177,7 +177,7 @@ base: components: sinks: sematext_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -159,11 +159,16 @@ base: components: sinks: sematext_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -176,8 +181,9 @@ base: components: sinks: sematext_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -162,7 +162,7 @@ base: components: sinks: sematext_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -181,9 +181,8 @@ base: components: sinks: sematext_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -163,7 +163,7 @@ base: components: sinks: sematext_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -507,9 +507,8 @@ base: components: sinks: splunk_hec_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -488,7 +488,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -489,7 +489,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -485,11 +485,16 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -502,8 +507,9 @@ base: components: sinks: splunk_hec_logs: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -239,11 +239,16 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -256,8 +261,9 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -261,9 +261,8 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -242,7 +242,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -243,7 +243,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -155,7 +155,7 @@ base: components: sinks: vector: configuration: {
 					Configuration for outbound request concurrency.
 
 					This can be set either to one of the below enum values or to a uint, which denotes
-					a fixed amount of concurrency limit.
+					a fixed concurrency limit.
 					"""
 				required: false
 				type: {

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -151,11 +151,16 @@ base: components: sinks: vector: configuration: {
 				}
 			}
 			concurrency: {
-				description: "Configuration for outbound request concurrency."
-				required:    false
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a uint, which denotes
+					a fixed amount of concurrency limit.
+					"""
+				required: false
 				type: {
 					string: {
-						default: "none"
+						default: "adaptive"
 						enum: {
 							adaptive: """
 															Concurrency will be managed by Vector's [Adaptive Request Concurrency][arc] feature.
@@ -168,8 +173,9 @@ base: components: sinks: vector: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
+						examples: ["none", "adaptive", 128]
 					}
-					uint: {}
+					uint: examples: ["none", "adaptive", 128]
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -173,9 +173,8 @@ base: components: sinks: vector: configuration: {
 															Only one request can be outstanding at any given time.
 															"""
 						}
-						examples: ["none", "adaptive", 128]
 					}
-					uint: examples: ["none", "adaptive", 128]
+					uint: {}
 				}
 			}
 			rate_limit_duration_secs: {

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -154,7 +154,7 @@ base: components: sinks: vector: configuration: {
 				description: """
 					Configuration for outbound request concurrency.
 
-					This can be set either to one of the below enum values or to a uint, which denotes
+					This can be set either to one of the below enum values or to a positive integer, which denotes
 					a fixed concurrency limit.
 					"""
 				required: false


### PR DESCRIPTION
Fixes: https://github.com/vectordotdev/vector/issues/18595, https://github.com/vectordotdev/vector/issues/18594, https://github.com/vectordotdev/vector/issues/18593

This is technically a breaking change, since `none` is changing from denoting adaptive concurrency to a fixed concurrency of 1. However, the docs always stated that `none` was a fixed concurrency of 1, so I would argue that this is a bug fix.