### PR TITLE
ehancement(sources): Add `keepalive.max_connection_age_secs` config option to HTTP-server sources

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -413,7 +413,7 @@ pub struct KeepaliveConfig {
 }
 
 const fn default_max_connection_age() -> Option<u64> {
-    None
+    Some(300) // 5 minutes
 }
 
 const fn default_max_connection_age_jitter_factor() -> f64 {

--- a/src/http.rs
+++ b/src/http.rs
@@ -411,7 +411,7 @@ pub struct KeepaliveConfig {
     /// The factor by which to jitter the `max_connection_age_secs` value.
     ///
     /// A value of 0.1 means that the actual duration will be between 90% and 110% of the
-    /// specified duration.
+    /// specified maximum duration.
     #[serde(default = "default_max_connection_age_jitter_factor")]
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
     pub max_connection_age_jitter_factor: f64,

--- a/src/http.rs
+++ b/src/http.rs
@@ -475,7 +475,7 @@ where
     fn layer(&self, service: S) -> Self::Service {
         MaxConnectionAgeService {
             service,
-            start_reference: self.start_reference.clone(),
+            start_reference: self.start_reference,
             max_connection_age: self.max_connection_age,
             peer_addr: self.peer_addr,
         }
@@ -512,7 +512,7 @@ where
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let start_reference = self.start_reference.clone();
+        let start_reference = self.start_reference;
         let max_connection_age = self.max_connection_age;
         let peer_addr = self.peer_addr;
         let future = self.service.call(req);

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 use std::{
     fmt,
+    net::SocketAddr,
     task::{Context, Poll},
     time::Duration,
 };
@@ -17,8 +18,11 @@ use hyper::{
 };
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
+use rand::Rng;
+use serde_with::serde_as;
 use snafu::{ResultExt, Snafu};
-use tower::Service;
+use tokio::time::Instant;
+use tower::{Layer, Service};
 use tower_http::{
     classify::{ServerErrorsAsFailures, SharedClassifier},
     trace::TraceLayer,
@@ -382,8 +386,151 @@ pub fn build_http_trace_layer(
         .on_eos(())
 }
 
+/// Configuration of HTTP server keepalive parameters.
+#[serde_as]
+#[configurable_component]
+#[derive(Clone, Debug, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct KeepaliveConfig {
+    /// The maximum amount of time a connection may exist before it is closed
+    /// by sending a `Connection: close` header on the HTTP response.
+    ///
+    /// A random jitter configured by `max_connection_age_jitter_factor` is added
+    /// to the specified duration to spread out connection storms.
+    ///
+    /// A value of `0` disables this feature.
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(
+        rename = "max_connection_age_secs",
+        default = "default_max_connection_age"
+    )]
+    #[configurable(metadata(docs::examples = 600))]
+    #[configurable(metadata(docs::human_name = "Maximum Connection Age"))]
+    pub max_connection_age: Duration,
+
+    /// The factor by which to jitter the `max_connection_age_secs` value.
+    ///
+    /// A value of 0.1 means that the actual duration will be between 90% and 110% of the
+    /// specified duration.
+    #[configurable(validation(range(min = 0.0, max = 1.0)))]
+    pub max_connection_age_jitter_factor: f64,
+}
+
+const fn default_max_connection_age() -> Duration {
+    Duration::from_secs(0)
+}
+
+/// A layer that limits the maximum duration of a client connection. It does so by adding a
+/// `Connection: close` header to the response if `max_connection_duration` time has elapsed
+/// since `start_reference`.
+///
+/// Note that this layer assumes that it is instantiated once per connectin.
+
+pub struct MaxConnectionAgeLayer {
+    start_reference: Instant,
+    max_connection_age: Duration,
+    peer_addr: SocketAddr,
+}
+
+impl MaxConnectionAgeLayer {
+    pub fn new(max_connection_age: Duration, jitter_factor: f64, peer_addr: SocketAddr) -> Self {
+        Self {
+            start_reference: Instant::now(),
+            max_connection_age: Self::jittered_duration(max_connection_age, jitter_factor),
+            peer_addr,
+        }
+    }
+
+    fn jittered_duration(duration: Duration, jitter_factor: f64) -> Duration {
+        // Ensure the jitter_factor is between 0.0 and 1.0
+        let jitter_factor = jitter_factor.clamp(0.0, 1.0);
+        // Generate a random jitter factor between `1 - jitter_factor`` and `1 + jitter_factor`.
+        let mut rng = rand::thread_rng();
+        let random_jitter_factor = rng.gen_range(-jitter_factor..=jitter_factor) + 1.;
+        duration.mul_f64(random_jitter_factor)
+    }
+}
+
+impl<S> Layer<S> for MaxConnectionAgeLayer
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Service = MaxConnectionAgeService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        MaxConnectionAgeService {
+            service,
+            start_reference: self.start_reference.clone(),
+            max_connection_age: self.max_connection_age,
+            peer_addr: self.peer_addr,
+        }
+    }
+}
+
+/// A service that limits the maximum age of a client connection. It does so by adding a
+/// `Connection: close` header to the response if `max_connection_age` time has elapsed
+/// since `start_reference`.
+///
+/// Note that this service assumes that it is instantiated once per connectin.
+#[derive(Clone)]
+pub struct MaxConnectionAgeService<S> {
+    service: S,
+    start_reference: Instant,
+    max_connection_age: Duration,
+    peer_addr: SocketAddr,
+}
+
+impl<S, E> Service<Request<Body>> for MaxConnectionAgeService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>, Error = E> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = E;
+    type Future = BoxFuture<'static, Result<Self::Response, E>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let start_reference = self.start_reference.clone();
+        let max_connection_age = self.max_connection_age;
+        let peer_addr = self.peer_addr;
+        let future = self.service.call(req);
+        Box::pin(async move {
+            let mut response = future.await?;
+            if !max_connection_age.is_zero() && start_reference.elapsed() >= max_connection_age {
+                debug!(
+                    message = "Closing connection due to max connection age.",
+                    ?max_connection_age,
+                    connection_age = ?start_reference.elapsed(),
+                    ?peer_addr,
+                );
+                // Tell the client to close this connection.
+                response.headers_mut().insert(
+                    hyper::header::CONNECTION,
+                    hyper::header::HeaderValue::from_static("close"),
+                );
+            }
+            Ok(response)
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
+    use hyper::{server::conn::AddrStream, service::make_service_fn, Server};
+    use tower::ServiceBuilder;
+
+    use crate::test_util::next_addr;
+
     use super::*;
 
     #[test]
@@ -414,5 +561,162 @@ mod tests {
             request.headers().get("User-Agent"),
             Some(&HeaderValue::from_static("foo"))
         );
+    }
+
+    #[test]
+    fn test_jittered_duration() {
+        // Non-zero duration
+        let duration = Duration::from_secs(60);
+        let jitter_factor = 0.1;
+        let jittered_duration = MaxConnectionAgeLayer::jittered_duration(duration, jitter_factor);
+        assert!(jittered_duration >= Duration::from_secs(54));
+        assert!(jittered_duration <= Duration::from_secs(66));
+
+        // Zero jitter factor
+        let duration = Duration::from_secs(60);
+        let jitter_factor = 0.0;
+        let jittered_duration = MaxConnectionAgeLayer::jittered_duration(duration, jitter_factor);
+        assert_eq!(jittered_duration, Duration::from_secs(60));
+
+        // Zero duration
+        let duration = Duration::from_secs(0);
+        let jitter_factor = 0.1;
+        let jittered_duration = MaxConnectionAgeLayer::jittered_duration(duration, jitter_factor);
+        assert_eq!(jittered_duration, Duration::from_secs(0));
+    }
+
+    #[tokio::test]
+    async fn test_max_connection_age_service() {
+        tokio::time::pause();
+
+        let start_reference = Instant::now();
+        let max_connection_age = Duration::from_secs(1);
+        let mut service = MaxConnectionAgeService {
+            service: tower::service_fn(|_req: Request<Body>| async {
+                Ok::<Response<Body>, hyper::Error>(Response::new(Body::empty()))
+            }),
+            start_reference,
+            max_connection_age,
+            peer_addr: "1.2.3.4:1234".parse().unwrap(),
+        };
+
+        let req = Request::get("http://example.com")
+            .body(Body::empty())
+            .unwrap();
+        let response = service.call(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
+
+        tokio::time::advance(Duration::from_millis(500)).await;
+        let req = Request::get("http://example.com")
+            .body(Body::empty())
+            .unwrap();
+        let response = service.call(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
+
+        tokio::time::advance(Duration::from_millis(500)).await;
+        let req = Request::get("http://example.com")
+            .body(Body::empty())
+            .unwrap();
+        let response = service.call(req).await.unwrap();
+        assert_eq!(
+            response.headers().get("Connection"),
+            Some(&HeaderValue::from_static("close"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_connection_age_service_zero_duration() {
+        tokio::time::pause();
+
+        let start_reference = Instant::now();
+        let max_connection_age = Duration::from_millis(0);
+        let mut service = MaxConnectionAgeService {
+            service: tower::service_fn(|_req: Request<Body>| async {
+                Ok::<Response<Body>, hyper::Error>(Response::new(Body::empty()))
+            }),
+            start_reference,
+            max_connection_age,
+            peer_addr: "1.2.3.4:1234".parse().unwrap(),
+        };
+
+        let req = Request::get("http://example.com")
+            .body(Body::empty())
+            .unwrap();
+        let response = service.call(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
+
+        tokio::time::advance(Duration::from_secs(60)).await;
+        let req = Request::get("http://example.com")
+            .body(Body::empty())
+            .unwrap();
+        let response = service.call(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
+    }
+
+    // Note that we unfortunately cannot mock the time in this test because the client calls
+    // sleep internally, which advances the clock.  However, this test shouldn't be flakey given
+    // the time bounds provided.
+    #[tokio::test]
+    async fn test_max_connection_age_service_with_hyper_server() {
+        // Create a hyper server with the max connection age layer.
+        let max_connection_age = Duration::from_secs(1);
+        let addr = next_addr();
+        let make_svc = make_service_fn(move |conn: &AddrStream| {
+            let svc = ServiceBuilder::new()
+                .layer(MaxConnectionAgeLayer::new(
+                    max_connection_age,
+                    0.,
+                    conn.remote_addr(),
+                ))
+                .service(tower::service_fn(|_req: Request<Body>| async {
+                    Ok::<Response<Body>, hyper::Error>(Response::new(Body::empty()))
+                }));
+            futures_util::future::ok::<_, Infallible>(svc)
+        });
+
+        tokio::spawn(async move {
+            Server::bind(&addr).serve(make_svc).await.unwrap();
+        });
+
+        // Wait for the server to start.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Create a client, which has its own connection pool.
+        let client = HttpClient::new(None, &ProxyConfig::default()).unwrap();
+
+        // Responses generated before the client's max connection age has elapsed do not
+        // include a `Connection: close` header in the response.
+        let req = Request::get(format!("http://{}/", addr))
+            .body(Body::empty())
+            .unwrap();
+        let response = client.send(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
+
+        let req = Request::get(format!("http://{}/", addr))
+            .body(Body::empty())
+            .unwrap();
+        let response = client.send(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
+
+        // The first response generated after the client's max connection age has elapsed should
+        // include the `Connection: close` header.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let req = Request::get(format!("http://{}/", addr))
+            .body(Body::empty())
+            .unwrap();
+        let response = client.send(req).await.unwrap();
+        assert_eq!(
+            response.headers().get("Connection"),
+            Some(&HeaderValue::from_static("close")),
+        );
+
+        // The next request should establish a new connection.
+        // Importantly, this also confirms that each connection has its own independent
+        // connection age timer.
+        let req = Request::get(format!("http://{}/", addr))
+            .body(Body::empty())
+            .unwrap();
+        let response = client.send(req).await.unwrap();
+        assert_eq!(response.headers().get("Connection"), None);
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -489,7 +489,7 @@ where
 /// A service that limits the maximum age of a client connection. It does so by adding a
 /// `Connection: close` header to the response if `max_connection_age` time has elapsed
 /// since `start_reference`.
-/// 
+///
 /// **Notes:**
 /// - This is intended to be used in a Hyper server (or similar) that will automatically close
 /// the connection after a response with a `Connection: close` header is sent.

--- a/src/http.rs
+++ b/src/http.rs
@@ -438,7 +438,11 @@ impl Default for KeepaliveConfig {
 /// `Connection: close` header to the response if `max_connection_duration` time has elapsed
 /// since `start_reference`.
 ///
-/// Note that this layer assumes that it is instantiated once per connection.
+/// **Notes:**
+/// - This is intended to be used in a Hyper server (or similar) that will automatically close
+/// the connection after a response with a `Connection: close` header is sent.
+/// - This layer assumes that it is instantiated once per connection, which is true within the
+/// Hyper framework.
 
 pub struct MaxConnectionAgeLayer {
     start_reference: Instant,
@@ -485,8 +489,12 @@ where
 /// A service that limits the maximum age of a client connection. It does so by adding a
 /// `Connection: close` header to the response if `max_connection_age` time has elapsed
 /// since `start_reference`.
-///
-/// Note that this service assumes that it is instantiated once per connection.
+/// 
+/// **Notes:**
+/// - This is intended to be used in a Hyper server (or similar) that will automatically close
+/// the connection after a response with a `Connection: close` header is sent.
+/// - This service assumes that it is instantiated once per connection, which is true within the
+/// Hyper framework.
 #[derive(Clone)]
 pub struct MaxConnectionAgeService<S> {
     service: S,
@@ -526,6 +534,7 @@ where
                     ?peer_addr,
                 );
                 // Tell the client to close this connection.
+                // Hyper will automatically close the connection after the response is sent.
                 response.headers_mut().insert(
                     hyper::header::CONNECTION,
                     hyper::header::HeaderValue::from_static("close"),

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -2,6 +2,7 @@ use std::{convert::Infallible, fmt, net::SocketAddr};
 
 use futures::FutureExt;
 use hyper::{service::make_service_fn, Server};
+use tokio::net::TcpStream;
 use tower::ServiceBuilder;
 use tracing::Span;
 use vector_lib::codecs::decoding::{DeserializerConfig, FramingConfig};
@@ -9,8 +10,10 @@ use vector_lib::config::{LegacyKey, LogNamespace};
 use vector_lib::configurable::configurable_component;
 use vector_lib::lookup::owned_value_path;
 use vector_lib::sensitive_string::SensitiveString;
+use vector_lib::tls::MaybeTlsIncomingStream;
 use vrl::value::Kind;
 
+use crate::http::{KeepaliveConfig, MaxConnectionAgeLayer};
 use crate::{
     codecs::DecodingConfig,
     config::{
@@ -96,6 +99,10 @@ pub struct AwsKinesisFirehoseConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    keepalive: KeepaliveConfig,
 }
 
 const fn access_keys_example() -> [&'static str; 2] {
@@ -174,12 +181,18 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
         let tls = MaybeTlsSettings::from_config(&self.tls, true)?;
         let listener = tls.bind(&self.address).await?;
 
+        let keepalive_settings = self.keepalive.clone();
         let shutdown = cx.shutdown;
         Ok(Box::pin(async move {
             let span = Span::current();
-            let make_svc = make_service_fn(move |_conn| {
+            let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
                 let svc = ServiceBuilder::new()
                     .layer(build_http_trace_layer(span.clone()))
+                    .layer(MaxConnectionAgeLayer::new(
+                        keepalive_settings.max_connection_age,
+                        keepalive_settings.max_connection_age_jitter_factor,
+                        conn.peer_addr(),
+                    ))
                     .service(warp::service(svc.clone()));
                 futures_util::future::ok::<_, Infallible>(svc)
             });
@@ -244,6 +257,7 @@ impl GenerateConfig for AwsKinesisFirehoseConfig {
             decoding: default_decoding(),
             acknowledgements: Default::default(),
             log_namespace: None,
+            keepalive: Default::default(),
         })
         .unwrap()
     }
@@ -336,6 +350,7 @@ mod tests {
                 decoding: default_decoding(),
                 acknowledgements: true.into(),
                 log_namespace: Some(log_namespace),
+                keepalive: Default::default(),
             }
             .build(cx)
             .await

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -30,6 +30,7 @@ use hyper::Server;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
+use tokio::net::TcpStream;
 use tower::ServiceBuilder;
 use tracing::Span;
 use vector_lib::codecs::decoding::{DeserializerConfig, FramingConfig};
@@ -38,11 +39,12 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::event::{BatchNotifier, BatchStatus};
 use vector_lib::internal_event::{EventsReceived, Registered};
 use vector_lib::lookup::owned_value_path;
+use vector_lib::tls::MaybeTlsIncomingStream;
 use vrl::path::OwnedTargetPath;
 use vrl::value::Kind;
 use warp::{filters::BoxedFilter, reject::Rejection, reply::Response, Filter, Reply};
 
-use crate::http::build_http_trace_layer;
+use crate::http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer};
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{
@@ -126,6 +128,10 @@ pub struct DatadogAgentConfig {
     #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    keepalive: KeepaliveConfig,
 }
 
 impl GenerateConfig for DatadogAgentConfig {
@@ -142,6 +148,7 @@ impl GenerateConfig for DatadogAgentConfig {
             disable_traces: false,
             multiple_outputs: false,
             log_namespace: Some(false),
+            keepalive: KeepaliveConfig::default(),
         })
         .unwrap()
     }
@@ -176,6 +183,7 @@ impl SourceConfig for DatadogAgentConfig {
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
         let filters = source.build_warp_filters(cx.out, acknowledgements, self)?;
         let shutdown = cx.shutdown;
+        let keepalive_settings = self.keepalive.clone();
 
         info!(message = "Building HTTP server.", address = %self.address);
 
@@ -191,9 +199,14 @@ impl SourceConfig for DatadogAgentConfig {
             });
 
             let span = Span::current();
-            let make_svc = make_service_fn(move |_conn| {
+            let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
                 let svc = ServiceBuilder::new()
                     .layer(build_http_trace_layer(span.clone()))
+                    .layer(MaxConnectionAgeLayer::new(
+                        keepalive_settings.max_connection_age,
+                        keepalive_settings.max_connection_age_jitter_factor,
+                        conn.peer_addr(),
+                    ))
                     .service(warp::service(routes.clone()));
                 futures_util::future::ok::<_, Infallible>(svc)
             });

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1869,6 +1869,7 @@ fn test_config_outputs() {
             disable_metrics: false,
             disable_traces: false,
             log_namespace: Some(false),
+            keepalive: Default::default(),
         };
 
         let mut outputs = config

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -30,6 +30,7 @@ use crate::{
         SourceContext, SourceOutput,
     },
     event::{Event, LogEvent},
+    http::KeepaliveConfig,
     internal_events::{HerokuLogplexRequestReadError, HerokuLogplexRequestReceived},
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::util::{
@@ -77,6 +78,10 @@ pub struct LogplexConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    keepalive: KeepaliveConfig,
 }
 
 impl LogplexConfig {
@@ -146,6 +151,7 @@ impl Default for LogplexConfig {
             decoding: default_decoding(),
             acknowledgements: SourceAcknowledgementsConfig::default(),
             log_namespace: None,
+            keepalive: KeepaliveConfig::default(),
         }
     }
 }
@@ -182,6 +188,7 @@ impl SourceConfig for LogplexConfig {
             &self.auth,
             cx,
             self.acknowledgements,
+            self.keepalive.clone(),
         )
     }
 
@@ -452,6 +459,7 @@ mod tests {
                 decoding: default_decoding(),
                 acknowledgements: acknowledgements.into(),
                 log_namespace: None,
+                keepalive: Default::default(),
             }
             .build(context)
             .await

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -28,6 +28,7 @@ use crate::{
         SourceOutput,
     },
     event::{Event, Value},
+    http::KeepaliveConfig,
     register_validatable_component,
     serde::{bool_or_struct, default_decoding},
     sources::util::{
@@ -154,6 +155,10 @@ pub struct SimpleHttpConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    keepalive: KeepaliveConfig,
 }
 
 impl SimpleHttpConfig {
@@ -256,6 +261,7 @@ impl Default for SimpleHttpConfig {
             decoding: Some(default_decoding()),
             acknowledgements: SourceAcknowledgementsConfig::default(),
             log_namespace: None,
+            keepalive: KeepaliveConfig::default(),
         }
     }
 }
@@ -347,6 +353,7 @@ impl SourceConfig for SimpleHttpConfig {
             &self.auth,
             cx,
             self.acknowledgements,
+            self.keepalive.clone(),
         )
     }
 
@@ -557,6 +564,7 @@ mod tests {
                 decoding,
                 acknowledgements: acknowledgements.into(),
                 log_namespace: None,
+                keepalive: Default::default(),
             }
             .build(context)
             .await

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use std::{convert::Infallible, net::SocketAddr};
 
 use bytes::Bytes;
@@ -60,11 +61,13 @@ pub(crate) async fn run_http_server(
     let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
         let svc = ServiceBuilder::new()
             .layer(build_http_trace_layer(span.clone()))
-            .layer(MaxConnectionAgeLayer::new(
-                keepalive_settings.max_connection_age,
-                keepalive_settings.max_connection_age_jitter_factor,
-                conn.peer_addr(),
-            ))
+            .option_layer(keepalive_settings.max_connection_age_secs.map(|secs| {
+                MaxConnectionAgeLayer::new(
+                    Duration::from_secs(secs),
+                    keepalive_settings.max_connection_age_jitter_factor,
+                    conn.peer_addr(),
+                )
+            }))
             .service(warp::service(routes.clone()));
         futures_util::future::ok::<_, Infallible>(svc)
     });

--- a/src/sources/opentelemetry/integration_tests.rs
+++ b/src/sources/opentelemetry/integration_tests.rs
@@ -43,6 +43,7 @@ async fn receive_logs_legacy_namespace() {
             http: HttpConfig {
                 address: source_http_address().parse().unwrap(),
                 tls: Default::default(),
+                keepalive: Default::default(),
             },
             acknowledgements: Default::default(),
             log_namespace: Default::default(),

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -47,6 +47,7 @@ async fn receive_grpc_logs_vector_namespace() {
             http: HttpConfig {
                 address: http_addr,
                 tls: Default::default(),
+                keepalive: Default::default(),
             },
             acknowledgements: Default::default(),
             log_namespace: Some(true),
@@ -184,6 +185,7 @@ async fn receive_grpc_logs_legacy_namespace() {
             http: HttpConfig {
                 address: http_addr,
                 tls: Default::default(),
+                keepalive: Default::default(),
             },
             acknowledgements: Default::default(),
             log_namespace: Default::default(),

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -374,6 +374,7 @@ mod integration_tests {
             auth: None,
             tls: None,
             acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
         };
 
         let events = run_and_assert_source_compliance(

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -13,6 +13,7 @@ use crate::{
         GenerateConfig, SourceAcknowledgementsConfig, SourceConfig, SourceContext, SourceOutput,
     },
     event::Event,
+    http::KeepaliveConfig,
     internal_events::PrometheusRemoteWriteParseError,
     serde::bool_or_struct,
     sources::{
@@ -45,6 +46,10 @@ pub struct PrometheusRemoteWriteConfig {
     #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    keepalive: KeepaliveConfig,
 }
 
 impl PrometheusRemoteWriteConfig {
@@ -55,6 +60,7 @@ impl PrometheusRemoteWriteConfig {
             tls: None,
             auth: None,
             acknowledgements: false.into(),
+            keepalive: KeepaliveConfig::default(),
         }
     }
 }
@@ -66,6 +72,7 @@ impl GenerateConfig for PrometheusRemoteWriteConfig {
             tls: None,
             auth: None,
             acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
         })
         .unwrap()
     }
@@ -86,6 +93,7 @@ impl SourceConfig for PrometheusRemoteWriteConfig {
             &self.auth,
             cx,
             self.acknowledgements,
+            self.keepalive.clone(),
         )
     }
 
@@ -183,6 +191,7 @@ mod test {
             auth: None,
             tls: tls.clone(),
             acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
         };
         let source = source
             .build(SourceContext::new_test(tx, None))
@@ -275,6 +284,7 @@ mod test {
             auth: None,
             tls: None,
             acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
         };
         let source = source
             .build(SourceContext::new_test(tx, None))

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -15,9 +15,9 @@ use hyper::{service::make_service_fn, Server};
 use serde::Serialize;
 use serde_json::{de::Read as JsonRead, Deserializer, Value as JsonValue};
 use snafu::Snafu;
+use tokio::net::TcpStream;
 use tower::ServiceBuilder;
 use tracing::Span;
-use vector_lib::configurable::configurable_component;
 use vector_lib::internal_event::{CountByteSize, InternalEventHandle as _, Registered};
 use vector_lib::lookup::lookup_v2::OptionalValuePath;
 use vector_lib::lookup::{self, event_path, owned_value_path};
@@ -28,6 +28,7 @@ use vector_lib::{
     schema::meaning,
     EstimatedJsonEncodedSizeOf,
 };
+use vector_lib::{configurable::configurable_component, tls::MaybeTlsIncomingStream};
 use vrl::value::{kind::Collection, Kind};
 use warp::{filters::BoxedFilter, path, reject::Rejection, reply::Response, Filter, Reply};
 
@@ -41,7 +42,7 @@ use self::{
 use crate::{
     config::{log_schema, DataType, Resource, SourceConfig, SourceContext, SourceOutput},
     event::{Event, LogEvent, Value},
-    http::build_http_trace_layer,
+    http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
         EventsReceived, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
         SplunkHecRequestReceived,
@@ -106,6 +107,10 @@ pub struct SplunkConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    keepalive: KeepaliveConfig,
 }
 
 impl_generate_config_from_default!(SplunkConfig);
@@ -120,6 +125,7 @@ impl Default for SplunkConfig {
             acknowledgements: Default::default(),
             store_hec_token: false,
             log_namespace: None,
+            keepalive: Default::default(),
         }
     }
 }
@@ -168,11 +174,17 @@ impl SourceConfig for SplunkConfig {
 
         let listener = tls.bind(&self.address).await?;
 
+        let keepalive_settings = self.keepalive.clone();
         Ok(Box::pin(async move {
             let span = Span::current();
-            let make_svc = make_service_fn(move |_conn| {
+            let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
                 let svc = ServiceBuilder::new()
                     .layer(build_http_trace_layer(span.clone()))
+                    .layer(MaxConnectionAgeLayer::new(
+                        keepalive_settings.max_connection_age,
+                        keepalive_settings.max_connection_age_jitter_factor,
+                        conn.peer_addr(),
+                    ))
                     .service(warp::service(services.clone()));
                 futures_util::future::ok::<_, Infallible>(svc)
             });
@@ -1287,6 +1299,7 @@ mod tests {
                 acknowledgements: acknowledgements.unwrap_or_default(),
                 store_hec_token,
                 log_namespace: None,
+                keepalive: Default::default(),
             }
             .build(cx)
             .await

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -15,7 +15,7 @@ Vector's 0.35.0 release includes **deprecations**:
 
 and **potentially impactful changes**:
 
-1. [HTTP server-based sources now include a `keepalive.max_connection_age_secs` config option that defaults to 5 minutes](#http-keepalive-max-connectino-age)
+1. [HTTP server-based sources now include a `keepalive.max_connection_age_secs` config option that defaults to 5 minutes](#http-keepalive-max-connection-age)
 1. [Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks](#component-sent-bytes-total)
 1. [Update `component_received_bytes_total` to correctly report decompressed bytes for all sources](#component-received-bytes-total)
 
@@ -40,7 +40,7 @@ existing behavior. In the next release, the config option will be updated to def
 HTTP server-based sources include a new `keepalive.max_connection_age_secs` configuration option, which defaults to 5 minutes (300 seconds).
 When enabled, this closes incoming TCP connections that reach the maximum age by sending a `Connection: close` header in the response.
 While this parameter is crucial for managing the lifespan of persistent, incoming connections to Vector and for effective load balancing, it
-can be disabled by setting `keepalive.max_sonnection_age_secs` to `null`.
+can be disabled by setting `keepalive.max_connection_age_secs` to `null`.
 
 #### Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks {#component-sent-bytes-total}
 

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -15,6 +15,7 @@ Vector's 0.35.0 release includes **deprecations**:
 
 and **potentially impactful changes**:
 
+1. [HTTP server-based sources now include a `keepalive.max_connection_age_secs` config option that defaults to 5 minutes](#http-keepalive-max-connectino-age)
 1. [Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks](#component-sent-bytes-total)
 1. [Update `component_received_bytes_total` to correctly report decompressed bytes for all sources](#component-received-bytes-total)
 
@@ -33,6 +34,13 @@ existing behavior. In the next release, the config option will be updated to def
 `tag` is likely to be of high cardinality.
 
 ### Potentially impactful changes
+
+#### HTTP server-based sources now include a `keepalive.max_connection_age_secs` config option that defaults to 5 minutes {#http-keepalive-max-connection-age}
+
+HTTP server-based sources include a new `keepalive.max_connection_age_secs` configuration option, which defaults to 5 minutes (300 seconds).
+When enabled, this closes incoming TCP connections that reach the maximum age by sending a `Connection: close` header in the response.
+While this parameter is crucial for managing the lifespan of persistent, incoming connections to Vector and for effective load balancing, it
+can be disabled by setting `keepalive.max_sonnection_age_secs` to `null`.
 
 #### Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks {#component-sent-bytes-total}
 

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -286,7 +286,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -298,12 +298,9 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -301,6 +301,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -277,6 +277,39 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 			}
 		}
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	record_compression: {
 		description: """
 			The compression scheme to use for decompressing records within the Firehose message.

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -298,6 +298,7 @@ base: components: sources: datadog_agent: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -274,6 +274,39 @@ base: components: sources: datadog_agent: configuration: {
 			}
 		}
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	multiple_outputs: {
 		description: """
 			If this is set to `true` logs, metrics, and traces are sent to different outputs.

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -283,7 +283,7 @@ base: components: sources: datadog_agent: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -295,12 +295,9 @@ base: components: sources: datadog_agent: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -295,6 +295,7 @@ base: components: sources: heroku_logs: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -271,6 +271,39 @@ base: components: sources: heroku_logs: configuration: {
 			}
 		}
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	query_parameters: {
 		description: """
 			A list of URL query parameters to include in the log event.

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -280,7 +280,7 @@ base: components: sources: heroku_logs: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -292,12 +292,9 @@ base: components: sources: heroku_logs: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -295,6 +295,39 @@ base: components: sources: http: configuration: {
 			items: type: string: examples: ["User-Agent", "X-My-Custom-Header"]
 		}
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	method: {
 		description: "Specifies the action of the HTTP request."
 		required:    false

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -319,6 +319,7 @@ base: components: sources: http: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -304,7 +304,7 @@ base: components: sources: http: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -316,12 +316,9 @@ base: components: sources: http: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -304,7 +304,7 @@ base: components: sources: http_server: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -316,12 +316,9 @@ base: components: sources: http_server: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -319,6 +319,7 @@ base: components: sources: http_server: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -295,6 +295,39 @@ base: components: sources: http_server: configuration: {
 			items: type: string: examples: ["User-Agent", "X-My-Custom-Header"]
 		}
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	method: {
 		description: "Specifies the action of the HTTP request."
 		required:    false

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -143,6 +143,10 @@ base: components: sources: opentelemetry: configuration: {
 		type: object: {
 			examples: [{
 				address: "0.0.0.0:4318"
+				keepalive: {
+					max_connection_age_jitter_factor: 0.1
+					max_connection_age_secs:          0
+				}
 			}]
 			options: {
 				address: {
@@ -153,6 +157,39 @@ base: components: sources: opentelemetry: configuration: {
 						"""
 					required: true
 					type: string: examples: ["0.0.0.0:4318", "localhost:4318"]
+				}
+				keepalive: {
+					description: "Configuration of HTTP server keepalive parameters."
+					required:    false
+					type: object: options: {
+						max_connection_age_jitter_factor: {
+							description: """
+																The factor by which to jitter the `max_connection_age_secs` value.
+
+																A value of 0.1 means that the actual duration will be between 90% and 110% of the
+																specified duration.
+																"""
+							required: false
+							type: float: default: 0.1
+						}
+						max_connection_age_secs: {
+							description: """
+																The maximum amount of time a connection may exist before it is closed
+																by sending a `Connection: close` header on the HTTP response.
+
+																A random jitter configured by `max_connection_age_jitter_factor` is added
+																to the specified duration to spread out connection storms.
+
+																A value of `0` disables this feature.
+																"""
+							required: false
+							type: uint: {
+								default: 0
+								examples: [600]
+								unit: "seconds"
+							}
+						}
+					}
 				}
 				tls: {
 					description: "Configures the TLS options for incoming/outgoing connections."

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -145,7 +145,7 @@ base: components: sources: opentelemetry: configuration: {
 				address: "0.0.0.0:4318"
 				keepalive: {
 					max_connection_age_jitter_factor: 0.1
-					max_connection_age_secs:          null
+					max_connection_age_secs:          300
 				}
 			}]
 			options: {
@@ -182,6 +182,7 @@ base: components: sources: opentelemetry: configuration: {
 																"""
 							required: false
 							type: uint: {
+								default: 300
 								examples: [600]
 								unit: "seconds"
 							}

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -145,7 +145,7 @@ base: components: sources: opentelemetry: configuration: {
 				address: "0.0.0.0:4318"
 				keepalive: {
 					max_connection_age_jitter_factor: 0.1
-					max_connection_age_secs:          0
+					max_connection_age_secs:          null
 				}
 			}]
 			options: {
@@ -167,7 +167,7 @@ base: components: sources: opentelemetry: configuration: {
 																The factor by which to jitter the `max_connection_age_secs` value.
 
 																A value of 0.1 means that the actual duration will be between 90% and 110% of the
-																specified duration.
+																specified maximum duration.
 																"""
 							required: false
 							type: float: default: 0.1
@@ -179,12 +179,9 @@ base: components: sources: opentelemetry: configuration: {
 
 																A random jitter configured by `max_connection_age_jitter_factor` is added
 																to the specified duration to spread out connection storms.
-
-																A value of `0` disables this feature.
 																"""
 							required: false
 							type: uint: {
-								default: 0
 								examples: [600]
 								unit: "seconds"
 							}

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -47,6 +47,39 @@ base: components: sources: prometheus_remote_write: configuration: {
 			}
 		}
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."
 		required:    false

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -56,7 +56,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -68,12 +68,9 @@ base: components: sources: prometheus_remote_write: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -71,6 +71,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -72,6 +72,39 @@ base: components: sources: splunk_hec: configuration: {
 		required: false
 		type: string: default: "0.0.0.0:8088"
 	}
+	keepalive: {
+		description: "Configuration of HTTP server keepalive parameters."
+		required:    false
+		type: object: options: {
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter the `max_connection_age_secs` value.
+
+					A value of 0.1 means that the actual duration will be between 90% and 110% of the
+					specified duration.
+					"""
+				required: false
+				type: float: default: 0.1
+			}
+			max_connection_age_secs: {
+				description: """
+					The maximum amount of time a connection may exist before it is closed
+					by sending a `Connection: close` header on the HTTP response.
+
+					A random jitter configured by `max_connection_age_jitter_factor` is added
+					to the specified duration to spread out connection storms.
+
+					A value of `0` disables this feature.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					examples: [600]
+					unit: "seconds"
+				}
+			}
+		}
+	}
 	store_hec_token: {
 		description: """
 			Whether or not to forward the Splunk HEC authentication token with events.

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -96,6 +96,7 @@ base: components: sources: splunk_hec: configuration: {
 					"""
 				required: false
 				type: uint: {
+					default: 300
 					examples: [600]
 					unit: "seconds"
 				}

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -81,7 +81,7 @@ base: components: sources: splunk_hec: configuration: {
 					The factor by which to jitter the `max_connection_age_secs` value.
 
 					A value of 0.1 means that the actual duration will be between 90% and 110% of the
-					specified duration.
+					specified maximum duration.
 					"""
 				required: false
 				type: float: default: 0.1
@@ -93,12 +93,9 @@ base: components: sources: splunk_hec: configuration: {
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
-
-					A value of `0` disables this feature.
 					"""
 				required: false
 				type: uint: {
-					default: 0
 					examples: [600]
 					unit: "seconds"
 				}


### PR DESCRIPTION
Clients often use indefinitely persistent connections. Given that we recommend network-level load balancers, this can result in sub-par balancing as the worker pool grows due to a lack of rebalancing.

To resolve this, sources with a HTTP server now support a configurable option to send a `Connection: close` header and close the connection after a certain time interval. 

The default max age is 5 minutes.