### PR TITLE
chore(deps): clean up VRL crate features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,7 +2296,7 @@ dependencies = [
  "futures-core",
  "prost 0.12.1",
  "prost-types 0.12.1",
- "tonic 0.10.1",
+ "tonic 0.10.2",
  "tracing-core 0.1.30",
 ]
 
@@ -2318,7 +2318,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.10.1",
+ "tonic 0.10.2",
  "tracing 0.1.37",
  "tracing-core 0.1.30",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ members = [
 ]
 
 [workspace.dependencies]
-vrl = { version = "0.7.0", default-features = false, features = ["cli", "arbitrary", "compiler", "value", "diagnostic", "path", "parser", "stdlib", "datadog", "core"] }
+vrl = { version = "0.7.0", features = ["cli"] }
 
 pin-project = { version = "1.1.3", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ members = [
 ]
 
 [workspace.dependencies]
-vrl = { version = "0.7.0", default-features = false, features = ["cli", "test", "test_framework", "arbitrary", "compiler", "value", "diagnostic", "path", "parser", "stdlib", "datadog", "core"] }
+vrl = { version = "0.7.0", default-features = false, features = ["cli", "arbitrary", "compiler", "value", "diagnostic", "path", "parser", "stdlib", "datadog", "core"] }
 
 pin-project = { version = "1.1.3", default-features = false }
 

--- a/lib/vector-vrl/tests/Cargo.toml
+++ b/lib/vector-vrl/tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 enrichment = { path = "../../enrichment" }
-vrl.workspace = true
+vrl = { version = "0.7.0", features = ["test", "test_framework"] }
 vector-vrl-functions = { path = "../../vector-vrl/functions" }
 
 ansi_term = "0.12"

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -6,13 +6,15 @@
 //! [geolite]: https://dev.maxmind.com/geoip/geoip2/geolite2/#Download_Access
 use std::{collections::BTreeMap, fs, net::IpAddr, sync::Arc, time::SystemTime};
 
-use enrichment::{Case, Condition, IndexHandle, Table};
 use maxminddb::{
     geoip2::{City, ConnectionType, Isp},
     MaxMindDBError, Reader,
 };
-use vector_config::configurable_component;
+use ordered_float::NotNan;
 use vrl::value::Value;
+
+use enrichment::{Case, Condition, IndexHandle, Table};
+use vector_config::configurable_component;
 
 use crate::config::{EnrichmentTableConfig, GenerateConfig};
 
@@ -180,10 +182,17 @@ impl Geoip {
 
                 let location = data.location.as_ref();
                 add_field!("timezone", location.and_then(|location| location.time_zone));
-                add_field!("latitude", location.and_then(|location| location.latitude));
+                add_field!(
+                    "latitude",
+                    location
+                        .and_then(|location| location.latitude)
+                        .map(|latitude| Value::Float(NotNan::new(latitude).unwrap()))
+                );
                 add_field!(
                     "longitude",
-                    location.and_then(|location| location.longitude)
+                    location
+                        .and_then(|location| location.longitude)
+                        .map(|longitude| NotNan::new(longitude).unwrap())
                 );
                 add_field!(
                     "metro_code",

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -186,13 +186,15 @@ impl Geoip {
                     "latitude",
                     location
                         .and_then(|location| location.latitude)
-                        .map(|latitude| Value::Float(NotNan::new(latitude).unwrap()))
+                        .map(|latitude| Value::Float(
+                            NotNan::new(latitude).expect("latitude cannot be Nan")
+                        ))
                 );
                 add_field!(
                     "longitude",
                     location
                         .and_then(|location| location.longitude)
-                        .map(|longitude| NotNan::new(longitude).unwrap())
+                        .map(|longitude| NotNan::new(longitude).expect("longitude cannot be Nan"))
                 );
                 add_field!(
                     "metro_code",

--- a/src/sources/datadog_agent/traces.rs
+++ b/src/sources/datadog_agent/traces.rs
@@ -6,10 +6,11 @@ use futures::future;
 use http::StatusCode;
 use ordered_float::NotNan;
 use prost::Message;
-use vector_common::internal_event::{CountByteSize, InternalEventHandle as _};
-use vector_core::EstimatedJsonEncodedSizeOf;
 use vrl::event_path;
 use warp::{filters::BoxedFilter, path, path::FullPath, reply::Response, Filter, Rejection, Reply};
+
+use vector_common::internal_event::{CountByteSize, InternalEventHandle as _};
+use vector_core::EstimatedJsonEncodedSizeOf;
 
 use crate::{
     event::{Event, TraceEvent, Value},
@@ -150,8 +151,14 @@ fn handle_dd_trace_payload_v1(
             trace_event.insert(&source.log_schema_host_key, hostname.clone());
             trace_event.insert(event_path!("env"), env.clone());
             trace_event.insert(event_path!("agent_version"), agent_version.clone());
-            trace_event.insert(event_path!("target_tps"), target_tps);
-            trace_event.insert(event_path!("error_tps"), error_tps);
+            trace_event.insert(
+                event_path!("target_tps"),
+                Value::Float(NotNan::new(target_tps).unwrap()),
+            );
+            trace_event.insert(
+                event_path!("error_tps"),
+                Value::Float(NotNan::new(error_tps).unwrap()),
+            );
             if let Some(Value::Object(span_tags)) = trace_event.get_mut(event_path!("tags")) {
                 span_tags.extend(tags.clone());
             } else {

--- a/src/sources/datadog_agent/traces.rs
+++ b/src/sources/datadog_agent/traces.rs
@@ -153,11 +153,11 @@ fn handle_dd_trace_payload_v1(
             trace_event.insert(event_path!("agent_version"), agent_version.clone());
             trace_event.insert(
                 event_path!("target_tps"),
-                Value::Float(NotNan::new(target_tps).unwrap()),
+                Value::Float(NotNan::new(target_tps).expect("target_tps cannot be Nan")),
             );
             trace_event.insert(
                 event_path!("error_tps"),
-                Value::Float(NotNan::new(error_tps).unwrap()),
+                Value::Float(NotNan::new(error_tps).expect("error_tps cannot be Nan")),
             );
             if let Some(Value::Object(span_tags)) = trace_event.get_mut(event_path!("tags")) {
                 span_tags.extend(tags.clone());


### PR DESCRIPTION
closes: #17377 

* We can now re-enable default features.
* Removed `test`, `test_framework` and `arbitrary` features from `Cargo.toml`. 
* Note that some of these features are still used by the VRL crate in `[dev-dependencies]`.