### PR TITLE
fix(vector source protobuf codec disk buffering) Build prost with no-recursion-limit feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ rmp-serde = { version = "1.1.2", default-features = false, optional = true }
 rmpv = { version = "1.0.1", default-features = false, features = ["with-serde"], optional = true }
 
 # Prost / Protocol Buffers
-prost = { version = "0.12", default-features = false, features = ["std"] }
+prost = { version = "0.12", default-features = false, features = ["std", "no-recursion-limit"] }
 prost-reflect = { version = "0.12", default-features = false, optional = true }
 prost-types = { version = "0.12", default-features = false, optional = true }
 


### PR DESCRIPTION
Related to issue #19315. The `prost` protobuf crate used by `tokio` and `serde` has a default decoding recursion limit of 100. When used by the Vector-native source, protobuf codec, and/or any sink with disk buffering, this leads to an effective field nesting depth limit for event payloads of 32. Payloads with fields nested deeper than 32-deep fail to decode, causing the event to fail to be received / read from disk buffer / etc. Depending on the location (the Vector-native source, disk buffering, etc), various unrecoverable failure-to-read errors can occur.

Enabling the `no-recursion-limit` feature in the `prost` crate removes this limitation.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
