### PR TITLE
enhancement(datadog): Add datadog global config options

### DIFF
--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -46,6 +46,7 @@ pub struct ConfigBuilder {
         feature = "sinks-datadog_traces",
     ))]
     #[configurable(derived)]
+    #[serde(default)]
     pub datadog: datadog::Options,
 
     #[configurable(derived)]
@@ -194,7 +195,6 @@ impl<'a> From<&'a ConfigBuilder> for ConfigBuilderHash<'a> {
             api: &value.api,
             schema: &value.schema,
             #[cfg(any(
-                feature = "sources-datadog_agent",
                 feature = "sinks-datadog_logs",
                 feature = "sinks-datadog_metrics",
                 feature = "sinks-datadog_traces",
@@ -220,7 +220,6 @@ impl From<Config> for ConfigBuilder {
             #[cfg(feature = "api")]
             api,
             #[cfg(any(
-                feature = "sources-datadog_agent",
                 feature = "sinks-datadog_logs",
                 feature = "sinks-datadog_metrics",
                 feature = "sinks-datadog_traces",
@@ -257,7 +256,6 @@ impl From<Config> for ConfigBuilder {
             #[cfg(feature = "api")]
             api,
             #[cfg(any(
-                feature = "sources-datadog_agent",
                 feature = "sinks-datadog_logs",
                 feature = "sinks-datadog_metrics",
                 feature = "sinks-datadog_traces",
@@ -477,6 +475,7 @@ mod tests {
         // reproducible across versions.
         let expected_keys = [
             "api",
+            "datadog",
             "enrichment_tables",
             "global",
             "healthchecks",
@@ -510,7 +509,7 @@ mod tests {
     /// the `ConfigBuilder` has changed what it serializes, or the implementation of `serde_json` has changed.
     /// If this test fails, we should ideally be able to fix so that the original hash passes!
     fn version_hash_match() {
-        let expected_hash = "6c98bea9d9e2f3133e2d39ba04592d17f96340a9bc4c8d697b09f5af388a76bd";
+        let expected_hash = "2c0ee2dfb8789e09dd953316fdef8b30b10fce3e259d44ca9461cf84ff63d12d";
         let builder = ConfigBuilder::default();
         let mut hash_builder = ConfigBuilderHash::from(&builder);
         hash_builder.version = "1.2.3".into();

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -12,6 +12,13 @@ use crate::{enrichment_tables::EnrichmentTables, providers::Providers, secrets::
 
 #[cfg(feature = "api")]
 use super::api;
+#[cfg(any(
+    feature = "sources-datadog_agent",
+    feature = "sinks-datadog_logs",
+    feature = "sinks-datadog_metrics",
+    feature = "sinks-datadog_traces",
+))]
+use super::datadog;
 #[cfg(feature = "enterprise")]
 use super::enterprise;
 use super::{
@@ -32,6 +39,14 @@ pub struct ConfigBuilder {
     #[configurable(derived)]
     #[serde(default)]
     pub api: api::Options,
+
+    #[cfg(any(
+        feature = "sinks-datadog_logs",
+        feature = "sinks-datadog_metrics",
+        feature = "sinks-datadog_traces",
+    ))]
+    #[configurable(derived)]
+    pub datadog: datadog::Options,
 
     #[configurable(derived)]
     #[configurable(metadata(docs::hidden))]
@@ -92,6 +107,13 @@ struct ConfigBuilderHash<'a> {
     #[cfg(feature = "api")]
     api: &'a api::Options,
     schema: &'a schema::Options,
+    #[cfg(any(
+        feature = "sources-datadog_agent",
+        feature = "sinks-datadog_logs",
+        feature = "sinks-datadog_metrics",
+        feature = "sinks-datadog_traces",
+    ))]
+    datadog: &'a datadog::Options,
     global: &'a GlobalOptions,
     healthchecks: &'a HealthcheckOptions,
     enrichment_tables: BTreeMap<&'a ComponentKey, &'a EnrichmentTableOuter>,
