### PR TITLE
chore(config): Skip serializing default proxy config fields

### DIFF
--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -5,6 +5,8 @@ use no_proxy::NoProxy;
 use url::Url;
 use vector_config::configurable_component;
 
+use crate::serde::skip_serializing_if_default;
+
 // suggestion of standardization coming from https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
 fn from_env(key: &str) -> Option<String> {
     // use lowercase first and the uppercase
@@ -52,7 +54,7 @@ pub struct ProxyConfig {
     /// Enables proxying support.
     #[serde(
         default = "ProxyConfig::default_enabled",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "skip_serializing_if_default"
     )]
     pub enabled: bool,
 
@@ -61,14 +63,14 @@ pub struct ProxyConfig {
     /// Must be a valid URI string.
     #[configurable(validation(format = "uri"))]
     #[configurable(metadata(docs::examples = "http://foo.bar:3128"))]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     pub http: Option<String>,
 
     /// Proxy endpoint to use when proxying HTTPS traffic.
     ///
     /// Must be a valid URI string.
     #[configurable(validation(format = "uri"))]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     #[configurable(metadata(docs::examples = "http://foo.bar:3128"))]
     pub https: Option<String>,
 
@@ -85,10 +87,7 @@ pub struct ProxyConfig {
     /// | Splat               | `*` matches all hosts                                                   |
     ///
     /// [cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
     #[configurable(metadata(docs::examples = "localhost"))]
     #[configurable(metadata(docs::examples = ".foo.bar"))]
     #[configurable(metadata(docs::examples = "*"))]


### PR DESCRIPTION
When the `ProxyConfig` struct is serialized to TOML or YAML but either of the `http` or `https` fields are at their default `None` values, they will be emitted as "Null" values that cannot be re-serialized again. This skip serializing those fields in that case.