### PR TITLE
chore(releasing): Bump Vector version to v0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9609,7 +9609,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "apache-avro",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
Now that v0.33.0 has been released

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
