### PR TITLE
docs: fix truncate arguments

### DIFF
--- a/website/cue/reference/remap/functions/truncate.cue
+++ b/website/cue/reference/remap/functions/truncate.cue
@@ -25,7 +25,7 @@ remap: functions: truncate: {
 				This argument is deprecated. An ellipsis (`...`) is appended if this is set to `true` _and_ the `value` string
 				ends up being truncated because it's exceeded the `limit`.
 				"""
-			required: true
+			required: false
 			type: ["boolean"]
 		},
 		{
@@ -34,7 +34,7 @@ remap: functions: truncate: {
 				A custom suffix (`...`) will be appended to truncated strings.
 				This is ignored if "ellipsis" is set to true for backwards compatibility.
 				"""
-			required: true
+			required: false
 			type: ["string"]
 		},
 	]

--- a/website/cue/reference/remap/functions/truncate.cue
+++ b/website/cue/reference/remap/functions/truncate.cue
@@ -35,7 +35,7 @@ remap: functions: truncate: {
 				This is ignored if "ellipsis" is set to true for backwards compatibility.
 				"""
 			required: true
-			type: ["boolean"]
+			type: ["string"]
 		},
 	]
 	internal_failure_reasons: []


### PR DESCRIPTION
The truncate arguments say that "suffix" is a boolean, but it's a string.  They also say that "ellipsis" and "suffix" are required, but they're not.