### PR TITLE
chore(releasing): Fix changelog not for kafka fix in 0.33.1

### DIFF
--- a/website/cue/reference/releases/0.33.1.cue
+++ b/website/cue/reference/releases/0.33.1.cue
@@ -41,9 +41,9 @@ releases: "0.33.1": {
 		},
 		{
 			type: "fix"
-			scopes: ["kafka source"]
+			scopes: ["kafka sink"]
 			description: """
-				A performance regression in the `kafka` source was corrected.
+				A performance regression in the `kafka` sink was corrected.
 				"""
 			pr_numbers: [18770]
 		},


### PR DESCRIPTION
Was actually for the sink, not the source.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
