### PR TITLE
fix(config): Only try default paths if the path is not specified

### DIFF
--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -69,17 +69,15 @@ pub fn merge_path_lists(
 /// Expand a list of paths (potentially containing glob patterns) into real
 /// config paths, replacing it with the default paths when empty.
 pub fn process_paths(config_paths: &[ConfigPath]) -> Option<Vec<ConfigPath>> {
-    let default_paths = default_config_paths();
-
     let starting_paths = if !config_paths.is_empty() {
-        config_paths
+        config_paths.to_owned()
     } else {
-        &default_paths
+        default_config_paths()
     };
 
     let mut paths = Vec::new();
 
-    for config_path in starting_paths {
+    for config_path in &starting_paths {
         let config_pattern: &PathBuf = config_path.into();
 
         let matches: Vec<PathBuf> = match glob(config_pattern.to_str().expect("No ability to glob"))


### PR DESCRIPTION
Otherwise it prints the warning about the default path change even if the user specified a path
themselves.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
