### PR TITLE
chore(releasing): Add upgrade note about TOML breaking change to v0.34.0

### DIFF
--- a/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-11-07-0-34-0-upgrade-guide.md
@@ -18,6 +18,7 @@ Vector's 0.34.0 release includes **breaking changes**:
 1. [Blackhole sink no longer reports by default](#blackhole-sink-reporting)
 1. [Remove direct OpenSSL legacy provider support](#openssl-legacy-provider)
 1. [Removal of the deprecated `armv7` rpm package](#armv7-rename)
+1. [Default config location change](#default-config-location-change)
 
 and **deprecations**:
 
@@ -114,6 +115,18 @@ desired through [options in OpenSSL's configuration](/docs/reference/configurati
 The deprecated name of the `armv7` RPM package, `vector-<version>-1.armv7.rpm`, is no longer
 published. Instead, it is published as `vector-<version>-1.armv7hl.rpm` to better follow RPM
 guidelines. If you are using `yum` to install the RPM, this change should be transparent.
+
+#### Default config location change {#default-config-location-change}
+
+The default config location is now `/etc/vector/vector.yaml` rather than `/etc/vector/vector.toml`.
+This is part of the migration to YAML as Vector's preferred configuration language (though TOML and
+JSON will still be supported for the forseeable future). If you need Vector to load
+`/etc/vector/vector.toml` you must now specify `--config /etc/vector/vector.toml` or
+`VECTOR_CONFIG=/etc/vector/vector.toml`
+
+See the associated [release highlight from v0.33.0](/highlights/2023-08-30-yaml-default-format) for
+more details on the motivation for migrating from TOML to YAML as the default configuration
+language.
 
 ### Deprecations
 


### PR DESCRIPTION
Closes: https://github.com/vectordotdev/vector/issues/19096

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
