### PR TITLE
enhancement(install vector): Allow downloading specific versions of Vector

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -12,7 +12,8 @@ set -u
 
 # If PACKAGE_ROOT is unset or empty, default it.
 PACKAGE_ROOT="${PACKAGE_ROOT:-"https://packages.timber.io/vector"}"
-VECTOR_VERSION="0.34.0"
+# If VECTOR_VERSION is unset or empty, default it.
+VECTOR_VERSION="${VECTOR_VERSION:-"0.34.0"}"
 _divider="--------------------------------------------------------------------------------"
 _prompt=">>>"
 _indent="   "

--- a/website/content/en/docs/setup/installation/manual/vector-installer.md
+++ b/website/content/en/docs/setup/installation/manual/vector-installer.md
@@ -9,6 +9,12 @@ The Vector installer enables you to install Vector using a platform-agnostic ins
 curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash
 ```
 
+You may use `VECTOR_VERSION` to specify a custom version like below:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | VECTOR_VERSION=0.34.1 bash
+```
+
 ## Management
 
 {{< jump "/docs/administration/management" "vector-executable" >}}


### PR DESCRIPTION
Currently, the VECTOR_VERSION is hardcoded in the script, which restricts users from downloading specific versions of Vector. This pull request aims to allow downloading specific versions of Vector.

Closes https://github.com/vectordotdev/vector/issues/5033