### PR TITLE
chore(external docs): Second batch of editorial edits for the Functions doc

### DIFF
--- a/website/cue/reference/remap/functions/array.cue
+++ b/website/cue/reference/remap/functions/array.cue
@@ -4,7 +4,7 @@ remap: functions: array: {
 	category: "Type"
 	description: """
 		Returns `value` if it is an array, otherwise returns an error. This enables the type checker to guarantee that the
-		returned value is an array and can be used in any function that expects one.
+		returned value is an array and can be used in any function that expects an array.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/array.cue
+++ b/website/cue/reference/remap/functions/array.cue
@@ -3,20 +3,20 @@ package metadata
 remap: functions: array: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's an array and errors otherwise. This enables the type checker to guarantee that the
+		Returns `value` if it is an array, otherwise returns an error. This enables the type checker to guarantee that the
 		returned value is an array and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is an array."
+			description: "The value to check if it is an array."
 			required:    true
 			type: ["any"]
 		},
 	]
 	internal_failure_reasons: [
-		"`value` isn't an array.",
+		"`value` is not an array.",
 	]
 	return: {
 		types: ["array"]

--- a/website/cue/reference/remap/functions/bool.cue
+++ b/website/cue/reference/remap/functions/bool.cue
@@ -3,20 +3,20 @@ package metadata
 remap: functions: bool: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's a Boolean and errors otherwise. This enables the type checker to guarantee that the
+		Returns `value` if it is a Boolean, otherwise returns an error. This enables the type checker to guarantee that the
 		returned value is a Boolean and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is a Boolean."
+			description: "The value to check if it is a Boolean."
 			required:    true
 			type: ["any"]
 		},
 	]
 	internal_failure_reasons: [
-		"`value` isn't a Boolean.",
+		"`value` is not a Boolean.",
 	]
 	return: {
 		types: ["boolean"]

--- a/website/cue/reference/remap/functions/bool.cue
+++ b/website/cue/reference/remap/functions/bool.cue
@@ -4,7 +4,7 @@ remap: functions: bool: {
 	category: "Type"
 	description: """
 		Returns `value` if it is a Boolean, otherwise returns an error. This enables the type checker to guarantee that the
-		returned value is a Boolean and can be used in any function that expects one.
+		returned value is a Boolean and can be used in any function that expects a Boolean.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/community_id.cue
+++ b/website/cue/reference/remap/functions/community_id.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: community_id: {
 	category:    "String"
 	description: """
-		Used to generate an id based on the [Community ID Spec](\(urls.community_id_spec)).
+		Generate an ID based on the [Community ID Spec](\(urls.community_id_spec)).
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/community_id.cue
+++ b/website/cue/reference/remap/functions/community_id.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: community_id: {
 	category:    "String"
 	description: """
-		Generate an ID based on the [Community ID Spec](\(urls.community_id_spec)).
+		Generates an ID based on the [Community ID Spec](\(urls.community_id_spec)).
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/del.cue
+++ b/website/cue/reference/remap/functions/del.cue
@@ -18,8 +18,8 @@ remap: functions: del: {
 		{
 			name: "compact"
 			description: """
-				After deletion, if `compact` is `true` and an empty object or array is left
-				behind, the empty object or array is also removed, cascading up to the root. This only
+				After deletion, if `compact` is `true` and there is an empty object or array left,
+				the empty object or array is also removed, cascading up to the root. This only
 				applies to the path being deleted, and any parent paths.
 				"""
 			required: false

--- a/website/cue/reference/remap/functions/del.cue
+++ b/website/cue/reference/remap/functions/del.cue
@@ -18,8 +18,8 @@ remap: functions: del: {
 		{
 			name: "compact"
 			description: """
-				If compact is true, after deletion, if an empty object or array is left
-				behind, it should be removed as well, cascading up to the root. This only
+				After deletion, if `compact` is `true` and an empty object or array is left
+				behind, the empty object or array is also removed, cascading up to the root. This only
 				applies to the path being deleted, and any parent paths.
 				"""
 			required: false

--- a/website/cue/reference/remap/functions/downcase.cue
+++ b/website/cue/reference/remap/functions/downcase.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: downcase: {
 	category: "String"
 	description: """
-		Downcases the `value` string, where downcase is defined according to the terms of the
+		Downcases the `value` string, where downcase is defined according to the
 		Unicode Derived Core Property Lowercase.
 		"""
 

--- a/website/cue/reference/remap/functions/downcase.cue
+++ b/website/cue/reference/remap/functions/downcase.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: downcase: {
 	category: "String"
 	description: """
-		Downcases the `value` string, where "downcase" is defined according to the terms of the
+		Downcases the `value` string, where downcase is defined according to the terms of the
 		Unicode Derived Core Property Lowercase.
 		"""
 

--- a/website/cue/reference/remap/functions/exists.cue
+++ b/website/cue/reference/remap/functions/exists.cue
@@ -5,10 +5,10 @@ remap: functions: exists: {
 	description: """
 		Checks whether the `path` exists for the target.
 
-		This function allows you to distinguish between a missing path,
-		or a path with a `null` value, something a regular path lookup
-		such as `.foo` would not allow, since that always returns `null`
-		if the path doesn't exist.
+		This function distinguishes between a missing path
+		and a path with a `null` value. A regular path lookup,
+		such as `.foo`, cannot distinguish between the two cases
+		since it always returns `null` if the path doesn't exist.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/find.cue
+++ b/website/cue/reference/remap/functions/find.cue
@@ -3,8 +3,8 @@ package metadata
 remap: functions: find: {
 	category: "String"
 	description: """
-		Determines the start position of the first found element in `value`,
-		from left to right, that matches `pattern` or returns `-1` if not found.
+		Determines from left to right the start position of the first found element in `value`
+		that matches `pattern`. Returns `-1` if not found.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/find.cue
+++ b/website/cue/reference/remap/functions/find.cue
@@ -4,7 +4,7 @@ remap: functions: find: {
 	category: "String"
 	description: """
 		Determines the start position of the first found element in `value`,
-		from left to right, that matches the `pattern` or returns -1 if not found.
+		from left to right, that matches the `pattern` or returns `-1` if not found.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/find.cue
+++ b/website/cue/reference/remap/functions/find.cue
@@ -4,7 +4,7 @@ remap: functions: find: {
 	category: "String"
 	description: """
 		Determines the start position of the first found element in `value`,
-		from left to right, that matches the `pattern` or returns `-1` if not found.
+		from left to right, that matches `pattern` or returns `-1` if not found.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/float.cue
+++ b/website/cue/reference/remap/functions/float.cue
@@ -3,20 +3,20 @@ package metadata
 remap: functions: float: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's a float and errors otherwise. This enables the type checker to guarantee that the
+		Returns `value` if it is a float, otherwise returns an error. This enables the type checker to guarantee that the
 		returned value is a float and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is a float."
+			description: "The value to check if it is a float."
 			required:    true
 			type: ["any"]
 		},
 	]
 	internal_failure_reasons: [
-		"`value` isn't a float.",
+		"`value` is not a float.",
 	]
 	return: {
 		types: ["float"]

--- a/website/cue/reference/remap/functions/float.cue
+++ b/website/cue/reference/remap/functions/float.cue
@@ -4,7 +4,7 @@ remap: functions: float: {
 	category: "Type"
 	description: """
 		Returns `value` if it is a float, otherwise returns an error. This enables the type checker to guarantee that the
-		returned value is a float and can be used in any function that expects one.
+		returned value is a float and can be used in any function that expects a float.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/format_timestamp.cue
+++ b/website/cue/reference/remap/functions/format_timestamp.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: format_timestamp: {
 	category: "Timestamp"
 	description: #"""
-		Formats the `value` into a string representation of the timestamp.
+		Formats `value` into a string representation of the timestamp.
 		"""#
 
 	arguments: [
@@ -21,7 +21,7 @@ remap: functions: format_timestamp: {
 		},
 		{
 			name:        "timezone"
-			description: "The timezone to use when formatting the timestamp. The uses the TZ identifier, or 'local'"
+			description: "The timezone to use when formatting the timestamp. The parameter uses the TZ identifier or `local`."
 			required:    false
 			type: ["string"]
 		},

--- a/website/cue/reference/remap/functions/get.cue
+++ b/website/cue/reference/remap/functions/get.cue
@@ -3,12 +3,12 @@ package metadata
 remap: functions: get: {
 	category: "Path"
 	description: """
-		Dynamically get the value of a given path.
+		Dynamically get the value of a given `path`.
 
-		When you know the path you want to look up, you should use
+		When you know the path you want to look up, use
 		static paths such as `.foo.bar[1]` to get the value of that
-		path. However, when you don't know the path names in advance,
-		you can use this dynamic get function to get at the requested
+		path. However, when you do not know the path names,
+		use this dynamic `get` function to get the requested
 		value.
 		"""
 
@@ -21,13 +21,13 @@ remap: functions: get: {
 		},
 		{
 			name:        "path"
-			description: "An array of path segments to look up the value for."
+			description: "An array of path segments to look up the value."
 			required:    true
 			type: ["array"]
 		},
 	]
 	internal_failure_reasons: [
-		#"path segment must be either "string" or "integer""#,
+		#"`path` segment must be a string or an integer."#,
 	]
 	return: types: ["any"]
 

--- a/website/cue/reference/remap/functions/get.cue
+++ b/website/cue/reference/remap/functions/get.cue
@@ -3,12 +3,12 @@ package metadata
 remap: functions: get: {
 	category: "Path"
 	description: """
-		Dynamically get the value of a given `path`.
+		Dynamically get the value of a given path.
 
-		When you know the path you want to look up, use
+		If you know the path you want to look up, use
 		static paths such as `.foo.bar[1]` to get the value of that
-		path. However, when you do not know the path names,
-		use this dynamic `get` function to get the requested
+		path. However, if you do not know the path names,
+		use the dynamic `get` function to get the requested
 		value.
 		"""
 
@@ -21,13 +21,13 @@ remap: functions: get: {
 		},
 		{
 			name:        "path"
-			description: "An array of path segments to look up the value."
+			description: "An array of path segments to look for the value."
 			required:    true
 			type: ["array"]
 		},
 	]
 	internal_failure_reasons: [
-		#"`path` segment must be a string or an integer."#,
+		#"The `path` segment must be a string or an integer."#,
 	]
 	return: types: ["any"]
 

--- a/website/cue/reference/remap/functions/get_env_var.cue
+++ b/website/cue/reference/remap/functions/get_env_var.cue
@@ -15,8 +15,8 @@ remap: functions: get_env_var: {
 		},
 	]
 	internal_failure_reasons: [
-		"Environment variable `name` doesn't exist",
-		"Value of environment variable `name` isn't valid Unicode",
+		"Environment variable `name` does not exist.",
+		"The value of environment variable `name` is not valid Unicode",
 	]
 	return: types: ["string"]
 

--- a/website/cue/reference/remap/functions/int.cue
+++ b/website/cue/reference/remap/functions/int.cue
@@ -4,7 +4,7 @@ remap: functions: int: {
 	category: "Type"
 	description: """
 		Returns `value` if it is an integer, otherwise returns an error. This enables the type checker to guarantee that the
-		returned value is an integer and can be used in any function that expects one.
+		returned value is an integer and can be used in any function that expects an integer.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/int.cue
+++ b/website/cue/reference/remap/functions/int.cue
@@ -3,14 +3,14 @@ package metadata
 remap: functions: int: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's an integer and errors otherwise. This enables the type checker to guarantee that the
+		Returns `value` if it is an integer, otherwise returns an error. This enables the type checker to guarantee that the
 		returned value is an integer and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is an integer."
+			description: "The value to check if it is an integer."
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_array.cue
+++ b/website/cue/reference/remap/functions/is_array.cue
@@ -9,7 +9,7 @@ remap: functions: is_array: {
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is an array."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_array.cue
+++ b/website/cue/reference/remap/functions/is_array.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_array: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is an array.
+		Check if the `value`'s type is an array.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_array.cue
+++ b/website/cue/reference/remap/functions/is_array.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_array: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is an array or not.
+		Check if the type of `value` is an array.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_boolean.cue
+++ b/website/cue/reference/remap/functions/is_boolean.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_boolean: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a boolean.
+		Check if the `value`'s type is a boolean.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_boolean.cue
+++ b/website/cue/reference/remap/functions/is_boolean.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_boolean: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is a boolean or not.
+		Check if the type of `value` is a boolean or not.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_boolean.cue
+++ b/website/cue/reference/remap/functions/is_boolean.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_boolean: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a boolean or not.
+		Check if the type of `value` is a boolean.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is a Boolean."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_empty.cue
+++ b/website/cue/reference/remap/functions/is_empty.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_empty: {
 	category: "Type"
 	description: """
-		Check if the object, array, or string has a length of 0.
+		Check if the object, array, or string has a length of `0`.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_float.cue
+++ b/website/cue/reference/remap/functions/is_float.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_float: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a float.
+		Check if the `value`'s type is a float.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_float.cue
+++ b/website/cue/reference/remap/functions/is_float.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_float: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is a float or not.
+		Check if the type of `value` is a float or not.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_float.cue
+++ b/website/cue/reference/remap/functions/is_float.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_float: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a float or not.
+		Check if the type of `value` is a float.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is a float."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_integer.cue
+++ b/website/cue/reference/remap/functions/is_integer.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_integer: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is an integer.
+		Check if the value`'s type is an integer.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_integer.cue
+++ b/website/cue/reference/remap/functions/is_integer.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_integer: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is an integer or not.
+		Check if the type of `value` is an integer.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check if it is an integer."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_json.cue
+++ b/website/cue/reference/remap/functions/is_json.cue
@@ -9,7 +9,7 @@ remap: functions: is_json: {
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["string"]
 		},

--- a/website/cue/reference/remap/functions/is_json.cue
+++ b/website/cue/reference/remap/functions/is_json.cue
@@ -9,7 +9,7 @@ remap: functions: is_json: {
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is a valid JSON document."#
 			required:    true
 			type: ["string"]
 		},

--- a/website/cue/reference/remap/functions/is_null.cue
+++ b/website/cue/reference/remap/functions/is_null.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_null: {
 	category:    "Type"
 	description: """
-		Check if the type of `value` is `null`. For a more relaxed function, 
+		Check if `value`'s type is `null`. For a more relaxed function, 
 		see [`is_nullish`](\(urls.vrl_functions)#\(remap.functions.is_nullish.anchor)).
 		"""
 

--- a/website/cue/reference/remap/functions/is_null.cue
+++ b/website/cue/reference/remap/functions/is_null.cue
@@ -3,14 +3,14 @@ package metadata
 remap: functions: is_null: {
 	category:    "Type"
 	description: """
-		Check if the type of a `value` is `null` or not. For a more relaxed function please
-		check [`is_nullish`](\(urls.vrl_functions)#\(remap.functions.is_nullish.anchor)).
+		Check if the type of `value` is `null`. For a more relaxed function, 
+		see [`is_nullish`](\(urls.vrl_functions)#\(remap.functions.is_nullish.anchor)).
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check if it is `null`."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_null.cue
+++ b/website/cue/reference/remap/functions/is_null.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_null: {
 	category:    "Type"
 	description: """
-		Check if `value`'s type is `null`. For a more relaxed function, 
+		Check if `value`'s type is `null`. For a more relaxed function,
 		see [`is_nullish`](\(urls.vrl_functions)#\(remap.functions.is_nullish.anchor)).
 		"""
 

--- a/website/cue/reference/remap/functions/is_nullish.cue
+++ b/website/cue/reference/remap/functions/is_nullish.cue
@@ -3,14 +3,14 @@ package metadata
 remap: functions: is_nullish: {
 	category: "Type"
 	description: """
-		Determines whether the `value` is "nullish," where nullish denotes the absence of a
+		Determines whether `value` is nullish, where nullish denotes the absence of a
 		meaningful value.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check for "nullishness," i.e. a useless value."#
+			description: #"The value to check for nullishness, for example, a useless value."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_object.cue
+++ b/website/cue/reference/remap/functions/is_object.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_object: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is an object or not.
+		Check if the type of `value` is an object.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check if it is an object."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_object.cue
+++ b/website/cue/reference/remap/functions/is_object.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_object: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is an object.
+		Check if `value`'s type is an object.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_regex.cue
+++ b/website/cue/reference/remap/functions/is_regex.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_regex: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is a regex or not.
+		Check if the type of `value` is a regex.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_regex.cue
+++ b/website/cue/reference/remap/functions/is_regex.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_regex: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a regex.
+		Check if `value`'s type is a regex.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_regex.cue
+++ b/website/cue/reference/remap/functions/is_regex.cue
@@ -9,7 +9,7 @@ remap: functions: is_regex: {
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is a regex."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_string.cue
+++ b/website/cue/reference/remap/functions/is_string.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_string: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a string.
+		Check if `value`'s type is a string.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_string.cue
+++ b/website/cue/reference/remap/functions/is_string.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_string: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is a string or not.
+		Check if the type of `value` is a string.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_string.cue
+++ b/website/cue/reference/remap/functions/is_string.cue
@@ -9,7 +9,7 @@ remap: functions: is_string: {
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is a string."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_timestamp.cue
+++ b/website/cue/reference/remap/functions/is_timestamp.cue
@@ -9,7 +9,7 @@ remap: functions: is_timestamp: {
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check."#
+			description: #"The value to check if it is a timestamp."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/is_timestamp.cue
+++ b/website/cue/reference/remap/functions/is_timestamp.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: is_timestamp: {
 	category: "Type"
 	description: """
-		Check if the type of `value` is a timestamp.
+		Check if `value`'s type is a timestamp.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/is_timestamp.cue
+++ b/website/cue/reference/remap/functions/is_timestamp.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: is_timestamp: {
 	category: "Type"
 	description: """
-		Check if the type of a `value` is a timestamp or not.
+		Check if the type of `value` is a timestamp.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: #"The value to check"#
+			description: #"The value to check."#
 			required:    true
 			type: ["any"]
 		},

--- a/website/cue/reference/remap/functions/match_any.cue
+++ b/website/cue/reference/remap/functions/match_any.cue
@@ -5,8 +5,8 @@ remap: functions: match_any: {
 	description: """
 		Determines whether `value` matches any of the given `patterns`. All
 		patterns are checked in a single pass over the target string, giving this
-		function a potentially significant performance advantage over multiple calls
-		to `match`.
+		function a potential performance advantage over the multiple calls
+		in the `match` function.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/match_any.cue
+++ b/website/cue/reference/remap/functions/match_any.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: match_any: {
 	category: "String"
 	description: """
-		Determines whether the `value` matches any the given `patterns`. All
+		Determines whether `value` matches any of the given `patterns`. All
 		patterns are checked in a single pass over the target string, giving this
 		function a potentially significant performance advantage over multiple calls
 		to `match`.

--- a/website/cue/reference/remap/functions/object.cue
+++ b/website/cue/reference/remap/functions/object.cue
@@ -4,7 +4,7 @@ remap: functions: object: {
 	category: "Type"
 	description: """
 		Returns `value` if it is an object, otherwise returns an error. This enables the type checker to guarantee that the
-		returned value is an object and can be used in any function that expects one.
+		returned value is an object and can be used in any function that expects an object.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/object.cue
+++ b/website/cue/reference/remap/functions/object.cue
@@ -3,20 +3,20 @@ package metadata
 remap: functions: object: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's an object and errors otherwise. This enables the type checker to guarantee that the
+		Returns `value` if it is an object, otherwise returns an error. This enables the type checker to guarantee that the
 		returned value is an object and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is an object."
+			description: "The value to check if it is an object."
 			required:    true
 			type: ["any"]
 		},
 	]
 	internal_failure_reasons: [
-		"`value` isn't an object.",
+		"`value` is not an object.",
 	]
 	return: {
 		types: ["object"]

--- a/website/cue/reference/remap/functions/random_bytes.cue
+++ b/website/cue/reference/remap/functions/random_bytes.cue
@@ -10,14 +10,14 @@ remap: functions: random_bytes: {
 	arguments: [
 		{
 			name:        "length"
-			description: "The number of bytes to generate. Must not be larger than 64k"
+			description: "The number of bytes to generate. Must not be larger than 64k."
 			required:    true
 			type: ["integer"]
 		},
 	]
 	internal_failure_reasons: [
-		"`length` is negative",
-		"`length` is larger than the maximum value (64k)",
+		"`length` is negative.",
+		"`length` is larger than the maximum value (64k).",
 	]
 	return: types: ["string"]
 

--- a/website/cue/reference/remap/functions/random_float.cue
+++ b/website/cue/reference/remap/functions/random_float.cue
@@ -9,19 +9,19 @@ remap: functions: random_float: {
 	arguments: [
 		{
 			name:        "min"
-			description: "Minimum value (inclusive)"
+			description: "Minimum value (inclusive)."
 			required:    true
 			type: ["float"]
 		},
 		{
 			name:        "max"
-			description: "Maximum value (exclusive)"
+			description: "Maximum value (exclusive)."
 			required:    true
 			type: ["float"]
 		},
 	]
 	internal_failure_reasons: [
-		"max is not greater than min",
+		"`max` is not greater than `min`.",
 	]
 	return: types: ["float"]
 

--- a/website/cue/reference/remap/functions/random_int.cue
+++ b/website/cue/reference/remap/functions/random_int.cue
@@ -9,19 +9,19 @@ remap: functions: random_int: {
 	arguments: [
 		{
 			name:        "min"
-			description: "Minimum value (inclusive)"
+			description: "Minimum value (inclusive)."
 			required:    true
 			type: ["integer"]
 		},
 		{
 			name:        "max"
-			description: "Maximum value (exclusive)"
+			description: "Maximum value (exclusive)."
 			required:    true
 			type: ["integer"]
 		},
 	]
 	internal_failure_reasons: [
-		"max is not greater than min",
+		"`max` is not greater than `min`.",
 	]
 	return: types: ["integer"]
 

--- a/website/cue/reference/remap/functions/redact.cue
+++ b/website/cue/reference/remap/functions/redact.cue
@@ -50,9 +50,8 @@ remap: functions: redact: {
 
 				See examples for more details.
 
-				This parameter must be a static expression. This to allow validation of the argument at compile-time
-				to avoid runtime errors. You cannot use variables or other dynamic expressions
-				with it.
+				This parameter must be a static expression so that the argument can be validated at compile-time
+				to avoid runtime errors. You cannot use variables or other dynamic expressions with it.
 				"""#
 			required: true
 			type: ["array"]

--- a/website/cue/reference/remap/functions/redact.cue
+++ b/website/cue/reference/remap/functions/redact.cue
@@ -17,7 +17,7 @@ remap: functions: redact: {
 			description: #"""
 				The value to redact sensitive data from.
 
-				The function's behavior depends on the type of `value`:
+				The function's behavior depends on `value`'s type:
 
 				- For strings, the sensitive data is redacted and a new string is returned.
 				- For arrays, the sensitive data is redacted in each string element.

--- a/website/cue/reference/remap/functions/redact.cue
+++ b/website/cue/reference/remap/functions/redact.cue
@@ -6,10 +6,9 @@ remap: functions: redact: {
 		Redact sensitive data in `value` such as:
 
 		- [US social security card numbers](\(urls.us_social_security_number))
-		- and other forms of personally identifiable information via custom patterns
-		- (more to come!)
+		- Other forms of personally identifiable information with custom patterns
 
-		This can help achieve compliance by ensuring sensitive data never leaves your network.
+		This can help achieve compliance by ensuring sensitive data does not leave your network.
 		"""
 
 	arguments: [
@@ -18,16 +17,16 @@ remap: functions: redact: {
 			description: #"""
 				The value to redact sensitive data from.
 
-				Its behavior differs depending on the type of `value`:
+				The function's behavior depends on the type of `value`:
 
-				- For strings, it simply redacts the sensitive data and returns a new string
-				- For arrays, it redacts the sensitive data in each string element
-				- For objects, it masks the sensitive data in each string value, but not keys
+				- For strings, the sensitive data is redacted and a new string is returned.
+				- For arrays, the sensitive data is redacted in each string element.
+				- For objects, the sensitive data in each string value is masked, but the keys are not.
 
-				For arrays and objects it will recurse into any nested arrays or objects. Any non-string elements will
-				be skipped.
+				For arrays and objects, the function recurses into any nested arrays or objects. Any non-string elements are
+				skipped.
 
-				Any redacted text will be replaced with `[REDACTED]`.
+				Redacted text is replaced with `[REDACTED]`.
 				"""#
 			required: true
 			type: ["string", "object", "array"]
@@ -35,24 +34,24 @@ remap: functions: redact: {
 		{
 			name: "filters"
 			description: #"""
-				List of filters to be applied to the `value`.
+				List of filters applied to `value`.
 
-				Each filter can be specified in one of three ways:
+				Each filter can be specified in one of the following ways:
 
-				- As a regular expression directly, which will be used to redact text matching it
-				- As an object with a `type` key that corresponds to a named filter and additional keys for customizing that filter
-				- As a named filter, if it has no required parameters
+				- As a regular expression directly, which is used to redact text that match it.
+				- As an object with a `type` key that corresponds to a named filter and additional keys for customizing that filter.
+				- As a named filter, if it has no required parameters.
 
 				Named filters are:
 
-				- `pattern`: Redact text matching any regular expressions specified in the, required, `patterns`
-					key. This is the expanded form of just passing a regular expression as a filter.
-				- `us_social_security_number`: Redact US social security card numbers.
+				- `pattern`: Redacts text matching any regular expressions specified in the `patterns`
+					key, which is required. This is the expanded version of just passing a regular expression as a filter.
+				- `us_social_security_number`: Redacts US social security card numbers.
 
 				See examples for more details.
 
 				This parameter must be a static expression. You cannot use variables or other dynamic expressions
-				with it. This allows us to validate the argument at compile-time to avoid runtime errors.
+				with it. This allows validation of the argument at compile-time to avoid runtime errors.
 				"""#
 			required: true
 			type: ["array"]

--- a/website/cue/reference/remap/functions/redact.cue
+++ b/website/cue/reference/remap/functions/redact.cue
@@ -21,7 +21,7 @@ remap: functions: redact: {
 
 				- For strings, the sensitive data is redacted and a new string is returned.
 				- For arrays, the sensitive data is redacted in each string element.
-				- For objects, the sensitive data in each string value is masked, but the keys are not.
+				- For objects, the sensitive data in each string value is masked, but the keys are not masked.
 
 				For arrays and objects, the function recurses into any nested arrays or objects. Any non-string elements are
 				skipped.
@@ -36,13 +36,13 @@ remap: functions: redact: {
 			description: #"""
 				List of filters applied to `value`.
 
-				Each filter can be specified in one of the following ways:
+				Each filter can be specified in the following ways:
 
-				- As a regular expression directly, which is used to redact text that match it.
+				- As a regular expression, which is used to redact text that match it.
 				- As an object with a `type` key that corresponds to a named filter and additional keys for customizing that filter.
 				- As a named filter, if it has no required parameters.
 
-				Named filters are:
+				Named filters can be a:
 
 				- `pattern`: Redacts text matching any regular expressions specified in the `patterns`
 					key, which is required. This is the expanded version of just passing a regular expression as a filter.
@@ -50,8 +50,9 @@ remap: functions: redact: {
 
 				See examples for more details.
 
-				This parameter must be a static expression. You cannot use variables or other dynamic expressions
-				with it. This allows validation of the argument at compile-time to avoid runtime errors.
+				This parameter must be a static expression. This to allow validation of the argument at compile-time
+				to avoid runtime errors. You cannot use variables or other dynamic expressions
+				with it.
 				"""#
 			required: true
 			type: ["array"]

--- a/website/cue/reference/remap/functions/remove.cue
+++ b/website/cue/reference/remap/functions/remove.cue
@@ -27,13 +27,13 @@ remap: functions: remove: {
 			type: ["array"]
 		},
 		{
-			name:        "compact"
+			name: "compact"
 			description: """
 				After deletion, if `compact` is `true`, any empty objects or
 				arrays left are also removed.
 				"""
-			required:    false
-			default:     false
+			required: false
+			default:  false
 			type: ["boolean"]
 		},
 	]

--- a/website/cue/reference/remap/functions/remove.cue
+++ b/website/cue/reference/remap/functions/remove.cue
@@ -3,15 +3,14 @@ package metadata
 remap: functions: remove: {
 	category: "Path"
 	description: """
-		Dynamically remove the value for a given path.
+		Dynamically remove the value for a given `path`.
 
-		When you know the path you want to remove, you should use
+		When you know the path you want to remove, use
 		the `del` function and static paths such as `del(.foo.bar[1])`
 		to remove the value at that path. The `del` function returns the
 		deleted value, and is more performant than this function.
-		However, when you don't know the path names in advance, you can
-		use this dynamic remove function to remove the value at the
-		provided path.
+		However, when you do not know the path names, use this dynamic
+		`remove` function to remove the value at the provided path.
 		"""
 
 	arguments: [
@@ -23,20 +22,23 @@ remap: functions: remove: {
 		},
 		{
 			name:        "path"
-			description: "An array of path segments to remove the value at."
+			description: "An array of path segments to remove the value from."
 			required:    true
 			type: ["array"]
 		},
 		{
 			name:        "compact"
-			description: "Whether — after deletion — empty objects or arrays should be removed."
+			description: """
+				After deletion, if `compact` is `true`, empty objects and
+				arrays left behind are also removed.
+				"""
 			required:    false
 			default:     false
 			type: ["boolean"]
 		},
 	]
 	internal_failure_reasons: [
-		#"path segment must be either "string" or "integer""#,
+		#"`path` segment must be a string or an integer."#,
 	]
 	return: types: ["object", "array"]
 

--- a/website/cue/reference/remap/functions/remove.cue
+++ b/website/cue/reference/remap/functions/remove.cue
@@ -3,13 +3,13 @@ package metadata
 remap: functions: remove: {
 	category: "Path"
 	description: """
-		Dynamically remove the value for a given `path`.
+		Dynamically remove the value for a given path.
 
-		When you know the path you want to remove, use
+		If you know the path you want to remove, use
 		the `del` function and static paths such as `del(.foo.bar[1])`
 		to remove the value at that path. The `del` function returns the
-		deleted value, and is more performant than this function.
-		However, when you do not know the path names, use this dynamic
+		deleted value, and is more performant than `remove`.
+		However, if you do not know the path names, use the dynamic
 		`remove` function to remove the value at the provided path.
 		"""
 
@@ -29,8 +29,8 @@ remap: functions: remove: {
 		{
 			name:        "compact"
 			description: """
-				After deletion, if `compact` is `true`, empty objects and
-				arrays left behind are also removed.
+				After deletion, if `compact` is `true`, any empty objects or
+				arrays left are also removed.
 				"""
 			required:    false
 			default:     false
@@ -38,7 +38,7 @@ remap: functions: remove: {
 		},
 	]
 	internal_failure_reasons: [
-		#"`path` segment must be a string or an integer."#,
+		#"The `path` segment must be a string or an integer."#,
 	]
 	return: types: ["object", "array"]
 

--- a/website/cue/reference/remap/functions/replace.cue
+++ b/website/cue/reference/remap/functions/replace.cue
@@ -3,9 +3,9 @@ package metadata
 remap: functions: replace: {
 	category: "String"
 	description: """
-		Replaces all matching instances of `pattern` in the `value`.
+		Replaces all matching instances of `pattern` in `value`.
 
-		The `pattern` argument accepts regular expression capture groups. Note that `$foo` is interpreted in a configuration file, instead use `$$foo`.
+		The `pattern` argument accepts regular expression capture groups. **Note**: Use `$$foo` instead of `$foo`, which is interpreted in a configuration file.
 		"""
 
 	arguments: [
@@ -29,7 +29,7 @@ remap: functions: replace: {
 		},
 		{
 			name:        "count"
-			description: "The maximum number of replacements to perform. -1 means replace all matches."
+			description: "The maximum number of replacements to perform. `-1` means replace all matches."
 			required:    false
 			default:     -1
 			type: ["integer"]
@@ -48,7 +48,7 @@ remap: functions: replace: {
 			return: "Apples not Bananas"
 		},
 		{
-			title: "Replace via regular expression"
+			title: "Replace using regular expression"
 			source: #"""
 				replace("Apples and Bananas", r'(?i)bananas', "Pineapples")
 				"""#

--- a/website/cue/reference/remap/functions/set.cue
+++ b/website/cue/reference/remap/functions/set.cue
@@ -5,11 +5,11 @@ remap: functions: set: {
 	description: """
 		Dynamically insert data into the path of a given object or array.
 
-		When you know the path you want to assign a value to, you should
+		When you know the path you want to assign a value to,
 		use static path assignments such as `.foo.bar[1] = true` for
-		improved performance and readability. However, when you don't
-		know the path names in advance, you can use this dynamic
-		insertion function to insert the data into the object or array.
+		improved performance and readability. However, when you do not
+		know the path names, use this dynamic `set` function to
+		insert the data into the object or array.
 		"""
 
 	arguments: [
@@ -21,7 +21,7 @@ remap: functions: set: {
 		},
 		{
 			name:        "path"
-			description: "An array of path segments to insert the value to."
+			description: "An array of path segments to insert the value into."
 			required:    true
 			type: ["array"]
 		},
@@ -33,7 +33,7 @@ remap: functions: set: {
 		},
 	]
 	internal_failure_reasons: [
-		#"path segment must be either "string" or "integer""#,
+		#"`path` segment must be a string or an integer."#,
 	]
 	return: types: ["object", "array"]
 

--- a/website/cue/reference/remap/functions/set.cue
+++ b/website/cue/reference/remap/functions/set.cue
@@ -5,10 +5,10 @@ remap: functions: set: {
 	description: """
 		Dynamically insert data into the path of a given object or array.
 
-		When you know the path you want to assign a value to,
+		If you know the path you want to assign a value to,
 		use static path assignments such as `.foo.bar[1] = true` for
-		improved performance and readability. However, when you do not
-		know the path names, use this dynamic `set` function to
+		improved performance and readability. However, if you do not
+		know the path names, use the dynamic `set` function to
 		insert the data into the object or array.
 		"""
 
@@ -33,7 +33,7 @@ remap: functions: set: {
 		},
 	]
 	internal_failure_reasons: [
-		#"`path` segment must be a string or an integer."#,
+		#"The `path` segment must be a string or an integer."#,
 	]
 	return: types: ["object", "array"]
 

--- a/website/cue/reference/remap/functions/slice.cue
+++ b/website/cue/reference/remap/functions/slice.cue
@@ -3,10 +3,10 @@ package metadata
 remap: functions: slice: {
 	category: "String"
 	description: """
-		Returns a slice of the `value` between the `start` and `end` positions.
+		Returns a slice of `value` between the `start` and `end` positions.
 
 		If the `start` and `end` parameters are negative, they refer to positions counting from the right of the
-		string or array. If `end` refers to a position that is greater than the length of the string or array
+		string or array. If `end` refers to a position that is greater than the length of the string or array,
 		a slice up to the end of the string or array is returned.
 		"""
 

--- a/website/cue/reference/remap/functions/split.cue
+++ b/website/cue/reference/remap/functions/split.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: split: {
 	category: "String"
 	description: """
-		Splits the `value` string via the `pattern`.
+		Splits the `value` string using `pattern`.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/starts_with.cue
+++ b/website/cue/reference/remap/functions/starts_with.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: starts_with: {
 	category: "String"
 	description: """
-		Determines whether the `value` begins with the `substring`.
+		Determines whether `value` begins with `substring`.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/string.cue
+++ b/website/cue/reference/remap/functions/string.cue
@@ -4,7 +4,7 @@ remap: functions: string: {
 	category: "Type"
 	description: """
 		Returns `value` if it is a string, otherwise returns an error. This enables the type checker to guarantee that the
-		returned value is a string and can be used in any function that expects one.
+		returned value is a string and can be used in any function that expects a string.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/string.cue
+++ b/website/cue/reference/remap/functions/string.cue
@@ -3,20 +3,20 @@ package metadata
 remap: functions: string: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's a string and errors otherwise. This enables the type checker to guarantee that the
+		Returns `value` if it is a string, otherwise returns an error. This enables the type checker to guarantee that the
 		returned value is a string and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is a string."
+			description: "The value to check if it is a string."
 			required:    true
 			type: ["any"]
 		},
 	]
 	internal_failure_reasons: [
-		"`value` isn't a string.",
+		"`value` is not a string.",
 	]
 	return: {
 		types: ["string"]

--- a/website/cue/reference/remap/functions/strip_ansi_escape_codes.cue
+++ b/website/cue/reference/remap/functions/strip_ansi_escape_codes.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: strip_ansi_escape_codes: {
 	category:    "String"
 	description: """
-		Strips [ANSI escape codes](\(urls.ansi_escape_codes)) from the `value`.
+		Strips [ANSI escape codes](\(urls.ansi_escape_codes)) from `value`.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/strip_whitespace.cue
+++ b/website/cue/reference/remap/functions/strip_whitespace.cue
@@ -3,8 +3,8 @@ package metadata
 remap: functions: strip_whitespace: {
 	category:    "String"
 	description: """
-		Strips whitespace from the start and end of the `value`, where whitespace is defined by the [Unicode
-		`White_Space` property](\(urls.unicode_whitespace))
+		Strips whitespace from the start and end of `value`, where whitespace is defined by the [Unicode
+		`White_Space` property](\(urls.unicode_whitespace)).
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/tag_types_externally.cue
+++ b/website/cue/reference/remap/functions/tag_types_externally.cue
@@ -5,7 +5,7 @@ remap: functions: tag_types_externally: {
 	description: """
 		Adds type information to all (nested) scalar values in the provided `value`.
 
-		The type information is added externally, meaning that `value` has the shape of `"type": value` after this
+		The type information is added externally, meaning that `value` has the form of `"type": value` after this
 		transformation.
 		"""
 	arguments: [

--- a/website/cue/reference/remap/functions/timestamp.cue
+++ b/website/cue/reference/remap/functions/timestamp.cue
@@ -3,8 +3,8 @@ package metadata
 remap: functions: timestamp: {
 	category: "Type"
 	description: """
-		Returns the `value` if it is a timestamp, otherwise returns an error. This enables the type checker to guarantee that
-		the returned value is a timestamp and can be used in any function that expects one.
+		Returns `value` if it is a timestamp, otherwise returns an error. This enables the type checker to guarantee that
+		the returned value is a timestamp and can be used in any function that expects a timestamp.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/timestamp.cue
+++ b/website/cue/reference/remap/functions/timestamp.cue
@@ -3,20 +3,20 @@ package metadata
 remap: functions: timestamp: {
 	category: "Type"
 	description: """
-		Returns the `value` if it's a timestamp and errors otherwise. This enables the type checker to guarantee that
+		Returns the `value` if it is a timestamp, otherwise returns an error. This enables the type checker to guarantee that
 		the returned value is a timestamp and can be used in any function that expects one.
 		"""
 
 	arguments: [
 		{
 			name:        "value"
-			description: "The value that you need to ensure is a timestamp."
+			description: "The value to check if it is a timestamp."
 			required:    true
 			type: ["any"]
 		},
 	]
 	internal_failure_reasons: [
-		"`value` isn't a timestamp.",
+		"`value` is not a timestamp.",
 	]
 	return: {
 		types: ["timestamp"]

--- a/website/cue/reference/remap/functions/truncate.cue
+++ b/website/cue/reference/remap/functions/truncate.cue
@@ -23,7 +23,7 @@ remap: functions: truncate: {
 			name: "ellipsis"
 			description: """
 				This argument is deprecated. An ellipsis (`...`) is appended if this is set to `true` _and_ the `value` string
-				ends up being truncated because it's exceeded the `limit`.
+				ends up being truncated because it exceeded the `limit`.
 				"""
 			required: false
 			type: ["boolean"]
@@ -31,8 +31,8 @@ remap: functions: truncate: {
 		{
 			name: "suffix"
 			description: """
-				A custom suffix (`...`) will be appended to truncated strings.
-				This is ignored if "ellipsis" is set to true for backwards compatibility.
+				A custom suffix (`...`) is appended to truncated strings.
+				If `ellipsis` is set to `true`, this parameter is ignored for backwards compatibility.
 				"""
 			required: false
 			type: ["string"]

--- a/website/cue/reference/remap/functions/truncate.cue
+++ b/website/cue/reference/remap/functions/truncate.cue
@@ -22,8 +22,8 @@ remap: functions: truncate: {
 		{
 			name: "ellipsis"
 			description: """
-				This argument is deprecated. An ellipsis (`...`) is appended if this is set to `true` _and_ the `value` string
-				ends up being truncated because it exceeded the `limit`.
+				This argument is deprecated. An ellipsis (`...`) is appended if the parameter is set to `true` _and_ the `value` string
+				is truncated because it exceeded the `limit`.
 				"""
 			required: false
 			type: ["boolean"]

--- a/website/cue/reference/remap/functions/upcase.cue
+++ b/website/cue/reference/remap/functions/upcase.cue
@@ -2,7 +2,7 @@ package metadata
 
 remap: functions: upcase: {
 	description: """
-		Upcases the `value`, where "upcase" is defined according to the terms of the Unicode Derived Core Property
+		Upcases `value`, where upcase is defined according to the terms of the Unicode Derived Core Property
 		Uppercase.
 		"""
 

--- a/website/cue/reference/remap/functions/upcase.cue
+++ b/website/cue/reference/remap/functions/upcase.cue
@@ -2,7 +2,7 @@ package metadata
 
 remap: functions: upcase: {
 	description: """
-		Upcases `value`, where upcase is defined according to the terms of the Unicode Derived Core Property
+		Upcases `value`, where upcase is defined according to the Unicode Derived Core Property
 		Uppercase.
 		"""
 


### PR DESCRIPTION
This PR makes editorial edits to the second half of the Functions doc (Path to Timestamps).

[DOCS-6327](https://datadoghq.atlassian.net/browse/DOCS-6327)

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->


[DOCS-6327]: https://datadoghq.atlassian.net/browse/DOCS-6327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