### PR TITLE
chore(ci): Configure spellchecker to ignore avro files

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -16,6 +16,7 @@
 \.ai$
 \.all-contributorsrc$
 \.avi$
+\.avro$
 \.bmp$
 \.bz2$
 \.class$


### PR DESCRIPTION
Suppresses some warnings we are currently seeing in CI like:

> Skipping `lib/codecs/tests/data/avro/generated/boolean.avro` because appears to be a binary file ('application/octet-stream'). (binary-file)

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
