### PR TITLE
fix(datadog_logs sink): use actual JSON size for batching

### DIFF
--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -289,8 +289,9 @@ where
 
         let partitioner = EventPartitioner;
         let batch_settings = self.batch_settings;
-        let input =
-            input.batched_partitioned(partitioner, || batch_settings.as_item_size_config(ActualJsonSize));
+        let input = input.batched_partitioned(partitioner, || {
+            batch_settings.as_item_size_config(ActualJsonSize)
+        });
         input
             .request_builder(
                 default_request_builder_concurrency_limit(),

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -556,7 +556,7 @@ async fn does_not_send_too_big_payloads() {
     // Generate input that will require escaping when serialized to json, and therefore grow in size
     // between batching and encoding. This is a very specific example that will fit in a batch of
     // <4,250,000 but serialize to >5,000,000, defeating the current 750k safety buffer.
-    let events = (0..1000).into_iter().map(|_n| {
+    let events = (0..1000).map(|_n| {
         let data = serde_json::json!({"a": "b"});
         let nested = serde_json::to_string(&data).unwrap();
         event_with_api_key(&nested.repeat(401), "foo")


### PR DESCRIPTION
This is definitely not optimal performance-wise, but it's a lot simpler than rearranging things to break up encoding. Opening this to try to measure the performance cost and weigh against a more complex fix.

Ref #10020 