### PR TITLE
fix: component validation runner and 'sinks::datadog::test_utils' feature gates

### DIFF
--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -280,7 +280,11 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(async {
-            let mut runner = Runner::from_configuration(configuration, test_case_data_path, ExtraContext::default());
+            let mut runner = Runner::from_configuration(
+                configuration,
+                test_case_data_path,
+                ExtraContext::default(),
+            );
             runner.add_validator(StandardValidators::ComponentSpec);
 
             match runner.run_validation().await {

--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -194,6 +194,7 @@ mod tests {
     use test_generator::test_resources;
 
     use crate::components::validation::{Runner, StandardValidators};
+    use crate::extra_context::ExtraContext;
 
     use super::{ComponentType, ValidatableComponentDescription, ValidationConfiguration};
 
@@ -279,7 +280,7 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(async {
-            let mut runner = Runner::from_configuration(configuration, test_case_data_path);
+            let mut runner = Runner::from_configuration(configuration, test_case_data_path, ExtraContext::default());
             runner.add_validator(StandardValidators::ComponentSpec);
 
             match runner.run_validation().await {

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -21,7 +21,10 @@ pub mod events;
 pub mod logs;
 #[cfg(feature = "sinks-datadog_metrics")]
 pub mod metrics;
-#[cfg(all(test, feature = "sinks-datadog_logs", feature = "sinks-datadog_metrics"))]
+#[cfg(any(
+    all(feature = "sinks-datadog_logs", test),
+    all(feature = "sinks-datadog_metrics", test)
+))]
 mod test_utils;
 #[cfg(feature = "sinks-datadog_traces")]
 pub mod traces;

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -21,7 +21,7 @@ pub mod events;
 pub mod logs;
 #[cfg(feature = "sinks-datadog_metrics")]
 pub mod metrics;
-#[cfg(test)]
+#[cfg(all(test, feature = "sinks-datadog_logs", feature = "sinks-datadog_metrics"))]
 mod test_utils;
 #[cfg(feature = "sinks-datadog_traces")]
 pub mod traces;

--- a/src/sinks/datadog/test_utils.rs
+++ b/src/sinks/datadog/test_utils.rs
@@ -1,3 +1,4 @@
+#![cfg(any(feature = "sinks-datadog_logs", feature = "sinks-datadog_metrics"))]
 use bytes::Bytes;
 use http::status::StatusCode;
 

--- a/src/sinks/datadog/test_utils.rs
+++ b/src/sinks/datadog/test_utils.rs
@@ -1,4 +1,3 @@
-// #![cfg(any(feature = "sinks-datadog_logs", feature = "sinks-datadog_metrics"))]
 use bytes::Bytes;
 use http::status::StatusCode;
 


### PR DESCRIPTION
The regression was introduced [here](https://github.com/vectordotdev/vector/commit/b297070f9ab5f90d6fdb7ffe36d7d59a86cf6f1d#diff-3cf117ccbd31eed50dba7e907112a464ddc8e9941ce649135d855b749828c171R165).