@@ -171,6 +193,13 @@ impl<'a> From<&'a ConfigBuilder> for ConfigBuilderHash<'a> {
             #[cfg(feature = "api")]
             api: &value.api,
             schema: &value.schema,
+            #[cfg(any(
+                feature = "sources-datadog_agent",
+                feature = "sinks-datadog_logs",
+                feature = "sinks-datadog_metrics",
+                feature = "sinks-datadog_traces",
+            ))]
+            datadog: &value.datadog,
             global: &value.global,
             healthchecks: &value.healthchecks,
             enrichment_tables: value.enrichment_tables.iter().collect(),
@@ -190,6 +219,13 @@ impl From<Config> for ConfigBuilder {
             global,
             #[cfg(feature = "api")]
             api,
+            #[cfg(any(
+                feature = "sources-datadog_agent",
+                feature = "sinks-datadog_logs",
+                feature = "sinks-datadog_metrics",
+                feature = "sinks-datadog_traces",
+            ))]
+            datadog,
             schema,
             #[cfg(feature = "enterprise")]
             enterprise,
@@ -220,6 +256,13 @@ impl From<Config> for ConfigBuilder {
             global,
             #[cfg(feature = "api")]
             api,
+            #[cfg(any(
+                feature = "sources-datadog_agent",
+                feature = "sinks-datadog_logs",
+                feature = "sinks-datadog_metrics",
+                feature = "sinks-datadog_traces",
+            ))]
+            datadog,
             schema,
             #[cfg(feature = "enterprise")]
             enterprise,

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -45,6 +45,12 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
         global,
         #[cfg(feature = "api")]
         api,
+        #[cfg(any(
+            feature = "sinks-datadog_logs",
+            feature = "sinks-datadog_metrics",
+            feature = "sinks-datadog_traces",
+        ))]
+        datadog,
         schema,
         #[cfg(feature = "enterprise")]
         enterprise,
@@ -102,6 +108,12 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
             #[cfg(feature = "api")]
             api,
             schema,
+            #[cfg(any(
+                feature = "sinks-datadog_logs",
+                feature = "sinks-datadog_metrics",
+                feature = "sinks-datadog_traces",
+            ))]
+            datadog,
             #[cfg(feature = "enterprise")]
             enterprise,
             hash,

