### PR TITLE
feat(unittests): add vrl as test input

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -505,7 +505,7 @@ pub struct TestInput {
 
     /// The type of the input event.
     ///
-    /// Can be either `raw`, `log`, or `metric.
+    /// Can be either `raw`, `vrl`, `log`, or `metric.
     #[serde(default = "default_test_input_type", rename = "type")]
     pub type_str: String,
 
@@ -514,6 +514,11 @@ pub struct TestInput {
     /// Use this only when the input event should be a raw event (i.e. unprocessed/undecoded log
     /// event) and when the input type is set to `raw`.
     pub value: Option<String>,
+
+    /// The vrl expression to generate the input event.
+    ///
+    /// Only relevant when `type` is `vrl`.
+    pub source: Option<String>,
 
     /// The set of log fields to use when creating a log input event.
     ///

--- a/tests/behavior/transforms/vrl_test_input.toml
+++ b/tests/behavior/transforms/vrl_test_input.toml
@@ -1,0 +1,19 @@
+[transforms.canary]
+  inputs = []
+  type = "remap"
+  source = ""
+
+[[tests]]
+  name = "canary"
+  [[tests.inputs]]
+    insert_at = "canary"
+    type = "vrl"
+    source = """
+      . = {"a": {"b": "c"}, "d": now()}
+    """
+
+  [[tests.outputs]]
+    extract_from = "canary"
+    [[tests.outputs.conditions]]
+      type = "vrl"
+      source = """.a.b == "c" && is_timestamp(.d)"""

--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -221,10 +221,12 @@ In the `inputs` array for the test, you have these options:
 
 Parameter | Type | Description
 :---------|:-----|:-----------
+`type` | string | The type of input you're providing. [`vrl`](#logs), [`log`](#logs), [`raw`](#logs), or [`metric`](#metrics) are currently the only valid values.
 `insert_at` | string (name of transform) | The name of the transform into which the test input is inserted. This is particularly useful when you want to test only a subset of a transform pipeline.
 `value` | string (raw event value) | A raw string value to act as an input event. Use only in cases where events are raw strings and not structured objects with event fields.
 `log_fields` | object | If the transform handles [log events](#logs), these are the key/value pairs that comprise the input event.
 `metric` | object | If the transform handles [metric events](#metrics), these are the fields that comprise that metric. Subfields include `name`, `tags`, `kind`, and others.
+`source` | string (vrl program) | If the transform handles [log events](#logs), the result of the vrl program will be the input event.
 
 Here's an example `inputs` declaration:
 
@@ -364,6 +366,19 @@ To specify a raw string value for a log event, use `value`:
 [[tests.inputs]]
 insert_at = "add_metadata"
 value = "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
+```
+
+##### VRL program
+
+To specify a program to construct the log event, use `source`:
+
+```toml
+[[tests.inputs]]
+  insert_at = "canary"
+  type = "vrl"
+  source = """
+    . = {"a": {"b": "c"}, "d": now()}
+  """
 ```
 
 #### Metrics


### PR DESCRIPTION
Add VRL as a valid input for unittests, this makes it possible to define test inputs as such:

```
[[tests.inputs]]
type = "vrl"
insert_at = "my_transform"
source = '''
. = {
  "message": "foo bar baz",
  "timestamp": now(),
  "tags": {
    "foo": "bar",
    "fizz": "buzz"
  }
}
'''
```

And it kinda works:
```
output payloads from ["my_transform"] (events encoded as JSON):
  {"message":"foo bar baz","tags":{"fizz":"buzz","foo":"bar"},"timestamp":"2023-11-09T20:17:08.072518248Z"}
```

Since i basically just hacked around a bit; is this something that is useful and worthy of refining?

Inspired by #12490 and #15304

Closes: https://github.com/vectordotdev/vector/issues/15304