### PR TITLE
chore(ci): Avoid installing homebrew formulas from source in CI

### DIFF
--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -6,9 +6,15 @@ unset HOMEBREW_NO_INSTALL_FROM_API
 
 brew update
 
-# `brew install` attempts to upgrade python as a dependency but fails
-# https://github.com/actions/setup-python/issues/577
-brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
+
+if [ -n "${CI-}" ] ; then
+  # avoid building formulas from source since this can take a _long_ time in CI
+  export HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=1
+
+  # `brew install` attempts to upgrade python as a dependency but fails
+  # https://github.com/actions/setup-python/issues/577
+  brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
+fi
 
 brew install ruby@2.7 coreutils cue-lang/tap/cue protobuf
 


### PR DESCRIPTION
Seeing if this avoids installing cmake build dependency to install protoc.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
