### PR TITLE
fix(ci): peg pulsar docker image for int tests to stable image

### DIFF
--- a/scripts/integration/pulsar/test.yaml
+++ b/scripts/integration/pulsar/test.yaml
@@ -7,7 +7,9 @@ env:
   PULSAR_ADDRESS: pulsar://pulsar:6650
 
 matrix:
-  version: [latest]
+  # Temporarily pegging to the latest known stable release
+  # since using `latest` is failing consistently.
+  version: [3.0.1]
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch


### PR DESCRIPTION
The latest image has an issue (https://github.com/apache/pulsar/issues/21655) which is blocking the merge queue. Rolling back to the latest stable image.
