### PR TITLE
chore(observability, blackhole sink)!: Don't report by default

### DIFF
--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 const fn default_print_interval_secs() -> Duration {
-    Duration::from_secs(1)
+    Duration::from_secs(0)
 }
 
 /// Configuration for the `blackhole` sink.
@@ -25,7 +25,7 @@ const fn default_print_interval_secs() -> Duration {
 pub struct BlackholeConfig {
     /// The interval between reporting a summary of activity.
     ///
-    /// Set to `0` to disable reporting.
+    /// Set to `0` (default) to disable reporting.
     #[derivative(Default(value = "default_print_interval_secs()"))]
     #[serde(default = "default_print_interval_secs")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]

--- a/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
@@ -13,6 +13,7 @@ Vector's 0.34.0 release includes **breaking changes**:
 
 1. [Removal of Deprecated Datadog Component Config Options](#datadog-deprecated-config-options)
 1. [Removal of Deprecated `component_name` Metric Tag](#deprecated-component-name)
+1. [Blackhole sink no longer reports by default](#blackhole-sink-reporting)
 
 We cover them below to help you upgrade quickly:
 
@@ -31,3 +32,9 @@ been removed from the Enterprise configuration. Instead of `region`, `site` shou
 #### Removal of Deprecated `component_name` Metric Tag {#deprecated-component-name}
 
 The deprecated `component_name` tag has been removed from all internal metrics. Instead the `component_id` tag should be used.
+
+#### Blackhole sink no longer reports by default {#blackhole-sink-reporting}
+
+The `blackhole` sink no longer reports events processed every second by default. Instead this
+behavior can be opted into by setting `print_interval_secs` to `1` (or any other integer). This
+change was made due to users being suprised that this sink generates output by default.

--- a/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
@@ -37,4 +37,4 @@ The deprecated `component_name` tag has been removed from all internal metrics. 
 
 The `blackhole` sink no longer reports events processed every second by default. Instead this
 behavior can be opted into by setting `print_interval_secs` to `1` (or any other integer). This
-change was made due to users being suprised that this sink generates output by default.
+change was made due to users being surprised that this sink generates output by default.

--- a/website/cue/reference/components/sinks/base/blackhole.cue
+++ b/website/cue/reference/components/sinks/base/blackhole.cue
@@ -31,11 +31,11 @@ base: components: sinks: blackhole: configuration: {
 		description: """
 			The interval between reporting a summary of activity.
 
-			Set to `0` to disable reporting.
+			Set to `0` (default) to disable reporting.
 			"""
 		required: false
 		type: uint: {
-			default: 1
+			default: 0
 			examples: [
 				10,
 			]


### PR DESCRIPTION
Users have been suprised by the `blackhole` sink emitting events processed logs at the `info` level
by default. This change changes the default to not report.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
