### PR TITLE
chore(deps): Bump Rust to 1.75.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,7 @@ load('ext://helm_resource', 'helm_resource', 'helm_repo')
 docker_build(
     ref='timberio/vector',
     context='.',
-    build_args={'RUST_VERSION': '1.72.1'},
+    build_args={'RUST_VERSION': '1.75.0'},
     dockerfile='tilt/Dockerfile'
     )
 

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4", default-features = false }
 csv-core = { version = "0.1.10", default-features = false }
 derivative = { version = "2", default-features = false }
 dyn-clone = { version = "1", default-features = false }
-lookup = { package = "vector-lookup", path = "../vector-lookup", default-features = false }
+lookup = { package = "vector-lookup", path = "../vector-lookup", default-features = false, features = ["test"] }
 memchr = { version = "2", default-features = false }
 once_cell = { version = "1.19", default-features = false }
 ordered-float = { version = "4.2.0", default-features = false }

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -318,7 +318,7 @@ mod tests {
         let mut tree = ObjectMap::new();
 
         for (field_name, field_value) in field_data.into_iter() {
-            let field = ConfigTargetPath::try_from(field_name.to_string()).unwrap();
+            let field = field_name.into();
             fields.push(field);
 
             let field_value = Value::from(field_value.to_string());
@@ -351,15 +351,15 @@ mod tests {
             "other" => Value::from("data"),
         }));
         let fields = vec![
-            ConfigTargetPath::try_from("foo".to_string()).unwrap(),
-            ConfigTargetPath::try_from("int".to_string()).unwrap(),
-            ConfigTargetPath::try_from("comma".to_string()).unwrap(),
-            ConfigTargetPath::try_from("float".to_string()).unwrap(),
-            ConfigTargetPath::try_from("missing".to_string()).unwrap(),
-            ConfigTargetPath::try_from("space".to_string()).unwrap(),
-            ConfigTargetPath::try_from("time".to_string()).unwrap(),
-            ConfigTargetPath::try_from("quote".to_string()).unwrap(),
-            ConfigTargetPath::try_from("bool".to_string()).unwrap(),
+            "foo".into(),
+            "int".into(),
+            "comma".into(),
+            "float".into(),
+            "missing".into(),
+            "space".into(),
+            "time".into(),
+            "quote".into(),
+            "bool".into(),
         ];
 
         let opts = CsvSerializerOptions {
@@ -388,11 +388,11 @@ mod tests {
             "field5" => Value::from("value5"),
         }));
         let fields = vec![
-            ConfigTargetPath::try_from("field1".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field5".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field5".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field3".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field2".to_string()).unwrap(),
+            "field1".into(),
+            "field5".into(),
+            "field5".into(),
+            "field3".into(),
+            "field2".into(),
         ];
         let opts = CsvSerializerOptions {
             fields,
@@ -419,10 +419,10 @@ mod tests {
             "field4" => Value::from("baz,bas"),
         }));
         let fields = vec![
-            ConfigTargetPath::try_from("field1".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field2".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field3".to_string()).unwrap(),
-            ConfigTargetPath::try_from("field4".to_string()).unwrap(),
+            "field1".into(),
+            "field2".into(),
+            "field3".into(),
+            "field4".into(),
         ];
 
         let mut default_bytes = BytesMut::new();

