### PR TITLE
chore(deps): Remove usages of atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9655,7 +9655,6 @@ name = "vdev"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "cached",
  "chrono",
  "clap 4.4.7",
@@ -9705,7 +9704,6 @@ dependencies = [
  "async-nats",
  "async-stream",
  "async-trait",
- "atty",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-cloudwatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,6 @@ mlua = { version = "0.9.1", default-features = false, features = ["lua54", "send
 windows-service = "0.6.0"
 
 [target.'cfg(unix)'.dependencies]
-atty = { version = "0.2.14", default-features = false }
 nix = { version = "0.26.2", default-features = false, features = ["socket", "signal"] }
 
 [build-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -333,7 +333,10 @@ impl Color {
     pub fn use_color(&self) -> bool {
         match self {
             #[cfg(unix)]
-            Color::Auto => atty::is(atty::Stream::Stdout),
+            Color::Auto => {
+                use std::io::IsTerminal;
+                std::io::stdout().is_terminal()
+            }
             #[cfg(windows)]
             Color::Auto => false, // ANSI colors are not supported by cmd.exe
             Color::Always => true,

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -122,7 +122,10 @@ pub fn next_addr_v6() -> SocketAddr {
 
 pub fn trace_init() {
     #[cfg(unix)]
-    let color = atty::is(atty::Stream::Stdout);
+    let color = {
+        use std::io::IsTerminal;
+        std::io::stdout().is_terminal()
+    };
     // Windows: ANSI colors are not supported by cmd.exe
     // Color is false for everything except unix.
     #[cfg(not(unix))]

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.75"
-atty = "0.2.14"
 cached = "0.46.0"
 chrono = { version = "0.4.31", default-features = false, features = ["serde", "clock"] }
 clap = { version = "4.4.7", features = ["derive"] }

--- a/vdev/src/util.rs
+++ b/vdev/src/util.rs
@@ -1,4 +1,5 @@
 use std::ffi::{OsStr, OsString};
+use std::io::IsTerminal;
 use std::process::{Command, Output};
 use std::{collections::BTreeMap, fmt::Debug, fs, io::ErrorKind, path::Path};
 
@@ -7,7 +8,7 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::Value;
 
-pub static IS_A_TTY: Lazy<bool> = Lazy::new(|| atty::is(atty::Stream::Stdout));
+pub static IS_A_TTY: Lazy<bool> = Lazy::new(|| std::io::stdout().is_terminal());
 
 #[derive(Deserialize)]
 pub struct CargoTomlPackage {


### PR DESCRIPTION
Turns out this is in the stdlib now.

Replaces: #18966

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
