### PR TITLE
fix(file source): emit the correct start offset for multiline aggregated lines

### DIFF
--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -782,7 +782,7 @@ mod tests {
 
         assert_results(
             results.await.unwrap(),
-            &[(expected.as_str(), lines.len() - 1, None)],
+            &[(expected.as_str(), 0, Some(lines.len() - 1))],
         );
     }
 

--- a/src/line_agg.rs
+++ b/src/line_agg.rs
@@ -108,7 +108,7 @@ pub struct LineAgg<T, K, C> {
     /// Draining queue. We switch to draining mode when we get `None` from
     /// the inner stream. In this mode we stop polling `inner` for new lines
     /// and just flush all the buffered data.
-    draining: Option<Vec<(K, Bytes, C)>>,
+    draining: Option<Vec<(K, Bytes, C, Option<C>)>>,
 }
 
 /// Core line aggregation logic.
@@ -162,8 +162,9 @@ where
 {
     /// `K` - file name, or other line source,
     /// `Bytes` - the line data,
-    /// `C` - the context related to the line data.
-    type Item = (K, Bytes, C);
+    /// `C` - the initial context related to the first line of data.
+    /// `Option<C>` - context related to the last-seen line data.
+    type Item = (K, Bytes, C, Option<C>);
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
@@ -207,8 +208,8 @@ where
                             .buffers
                             .drain()
                             .map(|(src, (_, aggregate))| {
-                                let (line, context) = aggregate.merge();
-                                (src, line, context)
+                                let (line, initial_context, last_context) = aggregate.merge();
+                                (src, line, initial_context, last_context)
                             })
                             .collect(),
                     );
@@ -220,8 +221,8 @@ where
                     {
                         let key = expired_key.into_inner();
                         if let Some((_, aggregate)) = this.logic.buffers.remove(&key) {
-                            let (line, context) = aggregate.merge();
-                            return Poll::Ready(Some((key, line, context)));
+                            let (line, initial_context, last_context) = aggregate.merge();
+                            return Poll::Ready(Some((key, line, initial_context, last_context)));
                         }
                     }
 
@@ -245,7 +246,7 @@ where
         src: K,
         line: Bytes,
         context: C,
-    ) -> Option<(K, Bytes, C)> {
+    ) -> Option<(K, Bytes, C, Option<C>)> {
         // Stashed line is always consumed at the start of the `poll`
         // loop before entering this line processing logic. If it's
         // non-empty here - it's a bug.
@@ -254,14 +255,17 @@ where
         let val = match val {
             // If we have to emit just one line - that's easy,
             // we just return it.
-            (src, Emit::One((line, context))) => (src, line, context),
+            (src, Emit::One((line, context, last_context))) => (src, line, context, last_context),
             // If we have to emit two lines - take the second
             // one and stash it, then return the first one.
             // This way, the stashed line will be returned
             // on the next stream poll.
-            (src, Emit::Two((line, context), (line_to_stash, context_to_stash))) => {
+            (
+                src,
+                Emit::Two((line, context, last_context), (line_to_stash, context_to_stash, _)),
+            ) => {
                 *this.stashed = Some((src.clone(), line_to_stash, context_to_stash));
-                (src, line, context)
+                (src, line, context, last_context)
             }
         };
         Some(val)
@@ -294,7 +298,7 @@ where
         src: K,
         line: Bytes,
         context: C,
-    ) -> Option<(K, Emit<(Bytes, C)>)> {
+    ) -> Option<(K, Emit<(Bytes, C, Option<C>)>)> {
         // Check if we already have the buffered data for the source.
         match self.buffers.entry(src) {
             Entry::Occupied(mut entry) => {
@@ -334,7 +338,7 @@ where
                     Decision::EndExclude => {
                         let (src, (key, buffered)) = entry.remove_entry();
                         self.timeouts.remove(&key);
-                        Some((src, Emit::Two(buffered.merge(), (line, context))))
+                        Some((src, Emit::Two(buffered.merge(), (line, context, None))))
                     }
                 }
             }
@@ -350,7 +354,7 @@ where
                     None
                 } else {
                     // It's just a regular line we don't really care about.
-                    Some((entry.into_key(), Emit::One((line, context))))
+                    Some((entry.into_key(), Emit::One((line, context, None))))
                 }
             }
         }
