### PR TITLE
chore(ci): Revet bump check-spelling/check-spelling from 0.0.21 to 0.0.22

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         suppress_push_for_open_pull_request: 1
         checkout: true


### PR DESCRIPTION
Reverts vectordotdev/vector#18723.

See https://github.com/check-spelling/check-spelling/releases/tag/v0.0.22