### PR TITLE
fix(dev): Gate config conversion tests

### DIFF
--- a/src/convert_config.rs
+++ b/src/convert_config.rs
@@ -201,7 +201,12 @@ fn walk_dir_and_convert(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "sources-demo_logs",
+    feature = "transforms-remap",
+    feature = "sinks-console"
+))]
 mod tests {
     use crate::config::{format, ConfigBuilder, Format};
     use crate::convert_config::{check_paths, walk_dir_and_convert, Opts};


### PR DESCRIPTION
These tests require `demo_logs`, `remap`, and `console` components.

Ideally we might update the component features check to run `cargo test` instead of just `cargo check` but I anticipate this would bloat the time significantly.

Fixes: #18697

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
