### PR TITLE
chore: Shorten name of `skip_serializing_if_default`

### DIFF
--- a/docs/tutorials/sinks/1_basic_sink.md
+++ b/docs/tutorials/sinks/1_basic_sink.md
@@ -41,7 +41,7 @@ pub struct BasicConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -31,10 +31,7 @@ use crate::{gelf_fields::*, VALID_FIELD_REGEX};
 #[derive(Debug, Clone, Default)]
 pub struct GelfDeserializerConfig {
     /// GELF-specific decoding options.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub gelf: GelfDeserializerOptions,
 }
 
@@ -90,7 +87,7 @@ pub struct GelfDeserializerOptions {
     /// [U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
     #[serde(
         default = "default_lossy",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     #[derivative(Default(value = "default_lossy()"))]
     pub lossy: bool,

--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -17,10 +17,7 @@ use super::{default_lossy, Deserializer};
 #[derive(Debug, Clone, Default)]
 pub struct JsonDeserializerConfig {
     /// JSON-specific decoding options.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub json: JsonDeserializerOptions,
 }
 
@@ -77,7 +74,7 @@ pub struct JsonDeserializerOptions {
     /// [U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
     #[serde(
         default = "default_lossy",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     #[derivative(Default(value = "default_lossy()"))]
     pub lossy: bool,

--- a/lib/codecs/src/decoding/format/native_json.rs
+++ b/lib/codecs/src/decoding/format/native_json.rs
@@ -14,10 +14,7 @@ use vector_core::config::LogNamespace;
 #[derive(Debug, Clone, Default)]
 pub struct NativeJsonDeserializerConfig {
     /// Vector's native JSON-specific decoding options.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub native_json: NativeJsonDeserializerOptions,
 }
 
@@ -67,7 +64,7 @@ pub struct NativeJsonDeserializerOptions {
     /// [U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
     #[serde(
         default = "default_lossy",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     #[derivative(Default(value = "default_lossy()"))]
     pub lossy: bool,

--- a/lib/codecs/src/decoding/format/protobuf.rs
+++ b/lib/codecs/src/decoding/format/protobuf.rs
@@ -24,10 +24,7 @@ use super::Deserializer;
 #[derive(Debug, Clone, Default)]
 pub struct ProtobufDeserializerConfig {
     /// Protobuf-specific decoding options.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub protobuf: ProtobufDeserializerOptions,
 }
 

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -24,10 +24,7 @@ pub struct SyslogDeserializerConfig {
     source: Option<&'static str>,
 
     /// Syslog-specific decoding options.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub syslog: SyslogDeserializerOptions,
 }
 
@@ -251,7 +248,7 @@ pub struct SyslogDeserializerOptions {
     /// [U+FFFD]: https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character
     #[serde(
         default = "default_lossy",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     #[derivative(Default(value = "default_lossy()"))]
     pub lossy: bool,

--- a/lib/codecs/src/decoding/framing/character_delimited.rs
+++ b/lib/codecs/src/decoding/framing/character_delimited.rs
@@ -47,7 +47,7 @@ pub struct CharacterDelimitedDecoderOptions {
     /// If there is a risk of processing malformed data, such as logs with user-controlled input,
     /// consider setting the maximum length to a reasonably large value as a safety net. This
     /// ensures that processing is not actually unbounded.
-    #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
+    #[serde(skip_serializing_if = "vector_core::serde::is_default")]
     pub max_length: Option<usize>,
 }
 

--- a/lib/codecs/src/decoding/framing/newline_delimited.rs
+++ b/lib/codecs/src/decoding/framing/newline_delimited.rs
@@ -10,10 +10,7 @@ use super::{BoxedFramingError, CharacterDelimitedDecoder};
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct NewlineDelimitedDecoderConfig {
     /// Options for the newline delimited decoder.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub newline_delimited: NewlineDelimitedDecoderOptions,
 }
 
@@ -33,7 +30,7 @@ pub struct NewlineDelimitedDecoderOptions {
     /// If there is a risk of processing malformed data, such as logs with user-controlled input,
     /// consider setting the maximum length to a reasonably large value as a safety net. This
     /// ensures that processing is not actually unbounded.
-    #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
+    #[serde(skip_serializing_if = "vector_core::serde::is_default")]
     pub max_length: Option<usize>,
 }
 

--- a/lib/codecs/src/decoding/framing/octet_counting.rs
+++ b/lib/codecs/src/decoding/framing/octet_counting.rs
@@ -12,10 +12,7 @@ use super::BoxedFramingError;
 #[configurable_component]
 #[derive(Debug, Clone, Default)]
 pub struct OctetCountingDecoderConfig {
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     /// Options for the octet counting decoder.
     pub octet_counting: OctetCountingDecoderOptions,
 }
@@ -37,7 +34,7 @@ impl OctetCountingDecoderConfig {
 #[derivative(Default)]
 pub struct OctetCountingDecoderOptions {
     /// The maximum length of the byte buffer.
-    #[serde(skip_serializing_if = "vector_core::serde::skip_serializing_if_default")]
+    #[serde(skip_serializing_if = "vector_core::serde::is_default")]
     pub max_length: Option<usize>,
 }
 

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -78,7 +78,7 @@ pub struct CsvSerializerOptions {
     #[serde(
         default = "default_delimiter",
         with = "vector_core::serde::ascii_char",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     pub delimiter: u8,
 
@@ -88,7 +88,7 @@ pub struct CsvSerializerOptions {
     /// field data are escaped instead of doubled.
     #[serde(
         default = "default_double_quote",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     pub double_quote: bool,
 
@@ -101,7 +101,7 @@ pub struct CsvSerializerOptions {
     #[serde(
         default = "default_escape",
         with = "vector_core::serde::ascii_char",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     pub escape: u8,
 
@@ -109,15 +109,12 @@ pub struct CsvSerializerOptions {
     #[serde(
         default = "default_escape",
         with = "vector_core::serde::ascii_char",
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
+        skip_serializing_if = "vector_core::serde::is_default"
     )]
     quote: u8,
 
     /// The quoting style to use when writing CSV data.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub quote_style: QuoteStyle,
 
     /// Set the capacity (in bytes) of the internal buffer used in the CSV writer.

--- a/lib/codecs/src/encoding/format/json.rs
+++ b/lib/codecs/src/encoding/format/json.rs
@@ -12,10 +12,7 @@ pub struct JsonSerializerConfig {
     ///
     /// When set to `single`, only the last non-bare value of tags are displayed with the
     /// metric.  When set to `full`, all metric tags are exposed as separate assignments.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub metric_tag_values: MetricTagValues,
 }
 

--- a/lib/codecs/src/encoding/format/text.rs
+++ b/lib/codecs/src/encoding/format/text.rs
@@ -13,10 +13,7 @@ pub struct TextSerializerConfig {
     ///
     /// When set to `single`, only the last non-bare value of tags are displayed with the
     /// metric.  When set to `full`, all metric tags are exposed as separate assignments.
-    #[serde(
-        default,
-        skip_serializing_if = "vector_core::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub metric_tag_values: MetricTagValues,
 }
 

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -50,20 +50,14 @@ pub struct GlobalOptions {
     ///
     /// This is used if a component does not have its own specific log schema. All events use a log
     /// schema, whether or not the default is used, to assign event fields on incoming events.
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub log_schema: LogSchema,
 
     /// Telemetry options.
     ///
     /// Determines whether `source` and `service` tags should be emitted with the
     /// `component_sent_*` and `component_received_*` events.
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub telemetry: Telemetry,
 
     /// The name of the time zone to apply to timestamp conversions that do not contain an explicit time zone.
@@ -72,17 +66,11 @@ pub struct GlobalOptions {
     /// local time.
     ///
     /// [tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub timezone: Option<TimeZone>,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub proxy: ProxyConfig,
 
     /// Controls how acknowledgements are handled for all sinks by default.
@@ -94,7 +82,7 @@ pub struct GlobalOptions {
     #[serde(
         default,
         deserialize_with = "bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
@@ -107,10 +95,7 @@ pub struct GlobalOptions {
     /// captured, but not so long that they continue to build up indefinitely, as this will consume
     /// a small amount of memory for each metric.
     #[configurable(deprecated)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub expire_metrics: Option<Duration>,
 
     /// The amount of time, in seconds, that internal metrics will persist after having not been
@@ -121,10 +106,7 @@ pub struct GlobalOptions {
     /// setting this to a value that ensures that metrics live long enough to be emitted and
     /// captured, but not so long that they continue to build up indefinitely, as this will consume
     /// a small amount of memory for each metric.
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub expire_metrics_secs: Option<f64>,
 }
 

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -5,7 +5,7 @@ use no_proxy::NoProxy;
 use url::Url;
 use vector_config::configurable_component;
 
-use crate::serde::skip_serializing_if_default;
+use crate::serde::is_default;
 
 // suggestion of standardization coming from https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
 fn from_env(key: &str) -> Option<String> {
@@ -54,7 +54,7 @@ pub struct ProxyConfig {
     /// Enables proxying support.
     #[serde(
         default = "ProxyConfig::default_enabled",
-        skip_serializing_if = "skip_serializing_if_default"
+        skip_serializing_if = "is_default"
     )]
     pub enabled: bool,
 
@@ -63,14 +63,14 @@ pub struct ProxyConfig {
     /// Must be a valid URI string.
     #[configurable(validation(format = "uri"))]
     #[configurable(metadata(docs::examples = "http://foo.bar:3128"))]
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub http: Option<String>,
 
     /// Proxy endpoint to use when proxying HTTPS traffic.
     ///
     /// Must be a valid URI string.
     #[configurable(validation(format = "uri"))]
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     #[configurable(metadata(docs::examples = "http://foo.bar:3128"))]
     pub https: Option<String>,
 
@@ -87,7 +87,7 @@ pub struct ProxyConfig {
     /// | Splat               | `*` matches all hosts                                                   |
     ///
     /// [cidr]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     #[configurable(metadata(docs::examples = "localhost"))]
     #[configurable(metadata(docs::examples = ".foo.bar"))]
     #[configurable(metadata(docs::examples = "*"))]

--- a/lib/vector-core/src/serde.rs
+++ b/lib/vector-core/src/serde.rs
@@ -2,10 +2,9 @@ use std::{fmt, marker::PhantomData};
 
 use serde::{de, Deserialize, Deserializer};
 
-/// Answers "Is it possible to skip serializing this value, because it's the
-/// default?"
+/// Answers "Is this value in it's default state?" which can be used to skip serializing the value.
 #[inline]
-pub fn skip_serializing_if_default<E: Default + PartialEq>(e: &E) -> bool {
+pub fn is_default<E: Default + PartialEq>(e: &E) -> bool {
     e == &E::default()
 }
 

--- a/src/codecs/encoding/transformer.rs
+++ b/src/codecs/encoding/transformer.rs
@@ -14,22 +14,22 @@ use vector_lib::schema::meaning;
 use vrl::path::OwnedValuePath;
 use vrl::value::Value;
 
-use crate::{event::Event, serde::skip_serializing_if_default};
+use crate::{event::Event, serde::is_default};
 
 /// Transformations to prepare an event for serialization.
 #[configurable_component(no_deser)]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Transformer {
     /// List of fields that are included in the encoded event.
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     only_fields: Option<Vec<ConfigValuePath>>,
 
     /// List of fields that are excluded from the encoded event.
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     except_fields: Option<Vec<ConfigValuePath>>,
 
     /// Format used for timestamp fields.
-    #[serde(default, skip_serializing_if = "skip_serializing_if_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     timestamp_format: Option<TimestampFormat>,
 }
 

--- a/src/config/enterprise.rs
+++ b/src/config/enterprise.rs
@@ -105,10 +105,7 @@ pub struct Options {
     pub max_retries: u32,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     proxy: ProxyConfig,
 
     /// A map of additional tags for metrics sent to Observability Pipelines.

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -67,17 +67,11 @@ where
     healthcheck: SinkHealthcheckOptions,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "vector_lib::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub buffer: BufferConfig,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "vector_lib::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     proxy: ProxyConfig,
 
     #[serde(flatten)]

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -51,10 +51,7 @@ impl<T: SourceConfig + 'static> From<T> for BoxedSource {
 #[derive(Clone, Debug)]
 pub struct SourceOuter {
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "vector_lib::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub proxy: ProxyConfig,
 
     #[serde(default, skip)]

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -51,10 +51,7 @@ pub struct HttpConfig {
     tls_options: Option<TlsConfig>,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     proxy: ProxyConfig,
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,7 +6,7 @@ use vector_lib::codecs::{
     BytesDecoderConfig, BytesDeserializerConfig,
 };
 use vector_lib::configurable::configurable_component;
-pub use vector_lib::serde::{bool_or_struct, skip_serializing_if_default};
+pub use vector_lib::serde::{bool_or_struct, is_default};
 
 pub const fn default_true() -> bool {
     true

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -61,7 +61,7 @@ pub struct AmqpSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub(crate) acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/appsignal/config.rs
+++ b/src/sinks/appsignal/config.rs
@@ -58,17 +58,14 @@ pub(super) struct AppsignalConfig {
     tls: Option<TlsEnableableConfig>,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     encoding: Transformer,
 
     #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -50,7 +50,7 @@ pub struct Retention {
     #[serde(
         default,
         deserialize_with = "retention_days",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub days: u32,
 }
@@ -161,7 +161,7 @@ pub struct CloudwatchLogsSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -107,7 +107,7 @@ pub struct CloudWatchMetricsSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/aws_kinesis/config.rs
+++ b/src/sinks/aws_kinesis/config.rs
@@ -62,7 +62,7 @@ pub struct KinesisSinkBaseConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -132,7 +132,7 @@ pub struct S3SinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/aws_s_s/config.rs
+++ b/src/sinks/aws_s_s/config.rs
@@ -71,7 +71,7 @@ pub(super) struct BaseSSSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -59,7 +59,7 @@ pub struct AxiomConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -145,7 +145,7 @@ pub struct AzureBlobSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/azure_monitor_logs/config.rs
+++ b/src/sinks/azure_monitor_logs/config.rs
@@ -80,10 +80,7 @@ pub struct AzureMonitorLogsConfig {
     pub(super) host: String,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
     #[configurable(derived)]
@@ -112,7 +109,7 @@ pub struct AzureMonitorLogsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -43,7 +43,7 @@ pub struct BlackholeConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -44,10 +44,7 @@ pub struct ClickhouseConfig {
     pub compression: Compression,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
     #[configurable(derived)]
@@ -68,7 +65,7 @@ pub struct ClickhouseConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -51,7 +51,7 @@ pub struct ConsoleSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -73,7 +73,7 @@ pub struct DatabendConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -58,10 +58,7 @@ pub struct DatadogLogsConfig {
     pub compression: Option<Compression>,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
     #[configurable(derived)]

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -83,7 +83,7 @@ pub struct LocalDatadogCommonConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -124,10 +124,7 @@ pub struct ElasticsearchConfig {
     #[configurable(derived)]
     pub compression: Compression,
 
-    #[serde(
-        skip_serializing_if = "crate::serde::skip_serializing_if_default",
-        default
-    )]
+    #[serde(skip_serializing_if = "crate::serde::is_default", default)]
     #[configurable(derived)]
     #[configurable(metadata(docs::advanced))]
     pub encoding: Transformer,
@@ -183,7 +180,7 @@ pub struct ElasticsearchConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     #[configurable(derived)]
     pub acknowledgements: AcknowledgementsConfig,

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -71,17 +71,14 @@ pub struct FileSinkConfig {
     pub encoding: EncodingConfigWithFraming,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub compression: Compression,
 
     #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -157,7 +157,7 @@ pub struct ChronicleUnstructuredConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -169,7 +169,7 @@ pub struct GcsSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -93,7 +93,7 @@ pub struct PubsubConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -81,10 +81,7 @@ pub(super) struct StackdriverConfig {
     pub(super) auth: GcpAuthConfig,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub(super) encoding: Transformer,
 
     #[configurable(derived)]
@@ -102,7 +99,7 @@ pub(super) struct StackdriverConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/gcp/stackdriver/metrics/config.rs
+++ b/src/sinks/gcp/stackdriver/metrics/config.rs
@@ -72,7 +72,7 @@ pub struct StackdriverConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/greptimedb/mod.rs
+++ b/src/sinks/greptimedb/mod.rs
@@ -102,7 +102,7 @@ pub struct GreptimeDBConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -52,17 +52,14 @@ pub struct HoneycombConfig {
     request: TowerRequestConfig,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     encoding: Transformer,
 
     #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -94,7 +94,7 @@ pub struct HttpSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -123,7 +123,7 @@ pub struct HumioLogsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -132,7 +132,7 @@ pub struct HumioMetricsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -84,10 +84,7 @@ pub struct InfluxDbLogsConfig {
     pub influxdb2_settings: Option<InfluxDb2Settings>,
 
     #[configurable(derived)]
-    #[serde(
-        skip_serializing_if = "crate::serde::skip_serializing_if_default",
-        default
-    )]
+    #[serde(skip_serializing_if = "crate::serde::is_default", default)]
     pub encoding: Transformer,
 
     #[configurable(derived)]
@@ -105,7 +102,7 @@ pub struct InfluxDbLogsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -100,7 +100,7 @@ pub struct InfluxDbConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -115,7 +115,7 @@ pub struct KafkaSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -99,7 +99,7 @@ pub struct LokiConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -98,10 +98,7 @@ pub struct MezmoConfig {
     tags: Option<Vec<Template>>,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
     /// The default app that is set for events that do not contain a `file` or `app` field.
@@ -126,7 +123,7 @@ pub struct MezmoConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -32,7 +32,7 @@ pub struct NatsSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -90,10 +90,7 @@ pub struct NewRelicConfig {
     pub compression: Compression,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
     #[configurable(derived)]
@@ -108,7 +105,7 @@ pub struct NewRelicConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -45,7 +45,7 @@ pub struct PapertrailConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -146,7 +146,7 @@ pub struct PrometheusExporterConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/prometheus/remote_write/config.rs
+++ b/src/sinks/prometheus/remote_write/config.rs
@@ -108,7 +108,7 @@ pub struct RemoteWriteConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -74,7 +74,7 @@ pub struct PulsarSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -111,7 +111,7 @@ pub struct RedisSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -43,10 +43,7 @@ pub struct SematextLogsConfig {
     token: SensitiveString,
 
     #[configurable(derived)]
-    #[serde(
-        skip_serializing_if = "crate::serde::skip_serializing_if_default",
-        default
-    )]
+    #[serde(skip_serializing_if = "crate::serde::is_default", default)]
     pub encoding: Transformer,
 
     #[configurable(derived)]
@@ -61,7 +58,7 @@ pub struct SematextLogsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -85,7 +85,7 @@ pub struct SematextMetricsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -23,7 +23,7 @@ pub struct SocketSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/splunk_hec/common/acknowledgements.rs
+++ b/src/sinks/splunk_hec/common/acknowledgements.rs
@@ -48,7 +48,7 @@ pub struct HecClientAcknowledgementsConfig {
         default,
         deserialize_with = "crate::serde::bool_or_struct",
         flatten,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub inner: AcknowledgementsConfig,
 }

--- a/src/sinks/statsd/config.rs
+++ b/src/sinks/statsd/config.rs
@@ -57,7 +57,7 @@ pub struct StatsdSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -74,7 +74,7 @@ pub struct VectorConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub(in crate::sinks::vector) acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -70,7 +70,7 @@ pub struct WebHdfsConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 }

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -57,7 +57,7 @@ pub struct WebSocketSinkConfig {
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
+        skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
 

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -123,10 +123,7 @@ pub struct Ec2Metadata {
     refresh_timeout_secs: Duration,
 
     #[configurable(derived)]
-    #[serde(
-        default,
-        skip_serializing_if = "crate::serde::skip_serializing_if_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     proxy: ProxyConfig,
 
     /// Requires the transform to be able to successfully query the EC2 metadata before starting to process the data.


### PR DESCRIPTION
The actual code in the function merely compares the value to its type default, so use a shorter name that reflects its actual function. This results in a serde condition of `skip_serializing_if = "is_default"` which is a more natural reading.  This ends up allowing `cargo fmt` to fold a number lines together, dropping 100 LOC.