### PR TITLE
fix(config): rustc warnings

### DIFF
--- a/src/convert_config.rs
+++ b/src/convert_config.rs
@@ -157,8 +157,7 @@ fn walk_dir_and_convert(
             let new_output_dir = if entry_path.is_dir() {
                 let last_component = entry_path
                     .file_name()
-                    .unwrap_or_else(|| panic!("Failed to get file_name for {entry_path:?}"))
-                    .clone();
+                    .unwrap_or_else(|| panic!("Failed to get file_name for {entry_path:?}"));
                 let new_dir = output_dir.join(last_component);
 
                 if !new_dir.exists() {


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
when compiling `vector` with `rust` version `1.73.0` there is a warning - this PR fixes the warning

thanks to @StephenWakely for their assistance in https://github.com/vectordotdev/vector/issues/18870#issuecomment-1798553232