--- a/src/config/datadog.rs
+++ b/src/config/datadog.rs
@@ -1,0 +1,27 @@
+use vector_config::configurable_component;
+
+use crate::sinks::util::UriSerde;
+
+/// Default settings to use for Datadog components.
+#[configurable_component]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    /// Default Datadog API key to use for Datadog components.
+    #[serde(default = "default_api_key")]
+    #[derivative(Default(value = "default_api_key()"))]
+    pub api_key: Option<String>,
+    /// Default site to use for DataDog components.
+    #[serde(default = "default_site")]
+    #[derivative(Default(value = "default_site()"))]
+    pub site: Option<UriSerde>,
+}
+
+fn default_api_key() -> Option<String> {
+    std::env::var("DD_API_KEY").ok().map(|s| s.to_string())
+}
+
+fn default_site() -> Option<UriSerde> {
+    std::env::var("DD_SITE").ok().and_then(|s| s.parse().ok())
+}

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -17,18 +17,15 @@ use url::{ParseError, Url};
 use vector_core::config::proxy::ProxyConfig;
 
 use super::{
-    load_source_from_paths, process_paths, ComponentKey, Config, ConfigPath, OutputId, SinkOuter,
-    SourceOuter, TransformOuter,
+    datadog::default_site, load_source_from_paths, process_paths, ComponentKey, Config, ConfigPath,
+    OutputId, SinkOuter, SourceOuter, TransformOuter,
 };
 use crate::{
     common::datadog::{get_api_base_endpoint, get_base_domain_region, Region},
     conditions::AnyCondition,
     http::{HttpClient, HttpError},
     sinks::{
-        datadog::{
-            default_site, logs::DatadogLogsConfig, metrics::DatadogMetricsConfig,
-            DatadogCommonConfig,
-        },
+        datadog::{logs::DatadogLogsConfig, metrics::DatadogMetricsConfig, DatadogCommonConfig},
         util::{http::RequestConfig, retries::ExponentialBackoff},
     },
     sources::{
@@ -481,12 +478,11 @@ fn setup_logs_reporting(
 
     // Create a Datadog logs sink to consume and emit internal logs.
     let datadog_logs = DatadogLogsConfig {
-        dd_common: DatadogCommonConfig {
-            endpoint: datadog.endpoint.clone(),
-            site: datadog.site.clone(),
-            default_api_key: api_key.into(),
-            ..Default::default()
-        },
+        dd_common: DatadogCommonConfig::new(
+            datadog.endpoint.clone(),
+            Some(datadog.site.clone()),
+            Some(api_key.into()),
+        ),
         region: datadog.region,
         request: RequestConfig {
             headers: IndexMap::from([(
@@ -589,12 +585,11 @@ fn setup_metrics_reporting(
 
     // Create a Datadog metrics sink to consume and emit internal + host metrics.
     let datadog_metrics = DatadogMetricsConfig {
-        dd_common: DatadogCommonConfig {
-            endpoint: datadog.endpoint.clone(),
-            site: datadog.site.clone(),
-            default_api_key: api_key.into(),
-            ..Default::default()
-        },
+        dd_common: DatadogCommonConfig::new(
+            datadog.endpoint.clone(),
+            Some(datadog.site.clone()),
+            Some(api_key.into()),
+        ),
         region: datadog.region,
         ..Default::default()
     };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,12 @@ pub mod api;
 mod builder;
 mod cmd;
 mod compiler;
+#[cfg(any(
+    feature = "sinks-datadog_logs",
+    feature = "sinks-datadog_metrics",
+    feature = "sinks-datadog_traces",
+))]
+pub mod datadog;
 mod diff;
 mod enrichment_table;
 #[cfg(feature = "enterprise")]
@@ -106,6 +112,12 @@ pub struct Config {
     #[cfg(feature = "api")]
     pub api: api::Options,
     pub schema: schema::Options,
+    #[cfg(any(
+        feature = "sinks-datadog_logs",
+        feature = "sinks-datadog_metrics",
+        feature = "sinks-datadog_traces",
+    ))]
+    pub datadog: datadog::Options,
     pub hash: Option<String>,
     #[cfg(feature = "enterprise")]
     pub enterprise: Option<enterprise::Options>,

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -14,6 +14,7 @@ use vector_core::{
     sink::VectorSink,
 };
 
+use super::datadog;
 use super::{id::Inputs, schema, ComponentKey, ProxyConfig, Resource};
 use crate::sinks::{util::UriSerde, Healthcheck};
 
@@ -239,6 +240,12 @@ dyn_clone::clone_trait_object!(SinkConfig);
 pub struct SinkContext {
     pub healthcheck: SinkHealthcheckOptions,
     pub globals: GlobalOptions,
+    #[cfg(any(
+        feature = "sinks-datadog_logs",
+        feature = "sinks-datadog_metrics",
+        feature = "sinks-datadog_traces",
+    ))]
+    pub datadog: datadog::Options,
     pub proxy: ProxyConfig,
     pub schema: schema::Options,
     pub app_name: String,
@@ -250,6 +257,7 @@ impl Default for SinkContext {
         Self {
             healthcheck: Default::default(),
             globals: Default::default(),
+            datadog: Default::default(),
             proxy: Default::default(),
             schema: Default::default(),
             app_name: crate::get_app_name().to_string(),

--- a/src/sinks/datadog/events/service.rs
+++ b/src/sinks/datadog/events/service.rs
@@ -8,7 +8,10 @@ use futures::{
 use http::Request;
 use hyper::Body;
 use tower::{Service, ServiceExt};
-use vector_common::request_metadata::{GroupedCountByteSize, MetaDescriptive};
+use vector_common::{
+    request_metadata::{GroupedCountByteSize, MetaDescriptive},
+    sensitive_string::SensitiveString,
+};
 use vector_core::stream::DriverResponse;
 
 use crate::{
@@ -53,7 +56,7 @@ pub struct DatadogEventsService {
 impl DatadogEventsService {
     pub fn new(
         endpoint: http::Uri,
-        default_api_key: String,
+        default_api_key: SensitiveString,
         http_client: HttpClient<Body>,
     ) -> Self {
         let batch_http_service = HttpBatchService::new(http_client, move |req| {
@@ -61,7 +64,7 @@ impl DatadogEventsService {
 
             let api_key = match req.metadata.api_key.as_ref() {
                 Some(x) => x.as_ref(),
-                None => default_api_key.as_str(),
+                None => default_api_key.inner(),
             };
 
             let request = Request::post(&endpoint)

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -10,7 +10,7 @@ use super::{service::LogApiRetry, sink::LogSinkBuilder};
 use crate::{
     codecs::Transformer,
     common::datadog::Region,
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{datadog, AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     schema,
     sinks::{
@@ -90,7 +90,7 @@ impl GenerateConfig for DatadogLogsConfig {
 impl DatadogLogsConfig {
     // TODO: We should probably hoist this type of base URI generation so that all DD sinks can
     // utilize it, since it all follows the same pattern.
-    fn get_uri(&self) -> http::Uri {
+    fn get_uri(&self, global: &datadog::Options) -> http::Uri {
         let base_url = self.dd_common.endpoint.clone().unwrap_or_else(|| {
             if let Some(region) = self.region {
                 match region {
@@ -98,23 +98,27 @@ impl DatadogLogsConfig {
                     Region::Us => "https://http-intake.logs.datadoghq.com".to_string(),
                 }
             } else {
-                format!("https://http-intake.logs.{}", self.dd_common.site)
+                format!("https://http-intake.logs.{}", self.dd_common.site(global))
             }
         });
 
         http::Uri::try_from(format!("{}/api/v2/logs", base_url)).expect("URI not valid")
     }
 
-    fn get_protocol(&self) -> String {
-        self.get_uri().scheme_str().unwrap_or("http").to_string()
+    fn get_protocol(&self, global: &datadog::Options) -> String {
+        self.get_uri(global)
+            .scheme_str()
+            .unwrap_or("http")
+            .to_string()
     }
 
     pub fn build_processor(
         &self,
+        global: &datadog::Options,
         client: HttpClient,
         dd_evp_origin: String,
     ) -> crate::Result<VectorSink> {
-        let default_api_key: Arc<str> = Arc::from(self.dd_common.default_api_key.inner());
+        let default_api_key: Arc<str> = Arc::from(self.dd_common.default_api_key(global).inner());
         let request_limits = self.request.tower.unwrap_with(&Default::default());
 
         // We forcefully cap the provided batch configuration to the size/log line limits imposed by
@@ -130,13 +134,13 @@ impl DatadogLogsConfig {
             .settings(request_limits, LogApiRetry)
             .service(LogApiService::new(
                 client,
-                self.get_uri(),
+                self.get_uri(global),
                 self.request.headers.clone(),
                 dd_evp_origin,
             )?);
 
         let encoding = self.encoding.clone();
-        let protocol = self.get_protocol();
+        let protocol = self.get_protocol(global);
 
         let sink = LogSinkBuilder::new(encoding, service, default_api_key, batch, protocol)
             .compression(self.compression.unwrap_or_default())
@@ -165,11 +169,11 @@ impl SinkConfig for DatadogLogsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = self.create_client(&cx.proxy)?;
 
-        let healthcheck = self
-            .dd_common
-            .build_healthcheck(client.clone(), self.region.as_ref())?;
+        let healthcheck =
+            self.dd_common
+                .build_healthcheck(&cx.datadog, client.clone(), self.region.as_ref())?;
 
-        let sink = self.build_processor(client, cx.app_name_slug)?;
+        let sink = self.build_processor(&cx.datadog, client, cx.app_name_slug)?;
 
         Ok((sink, healthcheck))
     }

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -533,3 +533,5 @@ async fn error_is_retriable() {
     //       but are not straightforward to instantiate due to the design of
     //       the crates they originate from.
 }
+
+// #[tokio::test]

--- a/src/sinks/util/test.rs
+++ b/src/sinks/util/test.rs
@@ -25,6 +25,15 @@ where
     Ok((sink_config, cx))
 }
 
+pub fn load_sink_with_context<T>(config: &str, cx: SinkContext) -> crate::Result<(T, SinkContext)>
+where
+    for<'a> T: Deserialize<'a> + SinkConfig,
+{
+    let sink_config: T = toml::from_str(config)?;
+
+    Ok((sink_config, cx))
+}
+
 pub fn build_test_server(
     addr: SocketAddr,
 ) -> (

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -568,6 +568,12 @@ impl<'a> Builder<'a> {
             let cx = SinkContext {
                 healthcheck,
                 globals: self.config.global.clone(),
+                #[cfg(any(
+                    feature = "sinks-datadog_logs",
+                    feature = "sinks-datadog_metrics",
+                    feature = "sinks-datadog_traces",
+                ))]
+                datadog: self.config.datadog.clone(),
                 proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
                 schema: self.config.schema,
                 app_name: crate::get_app_name().to_string(),

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -36,7 +36,7 @@ base: components: sinks: datadog_events: configuration: {
 
 			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
 			"""
-		required: true
+		required: false
 		type: string: examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 	}
 	endpoint: {
@@ -228,10 +228,7 @@ base: components: sinks: datadog_events: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {
-			default: "datadoghq.com"
-			examples: ["us3.datadoghq.com", "datadoghq.eu"]
-		}
+		type: string: examples: ["us3.datadoghq.com", "datadoghq.eu"]
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -97,7 +97,7 @@ base: components: sinks: datadog_logs: configuration: {
 
 			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
 			"""
-		required: true
+		required: false
 		type: string: examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 	}
 	encoding: {
@@ -324,10 +324,7 @@ base: components: sinks: datadog_logs: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {
-			default: "datadoghq.com"
-			examples: ["us3.datadoghq.com", "datadoghq.eu"]
-		}
+		type: string: examples: ["us3.datadoghq.com", "datadoghq.eu"]
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -68,7 +68,7 @@ base: components: sinks: datadog_metrics: configuration: {
 
 			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
 			"""
-		required: true
+		required: false
 		type: string: examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 	}
 	default_namespace: {
@@ -270,10 +270,7 @@ base: components: sinks: datadog_metrics: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {
-			default: "datadoghq.com"
-			examples: ["us3.datadoghq.com", "datadoghq.eu"]
-		}
+		type: string: examples: ["us3.datadoghq.com", "datadoghq.eu"]
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -97,7 +97,7 @@ base: components: sinks: datadog_traces: configuration: {
 
 			[api_key]: https://docs.datadoghq.com/api/?lang=bash#authentication
 			"""
-		required: true
+		required: false
 		type: string: examples: ["${DATADOG_API_KEY_ENV_VAR}", "ef8d5de700e7989468166c40fc8a0ccd"]
 	}
 	endpoint: {
@@ -279,10 +279,7 @@ base: components: sinks: datadog_traces: configuration: {
 			[dd_site]: https://docs.datadoghq.com/getting_started/site
 			"""
 		required: false
-		type: string: {
-			default: "datadoghq.com"
-			examples: ["us3.datadoghq.com", "datadoghq.eu"]
-		}
+		type: string: examples: ["us3.datadoghq.com", "datadoghq.eu"]
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."


### PR DESCRIPTION
OPW-43

This adds a global Datadog section to the configuration which then applies as defaults to the Datadog logs, metrics and traces sink.