### PR TITLE
Pront/config target path display

### DIFF
--- a/lib/vector-lookup/src/lookup_v2/mod.rs
+++ b/lib/vector-lookup/src/lookup_v2/mod.rs
@@ -64,11 +64,7 @@ pub struct ConfigTargetPath(pub OwnedTargetPath);
 
 impl fmt::Display for ConfigTargetPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let prefix_char = match self.0.prefix {
-            PathPrefix::Event => '.',
-            PathPrefix::Metadata => '%',
-        };
-        write!(f, "{}{}", prefix_char, self.0.path)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/lib/vector-lookup/src/lookup_v2/mod.rs
+++ b/lib/vector-lookup/src/lookup_v2/mod.rs
@@ -1,7 +1,7 @@
 mod optional_path;
 
-use std::fmt;
 pub use optional_path::{OptionalTargetPath, OptionalValuePath};
+use std::fmt;
 use vector_config_macros::configurable_component;
 
 pub use vrl::path::{
@@ -64,11 +64,11 @@ pub struct ConfigTargetPath(pub OwnedTargetPath);
 
 impl fmt::Display for ConfigTargetPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let p = match self.0.prefix {
+        let prefix_char = match self.0.prefix {
             PathPrefix::Event => '.',
             PathPrefix::Metadata => '%',
         };
-        write!(f, "{}{}", p, self.0.path)
+        write!(f, "{}{}", prefix_char, self.0.path)
     }
 }
 

--- a/lib/vector-lookup/src/lookup_v2/mod.rs
+++ b/lib/vector-lookup/src/lookup_v2/mod.rs
@@ -1,5 +1,6 @@
 mod optional_path;
 
+use std::fmt;
 pub use optional_path::{OptionalTargetPath, OptionalValuePath};
 use vector_config_macros::configurable_component;
 
@@ -60,6 +61,16 @@ impl From<&str> for ConfigValuePath {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(try_from = "String", into = "String")]
 pub struct ConfigTargetPath(pub OwnedTargetPath);
+
+impl fmt::Display for ConfigTargetPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let p = match self.0.prefix {
+            PathPrefix::Event => '.',
+            PathPrefix::Metadata => '%',
+        };
+        write!(f, "{}{}", p, self.0.path)
+    }
+}
 
 impl TryFrom<String> for ConfigTargetPath {
     type Error = PathParseError;


### PR DESCRIPTION
This allows `ConfigTargetPath` to be used in config `HashMap`s. 