### PR TITLE
enhancement(file source, kubernetes_logs source): add rotate_wait_ms config option

### DIFF
--- a/changelog.d/18863_k8s_logs_rotate_wait.enhancement.md
+++ b/changelog.d/18863_k8s_logs_rotate_wait.enhancement.md
@@ -1,0 +1,3 @@
+A new configuration option `rotate_wait_secs` was added to the `file` and `kubernetes_logs` sources. `rotate_wait_secs` determines for how long Vector keeps trying to read from a log file that has been deleted. Once that time span has expired, Vector stops reading from and closes the file descriptor of the deleted file, thus allowing the OS to reclaim the storage space occupied by the file.
+
+authors: syedriko

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -52,6 +52,7 @@ where
     pub remove_after: Option<Duration>,
     pub emitter: E,
     pub handle: tokio::runtime::Handle,
+    pub rotate_wait: Duration,
 }
 
 /// `FileServer` as Source
@@ -292,11 +293,18 @@ where
                 }
             }
 
+            for (_, watcher) in &mut fp_map {
+                if !watcher.file_findable() && watcher.last_seen().elapsed() > self.rotate_wait {
+                    watcher.set_dead();
+                }
+            }
+
             // A FileWatcher is dead when the underlying file has disappeared.
             // If the FileWatcher is dead we don't retain it; it will be deallocated.
             fp_map.retain(|file_id, watcher| {
                 if watcher.dead() {
-                    self.emitter.emit_file_unwatched(&watcher.path);
+                    self.emitter
+                        .emit_file_unwatched(&watcher.path, watcher.reached_eof());
                     checkpoints.set_dead(*file_id);
                     false
                 } else {

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -529,7 +529,7 @@ mod test {
             panic!();
         }
 
-        fn emit_file_unwatched(&self, _: &Path) {}
+        fn emit_file_unwatched(&self, _: &Path, _: bool) {}
 
         fn emit_file_deleted(&self, _: &Path) {}
 

--- a/lib/file-source/src/internal_events.rs
+++ b/lib/file-source/src/internal_events.rs
@@ -9,7 +9,7 @@ pub trait FileSourceInternalEvents: Send + Sync + Clone + 'static {
 
     fn emit_file_watch_error(&self, path: &Path, error: Error);
 
-    fn emit_file_unwatched(&self, path: &Path);
+    fn emit_file_unwatched(&self, path: &Path, reached_eof: bool);
 
     fn emit_file_deleted(&self, path: &Path);
 

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -305,21 +305,27 @@ mod source {
     pub struct FileUnwatched<'a> {
         pub file: &'a Path,
         pub include_file_metric_tag: bool,
+        pub reached_eof: bool,
     }
 
     impl<'a> InternalEvent for FileUnwatched<'a> {
         fn emit(self) {
+            let reached_eof = if self.reached_eof { "true" } else { "false" };
             info!(
                 message = "Stopped watching file.",
                 file = %self.file.display(),
+                reached_eof
             );
             if self.include_file_metric_tag {
                 counter!(
                     "files_unwatched_total", 1,
                     "file" => self.file.to_string_lossy().into_owned(),
+                    "reached_eof" => reached_eof,
                 );
             } else {
-                counter!("files_unwatched_total", 1);
+                counter!("files_unwatched_total", 1,
+                    "reached_eof" => reached_eof,
+                );
             }
         }
     }
@@ -505,10 +511,11 @@ mod source {
             });
         }
 
-        fn emit_file_unwatched(&self, file: &Path) {
+        fn emit_file_unwatched(&self, file: &Path, reached_eof: bool) {
             emit!(FileUnwatched {
                 file,
-                include_file_metric_tag: self.include_file_metric_tag
+                include_file_metric_tag: self.include_file_metric_tag,
+                reached_eof
             });
         }
 

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -368,4 +368,15 @@ base: components: sources: file: configuration: {
 			unit: "seconds"
 		}
 	}
+	rotate_wait_secs: {
+		description: """
+			How long to keep an open handle to a rotated log file.
+			The default value represents "no limit"
+			"""
+		required: false
+		type: uint: {
+			default: 9223372036854775807
+			unit:    "seconds"
+		}
+	}
 }

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -405,6 +405,17 @@ base: components: sources: kubernetes_logs: configuration: {
 			}
 		}
 	}
+	rotate_wait_secs: {
+		description: """
+			How long to keep an open handle to a rotated log file.
+			The default value represents "no limit"
+			"""
+		required: false
+		type: uint: {
+			default: 9223372036854775807
+			unit:    "seconds"
+		}
+	}
 	self_node_name: {
 		description: """
 			The name of the Kubernetes [Node][node] that is running.


### PR DESCRIPTION
* enhancement(file source)
* enhancement(kubernetes_logs source) 
For the file and kubernetes_logs sources, introduced a new configuration variable, rotate_wait, of type Duration, defaulting to practical infinity. Out of the box, this default effectively turns this feature off. rotate_wait determines for how long vector keeps trying to read from a log file that has been deleted (most likely due to log rotation, hence the name of the variable). Once that time span has expired, vector stops reading from and closes the file descriptor of the deleted file, thus allowing the OS to reclaim the storage space occupied by the file. This behavior is similar to that of Fluentd's tail plugin: https://docs.fluentd.org/input/tail#rotate_wait .

Addresses https://github.com/vectordotdev/vector/issues/18863