@@ -359,23 +363,25 @@ where
 
 struct Aggregate<C> {
     lines: Vec<Bytes>,
-    context: C,
+    initial_context: C,
+    context: Option<C>,
 }
 
 impl<C> Aggregate<C> {
-    fn new(first_line: Bytes, context: C) -> Self {
+    fn new(first_line: Bytes, initial_context: C) -> Self {
         Self {
             lines: vec![first_line],
-            context,
+            initial_context,
+            context: None,
         }
     }
 
     fn add_next_line(&mut self, line: Bytes, context: C) {
-        self.context = context;
+        self.context = Some(context);
         self.lines.push(line);
     }
 
-    fn merge(self) -> (Bytes, C) {
+    fn merge(self) -> (Bytes, C, Option<C>) {
         let capacity = self.lines.iter().map(|line| line.len() + 1).sum::<usize>() - 1;
         let mut bytes_mut = BytesMut::with_capacity(capacity);
         let mut first = true;
@@ -387,7 +393,7 @@ impl<C> Aggregate<C> {
             }
             bytes_mut.extend_from_slice(&line);
         }
-        (bytes_mut.freeze(), self.context)
+        (bytes_mut.freeze(), self.initial_context, self.context)
     }
 }
 
@@ -419,16 +425,21 @@ mod tests {
             timeout: Duration::from_millis(10),
         };
         let expected = vec![
-            ("some usual line", 0),
-            ("some other usual line", 1),
-            (concat!("first part\n", " second part\n", " last part"), 4),
-            ("another normal message", 5),
+            ("some usual line", 0, None),
+            ("some other usual line", 1, None),
+            (
+                concat!("first part\n", " second part\n", " last part"),
+                2,
+                Some(4),
+            ),
+            ("another normal message", 5, None),
             (
                 concat!(
                     "finishing message\n",
                     " last part of the incomplete finishing message"
                 ),
-                7,
+                6,
+                Some(7),
             ),
         ];
         run_and_assert(&lines, config, &expected).await;
@@ -453,19 +464,21 @@ mod tests {
             timeout: Duration::from_millis(10),
         };
         let expected = vec![
-            ("some usual line", 0),
-            ("some other usual line", 1),
+            ("some usual line", 0, None),
+            ("some other usual line", 1, None),
             (
                 concat!("first part \\\n", "second part \\\n", "last part"),
-                4,
+                2,
+                Some(4),
             ),
-            ("another normal message", 5),
+            ("another normal message", 5, None),
             (
                 concat!(
                     "finishing message \\\n",
                     "last part of the incomplete finishing message \\"
                 ),
-                7,
+                6,
+                Some(7),
             ),
         ];
         run_and_assert(&lines, config, &expected).await;
@@ -490,19 +503,21 @@ mod tests {
             timeout: Duration::from_millis(10),
         };
         let expected = vec![
-            ("INFO some usual line", 0),
-            ("INFO some other usual line", 1),
+            ("INFO some usual line", 0, None),
+            ("INFO some other usual line", 1, None),
             (
                 concat!("INFO first part\n", "second part\n", "last part"),
-                4,
+                2,
+                Some(4),
             ),
-            ("ERROR another normal message", 5),
+            ("ERROR another normal message", 5, None),
             (
                 concat!(
                     "ERROR finishing message\n",
                     "last part of the incomplete finishing message"
                 ),
-                7,
+                6,
+                Some(7),
             ),
         ];
         run_and_assert(&lines, config, &expected).await;
@@ -527,16 +542,21 @@ mod tests {
             timeout: Duration::from_millis(10),
         };
         let expected = vec![
-            ("some usual line;", 0),
-            ("some other usual line;", 1),
-            (concat!("first part\n", "second part\n", "last part;"), 4),
-            ("another normal message;", 5),
+            ("some usual line;", 0, None),
+            ("some other usual line;", 1, None),
+            (
+                concat!("first part\n", "second part\n", "last part;"),
+                2,
+                Some(4),
+            ),
+            ("another normal message;", 5, None),
             (
                 concat!(
                     "finishing message\n",
                     "last part of the incomplete finishing message"
                 ),
-                7,
+                6,
+                Some(7),
             ),
         ];
         run_and_assert(&lines, config, &expected).await;
@@ -561,7 +581,8 @@ mod tests {
                 "    at com.foo.bar(bar.java:123)\n",
                 "    at com.foo.baz(baz.java:456)",
             ),
-            2,
+            0,
+            Some(2),
         )];
         run_and_assert(&lines, config, &expected).await;
     }
@@ -587,7 +608,8 @@ mod tests {
                 "\tfrom foobar.rb:2:in `foo'\n",
                 "\tfrom foobar.rb:9:in `<main>'",
             ),
-            3,
+            0,
+            Some(3),
         )];
         run_and_assert(&lines, config, &expected).await;
     }
@@ -618,16 +640,16 @@ mod tests {
             timeout: Duration::from_millis(10),
         };
         let expected = vec![
-            ("not merged 1", 0),
-            (" merged 1\n merged 2", 2),
-            ("not merged 2", 3),
-            (" merged 3\n merged 4", 5),
-            ("not merged 3", 6),
-            ("not merged 4", 7),
-            (" merged 5", 8),
-            ("not merged 5", 9),
-            (" merged 6\n merged 7\n merged 8", 12),
-            ("not merged 6", 13),
+            ("not merged 1", 0, None),
+            (" merged 1\n merged 2", 1, Some(2)),
+            ("not merged 2", 3, None),
+            (" merged 3\n merged 4", 4, Some(5)),
+            ("not merged 3", 6, None),
+            ("not merged 4", 7, None),
+            (" merged 5", 8, None),
+            ("not merged 5", 9, None),
+            (" merged 6\n merged 7\n merged 8", 10, Some(12)),
+            ("not merged 6", 13, None),
         ];
         run_and_assert(&lines, config, &expected).await;
     }
