### PR TITLE
[WEB-3464] Adds TrustArc cookie consent banner

### DIFF
--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -3,6 +3,7 @@
 {{ $siteGeneration := site.Params.site_generation }}
 import '@ryangjchandler/spruce';
 import 'alpinejs';
+import './cookie-banner'
 
 const sayHello = () => {
   console.log('Welcome to the Vector website and documentation!');

--- a/website/assets/js/cookie-banner.js
+++ b/website/assets/js/cookie-banner.js
@@ -1,0 +1,40 @@
+window.addEventListener('load', function () {
+    const { env } = document.documentElement.dataset;
+
+    if (env !== 'development') {
+        // add trustarc script to head
+        const trustarc = document.createElement('script');
+        trustarc.setAttribute('src','https://consent.trustarc.com/v2/notice/ufocto');
+        document.head.appendChild(trustarc);
+
+        // add divs
+        const divA = document.createElement("div");
+        const divB = document.createElement("div");
+        divA.id = "teconsent";
+        divA.style = "cursor: pointer; color:#fff"
+        divB.id = "consent-banner";
+        divB.style = "position:fixed; bottom:0px; right:0px; width:100%;";
+        document.body.appendChild(divA);
+        document.body.appendChild(divB);
+        
+        // update Cookie link
+        this.setTimeout(function () {
+            const banner = document.getElementById('consent-banner');
+            const prefsElement = document.getElementById('teconsent');
+            const cookieLink = document.querySelector('footer a[href*="/cookies"]');
+
+            if (banner) {
+                // listen for click and remove banner to avoid interfering with 
+                document.addEventListener('click', function (event) {
+                    const targetElement = event.target;
+                    if (targetElement.matches('#truste-consent-required') || targetElement.matches('#truste-consent-button')) {
+                        banner.remove();
+                    }
+                });
+            }
+
+            // replace Cookie link with Prefs div
+            return (cookieLink && document.getElementById('teconsent').innerHTML.length > 0) ? cookieLink.replaceWith(prefsElement) : false;
+        }, 200);
+    }
+});

--- a/website/assets/js/cookie-banner.js
+++ b/website/assets/js/cookie-banner.js
@@ -22,6 +22,7 @@ window.addEventListener('load', function () {
             const banner = document.getElementById('consent-banner');
             const prefsElement = document.getElementById('teconsent');
             const cookieLink = document.querySelector('footer a[href*="/cookies"]');
+            prefsElement.className = cookieLink.className;
 
             if (banner) {
                 // listen for click and remove banner to avoid interfering with 

--- a/website/config.toml
+++ b/website/config.toml
@@ -176,6 +176,12 @@ parent = "about"
 weight = 3
 
 [[languages.en.menus.footer]]
+name = "Cookies"
+url = "https://www.datadoghq.com/legal/cookies/"
+parent = "about"
+weight = 4
+
+[[languages.en.menus.footer]]
 name = "Components"
 url = "/components"
 identifier = "components"

--- a/website/layouts/partials/meta.html
+++ b/website/layouts/partials/meta.html
@@ -16,6 +16,10 @@
 <meta name="author" content="{{ . }}">
 {{ end }}
 
+{{/* TrustArc */}}
+<script type="text/javascript" src="https://consent.trustarc.com/v2/autoblockasset/core.min.js?cmId=ufocto"></script>
+<script type="text/javascript" src="https://consent.trustarc.com/v2/autoblock?cmId=ufocto"></script>
+
 {{ hugo.Generator }}
 
 <link rel="shortcut icon" href="{{ $favicon }}">


### PR DESCRIPTION
## Description
- Adds TrustArc cookie consent banner dependencies and display script to the Vector website
- Adds Cookies link to footer to target with preferences behavior

## Motivation
https://datadoghq.atlassian.net/browse/WEB-3476

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
