### PR TITLE
chore(ci): Bump MacOS unit test runners to 13

### DIFF
--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   unit-mac:
-    runs-on: macos-11
+    runs-on: macos-13
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -2,7 +2,6 @@ name: Unit - Mac
 
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   unit-mac:

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -2,6 +2,7 @@ name: Unit - Mac
 
 on:
   workflow_call:
+  pull_request:
 
 jobs:
   unit-mac:


### PR DESCRIPTION
We've observed a spike in CI times for the Mac unit tests that seems to be due to the fact that protoc is installed from source now (which pulls in a lot of dependencies like cmake) due to the precompiled binaries for MacOS 11 being dropped in https://github.com/Homebrew/homebrew-core/commit/8f9e41364f0396ec6a3b06ae6a2e5130513c1798

This updates the workflow to use MacOS 13 runners, which do have precompiled protoc binaries. This brings the bootstrap step back down to a comparable amount of time as before (~4 minutes).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
