### PR TITLE
chore(ci): Add a summary if the regression workflow is skipped

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -821,7 +821,7 @@ jobs:
         run: |
            echo "### Workflow skipped" >> $GITHUB_STEP_SUMMARY
            echo "This workflow doesn't run on PR's automatically." >> $GITHUB_STEP_SUMMARY
-           echo "To trigger a run, leave a comment with `/ci-run-regression`" >> $GITHUB_STEP_SUMMARY
+           echo "To trigger a run, leave a comment with \`/ci-run-regression\`" >> $GITHUB_STEP_SUMMARY
 
       - name: exit
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -816,6 +816,13 @@ jobs:
           context: Regression Detection Suite
           status: 'success'
 
+      - name: (PR) Indicate why skipped
+        if: github.event_name == 'pull_request'
+        run: |
+           echo "### Workflow skipped" >> $GITHUB_STEP_SUMMARY
+           echo "This workflow doesn't run on PR's automatically." >> $GITHUB_STEP_SUMMARY
+           echo "To trigger a run, leave a comment with `/ci-run-regression`" >> $GITHUB_STEP_SUMMARY
+
       - name: exit
         run: |
           echo "failed=${{ env.FAILED }}"


### PR DESCRIPTION
Due to not running automatically on PRs.

Example output: https://github.com/vectordotdev/vector/actions/runs/6355487977

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
