### PR TITLE
chore(ci): Fix the check for external contributor author GH usernames

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -56,7 +56,7 @@ jobs:
           args=""
           if [[ $AUTHOR_IS_TEAM_MEMBER != 'true' ]] ; then
             echo "PR author detected to be an external contributor."
-            args="--author"
+            args="--authors"
           fi
 
           ./scripts/check_changelog_fragments.sh ${args}


### PR DESCRIPTION
Noticed in an external contributor PR that this check was not working correctly due to a typo.