### PR TITLE
chore(deps): cleanup unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,7 +1950,6 @@ dependencies = [
  "chrono",
  "chrono-tz-build",
  "phf",
- "serde",
 ]
 
 [[package]]
@@ -1992,12 +1991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cidr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d18b093eba54c9aaa1e3784d4361eb2ba944cf7d0a932a830132238f483e8d8"
-
-[[package]]
 name = "cidr-utils"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,17 +2001,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "regex",
-]
-
-[[package]]
-name = "cidr-utils"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c0a9fb70c2c2cc2a520aa259b1d1345650046a07df1b6da1d3cefcd327f43e"
-dependencies = [
- "cidr",
- "num-bigint",
- "num-traits",
 ]
 
 [[package]]
@@ -2156,8 +2138,6 @@ dependencies = [
  "tracing 0.1.40",
  "vector-common",
  "vector-config",
- "vector-config-common",
- "vector-config-macros",
  "vector-core",
  "vector-lookup",
  "vrl",
@@ -2758,12 +2738,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
-name = "db-key"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
-
-[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +2941,6 @@ dependencies = [
  "serde_json",
  "snafu",
  "tracing 0.1.40",
- "tracing-subscriber",
  "vector-config",
  "vector-config-common",
 ]
@@ -3373,8 +3346,6 @@ dependencies = [
  "tokio",
  "tracing 0.1.40",
  "vector-config",
- "vector-config-common",
- "vector-config-macros",
  "winapi",
 ]
 
@@ -5044,21 +5015,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "logfmt"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879777f0cc6f3646a044de60e4ab98c75617e3f9580f7a2032e6ad7ea0cd3054"
-
-[[package]]
 name = "loki-logproto"
 version = "0.1.0"
 dependencies = [
- "bytes 1.5.0",
  "chrono",
  "prost 0.12.3",
  "prost-build 0.12.3",
  "prost-types 0.12.3",
- "snap",
 ]
 
 [[package]]
@@ -5601,7 +5564,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b41e7479dc3678ea792431e04bafd62a31879035f4a5fa707602df062f58c77"
 dependencies = [
- "cidr-utils 0.5.11",
+ "cidr-utils",
  "serde",
 ]
 
@@ -5800,15 +5763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
-dependencies = [
- "num_enum_derive 0.7.1",
-]
-
-[[package]]
 name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5827,18 +5781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.70",
- "quote 1.0.33",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
-dependencies = [
- "proc-macro-crate 2.0.0",
  "proc-macro2 1.0.70",
  "quote 1.0.33",
  "syn 2.0.39",
@@ -6110,16 +6052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "os_info"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
-dependencies = [
- "log",
- "winapi",
 ]
 
 [[package]]
@@ -6796,10 +6728,8 @@ version = "0.1.0"
 dependencies = [
  "indexmap 2.1.0",
  "nom",
- "num_enum 0.7.1",
  "prost 0.12.3",
  "prost-build 0.12.3",
- "prost-types 0.12.3",
  "snafu",
  "vector-common",
 ]
@@ -8069,17 +7999,6 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.1",
  "serde",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -9938,7 +9857,6 @@ dependencies = [
  "itertools 0.12.0",
  "log",
  "once_cell",
- "os_info",
  "owo-colors",
  "paste",
  "regex",
@@ -10002,7 +9920,6 @@ dependencies = [
  "bytesize",
  "chrono",
  "chrono-tz",
- "cidr-utils 0.6.1",
  "clap 4.4.10",
  "colored",
  "console-subscriber",
@@ -10049,7 +9966,6 @@ dependencies = [
  "lapin",
  "libc",
  "listenfd",
- "logfmt",
  "loki-logproto",
  "lru",
  "maxminddb",
@@ -10208,8 +10124,6 @@ dependencies = [
  "tracing-subscriber",
  "vector-common",
  "vector-config",
- "vector-config-common",
- "vector-config-macros",
 ]
 
 [[package]]
@@ -10219,19 +10133,16 @@ dependencies = [
  "async-stream",
  "bytes 1.5.0",
  "chrono",
- "chrono-tz",
  "crossbeam-utils",
  "derivative",
  "futures 0.3.29",
  "indexmap 2.1.0",
  "metrics",
  "nom",
- "ordered-float 4.1.1",
  "paste",
  "pin-project",
  "quickcheck",
  "quickcheck_macros",
- "ryu",
  "serde",
  "serde_json",
  "smallvec",
@@ -10240,8 +10151,6 @@ dependencies = [
  "tokio",
  "tracing 0.1.40",
  "vector-config",
- "vector-config-common",
- "vector-config-macros",
  "vrl",
 ]
 
@@ -10313,7 +10222,6 @@ dependencies = [
  "chrono-tz",
  "criterion",
  "crossbeam-utils",
- "db-key",
  "dyn-clone",
  "enrichment",
  "enumflags2",
@@ -10366,15 +10274,11 @@ dependencies = [
  "toml 0.8.8",
  "tonic 0.10.2",
  "tracing 0.1.40",
- "tracing-core 0.1.32",
  "tracing-subscriber",
- "typetag",
  "url",
  "vector-buffers",
  "vector-common",
  "vector-config",
- "vector-config-common",
- "vector-config-macros",
  "vector-lookup",
  "vrl",
 ]
@@ -10447,14 +10351,10 @@ dependencies = [
 name = "vector-vrl-tests"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
- "chrono",
  "chrono-tz",
  "clap 4.4.10",
  "enrichment",
  "glob",
- "prettydiff",
- "regex",
  "serde",
  "serde_json",
  "tikv-jemallocator",
@@ -10469,10 +10369,8 @@ version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "enrichment",
- "getrandom 0.2.11",
  "gloo-utils",
  "serde",
- "serde-wasm-bindgen",
  "vector-vrl-functions",
  "vrl",
  "wasm-bindgen",
@@ -10509,7 +10407,7 @@ dependencies = [
  "charset",
  "chrono",
  "chrono-tz",
- "cidr-utils 0.5.11",
+ "cidr-utils",
  "clap 4.4.10",
  "codespan-reporting",
  "community-id",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,7 +446,6 @@ aws-core = [
   "dep:aws-smithy-async",
   "dep:aws-smithy-client",
   "dep:aws-smithy-http",
-  # "dep:aws-smithy-http-tower",
   "dep:aws-smithy-types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,6 @@ bytes = { version = "1.5.0", default-features = false, features = ["serde"] }
 bytesize = { version = "1.3.0", default-features = false }
 chrono = { version = "0.4.31", default-features = false, features = ["serde"] }
 chrono-tz = { version = "0.8.3", default-features = false }
-cidr-utils = { version = "0.6.1", default-features = false }
 clap = { version = "4.4.10", default-features = false, features = ["derive", "error-context", "env", "help", "std", "string", "usage", "wrap_help"] }
 colored = { version = "2.0.4", default-features = false }
 csv = { version = "1.3", default-features = false }
@@ -278,7 +277,6 @@ inventory = { version = "0.3.13", default-features = false }
 k8s-openapi = { version = "0.18.0", default-features = false, features = ["api", "v1_26"], optional = true }
 kube = { version = "0.82.0", default-features = false, features = ["client", "openssl-tls", "runtime"], optional = true }
 listenfd = { version = "1.0.1", default-features = false, optional = true }
-logfmt = { version = "0.0.2", default-features = false, optional = true }
 lru = { version = "0.12.1", default-features = false, optional = true }
 maxminddb = { version = "0.23.0", default-features = false, optional = true }
 md-5 = { version = "0.10", default-features = false, optional = true }
@@ -448,7 +446,7 @@ aws-core = [
   "dep:aws-smithy-async",
   "dep:aws-smithy-client",
   "dep:aws-smithy-http",
-  "dep:aws-smithy-http-tower",
+  # "dep:aws-smithy-http-tower",
   "dep:aws-smithy-types",
 ]
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -121,7 +121,6 @@ chacha20poly1305,https://github.com/RustCrypto/AEADs/tree/master/chacha20poly130
 charset,https://github.com/hsivonen/charset,MIT OR Apache-2.0,Henri Sivonen <hsivonen@hsivonen.fi>
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
 chrono-tz,https://github.com/chronotope/chrono-tz,MIT OR Apache-2.0,The chrono-tz Authors
-cidr,https://github.com/stbuehler/rust-cidr,MIT,Stefan Bühler <stbuehler@web.de>
 cidr-utils,https://github.com/magiclen/cidr-utils,MIT,Magic Len <len@magiclen.org>
 cipher,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 clap,https://github.com/clap-rs/clap,MIT,Kevin K. <kbknapp@gmail.com>

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -29,8 +29,6 @@ tracing = { version = "0.1", default-features = false }
 vrl.workspace = true
 vector-common = { path = "../vector-common", default-features = false }
 vector-config = { path = "../vector-config", default-features = false }
-vector-config-common = { path = "../vector-config-common", default-features = false }
-vector-config-macros = { path = "../vector-config-macros", default-features = false }
 vector-core = { path = "../vector-core", default-features = false }
 
 [dev-dependencies]

--- a/lib/docs-renderer/Cargo.toml
+++ b/lib/docs-renderer/Cargo.toml
@@ -11,6 +11,5 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 snafu = { version = "0.7.5", default-features = false }
 tracing = { version = "0.1.34", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["ansi", "env-filter", "fmt", "json", "registry", "tracing-log"] }
 vector-config = { path = "../vector-config" }
 vector-config-common = { path = "../vector-config-common" }

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -15,8 +15,6 @@ crc = "3.0.1"
 glob = "0.3.1"
 scan_fmt = "0.2.6"
 vector-config = { path = "../vector-config", default-features = false }
-vector-config-common = { path = "../vector-config-common", default-features = false }
-vector-config-macros = { path = "../vector-config-macros", default-features = false }
 
 [dependencies.bstr]
 version = "1.8"

--- a/lib/loki-logproto/Cargo.toml
+++ b/lib/loki-logproto/Cargo.toml
@@ -10,8 +10,6 @@ publish = false
 [dependencies]
 prost = { version = "0.12", default-features = false, features = ["std"] }
 prost-types = { version = "0.12", default-features = false, features = ["std"] }
-bytes = { version = "1.5.0", default-features = false }
-snap = { version = "1.1.0", default-features = false }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -11,9 +11,7 @@ license = "MPL-2.0"
 [dependencies]
 indexmap = "2.1.0"
 nom = "7.1.3"
-num_enum = "0.7.1"
 prost = "0.12"
-prost-types = "0.12"
 snafu = { version = "0.7" }
 vector-common = { path = "../vector-common", features = ["btreemap"] }
 

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -29,8 +29,6 @@ tokio-util = { version = "0.7.0", default-features = false }
 tokio = { version = "1.34.0", default-features = false, features = ["rt", "macros", "rt-multi-thread", "sync", "fs", "io-util", "time"] }
 tracing = { version = "0.1.34", default-features = false, features = ["attributes"] }
 vector-config = { path = "../vector-config", default-features = false }
-vector-config-common = { path = "../vector-config-common", default-features = false }
-vector-config-macros = { path = "../vector-config-macros", default-features = false }
 vector-common = { path = "../vector-common", default-features = false, features = ["byte_size_of", "serde"] }
 
 [dev-dependencies]

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -43,7 +43,6 @@ tokenize = [
 [dependencies]
 async-stream = "0.3.5"
 bytes = { version = "1.5.0", default-features = false, optional = true }
-chrono-tz = { version = "0.8.4", default-features = false, features = ["serde"] }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 crossbeam-utils = { version = "0.8.16", default-features = false }
 derivative = { version = "2.2.0", default-features = false }
@@ -51,10 +50,8 @@ futures = { version = "0.3.29", default-features = false, features = ["std"] }
 indexmap = { version = "2.1.0", default-features = false, features = ["std"] }
 metrics = "0.21.1"
 nom = { version = "7", optional = true }
-ordered-float = { version = "4.1.1", default-features = false }
 paste = "1.0.14"
 pin-project.workspace = true
-ryu = { version = "1", default-features = false }
 serde_json = { version = "1.0.107", default-features = false, features = ["std", "raw_value"] }
 serde = { version = "1.0.193", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false }
@@ -64,8 +61,6 @@ tokio = { version = "1.34.0", default-features = false, features = ["macros", "t
 tracing = { version = "0.1.34", default-features = false }
 vrl.workspace = true
 vector-config = { path = "../vector-config" }
-vector-config-common = { path = "../vector-config-common" }
-vector-config-macros = { path = "../vector-config-macros" }
 
 [dev-dependencies]
 futures = { version = "0.3.29", default-features = false, features = ["async-await", "std"] }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -12,7 +12,6 @@ bitmask-enum = { version = "2.2.3", default-features = false }
 bytes = { version = "1.5.0", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.31", default-features = false, features = ["serde"] }
 crossbeam-utils = { version = "0.8.16", default-features = false }
-db-key = { version = "0.0.5", default-features = false, optional = true }
 dyn-clone = { version = "1.0.16", default-features = false }
 enrichment = { path = "../enrichment", optional = true }
 enumflags2 = { version = "0.7.8", default-features = false }
@@ -53,15 +52,10 @@ tokio-util = { version = "0.7.0", default-features = false, features = ["time"] 
 toml = { version = "0.8.8", default-features = false }
 tonic = { version = "0.10", default-features = false, features = ["transport"] }
 tracing = { version = "0.1.34", default-features = false }
-tracing-core = { version = "0.1.26", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std"] }
-typetag = { version = "0.2.13", default-features = false }
 url = { version = "2", default-features = false }
 vector-buffers = { path = "../vector-buffers", default-features = false }
 vector-common = { path = "../vector-common" }
 vector-config = { path = "../vector-config" }
-vector-config-common = { path = "../vector-config-common" }
-vector-config-macros = { path = "../vector-config-macros" }
 vrl.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/lib/vector-vrl/tests/Cargo.toml
+++ b/lib/vector-vrl/tests/Cargo.toml
@@ -10,13 +10,9 @@ enrichment = { path = "../../enrichment" }
 vrl.workspace = true
 vector-vrl-functions = { path = "../../vector-vrl/functions" }
 
-ansi_term = "0.12"
-chrono = "0.4"
 chrono-tz = "0.8"
 clap = { version = "4.4.10", features = ["derive"] }
 glob = "0.3"
-prettydiff = "0.6"
-regex = "1"
 serde = "1"
 serde_json = "1"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt"] }

--- a/lib/vector-vrl/web-playground/Cargo.toml
+++ b/lib/vector-vrl/web-playground/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vector-vrl-web-playground"
 version = "0.1.0"
+authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,9 +13,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 vrl.workspace = true
 serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.6"
 gloo-utils = { version = "0.2", features = ["serde"] }
-getrandom = { version = "0.2", features = ["js"] }
 vector-vrl-functions = { path = "../functions" }
 enrichment = { path = "../../enrichment" }
 

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -25,7 +25,6 @@ indicatif = { version = "0.17.7", features = ["improved_unicode"] }
 itertools = "0.12.0"
 log = "0.4.20"
 once_cell = "1.18"
-os_info = { version = "3.7.0", default-features = false }
 # watch https://github.com/epage/anstyle for official interop with Clap
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 paste = "1.0.14"


### PR DESCRIPTION
Noticed some seemingly unused deps after running `cargo-machete` 🔪 
