### PR TITLE
enhancement(kubernetes): add support for include_paths_glob_patterns

### DIFF
--- a/changelog.d/include_paths_glob_patterns.enhancement.md
+++ b/changelog.d/include_paths_glob_patterns.enhancement.md
@@ -1,0 +1,3 @@
+A new configuration option include_paths_glob_patterns has been introduced in the Kubernetes Logs source. This option works alongside the existing exclude_paths_glob_patterns to help narrow down the selection of logs to be considered. include_paths_glob_patterns is evaluated before exclude_paths_glob_patterns.
+
+authors: syedriko

--- a/src/sources/kubernetes_logs/k8s_paths_provider.rs
+++ b/src/sources/kubernetes_logs/k8s_paths_provider.rs
@@ -16,6 +16,7 @@ use crate::kubernetes::pod_manager_logic::extract_static_pod_config_hashsum;
 pub struct K8sPathsProvider {
     pod_state: Store<Pod>,
     namespace_state: Store<Namespace>,
+    include_paths: Vec<glob::Pattern>,
     exclude_paths: Vec<glob::Pattern>,
 }
 
@@ -24,11 +25,13 @@ impl K8sPathsProvider {
     pub fn new(
         pod_state: Store<Pod>,
         namespace_state: Store<Namespace>,
+        include_paths: Vec<glob::Pattern>,
         exclude_paths: Vec<glob::Pattern>,
     ) -> Self {
         Self {
             pod_state,
             namespace_state,
+            include_paths,
             exclude_paths,
         }
     }
@@ -57,7 +60,12 @@ impl PathsProvider for K8sPathsProvider {
             .flat_map(|pod| {
                 trace!(message = "Providing log paths for pod.", pod = ?pod.metadata.name);
                 let paths_iter = list_pod_log_paths(real_glob, pod.as_ref());
-                exclude_paths(paths_iter, &self.exclude_paths).collect::<Vec<_>>()
+                filter_paths(
+                    filter_paths(paths_iter, &self.include_paths, true),
+                    &self.exclude_paths,
+                    false,
+                )
+                .collect::<Vec<_>>()
             })
             .collect()
     }
@@ -159,7 +167,7 @@ where
                 build_container_exclusion_patterns(dir, excluded_containers).collect();
 
             // Return paths filtered with container exclusion.
-            exclude_paths(path_iter, exclusion_patterns)
+            filter_paths(path_iter, exclusion_patterns, false)
         })
 }
 
@@ -175,12 +183,13 @@ fn real_glob(pattern: &str) -> impl Iterator<Item = PathBuf> {
     .flat_map(|paths| paths.into_iter())
 }
 
-fn exclude_paths<'a>(
+fn filter_paths<'a>(
     iter: impl Iterator<Item = PathBuf> + 'a,
     patterns: impl AsRef<[glob::Pattern]> + 'a,
+    include: bool,
 ) -> impl Iterator<Item = PathBuf> + 'a {
     iter.filter(move |path| {
-        !patterns.as_ref().iter().any(|pattern| {
+        let m = patterns.as_ref().iter().any(|pattern| {
             pattern.matches_path_with(
                 path,
                 glob::MatchOptions {
@@ -188,7 +197,12 @@ fn exclude_paths<'a>(
                     ..Default::default()
                 },
             )
-        })
+        });
+        if include {
+            m
+        } else {
+            !m
+        }
     })
 }
 
