### PR TITLE
chore(core): Set up internal topology API

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,5 @@
 #![allow(missing_docs)]
-use std::{
-    collections::HashMap, num::NonZeroUsize, path::PathBuf, process::ExitStatus, time::Duration,
-};
+use std::{num::NonZeroUsize, path::PathBuf, process::ExitStatus, time::Duration};
 
 use exitcode::ExitCode;
 use futures::StreamExt;
@@ -29,10 +27,7 @@ use crate::{
     config::{self, Config, ConfigPath},
     heartbeat,
     signal::{ShutdownError, SignalHandler, SignalPair, SignalRx, SignalTo},
-    topology::{
-        ReloadOutcome, RunningTopology, SharedTopologyController, TopologyController,
-        TopologyPieces,
-    },
+    topology::{ReloadOutcome, RunningTopology, SharedTopologyController, TopologyController},
     trace,
 };
 
@@ -100,17 +95,13 @@ impl ApplicationConfig {
         #[cfg(feature = "enterprise")]
         let enterprise = build_enterprise(&mut config, config_paths.clone())?;
 
-        let diff = config::ConfigDiff::initial(&config);
-        let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
-            .await
-            .ok_or(exitcode::CONFIG)?;
-
         #[cfg(feature = "api")]
         let api = config.api;
 
-        let result = RunningTopology::start_validated(config, diff, pieces).await;
         let (topology, (graceful_crash_sender, graceful_crash_receiver)) =
-            result.ok_or(exitcode::CONFIG)?;
+            RunningTopology::start_init_validated(config)
+                .await
+                .ok_or(exitcode::CONFIG)?;
 
         Ok(Self {
             config_paths,

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,30 +157,6 @@ impl ApplicationConfig {
     }
 }
 
-#[cfg(all(feature = "sources-internal_metrics", feature = "sinks-console"))]
-fn internal_config() -> Config {
-    use crate::sinks::console;
-    let mut config = crate::config::ConfigBuilder::default();
-    config.add_source(
-        "_internal_metrics",
-        crate::sources::internal_metrics::InternalMetricsConfig::default(),
-    );
-    config.add_sink(
-        "_internal_console",
-        &["_internal_metrics"],
-        console::ConsoleSinkConfig {
-            target: console::Target::Stdout,
-            encoding: crate::codecs::EncodingConfigWithFraming::new(
-                None,
-                codecs::encoding::SerializerConfig::Text(Default::default()),
-                Default::default(),
-            ),
-            acknowledgements: None.into(),
-        },
-    );
-    config.build().expect("Could not build internal config")
-}
-
 impl Application {
     pub fn run() -> ExitStatus {
         let (runtime, app) = Self::prepare_start().unwrap_or_else(|code| std::process::exit(code));
@@ -189,15 +165,8 @@ impl Application {
     }
 
     pub fn prepare_start() -> Result<(Runtime, StartedApplication), ExitCode> {
-        #[allow(unused_mut)]
-        Self::prepare().and_then(|(runtime, mut app)| {
-            #[cfg(all(feature = "sources-internal_metrics", feature = "sinks-console"))]
-            {
-                let config = internal_config();
-                runtime.block_on(app.config.add_internal_config(config))?;
-            }
-            app.start(runtime.handle()).map(|app| (runtime, app))
-        })
+        Self::prepare()
+            .and_then(|(runtime, app)| app.start(runtime.handle()).map(|app| (runtime, app)))
     }
 
     pub fn prepare() -> Result<(Runtime, Self), ExitCode> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,7 +107,7 @@ impl ApplicationConfig {
         #[cfg(feature = "api")]
         let api = config.api;
 
-        let result = topology::start_validated(config, diff, pieces).await;
+        let result = RunningTopology::start_validated(config, diff, pieces).await;
         let (topology, (graceful_crash_sender, graceful_crash_receiver)) =
             result.ok_or(exitcode::CONFIG)?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,8 @@ use crate::{
     heartbeat,
     signal::{ShutdownError, SignalHandler, SignalPair, SignalRx, SignalTo},
     topology::{
-        self, ReloadOutcome, RunningTopology, SharedTopologyController, TopologyController,
+        ReloadOutcome, RunningTopology, SharedTopologyController, TopologyController,
+        TopologyPieces,
     },
     trace,
 };
@@ -100,7 +101,7 @@ impl ApplicationConfig {
         let enterprise = build_enterprise(&mut config, config_paths.clone())?;
 
         let diff = config::ConfigDiff::initial(&config);
-        let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+        let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
             .await
             .ok_or(exitcode::CONFIG)?;
 

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -24,8 +24,8 @@ use vector_core::{event::Event, EstimatedJsonEncodedSizeOf};
 use crate::{
     codecs::Encoder,
     components::validation::{RunnerMetrics, TestCase},
-    config::{ConfigBuilder, ConfigDiff},
-    topology::{RunningTopology, TopologyPieces},
+    config::ConfigBuilder,
+    topology::RunningTopology,
 };
 
 use super::{
@@ -471,7 +471,6 @@ fn spawn_component_topology(
         .build()
         .expect("config should not have any errors");
     config.healthchecks.set_require_healthy(Some(true));
-    let config_diff = ConfigDiff::initial(&config);
 
     _ = std::thread::spawn(move || {
         let test_runtime = Builder::new_current_thread()
@@ -482,13 +481,8 @@ fn spawn_component_topology(
         test_runtime.block_on(async move {
             debug!("Building component topology...");
 
-            let pieces = TopologyPieces::build_or_log_errors(&config, &config_diff, HashMap::new())
-                .await
-                .unwrap();
             let (topology, (_, mut crash_rx)) =
-                RunningTopology::start_validated(config, config_diff, pieces)
-                    .await
-                    .unwrap();
+                RunningTopology::start_init_validated(config).await.unwrap();
 
             debug!("Component topology built and spawned.");
             topology_started.mark_as_done();

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -481,7 +481,7 @@ fn spawn_component_topology(
         test_runtime.block_on(async move {
             debug!("Building component topology...");
 
-            let (topology, (_, mut crash_rx)) =
+            let (topology, mut crash_rx) =
                 RunningTopology::start_init_validated(config).await.unwrap();
 
             debug!("Component topology built and spawned.");

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     codecs::Encoder,
     components::validation::{RunnerMetrics, TestCase},
     config::{ConfigBuilder, ConfigDiff},
-    topology,
+    topology::{self, RunningTopology},
 };
 
 use super::{
@@ -486,7 +486,7 @@ fn spawn_component_topology(
                 .await
                 .unwrap();
             let (topology, (_, mut crash_rx)) =
-                topology::start_validated(config, config_diff, pieces)
+                RunningTopology::start_validated(config, config_diff, pieces)
                     .await
                     .unwrap();
 

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     codecs::Encoder,
     components::validation::{RunnerMetrics, TestCase},
     config::{ConfigBuilder, ConfigDiff},
-    topology::{self, RunningTopology},
+    topology::{RunningTopology, TopologyPieces},
 };
 
 use super::{
@@ -482,7 +482,7 @@ fn spawn_component_topology(
         test_runtime.block_on(async move {
             debug!("Building component topology...");
 
-            let pieces = topology::build_or_log_errors(&config, &config_diff, HashMap::new())
+            let pieces = TopologyPieces::build_or_log_errors(&config, &config_diff, HashMap::new())
                 .await
                 .unwrap();
             let (topology, (_, mut crash_rx)) =

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -566,7 +566,7 @@ mod tests {
                 let c2 = config::load_from_str(config, format).unwrap();
                 match (
                     config::warnings(&c2),
-                    topology::builder::build_pieces(&c, &diff, HashMap::new()).await,
+                    topology::TopologyPieces::build(&c, &diff, HashMap::new()).await,
                 ) {
                     (warnings, Ok(_pieces)) => Ok(warnings),
                     (_, Err(errors)) => Err(errors),

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -29,10 +29,7 @@ use crate::{
     },
     event::{Event, LogEvent, Value},
     signal,
-    topology::{
-        builder::{self, TopologyPieces},
-        RunningTopology,
-    },
+    topology::{builder::TopologyPieces, RunningTopology},
 };
 
 pub struct UnitTest {
@@ -422,7 +419,7 @@ async fn build_unit_test(
     }
     let config = config_builder.build()?;
     let diff = config::ConfigDiff::initial(&config);
-    let pieces = builder::build_pieces(&config, &diff, HashMap::new()).await?;
+    let pieces = TopologyPieces::build(&config, &diff, HashMap::new()).await?;
 
     Ok(UnitTest {
         name: test.name,

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -31,14 +31,14 @@ use crate::{
     signal,
     topology::{
         self,
-        builder::{self, Pieces},
+        builder::{self, TopologyPieces},
     },
 };
 
 pub struct UnitTest {
     pub name: String,
     config: Config,
-    pieces: Pieces,
+    pieces: TopologyPieces,
     test_result_rxs: Vec<Receiver<UnitTestSinkResult>>,
 }
 

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -30,8 +30,8 @@ use crate::{
     event::{Event, LogEvent, Value},
     signal,
     topology::{
-        self,
         builder::{self, TopologyPieces},
+        RunningTopology,
     },
 };
 
@@ -49,7 +49,7 @@ pub struct UnitTestResult {
 impl UnitTest {
     pub async fn run(self) -> UnitTestResult {
         let diff = config::ConfigDiff::initial(&self.config);
-        let (topology, _) = topology::start_validated(self.config, diff, self.pieces)
+        let (topology, _) = RunningTopology::start_validated(self.config, diff, self.pieces)
             .await
             .unwrap();
         topology.sources_finished().await;

--- a/src/sinks/datadog/traces/apm_stats/integration_tests.rs
+++ b/src/sinks/datadog/traces/apm_stats/integration_tests.rs
@@ -16,11 +16,10 @@ use tokio::time::{sleep, Duration};
 
 use crate::{
     config::ConfigBuilder,
-    signal::ShutdownError,
     sinks::datadog::traces::{apm_stats::StatsPayload, DatadogTracesConfig},
     sources::datadog_agent::DatadogAgentConfig,
     test_util::{start_topology, trace_init},
-    topology::RunningTopology,
+    topology::{RunningTopology, ShutdownErrorReceiver},
 };
 
 /// The port on which the Agent will send traces to vector, and vector `datadog_agent` source will
@@ -320,13 +319,7 @@ fn validate_stats(agent_stats: &StatsPayload, vector_stats: &StatsPayload) {
 /// This creates a scenario where the stats payload that is output by the sink after processing the
 /// *second* batch of events (the second event) *should* contain the aggregated statistics of both
 /// of the trace events. i.e , the hit count for that bucket should be equal to "2" , not "1".
-async fn start_vector() -> (
-    RunningTopology,
-    (
-        tokio::sync::mpsc::UnboundedSender<ShutdownError>,
-        tokio::sync::mpsc::UnboundedReceiver<ShutdownError>,
-    ),
-) {
+async fn start_vector() -> (RunningTopology, ShutdownErrorReceiver) {
     let dd_agent_address = format!("0.0.0.0:{}", vector_receive_port());
 
     let source_config = toml::from_str::<DatadogAgentConfig>(&format!(

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -41,7 +41,7 @@ use zstd::Decoder as ZstdDecoder;
 
 use crate::{
     config::{Config, GenerateConfig},
-    topology::{RunningTopology, ShutdownErrorPair},
+    topology::{RunningTopology, ShutdownErrorReceiver},
     trace,
 };
 
@@ -680,7 +680,7 @@ impl CountReceiver<Event> {
 pub async fn start_topology(
     mut config: Config,
     require_healthy: impl Into<Option<bool>>,
-) -> (RunningTopology, ShutdownErrorPair) {
+) -> (RunningTopology, ShutdownErrorReceiver) {
     config.healthchecks.set_require_healthy(require_healthy);
     RunningTopology::start_init_validated(config).await.unwrap()
 }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -693,7 +693,7 @@ pub async fn start_topology(
     let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
-    topology::start_validated(config, diff, pieces)
+    RunningTopology::start_validated(config, diff, pieces)
         .await
         .unwrap()
 }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -42,7 +42,7 @@ use zstd::Decoder as ZstdDecoder;
 use crate::{
     config::{Config, ConfigDiff, GenerateConfig},
     signal::ShutdownError,
-    topology::{self, RunningTopology},
+    topology::{RunningTopology, TopologyPieces},
     trace,
 };
 
@@ -690,7 +690,7 @@ pub async fn start_topology(
 ) {
     config.healthchecks.set_require_healthy(require_healthy);
     let diff = ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+    let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
     RunningTopology::start_validated(config, diff, pieces)

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -73,15 +73,6 @@ static TRANSFORM_CONCURRENCY_LIMIT: Lazy<usize> = Lazy::new(|| {
 
 const INTERNAL_SOURCES: [&str; 2] = ["internal_logs", "internal_metrics"];
 
-/// Builds only the new pieces, and doesn't check their topology.
-pub async fn build_pieces(
-    config: &super::Config,
-    diff: &ConfigDiff,
-    buffers: HashMap<ComponentKey, BuiltBuffer>,
-) -> Result<TopologyPieces, Vec<String>> {
-    Builder::new(config, diff, buffers).build().await
-}
-
 struct Builder<'a> {
     config: &'a super::Config,
     diff: &'a ConfigDiff,
@@ -685,6 +676,17 @@ pub struct TopologyPieces {
     pub(super) healthchecks: HashMap<ComponentKey, Task>,
     pub(crate) shutdown_coordinator: SourceShutdownCoordinator,
     pub(crate) detach_triggers: HashMap<ComponentKey, Trigger>,
+}
+
+impl TopologyPieces {
+    /// Builds only the new pieces, and doesn't check their topology.
+    pub async fn build(
+        config: &super::Config,
+        diff: &ConfigDiff,
+        buffers: HashMap<ComponentKey, BuiltBuffer>,
+    ) -> Result<Self, Vec<String>> {
+        Builder::new(config, diff, buffers).build().await
+    }
 }
 
 const fn filter_events_type(events: &EventArray, data_type: DataType) -> bool {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -78,7 +78,7 @@ pub async fn build_pieces(
     config: &super::Config,
     diff: &ConfigDiff,
     buffers: HashMap<ComponentKey, BuiltBuffer>,
-) -> Result<Pieces, Vec<String>> {
+) -> Result<TopologyPieces, Vec<String>> {
     Builder::new(config, diff, buffers).build().await
 }
 
@@ -116,7 +116,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Builds the new pieces of the topology found in `self.diff`.
-    async fn build(mut self) -> Result<Pieces, Vec<String>> {
+    async fn build(mut self) -> Result<TopologyPieces, Vec<String>> {
         let enrichment_tables = self.load_enrichment_tables().await;
         let source_tasks = self.build_sources().await;
         self.build_transforms(enrichment_tables).await;
@@ -127,7 +127,7 @@ impl<'a> Builder<'a> {
         enrichment_tables.finish_load();
 
         if self.errors.is_empty() {
-            Ok(Pieces {
+            Ok(TopologyPieces {
                 inputs: self.inputs,
                 outputs: Self::finalize_outputs(self.outputs),
                 tasks: self.tasks,
@@ -677,7 +677,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-pub struct Pieces {
+pub struct TopologyPieces {
     pub(super) inputs: HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
     pub(crate) outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
     pub(super) tasks: HashMap<ComponentKey, Task>,

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -31,7 +31,7 @@ use vector_buffers::topology::channel::{BufferReceiverStream, BufferSender};
 
 pub use self::builder::TopologyPieces;
 pub use self::controller::{ReloadOutcome, SharedTopologyController, TopologyController};
-pub use self::running::{RunningTopology, ShutdownErrorPair};
+pub use self::running::{RunningTopology, ShutdownErrorReceiver};
 
 use self::task::{Task, TaskError, TaskResult};
 use crate::{

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -31,7 +31,7 @@ use vector_buffers::topology::channel::{BufferReceiverStream, BufferSender};
 
 pub use self::builder::TopologyPieces;
 pub use self::controller::{ReloadOutcome, SharedTopologyController, TopologyController};
-pub use self::running::RunningTopology;
+pub use self::running::{RunningTopology, ShutdownErrorPair};
 
 use self::task::{Task, TaskError, TaskResult};
 use crate::{

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -75,22 +75,6 @@ pub struct TapResource {
 type WatchTx = watch::Sender<TapResource>;
 pub type WatchRx = watch::Receiver<TapResource>;
 
-pub async fn build_or_log_errors(
-    config: &Config,
-    diff: &ConfigDiff,
-    buffers: HashMap<ComponentKey, BuiltBuffer>,
-) -> Option<TopologyPieces> {
-    match TopologyPieces::build(config, diff, buffers).await {
-        Err(errors) => {
-            for error in errors {
-                error!(message = "Configuration error.", %error);
-            }
-            None
-        }
-        Ok(new_pieces) => Some(new_pieces),
-    }
-}
-
 pub(super) fn take_healthchecks(
     diff: &ConfigDiff,
     pieces: &mut TopologyPieces,

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -29,10 +29,10 @@ use futures::{Future, FutureExt};
 use tokio::sync::{mpsc, watch};
 use vector_buffers::topology::channel::{BufferReceiverStream, BufferSender};
 
+pub use self::builder::TopologyPieces;
 pub use self::controller::{ReloadOutcome, SharedTopologyController, TopologyController};
 pub use self::running::RunningTopology;
 
-use self::builder::TopologyPieces;
 use self::task::{Task, TaskError, TaskResult};
 use crate::{
     config::{ComponentKey, Config, ConfigDiff, Inputs, OutputId},
@@ -80,7 +80,7 @@ pub async fn build_or_log_errors(
     diff: &ConfigDiff,
     buffers: HashMap<ComponentKey, BuiltBuffer>,
 ) -> Option<TopologyPieces> {
-    match builder::build_pieces(config, diff, buffers).await {
+    match TopologyPieces::build(config, diff, buffers).await {
         Err(errors) => {
             for error in errors {
                 error!(message = "Configuration error.", %error);

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -16,7 +16,7 @@ use vector_buffers::topology::channel::BufferSender;
 use vector_common::trigger::DisabledTrigger;
 
 use super::{
-    build_or_log_errors, builder,
+    builder,
     builder::TopologyPieces,
     fanout::{ControlChannel, ControlMessage},
     handle_errors, retain, take_healthchecks,
@@ -247,7 +247,8 @@ impl RunningTopology {
         // Try to build all of the new components coming from the new configuration.  If we can
         // successfully build them, we'll attempt to connect them up to the topology and spawn their
         // respective component tasks.
-        if let Some(mut new_pieces) = build_or_log_errors(&new_config, &diff, buffers.clone()).await
+        if let Some(mut new_pieces) =
+            TopologyPieces::build_or_log_errors(&new_config, &diff, buffers.clone()).await
         {
             // If healthchecks are configured for any of the changing/new components, try running
             // them before moving forward with connecting and spawning.  In some cases, healthchecks
@@ -272,7 +273,9 @@ impl RunningTopology {
         warn!("Failed to completely load new configuration. Restoring old configuration.");
 
         let diff = diff.flip();
-        if let Some(mut new_pieces) = build_or_log_errors(&self.config, &diff, buffers).await {
+        if let Some(mut new_pieces) =
+            TopologyPieces::build_or_log_errors(&self.config, &diff, buffers).await
+        {
             if self
                 .run_healthchecks(&diff, &mut new_pieces, self.config.healthchecks)
                 .await

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -24,7 +24,7 @@ use crate::{
     spawn_named,
     topology::{
         build_or_log_errors, builder,
-        builder::Pieces,
+        builder::TopologyPieces,
         fanout::{ControlChannel, ControlMessage},
         handle_errors, retain, take_healthchecks,
         task::TaskOutput,
@@ -295,7 +295,7 @@ impl RunningTopology {
     pub(crate) async fn run_healthchecks(
         &mut self,
         diff: &ConfigDiff,
-        pieces: &mut Pieces,
+        pieces: &mut TopologyPieces,
         options: HealthcheckOptions,
     ) -> bool {
         if options.enabled {
@@ -527,7 +527,11 @@ impl RunningTopology {
     }
 
     /// Connects all changed/added components in the given configuration diff.
-    pub(crate) async fn connect_diff(&mut self, diff: &ConfigDiff, new_pieces: &mut Pieces) {
+    pub(crate) async fn connect_diff(
+        &mut self,
+        diff: &ConfigDiff,
+        new_pieces: &mut TopologyPieces,
+    ) {
         debug!("Connecting changed/added component(s).");
 
         // Update tap metadata
@@ -654,7 +658,11 @@ impl RunningTopology {
         }
     }
 
-    async fn setup_outputs(&mut self, key: &ComponentKey, new_pieces: &mut builder::Pieces) {
+    async fn setup_outputs(
+        &mut self,
+        key: &ComponentKey,
+        new_pieces: &mut builder::TopologyPieces,
+    ) {
         let outputs = new_pieces.outputs.remove(key).unwrap();
         for (port, output) in outputs {
             debug!(component = %key, output_id = ?port, "Configuring output for component.");
@@ -672,7 +680,7 @@ impl RunningTopology {
         &mut self,
         key: &ComponentKey,
         diff: &ConfigDiff,
-        new_pieces: &mut builder::Pieces,
+        new_pieces: &mut builder::TopologyPieces,
     ) {
         let (tx, inputs) = new_pieces.inputs.remove(key).unwrap();
 
@@ -794,7 +802,7 @@ impl RunningTopology {
     }
 
     /// Starts any new or changed components in the given configuration diff.
-    pub(crate) fn spawn_diff(&mut self, diff: &ConfigDiff, mut new_pieces: Pieces) {
+    pub(crate) fn spawn_diff(&mut self, diff: &ConfigDiff, mut new_pieces: TopologyPieces) {
         for key in &diff.sources.to_change {
             debug!(message = "Spawning changed source.", key = %key);
             self.spawn_source(key, &mut new_pieces);
@@ -826,7 +834,7 @@ impl RunningTopology {
         }
     }
 
-    fn spawn_sink(&mut self, key: &ComponentKey, new_pieces: &mut builder::Pieces) {
+    fn spawn_sink(&mut self, key: &ComponentKey, new_pieces: &mut builder::TopologyPieces) {
         let task = new_pieces.tasks.remove(key).unwrap();
         let span = error_span!(
             "sink",
@@ -869,7 +877,7 @@ impl RunningTopology {
         }
     }
 
-    fn spawn_transform(&mut self, key: &ComponentKey, new_pieces: &mut builder::Pieces) {
+    fn spawn_transform(&mut self, key: &ComponentKey, new_pieces: &mut builder::TopologyPieces) {
         let task = new_pieces.tasks.remove(key).unwrap();
         let span = error_span!(
             "transform",
@@ -912,7 +920,7 @@ impl RunningTopology {
         }
     }
 
-    fn spawn_source(&mut self, key: &ComponentKey, new_pieces: &mut builder::Pieces) {
+    fn spawn_source(&mut self, key: &ComponentKey, new_pieces: &mut builder::TopologyPieces) {
         let task = new_pieces.tasks.remove(key).unwrap();
         let span = error_span!(
             "source",

--- a/src/topology/test/crash.rs
+++ b/src/topology/test/crash.rs
@@ -33,7 +33,7 @@ async fn test_source_error() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, (_, crash)) = start_topology(config.build().unwrap(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
 
     // Wait for our source to become ready to accept connections, and likewise, wait for our sink's target server to
     // receive its connection from the output sink.
@@ -78,7 +78,7 @@ async fn test_source_panic() {
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, (_, crash)) = start_topology(config.build().unwrap(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
 
     // Wait for our source to become ready to accept connections, and likewise, wait for our sink's target server to
     // receive its connection from the output sink.
@@ -125,7 +125,7 @@ async fn test_sink_error() {
 
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
-    let (topology, (_, crash)) = start_topology(config.build().unwrap(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
 
     // Wait for our sources to become ready to accept connections, and likewise, wait for our sink's target server to
     // receive its connection from the output sink.
@@ -174,7 +174,7 @@ async fn test_sink_panic() {
     let mut output_lines = CountReceiver::receive_lines(out_addr);
 
     std::panic::set_hook(Box::new(|_| {})); // Suppress panic print on background thread
-    let (topology, (_, crash)) = start_topology(config.build().unwrap(), false).await;
+    let (topology, crash) = start_topology(config.build().unwrap(), false).await;
 
     // Wait for our sources to become ready to accept connections, and likewise, wait for our sink's target server to
     // receive its connection from the output sink.

--- a/src/topology/test/end_to_end.rs
+++ b/src/topology/test/end_to_end.rs
@@ -10,10 +10,10 @@ use tokio::{
     time::{timeout, Duration},
 };
 
-use super::RunningTopology;
+use super::{RunningTopology, TopologyPieces};
 use crate::{
     config::{self, ConfigDiff, Format},
-    test_util, topology, Error,
+    test_util, Error,
 };
 
 type Lock = Arc<Mutex<()>>;
@@ -103,7 +103,7 @@ uri = "http://{address2}/"
     )
     .unwrap();
     let diff = ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+    let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
     let (_topology, _) = RunningTopology::start_validated(config, diff, pieces)

--- a/src/topology/test/end_to_end.rs
+++ b/src/topology/test/end_to_end.rs
@@ -1,9 +1,5 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use crate::{
-    config::{self, ConfigDiff, Format},
-    test_util, topology, Error,
-};
 use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
@@ -12,6 +8,12 @@ use tokio::{
     sync::{mpsc, oneshot, Mutex},
     task::JoinHandle,
     time::{timeout, Duration},
+};
+
+use super::RunningTopology;
+use crate::{
+    config::{self, ConfigDiff, Format},
+    test_util, topology, Error,
 };
 
 type Lock = Arc<Mutex<()>>;
@@ -104,7 +106,7 @@ uri = "http://{address2}/"
     let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
-    let (_topology, _) = topology::start_validated(config, diff, pieces)
+    let (_topology, _) = RunningTopology::start_validated(config, diff, pieces)
         .await
         .unwrap();
 

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -784,12 +784,7 @@ async fn topology_rebuild_connected_transform() {
 async fn topology_required_healthcheck_fails_start() {
     let mut config = basic_config_with_sink_failing_healthcheck();
     config.healthchecks.require_healthy = true;
-    let diff = ConfigDiff::initial(&config);
-    let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
-        .await
-        .unwrap();
-
-    assert!(RunningTopology::start_validated(config, diff, pieces)
+    assert!(RunningTopology::start_init_validated(config)
         .await
         .is_none());
 }
@@ -797,11 +792,7 @@ async fn topology_required_healthcheck_fails_start() {
 #[tokio::test]
 async fn topology_optional_healthcheck_does_not_fail_start() {
     let config = basic_config_with_sink_failing_healthcheck();
-    let diff = ConfigDiff::initial(&config);
-    let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
-        .await
-        .unwrap();
-    assert!(RunningTopology::start_validated(config, diff, pieces)
+    assert!(RunningTopology::start_init_validated(config)
         .await
         .is_some());
 }

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         start_topology, trace_init,
     },
-    topology::{self, builder},
+    topology::{self, builder, RunningTopology},
 };
 use futures::{future, stream, StreamExt};
 use tokio::{
@@ -789,7 +789,7 @@ async fn topology_required_healthcheck_fails_start() {
         .await
         .unwrap();
 
-    assert!(topology::start_validated(config, diff, pieces)
+    assert!(RunningTopology::start_validated(config, diff, pieces)
         .await
         .is_none());
 }
@@ -801,7 +801,7 @@ async fn topology_optional_healthcheck_does_not_fail_start() {
     let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
-    assert!(topology::start_validated(config, diff, pieces)
+    assert!(RunningTopology::start_validated(config, diff, pieces)
         .await
         .is_some());
 }

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         start_topology, trace_init,
     },
-    topology::{self, RunningTopology, TopologyPieces},
+    topology::{RunningTopology, TopologyPieces},
 };
 use futures::{future, stream, StreamExt};
 use tokio::{
@@ -785,7 +785,7 @@ async fn topology_required_healthcheck_fails_start() {
     let mut config = basic_config_with_sink_failing_healthcheck();
     config.healthchecks.require_healthy = true;
     let diff = ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+    let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
 
@@ -798,7 +798,7 @@ async fn topology_required_healthcheck_fails_start() {
 async fn topology_optional_healthcheck_does_not_fail_start() {
     let config = basic_config_with_sink_failing_healthcheck();
     let diff = ConfigDiff::initial(&config);
-    let pieces = topology::build_or_log_errors(&config, &diff, HashMap::new())
+    let pieces = TopologyPieces::build_or_log_errors(&config, &diff, HashMap::new())
         .await
         .unwrap();
     assert!(RunningTopology::start_validated(config, diff, pieces)

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         start_topology, trace_init,
     },
-    topology::{self, builder, RunningTopology},
+    topology::{self, RunningTopology, TopologyPieces},
 };
 use futures::{future, stream, StreamExt};
 use tokio::{
@@ -915,7 +915,7 @@ async fn topology_transform_error_definition() {
 
     let config = config.build().unwrap();
     let diff = ConfigDiff::initial(&config);
-    let errors = match builder::build_pieces(&config, &diff, HashMap::new()).await {
+    let errors = match TopologyPieces::build(&config, &diff, HashMap::new()).await {
         Ok(_) => panic!("build pieces should not succeed"),
         Err(err) => err,
     };

--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -250,7 +250,7 @@ async fn topology_readd_input() {
     old_config.add_source("in1", internal_metrics_source());
     old_config.add_source("in2", internal_metrics_source());
     old_config.add_sink("out", &["in1", "in2"], prom_exporter_sink(address_0, 1));
-    let (mut topology, (_, crash)) = start_topology(old_config.build().unwrap(), false).await;
+    let (mut topology, crash) = start_topology(old_config.build().unwrap(), false).await;
 
     // remove in2
     let mut new_config = Config::builder();
@@ -289,7 +289,7 @@ async fn reload_sink_test(
     new_address: SocketAddr,
 ) {
     // Start a topology from the "old" configuration, which should result in a component listening on `old_address`.
-    let (mut topology, (_, crash)) = start_topology(old_config, false).await;
+    let (mut topology, crash) = start_topology(old_config, false).await;
     let mut crash_stream = UnboundedReceiverStream::new(crash);
 
     wait_for_tcp(old_address).await;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -186,7 +186,7 @@ async fn validate_components(
     diff: &ConfigDiff,
     fmt: &mut Formatter,
 ) -> Option<TopologyPieces> {
-    match topology::builder::build_pieces(config, diff, HashMap::new()).await {
+    match topology::TopologyPieces::build(config, diff, HashMap::new()).await {
         Ok(pieces) => {
             fmt.success("Component configuration");
             Some(pieces)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -8,7 +8,7 @@ use exitcode::ExitCode;
 
 use crate::{
     config::{self, Config, ConfigDiff},
-    topology::{self, builder::Pieces},
+    topology::{self, builder::TopologyPieces},
 };
 
 const TEMPORARY_DIRECTORY: &str = "validate_tmp";
@@ -185,7 +185,7 @@ async fn validate_components(
     config: &Config,
     diff: &ConfigDiff,
     fmt: &mut Formatter,
-) -> Option<Pieces> {
+) -> Option<TopologyPieces> {
     match topology::builder::build_pieces(config, diff, HashMap::new()).await {
         Ok(pieces) => {
             fmt.success("Component configuration");
@@ -203,7 +203,7 @@ async fn validate_healthchecks(
     opts: &Opts,
     config: &Config,
     diff: &ConfigDiff,
-    pieces: &mut Pieces,
+    pieces: &mut TopologyPieces,
     fmt: &mut Formatter,
 ) -> bool {
     if !config.healthchecks.enabled {


### PR DESCRIPTION
This is a generalization of the work in #18888 which sets up a more generalized where one or more configs can be loaded as "internal" topologies. For simplicity, these internal configs are not connected to a controller and as such are not watched for changes nor participate in reloading. They are shut down after all the other components.

The last commit sets up a trivial internal topology in the standard runs to demonstrate the interface. It will be reverted before merging this PR.

This PR also contains a bunch of refactoring. The second-to-last commit contains the actual API, which is also [entirely localized to `app.rs`](https://github.com/vectordotdev/vector/pull/18919/files#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020).