### PR TITLE
chore(observability): Simplify the default log targets selection

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -465,21 +465,7 @@ fn get_log_levels(default: &str) -> String {
                 log
             })
         })
-        .unwrap_or_else(|_| match default {
-            "off" => "off".to_owned(),
-            level => [
-                format!("vector={}", level),
-                format!("codec={}", level),
-                format!("vrl={}", level),
-                format!("file_source={}", level),
-                format!("tower_limit={}", level),
-                format!("rdkafka={}", level),
-                format!("buffers={}", level),
-                format!("lapin={}", level),
-                format!("kube={}", level),
-            ]
-            .join(","),
-        })
+        .unwrap_or_else(|_| default.into())
 }
 
 pub fn build_runtime(threads: Option<usize>, thread_name: &str) -> Result<Runtime, ExitCode> {


### PR DESCRIPTION
When Vector sets a log level, either by the default `info` level or by adding `-v` or `-q` command-line options, it applies that log level to the following targets: `vector`, `codec`, `vrl`, `file_source`, `tower_limit`, `rdkafka`, `buffers`, `lapin`, and `kube`. These targets were set up to limit one or more of the _unlisted_ targets to reduce very chatty debug logs. By contrast, if the user specifies the environment variable setting `LOG_LEVEL=debug`, none of those targets are used.  This change drops all those hard-coded targets and sets all targets to the same level. If we discover there is still an issue with a chatty target, we can add an override for just that target instead of this list.