### PR TITLE
chore(ci): exclude dependabot from changelog job steps

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Generate authentication token
-        # don't run this step if the PR is from a fork since the secrets won't exist
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        # don't run this step if the PR is from a fork or dependabot since the secrets won't exist
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         id: generate_token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         with:
@@ -30,8 +30,8 @@ jobs:
           private_key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
 
       - name: Get PR comment author
-        # don't run this step if the PR is from a fork since the secrets won't exist
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        # don't run this step if the PR is from a fork or dependabot since the secrets won't exist
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         id: author
         uses: tspascoal/get-user-teams-membership@v3
         with:


### PR DESCRIPTION
Dependabot does not have access to the secrets.

https://docs.github.com/en/github-ae@latest/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
