### PR TITLE
chore(docs): Add alpha to traces and beta to metrics in descriptions

### DIFF
--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -87,20 +87,20 @@ pub struct DatadogAgentConfig {
     #[serde(default = "crate::serde::default_false")]
     disable_logs: bool,
 
-    /// If this is set to `true`, metrics are not accepted by the component.
+    /// If this is set to `true`, metrics (beta) are not accepted by the component.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     disable_metrics: bool,
 
-    /// If this is set to `true`, traces are not accepted by the component.
+    /// If this is set to `true`, traces (alpha) are not accepted by the component.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     disable_traces: bool,
 
-    /// If this is set to `true` logs, metrics, and traces are sent to different outputs.
+    /// If this is set to `true`, logs, metrics (beta), and traces (alpha) are sent to different outputs.
     ///
     ///
-    /// For a source component named `agent`, the received logs, metrics, and traces can then be
+    /// For a source component named `agent`, the received logs, metrics (beta), and traces (alpha) can then be
     /// configured as input to other components by specifying `agent.logs`, `agent.metrics`, and
     /// `agent.traces`, respectively.
     #[configurable(metadata(docs::advanced))]

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -81,7 +81,7 @@ enum BuildError {
     SubscribeError { source: rdkafka::error::KafkaError },
 }
 
-/// Metrics configuration.
+/// Metrics (beta) configuration.
 #[configurable_component]
 #[derive(Clone, Debug, Default)]
 struct Metrics {

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -24,7 +24,7 @@ use crate::{
 pub struct AggregateConfig {
     /// The interval between flushes, in milliseconds.
     ///
-    /// During this time frame, metrics with the same series data (name, namespace, tags, and so on) are aggregated.
+    /// During this time frame, metrics (beta) with the same series data (name, namespace, tags, and so on) are aggregated.
     #[serde(default = "default_interval_ms")]
     #[configurable(metadata(docs::human_name = "Flush Interval"))]
     pub interval_ms: u64,

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -174,12 +174,12 @@ base: components: sources: datadog_agent: configuration: {
 		type: bool: default: false
 	}
 	disable_metrics: {
-		description: "If this is set to `true`, metrics are not accepted by the component."
+		description: "If this is set to `true`, metrics (beta) are not accepted by the component."
 		required:    false
 		type: bool: default: false
 	}
 	disable_traces: {
-		description: "If this is set to `true`, traces are not accepted by the component."
+		description: "If this is set to `true`, traces (alpha) are not accepted by the component."
 		required:    false
 		type: bool: default: false
 	}
@@ -276,9 +276,9 @@ base: components: sources: datadog_agent: configuration: {
 	}
 	multiple_outputs: {
 		description: """
-			If this is set to `true` logs, metrics, and traces are sent to different outputs.
+			If this is set to `true`, logs, metrics (beta), and traces (alpha) are sent to different outputs.
 
-			For a source component named `agent`, the received logs, metrics, and traces can then be
+			For a source component named `agent`, the received logs, metrics (beta), and traces (alpha) can then be
 			configured as input to other components by specifying `agent.logs`, `agent.metrics`, and
 			`agent.traces`, respectively.
 			"""

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -361,7 +361,7 @@ base: components: sources: kafka: configuration: {
 		}
 	}
 	metrics: {
-		description: "Metrics configuration."
+		description: "Metrics (beta) configuration."
 		required:    false
 		type: object: options: topic_lag_metric: {
 			description: "Expose topic lag metrics for all topics and partitions. Metric names are `kafka_consumer_lag`."

--- a/website/cue/reference/components/transforms/base/aggregate.cue
+++ b/website/cue/reference/components/transforms/base/aggregate.cue
@@ -4,7 +4,7 @@ base: components: transforms: aggregate: configuration: interval_ms: {
 	description: """
 		The interval between flushes, in milliseconds.
 
-		During this time frame, metrics with the same series data (name, namespace, tags, and so on) are aggregated.
+		During this time frame, metrics (beta) with the same series data (name, namespace, tags, and so on) are aggregated.
 		"""
 	required: false
 	type: uint: default: 10000


### PR DESCRIPTION
This PR add `alpha` to mentions of traces and `beta` to mention of metrics in reference docs descriptions.

Related to [DOCS-6576](https://datadoghq.atlassian.net/browse/DOCS-6576).
Replaces this PR: https://github.com/vectordotdev/vector/pull/19031

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->


[DOCS-6576]: https://datadoghq.atlassian.net/browse/DOCS-6576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