### PR TITLE
chore(releasing): Add deprecation note about respositories.timber.io deprecation

### DIFF
--- a/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
@@ -22,6 +22,7 @@ Vector's 0.34.0 release includes **breaking changes**:
 and **deprecations**:
 
 1. [Deprecation of `requests_completed_total`, `request_duration_seconds`, and `requests_received_total` Internal Metrics](#deprecate-obsolete-http-metrics)
+1. [Deprecation of `repositories.timber.io` package repositories](#timber-package-deprecation)
 
 We cover them below to help you upgrade quickly:
 
@@ -125,3 +126,12 @@ The `requests_completed_total`, `request_duration_seconds`, and `requests_receiv
 | requests_completed_total    | http_client_responses_total         | apache metrics, aws ecs metrics, http client, prometheus remote write, prometheus scrape |
 | request_duration_seconds    | http_client_response_rtt_seconds    | apache metrics, aws ecs metrics, http client, prometheus remote write, prometheus scrape |
 | requests_received_total     | http_server_requests_received_total | aws kinesis firehose, heroku logplex, prometheus exporter, splunk hec                    |
+
+#### Deprecation of `repositories.timber.io` package repositories {#timber-package-deprecation}
+
+Starting with the `v0.34.0` release, we are starting our migration of OS package hosting from
+`repositories.timber.io` to `apt.vector.dev` and `yum.vector.dev`. This is the last point release
+that will be published to `repositories.timber.io` (any `v0.34.x` patch releases will still be
+published). The repositories at `repositories.timber.io` will be decommissioned on February 28th,
+2024. Please see the [release highlight](/highlights/2023-11-07-new-linux-repos) for details about
+this change and instructions on how to migrate.

--- a/website/cue/reference/releases/0.34.0.cue
+++ b/website/cue/reference/releases/0.34.0.cue
@@ -27,7 +27,7 @@ releases: "0.34.0": {
 		  `yum.vector.dev`. Please see the [release
 		  highlight](/highlights/2023-11-07-new-linux-repos) for details about this change and
 		  instructions on how to migrate. The repositories located at `repositories.timber.io` will
-		  be decomissioned on February 28th, 2024.
+		  be decommissioned on February 28th, 2024.
 		"""
 
 	changelog: [

--- a/website/cue/reference/releases/0.34.0.cue
+++ b/website/cue/reference/releases/0.34.0.cue
@@ -22,6 +22,12 @@ releases: "0.34.0": {
 		  change and recommended practices to either secure the disk buffers or to avoid
 		  storing secrets in events altogether.
 
+		  This release also marks the deprecation of the OS package repositories hosted at
+		  `repositories.timber.io`. Instead, packages have been moved to `apt.vector.dev` and
+		  `yum.vector.dev`. Please see the [release
+		  highlight](/highlights/2023-11-07-new-linux-repos) for details about this change and
+		  instructions on how to migrate. The repositories located at `repositories.timber.io` will
+		  be decomissioned on February 28th, 2024.
 		"""
 
 	changelog: [


### PR DESCRIPTION
As part of the cutover plan described by the release highlight.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
