### PR TITLE
chore(docs): Fix link to RFC 3339

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -676,7 +676,7 @@ _coercing_fields: """
 	:------|:------------|:-------
 	`%F %T` | `YYYY-MM-DD HH:MM:SS` | `2020-12-01 02:37:54`
 	`%v %T` | `DD-Mmm-YYYY HH:MM:SS` | `01-Dec-2020 02:37:54`
-	`%FT%T` | [ISO 8601](\(urls.iso_8601))\\[RFC 3339](\(urls.rfc_3339)) format without time zone | `2020-12-01T02:37:54`
+	`%FT%T` | [ISO 8601](\(urls.iso_8601))/[RFC 3339](\(urls.rfc_3339)) format without time zone | `2020-12-01T02:37:54`
 	`%a, %d %b %Y %T` | [RFC 822](\(urls.rfc_822))/[2822](\(urls.rfc_2822)) without time zone | `Tue, 01 Dec 2020 02:37:54`
 	`%a %d %b %T %Y` | [`date`](\(urls.date)) command output without time zone | `Tue 01 Dec 02:37:54 2020`
 	`%a %b %e %T %Y` | [ctime](\(urls.ctime)) format | `Tue Dec  1 02:37:54 2020`


### PR DESCRIPTION
The link has had a backslash as separator, effectively disabling the link itself, but actually like in the other examples, a forward slash was necessary.



Status quo on [the Website](https://vector.dev/docs/reference/configuration/global-options/#enrichment_tables.file.schema):

![image](https://github.com/vectordotdev/vector/assets/2073458/039ff583-45c2-4452-a7ba-d42fa9c4b6bf)

Will be fixed after being merged.