### PR TITLE
ci: mark otlp_http_to_blackhole experiment erratic

### DIFF
--- a/regression/cases/otlp_http_to_blackhole/experiment.yaml
+++ b/regression/cases/otlp_http_to_blackhole/experiment.yaml
@@ -1,0 +1,2 @@
+optimization_goal: ingress_throughput
+erratic: true


### PR DESCRIPTION
In light of regression detector results in #18650, #18740, and #18759 that report repeated suspicious regressions in the `otlp_http_to_blackhole` experiment, this commit / PR marks that experiment "erratic" so that its results do not prevent Vector PRs from merging.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
