### PR TITLE
fix(datadog_logs sink): use estimated JSON size for batching and count escapable characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,7 +5590,8 @@ dependencies = [
 [[package]]
 name = "ntapi"
 version = "0.3.7"
-source = "git+https://github.com/MSxDOS/ntapi.git?rev=24fc1e47677fc9f6e38e5f154e6011dc9b270da6#24fc1e47677fc9f6e38e5f154e6011dc9b270da6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -10222,6 +10229,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.5",
  "bitmask-enum",
+ "bytecount",
  "bytes 1.5.0",
  "chrono",
  "chrono-tz",
@@ -10239,7 +10247,6 @@ dependencies = [
  "http",
  "hyper-proxy",
  "indexmap 2.1.0",
- "memchr",
  "metrics",
  "metrics-tracing-context",
  "metrics-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10239,6 +10239,7 @@ dependencies = [
  "http",
  "hyper-proxy",
  "indexmap 2.1.0",
+ "memchr",
  "metrics",
  "metrics-tracing-context",
  "metrics-util",

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -63,7 +63,7 @@ vector-config = { path = "../vector-config" }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
 vrl.workspace = true
-memchr = "2.6.4"
+bytecount = "0.6.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2.9.2"

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -63,6 +63,7 @@ vector-config = { path = "../vector-config" }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
 vrl.workspace = true
+memchr = "2.6.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2.9.2"

--- a/lib/vector-core/src/event/estimated_json_encoded_size_of.rs
+++ b/lib/vector-core/src/event/estimated_json_encoded_size_of.rs
@@ -97,8 +97,7 @@ impl EstimatedJsonEncodedSizeOf for str {
 // serializing to JSON. The goal is improve our overall accuracy in the case of relatively common
 // scenarios like strings of nested JSON, etc.
 fn count_escapes(input: &[u8]) -> usize {
-    memchr::memchr3_iter(b'"', b'\\', b'\t', input).count()
-        + memchr::memchr2_iter(b'\n', b'\r', input).count()
+    bytecount::count(input, b'"')
 }
 
 impl EstimatedJsonEncodedSizeOf for String {

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -8,7 +8,7 @@ use vector_lib::lookup::event_path;
 use super::{config::MAX_PAYLOAD_BYTES, service::LogApiRequest};
 use crate::sinks::{
     prelude::*,
-    util::{encoding::Encoder as _, Compressor},
+    util::{encoding::Encoder as _, Compressor, http::HttpJsonBatchSizer},
 };
 #[derive(Default)]
 struct EventPartitioner;
@@ -263,7 +263,7 @@ where
         let partitioner = EventPartitioner;
         let batch_settings = self.batch_settings;
 
-        let input = input.batched_partitioned(partitioner, || batch_settings.as_byte_size_config());
+        let input = input.batched_partitioned(partitioner, || batch_settings.as_item_size_config(HttpJsonBatchSizer));
         input
             .request_builder(
                 default_request_builder_concurrency_limit(),

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -8,7 +8,7 @@ use vector_lib::lookup::event_path;
 use super::{config::MAX_PAYLOAD_BYTES, service::LogApiRequest};
 use crate::sinks::{
     prelude::*,
-    util::{encoding::Encoder as _, Compressor, http::HttpJsonBatchSizer},
+    util::{encoding::Encoder as _, http::HttpJsonBatchSizer, Compressor},
 };
 #[derive(Default)]
 struct EventPartitioner;
@@ -263,7 +263,9 @@ where
         let partitioner = EventPartitioner;
         let batch_settings = self.batch_settings;
 
-        let input = input.batched_partitioned(partitioner, || batch_settings.as_item_size_config(HttpJsonBatchSizer));
+        let input = input.batched_partitioned(partitioner, || {
+            batch_settings.as_item_size_config(HttpJsonBatchSizer)
+        });
         input
             .request_builder(
                 default_request_builder_concurrency_limit(),

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -556,7 +556,7 @@ async fn does_not_send_too_big_payloads() {
     // Generate input that will require escaping when serialized to json, and therefore grow in size
     // between batching and encoding. This is a very specific example that will fit in a batch of
     // <4,250,000 but serialize to >5,000,000, defeating the current 750k safety buffer.
-    let events = (0..1000).into_iter().map(|_n| {
+    let events = (0..1000).map(|_n| {
         let data = serde_json::json!({"a": "b"});
         let nested = serde_json::to_string(&data).unwrap();
         event_with_api_key(&nested.repeat(401), "foo")


### PR DESCRIPTION
Ref #10020 