@@ -656,12 +678,12 @@ mod tests {
             timeout: Duration::from_millis(10),
         };
         let expected = vec![
-            ("part 0.1\npart 0.2", 1),
-            ("START msg 1\npart 1.1\npart 1.2", 4),
-            ("START msg 2", 5),
-            ("START msg 3\npart 3.1", 7),
-            ("START msg 4\npart 4.1\npart 4.2\npart 4.3", 11),
-            ("START msg 5", 12),
+            ("part 0.1\npart 0.2", 0, Some(1)),
+            ("START msg 1\npart 1.1\npart 1.2", 2, Some(4)),
+            ("START msg 2", 5, None),
+            ("START msg 3\npart 3.1", 6, Some(7)),
+            ("START msg 4\npart 4.1\npart 4.2\npart 4.3", 8, Some(11)),
+            ("START msg 5", 12, None),
         ];
         run_and_assert(&lines, config, &expected).await;
     }
@@ -679,19 +701,21 @@ mod tests {
             "last part of the incomplete finishing message",
         ];
         let expected = vec![
-            ("INFO some usual line", 0),
-            ("INFO some other usual line", 1),
+            ("INFO some usual line", 0, None),
+            ("INFO some other usual line", 1, None),
             (
                 concat!("INFO first part\n", "second part\n", "last part"),
-                4,
+                2,
+                Some(4),
             ),
-            ("ERROR another normal message", 5),
+            ("ERROR another normal message", 5, None),
             (
                 concat!(
                     "ERROR finishing message\n",
                     "last part of the incomplete finishing message"
                 ),
-                7,
+                6,
+                Some(7),
             ),
         ];
 
@@ -753,7 +777,7 @@ mod tests {
 
         assert_results(
             results.await.unwrap(),
-            &[(expected.as_str(), lines.len() - 1)],
+            &[(expected.as_str(), lines.len() - 1, None)],
         );
     }
 
@@ -775,14 +799,18 @@ mod tests {
     }
 
     /// Compare actual output to expected; expected is a list of the expected strings and context
-    fn assert_results(actual: Vec<(Filename, Bytes, usize)>, expected: &[(&str, usize)]) {
-        let expected_mapped: Vec<(Filename, Bytes, usize)> = expected
+    fn assert_results(
+        actual: Vec<(Filename, Bytes, usize, Option<usize>)>,
+        expected: &[(&str, usize, Option<usize>)],
+    ) {
+        let expected_mapped: Vec<(Filename, Bytes, usize, Option<usize>)> = expected
             .iter()
-            .map(|(line, context)| {
+            .map(|(line, context, last_context)| {
                 (
                     "test.log".to_owned(),
                     Bytes::copy_from_slice(line.as_bytes()),
                     *context,
+                    *last_context,
                 )
             })
             .collect();
@@ -796,7 +824,7 @@ mod tests {
     async fn run_and_assert(
         lines: &[&'static str],
         config: Config,
-        expected: &[(&'static str, usize)],
+        expected: &[(&'static str, usize, Option<usize>)],
     ) {
         let stream = stream_from_lines(lines);
         let logic = Logic::new(config);

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -537,7 +537,7 @@ impl IngestorProcess {
                     lines.map(|line| ((), line, ())),
                     line_agg::Logic::new(config.clone()),
                 )
-                .map(|(_src, line, _context)| line),
+                .map(|(_src, line, _context, _lastline_context)| line),
             ),
             None => lines,
         };

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -1308,7 +1308,7 @@ fn line_agg_adapter(
         (stream, message, log)
     });
     let line_agg_out = LineAgg::<_, Bytes, LogEvent>::new(line_agg_in, logic);
-    line_agg_out.map(move |(_, message, mut log)| {
+    line_agg_out.map(move |(_, message, mut log, _)| {
         match log_namespace {
             LogNamespace::Vector => log.insert(event_path!(), message),
             LogNamespace::Legacy => log.insert(


### PR DESCRIPTION
This should fix https://github.com/vectordotdev/vector/issues/18955 by updating `line_agg::Aggregate<C>` so that it carries both an initial context for the first line seen, and optionally (in the case of lines being merged) the context associated with the last line seen. The file source is then able to use those context objects to emit the correct start `offset` value for aggregated lines (the start position of the first line), and use the correct end offset for checkpointing. 

Related to this previous change: https://github.com/vectordotdev/vector/pull/14858

Fixes: https://github.com/vectordotdev/vector/issues/18955
