### PR TITLE
feat(dev): add environment networking overrides to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ export ENVIRONMENT_AUTOBUILD ?= true
 export ENVIRONMENT_AUTOPULL ?= true
 # Override this when appropriate to disable a TTY being available in commands with `ENVIRONMENT=true`
 export ENVIRONMENT_TTY ?= true
+# Override to specify which network the environment will be connected to (leave empty to use the container tool default)
+export ENVIRONMENT_NETWORK ?= host
+# Override to specify environment port(s) to publish to the host (leave empty to not configure any port publishing)
+# Multiple port publishing can be provided using spaces, for example: 8686:8686 8080:8080/udp
+export ENVIRONMENT_PUBLISH ?=
 
 # Set dummy AWS credentials if not present - used for AWS and ES integration tests
 export AWS_ACCESS_KEY_ID ?= "dummy"
@@ -126,12 +131,13 @@ define ENVIRONMENT_EXEC
 			--init \
 			--interactive \
 			--env INSIDE_ENVIRONMENT=true \
-			--network host \
+			$(if $(ENVIRONMENT_NETWORK),--network $(ENVIRONMENT_NETWORK),) \
 			--mount type=bind,source=${CURRENT_DIR},target=/git/vectordotdev/vector \
 			$(if $(findstring docker,$(CONTAINER_TOOL)),--mount type=bind$(COMMA)source=/var/run/docker.sock$(COMMA)target=/var/run/docker.sock,) \
 			--mount type=volume,source=vector-target,target=/git/vectordotdev/vector/target \
 			--mount type=volume,source=vector-cargo-cache,target=/root/.cargo \
 			--mount type=volume,source=vector-rustup-cache,target=/root/.rustup \
+			$(foreach publish,$(ENVIRONMENT_PUBLISH),--publish $(publish)) \
 			$(ENVIRONMENT_UPSTREAM)
 endef
 


### PR DESCRIPTION
This commit adds two new Makefile overrides for configuring the networking of the environment:

* `ENVIRONMENT_NETWORK`: When non-empty, the value is passed to the container tool using `--network VALUE`. The default value is `host` to preserve the current behavior.
* `ENVIRONMENT_PUBLISH`: When non-empty, all space-separated values are passed to the container tool using `--publish VALUE` arguments. The default is empty to preserve the current behavior.

Before this change, the environment was hard-coded to always be started using `--network host`.
This behavior is not always convenient. For example, when using Docker Desktop for Windows, the `host` network is not supported and does not behave the same way as in Linux. In this scenario, publishing ports with the default `bridge` network can be used instead as follows:

    make environment ENVIRONMENT_NETWORK=bridge ENVIRONMENT_PUBLISH='8686:8686 8080:8080/udp'

In Docker, `ENVIRONMENT_NETWORK` can also be left empty given that `bridge` is the default.