### PR TITLE
chore(website): WEB-4247 | Update references from s3 to setup.vector.dev

### DIFF
--- a/website/content/en/docs/setup/installation/package-managers/apt.md
+++ b/website/content/en/docs/setup/installation/package-managers/apt.md
@@ -19,7 +19,7 @@ Our APT repositories are provided by [Cloudsmith] and you can find [instructions
 First, add the Vector repo:
 
 ```shell
-bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_vector0.sh)"
+bash -c "$(curl -L https://setup.vector.dev)"
 ```
 
 Then you can install the `vector` package:

--- a/website/content/en/docs/setup/installation/package-managers/yum.md
+++ b/website/content/en/docs/setup/installation/package-managers/yum.md
@@ -13,7 +13,7 @@ Our Yum repositories are provided by [Cloudsmith] and you can find [instructions
 Add the repo:
 
 ```shell
-bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_vector0.sh)"
+bash -c "$(curl -L https://setup.vector.dev)"
 ```
 
 Then you can install Vector:

--- a/website/content/en/highlights/2023-11-07-new-linux-repos.md
+++ b/website/content/en/highlights/2023-11-07-new-linux-repos.md
@@ -38,7 +38,7 @@ The following command **removes** the existing repository and configures the
 new repository.
 
 ```sh
-CSM_MIGRATE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_vector0.sh)"
+CSM_MIGRATE=true bash -c "$(curl -L https://setup.vector.dev)"
 ```
 
 Alternatively, `CSM_MIGRATE` may be left unset to leave the removal of the


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Updates the 3 files to reference https://setup.vector.dev instead of the direct s3 link now that the subdoomain is setup again