### PR TITLE
fix(http_server source): panic when http server receives metric events

### DIFF
--- a/src/sources/util/http/query.rs
+++ b/src/sources/util/http/query.rs
@@ -16,19 +16,15 @@ pub fn add_query_parameters(
     for query_parameter_name in query_parameters_config {
         let value = query_parameters.get(query_parameter_name);
         for event in events.iter_mut() {
-            let log = if let Event::Log(ref mut log_event) = event {
-                log_event
-            } else {
-                continue;
-            };
-
-            log_namespace.insert_source_metadata(
-                source_name,
-                log,
-                Some(LegacyKey::Overwrite(path!(query_parameter_name))),
-                path!("query_parameters"),
-                crate::event::Value::from(value.map(String::to_owned)),
-            );
+            if let Event::Log(log) = event {
+                log_namespace.insert_source_metadata(
+                    source_name,
+                    log,
+                    Some(LegacyKey::Overwrite(path!(query_parameter_name))),
+                    path!("query_parameters"),
+                    crate::event::Value::from(value.map(String::to_owned)),
+                );
+            }
         }
     }
 }

--- a/src/sources/util/http/query.rs
+++ b/src/sources/util/http/query.rs
@@ -16,9 +16,15 @@ pub fn add_query_parameters(
     for query_parameter_name in query_parameters_config {
         let value = query_parameters.get(query_parameter_name);
         for event in events.iter_mut() {
+            let log = if let Event::Log(ref mut log_event) = event {
+                log_event
+            } else {
+                continue;
+            };
+
             log_namespace.insert_source_metadata(
                 source_name,
-                event.as_mut_log(),
+                log,
                 Some(LegacyKey::Overwrite(path!(query_parameter_name))),
                 path!("query_parameters"),
                 crate::event::Value::from(value.map(String::to_owned)),


### PR DESCRIPTION
closes: #17056 

Used [this setup](https://github.com/vectordotdev/vector/issues/18558#issuecomment-1720833363) to reproduce and confirm the fix. Note this PR is targeted to this specific bug, we are still using `event.as_mut_log()` in other places.