### PR TITLE
fix(http client): cleanup error_kind metric tag values

### DIFF
--- a/src/internal_events/http_client.rs
+++ b/src/internal_events/http_client.rs
@@ -79,9 +79,9 @@ impl<'a> InternalEvent for GotHttpWarning<'a> {
             stage = error_stage::PROCESSING,
             internal_log_rate_limit = true,
         );
-        counter!("http_client_errors_total", 1, "error_kind" => self.error.to_string());
+        counter!("http_client_errors_total", 1, "error_kind" => self.error.message().to_string());
         histogram!("http_client_rtt_seconds", self.roundtrip);
-        histogram!("http_client_error_rtt_seconds", self.roundtrip, "error_kind" => self.error.to_string());
+        histogram!("http_client_error_rtt_seconds", self.roundtrip, "error_kind" => self.error.message().to_string());
     }
 }
 


### PR DESCRIPTION
`error.to_string()` includes the inner error as well, whereas `error.message().to_string()` only includes a descriptive string for the outer error.

Existing tag values:
<img width="747" alt="Screenshot 2023-11-13 at 10 14 37 AM" src="https://github.com/vectordotdev/vector/assets/20198397/a811a4e3-2003-44ce-868d-06cd676c09fa">
