### PR TITLE
chore(website): Fix commenting step on workflow

### DIFF
--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -64,6 +64,7 @@ jobs:
         REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
         ENDPOINT: ${{ secrets.ENDPOINT }}
       run: |
+        sleep 20
         HMAC_KEY=$(echo -n $REQUEST_MESSAGE | openssl dgst -sha256 -hmac "$REQUEST_TOKEN" -binary | od -An -tx1 | tr -d ' \n'; echo)
         SIGNATURE="sha256=$HMAC_KEY"
         RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -52,8 +52,9 @@ jobs:
       run: |
         unzip pr.zip -d pr
         BRANCH_NAME=$(cat ./pr/branch)
-        SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/\./-/g')
+        SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/\.]/-/g')
         echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> $GITHUB_ENV
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
     # Kick off the job in amplify
     - name: Deploy Site
@@ -70,7 +71,7 @@ jobs:
         RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
              -H "Content-Type: application/json" \
              -H "X-Hub-Signature: $SIGNATURE" \
-             -d "{\"app_id\": \"$APP_ID\", \"branch_name\": \"$SANITIZED_BRANCH_NAME\"}" \
+             -d "{\"app_id\": \"$APP_ID\", \"branch_name\": \"$BRANCH_NAME\"}" \
           "$ENDPOINT")
 
         # check the response code and fail if not 200

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -91,6 +91,7 @@ jobs:
           const fs = require('fs');
           const prNumber = fs.readFileSync('./pr/number', 'utf8');
           const issueNumber = parseInt(prNumber);
+          const { APP_ID, APP_NAME, SANITIZED_BRANCH_NAME } = process.env
 
           await github.rest.issues.createComment({
             owner: context.repo.owner,


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

- Extracts the environment variables in the github script so they can be passed into the PR commenter
- Adds a sleep to the curl to allow the branch connection to happen with AWS, the job sometimes runs before aws knows about the branch 
- Reverts the sanitized branch name to remove both`/` and `.` and replace them with `-` for the urls
- Uses the standard branch name in the curl request