### PR TITLE
chore(docs): Remove traces and add beta for metrics

### DIFF
--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -97,12 +97,11 @@ pub struct DatadogAgentConfig {
     #[serde(default = "crate::serde::default_false")]
     disable_traces: bool,
 
-    /// If this is set to `true` logs, metrics, and traces are sent to different outputs.
+    /// If this is set to `true`, logs and metrics (beta) are sent to different outputs.
     ///
     ///
-    /// For a source component named `agent`, the received logs, metrics, and traces can then be
-    /// configured as input to other components by specifying `agent.logs`, `agent.metrics`, and
-    /// `agent.traces`, respectively.
+    /// For a source component named `agent`, the received logs and metrics (beta) can then be
+    /// configured as input to other components by specifying `agent.logs` and `agent.metrics`, respectively.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     multiple_outputs: bool,

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -276,11 +276,10 @@ base: components: sources: datadog_agent: configuration: {
 	}
 	multiple_outputs: {
 		description: """
-			If this is set to `true` logs, metrics, and traces are sent to different outputs.
+			If this is set to `true`, logs and metrics (beta) are sent to different outputs.
 
-			For a source component named `agent`, the received logs, metrics, and traces can then be
-			configured as input to other components by specifying `agent.logs`, `agent.metrics`, and
-			`agent.traces`, respectively.
+			For a source component named `agent`, the received logs and metrics (beta) can then be
+			configured as input to other components by specifying `agent.logs` and `agent.metrics`, respectively.
 			"""
 		required: false
 		type: bool: default: false


### PR DESCRIPTION
This PR remove traces and adds beta for metrics mention in the reference docs.

Related to [DOCS-6576](https://datadoghq.atlassian.net/browse/DOCS-6576).

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->


[DOCS-6576]: https://datadoghq.atlassian.net/browse/DOCS-6576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