### PR TITLE
enhancement(performance): Enable jemallocator for all non rust-code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,7 @@ socket2 = { version = "0.5.5", default-features = false }
 stream-cancel = { version = "0.8.1", default-features = false }
 strip-ansi-escapes = { version = "0.2.0", default-features = false }
 syslog = { version = "6.1.0", default-features = false, optional = true }
-tikv-jemallocator = { version = "0.5.4", default-features = false, optional = true }
+tikv-jemallocator = { version = "0.5.4", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 tokio-postgres = { version = "0.7.10", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = {version = "0.20.1", default-features = false, features = ["connect"], optional = true}
 toml = { version = "0.8.8", default-features = false, features = ["parse", "display"] }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
This change enables the use of jemalloc in all non-rust (C/C++) code used in vector, since it forces the `*malloc()` functions to point to jemalloc versions instead of libc. [read about `unprefixed_malloc_on_supported_platforms` feature](https://github.com/tikv/jemallocator/blob/master/jemalloc-sys/README.md#cargo-features)
Jemalloc releases memory back to the OS much more efficiently, which is also good for C/C++ code.

This results in significantly lower memory consumption when using Kafka sinks and sources, possibly because `librdkafka` uses a lot of internal buffering.


Our experience with vector-aggregator with kafka multiple sinks and sources:
Memory consumption without patch
![image](https://github.com/vectordotdev/vector/assets/86586309/c2f65e39-c5f8-47e2-a3ba-8faf6608e61d)

Memory consumption with patch
![image](https://github.com/vectordotdev/vector/assets/86586309/04edee1d-2b71-42fa-bb06-abf2fd662566)
