### PR TITLE
chore(docs): update GELF codec

### DIFF
--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -236,7 +236,20 @@ pub enum DeserializerConfig {
 
     /// Decodes the raw bytes as a [GELF][gelf] message.
     ///
+    /// This codec is experimental for the following reason:
+    ///
+    /// The GELF specification is more strict than the actual Graylog receiver.
+    /// Vector's decoder currently adheres more strictly to the GELF spec, with
+    /// the exception that some characters such as `@`  are allowed in field names.
+    ///
+    /// Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+    /// by Graylog, and is much more relaxed than the GELF spec.
+    ///
+    /// Going forward, Vector will use that as the reference implementation, which means
+    /// the codec may continue to relax the enforcement of specification.
+    ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
+    /// [implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
     Gelf(GelfDeserializerConfig),
 
     /// Decodes the raw bytes as as an [Apache Avro][apache_avro] message.

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -242,11 +242,12 @@ pub enum DeserializerConfig {
     /// Vector's decoder currently adheres more strictly to the GELF spec, with
     /// the exception that some characters such as `@`  are allowed in field names.
     ///
-    /// Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+    /// Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
     /// by Graylog, and is much more relaxed than the GELF spec.
     ///
-    /// Going forward, Vector will use that as the reference implementation, which means
+    /// Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
     /// the codec may continue to relax the enforcement of specification.
+
     ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
     /// [implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -200,10 +200,10 @@ pub enum SerializerConfig {
     /// Vector's encoder currently adheres more strictly to the GELF spec, with
     /// the exception that some characters such as `@`  are allowed in field names.
     ///
-    /// Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+    /// Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
     /// by Graylog, and is much more relaxed than the GELF spec.
     ///
-    /// Going forward, Vector will use that as the reference implementation, which means
+    /// Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
     /// the codec may continue to relax the enforcement of specification.
     ///
     /// [gelf]: https://docs.graylog.org/docs/gelf

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -194,7 +194,20 @@ pub enum SerializerConfig {
 
     /// Encodes an event as a [GELF][gelf] message.
     ///
+    /// This codec is experimental for the following reason:
+    ///
+    /// The GELF specification is more strict than the actual Graylog receiver.
+    /// Vector's encoder currently adheres more strictly to the GELF spec, with
+    /// the exception that some characters such as `@`  are allowed in field names.
+    ///
+    /// Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+    /// by Graylog, and is much more relaxed than the GELF spec.
+    ///
+    /// Going forward, Vector will use that as the reference implementation, which means
+    /// the codec may continue to relax the enforcement of specification.
+    ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
+    /// [implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
     Gelf,
 
     /// Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -74,7 +74,20 @@ base: components: sinks: amqp: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -80,10 +80,10 @@ base: components: sinks: amqp: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -250,7 +250,20 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -256,10 +256,10 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -229,7 +229,20 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -235,10 +235,10 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -235,10 +235,10 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -229,7 +229,20 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -344,10 +344,10 @@ base: components: sinks: aws_s3: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -338,7 +338,20 @@ base: components: sinks: aws_s3: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -166,10 +166,10 @@ base: components: sinks: aws_sns: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -160,7 +160,20 @@ base: components: sinks: aws_sns: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -160,7 +160,20 @@ base: components: sinks: aws_sqs: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -166,10 +166,10 @@ base: components: sinks: aws_sqs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -198,10 +198,10 @@ base: components: sinks: azure_blob: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -192,7 +192,20 @@ base: components: sinks: azure_blob: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -64,10 +64,10 @@ base: components: sinks: console: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -58,7 +58,20 @@ base: components: sinks: console: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -78,7 +78,20 @@ base: components: sinks: file: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -84,10 +84,10 @@ base: components: sinks: file: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -127,7 +127,20 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -133,10 +133,10 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -222,10 +222,10 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -216,7 +216,20 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -131,10 +131,10 @@ base: components: sinks: gcp_pubsub: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -125,7 +125,20 @@ base: components: sinks: gcp_pubsub: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -177,10 +177,10 @@ base: components: sinks: http: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -171,7 +171,20 @@ base: components: sinks: http: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -130,10 +130,10 @@ base: components: sinks: humio_logs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -124,7 +124,20 @@ base: components: sinks: humio_logs: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -119,10 +119,10 @@ base: components: sinks: kafka: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -113,7 +113,20 @@ base: components: sinks: kafka: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -173,7 +173,20 @@ base: components: sinks: loki: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -179,10 +179,10 @@ base: components: sinks: loki: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -158,7 +158,20 @@ base: components: sinks: nats: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -164,10 +164,10 @@ base: components: sinks: nats: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -58,7 +58,20 @@ base: components: sinks: papertrail: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -64,10 +64,10 @@ base: components: sinks: papertrail: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -152,7 +152,20 @@ base: components: sinks: pulsar: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -158,10 +158,10 @@ base: components: sinks: pulsar: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -111,7 +111,20 @@ base: components: sinks: redis: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -117,10 +117,10 @@ base: components: sinks: redis: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -70,7 +70,20 @@ base: components: sinks: socket: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -76,10 +76,10 @@ base: components: sinks: socket: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -180,10 +180,10 @@ base: components: sinks: splunk_hec_logs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -174,7 +174,20 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -124,7 +124,20 @@ base: components: sinks: webhdfs: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -130,10 +130,10 @@ base: components: sinks: webhdfs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -105,7 +105,20 @@ base: components: sinks: websocket: configuration: {
 					gelf: """
 						Encodes an event as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's encoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Encodes an event as [JSON][json].

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -111,10 +111,10 @@ base: components: sinks: websocket: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -99,10 +99,10 @@ base: components: sources: amqp: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -93,7 +93,20 @@ base: components: sources: amqp: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -96,7 +96,20 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -102,10 +102,10 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -197,10 +197,10 @@ base: components: sources: aws_s3: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -191,7 +191,20 @@ base: components: sources: aws_s3: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -192,10 +192,10 @@ base: components: sources: aws_sqs: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -186,7 +186,20 @@ base: components: sources: aws_sqs: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -78,7 +78,20 @@ base: components: sources: datadog_agent: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -84,10 +84,10 @@ base: components: sources: datadog_agent: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -57,7 +57,20 @@ base: components: sources: demo_logs: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -63,10 +63,10 @@ base: components: sources: demo_logs: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -64,10 +64,10 @@ base: components: sources: exec: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -58,7 +58,20 @@ base: components: sources: exec: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -48,7 +48,20 @@ base: components: sources: file_descriptor: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -54,10 +54,10 @@ base: components: sources: file_descriptor: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -130,10 +130,10 @@ base: components: sources: gcp_pubsub: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -124,7 +124,20 @@ base: components: sources: gcp_pubsub: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -96,10 +96,10 @@ base: components: sources: heroku_logs: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -90,7 +90,20 @@ base: components: sources: heroku_logs: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -98,10 +98,10 @@ base: components: sources: http: configuration: {
 						Vector's decoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -92,7 +92,20 @@ base: components: sources: http: configuration: {
 					gelf: """
 						Decodes the raw bytes as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's decoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -96,10 +96,10 @@ base: components: sources: http_client: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -90,7 +90,20 @@ base: components: sources: http_client: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -92,7 +92,20 @@ base: components: sources: http_server: configuration: {
 					gelf: """
 						Decodes the raw bytes as a [GELF][gelf] message.
 
+						This codec is experimental for the following reason:
+
+						The GELF specification is more strict than the actual Graylog receiver.
+						Vector's decoder currently adheres more strictly to the GELF spec, with
+						the exception that some characters such as `@`  are allowed in field names.
+
+						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						by Graylog, and is much more relaxed than the GELF spec.
+
+						Going forward, Vector will use that as the reference implementation, which means
+						the codec may continue to relax the enforcement of specification.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
+						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					json: """
 						Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -98,10 +98,10 @@ base: components: sources: http_server: configuration: {
 						Vector's decoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 						by Graylog, and is much more relaxed than the GELF spec.
 
-						Going forward, Vector will use that as the reference implementation, which means
+						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -108,10 +108,10 @@ base: components: sources: kafka: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -102,7 +102,20 @@ base: components: sources: kafka: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -151,10 +151,10 @@ base: components: sources: nats: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -145,7 +145,20 @@ base: components: sources: nats: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -63,7 +63,20 @@ base: components: sources: redis: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -69,10 +69,10 @@ base: components: sources: redis: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -65,7 +65,20 @@ base: components: sources: socket: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -71,10 +71,10 @@ base: components: sources: socket: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -48,7 +48,20 @@ base: components: sources: stdin: configuration: {
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
+															This codec is experimental for the following reason:
+
+															The GELF specification is more strict than the actual Graylog receiver.
+															Vector's decoder currently adheres more strictly to the GELF spec, with
+															the exception that some characters such as `@`  are allowed in field names.
+
+															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															by Graylog, and is much more relaxed than the GELF spec.
+
+															Going forward, Vector will use that as the reference implementation, which means
+															the codec may continue to relax the enforcement of specification.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
+															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -54,10 +54,10 @@ base: components: sources: stdin: configuration: {
 															Vector's decoder currently adheres more strictly to the GELF spec, with
 															the exception that some characters such as `@`  are allowed in field names.
 
-															Other GELF codecs such as Loki's, use an [implementation][implementation] that is maintained
+															Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
 															by Graylog, and is much more relaxed than the GELF spec.
 
-															Going forward, Vector will use that as the reference implementation, which means
+															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
 															[gelf]: https://docs.graylog.org/docs/gelf


### PR DESCRIPTION
Update the rendered doc strings for the GELF codec to explain the experimental nature of the codec due to the inconsistencies between the GELF spec and the Graylog receiver.