### PR TITLE
feat(timestamp encoding): add unixtime formats

### DIFF
--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -186,7 +186,7 @@ impl Transformer {
             let mut unix_timestamps = Vec::new();
             for (k, v) in log.all_event_fields().expect("must be an object") {
                 if let Value::Timestamp(ts) = v {
-                    unix_timestamps.push((k.clone(), extract(&ts).into()));
+                    unix_timestamps.push((k.clone(), extract(ts).into()));
                 }
             }
             for (k, v) in unix_timestamps {
@@ -195,7 +195,7 @@ impl Transformer {
         } else {
             // root is not an object
             let timestamp = if let Value::Timestamp(ts) = log.value() {
-                Some(extract(&ts))
+                Some(extract(ts))
             } else {
                 None
             };

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 
+use chrono::{DateTime, Utc};
 use core::fmt::Debug;
 use std::collections::BTreeMap;
 
@@ -176,31 +177,45 @@ impl Transformer {
         }
     }
 
+    fn format_timestamps<F, T>(&self, log: &mut LogEvent, extract: F)
+    where
+        F: Fn(&DateTime<Utc>) -> T,
+        T: Into<Value>,
+    {
+        if log.value().is_object() {
+            let mut unix_timestamps = Vec::new();
+            for (k, v) in log.all_event_fields().expect("must be an object") {
+                if let Value::Timestamp(ts) = v {
+                    unix_timestamps.push((k.clone(), extract(&ts).into()));
+                }
+            }
+            for (k, v) in unix_timestamps {
+                log.parse_path_and_insert(k, v).unwrap();
+            }
+        } else {
+            // root is not an object
+            let timestamp = if let Value::Timestamp(ts) = log.value() {
+                Some(extract(&ts))
+            } else {
+                None
+            };
+            if let Some(ts) = timestamp {
+                log.insert(event_path!(), ts.into());
+            }
+        }
+    }
+
     fn apply_timestamp_format(&self, log: &mut LogEvent) {
         if let Some(timestamp_format) = self.timestamp_format.as_ref() {
             match timestamp_format {
-                TimestampFormat::Unix => {
-                    if log.value().is_object() {
-                        let mut unix_timestamps = Vec::new();
-                        for (k, v) in log.all_event_fields().expect("must be an object") {
-                            if let Value::Timestamp(ts) = v {
-                                unix_timestamps.push((k.clone(), Value::Integer(ts.timestamp())));
-                            }
-                        }
-                        for (k, v) in unix_timestamps {
-                            log.parse_path_and_insert(k, v).unwrap();
-                        }
-                    } else {
-                        // root is not an object
-                        let timestamp = if let Value::Timestamp(ts) = log.value() {
-                            Some(ts.timestamp())
-                        } else {
-                            None
-                        };
-                        if let Some(ts) = timestamp {
-                            log.insert(event_path!(), Value::Integer(ts));
-                        }
-                    }
+                TimestampFormat::Unix => self.format_timestamps(log, |ts| ts.timestamp()),
+                TimestampFormat::UnixMs => self.format_timestamps(log, |ts| ts.timestamp_millis()),
+                TimestampFormat::UnixUs => self.format_timestamps(log, |ts| ts.timestamp_micros()),
+                TimestampFormat::UnixNs => self.format_timestamps(log, |ts| {
+                    ts.timestamp_nanos_opt().expect("Timestamp out of range")
+                }),
+                TimestampFormat::UnixFloat => {
+                    self.format_timestamps(log, |ts| ts.timestamp_micros() as f64 / 1e6)
                 }
                 // RFC3339 is the default serialization of a timestamp.
                 TimestampFormat::Rfc3339 => (),
@@ -225,7 +240,7 @@ impl Transformer {
 
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 /// The format in which a timestamp should be represented.
 pub enum TimestampFormat {
     /// Represent the timestamp as a Unix timestamp.
@@ -233,6 +248,18 @@ pub enum TimestampFormat {
 
     /// Represent the timestamp as a RFC 3339 timestamp.
     Rfc3339,
+
+    /// Represent the timestamp as a Unix timestamp in milliseconds.
+    UnixMs,
+
+    /// Represent the timestamp as a Unix timestamp in microseconds
+    UnixUs,
+
+    /// Represent the timestamp as a Unix timestamp in nanoseconds.
+    UnixNs,
+
+    /// Represent the timestamp as a Unix timestamp in floating point.
+    UnixFloat,
 }
 
 #[cfg(test)]
@@ -344,9 +371,8 @@ mod tests {
 
     #[test]
     fn deserialize_and_transform_timestamp() {
-        let transformer: Transformer = toml::from_str(r#"timestamp_format = "unix""#).unwrap();
-        let mut event = Event::Log(LogEvent::from("Demo"));
-        let timestamp = event
+        let mut base = Event::Log(LogEvent::from("Demo"));
+        let timestamp = base
             .as_mut_log()
             .get((
                 lookup::PathPrefix::Event,
@@ -355,32 +381,44 @@ mod tests {
             .unwrap()
             .clone();
         let timestamp = timestamp.as_timestamp().unwrap();
-        event
-            .as_mut_log()
+        base.as_mut_log()
             .insert("another", Value::Timestamp(*timestamp));
 
-        transformer.transform(&mut event);
+        let cases = [
+            ("unix", Value::from(timestamp.timestamp())),
+            ("unix_ms", Value::from(timestamp.timestamp_millis())),
+            ("unix_us", Value::from(timestamp.timestamp_micros())),
+            (
+                "unix_ns",
+                Value::from(timestamp.timestamp_nanos_opt().unwrap()),
+            ),
+            (
+                "unix_float",
+                Value::from(timestamp.timestamp_micros() as f64 / 1e6),
+            ),
+        ];
+        for (fmt, expected) in cases {
+            let config: String = format!(r#"timestamp_format = "{}""#, fmt);
+            let transformer: Transformer = toml::from_str(&config).unwrap();
+            let mut event = base.clone();
+            transformer.transform(&mut event);
+            let log = event.as_mut_log();
 
-        match event
-            .as_mut_log()
-            .get((
-                lookup::PathPrefix::Event,
-                log_schema().timestamp_key().unwrap(),
-            ))
-            .unwrap()
-        {
-            Value::Integer(_) => {}
-            e => panic!(
-                "Timestamp was not transformed into a Unix timestamp. Was {:?}",
-                e
-            ),
-        }
-        match event.as_mut_log().get("another").unwrap() {
-            Value::Integer(_) => {}
-            e => panic!(
-                "Timestamp was not transformed into a Unix timestamp. Was {:?}",
-                e
-            ),
+            for actual in [
+                // original key
+                log.get((
+                    lookup::PathPrefix::Event,
+                    log_schema().timestamp_key().unwrap(),
+                ))
+                .unwrap(),
+                // second key
+                log.get("another").unwrap(),
+            ] {
+                // type matches
+                assert_eq!(expected.kind_str(), actual.kind_str());
+                // value matches
+                assert_eq!(&expected, actual);
+            }
         }
     }
 

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 use lookup::lookup_v2::ConfigValuePath;
 use lookup::{event_path, PathPrefix};
+use ordered_float::NotNan;
 use serde::{Deserialize, Deserializer};
 use vector_config::configurable_component;
 use vector_core::event::{LogEvent, MaybeAsLogMut};
@@ -214,9 +215,9 @@ impl Transformer {
                 TimestampFormat::UnixNs => self.format_timestamps(log, |ts| {
                     ts.timestamp_nanos_opt().expect("Timestamp out of range")
                 }),
-                TimestampFormat::UnixFloat => {
-                    self.format_timestamps(log, |ts| ts.timestamp_micros() as f64 / 1e6)
-                }
+                TimestampFormat::UnixFloat => self.format_timestamps(log, |ts| {
+                    NotNan::new(ts.timestamp_micros() as f64 / 1e6).unwrap()
+                }),
                 // RFC3339 is the default serialization of a timestamp.
                 TimestampFormat::Rfc3339 => (),
             }

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -254,6 +254,10 @@ components: sinks: [Name=string]: {
 										enum: {
 											rfc3339: "Formats as a RFC3339 string"
 											unix:    "Formats as a unix timestamp"
+											unix_ms: "Formats as a unix timestamp in milliseconds"
+											unix_us: "Formats as a unix timestamp in microseconds"
+											unix_ns: "Formats as a unix timestamp in nanoseconds"
+											unix_float: "Formats as a unix timestamp in floating point"
 										}
 									}
 								}

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -252,11 +252,11 @@ components: sinks: [Name=string]: {
 									type: string: {
 										default: "rfc3339"
 										enum: {
-											rfc3339: "Formats as a RFC3339 string"
-											unix:    "Formats as a unix timestamp"
-											unix_ms: "Formats as a unix timestamp in milliseconds"
-											unix_us: "Formats as a unix timestamp in microseconds"
-											unix_ns: "Formats as a unix timestamp in nanoseconds"
+											rfc3339:    "Formats as a RFC3339 string"
+											unix:       "Formats as a unix timestamp"
+											unix_ms:    "Formats as a unix timestamp in milliseconds"
+											unix_us:    "Formats as a unix timestamp in microseconds"
+											unix_ns:    "Formats as a unix timestamp in nanoseconds"
 											unix_float: "Formats as a unix timestamp in floating point"
 										}
 									}

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -266,11 +266,11 @@ base: components: sinks: amqp: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -268,6 +268,10 @@ base: components: sinks: amqp: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -268,10 +268,10 @@ base: components: sinks: amqp: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -111,6 +111,10 @@ base: components: sinks: appsignal: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -109,11 +109,11 @@ base: components: sinks: appsignal: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -111,10 +111,10 @@ base: components: sinks: appsignal: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -437,11 +437,11 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -439,6 +439,10 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -439,10 +439,10 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -418,10 +418,10 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -416,11 +416,11 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -418,6 +418,10 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -416,11 +416,11 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -418,10 +418,10 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -418,6 +418,10 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -525,11 +525,11 @@ base: components: sinks: aws_s3: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -527,10 +527,10 @@ base: components: sinks: aws_s3: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -527,6 +527,10 @@ base: components: sinks: aws_s3: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -354,10 +354,10 @@ base: components: sinks: aws_sns: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -352,11 +352,11 @@ base: components: sinks: aws_sns: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -354,6 +354,10 @@ base: components: sinks: aws_sns: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -354,6 +354,10 @@ base: components: sinks: aws_sqs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -352,11 +352,11 @@ base: components: sinks: aws_sqs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -354,10 +354,10 @@ base: components: sinks: aws_sqs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -381,10 +381,10 @@ base: components: sinks: azure_blob: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -379,11 +379,11 @@ base: components: sinks: azure_blob: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -381,6 +381,10 @@ base: components: sinks: azure_blob: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -95,11 +95,11 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -97,6 +97,10 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -97,10 +97,10 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -168,6 +168,10 @@ base: components: sinks: clickhouse: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -166,11 +166,11 @@ base: components: sinks: clickhouse: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -168,10 +168,10 @@ base: components: sinks: clickhouse: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -252,6 +252,10 @@ base: components: sinks: console: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -250,11 +250,11 @@ base: components: sinks: console: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -252,10 +252,10 @@ base: components: sinks: console: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -271,10 +271,10 @@ base: components: sinks: databend: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -271,6 +271,10 @@ base: components: sinks: databend: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -269,11 +269,11 @@ base: components: sinks: databend: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -118,11 +118,11 @@ base: components: sinks: datadog_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -120,6 +120,10 @@ base: components: sinks: datadog_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -120,10 +120,10 @@ base: components: sinks: datadog_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -400,11 +400,11 @@ base: components: sinks: elasticsearch: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -402,10 +402,10 @@ base: components: sinks: elasticsearch: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -402,6 +402,10 @@ base: components: sinks: elasticsearch: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -272,10 +272,10 @@ base: components: sinks: file: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -272,6 +272,10 @@ base: components: sinks: file: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -270,11 +270,11 @@ base: components: sinks: file: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -319,11 +319,11 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -321,10 +321,10 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -321,6 +321,10 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -405,6 +405,10 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -405,10 +405,10 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -403,11 +403,11 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -319,10 +319,10 @@ base: components: sinks: gcp_pubsub: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -317,11 +317,11 @@ base: components: sinks: gcp_pubsub: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -319,6 +319,10 @@ base: components: sinks: gcp_pubsub: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -120,6 +120,10 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -118,11 +118,11 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -120,10 +120,10 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -89,6 +89,10 @@ base: components: sinks: honeycomb: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -89,10 +89,10 @@ base: components: sinks: honeycomb: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -87,11 +87,11 @@ base: components: sinks: honeycomb: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -360,10 +360,10 @@ base: components: sinks: http: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -358,11 +358,11 @@ base: components: sinks: http: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -360,6 +360,10 @@ base: components: sinks: http: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -313,6 +313,10 @@ base: components: sinks: humio_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -313,10 +313,10 @@ base: components: sinks: humio_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -311,11 +311,11 @@ base: components: sinks: humio_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -106,10 +106,10 @@ base: components: sinks: influxdb_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -106,6 +106,10 @@ base: components: sinks: influxdb_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -104,11 +104,11 @@ base: components: sinks: influxdb_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -305,11 +305,11 @@ base: components: sinks: kafka: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -307,6 +307,10 @@ base: components: sinks: kafka: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -307,10 +307,10 @@ base: components: sinks: kafka: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -102,6 +102,10 @@ base: components: sinks: logdna: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -102,10 +102,10 @@ base: components: sinks: logdna: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -100,11 +100,11 @@ base: components: sinks: logdna: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -362,11 +362,11 @@ base: components: sinks: loki: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -364,6 +364,10 @@ base: components: sinks: loki: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -364,10 +364,10 @@ base: components: sinks: loki: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -102,10 +102,10 @@ base: components: sinks: mezmo: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -102,6 +102,10 @@ base: components: sinks: mezmo: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -100,11 +100,11 @@ base: components: sinks: mezmo: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -350,11 +350,11 @@ base: components: sinks: nats: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -352,10 +352,10 @@ base: components: sinks: nats: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -352,6 +352,10 @@ base: components: sinks: nats: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -125,10 +125,10 @@ base: components: sinks: new_relic: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -125,6 +125,10 @@ base: components: sinks: new_relic: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -123,11 +123,11 @@ base: components: sinks: new_relic: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -252,10 +252,10 @@ base: components: sinks: papertrail: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -252,6 +252,10 @@ base: components: sinks: papertrail: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -250,11 +250,11 @@ base: components: sinks: papertrail: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -344,11 +344,11 @@ base: components: sinks: pulsar: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -346,10 +346,10 @@ base: components: sinks: pulsar: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -346,6 +346,10 @@ base: components: sinks: pulsar: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -305,10 +305,10 @@ base: components: sinks: redis: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -303,11 +303,11 @@ base: components: sinks: redis: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -305,6 +305,10 @@ base: components: sinks: redis: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -79,10 +79,10 @@ base: components: sinks: sematext_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -77,11 +77,11 @@ base: components: sinks: sematext_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -79,6 +79,10 @@ base: components: sinks: sematext_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -262,11 +262,11 @@ base: components: sinks: socket: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -264,10 +264,10 @@ base: components: sinks: socket: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -264,6 +264,10 @@ base: components: sinks: socket: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -363,10 +363,10 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -361,11 +361,11 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -363,6 +363,10 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -313,6 +313,10 @@ base: components: sinks: webhdfs: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -313,10 +313,10 @@ base: components: sinks: webhdfs: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -311,11 +311,11 @@ base: components: sinks: webhdfs: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -297,11 +297,11 @@ base: components: sinks: websocket: configuration: {
 				description: "Format used for timestamp fields."
 				required:    false
 				type: string: enum: {
-					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
-					unix:    "Represent the timestamp as a Unix timestamp."
-					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
+					unix:       "Represent the timestamp as a Unix timestamp."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -299,10 +299,10 @@ base: components: sinks: websocket: configuration: {
 				type: string: enum: {
 					rfc3339:    "Represent the timestamp as a RFC 3339 timestamp."
 					unix:       "Represent the timestamp as a Unix timestamp."
-					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
-					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds."
-					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
 					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
+					unix_ms:    "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_ns:    "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_us:    "Represent the timestamp as a Unix timestamp in microseconds"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -299,6 +299,10 @@ base: components: sinks: websocket: configuration: {
 				type: string: enum: {
 					rfc3339: "Represent the timestamp as a RFC 3339 timestamp."
 					unix:    "Represent the timestamp as a Unix timestamp."
+					unix_ms: "Represent the timestamp as a Unix timestamp in milliseconds."
+					unix_us: "Represent the timestamp as a Unix timestamp in microseconds."
+					unix_ns: "Represent the timestamp as a Unix timestamp in nanoseconds."
+					unix_float: "Represent the timestamp as a Unix timestamp in floating point."
 				}
 			}
 		}


### PR DESCRIPTION
* `unix_ms`: milliseconds
* `unix_us`: microseconds
* `unix_ns`: nanoseconds
* `unix_float`: seconds float

closes: https://github.com/vectordotdev/vector/issues/17323