### PR TITLE
chore(ci): Remove Cloudsmith package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,6 @@ jobs:
       vector_version: ${{ steps.generate-publish-metadata.outputs.vector_version }}
       vector_build_desc: ${{ steps.generate-publish-metadata.outputs.vector_build_desc }}
       vector_release_channel: ${{ steps.generate-publish-metadata.outputs.vector_release_channel }}
-      vector_cloudsmith_repo: ${{ steps.generate-publish-metadata.outputs.vector_cloudsmith_repo }}
     steps:
       - name: Checkout Vector
         uses: actions/checkout@v3
@@ -628,120 +627,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PACKAGE_PUBLISHER_TOKEN }}
         run: make release-homebrew
-
-  publish-cloudsmith:
-    name: Publish to Cloudsmith
-    # We only publish to CloudSmith for versioned releases, not nightlies.
-    if:  inputs.channel == 'release'
-    runs-on: ubuntu-20.04
-    needs:
-      - generate-publish-metadata
-      - build-x86_64-unknown-linux-gnu-packages
-      - build-aarch64-unknown-linux-gnu-packages
-      - build-armv7-unknown-linux-gnueabihf-packages
-      - deb-verify
-      - rpm-verify
-    env:
-      VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
-      CLOUDSMITH_REPO: ${{ needs.generate-publish-metadata.outputs.vector_cloudsmith_repo }}
-    steps:
-      - name: Checkout Vector
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.git_ref }}
-      - name: Download staged package artifacts (aarch64-unknown-linux-gnu)
-        uses: actions/download-artifact@v3
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu
-          path: target/artifacts
-      - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
-        uses: actions/download-artifact@v3
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
-          path: target/artifacts
-      - name: Download staged package artifacts (armv7-unknown-linux-gnueabihf)
-        uses: actions/download-artifact@v3
-        with:
-          name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-gnueabihf
-          path: target/artifacts
-      - name: Push amd64 deb
-        id: push-deb-amd64
-        uses: cloudsmith-io/action@v0.5.4
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "timber"
-          repo: ${{ env.CLOUDSMITH_REPO }}
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb"
-      - name: Push arm64 deb
-        id: push-deb-arm64
-        uses: cloudsmith-io/action@v0.5.4
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "timber"
-          repo: ${{ env.CLOUDSMITH_REPO }}
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_arm64.deb"
-      - name: Push armhf deb
-        id: push-deb-armhf
-        uses: cloudsmith-io/action@v0.5.4
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "timber"
-          repo: ${{ env.CLOUDSMITH_REPO }}
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_armhf.deb"
-      - name: Push x86_64 RPM
-        id: push-rpm-x86_64
-        uses: cloudsmith-io/action@v0.5.4
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "rpm"
-          owner: "timber"
-          repo: ${{ env.CLOUDSMITH_REPO }}
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm"
-      - name: Push aarch64 RPM
-        id: push-rpm-aarch64
-        uses: cloudsmith-io/action@v0.5.4
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "rpm"
-          owner: "timber"
-          repo: ${{ env.CLOUDSMITH_REPO }}
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.aarch64.rpm"
-      - name: Push armv7hl-gnu RPM
-        id: push-rpm-armv7hl-gnu
-        uses: cloudsmith-io/action@v0.5.4
-        with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "rpm"
-          owner: "timber"
-          repo: ${{ env.CLOUDSMITH_REPO }}
-          distro: "any-distro"
-          release: "any-version"
-          republish: "true"
-          file: "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.armv7hl.rpm"
 
   generate-sha256sum:
     name: Generate SHA256 checksums

--- a/vdev/src/commands/build/publish_metadata.rs
+++ b/vdev/src/commands/build/publish_metadata.rs
@@ -8,10 +8,10 @@ use std::io::{self, Write};
 
 /// Setting necessary metadata for our publish workflow in CI.
 ///
-/// Responsible for setting necessary metadata for our publish workflow in CI.
-/// Computes the Vector version (from Cargo.toml), the release channel (nightly vs release), which Cloudsmith
-/// repository to publish to, and more. All of this information is emitted in a way that sets native outputs on the
-/// GitHub Actions workflow step running the script, which can be passed on to subsequent jobs/steps.
+/// Responsible for setting necessary metadata for our publish workflow in CI. Computes the Vector
+/// version (from Cargo.toml), the release channel (nightly vs release), and more. All of this
+/// information is emitted in a way that sets native outputs on the GitHub Actions workflow step
+/// running the script, which can be passed on to subsequent jobs/steps.
 #[derive(clap::Args, Debug)]
 #[command()]
 pub struct Cli {}
@@ -28,12 +28,6 @@ impl Cli {
         // Figure out what our release channel is.
         let channel = util::get_channel();
 
-        // Depending on the channel, this influences which Cloudsmith repository we publish to.
-        let cloudsmith_repo = match channel.as_str() {
-            "nightly" => "vector-nightly",
-            _ => "vector",
-        };
-
         let mut output_file: Box<dyn Write> = match env::var("GITHUB_OUTPUT") {
             Ok(file_name) if !file_name.is_empty() => {
                 let file = OpenOptions::new()
@@ -47,7 +41,6 @@ impl Cli {
         writeln!(output_file, "vector_version={version}")?;
         writeln!(output_file, "vector_build_desc={build_desc}")?;
         writeln!(output_file, "vector_release_channel={channel}")?;
-        writeln!(output_file, "vector_cloudsmith_repo={cloudsmith_repo}")?;
         Ok(())
     }
 }


### PR DESCRIPTION
As part of migration of package hosting: https://vector.dev/highlights/2023-11-07-new-linux-repos/

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
