### PR TITLE
chore: Fix aws feature error

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -12,10 +12,13 @@ use aws_sigv4::{
 use aws_smithy_async::rt::sleep::TokioSleep;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use aws_smithy_runtime_api::client::{
-    http::{HttpConnector, HttpConnectorFuture, SharedHttpConnector},
+    http::{
+        HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpConnector,
+    },
     identity::Identity,
     orchestrator::{HttpRequest, HttpResponse},
     result::SdkError,
+    runtime_components::RuntimeComponents,
 };
 use aws_smithy_types::body::SdkBody;
 use bytes::Bytes;
@@ -243,14 +246,14 @@ struct AwsHttpClient<T> {
     region: Region,
 }
 
-impl<T> aws_smithy_runtime_api::client::http::HttpClient for AwsHttpClient<T>
+impl<T> HttpClient for AwsHttpClient<T>
 where
-    T: aws_smithy_runtime_api::client::http::HttpClient,
+    T: HttpClient,
 {
     fn http_connector(
         &self,
-        settings: &aws_smithy_runtime_api::client::http::HttpConnectorSettings,
-        components: &aws_sdk_cloudwatch::config::RuntimeComponents,
+        settings: &HttpConnectorSettings,
+        components: &RuntimeComponents,
     ) -> SharedHttpConnector {
         let http_connector = self.http.http_connector(settings, components);
 

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -71,11 +71,11 @@ impl<T: Send + Sync + 'static> RetryLogic for CloudwatchRetryLogic<T> {
 #[cfg(test)]
 mod test {
     use aws_sdk_cloudwatchlogs::operation::put_log_events::PutLogEventsError;
-    use aws_sdk_s3::primitives::SdkBody;
     use aws_smithy_runtime_api::{
         client::{orchestrator::HttpResponse, result::SdkError},
         http::StatusCode,
     };
+    use aws_smithy_types::body::SdkBody;
 
     use crate::sinks::aws_cloudwatch_logs::{
         retry::CloudwatchRetryLogic, service::CloudwatchError,


### PR DESCRIPTION
ref https://github.com/vectordotdev/vector/pull/19312

There was a failure in the feature tests for the PR because
[aws_sdk_cloudwatch::config::RuntimeComponents](https://github.com/vectordotdev/vector/blob/c2cc94a262ecf39798009d29751d59cc97baa0c5/src/aws/mod.rs#L253) was being used as a parameter. This crate is only pulled in for the cloudwatch features.

This updates it to use use `aws_smithy_runtime_api::client::runtime_components::RuntimeComponents` instead. The `aws_smithy_runtime_api` crate is used by all AWS components.
