### PR TITLE
chore(docs): Replace setup.vector.dev references

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/apt.md
+++ b/website/content/en/docs/setup/installation/package-managers/apt.md
@@ -19,7 +19,7 @@ Our APT repositories are provided by [Cloudsmith] and you can find [instructions
 First, add the Vector repo:
 
 ```shell
-bash -c "$(curl -L https://setup.vector.dev)"
+bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_vector0.sh)"
 ```
 
 Then you can install the `vector` package:

--- a/website/content/en/docs/setup/installation/package-managers/yum.md
+++ b/website/content/en/docs/setup/installation/package-managers/yum.md
@@ -13,7 +13,7 @@ Our Yum repositories are provided by [Cloudsmith] and you can find [instructions
 Add the repo:
 
 ```shell
-bash -c "$(curl -L https://setup.vector.dev)"
+bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_vector0.sh)"
 ```
 
 Then you can install Vector:

--- a/website/content/en/highlights/2023-11-07-new-linux-repos.md
+++ b/website/content/en/highlights/2023-11-07-new-linux-repos.md
@@ -38,7 +38,7 @@ The following command **removes** the existing repository and configures the
 new repository.
 
 ```sh
-CSM_MIGRATE=true bash -c "$(curl -L https://setup.vector.dev)"
+CSM_MIGRATE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_vector0.sh)"
 ```
 
 Alternatively, `CSM_MIGRATE` may be left unset to leave the removal of the


### PR DESCRIPTION
We need to setup this redirect again with the new site hosting. Until we do that, putting a direct
link to the script.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
