### PR TITLE
chore(aws_kinesis_streams sink): re-enable int test for partition_key

### DIFF
--- a/scripts/integration/aws/test.yaml
+++ b/scripts/integration/aws/test.yaml
@@ -22,11 +22,11 @@ matrix:
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch
 paths:
-- "src/aws_**"
-- "src/internal_events/aws_**"
-- "src/sources/aws_**"
+- "src/aws/**"
+- "src/internal_events/aws_*"
+- "src/sources/aws_*/**"
 - "src/sources/util/**"
-- "src/sinks/aws_**"
+- "src/sinks/aws_*/**"
 - "src/sinks/util/**"
-- "src/transforms/aws_**"
+- "src/transforms/aws_*"
 - "scripts/integration/aws/**"

--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -74,6 +74,7 @@ async fn kinesis_put_records_with_partition_key() {
 
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
 
+    // Hard-coded sleeps are bad, but we're waiting on localstack's state to converge.
     sleep(Duration::from_secs(1)).await;
 
     let records = fetch_records(stream, timestamp).await.unwrap();
@@ -129,6 +130,7 @@ async fn kinesis_put_records_without_partition_key() {
 
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
 
+    // Hard-coded sleeps are bad, but we're waiting on localstack's state to converge.
     sleep(Duration::from_secs(1)).await;
 
     let records = fetch_records(stream, timestamp).await.unwrap();

--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -1,12 +1,15 @@
 #![cfg(feature = "aws-kinesis-streams-integration-tests")]
 #![cfg(test)]
 
+use futures::StreamExt;
+
 use aws_sdk_kinesis::{
     model::{Record, ShardIteratorType},
     types::DateTime,
 };
 use tokio::time::{sleep, Duration};
 use vector_lib::codecs::TextSerializerConfig;
+use vector_lib::lookup::lookup_v2::ConfigValuePath;
 
 use super::{config::KinesisClientBuilder, *};
 use crate::{
@@ -23,62 +26,71 @@ fn kinesis_address() -> String {
     std::env::var("KINESIS_ADDRESS").unwrap_or_else(|_| "http://localhost:4566".into())
 }
 
-// TODO: temporarily disabling as this is failing
-//#[tokio::test]
-//async fn kinesis_put_records_with_partition_key() {
-//    let stream = gen_stream();
-//
-//    ensure_stream(stream.clone()).await;
-//
-//    let mut batch = BatchConfig::default();
-//    batch.max_events = Some(2);
-//
-//    let base = KinesisSinkBaseConfig {
-//        stream_name: stream.clone(),
-//        region: RegionOrEndpoint::with_both("localstack", kinesis_address().as_str()),
-//        encoding: TextSerializerConfig::default().into(),
-//        compression: Compression::None,
-//        request: Default::default(),
-//        tls: Default::default(),
-//        auth: Default::default(),
-//        acknowledgements: Default::default(),
-//    };
-//
-//    let partition_key: String = "partition_key".to_string();
-//
-//    let config = KinesisStreamsSinkConfig {
-//        partition_key_field: Some(partition_key.clone()),
-//        batch,
-//        base,
-//    };
-//
-//    let cx = SinkContext::default();
-//
-//    let sink = config.build(cx).await.unwrap().0;
-//
-//    let timestamp = chrono::Utc::now().timestamp_millis();
-//
-//    let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
-//
-//    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
-//
-//    sleep(Duration::from_secs(1)).await;
-//
-//    let records = fetch_records(stream, timestamp).await.unwrap();
-//
-//    let mut output_lines = records
-//        .into_iter()
-//        .map(|e| {
-//            assert_eq!(Some(partition_key.as_str()), e.partition_key());
-//            e
-//        })
-//        .map(|e| String::from_utf8(e.data.unwrap().into_inner()).unwrap())
-//        .collect::<Vec<_>>();
-//
-//    input_lines.sort();
-//    output_lines.sort();
-//    assert_eq!(output_lines, input_lines)
-//}
+#[tokio::test]
+async fn kinesis_put_records_with_partition_key() {
+    let stream = gen_stream();
+
+    ensure_stream(stream.clone()).await;
+
+    let mut batch = BatchConfig::default();
+    batch.max_events = Some(2);
+
+    let partition_value = "a_value";
+
+    let base = KinesisSinkBaseConfig {
+        stream_name: stream.clone(),
+        region: RegionOrEndpoint::with_both("localstack", kinesis_address().as_str()),
+        encoding: TextSerializerConfig::default().into(),
+        compression: Compression::None,
+        request: Default::default(),
+        tls: Default::default(),
+        auth: Default::default(),
+        acknowledgements: Default::default(),
+        request_retry_partial: Default::default(),
+    };
+
+    let partition_key = ConfigValuePath::try_from("partition_key".to_string()).unwrap();
+
+    let config = KinesisStreamsSinkConfig {
+        partition_key_field: Some(partition_key.clone()),
+        batch,
+        base,
+    };
+
+    let cx = SinkContext::default();
+
+    let sink = config.build(cx).await.unwrap().0;
+
+    let timestamp = chrono::Utc::now().timestamp_millis();
+
+    let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
+
+    let events = events.map(move |mut events| {
+        events.iter_logs_mut().for_each(move |log| {
+            log.insert("partition_key", partition_value);
+        });
+        events
+    });
+
+    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
+
+    sleep(Duration::from_secs(1)).await;
+
+    let records = fetch_records(stream, timestamp).await.unwrap();
+
+    let mut output_lines = records
+        .into_iter()
+        .map(|e| {
+            assert_eq!(Some(partition_value), e.partition_key());
+            e
+        })
+        .map(|e| String::from_utf8(e.data.unwrap().into_inner()).unwrap())
+        .collect::<Vec<_>>();
+
+    input_lines.sort();
+    output_lines.sort();
+    assert_eq!(output_lines, input_lines)
+}
 
 #[tokio::test]
 async fn kinesis_put_records_without_partition_key() {


### PR DESCRIPTION
Fixes: #16376

The integration test was disabled because it was failing on master when it was first introduced. Just needed a couple modifications.
