### PR TITLE
enhancement(packaging):Add soft dependency on datadog-signing-keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,18 +73,23 @@ start = false
 # Though, it seems like aarch64 libc is actually 2.18 and not 2.19
 [package.metadata.deb.variants.armv7-unknown-linux-gnueabihf]
 depends = "libc6 (>= 2.15)"
+recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.x86_64-unknown-linux-gnu]
 depends = "libc6 (>= 2.15)"
+recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.x86_64-unknown-linux-musl]
 depends = ""
+recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.aarch64-unknown-linux-gnu]
 depends = "libc6 (>= 2.18)"
+recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.aarch64-unknown-linux-musl]
 depends = ""
+recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [workspace]
 members = [


### PR DESCRIPTION
datadog-signing-keys is an APT package to ease the management of signing keys for datadog-related packages. Adding it as soft dependency could simplify the key update for next rotation (2026)
I assume the `recommends` will work like the `depends`

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
