### PR TITLE
fix(ci): Use correct concurrency group settings for comment trigger & PR commit workflows

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -25,7 +25,13 @@ on:
     - cron: '0 0 * * 2-6'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.comment.html_url || github.event.merge_group.head_sha || github.event.schedule || github.sha }}
+  # In flight runs will be canceled through re-trigger in the merge queue, scheduled run. The comment.html_url should always be unique.
+  # Note that technically this workflow can run on PRs which have code changes that affect K8s. Choosing not to add the PR commit to
+  # the concurrency group settings- since that would result in new PR commits canceling out manual runs on any PR that doesn't flag
+  # change detection. This is a "conservative" approach that means we may have some runs that could be canceled, but it's safer than
+  # having user's runs canceled when they shouldn't be. In practice this shouldn't happen very often given this component does not change
+  # often so any increased cost from the conservative approach should be negligible.
+  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.event.merge_group.head_sha || github.event.schedule }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,7 +34,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.event.merge_group.head_sha || github.sha }}
+  # In flight runs will be canceled only by re-trigger through the merge queue. The comment.html_url should always be unique.
+  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
We saw empirically that if the `github.sha` event context is used on workflows that are dispatched via comment trigger AND pull_request trigger, results in any commit to the PR during in flight comment trigger executions , canceling the in progress run undesirably.

This removes that commit sha from the concurrency group settings. For regression workflow it's a "pure" fix because we don't do code changes detection on the PR commit event, but for k8s workflow there is a compromise that must be made. I selected the conservative approach which means we might have some runs that could be cancelled but aren't, as opposed to potentially having runs cancelled that we don't want. 