@@ -199,8 +213,8 @@ mod tests {
     use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 
     use super::{
-        build_container_exclusion_patterns, exclude_paths, extract_excluded_containers_for_pod,
-        extract_pod_logs_directory, list_pod_log_paths,
+        build_container_exclusion_patterns, extract_excluded_containers_for_pod,
+        extract_pod_logs_directory, filter_paths, list_pod_log_paths,
     };
 
     #[test]
@@ -508,7 +522,59 @@ mod tests {
                 .map(|pattern| glob::Pattern::new(pattern).unwrap())
                 .collect();
             let actual_paths: Vec<_> =
-                exclude_paths(input_paths.into_iter().map(Into::into), &patterns).collect();
+                filter_paths(input_paths.into_iter().map(Into::into), &patterns, false).collect();
+            let expected_paths: Vec<_> = expected_paths.into_iter().map(PathBuf::from).collect();
+            assert_eq!(
+                actual_paths, expected_paths,
+                "failed for patterns {:?}",
+                &str_patterns
+            )
+        }
+    }
+
+    #[test]
+    fn test_include_paths() {
+        let cases = vec![
+            (
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log.foo",
+                    "/var/log/pods/d.logbar",
+                    "/tmp/foo",
+                ],
+                vec!["/var/log/pods/*"],
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log.foo",
+                    "/var/log/pods/d.logbar",
+                ],
+            ),
+            (
+                vec![
+                    "/var/log/pods/a.log",
+                    "/var/log/pods/b.log",
+                    "/var/log/pods/c.log.foo",
+                    "/var/log/pods/d.logbar",
+                ],
+                vec!["/tmp/*"],
+                vec![],
+            ),
+            (
+                vec!["/var/log/pods/a.log", "/tmp/foo"],
+                vec!["**/*"],
+                vec!["/var/log/pods/a.log", "/tmp/foo"],
+            ),
+        ];
+
+        for (input_paths, str_patterns, expected_paths) in cases {
+            let patterns: Vec<_> = str_patterns
+                .iter()
+                .map(|pattern| glob::Pattern::new(pattern).unwrap())
+                .collect();
+            let actual_paths: Vec<_> =
+                filter_paths(input_paths.into_iter().map(Into::into), &patterns, true).collect();
             let expected_paths: Vec<_> = expected_paths.into_iter().map(PathBuf::from).collect();
             assert_eq!(
                 actual_paths, expected_paths,

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -152,6 +152,10 @@ pub struct Config {
     #[configurable(derived)]
     node_annotation_fields: node_metadata_annotator::FieldsSpec,
 
+    /// A list of glob patterns to include while reading the files.
+    #[configurable(metadata(docs::examples = "**/include/**"))]
+    include_paths_glob_patterns: Vec<PathBuf>,
+
     /// A list of glob patterns to exclude from reading the files.
     #[configurable(metadata(docs::examples = "**/exclude/**"))]
     exclude_paths_glob_patterns: Vec<PathBuf>,
@@ -279,6 +283,7 @@ impl Default for Config {
             pod_annotation_fields: pod_metadata_annotator::FieldsSpec::default(),
             namespace_annotation_fields: namespace_metadata_annotator::FieldsSpec::default(),
             node_annotation_fields: node_metadata_annotator::FieldsSpec::default(),
+            include_paths_glob_patterns: default_path_inclusion(),
             exclude_paths_glob_patterns: default_path_exclusion(),
             read_from: default_read_from(),
             ignore_older_secs: None,
@@ -534,6 +539,7 @@ struct Source {
     namespace_label_selector: String,
     node_selector: String,
     self_node_name: String,
+    include_paths: Vec<glob::Pattern>,
     exclude_paths: Vec<glob::Pattern>,
     read_from: ReadFrom,
     ignore_older_secs: Option<u64>,
@@ -591,6 +597,8 @@ impl Source {
 
         let data_dir = globals.resolve_and_make_data_subdir(config.data_dir.as_ref(), key.id())?;
 
+        let include_paths = prepare_include_paths(config)?;
+
         let exclude_paths = prepare_exclude_paths(config)?;
 
         let glob_minimum_cooldown = config.glob_minimum_cooldown_ms;
@@ -614,6 +622,7 @@ impl Source {
             namespace_label_selector,
             node_selector,
             self_node_name,
+            include_paths,
             exclude_paths,
             read_from: ReadFrom::from(config.read_from),
             ignore_older_secs: config.ignore_older_secs,
@@ -648,6 +657,7 @@ impl Source {
             namespace_label_selector,
             node_selector,
             self_node_name,
+            include_paths,
             exclude_paths,
             read_from,
             ignore_older_secs,
@@ -740,8 +750,12 @@ impl Source {
             delay_deletion,
         )));
 
-        let paths_provider =
-            K8sPathsProvider::new(pod_state.clone(), ns_state.clone(), exclude_paths);
+        let paths_provider = K8sPathsProvider::new(
+            pod_state.clone(),
+            ns_state.clone(),
+            include_paths,
+            exclude_paths,
+        );
         let annotator = PodMetadataAnnotator::new(pod_state, pod_fields_spec, log_namespace);
         let ns_annotator =
             NamespaceMetadataAnnotator::new(ns_state, namespace_fields_spec, log_namespace);
@@ -968,6 +982,10 @@ fn default_self_node_name_env_template() -> String {
     format!("${{{}}}", SELF_NODE_NAME_ENV_KEY.to_owned())
 }
 
+fn default_path_inclusion() -> Vec<PathBuf> {
+    vec![PathBuf::from("**/*")]
+}
+
 fn default_path_exclusion() -> Vec<PathBuf> {
     vec![PathBuf::from("**/*.gz"), PathBuf::from("**/*.tmp")]
 }
@@ -1011,11 +1029,22 @@ const fn default_rotate_wait() -> Duration {
     Duration::from_secs(u64::MAX / 2)
 }
 
+// This function constructs the patterns we include for file watching, created
+// from the defaults or user provided configuration.
+fn prepare_include_paths(config: &Config) -> crate::Result<Vec<glob::Pattern>> {
+    prepare_glob_patterns(&config.include_paths_glob_patterns, "Including")
+}
+
 // This function constructs the patterns we exclude from file watching, created
 // from the defaults or user provided configuration.
 fn prepare_exclude_paths(config: &Config) -> crate::Result<Vec<glob::Pattern>> {
-    let exclude_paths = config
-        .exclude_paths_glob_patterns
+    prepare_glob_patterns(&config.exclude_paths_glob_patterns, "Excluding")
+}
+
+// This function constructs the patterns for file watching, created
+// from the defaults or user provided configuration.
+fn prepare_glob_patterns(paths: &[PathBuf], op: &str) -> crate::Result<Vec<glob::Pattern>> {
+    let ret = paths
         .iter()
         .map(|pattern| {
             let pattern = pattern
@@ -1026,14 +1055,14 @@ fn prepare_exclude_paths(config: &Config) -> crate::Result<Vec<glob::Pattern>> {
         .collect::<crate::Result<Vec<_>>>()?;
 
     info!(
-        message = "Excluding matching files.",
-        exclude_paths = ?exclude_paths
+        message = format!("{op} matching files."),
+        ret = ?ret
             .iter()
             .map(glob::Pattern::as_str)
             .collect::<Vec<_>>()
     );
 
-    Ok(exclude_paths)
+    Ok(ret)
 }
 
 // This function constructs the effective field selector to use, based on

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -133,6 +133,16 @@ base: components: sources: kubernetes_logs: configuration: {
 			unit: "seconds"
 		}
 	}
+	include_paths_glob_patterns: {
+		description: "A list of glob patterns to include while reading the files."
+		required:    false
+		type: array: {
+			default: [
+				"**/*",
+			]
+			items: type: string: examples: ["**/include/**"]
+		}
+	}
 	ingestion_timestamp_field: {
 		description: """
 			Overrides the name of the log field used to add the ingestion timestamp to each event.

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -279,8 +279,12 @@ components: sources: kubernetes_logs: {
 
 				* Built-in [Pod](#pod-exclusion) and [Container](#container-exclusion)
 				  exclusion rules.
+				* The `include_paths_glob_patterns` option allows you to include
+				  Kubernetes log files by the file name and path.
 				* The `exclude_paths_glob_patterns` option allows you to exclude
 				  Kubernetes log files by the file name and path.
+				* The `include_paths_glob_patterns` option defaults to `include all` and is
+				  evaluated before the `exclude_paths_glob_patterns` option.
 				* The `extra_field_selector` option specifies the field selector to
 				  filter Pods with, to be used in addition to the built-in Node filter.
 				* The `extra_label_selector` option specifies the label selector to


### PR DESCRIPTION
In addition to the existing `exclude_paths_glob_patterns` configuration option in the kubernetes source, it would be useful to be able to limit the set of candidate logs with the `include_paths_glob_patterns` option, evaluated first.