### PR TITLE
enhancement(codec): Allow @ as valid GELF field character in decoder

### DIFF
--- a/changelog.d/gelf_at_character.enhancement.md
+++ b/changelog.d/gelf_at_character.enhancement.md
@@ -1,0 +1,1 @@
+gracefully accept @ characters in labels when decoding GELF

--- a/changelog.d/gelf_at_character.enhancement.md
+++ b/changelog.d/gelf_at_character.enhancement.md
@@ -1,1 +1,2 @@
-gracefully accept @ characters in labels when decoding GELF
+Gracefully accept `@` characters in labels when decoding GELF.
+authors: MartinEmrich

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -18,7 +18,7 @@ use vrl::value::{Kind, Value};
 
 use super::{default_lossy, Deserializer};
 use crate::gelf::GELF_TARGET_PATHS;
-use crate::{gelf_fields::*, VALID_DECODE_FIELD_REGEX};
+use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 
 // On GELF decoding behavior:
 //   Graylog has a relaxed decoding. They are much more lenient than the spec would
@@ -180,7 +180,7 @@ impl GelfDeserializer {
                     .into());
                 }
                 // per GELF spec, Additional field names must be characters dashes or dots
-                if !VALID_DECODE_FIELD_REGEX.is_match(key) {
+                if !VALID_FIELD_REGEX.is_match(key) {
                     return Err(format!("'{}' field contains invalid characters. Field names may \
                                        contain only letters, numbers, underscores, dashes and dots.", key).into());
                 }

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -25,6 +25,9 @@ use crate::{gelf_fields::*, VALID_DECODE_FIELD_REGEX};
 //   suggest. We've elected to take a more strict approach to maintain backwards compatibility
 //   in the event that we need to change the behavior to be more relaxed, so that prior versions
 //   of vector will still work with the new relaxed decoding.
+//
+//   Additionally, Graylog's own GELF Output produces GELF messages with any field names present
+//   in the sending Stream, exceeding the specified field name character set.
 
 /// Config used to build a `GelfDeserializer`.
 #[configurable_component]

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -18,7 +18,7 @@ use vrl::value::{Kind, Value};
 
 use super::{default_lossy, Deserializer};
 use crate::gelf::GELF_TARGET_PATHS;
-use crate::{gelf_fields::*, VALID_FIELD_REGEX};
+use crate::{gelf_fields::*, VALID_DECODE_FIELD_REGEX};
 
 // On GELF decoding behavior:
 //   Graylog has a relaxed decoding. They are much more lenient than the spec would
@@ -177,7 +177,7 @@ impl GelfDeserializer {
                     .into());
                 }
                 // per GELF spec, Additional field names must be characters dashes or dots
-                if !VALID_FIELD_REGEX.is_match(key) {
+                if !VALID_DECODE_FIELD_REGEX.is_match(key) {
                     return Err(format!("'{}' field contains invalid characters. Field names may \
                                        contain only letters, numbers, underscores, dashes and dots.", key).into());
                 }

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -65,13 +65,11 @@ pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTa
     short_message: OwnedTargetPath::event(owned_value_path!(gelf_fields::SHORT_MESSAGE)),
 });
 
-/// Regex for matching valid field names in the encoder. Must contain only word chars, periods
-/// and dashes. Additional field names must also be prefixed with an `_` , however that is
-/// intentionally omitted from this regex to be checked separately to create a specific
-/// error message.
-pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-]*$").unwrap());
+/// Regex for matching valid field names in the encoder. According to the original spec by graylog,
+/// must contain only word chars, periods and dashes. Additional field names must also be prefixed
+/// with an `_` , however that is intentionally omitted from this regex to be checked separately
+/// to create a specific error message.
+/// As Graylog itself will produce GELF with any existing field names on the Graylog GELF Output,
+/// vector is more lenient, too.
+pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());
 
-/// Regex for matching valid field names in the decoder. Additionally, allow more characters
-/// (include `@`) possibly sent by the Graylog GELF Output, which not only produces field names matching
-/// VALID_FIELD_REGEX, but in fact any field names in Events present by Graylog.
-pub static VALID_DECODE_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -72,4 +72,3 @@ pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTa
 /// As Graylog itself will produce GELF with any existing field names on the Graylog GELF Output,
 /// vector is more lenient, too, at least allowing the additional `@` character.
 pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());
