### PR TITLE
docs: fix mismatch in config vs config file name

### DIFF
--- a/website/content/en/docs/setup/installation/platforms/docker.md
+++ b/website/content/en/docs/setup/installation/platforms/docker.md
@@ -36,21 +36,23 @@ Vector is an end-to-end observability data pipeline designed to deploy under var
 Create a new Vector configuration. The below will output dummy logs to stdout.
 
 ```shell
-cat <<-EOF > $PWD/vector.toml
-[api]
-enabled = true
-address = "0.0.0.0:8686"
-
-[sources.demo_logs]
-type = "demo_logs"
-interval = 1.0
-format = "json"
-
-[sinks.console]
-inputs = ["demo_logs"]
-target = "stdout"
-type = "console"
-encoding.codec = "json"
+cat <<-EOF > $PWD/vector.yaml
+api:
+  enabled: true
+  address: 0.0.0.0:8686
+sources:
+  demo_logs:
+    type: demo_logs
+    interval: 1
+    format: json
+sinks:
+  console:
+    inputs:
+      - demo_logs
+    target: stdout
+    type: console
+    encoding:
+      codec: json
 EOF
 ```
 
@@ -59,7 +61,7 @@ EOF
 ```shell
 docker run \
   -d \
-  -v $PWD/vector.yaml:/etc/vector/vector.yaml:ro \
+  -v $PWD/vector.toml:/etc/vector/vector.toml:ro \
   -p 8686:8686 \
   timberio/vector:{{< version >}}-debian
 ```


### PR DESCRIPTION
The example configuration creates a TOML file:

    cat <<-EOF > $PWD/vector.toml
    [snip]

but the start command example referred to a YAML.

Now they match!