### PR TITLE
fix(file source, kubernetes_logs source, file sink): make file internal metric tag opt-in

### DIFF
--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -16,8 +16,6 @@ For example:
 
 ## To be migrated
 
-- file_metric_tag v0.36.0 The `internal_metrics.include_file_tag` should default to `false`.
-
 ## To be removed
 
 - datadog_v1_metrics v0.35.0 Support for `v1` series endpoint in the `datadog_metrics` sink should be removed.

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -12,16 +12,14 @@ use vector_lib::internal_event::{error_stage, error_type};
 
 /// Configuration of internal metrics for file-based components.
 #[configurable_component]
-#[derive(Clone, Debug, PartialEq, Eq, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct FileInternalMetricsConfig {
     /// Whether or not to include the "file" tag on the component's corresponding internal metrics.
     ///
     /// This is useful for distinguishing between different files while monitoring. However, the tag's
-    /// cardinality is unbounded. This defaults to true for now but will default to false in a future version.
-    #[serde(default = "crate::serde::default_true")]
-    #[derivative(Default(value = "true"))]
+    /// cardinality is unbounded.
+    #[serde(default = "crate::serde::default_false")]
     pub include_file_tag: bool,
 }
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -476,7 +476,9 @@ mod tests {
             compression: Compression::None,
             acknowledgements: Default::default(),
             timezone: Default::default(),
-            internal_metrics: Default::default(),
+            internal_metrics: FileInternalMetricsConfig {
+                include_file_tag: true,
+            },
         };
 
         let (input, _events) = random_lines_with_stream(100, 64, None);
@@ -500,7 +502,9 @@ mod tests {
             compression: Compression::Gzip,
             acknowledgements: Default::default(),
             timezone: Default::default(),
-            internal_metrics: Default::default(),
+            internal_metrics: FileInternalMetricsConfig {
+                include_file_tag: true,
+            },
         };
 
         let (input, _) = random_lines_with_stream(100, 64, None);
@@ -524,7 +528,9 @@ mod tests {
             compression: Compression::Zstd,
             acknowledgements: Default::default(),
             timezone: Default::default(),
-            internal_metrics: Default::default(),
+            internal_metrics: FileInternalMetricsConfig {
+                include_file_tag: true,
+            },
         };
 
         let (input, _) = random_lines_with_stream(100, 64, None);
@@ -553,7 +559,9 @@ mod tests {
             compression: Compression::None,
             acknowledgements: Default::default(),
             timezone: Default::default(),
-            internal_metrics: Default::default(),
+            internal_metrics: FileInternalMetricsConfig {
+                include_file_tag: true,
+            },
         };
 
         let (mut input, _events) = random_events_with_stream(32, 8, None);
@@ -633,7 +641,9 @@ mod tests {
             compression: Compression::None,
             acknowledgements: Default::default(),
             timezone: Default::default(),
-            internal_metrics: Default::default(),
+            internal_metrics: FileInternalMetricsConfig {
+                include_file_tag: true,
+            },
         };
 
         let (mut input, _events) = random_lines_with_stream(10, 64, None);

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -859,6 +859,9 @@ mod tests {
             },
             data_dir: Some(dir.path().to_path_buf()),
             glob_minimum_cooldown_ms: Duration::from_millis(100),
+            internal_metrics: FileInternalMetricsConfig {
+                include_file_tag: true,
+            },
             ..Default::default()
         }
     }

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -12,10 +12,7 @@ badges:
 Vector's 0.35.0 release includes **breaking changes**:
 
 1. [The Throttle transform's `events_discarded_total` internal metric is now opt-in](#events-discarded-total-opt-in)
-
-and **deprecations**:
-
-1. [Deprecation of `file` internal metric tag for file-based components](#deprecate-file-tag)
+1. [The `file` internal metric tag is now opt-in for file-based components](#file-tag-opt-in)
 
 and **potentially impactful changes**:
 
@@ -37,15 +34,12 @@ potentially unbounded cardinality.
 
 To view events discarded without the `key` tag, use the `component_discarded_events_total` internal metric.
 
-### Deprecations
-
-#### Deprecation of `file` internal metric tag for file-based components {#deprecate-file-tag}
+#### The `file` internal metric tag is now opt-in for file-based components {#file-tag-opt-in}
 
 File-based components (file source, Kubernetes logs source, file sink) now include a
 `internal_metrics.include_file_tag` config option that determines whether the `file` tag is included on the
-component's corresponding internal metrics. This config option defaults to `true` for now to retain the
-existing behavior. In the next release, the config option will be updated to default to `false`, as this
-`tag` is likely to be of high cardinality.
+component's corresponding internal metrics. This config option defaults to `false`, as this `tag` is likely to
+be of high cardinality.
 
 ### Potentially impactful changes
 

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -333,10 +333,10 @@ base: components: sinks: file: configuration: {
 				Whether or not to include the "file" tag on the component's corresponding internal metrics.
 
 				This is useful for distinguishing between different files while monitoring. However, the tag's
-				cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+				cardinality is unbounded.
 				"""
 			required: false
-			type: bool: default: true
+			type: bool: default: false
 		}
 	}
 	path: {

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -213,10 +213,10 @@ base: components: sources: file: configuration: {
 				Whether or not to include the "file" tag on the component's corresponding internal metrics.
 
 				This is useful for distinguishing between different files while monitoring. However, the tag's
-				cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+				cardinality is unbounded.
 				"""
 			required: false
-			type: bool: default: true
+			type: bool: default: false
 		}
 	}
 	line_delimiter: {

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -148,10 +148,10 @@ base: components: sources: kubernetes_logs: configuration: {
 				Whether or not to include the "file" tag on the component's corresponding internal metrics.
 
 				This is useful for distinguishing between different files while monitoring. However, the tag's
-				cardinality is unbounded. This defaults to true for now but will default to false in a future version.
+				cardinality is unbounded.
 				"""
 			required: false
-			type: bool: default: true
+			type: bool: default: false
 		}
 	}
 	kube_config_file: {


### PR DESCRIPTION
Similar to https://github.com/vectordotdev/vector/pull/19083, we have decided to make this opt-in immediately due to the impact it is having on users and downstream systems.