### PR TITLE
chore: only export RemoteWriteConfig for remote-write feature

### DIFF
--- a/src/sinks/prometheus/remote_write/mod.rs
+++ b/src/sinks/prometheus/remote_write/mod.rs
@@ -24,7 +24,7 @@ mod tests;
 #[cfg(all(test, feature = "prometheus-integration-tests"))]
 mod integration_tests;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sources-prometheus-remote-write"))]
 pub use config::RemoteWriteConfig;
 
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
A recent PR #10304 caused an error in the features CI check. This fixes that error.

Note the features job still fails due to errors that are fixed in #19567.