### PR TITLE
Revert "chore(ci): Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Reverts vectordotdev/vector#19300

Failure needs to be investigated: https://github.com/vectordotdev/vector/actions/runs/7144526651/job/19458318833?pr=19342