### PR TITLE
chore(ci): Fix test of install script

### DIFF
--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - run: sudo apt-get install --yes curl bc
-      - run:  curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y
+      - run:  curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y
       - run: ~/.vector/bin/vector --version
 
       - name: (PR comment) Get PR branch


### PR DESCRIPTION
Missed one when updating them in 9893b86. `sh.vector.dev` is now has a HTTP redirect with the move
to Amplify for hosting (from Netlify).

It is causing a failure here: https://github.com/vectordotdev/vector/actions/runs/7265676030/job/19796083515

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
