### PR TITLE
chore(deps): Replace trust_dns_proto with hickory_proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,8 +2940,8 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "data-encoding",
+ "hickory-proto",
  "thiserror",
- "trust-dns-proto 0.23.2",
 ]
 
 [[package]]
@@ -4065,6 +4065,30 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner 0.6.0",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing 0.1.40",
+ "url",
+]
 
 [[package]]
 name = "hkdf"
@@ -5359,7 +5383,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
- "trust-dns-proto 0.21.2",
+ "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder 0.10.0",
  "uuid",
@@ -9497,31 +9521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.6.0",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing 0.1.40",
- "url",
-]
-
-[[package]]
 name = "trust-dns-resolver"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9538,7 +9537,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "trust-dns-proto 0.21.2",
+ "trust-dns-proto",
 ]
 
 [[package]]
@@ -9945,6 +9944,7 @@ dependencies = [
  "headers",
  "heim",
  "hex",
+ "hickory-proto",
  "hostname",
  "http",
  "http-body",
@@ -10046,7 +10046,6 @@ dependencies = [
  "tracing-limit",
  "tracing-subscriber",
  "tracing-tower",
- "trust-dns-proto 0.23.2",
  "typetag",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ tokio-postgres = { version = "0.7.10", default-features = false, features = ["ru
 tokio-tungstenite = {version = "0.20.1", default-features = false, features = ["connect"], optional = true}
 toml = { version = "0.8.8", default-features = false, features = ["parse", "display"] }
 tonic = { version = "0.10", optional = true, default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
-trust-dns-proto = { version = "0.23.2", default-features = false, features = ["dnssec"], optional = true }
+hickory-proto = { version = "0.24.0", default-features = false, features = ["dnssec"], optional = true }
 typetag = { version = "0.2.13", default-features = false }
 url = { version = "2.4.1", default-features = false, features = ["serde"] }
 uuid = { version = "1", default-features = false, features = ["serde", "v4"] }
@@ -513,7 +513,7 @@ sources-aws_s3 = ["aws-core", "dep:aws-sdk-sqs", "dep:aws-sdk-s3", "dep:semver",
 sources-aws_sqs = ["aws-core", "dep:aws-sdk-sqs"]
 sources-datadog_agent = ["sources-utils-http-error", "protobuf-build"]
 sources-demo_logs = ["dep:fakedata"]
-sources-dnstap = ["dep:base64", "dep:trust-dns-proto", "dep:dnsmsg-parser", "protobuf-build"]
+sources-dnstap = ["dep:base64", "dep:hickory-proto", "dep:dnsmsg-parser", "protobuf-build"]
 sources-docker_logs = ["docker"]
 sources-eventstoredb_metrics = []
 sources-exec = []

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -252,6 +252,7 @@ heim,https://github.com/heim-rs/heim,Apache-2.0 OR MIT,svartalf <self@svartalf.i
 hermit-abi,https://github.com/hermitcore/hermit-rs,MIT OR Apache-2.0,Stefan Lankes
 hermit-abi,https://github.com/hermitcore/libhermit-rs,MIT OR Apache-2.0,Stefan Lankes
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
+hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hkdf,https://github.com/RustCrypto/KDFs,MIT OR Apache-2.0,RustCrypto Developers
 hmac,https://github.com/RustCrypto/MACs,MIT OR Apache-2.0,RustCrypto Developers
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
@@ -595,7 +596,6 @@ tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza
 tracing-tower,https://github.com/tokio-rs/tracing,MIT,Eliza Weisman <eliza@buoyant.io>
 treediff,https://github.com/Byron/treediff-rs,MIT OR Apache-2.0,Sebastian Thiel <byronimo@gmail.com>
 trust-dns-proto,https://github.com/bluejekyll/trust-dns,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
-trust-dns-proto,https://github.com/bluejekyll/trust-dns,MIT OR Apache-2.0,The contributors to Trust-DNS
 trust-dns-resolver,https://github.com/bluejekyll/trust-dns,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
 tungstenite,https://github.com/snapview/tungstenite-rs,MIT OR Apache-2.0,"Alexey Galakhov, Daniel Abramov"

--- a/lib/dnsmsg-parser/Cargo.toml
+++ b/lib/dnsmsg-parser/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 data-encoding = "2.4"
 thiserror = "1.0"
-trust-dns-proto = { version = "0.23", features = ["dnssec"] }
+hickory-proto = { version = "0.24", features = ["dnssec"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/lib/dnsmsg-parser/benches/benches.rs
+++ b/lib/dnsmsg-parser/benches/benches.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use data_encoding::BASE64;
 use dnsmsg_parser::dns_message_parser::DnsMessageParser;
-use trust_dns_proto::rr::rdata::NULL;
+use hickory_proto::rr::rdata::NULL;
 
 fn benchmark_parse_as_query_message(c: &mut Criterion) {
     let raw_dns_message = "szgAAAABAAAAAAAAAmg1B2V4YW1wbGUDY29tAAAGAAE=";

--- a/lib/dnsmsg-parser/src/dns_message.rs
+++ b/lib/dnsmsg-parser/src/dns_message.rs
@@ -1,4 +1,4 @@
-use trust_dns_proto::op::ResponseCode;
+use hickory_proto::op::ResponseCode;
 
 pub(super) const RTYPE_MB: u16 = 7;
 pub(super) const RTYPE_MG: u16 = 8;

--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -150,7 +150,9 @@ impl DnsMessageParser {
 
     fn parse_dns_record(&mut self, record: &Record) -> DnsParserResult<DnsRecord> {
         let record_data = match record.data() {
-            Some(RData::Unknown { code, rdata }) => self.format_unknown_rdata(*code, rdata),
+            Some(RData::Unknown { code, rdata }) => {
+                self.format_unknown_rdata((*code).into(), rdata)
+            }
             Some(rdata) => format_rdata(rdata),
             None => Ok((Some(String::from("")), None)), // NULL record
         }?;

--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -2,8 +2,7 @@ use std::fmt::Write as _;
 use std::str::Utf8Error;
 
 use data_encoding::{BASE32HEX_NOPAD, BASE64, HEXUPPER};
-use thiserror::Error;
-use trust_dns_proto::{
+use hickory_proto::{
     error::ProtoError,
     op::{message::Message as TrustDnsMessage, Edns, Query},
     rr::{
@@ -19,6 +18,7 @@ use trust_dns_proto::{
     },
     serialize::binary::{BinDecodable, BinDecoder},
 };
+use thiserror::Error;
 
 use super::dns_message::{
     self, DnsQueryMessage, DnsRecord, DnsUpdateMessage, EdnsOptionEntry, OptPseudoSection,
@@ -1133,7 +1133,7 @@ mod tests {
         str::FromStr,
     };
 
-    use trust_dns_proto::rr::{
+    use hickory_proto::rr::{
         dnssec::{
             rdata::{
                 dnskey::DNSKEY, ds::DS, nsec::NSEC, nsec3::NSEC3, nsec3param::NSEC3PARAM, sig::SIG,
@@ -1324,7 +1324,7 @@ mod tests {
 
     #[test]
     fn test_format_rdata_for_cname_type() {
-        let rdata = RData::CNAME(trust_dns_proto::rr::rdata::CNAME(
+        let rdata = RData::CNAME(hickory_proto::rr::rdata::CNAME(
             Name::from_str("www.example.com.").unwrap(),
         ));
         let rdata_text = format_rdata(&rdata);

--- a/src/sources/dnstap/parser.rs
+++ b/src/sources/dnstap/parser.rs
@@ -8,13 +8,13 @@ use std::{
 use base64::prelude::{Engine as _, BASE64_STANDARD};
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
-use once_cell::sync::Lazy;
-use prost::Message;
-use snafu::Snafu;
-use trust_dns_proto::{
+use hickory_proto::{
     rr::domain::Name,
     serialize::binary::{BinDecodable, BinDecoder},
 };
+use once_cell::sync::Lazy;
+use prost::Message;
+use snafu::Snafu;
 use vrl::{owned_value_path, path};
 
 use crate::{


### PR DESCRIPTION
This crate was rehomed for the 0.24 release: https://www.memorysafety.org/blog/announcing-hickory-dns/

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
