### PR TITLE
fix(loki sink): update to use the global list of compression algorithms

### DIFF
--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -9,42 +9,8 @@ use crate::{
     sinks::{prelude::*, util::UriSerde},
 };
 
-/// Loki-specific compression.
-#[configurable_component]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum ExtendedCompression {
-    /// Snappy compression.
-    ///
-    /// This implies sending push requests as Protocol Buffers.
-    #[serde(rename = "snappy")]
-    Snappy,
-}
-
-/// Compression configuration.
-#[configurable_component]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[serde(untagged)]
-pub enum CompressionConfigAdapter {
-    /// Basic compression.
-    Original(Compression),
-
-    /// Loki-specific compression.
-    Extended(ExtendedCompression),
-}
-
-impl CompressionConfigAdapter {
-    pub const fn content_encoding(self) -> Option<&'static str> {
-        match self {
-            CompressionConfigAdapter::Original(compression) => compression.content_encoding(),
-            CompressionConfigAdapter::Extended(_) => Some("snappy"),
-        }
-    }
-}
-
-impl Default for CompressionConfigAdapter {
-    fn default() -> Self {
-        CompressionConfigAdapter::Extended(ExtendedCompression::Snappy)
-    }
+const fn default_compression() -> Compression {
+    Compression::Snappy
 }
 
 fn default_loki_path() -> String {
@@ -107,8 +73,8 @@ pub struct LokiConfig {
     pub remove_timestamp: bool,
 
     #[configurable(derived)]
-    #[serde(default)]
-    pub compression: CompressionConfigAdapter,
+    #[serde(default = "default_compression")]
+    pub compression: Compression,
 
     #[configurable(derived)]
     #[serde(default)]

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -72,7 +72,8 @@ pub struct LokiConfig {
     #[serde(default = "crate::serde::default_true")]
     pub remove_timestamp: bool,
 
-    #[configurable(derived)]
+    /// Compression configuration.
+    /// Snappy compression implies sending push requests as Protocol Buffers.
     #[serde(default = "default_compression")]
     pub compression: Compression,
 

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -91,7 +91,13 @@ impl RequestBuilder<(PartitionKey, Vec<LokiRecord>)> for LokiRequestBuilder {
     type Error = RequestBuildError;
 
     fn compression(&self) -> Compression {
-        self.compression
+        if self.compression == Compression::Snappy {
+            // Snappy compression is applied after converting the batch to protobuf so
+            // we need to handle this separately.
+            Compression::None
+        } else {
+            self.compression
+        }
     }
 
     fn encoder(&self) -> &Self::Encoder {

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -12,7 +12,6 @@ use super::{
     event::{LokiBatchEncoder, LokiEvent, LokiRecord, PartitionKey},
     service::{LokiRequest, LokiRetryLogic, LokiService},
 };
-use crate::sinks::loki::config::{CompressionConfigAdapter, ExtendedCompression};
 use crate::sinks::loki::event::LokiBatchEncoding;
 use crate::{
     http::{get_http_scheme_from_uri, HttpClient},
@@ -65,7 +64,7 @@ impl Partitioner for RecordPartitioner {
 
 #[derive(Clone)]
 pub struct LokiRequestBuilder {
-    compression: CompressionConfigAdapter,
+    compression: Compression,
     encoder: LokiBatchEncoder,
 }
 
@@ -92,10 +91,7 @@ impl RequestBuilder<(PartitionKey, Vec<LokiRecord>)> for LokiRequestBuilder {
     type Error = RequestBuildError;
 
     fn compression(&self) -> Compression {
-        match self.compression {
-            CompressionConfigAdapter::Original(compression) => compression,
-            CompressionConfigAdapter::Extended(_) => Compression::None,
-        }
+        self.compression
     }
 
     fn encoder(&self) -> &Self::Encoder {
@@ -415,10 +411,8 @@ impl LokiSink {
         let serializer = config.encoding.build()?;
         let encoder = Encoder::<()>::new(serializer);
         let batch_encoder = match config.compression {
-            CompressionConfigAdapter::Original(_) => LokiBatchEncoder(LokiBatchEncoding::Json),
-            CompressionConfigAdapter::Extended(ExtendedCompression::Snappy) => {
-                LokiBatchEncoder(LokiBatchEncoding::Protobuf)
-            }
+            Compression::Snappy => LokiBatchEncoder(LokiBatchEncoding::Protobuf),
+            _ => LokiBatchEncoder(LokiBatchEncoding::Json),
         };
 
         Ok(Self {

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -112,8 +112,7 @@ base: components: sinks: loki: configuration: {
 	compression: {
 		description: """
 			Compression configuration.
-
-			All compression algorithms use the default compression level unless otherwise specified.
+			Snappy compression implies sending push requests as Protocol Buffers.
 			"""
 		required: false
 		type: string: {

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -110,8 +110,12 @@ base: components: sinks: loki: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
 		type: string: {
 			default: "snappy"
 			enum: {
@@ -122,9 +126,9 @@ base: components: sinks: loki: configuration: {
 					"""
 				none: "No compression."
 				snappy: """
-					Snappy compression.
+					[Snappy][snappy] compression.
 
-					This implies sending push requests as Protocol Buffers.
+					[snappy]: https://github.com/google/snappy/blob/main/docs/README.md
 					"""
 				zlib: """
 					[Zlib][zlib] compression.


### PR DESCRIPTION
The Loki sink had some special code to handle snappy. snappy was https://github.com/vectordotdev/vector/pull/18676 to the global list of compression schemes. This meant Loki was specifying snappy twice. It looks like this broke the schema validation.

This PR removes the special config option for snappy, but hopefully still handles the choice of snappy differently (encodes it as protobuf), as it did before.