### PR TITLE
fix(dev): update environment for website development

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -197,6 +197,7 @@ copypasta'd
 copypasted
 copytruncate
 corechecks
+corepack
 could've
 counteraaaaaaaaaaa
 cpf
@@ -740,6 +741,7 @@ noauth
 nocapture
 nochild
 nodebuginfo
+nodistro
 nofield
 nofree
 nomac


### PR DESCRIPTION
The `nodejs` and `npm` packages installed from the stock Ubuntu Focal repository are outdated for the current website dependencies. This commit installs an updated Node.js (current LTS version) directly from the NodeSource repository instead.

The `yarn` package in the stock Ubuntu Focal repository is not the Yarn package manager. The package is actually an alias package for the unrelated `cmdtest` package (ref: <https://packages.ubuntu.com/focal/yarn>). This commit installs (enables) the correct `yarn` command using the same updated Node.js installation above.

Website development requires two tools not currently installed in the environment:

* Hugo (static site generator).
* htmltest (HTML checker for the website content).

This commit also installs these tools directly from their GitHub release assets. In the case of Hugo, the installed version matches the version currently specified in 'netlify.toml'.

In addition to all the above, this commit also improves the Ubuntu bootstrap script:

* Switches `apt` for `apt-get` as recommended for non-interactive scripts.
* Add missing temporary directory cleaning commands.

After all the above changes, the following now works properly in `website/` in the environment:

    make serve
    make local-preview-build

