### PR TITLE
fix(kafka sink): Make KafkaService return `Poll::Pending` when producer queue is full

### DIFF
--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -10,6 +10,9 @@ use crate::{
     internal_events::KafkaStatisticsReceived, tls::TlsEnableableConfig, tls::PEM_START_MARKER,
 };
 
+pub const KAFKA_DEFAULT_QUEUE_MESSAGES_MAX: &str = "100000";
+pub const KAFKA_DEFAULT_QUEUE_BYTES_MAX: &str = "1048576";
+
 #[derive(Debug, Snafu)]
 enum KafkaError {
     #[snafu(display("invalid path: {:?}", path))]

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -10,9 +10,6 @@ use crate::{
     internal_events::KafkaStatisticsReceived, tls::TlsEnableableConfig, tls::PEM_START_MARKER,
 };
 
-pub const KAFKA_DEFAULT_QUEUE_MESSAGES_MAX: &str = "100000";
-pub const KAFKA_DEFAULT_QUEUE_BYTES_MAX: &str = "1048576";
-
 #[derive(Debug, Snafu)]
 enum KafkaError {
     #[snafu(display("invalid path: {:?}", path))]

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -163,7 +163,7 @@ impl Service<KafkaRequest> for KafkaService {
                     )) => {
                         if blocked_state.is_none() {
                             blocked_state =
-                                Some(BlockedRecordState::new(this.records_blocked.clone()));
+                                Some(BlockedRecordState::new(Arc::clone(&this.records_blocked)));
                         }
                         record = original_record;
                         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -107,7 +107,7 @@ impl Service<KafkaRequest> for KafkaService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // The Kafka service is unavailable if any records are currently blocked from being enqueued
+        // The Kafka service is at capacity if any records are currently blocked from being enqueued
         // on the producer.
         if self.records_blocked.load(Ordering::Relaxed) > 0 {
             Poll::Pending
@@ -143,7 +143,7 @@ impl Service<KafkaRequest> for KafkaService {
             let mut blocked_state: Option<BlockedRecordState> = None;
             loop {
                 match this.kafka_producer.send_result(record) {
-                    // Record was successully enqueued on the producer.
+                    // Record was successfully enqueued on the producer.
                     Ok(fut) => {
                         // Drop the blocked state (if any), as the producer is no longer blocked.
                         drop(blocked_state.take());

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -1,9 +1,10 @@
 use std::{
     sync::{
-        atomic::{AtomicI64, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
         Arc,
     },
     task::{Context, Poll},
+    time::Duration,
 };
 
 use bytes::Bytes;
@@ -11,7 +12,7 @@ use rdkafka::{
     error::KafkaError,
     message::OwnedHeaders,
     producer::{FutureProducer, FutureRecord},
-    util::Timeout,
+    types::RDKafkaErrorCode,
 };
 
 use crate::{kafka::KafkaStatisticsContext, sinks::prelude::*};
@@ -65,30 +66,37 @@ impl MetaDescriptive for KafkaRequest {
     }
 }
 
+/// BlockedRecordState manages state for a record blocked from being enqueued on the producer.
+struct BlockedRecordState {
+    records_blocked: Arc<AtomicUsize>,
+}
+
+impl BlockedRecordState {
+    fn new(records_blocked: Arc<AtomicUsize>) -> Self {
+        records_blocked.fetch_add(1, Ordering::Relaxed);
+        Self { records_blocked }
+    }
+}
+
+impl Drop for BlockedRecordState {
+    fn drop(&mut self) {
+        self.records_blocked.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 #[derive(Clone)]
 pub struct KafkaService {
     kafka_producer: FutureProducer<KafkaStatisticsContext>,
 
-    // State to keep track of the producer queue's current size and limits. We use i64 here instead
-    // of i32 to avoid any potential overflow bugs that might result from race conditions.
-    queue_messages_max: i64,
-    queue_bytes_max: i64,
-    queue_messages_current: Arc<AtomicI64>,
-    queue_bytes_current: Arc<AtomicI64>,
+    /// The number of records blocked from being enqueued on the producer.
+    records_blocked: Arc<AtomicUsize>,
 }
 
 impl KafkaService {
-    pub(crate) const fn new(
-        kafka_producer: FutureProducer<KafkaStatisticsContext>,
-        queue_messages_max: i32,
-        queue_bytes_max: i32,
-    ) -> KafkaService {
+    pub(crate) fn new(kafka_producer: FutureProducer<KafkaStatisticsContext>) -> KafkaService {
         KafkaService {
             kafka_producer,
-            queue_messages_max: queue_messages_max as i64,
-            queue_bytes_max: queue_bytes_max as i64,
-            queue_messages_current: Arc::new(AtomicI64::new(0)),
-            queue_bytes_current: Arc::new(AtomicI64::new(0)),
+            records_blocked: Arc::new(AtomicUsize::new(0)),
         }
     }
 }
@@ -99,26 +107,21 @@ impl Service<KafkaRequest> for KafkaService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // The Kafka service is available if its producer queue is not full.
-        if self.queue_messages_current.load(Ordering::Relaxed) < self.queue_messages_max
-            && self.queue_bytes_current.load(Ordering::Relaxed) < self.queue_bytes_max
-        {
-            Poll::Ready(Ok(()))
-        } else {
+        // The Kafka service is unavailable if any records are currently blocked from being enqueued
+        // on the producer.
+        if self.records_blocked.load(Ordering::Relaxed) > 0 {
             Poll::Pending
+        } else {
+            Poll::Ready(Ok(()))
         }
     }
 
     fn call(&mut self, request: KafkaRequest) -> Self::Future {
         let this = self.clone();
 
-        // Update state for the producer queue.
-        let raw_byte_size = request.body.len() + request.metadata.key.map_or(0, |x| x.len());
-        this.queue_messages_current.fetch_add(1, Ordering::Relaxed);
-        this.queue_bytes_current
-            .fetch_add(raw_byte_size as i64, Ordering::Relaxed);
-
         Box::pin(async move {
+            let raw_byte_size =
+                request.body.len() + request.metadata.key.as_ref().map_or(0, |x| x.len());
             let event_byte_size = request
                 .request_metadata
                 .into_events_estimated_json_encoded_byte_size();
@@ -135,21 +138,40 @@ impl Service<KafkaRequest> for KafkaService {
                 record = record.headers(headers);
             }
 
-            // rdkafka will internally retry forever if the queue is full
-            let res = match this.kafka_producer.send(record, Timeout::Never).await {
-                Ok((_partition, _offset)) => Ok(KafkaResponse {
-                    event_byte_size,
-                    raw_byte_size,
-                }),
-                Err((kafka_err, _original_record)) => Err(kafka_err),
-            };
-
-            // Update state for the producer queue.
-            this.queue_messages_current.fetch_sub(1, Ordering::Relaxed);
-            this.queue_bytes_current
-                .fetch_sub(raw_byte_size as i64, Ordering::Relaxed);
-
-            res
+            // Manually poll [FutureProducer::send_result] instead of [FutureProducer::send] to track
+            // records that fail to be enqueued on the producer.
+            let mut blocked_state: Option<BlockedRecordState> = None;
+            loop {
+                match this.kafka_producer.send_result(record) {
+                    // Record was successully enqueued on the producer.
+                    Ok(fut) => {
+                        // Drop the blocked state (if any), as the producer is no longer blocked.
+                        drop(blocked_state.take());
+                        return fut
+                            .await
+                            .expect("producer unexpectedly dropped")
+                            .map(|_| KafkaResponse {
+                                event_byte_size,
+                                raw_byte_size,
+                            })
+                            .map_err(|(err, _)| err);
+                    }
+                    // Producer queue is full.
+                    Err((
+                        KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull),
+                        original_record,
+                    )) => {
+                        if blocked_state.is_none() {
+                            blocked_state =
+                                Some(BlockedRecordState::new(this.records_blocked.clone()));
+                        }
+                        record = original_record;
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                    // A different error occurred.
+                    Err((err, _)) => return Err(err),
+                };
+            }
         })
     }
 }

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -1,4 +1,10 @@
-use std::task::{Context, Poll};
+use std::{
+    sync::{
+        atomic::{AtomicI64, AtomicUsize, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use rdkafka::{
@@ -62,13 +68,28 @@ impl MetaDescriptive for KafkaRequest {
 #[derive(Clone)]
 pub struct KafkaService {
     kafka_producer: FutureProducer<KafkaStatisticsContext>,
+
+    // State to keep track of the producer queue's current size and limits. We use i64 here instead
+    // of i32 to avoid any potential overflow bugs that might result from race conditions.
+    queue_messages_max: i64,
+    queue_bytes_max: i64,
+    queue_messages_current: Arc<AtomicI64>,
+    queue_bytes_current: Arc<AtomicI64>,
 }
 
 impl KafkaService {
     pub(crate) const fn new(
         kafka_producer: FutureProducer<KafkaStatisticsContext>,
+        queue_messages_max: i32,
+        queue_bytes_max: i32,
     ) -> KafkaService {
-        KafkaService { kafka_producer }
+        KafkaService {
+            kafka_producer,
+            queue_messages_max: queue_messages_max as i64,
+            queue_bytes_max: queue_bytes_max as i64,
+            queue_messages_current: Arc::new(AtomicI64::new(0)),
+            queue_bytes_current: Arc::new(AtomicI64::new(0)),
+        }
     }
 }
 
@@ -78,11 +99,24 @@ impl Service<KafkaRequest> for KafkaService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+        // The Kafka service is available if its producer queue is not full.
+        if self.queue_messages_current.load(Ordering::Relaxed) < self.queue_messages_max
+            && self.queue_bytes_current.load(Ordering::Relaxed) < self.queue_bytes_max
+        {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
     }
 
     fn call(&mut self, request: KafkaRequest) -> Self::Future {
         let this = self.clone();
+
+        // Update state for the producer queue.
+        let raw_byte_size = request.body.len() + request.metadata.key.map_or(0, |x| x.len());
+        this.queue_messages_current.fetch_add(1, Ordering::Relaxed);
+        this.queue_bytes_current
+            .fetch_add(raw_byte_size as i64, Ordering::Relaxed);
 
         Box::pin(async move {
             let event_byte_size = request
@@ -102,17 +136,20 @@ impl Service<KafkaRequest> for KafkaService {
             }
 
             // rdkafka will internally retry forever if the queue is full
-            match this.kafka_producer.send(record, Timeout::Never).await {
-                Ok((_partition, _offset)) => {
-                    let raw_byte_size =
-                        request.body.len() + request.metadata.key.map_or(0, |x| x.len());
-                    Ok(KafkaResponse {
-                        event_byte_size,
-                        raw_byte_size,
-                    })
-                }
+            let res = match this.kafka_producer.send(record, Timeout::Never).await {
+                Ok((_partition, _offset)) => Ok(KafkaResponse {
+                    event_byte_size,
+                    raw_byte_size,
+                }),
                 Err((kafka_err, _original_record)) => Err(kafka_err),
-            }
+            };
+
+            // Update state for the producer queue.
+            this.queue_messages_current.fetch_sub(1, Ordering::Relaxed);
+            this.queue_bytes_current
+                .fetch_sub(raw_byte_size as i64, Ordering::Relaxed);
+
+            res
         })
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vectordotdev/vector/issues/18762

It isn't correct to set a concurrency limit on the service because the Kafka client does not return until the record is sent downstream and an acknowledgement is received. Rather, we remove the concurrency limit and use the underlying `FutureProducer` to determine whether or not the service is at capacity.