### PR TITLE
fix(codecs): cargo test compilation error

### DIFF
--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -318,7 +318,7 @@ mod tests {
         let mut tree = ObjectMap::new();
 
         for (field_name, field_value) in field_data.into_iter() {
-            let field = ConfigTargetPath::try_from(field_name.clone()).unwrap();
+            let field = ConfigTargetPath::try_from(field_name.to_string()).unwrap();
             fields.push(field);
 
             let field_value = Value::from(field_value.to_string());


### PR DESCRIPTION
```
cargo vdev test  encoding::format::csv::tests

Summary [   0.138s] 9 tests run: 9 passed, 2007 skipped
```


However:
```
cargo test --lib encoding::format::csv::tests --manifest-path ..../vector/lib/codecs/Cargo.toml

error[E0277]: the trait bound `vector_lookup::lookup_v2::ConfigTargetPath: From<&str>` is not satisfied
   --> lib/codecs/src/encoding/format/csv.rs:321:52
    |
321 |             let field = ConfigTargetPath::try_from(field_name.clone()).unwrap();
    |                         -------------------------- ^^^^^^^^^^^^^^^^^^ the trait `From<&str>` is not implemented for `vector_lookup::lookup_v2::ConfigTargetPath`
    |                         |
    |                         required by a bound introduced by this call
```

