### PR TITLE
enhancement(influxdb_logs sink): Add namespaceable global schema key fields support

### DIFF
--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -5,13 +5,12 @@ use futures::SinkExt;
 use http::{Request, Uri};
 use indoc::indoc;
 use vrl::event_path;
-use vrl::path::OwnedValuePath;
+use vrl::path::OwnedTargetPath;
 use vrl::value::Kind;
 
 use vector_lib::config::log_schema;
 use vector_lib::configurable::configurable_component;
-use vector_lib::lookup::lookup_v2::OptionalValuePath;
-use vector_lib::lookup::PathPrefix;
+use vector_lib::lookup::lookup_v2::OptionalTargetPath;
 use vector_lib::schema;
 
 use super::{
@@ -117,19 +116,19 @@ pub struct InfluxDbLogsConfig {
     ///
     /// The setting of `log_schema.host_key`, usually `host`, is used here by default.
     #[configurable(metadata(docs::examples = "hostname"))]
-    pub host_key: Option<OptionalValuePath>,
+    pub host_key: Option<OptionalTargetPath>,
 
     /// Use this option to customize the key containing the message.
     ///
     /// The setting of `log_schema.message_key`, usually `message`, is used here by default.
     #[configurable(metadata(docs::examples = "text"))]
-    pub message_key: Option<OptionalValuePath>,
+    pub message_key: Option<OptionalTargetPath>,
 
     /// Use this option to customize the key containing the source_type.
     ///
     /// The setting of `log_schema.source_type_key`, usually `source_type`, is used here by default.
     #[configurable(metadata(docs::examples = "source"))]
-    pub source_type_key: Option<OptionalValuePath>,
+    pub source_type_key: Option<OptionalTargetPath>,
 }
 
 #[derive(Debug)]
@@ -140,9 +139,9 @@ struct InfluxDbLogsSink {
     measurement: String,
     tags: HashSet<KeyString>,
     transformer: Transformer,
-    host_key: OwnedValuePath,
-    message_key: OwnedValuePath,
-    source_type_key: OwnedValuePath,
+    host_key: OwnedTargetPath,
+    message_key: OwnedTargetPath,
+    source_type_key: OwnedTargetPath,
 }
 
 impl GenerateConfig for InfluxDbLogsConfig {
@@ -189,21 +188,21 @@ impl SinkConfig for InfluxDbLogsConfig {
             .host_key
             .as_ref()
             .and_then(|k| k.path.clone())
-            .or_else(|| log_schema().host_key().cloned())
+            .or_else(|| log_schema().host_key_target_path().cloned())
             .expect("global log_schema.host_key to be valid path");
 
         let message_key = self
             .message_key
             .as_ref()
             .and_then(|k| k.path.clone())
-            .or_else(|| log_schema().message_key().cloned())
+            .or_else(|| log_schema().message_key_target_path().cloned())
             .expect("global log_schema.message_key to be valid path");
 
         let source_type_key = self
             .source_type_key
             .as_ref()
             .and_then(|k| k.path.clone())
-            .or_else(|| log_schema().source_type_key().cloned())
+            .or_else(|| log_schema().source_type_key_target_path().cloned())
             .expect("global log_schema.source_type_key to be valid path");
 
         let sink = InfluxDbLogsSink {
@@ -250,9 +249,9 @@ struct InfluxDbLogsEncoder {
     measurement: String,
     tags: HashSet<KeyString>,
     transformer: Transformer,
-    host_key: OwnedValuePath,
-    message_key: OwnedValuePath,
-    source_type_key: OwnedValuePath,
+    host_key: OwnedTargetPath,
+    message_key: OwnedTargetPath,
+    source_type_key: OwnedTargetPath,
 }
 
 impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
@@ -263,18 +262,18 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         // the path that points to "message" such that it has a dedicated key.
         // TODO: add a `TargetPath::is_event_root()` to conditionally rename?
         if let Some(message_path) = log.message_path().cloned().as_ref() {
-            log.rename_key(message_path, (PathPrefix::Event, &self.message_key));
+            log.rename_key(message_path, &self.message_key);
         }
         // Add the `host` and `source_type` to the HashSet of tags to include
         // Ensure those paths are on the event to be encoded, rather than metadata
         if let Some(host_path) = log.host_path().cloned().as_ref() {
             self.tags.replace(host_path.path.to_string().into());
-            log.rename_key(host_path, (PathPrefix::Event, &self.host_key));
+            log.rename_key(host_path, &self.host_key);
         }
 
         if let Some(source_type_path) = log.source_type_path().cloned().as_ref() {
             self.tags.replace(source_type_path.path.to_string().into());
-            log.rename_key(source_type_path, (PathPrefix::Event, &self.source_type_key));
+            log.rename_key(source_type_path, &self.source_type_key);
         }
 
         self.tags.replace("metric_type".into());
@@ -862,9 +861,9 @@ mod tests {
             measurement,
             tags,
             transformer: Default::default(),
-            host_key: owned_value_path!("host"),
-            message_key: owned_value_path!("message"),
-            source_type_key: owned_value_path!("source_type"),
+            host_key: OwnedTargetPath::event(owned_value_path!("host")),
+            message_key: OwnedTargetPath::event(owned_value_path!("message")),
+            source_type_key: OwnedTargetPath::event(owned_value_path!("source_type")),
         }
     }
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Adds support to the InfluxDB sink for key fields to be namespaced, as in `log_namespace` usage. This covers the `host_key`, `source_type_key`, and `message_key` fields potentially being defined to a non-event namespace field in the global config. This matches enhancements added in #19086 on the Splunk-related sinks, fixing original issue #18867. InfluxDB is the only other sink that references the global key fields.

What I need a double-check on is the implication of the comment on line 267 onward, where the potentially-namespaced field on the original event is to be encoded / renamed into the event namespace?
