### PR TITLE
chore(ci): revert peg pulsar docker image for int tests to stable image

### DIFF
--- a/scripts/integration/pulsar/test.yaml
+++ b/scripts/integration/pulsar/test.yaml
@@ -7,9 +7,7 @@ env:
   PULSAR_ADDRESS: pulsar://pulsar:6650
 
 matrix:
-  # Temporarily pegging to the latest known stable release
-  # since using `latest` is failing consistently.
-  version: [3.0.1]
+  version: [latest]
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch


### PR DESCRIPTION
This reverts commit c2c2dbd7f86112ce8a0aa6a92ee92ee7e3a023e4.

Appears to have been fixed upstream by https://github.com/apache/pulsar/issues/21655#issuecomment-1837676414

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
