### PR TITLE
fix(arc): Remove static maximum concurrency

### DIFF
--- a/src/sinks/util/adaptive_concurrency/controller.rs
+++ b/src/sinks/util/adaptive_concurrency/controller.rs
@@ -67,8 +67,7 @@ impl<L> Controller<L> {
     ) -> Self {
         // If a `concurrency` is specified, it becomes both the
         // current limit and the maximum, effectively bypassing all the
-        // mechanisms. Otherwise, the current limit is set to 1 and the
-        // maximum to MAX_CONCURRENCY.
+        // mechanisms. Otherwise, the current limit is set to 1.
         let current_limit = concurrency.unwrap_or(settings.initial_concurrency);
         Self {
             semaphore: Arc::new(ShrinkableSemaphore::new(current_limit)),
@@ -226,8 +225,7 @@ impl<L> Controller<L> {
         // concurrency limit. Note that we only check this if we had
         // requests to go beyond the current limit to prevent
         // increasing the limit beyond what we have evidence for.
-        if inner.current_limit < super::MAX_CONCURRENCY
-            && inner.reached_limit
+        if inner.reached_limit
             && !inner.had_back_pressure
             && current_rtt.is_some()
             && current_rtt.unwrap() <= past_rtt.mean

--- a/src/sinks/util/adaptive_concurrency/mod.rs
+++ b/src/sinks/util/adaptive_concurrency/mod.rs
@@ -9,10 +9,6 @@ mod service;
 #[cfg(test)]
 pub mod tests;
 
-// Make sure to update the max range of the `AdaptiveConcurrencySettings::initial_concurrency` when changing
-// this constant.
-pub(super) const MAX_CONCURRENCY: usize = 200;
-
 pub(crate) use layer::AdaptiveConcurrencyLimitLayer;
 pub(crate) use service::AdaptiveConcurrencyLimit;
 use vector_config::configurable_component;
@@ -36,7 +32,7 @@ pub struct AdaptiveConcurrencySettings {
     /// It is recommended to set this value to your service's average limit if you're seeing that it takes a
     /// long time to ramp up adaptive concurrency after a restart. You can find this value by looking at the
     /// `adaptive_concurrency_limit` metric.
-    #[configurable(validation(range(min = 1, max = 200)))]
+    #[configurable(validation(range(min = 1)))]
     #[serde(default = "default_initial_concurrency")]
     pub(super) initial_concurrency: usize,
 
@@ -88,12 +84,6 @@ const fn default_ewma_alpha() -> f64 {
 
 const fn default_rtt_deviation_scale() -> f64 {
     2.5
-}
-
-impl AdaptiveConcurrencySettings {
-    pub const fn max_concurrency() -> usize {
-        MAX_CONCURRENCY
-    }
 }
 
 impl Default for AdaptiveConcurrencySettings {

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -25,6 +25,7 @@ use crate::{
         adaptive_concurrency::{
             AdaptiveConcurrencyLimit, AdaptiveConcurrencyLimitLayer, AdaptiveConcurrencySettings,
         },
+        request_builder::default_request_builder_concurrency_limit,
         retries::{FixedRetryPolicy, RetryLogic},
         service::map::MapLayer,
         sink::Response,
@@ -360,7 +361,7 @@ impl TowerRequestSettings {
 
         // Build services
         let open = OpenGauge::new();
-        let max_concurrency = services.len() * AdaptiveConcurrencySettings::max_concurrency();
+        let max_concurrency = services.len() * default_request_builder_concurrency_limit();
         let services = services
             .into_iter()
             .map(|(endpoint, inner)| {


### PR DESCRIPTION
It was added in
https://github.com/vectordotdev/vector/commit/8605d64b41ca3174ef6540cb7bff9bb1ef355042 but there
doesn't _seem_ to be a justification for this static maximum.

Users can control the maximum via the existing `rate_limit_num` and `rate_limit_secs` `request` options.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
