### PR TITLE
fix(datadog_agent source, datadog_metrics sink): handle interval for non-rate series metrics

### DIFF
--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -72,11 +72,15 @@ fn generate_counter_gauge_set() -> Vec<Event> {
     let ts = Utc::now().trunc_subsecs(3);
     let events = vec![
         // gauge
-        Event::Metric(Metric::new(
-            "gauge",
-            MetricKind::Incremental,
-            MetricValue::Gauge { value: 5678.0 },
-        )),
+        Event::Metric(
+            Metric::new(
+                "gauge",
+                MetricKind::Incremental,
+                MetricValue::Gauge { value: 5678.0 },
+            )
+            // Dogstatsd outputs guages with an interval
+            .with_interval_ms(NonZeroU32::new(10000)),
+        ),
         // counter with interval
         Event::Metric(
             Metric::new(
@@ -306,7 +310,7 @@ fn validate_protobuf_set_gauge_rate(request: &(Parts, Bytes)) {
             gauge.r#type(),
             ddmetric_proto::metric_payload::MetricType::Gauge
         );
-        assert_eq!(gauge.interval, 0);
+        assert_eq!(gauge.interval, 10);
         assert_eq!(gauge.points[0].value, 2_f64);
     }
 

--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -310,7 +310,7 @@ fn validate_protobuf_set_gauge_rate(request: &(Parts, Bytes)) {
             gauge.r#type(),
             ddmetric_proto::metric_payload::MetricType::Gauge
         );
-        assert_eq!(gauge.interval, 10);
+        assert_eq!(gauge.interval, 0);
         assert_eq!(gauge.points[0].value, 2_f64);
     }
 
@@ -322,7 +322,7 @@ fn validate_protobuf_set_gauge_rate(request: &(Parts, Bytes)) {
             ddmetric_proto::metric_payload::MetricType::Gauge
         );
         assert_eq!(gauge.points[0].value, 5678.0);
-        assert_eq!(gauge.interval, 0);
+        assert_eq!(gauge.interval, 10);
     }
 
     // validate counter w interval = rate

--- a/src/sinks/datadog/metrics/integration_tests.rs
+++ b/src/sinks/datadog/metrics/integration_tests.rs
@@ -78,7 +78,7 @@ fn generate_counter_gauge_set() -> Vec<Event> {
                 MetricKind::Incremental,
                 MetricValue::Gauge { value: 5678.0 },
             )
-            // Dogstatsd outputs guages with an interval
+            // Dogstatsd outputs gauges with an interval
             .with_interval_ms(NonZeroU32::new(10000)),
         ),
         // counter with interval

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -273,7 +273,7 @@ pub(crate) fn decode_ddseries_v2(
             // we are distinguishing Rate from Count by setting an interval to Rate but not Count.
             //
             // In theory we should be safe to set this non-rate-interval to Count metrics below, but to be safe,
-            // we will only set it for Rate and Guage. This matches the behavior of dogstatsd<->Agent<->Datadog.
+            // we will only set it for Rate and Gauge. This matches the behavior of dogstatsd<->Agent<->Datadog.
             //
             // Ultimately we should have a unique internal representation of a Rate metric type.
             let non_rate_interval = if serie.interval.is_positive() {

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -268,7 +268,7 @@ pub(crate) fn decode_ddseries_v2(
 
             // The Agent can send non-rate metrics with an interval, and that is used in the Datadog UI,
             // thus we pass through the interval regardless of metric type, if it is set. This happens
-            // in the case of DogstatsD. Critically, the only time a Count metric type is emitted by Dogstatsd,
+            // in the case of DogStatsD. Critically, the only time a Count metric type is emitted by DogStatsD,
             // is in the Sketch endpoint. Because Vector does not yet have a specific Metric type to handle Rate,
             // we are distinguishing Rate from Count by setting an interval to Rate but not Count.
             //

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1902,7 +1902,7 @@ async fn decode_series_endpoint_v2() {
                 r#type: ddmetric_proto::metric_payload::MetricType::Gauge as i32,
                 unit: "".to_string(),
                 source_type_name: "a_random_source_type_name".to_string(),
-                interval: 0,
+                interval: 10, // Dogstatsd sets Gauge interval to 10 by default
                 metadata: None,
             },
             ddmetric_proto::metric_payload::MetricSeries {
@@ -1982,6 +1982,13 @@ async fn decode_series_endpoint_v2() {
                 )
             );
             assert_eq!(metric.kind(), MetricKind::Absolute);
+            assert_eq!(
+                metric
+                    .interval_ms()
+                    .expect("should have set interval")
+                    .get(),
+                10000
+            );
             assert_eq!(*metric.value(), MetricValue::Gauge { value: 3.14 });
             assert_tags(
                 metric,
@@ -2006,6 +2013,13 @@ async fn decode_series_endpoint_v2() {
             );
             assert_eq!(metric.kind(), MetricKind::Absolute);
             assert_eq!(*metric.value(), MetricValue::Gauge { value: 3.1415 });
+            assert_eq!(
+                metric
+                    .interval_ms()
+                    .expect("should have set interval")
+                    .get(),
+                10000
+            );
             assert_tags(
                 metric,
                 metric_tags!(


### PR DESCRIPTION
At a high level this change is essentially motivated by an inconsistency in behavior between Vector and the Agent when dealing with non-rate Series metrics that have an interval set. This was discovered while implementing #18533.

### The problem

Vector currently when decoding incoming (series) metrics coming from the `datadog_agent` source, only sets an interval to ingested rate metrics. But, it is possible to receive non-rate metrics with intervals set. This is relevant to users of the Datadog platform, where in the UI one can select the `as_rate` option.

An example of this is that DogStatsD by default sets all metrics with an interval of `10` seconds, regardless of type. Due to the matrix of input metrics on series (count, rate, gauge) , crossed with the submission types from DogStatsD (https://docs.datadoghq.com/metrics/types/?tab=count#submission-types-and-datadog-in-app-types) , this boils down to Rate and Gauge metric types, since Count are sent as Rate.

Why is that important?

Because Vector does not yet represent Rate in it's internal data model of metrics. Instead we rely on setting the interval for rate metrics in order to distinguish them from counters. The ultimate solution is to implement support for a unique Rate metric type in Vector, but that is not a small effort. Thus,

### The solution

(1)  In the `datadog_agent` source, if a gauge is ingested with an interval set, we will set the interval for that metric in Vector. Note we don't do this for Counters because of the aforementioned lack of proper Rate type. We are generally "safe" in this case though, because DogStatsD does not emit count metrics, it emits rate metrics (ok it does on distributions but those are on the Sketches endpoint).

(2) In the `datadog_metrics` sink, if any internal representation of a series metric has an interval set, we encode that interval.  

This provides us with more consistent behavior with the Agent. It is not _exactly_ consistent, because in theory a counter could be emitted with an interval. But it's closer.

Additionally, this is more correct behavior for metrics ingested from non-Agent sources, which may have set an interval on their Count metrics
