### PR TITLE
enhancement(codec): length_delimited decoder set max frame size option. Fixes #14580

### DIFF
--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -88,7 +88,7 @@ pub enum FramingConfig {
     CharacterDelimited(CharacterDelimitedDecoderConfig),
 
     /// Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length.
-    LengthDelimited,
+    LengthDelimited(LengthDelimitedDecoderConfig),
 
     /// Byte frames which are delimited by a newline character.
     NewlineDelimited(NewlineDelimitedDecoderConfig),
@@ -112,8 +112,8 @@ impl From<CharacterDelimitedDecoderConfig> for FramingConfig {
 }
 
 impl From<LengthDelimitedDecoderConfig> for FramingConfig {
-    fn from(_: LengthDelimitedDecoderConfig) -> Self {
-        Self::LengthDelimited
+    fn from(config: LengthDelimitedDecoderConfig) -> Self {
+        Self::LengthDelimited(config)
     }
 }
 
@@ -135,9 +135,7 @@ impl FramingConfig {
         match self {
             FramingConfig::Bytes => Framer::Bytes(BytesDecoderConfig.build()),
             FramingConfig::CharacterDelimited(config) => Framer::CharacterDelimited(config.build()),
-            FramingConfig::LengthDelimited => {
-                Framer::LengthDelimited(LengthDelimitedDecoderConfig.build())
-            }
+            FramingConfig::LengthDelimited(config) => Framer::LengthDelimited(config.build()),
             FramingConfig::NewlineDelimited(config) => Framer::NewlineDelimited(config.build()),
             FramingConfig::OctetCounting(config) => Framer::OctetCounting(config.build()),
         }
@@ -312,7 +310,7 @@ impl DeserializerConfig {
     pub fn default_stream_framing(&self) -> FramingConfig {
         match self {
             DeserializerConfig::Avro { .. } => FramingConfig::Bytes,
-            DeserializerConfig::Native => FramingConfig::LengthDelimited,
+            DeserializerConfig::Native => FramingConfig::LengthDelimited(Default::default()),
             DeserializerConfig::Bytes
             | DeserializerConfig::Json(_)
             | DeserializerConfig::Gelf(_)

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -176,7 +176,7 @@ fn decoder_framing_to_encoding_framer(framing: &decoding::FramingConfig) -> enco
                 },
             })
         }
-        decoding::FramingConfig::LengthDelimited => encoding::FramingConfig::LengthDelimited,
+        decoding::FramingConfig::LengthDelimited(_) => encoding::FramingConfig::LengthDelimited,
         decoding::FramingConfig::NewlineDelimited(_) => encoding::FramingConfig::NewlineDelimited,
         // TODO: There's no equivalent octet counting framer for encoding... although
         // there's no particular reason that would make it hard to write.
@@ -222,7 +222,9 @@ fn encoder_framing_to_decoding_framer(framing: encoding::FramingConfig) -> decod
                 },
             })
         }
-        encoding::FramingConfig::LengthDelimited => decoding::FramingConfig::LengthDelimited,
+        encoding::FramingConfig::LengthDelimited => {
+            decoding::FramingConfig::LengthDelimited(Default::default())
+        }
         encoding::FramingConfig::NewlineDelimited => {
             decoding::FramingConfig::NewlineDelimited(Default::default())
         }

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -126,6 +126,24 @@ components: sources: [Name=string]: {
 									}
 								}
 							}
+							length_delimited: {
+								description:   "Options for `length_delimited` framing."
+								required:      false
+								common:        false
+								relevant_when: "method = `length_delimited`"
+								type: object: options: {
+									max_length: {
+										description: "The maximum frame length limit. A connection that sends a frame larger than `max_frame_length` will be closed."
+										required:    false
+										common:      false
+										type: uint: {
+											default: null
+											examples: [65535, 102400]
+											unit: "bytes"
+										}
+									}
+								}
+							}
 							newline_delimited: {
 								description:   "Options for `newline_delimited` framing."
 								required:      false


### PR DESCRIPTION
Fixes [14580](https://github.com/vectordotdev/vector/issues/14580).

Do I need to add more docs?