### PR TITLE
chore(ci): fix and simplify concurrency groups

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -33,7 +33,7 @@ concurrency:
   # change detection. This is a "conservative" approach that means we may have some runs that could be canceled, but it's safer than
   # having user's runs canceled when they shouldn't be. In practice this shouldn't happen very often given this component does not change
   # often so any increased cost from the conservative approach should be negligible.
-  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.event_number || github.event.merge_group.head_sha || github.event.schedule }}
+  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.ref || github.event.schedule }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/master_merge_queue.yml
+++ b/.github/workflows/master_merge_queue.yml
@@ -20,8 +20,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-  # `github.event.number` exists for pull requests, otherwise fall back to SHA for merge queue
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.head_sha }}
+  # `github.ref` is unique for MQ runs and PRs
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -9,8 +9,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-    # `github.event.number` exists for pull requests, otherwise fall back to SHA for merge queue
-    group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.head_sha }}
+    # `github.ref` is unique for MQ runs and PRs
+    group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,8 +34,9 @@ on:
   pull_request:
 
 concurrency:
-  # In flight runs will be canceled only by re-trigger through the merge queue or if additional PR commits are pushed. The comment.html_url should always be unique.
-  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.event_number || github.event.merge_group.head_sha }}
+  # In flight runs will be canceled only by re-trigger through the merge queue or if additional PR commits are pushed.
+  # The comment.html_url should always be unique.
+  group: ${{ github.workflow }}-${{ github.event.comment.html_url || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-  # `github.event.number` exists for pull requests, otherwise fall back to SHA for merge queue
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.head_sha }}
+  # `github.ref` is unique for MQ runs and PRs
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
`github.ref` applies to both MQ and PR runs.