--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -131,7 +131,7 @@ impl DnsMessageParser {
             .collect::<Vec<ZoneInfo>>();
 
         zones
-            .get(0)
+            .first()
             .cloned()
             .ok_or_else(|| DnsMessageParserError::SimpleError {
                 cause: format!(

--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -282,7 +282,7 @@ impl MetricGroup {
 }
 
 fn matching_group<T: Default>(values: &mut MetricMap<T>, group: GroupKey) -> &mut T {
-    values.entry(group).or_insert_with(T::default)
+    values.entry(group).or_default()
 }
 
 /// Parse the given text input, and group the result into higher-level

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -425,9 +425,9 @@ mod test {
 
     #[test]
     fn parse_partial_invalid_keys() {
-        let source = r#"max_size: 100
+        let source = r"max_size: 100
 max_events: 42
-"#;
+";
         let error = serde_yaml::from_str::<BufferConfig>(source).unwrap_err();
         assert_eq!(error.to_string(), BUFFER_CONFIG_NO_MATCH_ERR);
     }
@@ -435,9 +435,9 @@ max_events: 42
     #[test]
     fn parse_without_type_tag() {
         check_single_stage(
-            r#"
+            r"
           max_events: 100
-          "#,
+          ",
             BufferType::Memory {
                 max_events: NonZeroUsize::new(100).unwrap(),
                 when_full: WhenFull::Block,
@@ -448,11 +448,11 @@ max_events: 42
     #[test]
     fn parse_multiple_stages() {
         check_multiple_stages(
-            r#"
+            r"
           - max_events: 42
           - max_events: 100
             when_full: drop_newest
-          "#,
+          ",
             &[
                 BufferType::Memory {
                     max_events: NonZeroUsize::new(42).unwrap(),
@@ -469,9 +469,9 @@ max_events: 42
     #[test]
     fn ensure_field_defaults_for_all_types() {
         check_single_stage(
-            r#"
+            r"
           type: memory
-          "#,
+          ",
             BufferType::Memory {
                 max_events: NonZeroUsize::new(500).unwrap(),
                 when_full: WhenFull::Block,
@@ -479,10 +479,10 @@ max_events: 42
         );
 
         check_single_stage(
-            r#"
+            r"
           type: memory
           max_events: 100
-          "#,
+          ",
             BufferType::Memory {
                 max_events: NonZeroUsize::new(100).unwrap(),
                 when_full: WhenFull::Block,
@@ -490,10 +490,10 @@ max_events: 42
         );
 
         check_single_stage(
-            r#"
+            r"
           type: memory
           when_full: drop_newest
-          "#,
+          ",
             BufferType::Memory {
                 max_events: NonZeroUsize::new(500).unwrap(),
                 when_full: WhenFull::DropNewest,
@@ -501,10 +501,10 @@ max_events: 42
         );
 
         check_single_stage(
-            r#"
+            r"
           type: memory
           when_full: overflow
-          "#,
+          ",
             BufferType::Memory {
                 max_events: NonZeroUsize::new(500).unwrap(),
                 when_full: WhenFull::Overflow,
@@ -512,10 +512,10 @@ max_events: 42
         );
 
         check_single_stage(
-            r#"
+            r"
           type: disk
           max_size: 1024
-          "#,
+          ",
             BufferType::DiskV2 {
                 max_size: NonZeroU64::new(1024).unwrap(),
                 when_full: WhenFull::Block,

--- a/lib/vector-buffers/src/encoding.rs
+++ b/lib/vector-buffers/src/encoding.rs
@@ -177,7 +177,7 @@ impl<T: FixedEncodable> Encodable for T {
 
     fn get_metadata() -> Self::Metadata {}
 
-    fn can_decode(_: Self::Metadata) -> bool {
+    fn can_decode((): Self::Metadata) -> bool {
         true
     }
 
@@ -189,7 +189,7 @@ impl<T: FixedEncodable> Encodable for T {
         FixedEncodable::encoded_size(self)
     }
 
-    fn decode<B: Buf + Clone>(_: Self::Metadata, buffer: B) -> Result<Self, Self::DecodeError> {
+    fn decode<B: Buf + Clone>((): Self::Metadata, buffer: B) -> Result<Self, Self::DecodeError> {
         <Self as FixedEncodable>::decode(buffer)
     }
 }

--- a/lib/vector-buffers/src/test/variant.rs
+++ b/lib/vector-buffers/src/test/variant.rs
@@ -103,12 +103,8 @@ impl Arbitrary for Variant {
         let use_memory_buffer = bool::arbitrary(g);
 
         // Using a u16 ensures we avoid any allocation errors for our holding buffers, etc.
-        let max_events = NonZeroU16::arbitrary(g)
-            .try_into()
-            .expect("we don't support 16-bit platforms");
-        let max_size = NonZeroU16::arbitrary(g)
-            .try_into()
-            .expect("we don't support 16-bit platforms");
+        let max_events = NonZeroU16::arbitrary(g).into();
+        let max_size = NonZeroU16::arbitrary(g).into();
 
         let when_full = WhenFull::arbitrary(g);
 

--- a/lib/vector-buffers/src/topology/acks.rs
+++ b/lib/vector-buffers/src/topology/acks.rs
@@ -730,7 +730,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "overflowing unclaimed acknowledgements is a serious bug")]
     fn panic_when_unclaimed_acks_overflows() {
         let actions = vec![Action::Acknowledge(u64::MAX), Action::Acknowledge(1)];
 

--- a/lib/vector-buffers/src/topology/channel/receiver.rs
+++ b/lib/vector-buffers/src/topology/channel/receiver.rs
@@ -24,7 +24,7 @@ pub enum ReceiverAdapter<T: Bufferable> {
     InMemory(LimitedReceiver<T>),
 
     /// The disk v2 buffer.
-    DiskV2(disk_v2::Reader<T, ProductionFilesystem>),
+    DiskV2(disk_v2::BufferReader<T, ProductionFilesystem>),
 }
 
 impl<T: Bufferable> From<LimitedReceiver<T>> for ReceiverAdapter<T> {
@@ -33,8 +33,8 @@ impl<T: Bufferable> From<LimitedReceiver<T>> for ReceiverAdapter<T> {
     }
 }
 
-impl<T: Bufferable> From<disk_v2::Reader<T, ProductionFilesystem>> for ReceiverAdapter<T> {
-    fn from(v: disk_v2::Reader<T, ProductionFilesystem>) -> Self {
+impl<T: Bufferable> From<disk_v2::BufferReader<T, ProductionFilesystem>> for ReceiverAdapter<T> {
+    fn from(v: disk_v2::BufferReader<T, ProductionFilesystem>) -> Self {
         Self::DiskV2(v)
     }
 }

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -21,7 +21,7 @@ pub enum SenderAdapter<T: Bufferable> {
     InMemory(LimitedSender<T>),
 
     /// The disk v2 buffer.
-    DiskV2(Arc<Mutex<disk_v2::Writer<T, ProductionFilesystem>>>),
+    DiskV2(Arc<Mutex<disk_v2::BufferWriter<T, ProductionFilesystem>>>),
 }
 
 impl<T: Bufferable> From<LimitedSender<T>> for SenderAdapter<T> {
@@ -30,8 +30,8 @@ impl<T: Bufferable> From<LimitedSender<T>> for SenderAdapter<T> {
     }
 }
 
-impl<T: Bufferable> From<disk_v2::Writer<T, ProductionFilesystem>> for SenderAdapter<T> {
-    fn from(v: disk_v2::Writer<T, ProductionFilesystem>) -> Self {
+impl<T: Bufferable> From<disk_v2::BufferWriter<T, ProductionFilesystem>> for SenderAdapter<T> {
+    fn from(v: disk_v2::BufferWriter<T, ProductionFilesystem>) -> Self {
         Self::DiskV2(Arc::new(Mutex::new(v)))
     }
 }

--- a/lib/vector-buffers/src/variants/disk_v2/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/common.rs
@@ -428,7 +428,7 @@ mod tests {
     };
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "`amount` must be less than `MAX_ALIGNABLE_AMOUNT`")]
     fn test_align16_too_large() {
         // We forcefully panic if the input to `align16` is too large to align without overflow, primarily because
         // that's a huge amount even on 32-bit systems and in non-test code, we only use `align16` in a const context,

--- a/lib/vector-buffers/src/variants/disk_v2/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/mod.rs
@@ -199,8 +199,8 @@ pub use self::{
     common::{DiskBufferConfig, DiskBufferConfigBuilder},
     io::{Filesystem, ProductionFilesystem},
     ledger::LedgerLoadCreateError,
-    reader::{Reader, ReaderError},
-    writer::{Writer, WriterError},
+    reader::{BufferReader, ReaderError},
+    writer::{BufferWriter, WriterError},
 };
 use crate::{
     buffer_usage_data::BufferUsageHandle,
@@ -243,7 +243,7 @@ where
     pub(crate) async fn from_config_inner<FS>(
         config: DiskBufferConfig<FS>,
         usage_handle: BufferUsageHandle,
-    ) -> Result<(Writer<T, FS>, Reader<T, FS>, Arc<Ledger<FS>>), BufferError<T>>
+    ) -> Result<(BufferWriter<T, FS>, BufferReader<T, FS>, Arc<Ledger<FS>>), BufferError<T>>
     where
         FS: Filesystem + fmt::Debug + Clone + 'static,
         FS::File: Unpin,
@@ -253,7 +253,7 @@ where
             .context(LedgerSnafu)?;
         let ledger = Arc::new(ledger);
 
-        let mut writer = Writer::new(Arc::clone(&ledger));
+        let mut writer = BufferWriter::new(Arc::clone(&ledger));
         writer
             .validate_last_write()
             .await
@@ -261,7 +261,7 @@ where
 
         let finalizer = Arc::clone(&ledger).spawn_finalizer();
 
-        let mut reader = Reader::new(Arc::clone(&ledger), finalizer);
+        let mut reader = BufferReader::new(Arc::clone(&ledger), finalizer);
         reader
             .seek_to_next_record()
             .await
@@ -286,7 +286,7 @@ where
     pub async fn from_config<FS>(
         config: DiskBufferConfig<FS>,
         usage_handle: BufferUsageHandle,
-    ) -> Result<(Writer<T, FS>, Reader<T, FS>), BufferError<T>>
+    ) -> Result<(BufferWriter<T, FS>, BufferReader<T, FS>), BufferError<T>>
     where
         FS: Filesystem + fmt::Debug + Clone + 'static,
         FS::File: Unpin,
@@ -345,8 +345,8 @@ async fn build_disk_v2_buffer<T>(
     max_size: NonZeroU64,
 ) -> Result<
     (
-        Writer<T, ProductionFilesystem>,
-        Reader<T, ProductionFilesystem>,
+        BufferWriter<T, ProductionFilesystem>,
+        BufferReader<T, ProductionFilesystem>,
     ),
     Box<dyn Error + Send + Sync>,
 >

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -53,7 +53,7 @@ impl ReadToken {
     }
 }
 
-/// Error that occurred during calls to [`Reader`].
+/// Error that occurred during calls to [`BufferReader`].
 #[derive(Debug, Snafu)]
 pub enum ReaderError<T>
 where
@@ -70,7 +70,7 @@ where
     /// The reader failed to deserialize the record.
     ///
     /// In most cases, this indicates that the data file being read was corrupted or truncated in
-    /// some fashion.  Callers of [`Reader::next`] will not actually receive this error, as it is
+    /// some fashion.  Callers of [`BufferReader::next`] will not actually receive this error, as it is
     /// handled internally by moving to the next data file, as corruption may have affected other
     /// records in a way that is not easily detectable and could lead to records which
     /// deserialize/decode but contain invalid data.
@@ -80,7 +80,7 @@ where
     /// The record's checksum did not match.
     ///
     /// In most cases, this indicates that the data file being read was corrupted or truncated in
-    /// some fashion.  Callers of [`Reader::next`] will not actually receive this error, as it is
+    /// some fashion.  Callers of [`BufferReader::next`] will not actually receive this error, as it is
     /// handled internally by moving to the next data file, as corruption may have affected other
     /// records in a way that is not easily detectable and could lead to records which
     /// deserialize/decode but contain invalid data.
@@ -394,7 +394,7 @@ where
 
 /// Reads records from the buffer.
 #[derive(Debug)]
-pub struct Reader<T, FS>
+pub struct BufferReader<T, FS>
 where
     FS: Filesystem,
 {
@@ -412,13 +412,13 @@ where
     _t: PhantomData<T>,
 }
 
-impl<T, FS> Reader<T, FS>
+impl<T, FS> BufferReader<T, FS>
 where
     T: Bufferable,
     FS: Filesystem,
     FS::File: Unpin,
 {
-    /// Creates a new [`Reader`] attached to the given [`Ledger`].
+    /// Creates a new [`BufferReader`] attached to the given [`Ledger`].
     pub(crate) fn new(ledger: Arc<Ledger<FS>>, finalizer: OrderedFinalizer<u64>) -> Self {
         let ledger_last_reader_record_id = ledger.state().get_last_reader_record_id();
         let next_expected_record_id = ledger_last_reader_record_id.wrapping_add(1);

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -14,7 +14,7 @@ use super::{
     io::{AsyncFile, Metadata, ProductionFilesystem, ReadableMemoryMap, WritableMemoryMap},
     ledger::LEDGER_LEN,
     record::RECORD_HEADER_LEN,
-    Buffer, DiskBufferConfigBuilder, Filesystem, Ledger, Reader, Writer,
+    Buffer, BufferReader, BufferWriter, DiskBufferConfigBuilder, Filesystem, Ledger,
 };
 use crate::{
     buffer_usage_data::BufferUsageHandle, encoding::FixedEncodable,
@@ -197,8 +197,8 @@ macro_rules! set_data_file_length {
 pub(crate) async fn create_default_buffer_v2<P, R>(
     data_dir: P,
 ) -> (
-    Writer<R, FilesystemUnderTest>,
-    Reader<R, FilesystemUnderTest>,
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
     Arc<Ledger<FilesystemUnderTest>>,
 )
 where
@@ -218,8 +218,8 @@ where
 pub(crate) async fn create_default_buffer_v2_with_usage<P, R>(
     data_dir: P,
 ) -> (
-    Writer<R, FilesystemUnderTest>,
-    Reader<R, FilesystemUnderTest>,
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
     Arc<Ledger<FilesystemUnderTest>>,
     BufferUsageHandle,
 )
@@ -247,8 +247,8 @@ pub(crate) async fn create_buffer_v2_with_data_file_count_limit<P, R>(
     max_data_file_size: u64,
     data_file_count_limit: u64,
 ) -> (
-    Writer<R, FilesystemUnderTest>,
-    Reader<R, FilesystemUnderTest>,
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
     Arc<Ledger<FilesystemUnderTest>>,
 )
 where
@@ -291,8 +291,8 @@ pub(crate) async fn create_buffer_v2_with_max_record_size<P, R>(
     data_dir: P,
     max_record_size: usize,
 ) -> (
-    Writer<R, FilesystemUnderTest>,
-    Reader<R, FilesystemUnderTest>,
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
     Arc<Ledger<FilesystemUnderTest>>,
 )
 where
@@ -317,8 +317,8 @@ pub(crate) async fn create_buffer_v2_with_max_data_file_size<P, R>(
     data_dir: P,
     max_data_file_size: u64,
 ) -> (
-    Writer<R, FilesystemUnderTest>,
-    Reader<R, FilesystemUnderTest>,
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
     Arc<Ledger<FilesystemUnderTest>>,
 )
 where
@@ -344,8 +344,8 @@ pub(crate) async fn create_buffer_v2_with_write_buffer_size<P, R>(
     data_dir: P,
     write_buffer_size: usize,
 ) -> (
-    Writer<R, FilesystemUnderTest>,
-    Reader<R, FilesystemUnderTest>,
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
     Arc<Ledger<FilesystemUnderTest>>,
 )
 where
@@ -384,7 +384,7 @@ where
     u64::try_from(max_record_size).unwrap()
 }
 
-pub(crate) async fn read_next<T, FS>(reader: &mut Reader<T, FS>) -> Option<T>
+pub(crate) async fn read_next<T, FS>(reader: &mut BufferReader<T, FS>) -> Option<T>
 where
     T: Bufferable,
     FS: Filesystem,
@@ -393,7 +393,7 @@ where
     reader.next().await.expect("read should not fail")
 }
 
-pub(crate) async fn read_next_some<T, FS>(reader: &mut Reader<T, FS>) -> T
+pub(crate) async fn read_next_some<T, FS>(reader: &mut BufferReader<T, FS>) -> T
 where
     T: Bufferable,
     FS: Filesystem,

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/common.rs
@@ -4,11 +4,11 @@ use proptest::{arbitrary::any, strategy::Strategy};
 
 use super::{filesystem::TestFilesystem, record::Record};
 use crate::variants::disk_v2::{
-    DiskBufferConfig, DiskBufferConfigBuilder, Reader, ReaderError, Writer, WriterError,
+    BufferReader, BufferWriter, DiskBufferConfig, DiskBufferConfigBuilder, ReaderError, WriterError,
 };
 
-pub type TestReader = Reader<Record, TestFilesystem>;
-pub type TestWriter = Writer<Record, TestFilesystem>;
+pub type TestReader = BufferReader<Record, TestFilesystem>;
+pub type TestWriter = BufferWriter<Record, TestFilesystem>;
 pub type ReaderResult<T> = Result<T, ReaderError<Record>>;
 pub type WriterResult<T> = Result<T, WriterError<Record>>;
 
@@ -37,9 +37,7 @@ pub fn arb_buffer_config() -> impl Strategy<Value = DiskBufferConfig<TestFilesys
         .prop_map(|(n1, n2, n3)| {
             let max_buffer_size = u64::from(n1) * 64;
             let max_data_file_size = u64::from(n2) * 2;
-            let max_record_size = n3
-                .try_into()
-                .expect("u16 should never be smaller than usize");
+            let max_record_size = n3.into();
 
             let mut path = std::env::temp_dir();
             path.push("vector-disk-v2-model");

--- a/lib/vector-common/src/finalizer.rs
+++ b/lib/vector-common/src/finalizer.rs
@@ -115,7 +115,7 @@ where
             tokio::select! {
                 biased;
                 _ = &mut shutdown, if handle_shutdown => break,
-                _ = flush.notified() => {
+                () = flush.notified() => {
                     // Drop all the existing status receivers and start over.
                     status_receivers = S::default();
                 },

--- a/lib/vector-config/src/schema/helpers.rs
+++ b/lib/vector-config/src/schema/helpers.rs
@@ -650,7 +650,7 @@ pub(crate) fn assert_string_schema_for_map(
                 SingleOrVec::Vec(its) => {
                     its.len() == 1
                         && its
-                            .get(0)
+                            .first()
                             .filter(|it| *it == &InstanceType::String)
                             .is_some()
                 }

--- a/lib/vector-config/src/schema/visitors/inline_single.rs
+++ b/lib/vector-config/src/schema/visitors/inline_single.rs
@@ -177,7 +177,7 @@ impl Visitor for OccurrenceVisitor {
             let occurrences = self
                 .occurrence_map
                 .entry(current_schema_ref.into())
-                .or_insert_with(HashSet::new);
+                .or_default();
             occurrences.insert(current_parent_schema_ref);
         }
     }

--- a/lib/vector-core/src/config/telemetry.rs
+++ b/lib/vector-core/src/config/telemetry.rs
@@ -87,9 +87,9 @@ mod test {
 
     #[test]
     fn partial_telemetry() {
-        let toml = r#"
+        let toml = r"
             emit_source = true
-        "#;
+        ";
         toml::from_str::<Telemetry>(toml).unwrap();
     }
 }

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -434,7 +434,7 @@ impl LogEvent {
         &self,
     ) -> Option<impl Iterator<Item = (KeyString, &Value)> + Serialize> {
         match self.metadata.value() {
-            Value::Object(metadata_map) => Some(metadata_map).map(all_metadata_fields),
+            Value::Object(metadata_map) => Some(all_metadata_fields(metadata_map)),
             _ => None,
         }
     }

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -168,12 +168,9 @@ mod test {
         vector_common::assert_event_data_eq!(event, expected);
     }
 
-    // The expected panic is a clippy lint. The resulting error message is platform dependent, so only run this test on non-windows.
-    #[cfg(not(windows))]
+    // the panic message a) is platform dependent and b) can change if any code is added before this function.
+    #[allow(clippy::should_panic_without_expect)]
     #[test]
-    #[should_panic(
-        expected = "called `Result::unwrap()` on an `Err` value: SyntaxError { message: \"[string \\\"lib/vector-core/src/event/lua/event.rs:179:20...\\\"]:1: unexpected symbol near '{'\", incomplete_input: false }"
-    )]
     fn from_lua_missing_log_and_metric() {
         let lua_event = r"{
             some_field: {}

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -168,9 +168,10 @@ mod test {
         vector_common::assert_event_data_eq!(event, expected);
     }
 
+    #[test]
     // the panic message a) is platform dependent and b) can change if any code is added before this function.
     #[allow(clippy::should_panic_without_expect)]
-    #[test]
+    #[should_panic]
     fn from_lua_missing_log_and_metric() {
         let lua_event = r"{
             some_field: {}

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -169,11 +169,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: SyntaxError { message: \"[string \\\"lib/vector-core/src/event/lua/event.rs:179:20...\\\"]:1: unexpected symbol near '{'\", incomplete_input: false }"
+    )]
     fn from_lua_missing_log_and_metric() {
-        let lua_event = r#"{
+        let lua_event = r"{
             some_field: {}
-        }"#;
+        }";
         Lua::new().load(lua_event).eval::<Event>().unwrap();
     }
 }

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -168,6 +168,8 @@ mod test {
         vector_common::assert_event_data_eq!(event, expected);
     }
 
+    // The expected panic is a clippy lint. The resulting error message is platform dependent, so only run this test on non-windows.
+    #[cfg(not(windows))]
     #[test]
     #[should_panic(
         expected = "called `Result::unwrap()` on an `Err` value: SyntaxError { message: \"[string \\\"lib/vector-core/src/event/lua/event.rs:179:20...\\\"]:1: unexpected symbol near '{'\", incomplete_input: false }"

--- a/lib/vector-core/src/event/lua/log.rs
+++ b/lib/vector-core/src/event/lua/log.rs
@@ -53,7 +53,7 @@ mod test {
 
     #[test]
     fn from_lua() {
-        let lua_event = r#"
+        let lua_event = r"
         {
             a = 1,
             nested = {
@@ -61,7 +61,7 @@ mod test {
                 array = {'example value', '', 'another value'}
             }
         }
-        "#;
+        ";
 
         let event: LogEvent = Lua::new().load(lua_event).eval().unwrap();
 

--- a/lib/vector-core/src/event/metric/arbitrary.rs
+++ b/lib/vector-core/src/event/metric/arbitrary.rs
@@ -21,7 +21,7 @@ impl Arbitrary for MetricValue {
     // https://github.com/proptest-rs/proptest/commit/466d59daeca317f815bb8358e8d981bb9bd9431a is
     // released
     #[allow(clippy::arc_with_non_send_sync)]
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         let strategy = prop_oneof![
             realistic_float().prop_map(|value| MetricValue::Counter { value }),
             realistic_float().prop_map(|value| MetricValue::Gauge { value }),
@@ -68,7 +68,7 @@ impl Arbitrary for MetricSketch {
     type Parameters = ();
     type Strategy = BoxedStrategy<MetricSketch>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         let strategy = prop_oneof![any::<AgentDDSketch>().prop_map(MetricSketch::AgentDDSketch),];
         strategy.boxed()
     }
@@ -78,7 +78,7 @@ impl Arbitrary for StatisticKind {
     type Parameters = ();
     type Strategy = BoxedStrategy<StatisticKind>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         let strategy = prop_oneof![Just(StatisticKind::Histogram), Just(StatisticKind::Summary)];
         strategy.boxed()
     }
@@ -88,7 +88,7 @@ impl Arbitrary for Sample {
     type Parameters = ();
     type Strategy = BoxedStrategy<Sample>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         (realistic_float(), any::<u32>())
             .prop_map(|(value, rate)| Sample { value, rate })
             .boxed()
@@ -99,7 +99,7 @@ impl Arbitrary for Bucket {
     type Parameters = ();
     type Strategy = BoxedStrategy<Bucket>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         (realistic_float(), any::<u64>())
             .prop_map(|(upper_limit, count)| Bucket { upper_limit, count })
             .boxed()
@@ -110,7 +110,7 @@ impl Arbitrary for Quantile {
     type Parameters = ();
     type Strategy = BoxedStrategy<Quantile>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         (0.0..=1.0, realistic_float())
             .prop_map(|(quantile, value)| Quantile { quantile, value })
             .boxed()
@@ -121,7 +121,7 @@ impl Arbitrary for AgentDDSketch {
     type Parameters = ();
     type Strategy = BoxedStrategy<AgentDDSketch>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         use proptest::collection::vec as arb_vec;
 
         arb_vec(realistic_float(), 16..128)
@@ -138,7 +138,7 @@ impl Arbitrary for TagValue {
     type Parameters = ();
     type Strategy = BoxedStrategy<TagValue>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         option::of("[[:^cntrl:]]{0,16}")
             .prop_map(TagValue::from)
             .boxed()
@@ -149,7 +149,7 @@ impl Arbitrary for TagValueSet {
     type Parameters = ();
     type Strategy = BoxedStrategy<TagValueSet>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         hash_set("[[:^cntrl:]]{0,16}", 1..16)
             .prop_map(|values| values.into_iter().collect())
             .boxed()
@@ -160,7 +160,7 @@ impl Arbitrary for MetricTags {
     type Parameters = ();
     type Strategy = BoxedStrategy<MetricTags>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         hash_map("[[:word:]]{1,32}", "[[:^cntrl:]]{1,32}", 0..16)
             .prop_map(|values| values.into_iter().collect())
             .boxed()

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -939,7 +939,7 @@ mod test {
                 )
                 .with_namespace(Some("vector"))
             ),
-            r#"vector_namespace{} = 1.23"#
+            r"vector_namespace{} = 1.23"
         );
 
         assert_eq!(
@@ -980,7 +980,7 @@ mod test {
                     }
                 )
             ),
-            r#"four{} = histogram 3@1 4@2"#
+            r"four{} = histogram 3@1 4@2"
         );
 
         assert_eq!(
@@ -996,7 +996,7 @@ mod test {
                     }
                 )
             ),
-            r#"five{} = count=107 sum=103 53@51 54@52"#
+            r"five{} = count=107 sum=103 53@51 54@52"
         );
 
         assert_eq!(
@@ -1012,7 +1012,7 @@ mod test {
                     }
                 )
             ),
-            r#"six{} = count=2 sum=127 1@63 2@64"#
+            r"six{} = count=2 sum=127 1@63 2@64"
         );
     }
 

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -282,8 +282,9 @@ impl Target for VrlTarget {
                         return Err(MetricPathError::SetPathError.to_string());
                     }
 
-                    if let Some(paths) =
-                        path.to_alternative_components(MAX_METRIC_PATH_DEPTH).get(0)
+                    if let Some(paths) = path
+                        .to_alternative_components(MAX_METRIC_PATH_DEPTH)
+                        .first()
                     {
                         match paths.as_slice() {
                             ["tags"] => {
@@ -406,7 +407,7 @@ impl Target for VrlTarget {
                     if let Some(paths) = target_path
                         .path
                         .to_alternative_components(MAX_METRIC_PATH_DEPTH)
-                        .get(0)
+                        .first()
                     {
                         let removed_value = match paths.as_slice() {
                             ["namespace"] => metric.series.name.namespace.take().map(Into::into),
@@ -784,7 +785,7 @@ mod test {
             ),
             (
                 btreemap! { "foo" => btreemap! { "bar baz" => btreemap! { "baz" => 2 } } },
-                owned_value_path!("foo", vec!["qux", r#"bar baz"#], "baz"),
+                owned_value_path!("foo", vec!["qux", r"bar baz"], "baz"),
                 Ok(Some(2.into())),
             ),
         ];
@@ -939,7 +940,7 @@ mod test {
             ),
             (
                 BTreeMap::from([("foo".into(), "bar".into())]),
-                owned_value_path!(vec![r#"foo bar"#, "foo"]),
+                owned_value_path!(vec![r"foo bar", "foo"]),
                 false,
                 Some(BTreeMap::new().into()),
             ),
@@ -972,7 +973,7 @@ mod test {
                     "foo" => btreemap! { "bar baz" => vec![0] },
                     "bar" => "baz",
                 },
-                owned_value_path!("foo", r#"bar baz"#, 0),
+                owned_value_path!("foo", r"bar baz", 0),
                 false,
                 Some(
                     btreemap! {
@@ -987,7 +988,7 @@ mod test {
                     "foo" => btreemap! { "bar baz" => vec![0] },
                     "bar" => "baz",
                 },
-                owned_value_path!("foo", r#"bar baz"#, 0),
+                owned_value_path!("foo", r"bar baz", 0),
                 true,
                 Some(btreemap! { "bar" => "baz" }.into()),
             ),

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -571,7 +571,7 @@ impl MaybeTlsSettings {
 
     pub const fn http_protocol_name(&self) -> &'static str {
         match self {
-            MaybeTls::Raw(_) => "http",
+            MaybeTls::Raw(()) => "http",
             MaybeTls::Tls(_) => "https",
         }
     }

--- a/lib/vector-stream/src/partitioned_batcher.rs
+++ b/lib/vector-stream/src/partitioned_batcher.rs
@@ -542,7 +542,7 @@ mod test {
             .fold(
                 HashMap::default(),
                 |mut acc: HashMap<u8, Vec<u64>>, (key, item)| {
-                    let arr: &mut Vec<u64> = acc.entry(key).or_insert_with(Vec::default);
+                    let arr: &mut Vec<u64> = acc.entry(key).or_default();
                     arr.push(item);
                     acc
                 },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.75.0"
 profile = "default"

--- a/src/api/schema/metrics/filter.rs
+++ b/src/api/schema/metrics/filter.rs
@@ -379,10 +379,13 @@ fn component_to_filtered_metrics(
         m.into_iter()
             .filter(filter_fn)
             .filter_map(|m| m.tag_value("component_id").map(|id| (id, m)))
-            .fold(BTreeMap::new(), |mut map, (id, m)| {
-                map.entry(id).or_insert_with(Vec::new).push(m);
-                map
-            })
+            .fold(
+                BTreeMap::new(),
+                |mut map: BTreeMap<String, Vec<Metric>>, (id, m)| {
+                    map.entry(id).or_default().push(m);
+                    map
+                },
+            )
     })
 }
 

--- a/src/api/schema/metrics/source/file.rs
+++ b/src/api/schema/metrics/source/file.rs
@@ -65,10 +65,13 @@ impl FileSourceMetrics {
         self.0
             .iter()
             .filter_map(|m| m.tag_value("file").map(|file| (file, m)))
-            .fold(BTreeMap::new(), |mut map, (file, m)| {
-                map.entry(file).or_insert_with(Vec::new).push(m);
-                map
-            })
+            .fold(
+                BTreeMap::new(),
+                |mut map: BTreeMap<String, Vec<&Metric>>, (file, m)| {
+                    map.entry(file).or_default().push(m);
+                    map
+                },
+            )
             .into_iter()
             .map(FileSourceMetricFile::from_tuple)
             .collect()

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -394,7 +394,7 @@ pub(crate) fn report_on_reload(
 ) -> Option<EnterpriseReporter<BoxFuture<'static, ()>>> {
     attach_enterprise_components(config, &metadata);
 
-    let enterprise = match enterprise {
+    match enterprise {
         Some(enterprise) => {
             enterprise.send(report_configuration(config_paths, metadata));
             None
@@ -404,9 +404,7 @@ pub(crate) fn report_on_reload(
             enterprise.send(report_configuration(config_paths, metadata));
             Some(enterprise)
         }
-    };
-
-    enterprise
+    }
 }
 
 pub(crate) fn attach_enterprise_components(config: &mut Config, metadata: &EnterpriseMetadata) {

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use config_builder::ConfigBuilderLoader;
-pub use config_builder::*;
 use glob::glob;
 use loader::process::Process;
 pub use loader::*;

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -3,7 +3,7 @@ use futures_util::{stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use heim::{disk::Partition, units::information::byte};
 use indexmap::IndexMap;
 use std::{collections::HashMap, path::PathBuf};
-use vector_lib::internal_event::DEFAULT_OUTPUT;
+use vector_lib::{buffers::config::DiskUsage, internal_event::DEFAULT_OUTPUT};
 
 use super::{
     builder::ConfigBuilder, transform::get_transform_output_ids, ComponentKey, Config, OutputId,
@@ -248,35 +248,32 @@ pub async fn check_buffer_preconditions(config: &Config) -> Result<(), Vec<Strin
     };
 
     // Now build a mapping of buffer IDs/usage configuration to the mountpoint they reside on.
-    let mountpoint_buffer_mapping =
-        configured_disk_buffers
-            .into_iter()
-            .fold(HashMap::new(), |mut mappings, usage| {
-                let canonicalized_data_dir = usage
-                    .data_dir()
-                    .canonicalize()
-                    .unwrap_or_else(|_| usage.data_dir().to_path_buf());
-                let mountpoint = mountpoints
-                    .keys()
-                    .find(|mountpoint| canonicalized_data_dir.starts_with(mountpoint));
+    let mountpoint_buffer_mapping = configured_disk_buffers.into_iter().fold(
+        HashMap::new(),
+        |mut mappings: HashMap<PathBuf, Vec<DiskUsage>>, usage| {
+            let canonicalized_data_dir = usage
+                .data_dir()
+                .canonicalize()
+                .unwrap_or_else(|_| usage.data_dir().to_path_buf());
+            let mountpoint = mountpoints
+                .keys()
+                .find(|mountpoint| canonicalized_data_dir.starts_with(mountpoint));
 
-                match mountpoint {
-                    None => warn!(
-                        buffer_id = usage.id().id(),
-                        data_dir = usage.data_dir().to_string_lossy().as_ref(),
-                        canonicalized_data_dir = canonicalized_data_dir.to_string_lossy().as_ref(),
-                        message = "Found no matching mountpoint for buffer data directory.",
-                    ),
-                    Some(mountpoint) => {
-                        mappings
-                            .entry(mountpoint.clone())
-                            .or_insert_with(Vec::new)
-                            .push(usage);
-                    }
+            match mountpoint {
+                None => warn!(
+                    buffer_id = usage.id().id(),
+                    data_dir = usage.data_dir().to_string_lossy().as_ref(),
+                    canonicalized_data_dir = canonicalized_data_dir.to_string_lossy().as_ref(),
+                    message = "Found no matching mountpoint for buffer data directory.",
+                ),
+                Some(mountpoint) => {
+                    mappings.entry(mountpoint.clone()).or_default().push(usage);
                 }
+            }
 
-                mappings
-            });
+            mappings
+        },
+    );
 
     // Finally, we have a mapping of disk buffers, based on their underlying mountpoint. Go through
     // and check to make sure the sum total of `max_size` for all buffers associated with each

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -264,7 +264,7 @@ impl Table for Geoip {
         select: Option<&[String]>,
         _: Option<IndexHandle>,
     ) -> Result<Vec<ObjectMap>, String> {
-        match condition.get(0) {
+        match condition.first() {
             Some(_) if condition.len() > 1 => Err("Only one condition is allowed".to_string()),
             Some(Condition::Equals { value, .. }) => {
                 let ip = value

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -133,7 +133,7 @@ pub(crate) fn generate_example(
     let mut errs = Vec::new();
 
     let mut source_names = Vec::new();
-    if let Some(source_types) = components.get(0) {
+    if let Some(source_types) = components.first() {
         let mut sources = IndexMap::new();
 
         for (i, source_expr) in source_types.iter().enumerate() {

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -224,7 +224,7 @@ async fn handle_metrics() {
     let encoded_lines = encoded.split('\n').map(String::from).collect::<Vec<_>>();
     assert_eq!(encoded_lines.len(), 3); // there's an empty line at the end
     assert_eq!(
-        encoded_lines.get(0).unwrap(),
+        encoded_lines.first().unwrap(),
         r#"{"create":{"_index":"vector","_type":"_doc"}}"#
     );
     assert!(encoded_lines

--- a/src/sinks/prometheus/remote_write/integration_tests.rs
+++ b/src/sinks/prometheus/remote_write/integration_tests.rs
@@ -2,11 +2,12 @@ use std::{collections::HashMap, ops::Range};
 
 use serde_json::Value;
 
-use super::{tests::*, *};
+use super::tests::*;
 use crate::{
     config::{SinkConfig, SinkContext},
     event::{metric::MetricValue, Event},
     sinks::influxdb::test_util::{cleanup_v1, format_timestamp, onboarding_v1, query_v1},
+    sinks::prometheus::remote_write::config::RemoteWriteConfig,
     test_util::components::{assert_sink_compliance, HTTP_SINK_TAGS},
     tls::{self, TlsConfig},
 };

--- a/src/sinks/prometheus/remote_write/mod.rs
+++ b/src/sinks/prometheus/remote_write/mod.rs
@@ -24,8 +24,6 @@ mod tests;
 #[cfg(all(test, feature = "prometheus-integration-tests"))]
 mod integration_tests;
 
-pub use config::RemoteWriteConfig;
-
 #[derive(Debug, Snafu)]
 enum Errors {
     #[cfg(feature = "aws-core")]

--- a/src/sinks/prometheus/remote_write/mod.rs
+++ b/src/sinks/prometheus/remote_write/mod.rs
@@ -24,6 +24,9 @@ mod tests;
 #[cfg(all(test, feature = "prometheus-integration-tests"))]
 mod integration_tests;
 
+#[cfg(test)]
+pub use config::RemoteWriteConfig;
+
 #[derive(Debug, Snafu)]
 enum Errors {
     #[cfg(feature = "aws-core")]

--- a/src/sinks/prometheus/remote_write/tests.rs
+++ b/src/sinks/prometheus/remote_write/tests.rs
@@ -10,7 +10,7 @@ use super::*;
 use crate::{
     config::SinkContext,
     event::{MetricKind, MetricValue},
-    sinks::{prometheus::remote_write::RemoteWriteConfig, util::test::build_test_server},
+    sinks::{prometheus::remote_write::config::RemoteWriteConfig, util::test::build_test_server},
     test_util::{
         self,
         components::{assert_sink_compliance, HTTP_SINK_TAGS},

--- a/src/sinks/splunk_hec/common/acknowledgements.rs
+++ b/src/sinks/splunk_hec/common/acknowledgements.rs
@@ -123,7 +123,8 @@ impl HecAckClient {
                     let acked_ack_ids = ack_query_response
                         .acks
                         .iter()
-                        .filter_map(|(ack_id, ack_status)| ack_status.then(|| *ack_id))
+                        .filter(|&(_ack_id, ack_status)| *ack_status)
+                        .map(|(ack_id, _ack_status)| *ack_id)
                         .collect::<Vec<u64>>();
                     self.finalize_delivered_ack_ids(acked_ack_ids.as_slice());
                     self.expire_ack_ids_with_status(EventStatus::Rejected);

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -393,7 +393,7 @@ impl Statistics {
     /// number of requests per second.
     fn prune_old_requests(&mut self, now: Instant) {
         let then = now - Duration::from_secs(1);
-        while let Some(&first) = self.requests.get(0) {
+        while let Some(&first) = self.requests.front() {
             if first > then {
                 break;
             }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -1,7 +1,7 @@
 pub mod adaptive_concurrency;
 pub mod auth;
 // https://github.com/mcarton/rust-derivative/issues/112
-#[allow(clippy::incorrect_clone_impl_on_copy_type)]
+#[allow(clippy::non_canonical_clone_impl)]
 pub mod batch;
 pub mod buffer;
 pub mod builder;

--- a/src/sources/datadog_agent/integration_tests.rs
+++ b/src/sources/datadog_agent/integration_tests.rs
@@ -97,7 +97,7 @@ async fn wait_for_message() {
     )
     .await;
     assert_eq!(events.len(), 2);
-    let event = events.get(0).unwrap().as_log();
+    let event = events.first().unwrap().as_log();
     let msg = event.get("message").unwrap().coerce_to_bytes();
     assert_eq!(msg, "hello world");
     let event = events.get(1).unwrap().as_log();
@@ -146,10 +146,10 @@ async fn wait_for_traces() {
     .await;
 
     assert_eq!(events.len(), 1);
-    let trace = events.get(0).unwrap().as_trace();
+    let trace = events.first().unwrap().as_trace();
     let spans = trace.get("spans").unwrap().as_array().unwrap();
     assert_eq!(spans.len(), 1);
-    let span = spans.get(0).unwrap();
+    let span = spans.first().unwrap();
     assert_eq!(span.get("name"), Some(&Value::from("a_name")));
     assert_eq!(span.get("service"), Some(&Value::from("a_service")));
     assert_eq!(span.get("resource"), Some(&Value::from("a_resource")));

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -179,9 +179,7 @@ async fn request_query_applied() {
         for (k, v) in
             url::form_urlencoded::parse(query.as_bytes().expect("byte conversion should succeed"))
         {
-            got.entry(k.to_string())
-                .or_insert_with(Vec::new)
-                .push(v.to_string());
+            got.entry(k.to_string()).or_default().push(v.to_string());
         }
         for v in got.values_mut() {
             v.sort();

--- a/src/sources/kubernetes_logs/partial_events_merger.rs
+++ b/src/sources/kubernetes_logs/partial_events_merger.rs
@@ -130,7 +130,7 @@ fn merge_partial_events_with_custom_expiration(
                 .get(&file_path)
                 .and_then(|x| x.as_str())
                 .map(|x| x.to_string())
-                .unwrap_or_else(String::new);
+                .unwrap_or_default();
 
             state.add_event(event, &file, &message_path, expiration_time);
             if !is_partial {

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -1034,7 +1034,7 @@ mod integration_tests {
         assert_source_compliance(&PULL_SOURCE_TAGS, async move {
             let config: Config = endpoint.parse().unwrap();
             let tags_endpoint = config_to_endpoint(&config);
-            let tags_host = match config.get_hosts().get(0).unwrap() {
+            let tags_host = match config.get_hosts().first().unwrap() {
                 Host::Tcp(host) => host.clone(),
                 #[cfg(unix)]
                 Host::Unix(path) => path.to_string_lossy().to_string(),

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -616,9 +616,7 @@ mod test {
             let query = metric.tag_value("query").expect("query must be tagged");
             let mut got: HashMap<String, Vec<String>> = HashMap::new();
             for (k, v) in url::form_urlencoded::parse(query.as_bytes()) {
-                got.entry(k.to_string())
-                    .or_insert_with(Vec::new)
-                    .push(v.to_string());
+                got.entry(k.to_string()).or_default().push(v.to_string());
             }
             for v in got.values_mut() {
                 v.sort();

--- a/src/sources/util/grpc/decompression.rs
+++ b/src/sources/util/grpc/decompression.rs
@@ -83,8 +83,7 @@ impl Default for State {
 fn new_decompressor() -> GzDecoder<Vec<u8>> {
     // Create the backing buffer for the decompressor and set the compression flag to false (0) and pre-allocate
     // the space for the length prefix, which we'll fill out once we've finalized the decompressor.
-    let mut buf = Vec::new();
-    buf.resize(GRPC_MESSAGE_HEADER_LEN, 0x00);
+    let buf = vec![0; GRPC_MESSAGE_HEADER_LEN];
 
     GzDecoder::new(buf)
 }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -494,7 +494,7 @@ where
                         self.component_key
                             .as_ref()
                             .map(ToString::to_string)
-                            .unwrap_or_else(String::new),
+                            .unwrap_or_default(),
                     );
                     metric.replace_tag(
                         format!("{}.dropped.component_type", metadata_key),


### PR DESCRIPTION
Apologies for not separating the clippy fixes by rust version- will keep that in mind in the future.

There weren't really many changes that required decisions. Closest being a couple of field / struct name changes.