### PR TITLE
feat(dev): add networking overrides to website Makefile

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,5 +1,10 @@
 CUE = ./scripts/cue.sh
 
+# Override to specify which network address to use in Hugo/HTTP servers for binding
+export SERVER_BIND ?= 127.0.0.1
+# Override to specify which port to use in Hugo/HTTP servers for listening
+export SERVER_PORT ?= 1313
+
 clean:
 	rm -rf public resources data/docs.json
 
@@ -33,6 +38,8 @@ structured-data: cue-build config-examples
 
 serve: clean setup structured-data
 	hugo server \
+	--bind $(SERVER_BIND) \
+	--port $(SERVER_PORT) \
 	--buildDrafts \
 	--buildFuture \
 	--environment "development"
@@ -48,7 +55,7 @@ ci-production-build: setup structured-data production-build run-link-checker alg
 # Preview site
 preview-build:
 	hugo \
-	--baseURL $(DEPLOY_PRIME_URL) \
+	$(if $(DEPLOY_PRIME_URL),--baseURL $(DEPLOY_PRIME_URL),) \
 	--buildFuture \
 	--environment "preview" \
 	--minify
@@ -74,7 +81,7 @@ algolia:
 # Useful for locally debugging issues that arise only on the deployed production site
 run-production-site-locally:
 	make setup structured-data production-build
-	python3 -m http.server 1313 --directory ./public --bind 127.0.0.1
+	python3 -m http.server $(SERVER_PORT) --bind $(SERVER_BIND) --directory ./public
 
 # Local dev build with no link checking and no Yarn dependency fetching
 quick-build: clean structured-data production-build


### PR DESCRIPTION
This commit adds two new Makefile overrides for configuring the networking in the website Makefile:

* `SERVER_BIND`: Specify which network address to use in Hugo/HTTP servers for binding. The default value is `127.0.0.1` to preserve the current behavior.
* `SERVER_PORT`: Specify which port to use in Hugo/HTTP servers for listening. The default value is `1313` to preserve the current behavior.

Before this change, the Hugo/HTTP bind address and port was hard-coded to `127.0.0.1:1313`. This behavior is not always convenient. For example, when running Hugo inside of a Docker container. In this scenario, the Hugo/HTTP servers can be accessed form outside of the container as follows:

    make serve SERVER_BIND=0.0.0.0
    make run-production-site-locally SERVER_BIND=0.0.0.0

I also added a safety check for `DEPLOY_PRIME_URL` in the `preview-build` Makefile target. Without this check, Hugo is incorrectly started with a bare `--baseURL` if that variable is not defined.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
