### PR TITLE
fix(ci): Change regression test report path

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -719,7 +719,7 @@ jobs:
         id: read-analysis
         uses: juliangruber/read-file-action@v1
         with:
-          path: ${{ runner.temp }}/outputs/report.html
+          path: ${{ runner.temp }}/outputs/report.md
 
       - name: Post report to PR
         uses: peter-evans/create-or-update-comment@v3


### PR DESCRIPTION
This appears to have changed to `report.md`.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
