### PR TITLE
fix(remap): filter out file contents from error logs

### DIFF
--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -139,11 +139,11 @@ pub struct RemapConfig {
 
 /// The propagated errors should not contain file contents to prevent exposing sensitive data.
 fn redacted_diagnostics(source: &str, diagnostics: DiagnosticList) -> String {
-    let placehoder = '*';
+    let placeholder = '*';
     // The formatter depends on whitespaces.
     let redacted_source: String = source
         .chars()
-        .map(|c| if c.is_whitespace() { c } else { placehoder })
+        .map(|c| if c.is_whitespace() { c } else { placeholder })
         .collect();
     // Remove placeholder chars to hide the content length.
     format!(
@@ -152,7 +152,7 @@ fn redacted_diagnostics(source: &str, diagnostics: DiagnosticList) -> String {
         Formatter::new(&redacted_source, diagnostics)
             .colored()
             .to_string()
-            .replace(placehoder, " ")
+            .replace(placeholder, " ")
     )
 }
 


### PR DESCRIPTION
Error example:
```
2023-12-12T11:01:03.808753Z ERROR vector::topology::builder: Configuration error. error=Transform "my_transform_id": File contents were redacted.
error[E203]: syntax error
   ┌─ :11:7
   │
11 │                                                           
   │       ^
   │       │
   │       unexpected syntax token: "Colon"
   │       expected one of: "\n", "!=", "&&", " ", "+", ",", "-", "/", ";", "<", "<=", "=", "==", ">", ">=", "??", "|", "|", "|=", "||"
   │
   = see language documentation at https://vrl.dev
   = try your code in the VRL REPL, learn more at https://vrl.dev/examples

```