### PR TITLE
chore(website): Set download page dropdown to latest version

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -94,13 +94,3 @@ local-preview-build: clean setup structured-data preview-build run-link-checker
 # Generate Lighthouse scores locally
 lighthouse-report:
 	yarn lighthouse
-
-# Hot reload dev environment for the website
-local-server:
-	hugo server \
-	--disableFastRender \
-	 -verbose \
-	 --debug
-
-# local dev environment with hot reload
-local-dev: clean structured-data local-server

--- a/website/Makefile
+++ b/website/Makefile
@@ -94,3 +94,13 @@ local-preview-build: clean setup structured-data preview-build run-link-checker
 # Generate Lighthouse scores locally
 lighthouse-report:
 	yarn lighthouse
+
+# Hot reload dev environment for the website
+local-server:
+	hugo server \
+	--disableFastRender \
+	 -verbose \
+	 --debug
+
+# local dev environment with hot reload
+local-dev: clean structured-data local-server

--- a/website/layouts/download/section.html
+++ b/website/layouts/download/section.html
@@ -6,7 +6,7 @@ Download | {{ site.Title }}
 {{ $releases := site.Data.docs.releases }}
 {{ $versions := site.Data.docs.versions }}
 {{ $latest := index $versions 0 }}
-<div class="relative max-w-3xl lg:max-w-7xl px-6 lg:px-8 mx-auto">
+<div x-data x-init="$store.global.setToLatest()" class="relative max-w-3xl lg:max-w-7xl px-6 lg:px-8 mx-auto">
   <div class="my-16">
     {{ partial "hero.html" . }}
   </div>


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Sets the version to `latest` when the Download page loads for the first time.
[Jira Request](https://datadoghq.atlassian.net/browse/WEB-4065)

Also adds a make command to allow a hot reload environment for local development

### To test:

- Goto the website preview deployment
- Click `Download` in the nav
- Select a different version other than `latest`
- Navigate to the home page
- Go back to the download page and ensure that the version has reset to `latest`
