### PR TITLE
chore(ci): fix filter out PRs for gardener issue comment workflow

### DIFF
--- a/.github/workflows/gardener_issue_comment.yml
+++ b/.github/workflows/gardener_issue_comment.yml
@@ -14,7 +14,7 @@ jobs:
   move-to-backlog:
     name: Move issues back to Gardener project board Triage
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.url, 'issues')
+    if: ${{ !github.event.issue.pull_request }}
     steps:
       - name: Generate authentication token
         id: generate_token


### PR DESCRIPTION
Noticed this filter seems to not be working.

Example: https://github.com/vectordotdev/vector/actions/runs/7508592931/job/20444305046