### PR TITLE
chore(external docs): Remove or replace mentions of vector in functions doc

### DIFF
--- a/website/cue/reference/remap/functions.cue
+++ b/website/cue/reference/remap/functions.cue
@@ -104,7 +104,7 @@ remap: {
 		* Connection-Type databases:
 			* `connection_type`
 
-		To use this function, you need to update your Vector configuration to
+		To use this function, you need to update your configuration to
 		include an
 		[`enrichment_tables`](\(urls.vector_configuration_global)/#enrichment_tables)
 		parameter.

--- a/website/cue/reference/remap/functions/encode_key_value.cue
+++ b/website/cue/reference/remap/functions/encode_key_value.cue
@@ -70,16 +70,16 @@ remap: functions: encode_key_value: {
 		{
 			title: "Encode with default delimiters (nested fields)"
 			source: """
-				encode_key_value({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log"})
+				encode_key_value({"agent": {"name": "foo"}, "log": {"file": {"path": "my.log"}}, "event": "log"})
 				"""
-			return: #"agent.name=vector event=log log.file.path=my.log"#
+			return: #"agent.name=foo event=log log.file.path=my.log"#
 		},
 		{
 			title: "Encode with default delimiters (nested fields ordering)"
 			source: """
-				encode_key_value!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log"}, ["event", "log.file.path", "agent.name"])
+				encode_key_value!({"agent": {"name": "foo"}, "log": {"file": {"path": "my.log"}}, "event": "log"}, ["event", "log.file.path", "agent.name"])
 				"""
-			return: #"event=log log.file.path=my.log agent.name=vector"#
+			return: #"event=log log.file.path=my.log agent.name=foo"#
 		},
 		{
 			title: "Encode with custom delimiters (no ordering)"

--- a/website/cue/reference/remap/functions/encode_logfmt.cue
+++ b/website/cue/reference/remap/functions/encode_logfmt.cue
@@ -44,16 +44,16 @@ remap: functions: encode_logfmt: {
 		{
 			title: "Encode to logfmt (nested fields)"
 			source: """
-				encode_logfmt({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log"})
+				encode_logfmt({"agent": {"name": "foo"}, "log": {"file": {"path": "my.log"}}, "event": "log"})
 				"""
-			return: #"agent.name=vector event=log log.file.path=my.log"#
+			return: #"agent.name=foo event=log log.file.path=my.log"#
 		},
 		{
 			title: "Encode to logfmt (nested fields ordering)"
 			source: """
-				encode_logfmt!({"agent": {"name": "vector"}, "log": {"file": {"path": "my.log"}}, "event": "log"}, ["event", "log.file.path", "agent.name"])
+				encode_logfmt!({"agent": {"name": "foo"}, "log": {"file": {"path": "my.log"}}, "event": "log"}, ["event", "log.file.path", "agent.name"])
 				"""
-			return: #"event=log log.file.path=my.log agent.name=vector"#
+			return: #"event=log log.file.path=my.log agent.name=foo"#
 		},
 	]
 }

--- a/website/cue/reference/remap/functions/log.cue
+++ b/website/cue/reference/remap/functions/log.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: log: {
 	category:    "Debug"
 	description: """
-		Logs the `value` to Vector's [stdout](\(urls.stdout)) at the specified `level`.
+		Logs the `value` to [stdout](\(urls.stdout)) at the specified `level`.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/match_array.cue
+++ b/website/cue/reference/remap/functions/match_array.cue
@@ -34,28 +34,28 @@ remap: functions: match_array: {
 		{
 			title: "Match at least one element"
 			source: #"""
-					match_array(["foobar", "bazqux"], r'foo')
+				match_array(["foobar", "bazqux"], r'foo')
 				"""#
 			return: true
 		},
 		{
 			title: "Match all elements"
 			source: #"""
-					match_array(["foo", "foobar", "barfoo"], r'foo', all: true)
+				match_array(["foo", "foobar", "barfoo"], r'foo', all: true)
 				"""#
 			return: true
 		},
 		{
 			title: "No matches"
 			source: #"""
-					match_array(["bazqux", "xyz"], r'foo')
+				match_array(["bazqux", "xyz"], r'foo')
 				"""#
 			return: false
 		},
 		{
 			title: "Not all elements match"
 			source: #"""
-					match_array(["foo", "foobar", "baz"], r'foo', all: true)
+				match_array(["foo", "foobar", "baz"], r'foo', all: true)
 				"""#
 			return: false
 		},

--- a/website/cue/reference/remap/functions/match_datadog_query.cue
+++ b/website/cue/reference/remap/functions/match_datadog_query.cue
@@ -41,7 +41,7 @@ remap: functions: match_datadog_query: {
 		{
 			title: "Facet wildcard"
 			source: #"""
-				match_datadog_query({"custom": {"name": "vector"}}, "@name:vec*")
+				match_datadog_query({"custom": {"name": "foo"}}, "@name:foo*")
 				"""#
 			return: true
 		},

--- a/website/cue/reference/remap/functions/parse_url.cue
+++ b/website/cue/reference/remap/functions/parse_url.cue
@@ -35,13 +35,13 @@ remap: functions: parse_url: {
 		{
 			title: "Parse URL"
 			source: #"""
-				parse_url!("ftp://foo:bar@vector.dev:4343/foobar?hello=world#123")
+				parse_url!("ftp://foo:bar@example.com:4343/foobar?hello=world#123")
 				"""#
 			return: {
 				scheme:   "ftp"
 				username: "foo"
 				password: "bar"
-				host:     "vector.dev"
+				host:     "example.com"
 				port:     4343
 				path:     "/foobar"
 				query: hello: "world"
@@ -51,13 +51,13 @@ remap: functions: parse_url: {
 		{
 			title: "Parse URL with default port"
 			source: #"""
-				parse_url!("https://vector.dev", default_known_ports: true)
+				parse_url!("https://example.com", default_known_ports: true)
 				"""#
 			return: {
 				scheme:   "https"
 				username: ""
 				password: ""
-				host:     "vector.dev"
+				host:     "example.com"
 				port:     443
 				path:     "/"
 				query: {}

--- a/website/cue/reference/remap/functions/replace.cue
+++ b/website/cue/reference/remap/functions/replace.cue
@@ -5,7 +5,7 @@ remap: functions: replace: {
 	description: """
 		Replaces all matching instances of `pattern` in the `value`.
 
-		The `pattern` argument accepts regular expression capture groups. Note that `$foo` is interpreted in a Vector configuration file, instead use `$$foo`.
+		The `pattern` argument accepts regular expression capture groups. Note that `$foo` is interpreted in a configuration file, instead use `$$foo`.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/set_semantic_meaning.cue
+++ b/website/cue/reference/remap/functions/set_semantic_meaning.cue
@@ -4,7 +4,7 @@ remap: functions: set_semantic_meaning: {
 	category: "Event"
 	description: """
 		Sets a semantic meaning for an event. Note that this function assigns
-		meaning at Vector startup, and has _no_ runtime behavior. It is suggested
+		meaning at startup, and has _no_ runtime behavior. It is suggested
 		to put all calls to this function at the beginning of a VRL function. The function
 		cannot be conditionally called (eg: using an if statement cannot stop the meaning
 		from being assigned).


### PR DESCRIPTION
This PR removes or replaces mentions of "Vector" in the function docs that are getting added to Datadog docs.

Related to [DOCS-6159](https://datadoghq.atlassian.net/browse/DOCS-6159).

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
