### PR TITLE
fix(datadog_metrics sink): the integration tests weren't actually validating anything

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -56,8 +56,14 @@ on:
         value: ${{ jobs.int_tests.outputs.clickhouse }}
       databend:
         value: ${{ jobs.int_tests.outputs.databend }}
-      datadog:
-        value: ${{ jobs.int_tests.outputs.datadog }}
+      datadog-agent:
+        value: ${{ jobs.int_tests.outputs.datadog-agent }}
+      datadog-logs:
+        value: ${{ jobs.int_tests.outputs.datadog-logs }}
+      datadog-metrics:
+        value: ${{ jobs.int_tests.outputs.datadog-metrics }}
+      datadog-traces:
+        value: ${{ jobs.int_tests.outputs.datadog-traces }}
       dnstap:
         value: ${{ jobs.int_tests.outputs.dnstap }}
       docker-logs:
@@ -189,7 +195,10 @@ jobs:
       azure: ${{ steps.filter.outputs.azure }}
       clickhouse: ${{ steps.filter.outputs.clickhouse }}
       databend: ${{ steps.filter.outputs.databend }}
-      datadog: ${{ steps.filter.outputs.datadog }}
+      datadog-agent: ${{ steps.filter.outputs.datadog-agent }}
+      datadog-logs: ${{ steps.filter.outputs.datadog-logs }}
+      datadog-metrics: ${{ steps.filter.outputs.datadog-metrics }}
+      datadog-traces: ${{ steps.filter.outputs.datadog-traces }}
       dnstap: ${{ steps.filter.outputs.dnstap }}
       docker-logs: ${{ steps.filter.outputs.docker-logs }}
       elasticsearch: ${{ steps.filter.outputs.elasticsearch }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,10 @@ jobs:
             || needs.changes.outputs.azure == 'true'
             || needs.changes.outputs.clickhouse == 'true'
             || needs.changes.outputs.databend == 'true'
-            || needs.changes.outputs.datadog == 'true'
+            || needs.changes.outputs.datadog-agent == 'true'
+            || needs.changes.outputs.datadog-logs == 'true'
+            || needs.changes.outputs.datadog-metrics == 'true'
+            || needs.changes.outputs.datadog-traces == 'true'
             || needs.changes.outputs.dnstap == 'true'
             || needs.changes.outputs.docker-logs == 'true'
             || needs.changes.outputs.elasticsearch == 'true'
@@ -166,7 +169,7 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  databend
 
-      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog-agent == 'true') &&
           (github.event_name != 'pull_request' || env.PR_HAS_ACCESS_TO_SECRETS == 'true')
         name: datadog-agent
         uses: nick-fields/retry@v2
@@ -175,7 +178,7 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  datadog-agent
 
-      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog-logs == 'true') &&
           (github.event_name != 'pull_request' || env.PR_HAS_ACCESS_TO_SECRETS == 'true')
         name: datadog-logs
         uses: nick-fields/retry@v2
@@ -184,7 +187,7 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  datadog-logs
 
-      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog-metrics == 'true') &&
           (github.event_name != 'pull_request' || env.PR_HAS_ACCESS_TO_SECRETS == 'true')
         name: datadog-metrics
         uses: nick-fields/retry@v2
@@ -193,7 +196,7 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-integration-test.sh  datadog-metrics
 
-      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog == 'true') &&
+      - if: (github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.datadog-traces == 'true') &&
           (github.event_name != 'pull_request' || env.PR_HAS_ACCESS_TO_SECRETS == 'true')
         name: datadog-traces
         uses: nick-fields/retry@v2

--- a/scripts/integration/datadog-metrics/test.yaml
+++ b/scripts/integration/datadog-metrics/test.yaml
@@ -1,7 +1,7 @@
 features:
 - datadog-metrics-integration-tests
 
-test_filter: '::datadog::metrics::'
+test_filter: '::datadog::metrics::integration_tests'
 
 runner:
   env:

--- a/scripts/integration/datadog-traces/test.yaml
+++ b/scripts/integration/datadog-traces/test.yaml
@@ -19,6 +19,6 @@ matrix:
 paths:
 - "src/common/datadog.rs"
 - "src/internal_events/datadog_*"
-- "src/sinks/datadog/**"
+- "src/sinks/datadog/traces/**"
 - "src/sinks/util/**"
 - "scripts/integration/datadog-traces/**"


### PR DESCRIPTION
The integration tests for this sink were silently validating nothing ... The input events generated for the test cases were getting filtered out silently during the conversion from absolute to incremental counters. So the batch status was saying delivered, but we never were validating that any events were _actually_ received , so all the logic to check the correctness of the responses was never getting executed.

Note this also fixes the workflow logic to run the dd int tests based on files changes.