### PR TITLE
fix(dnstap source): support DNSSEC RRSIG record data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 docs/ @vectordotdev/ux-team
+lib/dnsmsg-parser/ @vectordotdev/integrations-team
 lib/file-source/ @vectordotdev/integrations-team
 lib/k8s-e2e-tests/ @vectordotdev/integrations-team
 lib/k8s-test-framework/ @vectordotdev/integrations-team


### PR DESCRIPTION
Fixes: https://github.com/vectordotdev/vector/issues/18854

In Vector v0.33.0, we upgraded the trust-dns-proto crate, which is used in the parsing of the dns messages for the dnstap source.

That dependency crate upgrade from v0.22.0 to v0.23.0 , introduced a change wherein the enum DNSSECRData was expanded with a new variant, RRSIG.

In the parser logic for that enum, that rdata type was previously considered "Unknown" by the trust-dns-proto , and in Vector we considered that Ok. But now it falls into the catch-all case in Vector, because we don't have a specific handling for the RSIG rdata type, which results in a `WARN` log to the user because we failed to parse the incoming data into an event.

So this is a case of an upstream dependency upgrade silently (our existing tests didn't cover this case) introducing logic that results in a functional regression in Vector.

The fix is to properly handle the RRSIG variant in the parser logic.

### Testing done

- I first added the unit test, and confirmed it fails when the parser logic is unmodified.
- Also manually validated the `dnstap` source works with the DNSSEC RRSIG record type using the methods provided by the bug reporter (https://github.com/vectordotdev/vector/issues/18854#issuecomment-1766908103)
