### PR TITLE
fix: remove gh token call

### DIFF
--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -16,7 +16,6 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_rust_doc_preview_site:
     uses: ./.github/workflows/create_preview_sites.yml
@@ -27,7 +26,6 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_vrl_playground_preview_site:
     uses: ./.github/workflows/create_preview_sites.yml
@@ -38,4 +36,4 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -21,9 +21,6 @@ on:
       ENDPOINT:
         description: "Request endpoint"
         required: true
-      GITHUB_TOKEN:
-        description: "GitHub Token"
-        required: true
 
 jobs:
   create_preview_site:


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Workflow call has access to this specific secret for the token, and passing it causes the workflow to trip a check since it's a reserved variable name. Removing it from both the reusable workflow and caller.