### PR TITLE
fix(tls): for incoming connection alpn negotiation should be done using set_alpn_select_callback

### DIFF
--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -32,7 +32,7 @@ impl TlsSettings {
             Some(_) => {
                 let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls())
                     .context(CreateAcceptorSnafu)?;
-                self.apply_context(&mut acceptor)?;
+                self.apply_context_base(&mut acceptor, true)?;
                 Ok(acceptor.build())
             }
         }

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -9,7 +9,7 @@ use lookup::lookup_v2::OptionalValuePath;
 use openssl::{
     pkcs12::{ParsedPkcs12_2, Pkcs12},
     pkey::{PKey, Private},
-    ssl::{ConnectConfiguration, SslContextBuilder, SslVerifyMode},
+    ssl::{AlpnError, ConnectConfiguration, SslContextBuilder, SslVerifyMode, select_next_proto},
     stack::Stack,
     x509::{store::X509StoreBuilder, X509},
 };
@@ -268,6 +268,10 @@ impl TlsSettings {
     }
 
     pub(super) fn apply_context(&self, context: &mut SslContextBuilder) -> Result<()> {
+        self.apply_context_base(context, false)
+    }
+
+    pub(super) fn apply_context_base(&self, context: &mut SslContextBuilder, for_server: bool) -> Result<()> {
         context.set_verify(if self.verify_certificate {
             SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT
         } else {
@@ -310,9 +314,18 @@ impl TlsSettings {
         }
 
         if let Some(alpn) = &self.alpn_protocols {
-            context
-                .set_alpn_protos(alpn.as_slice())
-                .context(SetAlpnProtocolsSnafu)?;
+            if !for_server {
+                context
+                    .set_alpn_protos(alpn.as_slice())
+                    .context(SetAlpnProtocolsSnafu)?;
+            }
+            else {
+                let server_proto = alpn.clone();
+                context
+                    .set_alpn_select_callback(move |_, client_proto| {
+                        select_next_proto(server_proto.as_slice(), client_proto).ok_or(AlpnError::NOACK)
+                     })
+            }
         }
 
         Ok(())

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -318,15 +318,15 @@ impl TlsSettings {
         }
 
         if let Some(alpn) = &self.alpn_protocols {
-            if !for_server {
-                context
-                    .set_alpn_protos(alpn.as_slice())
-                    .context(SetAlpnProtocolsSnafu)?;
-            } else {
+            if for_server {
                 let server_proto = alpn.clone();
                 context.set_alpn_select_callback(move |_, client_proto| {
                     select_next_proto(server_proto.as_slice(), client_proto).ok_or(AlpnError::NOACK)
-                })
+                });
+            } else {
+                context
+                    .set_alpn_protos(alpn.as_slice())
+                    .context(SetAlpnProtocolsSnafu)?;
             }
         }
 


### PR DESCRIPTION
as reported in the issue https://github.com/vectordotdev/vector/issues/18842 for incoming connect alpn protocol negotiation do not happen.

as documented in https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_alpn_select_cb.html server should use SSL_CTX_set_alpn_select_cb() ([set_alpn_select_callback](https://docs.rs/openssl/latest/openssl/ssl/struct.SslContextBuilder.html#method.set_alpn_select_callback)) for selecting protocol while client should use SSL_CTX_set_alpn_protos() 

in this PR, allow setting alpn based on wether context is for client or server and use for_server flag in incoming connections.

after fix same curl returns below
```
curl -k -vv  -X POST https://localhost:443 -d "hello"
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:443...
* Connected to localhost (127.0.0.1) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=localhost
*  start date: Sep 20 01:21:19 2023 GMT
*  expire date: Dec 23 01:21:19 2025 GMT
*  issuer: C=US; ST=CA; CN=localhost
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* using HTTP/2
* h2 [:method: POST]
* h2 [:scheme: https]
* h2 [:authority: localhost]
* h2 [:path: /]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* h2 [content-length: 5]
* h2 [content-type: application/x-www-form-urlencoded]
* Using Stream ID: 1 (easy handle 0x7f9777810a00)
> POST / HTTP/2
> Host: localhost
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Length: 5
> Content-Type: application/x-www-form-urlencoded
> 
* We are completely uploaded and fine
< HTTP/2 200 
< date: Sat, 14 Oct 2023 17:33:34 GMT
< 
* Connection #0 to host localhost left intact

```

 
 