-

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -68,4 +68,4 @@ pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTa
 /// Regex for matching valid field names. Must contain only word chars, periods and dashes.
 /// Additional field names must also be prefixed with an `_` , however that is intentionally
 /// omitted from this regex to be checked separately to create a specific error message.
-pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-]*$").unwrap());
+pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -68,4 +68,8 @@ pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTa
 /// Regex for matching valid field names. Must contain only word chars, periods and dashes.
 /// Additional field names must also be prefixed with an `_` , however that is intentionally
 /// omitted from this regex to be checked separately to create a specific error message.
-pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());
+pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-]*$").unwrap());
+
+/// Regex for matching valid field names in the decoder. Additionally, allow @ characters
+/// produced by Graylog GELF outputs, which are strictly not valid in the GELF specification
+pub static VALID_DECODE_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -70,6 +70,6 @@ pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTa
 /// with an `_` , however that is intentionally omitted from this regex to be checked separately
 /// to create a specific error message.
 /// As Graylog itself will produce GELF with any existing field names on the Graylog GELF Output,
-/// vector is more lenient, too.
+/// vector is more lenient, too, at least allowing the additional `@` character.
 pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());
 

--- a/lib/codecs/src/gelf.rs
+++ b/lib/codecs/src/gelf.rs
@@ -65,11 +65,13 @@ pub(crate) static GELF_TARGET_PATHS: Lazy<GelfTargetPaths> = Lazy::new(|| GelfTa
     short_message: OwnedTargetPath::event(owned_value_path!(gelf_fields::SHORT_MESSAGE)),
 });
 
-/// Regex for matching valid field names. Must contain only word chars, periods and dashes.
-/// Additional field names must also be prefixed with an `_` , however that is intentionally
-/// omitted from this regex to be checked separately to create a specific error message.
+/// Regex for matching valid field names in the encoder. Must contain only word chars, periods
+/// and dashes. Additional field names must also be prefixed with an `_` , however that is
+/// intentionally omitted from this regex to be checked separately to create a specific
+/// error message.
 pub static VALID_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-]*$").unwrap());
 
-/// Regex for matching valid field names in the decoder. Additionally, allow @ characters
-/// produced by Graylog GELF outputs, which are strictly not valid in the GELF specification
+/// Regex for matching valid field names in the decoder. Additionally, allow more characters
+/// (include `@`) possibly sent by the Graylog GELF Output, which not only produces field names matching
+/// VALID_FIELD_REGEX, but in fact any field names in Events present by Graylog.
 pub static VALID_DECODE_FIELD_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[\w\.\-@]*$").unwrap());

--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -28,7 +28,7 @@ pub use encoding::{
     NativeSerializerConfig, NewlineDelimitedEncoder, NewlineDelimitedEncoderConfig,
     RawMessageSerializer, RawMessageSerializerConfig, TextSerializer, TextSerializerConfig,
 };
-pub use gelf::{gelf_fields, VALID_FIELD_REGEX, VALID_DECODE_FIELD_REGEX };
+pub use gelf::{gelf_fields, VALID_FIELD_REGEX};
 use vector_config::configurable_component;
 
 /// The user configuration to choose the metric tag strategy.

--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -28,7 +28,7 @@ pub use encoding::{
     NativeSerializerConfig, NewlineDelimitedEncoder, NewlineDelimitedEncoderConfig,
     RawMessageSerializer, RawMessageSerializerConfig, TextSerializer, TextSerializerConfig,
 };
-pub use gelf::{gelf_fields, VALID_FIELD_REGEX};
+pub use gelf::{gelf_fields, VALID_FIELD_REGEX, VALID_DECODE_FIELD_REGEX };
 use vector_config::configurable_component;
 
 /// The user configuration to choose the metric tag strategy.


### PR DESCRIPTION
Graylog itself emits labels containing @ characters on its "Output" feature (relaying GELF to another GELF receiver).

Observed examples are `_@timestamp` and `_@version`.

With this change, vector `socket` source with the `gelf` codec accepts all log events from Graylog Output.