### PR TITLE
chore(docs): Remove stale docs content around schemas

### DIFF
--- a/website/content/en/docs/about/under-the-hood/architecture/data-model/log.md
+++ b/website/content/en/docs/about/under-the-hood/architecture/data-model/log.md
@@ -30,10 +30,6 @@ Here's an example representation of a log event (as JSON):
 Vector is schema-neutral and doesn't require any specific schema. This ensures that Vector can work
 with a variety of schemas, supporting legacy schemas as well as future schemas.
 
-We *do* plan to implement a common information model for Vector that would recognize popular
-schemas, allowing you to seamlessly transform between schemas. You can track progress on this work
-in [issue 3910][3910].
-
 ### Types
 
 #### Strings


### PR DESCRIPTION
This is not a current priority and so I don't think mentioning it in the docs is useful.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
