### PR TITLE
chore: Follow redirects for `sh.vector.dev`

### DIFF
--- a/website/content/en/docs/setup/installation/manual/vector-installer.md
+++ b/website/content/en/docs/setup/installation/manual/vector-installer.md
@@ -6,7 +6,7 @@ short: Vector installer
 The Vector installer enables you to install Vector using a platform-agnostic installation script:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash
 ```
 
 ## Management

--- a/website/content/en/docs/setup/quickstart.md
+++ b/website/content/en/docs/setup/quickstart.md
@@ -18,7 +18,7 @@ We can install Vector using an installation script or Docker:
 {{< tab title="Script" >}}
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash
 ```
 
 {{< /tab >}}

--- a/website/content/en/guides/getting-started/getting-started.md
+++ b/website/content/en/guides/getting-started/getting-started.md
@@ -17,7 +17,7 @@ and create our first observability data pipeline so you can begin to see what Ve
 Installing Vector is quick and easy. We can use this handy installation script:
 
 ```shell
-curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash
 ```
 
 Or you can [choose your preferred installation method][docs.installation].

--- a/website/content/en/highlights/2020-07-09-add-musl-and-glibc-support-to-install-sh.md
+++ b/website/content/en/highlights/2020-07-09-add-musl-and-glibc-support-to-install-sh.md
@@ -43,7 +43,7 @@ You **should not need to do anything**. If you are using a normal, recommended m
 If you're provisioning Vector, the best way to make sure you get the most up to date stable version is to run this:
 
 ```bash title="provision_vector.sh"
-curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y
+curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y
 ```
 
 If you don't need the latest and greatest, **check your official distribution repository.** Some distributions, such as [NixOS][urls.nixos], have official Vector packages. You can also find Vector packages in the official [FreeBSD][urls.freebsd] repositories.

--- a/website/cue/reference/administration/example_docker_install_commands.cue
+++ b/website/cue/reference/administration/example_docker_install_commands.cue
@@ -9,6 +9,6 @@ package metadata
 administration: {
 	example_docker_install_commands: [#Command, ...#Command] & [{
 		title:   "Docker example"
-		command: "RUN apk add --no-cache curl bash && \\ \n    curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y --prefix /usr/local"
+		command: "RUN apk add --no-cache curl bash && \\ \n    curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local"
 	}]
 }

--- a/website/cue/reference/administration/install_commands.cue
+++ b/website/cue/reference/administration/install_commands.cue
@@ -10,11 +10,11 @@ administration: {
 	install_commands: [#Command, ...#Command] & [
 				{
 			title:   "For humans"
-			command: "curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash"
+			command: "curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash"
 		},
 		{
 			title:   "For machines"
-			command: "curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y"
+			command: "curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y"
 		},
 	]
 }

--- a/website/cue/reference/administration/interfaces/vector_installer.cue
+++ b/website/cue/reference/administration/interfaces/vector_installer.cue
@@ -18,7 +18,7 @@ administration: interfaces: vector_installer: {
 
 	role_implementations: [Name=string]: {
 		commands: {
-			install:   "curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash"
+			install:   "curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash"
 			logs:      null
 			reload:    "killall -s SIGHUP vector"
 			restart:   null


### PR DESCRIPTION
New hosting uses an HTTP redirect rather than passing the content back transparently.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
