### PR TITLE
chore(regression): Unmark regression tests as erratic now

### DIFF
--- a/regression/cases/file_to_blackhole/experiment.yaml
+++ b/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,2 +1,1 @@
 optimization_goal: egress_throughput
-erratic: true

--- a/regression/cases/otlp_http_to_blackhole/experiment.yaml
+++ b/regression/cases/otlp_http_to_blackhole/experiment.yaml
@@ -1,2 +1,1 @@
 optimization_goal: ingress_throughput
-erratic: true

--- a/regression/cases/syslog_regex_logs2metric_ddmetrics/experiment.yaml
+++ b/regression/cases/syslog_regex_logs2metric_ddmetrics/experiment.yaml
@@ -1,2 +1,1 @@
 optimization_goal: ingress_throughput
-erratic: true


### PR DESCRIPTION
Now that we seem to have stablized the tests, we can see if these show up as erratic again.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
