### PR TITLE
chore(ci): filter team members from gardener issue comment workflow

### DIFF
--- a/.github/workflows/gardener_issue_comment.yml
+++ b/.github/workflows/gardener_issue_comment.yml
@@ -1,7 +1,8 @@
 # Gardener Issue Comment
 #
 # This workflow moves GH issues from the Gardener board's "Blocked / Waiting" column
-# to the "Triage", so that the Gardener can assess the issue in light of new information.
+# to "Triage", when a comment is posted on an issue from a non-team member
+# so that the Gardener can assess the issue in light of new information.
 
 name: Gardener Issue Comment
 
@@ -15,6 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.issue.url, 'issues')
     steps:
+      - name: Generate authentication token
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          app_id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
+          private_key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
+
+      - name: Get PR comment author
+        id: comment
+        uses: tspascoal/get-user-teams-membership@v3
+        with:
+          username: ${{ github.actor }}
+          team: 'Vector'
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Exit if author is team member
+        if: steps.comment.outputs.isTeamMember == 'true'
+        run: exit 0
+
       - name: Move issue back to Triage if status is Blocked/Waiting
         env:
           GH_TOKEN: ${{ secrets.GH_PROJECT_PAT }}

--- a/.github/workflows/gardener_issue_comment.yml
+++ b/.github/workflows/gardener_issue_comment.yml
@@ -31,11 +31,8 @@ jobs:
           team: 'Vector'
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      - name: Exit if author is team member
-        if: steps.comment.outputs.isTeamMember == 'true'
-        run: exit 0
-
       - name: Move issue back to Triage if status is Blocked/Waiting
+        if: steps.comment.outputs.isTeamMember == 'false'
         env:
           GH_TOKEN: ${{ secrets.GH_PROJECT_PAT }}
         run: |


### PR DESCRIPTION
Currently one annoyance is that when an issue is in Triage column and a team member posts a comment and moves that issue to Blocked/Waiting at the same time, the workflow triggers and moves that back to the Triage column 😭  so this change disables the movement for team members.
