### PR TITLE
chore(metrics): improve creation of Origin metadata structures

### DIFF
--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -76,38 +76,31 @@ pub struct DatadogMetricOriginMetadata {
 }
 
 impl DatadogMetricOriginMetadata {
-    /// Replaces the `OriginProduct`.
+    /// Creates a new `DatadogMetricOriginMetadata`.
+    /// When Vector sends out metrics containing the Origin metadata, it should do so with
+    /// all of the fields defined.
+    /// The edge case where the Orign metadata is created within a component and does not
+    /// initially contain all of the metadata fields, is in the `log_to_metric` transform.
     #[must_use]
-    pub fn with_product(mut self, product: u32) -> Self {
-        self.product = Some(product);
-        self
+    pub fn new(product: Option<u32>, category: Option<u32>, service: Option<u32>) -> Self {
+        Self {
+            product,
+            category,
+            service,
+        }
     }
 
-    /// Replaces the `OriginCategory`.
-    #[must_use]
-    pub fn with_category(mut self, category: u32) -> Self {
-        self.category = Some(category);
-        self
-    }
-
-    /// Replaces the `OriginService`.
-    #[must_use]
-    pub fn with_service(mut self, service: u32) -> Self {
-        self.service = Some(service);
-        self
-    }
-
-    /// Returns a reference to the `OriginProduct`
+    /// Returns a reference to the `OriginProduct`.
     pub fn product(&self) -> Option<u32> {
         self.product
     }
 
-    /// Returns a reference to the `OriginCategory`
+    /// Returns a reference to the `OriginCategory`.
     pub fn category(&self) -> Option<u32> {
         self.category
     }
 
-    /// Returns a reference to the `OriginService`
+    /// Returns a reference to the `OriginService`.
     pub fn service(&self) -> Option<u32> {
         self.service
     }

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -79,7 +79,7 @@ impl DatadogMetricOriginMetadata {
     /// Creates a new `DatadogMetricOriginMetadata`.
     /// When Vector sends out metrics containing the Origin metadata, it should do so with
     /// all of the fields defined.
-    /// The edge case where the Orign metadata is created within a component and does not
+    /// The edge case where the Origin metadata is created within a component and does not
     /// initially contain all of the metadata fields, is in the `log_to_metric` transform.
     #[must_use]
     pub fn new(product: Option<u32>, category: Option<u32>, service: Option<u32>) -> Self {

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -564,28 +564,15 @@ fn decode_metadata(
 ) {
     let value = input.value.and_then(decode_value);
 
-    let datadog_origin_metadata = input
-        .datadog_origin_metadata
-        .as_ref()
-        .map(decode_origin_metadata);
+    let datadog_origin_metadata = input.datadog_origin_metadata.as_ref().map(|input| {
+        super::DatadogMetricOriginMetadata::new(
+            input.origin_product,
+            input.origin_category,
+            input.origin_service,
+        )
+    });
 
     (value, datadog_origin_metadata)
-}
-
-fn decode_origin_metadata(input: &DatadogOriginMetadata) -> super::DatadogMetricOriginMetadata {
-    let mut origin = super::DatadogMetricOriginMetadata::default();
-
-    if let Some(product) = input.origin_product {
-        origin = origin.with_product(product);
-    }
-    if let Some(category) = input.origin_category {
-        origin = origin.with_category(category);
-    }
-    if let Some(service) = input.origin_service {
-        origin = origin.with_service(service);
-    }
-
-    origin
 }
 
 fn decode_value(input: Value) -> Option<event::Value> {

--- a/src/sinks/datadog/metrics/encoder.rs
+++ b/src/sinks/datadog/metrics/encoder.rs
@@ -416,7 +416,9 @@ fn generate_sketch_metadata(
 ) -> Option<ddmetric_proto::Metadata> {
     generate_origin_metadata(maybe_pass_through, maybe_source_type, origin_product_value).map(
         |origin| {
-            if origin.product().is_none() | origin.category().is_none() | origin.service().is_none()
+            if origin.product().is_none()
+                || origin.category().is_none()
+                || origin.service().is_none()
             {
                 warn!(
                     message = "Generated sketch origin metadata should have each field set.",
@@ -427,9 +429,9 @@ fn generate_sketch_metadata(
             }
             ddmetric_proto::Metadata {
                 origin: Some(ddmetric_proto::Origin {
-                    origin_product: origin.product().expect("OriginProduct should be set"),
-                    origin_category: origin.category().expect("OriginCategory should be set"),
-                    origin_service: origin.service().expect("OriginService should be set"),
+                    origin_product: origin.product().unwrap_or_default(),
+                    origin_category: origin.category().unwrap_or_default(),
+                    origin_service: origin.service().unwrap_or_default(),
                 }),
             }
         },

--- a/src/sinks/datadog/metrics/encoder.rs
+++ b/src/sinks/datadog/metrics/encoder.rs
@@ -415,12 +415,23 @@ fn generate_sketch_metadata(
     origin_product_value: u32,
 ) -> Option<ddmetric_proto::Metadata> {
     generate_origin_metadata(maybe_pass_through, maybe_source_type, origin_product_value).map(
-        |origin| ddmetric_proto::Metadata {
-            origin: Some(ddmetric_proto::Origin {
-                origin_product: origin.product().expect("OriginProduct should be set"),
-                origin_category: origin.category().expect("OriginCategory should be set"),
-                origin_service: origin.service().expect("OriginService should be set"),
-            }),
+        |origin| {
+            if origin.product().is_none() | origin.category().is_none() | origin.service().is_none()
+            {
+                warn!(
+                    message = "Generated sketch origin metadata should have each field set.",
+                    product = origin.product(),
+                    category = origin.category(),
+                    service = origin.service()
+                );
+            }
+            ddmetric_proto::Metadata {
+                origin: Some(ddmetric_proto::Origin {
+                    origin_product: origin.product().expect("OriginProduct should be set"),
+                    origin_category: origin.category().expect("OriginCategory should be set"),
+                    origin_service: origin.service().expect("OriginService should be set"),
+                }),
+            }
         },
     )
 }
@@ -626,12 +637,11 @@ fn generate_origin_metadata(
     //     - `log_to_metric` transform set the OriginService in the EventMetadata when it creates
     //        the new metric.
     if let Some(pass_through) = maybe_pass_through {
-        Some(
-            DatadogMetricOriginMetadata::default()
-                .with_product(pass_through.product().unwrap_or(origin_product_value))
-                .with_category(pass_through.category().unwrap_or(ORIGIN_CATEGORY_VALUE))
-                .with_service(pass_through.service().unwrap_or(no_value)),
-        )
+        Some(DatadogMetricOriginMetadata::new(
+            pass_through.product().or(Some(origin_product_value)),
+            pass_through.category().or(Some(ORIGIN_CATEGORY_VALUE)),
+            pass_through.service().or(Some(no_value)),
+        ))
 
     // No metadata has been set upstream
     } else {
@@ -640,10 +650,11 @@ fn generate_origin_metadata(
             // In order to preserve consistent behavior, we intentionally don't set origin metadata
             // for the case where the Datadog Agent did not set it.
             source_type_to_service(source_type).map(|origin_service_value| {
-                DatadogMetricOriginMetadata::default()
-                    .with_product(origin_product_value)
-                    .with_category(ORIGIN_CATEGORY_VALUE)
-                    .with_service(origin_service_value)
+                DatadogMetricOriginMetadata::new(
+                    Some(origin_product_value),
+                    Some(ORIGIN_CATEGORY_VALUE),
+                    Some(origin_service_value),
+                )
             })
         })
     }
@@ -1073,10 +1084,7 @@ mod tests {
         let service = 9;
 
         let event_metadata = EventMetadata::default().with_origin_metadata(
-            DatadogMetricOriginMetadata::default()
-                .with_product(product)
-                .with_category(category)
-                .with_service(service),
+            DatadogMetricOriginMetadata::new(Some(product), Some(category), Some(service)),
         );
         let counter = get_simple_counter_with_metadata(event_metadata);
 

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -244,12 +244,11 @@ fn get_event_metadata(metadata: Option<&Metadata>) -> EventMetadata {
                 origin.origin_category,
                 origin.origin_service,
             );
-            EventMetadata::default().with_origin_metadata(
-                DatadogMetricOriginMetadata::default()
-                    .with_product(origin.origin_product)
-                    .with_category(origin.origin_category)
-                    .with_service(origin.origin_service),
-            )
+            EventMetadata::default().with_origin_metadata(DatadogMetricOriginMetadata::new(
+                Some(origin.origin_product),
+                Some(origin.origin_category),
+                Some(origin.origin_service),
+            ))
         })
 }
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -268,9 +268,11 @@ fn to_metric(config: &MetricConfig, event: &Event) -> Result<Metric, TransformEr
         .metadata()
         .clone()
         .with_schema_definition(&Arc::new(Definition::any()))
-        .with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        .with_origin_metadata(DatadogMetricOriginMetadata::new(
+            None,
+            None,
+            Some(ORIGIN_SERVICE_VALUE),
+        ));
 
     let field = parse_target_path(config.field()).map_err(|_e| FieldNotFound {
         field: config.field().to_string(),
@@ -520,9 +522,15 @@ mod tests {
         );
 
         let event = create_event("status", "42");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
         metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
@@ -557,9 +565,15 @@ mod tests {
         let mut event = create_event("message", "i am log");
         event.as_mut_log().insert("method", "post");
         event.as_mut_log().insert("code", "200");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
         metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
@@ -651,9 +665,15 @@ mod tests {
         );
 
         let event = create_event("backtrace", "message");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
         metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
@@ -701,9 +721,15 @@ mod tests {
         );
 
         let event = create_event("amount", "33.99");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
         metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
@@ -736,9 +762,15 @@ mod tests {
         );
 
         let event = create_event("amount", "33.99");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
         metadata.set_source_id(Arc::new(ComponentKey::from("in")));
@@ -770,9 +802,15 @@ mod tests {
         );
 
         let event = create_event("memory_rss", "123");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
@@ -861,9 +899,15 @@ mod tests {
             .insert(log_schema().timestamp_key_target_path().unwrap(), ts());
         event.as_mut_log().insert("status", "42");
         event.as_mut_log().insert("backtrace", "message");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
@@ -921,9 +965,15 @@ mod tests {
         event.as_mut_log().insert("host", "local");
         event.as_mut_log().insert("worker", "abc");
         event.as_mut_log().insert("service", "xyz");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
@@ -970,9 +1020,15 @@ mod tests {
         );
 
         let event = create_event("user_ip", "1.2.3.4");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
         metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
@@ -1005,9 +1061,15 @@ mod tests {
         );
 
         let event = create_event("response_time", "2.5");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
@@ -1042,9 +1104,15 @@ mod tests {
         );
 
         let event = create_event("response_time", "2.5");
-        let mut metadata = event.metadata().clone().with_origin_metadata(
-            DatadogMetricOriginMetadata::default().with_service(ORIGIN_SERVICE_VALUE),
-        );
+        let mut metadata =
+            event
+                .metadata()
+                .clone()
+                .with_origin_metadata(DatadogMetricOriginMetadata::new(
+                    None,
+                    None,
+                    Some(ORIGIN_SERVICE_VALUE),
+                ));
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));


### PR DESCRIPTION
This changes the way we create the `DatadogMetricOriginMetadata` structure, so the design more closely matches the expected behavior that metrics sent from the `datadog_metrics` sink which have the Origin metadata set within Vector, will contain all of the fields.

It was motivated by a comment in https://github.com/vectordotdev/vector/pull/18761 , to suggest not panicking if all the fields are not set (which this also changes). 
