### PR TITLE
chore(ci): Run deny check nightly instead of on every PR

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -149,9 +149,6 @@ jobs:
             - "Makefile"
             - "rust-toolchain.toml"
             - "vdev/**"
-          deny:
-            - 'deny.toml'
-            - "vdev/**"
           dependencies:
             - ".cargo/**"
             - 'Cargo.toml'

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -9,6 +9,7 @@
 # /ci-run-all                 : runs all of the below
 # /ci-run-cli                 : runs CLI - Linux
 # /ci-run-misc                : runs Miscellaneous - Linux
+# /ci-run-deny                : runs Deny - Linux
 # /ci-run-component-features  : runs Component Features - Linux
 # /ci-run-cross               : runs Cross
 # /ci-run-unit-mac            : runs Unit - Mac
@@ -50,6 +51,7 @@ jobs:
       github.event.issue.pull_request && ( contains(github.event.comment.body, '/ci-run-all')
           || contains(github.event.comment.body, '/ci-run-cli')
           || contains(github.event.comment.body, '/ci-run-misc')
+          || contains(github.event.comment.body, '/ci-run-deny')
           || contains(github.event.comment.body, '/ci-run-component-features')
           || contains(github.event.comment.body, '/ci-run-cross')
           || contains(github.event.comment.body, '/ci-run-unit-mac')
@@ -87,6 +89,12 @@ jobs:
     needs: validate
     if: contains(github.event.comment.body, '/ci-run-all') || contains(github.event.comment.body, '/ci-run-misc')
     uses: ./.github/workflows/misc.yml
+    secrets: inherit
+
+  deny:
+    needs: validate
+    if: contains(github.event.comment.body, '/ci-run-all') || contains(github.event.comment.body, '/ci-run-deny')
+    uses: ./.github/workflows/deny.yml
     secrets: inherit
 
   component-features:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,3 +1,12 @@
+# Deny - Linux
+#
+# Checks for security vulnerabilities or license incompatibilities
+#
+# Runs on:
+#  - scheduled UTC midnight
+#  - on PR comment (see comment-trigger.yml)
+#  - on demand from github actions UI
+
 name: Deny - Linux
 
 on:
@@ -8,8 +17,8 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  test-misc:
-    runs-on: [linux, ubuntu-20.04-4core]
+  test-deny:
+    runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,65 @@
+name: Deny - Linux
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    # At midnight UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  test-misc:
+    runs-on: [linux, ubuntu-20.04-4core]
+    env:
+      CARGO_INCREMENTAL: 0
+    steps:
+      - name: (PR comment) Get PR branch
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: (PR comment) Set latest commit status as pending
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: myrotvorets/set-commit-status-action@v2.0.0
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          context: Deny - Linux
+          status: pending
+
+      - name: (PR comment) Checkout PR branch
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+      - name: Checkout branch
+        if: ${{ github.event_name != 'issue_comment' }}
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh
+      - run: bash scripts/environment/prepare.sh
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - name: Check cargo deny advisories/licenses
+        run: make check-deny
+
+      - name: (PR comment) Set latest commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@v2.0.0
+        if: always() && github.event_name == 'issue_comment'
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          context: Deny - Linux
+          status: ${{ job.status }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,6 @@ jobs:
         if: needs.changes.outputs.source == 'true'
         run: make check-events
 
-      - name: Check cargo deny advisories/licenses
-        if: needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.deny == 'true'
-        run: make check-deny
-
       - name: Check that the 3rd-party license file is up to date
         if: needs.changes.outputs.dependencies == 'true'
         run: make check-licenses


### PR DESCRIPTION
With the goal of not blocking PRs due to a new security vulnerability being reported on `master`.
There is a risk that this allows PRs to introduce vulnerabilities that won't be flagged until after
merge but we see this risk as small and easily remedied after the fact. We will also run these
checks before releases, when it is most important to resolve any extant CVEs.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
