### PR TITLE
fix(buffers): apply stricter file permissions to buffer data files when possible

### DIFF
--- a/lib/vector-buffers/src/variants/disk_v2/io.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/io.rs
@@ -6,6 +6,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
 };
 
+#[cfg(unix)]
 const FILE_MODE_OWNER_RW_GROUP_RO: u32 = 0o640;
 
 /// File metadata.

--- a/lib/vector-buffers/src/variants/disk_v2/io.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/io.rs
@@ -3,7 +3,7 @@ use std::{io, path::Path};
 use async_trait::async_trait;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-const FILE_MODE_OWNER_RW_ONLY: u32 = 0o600;
+const FILE_MODE_OWNER_RW_GROUP_RO: u32 = 0o640;
 
 /// File metadata.
 pub struct Metadata {
@@ -176,7 +176,7 @@ impl Filesystem for ProductionFilesystem {
 
 #[cfg(unix)]
 fn configure_file_open_options_for_write(open_options: &mut tokio::fs::OpenOptions) {
-    open_options.mode(FILE_MODE_OWNER_RW_ONLY);
+    open_options.mode(FILE_MODE_OWNER_RW_GROUP_RO);
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
This PR adds logic that constrains the file permissions for disk buffer data files, as well as the ledger, to only be readable/writable by the file owner: the user that the Vector process is running as.

Currently, the default permissions will typically to the files being readable by the group owner and world/other. There is no reason for outside processes to be able to read the disk buffer files. With the addition of secrets metadata to events stored in disk buffers, we want to ensure that the data files are as narrowly scoped to Vector as possible.

This has no affect on Windows systems, where setting file ACLs is more complex and does not have anywhere near as easy of a solution in code as doing so for Unix-based systems. This will likely be addressed in a future PR.

Fixes #18853.