### PR TITLE
chore(deps): Replace atty with is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9646,7 +9646,6 @@ name = "vdev"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "cached",
  "chrono",
  "clap 4.4.7",
@@ -9659,6 +9658,7 @@ dependencies = [
  "hex",
  "indexmap 2.0.2",
  "indicatif",
+ "is-terminal",
  "itertools 0.11.0",
  "log",
  "once_cell",
@@ -9696,7 +9696,6 @@ dependencies = [
  "async-nats",
  "async-stream",
  "async-trait",
- "atty",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-cloudwatch",
@@ -9768,6 +9767,7 @@ dependencies = [
  "indoc",
  "infer 0.15.0",
  "inventory",
+ "is-terminal",
  "itertools 0.11.0",
  "k8s-openapi 0.18.0",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,7 +341,7 @@ mlua = { version = "0.9.1", default-features = false, features = ["lua54", "send
 windows-service = "0.6.0"
 
 [target.'cfg(unix)'.dependencies]
-atty = { version = "0.2.14", default-features = false }
+is-terminal = { version = "0.4", default-features = false }
 nix = { version = "0.26.2", default-features = false, features = ["socket", "signal"] }
 
 [build-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -331,9 +331,10 @@ pub enum Color {
 
 impl Color {
     pub fn use_color(&self) -> bool {
+        use is_terminal::IsTerminal;
         match self {
             #[cfg(unix)]
-            Color::Auto => atty::is(atty::Stream::Stdout),
+            Color::Auto => std::io::stdout().is_terminal(),
             #[cfg(windows)]
             Color::Auto => false, // ANSI colors are not supported by cmd.exe
             Color::Always => true,

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -122,7 +122,10 @@ pub fn next_addr_v6() -> SocketAddr {
 
 pub fn trace_init() {
     #[cfg(unix)]
-    let color = atty::is(atty::Stream::Stdout);
+    let color = {
+        use is_terminal::IsTerminal;
+        std::io::stdout().is_terminal()
+    };
     // Windows: ANSI colors are not supported by cmd.exe
     // Color is false for everything except unix.
     #[cfg(not(unix))]

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.75"
-atty = "0.2.14"
+is-terminal = { version = "0.4" }
 cached = "0.46.0"
 chrono = { version = "0.4.31", default-features = false, features = ["serde", "clock"] }
 clap = { version = "4.4.7", features = ["derive"] }

--- a/vdev/src/util.rs
+++ b/vdev/src/util.rs
@@ -3,11 +3,12 @@ use std::process::{Command, Output};
 use std::{collections::BTreeMap, fmt::Debug, fs, io::ErrorKind, path::Path};
 
 use anyhow::{Context as _, Result};
+use is_terminal::IsTerminal;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::Value;
 
-pub static IS_A_TTY: Lazy<bool> = Lazy::new(|| atty::is(atty::Stream::Stdout));
+pub static IS_A_TTY: Lazy<bool> = Lazy::new(|| std::io::stdout().is_terminal());
 
 #[derive(Deserialize)]
 pub struct CargoTomlPackage {


### PR DESCRIPTION
`atty` seems to be unmaintained and vulnerable to https://github.com/advisories/GHSA-g98v-hv3f-hcfr.
I followed `clap`'s lead and replaced with `is-termianl`
(https://github.com/clap-rs/clap/pull/4249).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
