### PR TITLE
feat(apt platform): Add datadog-signing-keys package as recommended

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,23 +74,18 @@ start = false
 # Though, it seems like aarch64 libc is actually 2.18 and not 2.19
 [package.metadata.deb.variants.armv7-unknown-linux-gnueabihf]
 depends = "libc6 (>= 2.15)"
-recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.x86_64-unknown-linux-gnu]
 depends = "libc6 (>= 2.15)"
-recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.x86_64-unknown-linux-musl]
 depends = ""
-recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.aarch64-unknown-linux-gnu]
 depends = "libc6 (>= 2.18)"
-recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.variants.aarch64-unknown-linux-musl]
 depends = ""
-recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ assets = [
 ]
 license-file = ["target/debian-license.txt"]
 extended-description-file = "target/debian-extended-description.txt"
+recommends = "datadog-signing-keys (>= 1:1.3.1)"
 
 [package.metadata.deb.systemd-units]
 unit-scripts = "distribution/systemd/"


### PR DESCRIPTION
[APL-2390] Adds `datadog-signing-keys` as a recommended package for the Vector deb package, to support validating individual packages are signed.

[APL-2390]: https://datadoghq.atlassian.net/browse/APL-2390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