### PR TITLE
fix(file source, kubernetes_logs source, file sink): make `file` internal metric tag opt-out

### DIFF
--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -16,6 +16,8 @@ For example:
 
 ## To be migrated
 
+- file_metric_tag v0.36.0 The `internal_metrics.include_file_tag` should default to `false`.
+
 ## To be removed
 
 - datadog_v1_metrics v0.35.0 Support for `v1` series endpoint in the `datadog_metrics` sink should be removed.

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -163,7 +163,6 @@ the reception of Vector events from an upstream component.
   - `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
     `unix`, `http`, `https`, `file`, etc.).
   - `http_path` - If relevant, the HTTP path, excluding query strings.
-  - `socket` - If relevant, the socket number that bytes were received from.
 - Metrics
   - MUST increment the `component_received_bytes_total` counter by the defined value with
     the defined properties as metric tags.

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -1,6 +1,9 @@
 use metrics::{counter, gauge};
 use std::borrow::Cow;
-use vector_lib::internal_event::{ComponentEventsDropped, InternalEvent, UNINTENTIONAL};
+use vector_lib::{
+    configurable::configurable_component,
+    internal_event::{ComponentEventsDropped, InternalEvent, UNINTENTIONAL},
+};
 
 use crate::emit;
 
@@ -8,6 +11,21 @@ use crate::emit;
 pub use self::source::*;
 
 use vector_lib::internal_event::{error_stage, error_type};
+
+/// Configuration of internal metrics for file-based components.
+#[configurable_component]
+#[derive(Clone, Debug, PartialEq, Eq, Derivative)]
+#[derivative(Default)]
+#[serde(deny_unknown_fields)]
+pub struct FileInternalMetricsConfig {
+    /// Whether or not to include the "file" tag on the component's corresponding internal metrics.
+    ///
+    /// This is useful for distinguishing between different files while monitoring. However, the tag's
+    /// cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+    #[serde(default = "crate::serde::default_true")]
+    #[derivative(Default(value = "true"))]
+    pub include_file_tag: bool,
+}
 
 #[derive(Debug)]
 pub struct FileOpen {
@@ -24,6 +42,7 @@ impl InternalEvent for FileOpen {
 pub struct FileBytesSent<'a> {
     pub byte_size: usize,
     pub file: Cow<'a, str>,
+    pub include_file_metric_tag: bool,
 }
 
 impl InternalEvent for FileBytesSent<'_> {
@@ -34,11 +53,18 @@ impl InternalEvent for FileBytesSent<'_> {
             protocol = "file",
             file = %self.file,
         );
-        counter!(
-            "component_sent_bytes_total", self.byte_size as u64,
-            "protocol" => "file",
-            "file" => self.file.clone().into_owned(),
-        );
+        if self.include_file_metric_tag {
+            counter!(
+                "component_sent_bytes_total", self.byte_size as u64,
+                "protocol" => "file",
+                "file" => self.file.clone().into_owned(),
+            );
+        } else {
+            counter!(
+                "component_sent_bytes_total", self.byte_size as u64,
+                "protocol" => "file",
+            );
+        }
     }
 }
 
@@ -96,6 +122,7 @@ mod source {
     pub struct FileBytesReceived<'a> {
         pub byte_size: usize,
         pub file: &'a str,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileBytesReceived<'a> {
@@ -106,11 +133,18 @@ mod source {
                 protocol = "file",
                 file = %self.file,
             );
-            counter!(
-                "component_received_bytes_total", self.byte_size as u64,
-                "protocol" => "file",
-                "file" => self.file.to_owned()
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "component_received_bytes_total", self.byte_size as u64,
+                    "protocol" => "file",
+                    "file" => self.file.to_owned()
+                );
+            } else {
+                counter!(
+                    "component_received_bytes_total", self.byte_size as u64,
+                    "protocol" => "file",
+                );
+            }
         }
     }
 
@@ -119,6 +153,7 @@ mod source {
         pub count: usize,
         pub file: &'a str,
         pub byte_size: JsonSize,
+        pub include_file_metric_tag: bool,
     }
 
     impl InternalEvent for FileEventsReceived<'_> {
@@ -129,20 +164,29 @@ mod source {
                 byte_size = %self.byte_size,
                 file = %self.file
             );
-            counter!(
-                "component_received_events_total", self.count as u64,
-                "file" => self.file.to_owned(),
-            );
-            counter!(
-                "component_received_event_bytes_total", self.byte_size.get() as u64,
-                "file" => self.file.to_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "component_received_events_total", self.count as u64,
+                    "file" => self.file.to_owned(),
+                );
+                counter!(
+                    "component_received_event_bytes_total", self.byte_size.get() as u64,
+                    "file" => self.file.to_owned(),
+                );
+            } else {
+                counter!("component_received_events_total", self.count as u64);
+                counter!(
+                    "component_received_event_bytes_total",
+                    self.byte_size.get() as u64,
+                );
+            }
         }
     }
 
     #[derive(Debug)]
     pub struct FileChecksumFailed<'a> {
         pub file: &'a Path,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileChecksumFailed<'a> {
@@ -151,10 +195,14 @@ mod source {
                 message = "Currently ignoring file too small to fingerprint.",
                 file = %self.file.display(),
             );
-            counter!(
-                "checksum_errors_total", 1,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "checksum_errors_total", 1,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!("checksum_errors_total", 1);
+            }
         }
     }
 
@@ -162,6 +210,7 @@ mod source {
     pub struct FileFingerprintReadError<'a> {
         pub file: &'a Path,
         pub error: Error,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileFingerprintReadError<'a> {
@@ -175,13 +224,22 @@ mod source {
                 stage = error_stage::RECEIVING,
                 internal_log_rate_limit = true,
             );
-            counter!(
-                "component_errors_total", 1,
-                "error_code" => "reading_fingerprint",
-                "error_type" => error_type::READER_FAILED,
-                "stage" => error_stage::RECEIVING,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "component_errors_total", 1,
+                    "error_code" => "reading_fingerprint",
+                    "error_type" => error_type::READER_FAILED,
+                    "stage" => error_stage::RECEIVING,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!(
+                    "component_errors_total", 1,
+                    "error_code" => "reading_fingerprint",
+                    "error_type" => error_type::READER_FAILED,
+                    "stage" => error_stage::RECEIVING,
+                );
+            }
         }
     }
 
@@ -191,6 +249,7 @@ mod source {
     pub struct FileDeleteError<'a> {
         pub file: &'a Path,
         pub error: Error,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileDeleteError<'a> {
@@ -204,19 +263,29 @@ mod source {
                 stage = error_stage::RECEIVING,
                 internal_log_rate_limit = true,
             );
-            counter!(
-                "component_errors_total", 1,
-                "file" => self.file.to_string_lossy().into_owned(),
-                "error_code" => DELETION_FAILED,
-                "error_type" => error_type::COMMAND_FAILED,
-                "stage" => error_stage::RECEIVING,
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "component_errors_total", 1,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                    "error_code" => DELETION_FAILED,
+                    "error_type" => error_type::COMMAND_FAILED,
+                    "stage" => error_stage::RECEIVING,
+                );
+            } else {
+                counter!(
+                    "component_errors_total", 1,
+                    "error_code" => DELETION_FAILED,
+                    "error_type" => error_type::COMMAND_FAILED,
+                    "stage" => error_stage::RECEIVING,
+                );
+            }
         }
     }
 
     #[derive(Debug)]
     pub struct FileDeleted<'a> {
         pub file: &'a Path,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileDeleted<'a> {
@@ -225,16 +294,21 @@ mod source {
                 message = "File deleted.",
                 file = %self.file.display(),
             );
-            counter!(
-                "files_deleted_total", 1,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "files_deleted_total", 1,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!("files_deleted_total", 1);
+            }
         }
     }
 
     #[derive(Debug)]
     pub struct FileUnwatched<'a> {
         pub file: &'a Path,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileUnwatched<'a> {
@@ -243,10 +317,14 @@ mod source {
                 message = "Stopped watching file.",
                 file = %self.file.display(),
             );
-            counter!(
-                "files_unwatched_total", 1,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "files_unwatched_total", 1,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!("files_unwatched_total", 1);
+            }
         }
     }
 
@@ -254,6 +332,7 @@ mod source {
     struct FileWatchError<'a> {
         pub file: &'a Path,
         pub error: Error,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileWatchError<'a> {
@@ -267,13 +346,22 @@ mod source {
                 file = %self.file.display(),
                 internal_log_rate_limit = true,
             );
-            counter!(
-                "component_errors_total", 1,
-                "error_code" => "watching",
-                "error_type" => error_type::COMMAND_FAILED,
-                "stage" => error_stage::RECEIVING,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "component_errors_total", 1,
+                    "error_code" => "watching",
+                    "error_type" => error_type::COMMAND_FAILED,
+                    "stage" => error_stage::RECEIVING,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!(
+                    "component_errors_total", 1,
+                    "error_code" => "watching",
+                    "error_type" => error_type::COMMAND_FAILED,
+                    "stage" => error_stage::RECEIVING,
+                );
+            }
         }
     }
 
@@ -281,6 +369,7 @@ mod source {
     pub struct FileResumed<'a> {
         pub file: &'a Path,
         pub file_position: u64,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileResumed<'a> {
@@ -290,16 +379,21 @@ mod source {
                 file = %self.file.display(),
                 file_position = %self.file_position
             );
-            counter!(
-                "files_resumed_total", 1,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "files_resumed_total", 1,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!("files_resumed_total", 1);
+            }
         }
     }
 
     #[derive(Debug)]
     pub struct FileAdded<'a> {
         pub file: &'a Path,
+        pub include_file_metric_tag: bool,
     }
 
     impl<'a> InternalEvent for FileAdded<'a> {
@@ -308,10 +402,14 @@ mod source {
                 message = "Found new file to watch.",
                 file = %self.file.display(),
             );
-            counter!(
-                "files_added_total", 1,
-                "file" => self.file.to_string_lossy().into_owned(),
-            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "files_added_total", 1,
+                    "file" => self.file.to_string_lossy().into_owned(),
+                );
+            } else {
+                counter!("files_added_total", 1);
+            }
         }
     }
 
@@ -378,48 +476,74 @@ mod source {
                 "error_code" => "globbing",
                 "error_type" => error_type::READER_FAILED,
                 "stage" => error_stage::RECEIVING,
-                "path" => self.path.to_string_lossy().into_owned(),
             );
         }
     }
 
     #[derive(Clone)]
-    pub struct FileSourceInternalEventsEmitter;
+    pub struct FileSourceInternalEventsEmitter {
+        pub include_file_metric_tag: bool,
+    }
 
     impl FileSourceInternalEvents for FileSourceInternalEventsEmitter {
         fn emit_file_added(&self, file: &Path) {
-            emit!(FileAdded { file });
+            emit!(FileAdded {
+                file,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_resumed(&self, file: &Path, file_position: u64) {
             emit!(FileResumed {
                 file,
-                file_position
+                file_position,
+                include_file_metric_tag: self.include_file_metric_tag
             });
         }
 
         fn emit_file_watch_error(&self, file: &Path, error: Error) {
-            emit!(FileWatchError { file, error });
+            emit!(FileWatchError {
+                file,
+                error,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_unwatched(&self, file: &Path) {
-            emit!(FileUnwatched { file });
+            emit!(FileUnwatched {
+                file,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_deleted(&self, file: &Path) {
-            emit!(FileDeleted { file });
+            emit!(FileDeleted {
+                file,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_delete_error(&self, file: &Path, error: Error) {
-            emit!(FileDeleteError { file, error });
+            emit!(FileDeleteError {
+                file,
+                error,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_fingerprint_read_error(&self, file: &Path, error: Error) {
-            emit!(FileFingerprintReadError { file, error });
+            emit!(FileFingerprintReadError {
+                file,
+                error,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_checksum_failed(&self, file: &Path) {
-            emit!(FileChecksumFailed { file });
+            emit!(FileChecksumFailed {
+                file,
+                include_file_metric_tag: self.include_file_metric_tag
+            });
         }
 
         fn emit_file_checkpointed(&self, count: usize, duration: Duration) {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -33,8 +33,8 @@ use crate::{
     encoding_transcode::{Decoder, Encoder},
     event::{BatchNotifier, BatchStatus, LogEvent},
     internal_events::{
-        FileBytesReceived, FileEventsReceived, FileOpen, FileSourceInternalEventsEmitter,
-        StreamClosedError,
+        FileBytesReceived, FileEventsReceived, FileInternalMetricsConfig, FileOpen,
+        FileSourceInternalEventsEmitter, StreamClosedError,
     },
     line_agg::{self, LineAgg},
     serde::bool_or_struct,
@@ -246,6 +246,10 @@ pub struct FileConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    internal_metrics: FileInternalMetricsConfig,
 }
 
 fn default_max_line_bytes() -> usize {
@@ -397,6 +401,7 @@ impl Default for FileConfig {
             encoding: None,
             acknowledgements: Default::default(),
             log_namespace: None,
+            internal_metrics: Default::default(),
         }
     }
 }
@@ -508,11 +513,15 @@ pub fn file_source(
         Some(config.read_from),
     );
 
+    let emitter = FileSourceInternalEventsEmitter {
+        include_file_metric_tag: config.internal_metrics.include_file_tag,
+    };
+
     let paths_provider = Glob::new(
         &config.include,
         &config.exclude,
         MatchOptions::default(),
-        FileSourceInternalEventsEmitter,
+        emitter.clone(),
     )
     .expect("invalid glob patterns");
 
@@ -543,7 +552,7 @@ pub fn file_source(
         },
         oldest_first: config.oldest_first,
         remove_after: config.remove_after_secs.map(Duration::from_secs),
-        emitter: FileSourceInternalEventsEmitter,
+        emitter,
         handle: tokio::runtime::Handle::current(),
     };
 
@@ -588,6 +597,7 @@ pub fn file_source(
     };
 
     let checkpoints = checkpointer.view();
+    let include_file_metric_tag = config.internal_metrics.include_file_tag;
     Box::pin(async move {
         info!(message = "Starting file server.", include = ?include, exclude = ?exclude);
 
@@ -602,6 +612,7 @@ pub fn file_source(
                 emit!(FileBytesReceived {
                     byte_size: line.text.len(),
                     file: &line.filename,
+                    include_file_metric_tag,
                 });
                 // transcode each line from the file's encoding charset to utf8
                 line.text = match encoding_decoder.as_mut() {
@@ -639,6 +650,7 @@ pub fn file_source(
                 &line.filename,
                 &event_metadata,
                 log_namespace,
+                include_file_metric_tag,
             );
 
             if let Some(finalizer) = &finalizer {
@@ -749,6 +761,7 @@ fn create_event(
     file: &str,
     meta: &EventMetadata,
     log_namespace: LogNamespace,
+    include_file_metric_tag: bool,
 ) -> LogEvent {
     let deserializer = BytesDeserializer;
     let mut event = deserializer.parse_single(line, log_namespace);
@@ -800,6 +813,7 @@ fn create_event(
         count: 1,
         file,
         byte_size: event.estimated_json_encoded_size_of(),
+        include_file_metric_tag,
     });
 
     event
@@ -1035,7 +1049,7 @@ mod tests {
             file_key: Some(owned_value_path!("file")),
             offset_key: Some(owned_value_path!("offset")),
         };
-        let log = create_event(line, offset, file, &meta, LogNamespace::Legacy);
+        let log = create_event(line, offset, file, &meta, LogNamespace::Legacy, false);
 
         assert_eq!(log["file"], "some_file.rs".into());
         assert_eq!(log["host"], "Some.Machine".into());
@@ -1057,7 +1071,7 @@ mod tests {
             file_key: Some(owned_value_path!("file_path")),
             offset_key: Some(owned_value_path!("off")),
         };
-        let log = create_event(line, offset, file, &meta, LogNamespace::Legacy);
+        let log = create_event(line, offset, file, &meta, LogNamespace::Legacy, false);
 
         assert_eq!(log["file_path"], "some_file.rs".into());
         assert_eq!(log["hostname"], "Some.Machine".into());
@@ -1079,7 +1093,7 @@ mod tests {
             file_key: Some(owned_value_path!("ignored")),
             offset_key: Some(owned_value_path!("ignored")),
         };
-        let log = create_event(line, offset, file, &meta, LogNamespace::Vector);
+        let log = create_event(line, offset, file, &meta, LogNamespace::Vector, false);
 
         assert_eq!(log.value(), &value!("hello world"));
 

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     },
     event::Event,
     internal_events::{
-        FileSourceInternalEventsEmitter, KubernetesLifecycleError,
+        FileInternalMetricsConfig, FileSourceInternalEventsEmitter, KubernetesLifecycleError,
         KubernetesLogsEventAnnotationError, KubernetesLogsEventNamespaceAnnotationError,
         KubernetesLogsEventNodeAnnotationError, KubernetesLogsEventsReceived,
         KubernetesLogsPodInfo, StreamClosedError,
@@ -235,6 +235,10 @@ pub struct Config {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    internal_metrics: FileInternalMetricsConfig,
 }
 
 const fn default_read_from() -> ReadFromConfig {
@@ -278,6 +282,7 @@ impl Default for Config {
             use_apiserver_cache: false,
             delay_deletion_ms: default_delay_deletion_ms(),
             log_namespace: None,
+            internal_metrics: Default::default(),
         }
     }
 }
@@ -528,6 +533,7 @@ struct Source {
     use_apiserver_cache: bool,
     ingestion_timestamp_field: Option<OwnedTargetPath>,
     delay_deletion: Duration,
+    include_file_metric_tag: bool,
 }
 
 impl Source {
@@ -606,6 +612,7 @@ impl Source {
             use_apiserver_cache: config.use_apiserver_cache,
             ingestion_timestamp_field,
             delay_deletion,
+            include_file_metric_tag: config.internal_metrics.include_file_tag,
         })
     }
 
@@ -638,6 +645,7 @@ impl Source {
             use_apiserver_cache,
             ingestion_timestamp_field,
             delay_deletion,
+            include_file_metric_tag,
         } = self;
 
         let mut reflectors = Vec::new();
@@ -775,7 +783,9 @@ impl Source {
             // We do not remove the log files, `kubelet` is responsible for it.
             remove_after: None,
             // The standard emitter.
-            emitter: FileSourceInternalEventsEmitter,
+            emitter: FileSourceInternalEventsEmitter {
+                include_file_metric_tag,
+            },
             // A handle to the current tokio runtime
             handle: tokio::runtime::Handle::current(),
         };

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -22,7 +22,7 @@ We cover them below to help you upgrade quickly:
 #### Deprecation of `file` internal metric tag for file-based components {#deprecate-file-tag}
 
 File-based components (file source, Kubernetes logs source, file sink) now include a
-`internal_metrics.include_file_tag` config option that determines whether the `file` tag is included on the 
-component's corresponding internal metrics. This config option defaults to `true` for now to retain the 
+`internal_metrics.include_file_tag` config option that determines whether the `file` tag is included on the
+component's corresponding internal metrics. This config option defaults to `true` for now to retain the
 existing behavior. In the next release, the config option will be updated to default to `false`, as this
 `tag` is likely to be of high cardinality.

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -1,0 +1,28 @@
+---
+date: "2023-12-19"
+title: "0.35 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.35.0"
+authors: ["dsmith3197"]
+release: "0.35.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+Vector's 0.35.0 release includes **deprecations**:
+
+1. [Deprecation of `file` internal metric tag for file-based components](#deprecate-file-tag)
+
+We cover them below to help you upgrade quickly:
+
+## Upgrade guide
+
+### Deprecations
+
+#### Deprecation of `file` internal metric tag for file-based components {#deprecate-file-tag}
+
+File-based components (file source, Kubernetes logs source, file sink) now include a
+`internal_metrics.include_file_tag` config option that determines whether the `file` tag is included on the 
+component's corresponding internal metrics. This config option defaults to `true` for now to retain the 
+existing behavior. In the next release, the config option will be updated to default to `false`, as this
+`tag` is likely to be of high cardinality.

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -325,6 +325,20 @@ base: components: sinks: file: configuration: {
 			unit: "seconds"
 		}
 	}
+	internal_metrics: {
+		description: "Configuration of internal metrics for file-based components."
+		required:    false
+		type: object: options: include_file_tag: {
+			description: """
+				Whether or not to include the "file" tag on the component's corresponding internal metrics.
+
+				This is useful for distinguishing between different files while monitoring. However, the tag's
+				cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+				"""
+			required: false
+			type: bool: default: true
+		}
+	}
 	path: {
 		description: """
 			File path to write events to.

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -205,6 +205,20 @@ base: components: sources: file: configuration: {
 		required:    true
 		type: array: items: type: string: examples: ["/var/log/**/*.log"]
 	}
+	internal_metrics: {
+		description: "Configuration of internal metrics for file-based components."
+		required:    false
+		type: object: options: include_file_tag: {
+			description: """
+				Whether or not to include the "file" tag on the component's corresponding internal metrics.
+
+				This is useful for distinguishing between different files while monitoring. However, the tag's
+				cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+				"""
+			required: false
+			type: bool: default: true
+		}
+	}
 	line_delimiter: {
 		description: "String sequence used to separate one file line from another."
 		required:    false

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -140,6 +140,20 @@ base: components: sources: kubernetes_logs: configuration: {
 		required: false
 		type: string: examples: [".ingest_timestamp", "ingest_ts"]
 	}
+	internal_metrics: {
+		description: "Configuration of internal metrics for file-based components."
+		required:    false
+		type: object: options: include_file_tag: {
+			description: """
+				Whether or not to include the "file" tag on the component's corresponding internal metrics.
+
+				This is useful for distinguishing between different files while monitoring. However, the tag's
+				cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+				"""
+			required: false
+			type: bool: default: true
+		}
+	}
 	kube_config_file: {
 		description: """
 			Optional path to a readable [kubeconfig][kubeconfig] file.


### PR DESCRIPTION
I would ideally like to remove this altogether or move towards the `file_tag_pattern` config option that @hhromic suggested [here](https://github.com/vectordotdev/vector/issues/11821#issuecomment-1185354328), but this is a good first step. I understand that it does provide value to users so it's unlikely we remove it altogether.

https://github.com/vectordotdev/vector/issues/15426
https://github.com/vectordotdev/vector/issues/11821