### PR TITLE
fix(config): revert acquire exclusive lock to global data dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,16 +3362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
-dependencies = [
- "rustix 0.38.28",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9800,7 +9790,6 @@ dependencies = [
  "exitcode",
  "fakedata",
  "flate2",
- "fs4",
  "futures 0.3.30",
  "futures-util",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,6 @@ enum_dispatch = { version = "0.3.12", default-features = false }
 exitcode = { version = "1.1.2", default-features = false }
 flate2 = { version = "1.0.28", default-features = false, features = ["default"] }
 futures-util = { version = "0.3.29", default-features = false }
-fs4 = { version = "0.7.0" }
 glob = { version = "0.3.1", default-features = false }
 governor = { version = "0.6.0", default-features = false, features = ["dashmap", "jitter", "std"], optional = true }
 grok = { version = "2.0.0", default-features = false, optional = true }
@@ -311,7 +310,6 @@ socket2 = { version = "0.5.5", default-features = false }
 stream-cancel = { version = "0.8.2", default-features = false }
 strip-ansi-escapes = { version = "0.2.0", default-features = false }
 syslog = { version = "6.1.0", default-features = false, optional = true }
-tempfile = "3.9.0"
 tikv-jemallocator = { version = "0.5.4", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 tokio-postgres = { version = "0.7.10", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = {version = "0.20.1", default-features = false, features = ["connect"], optional = true}

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -205,7 +205,6 @@ float_eq,https://github.com/jtempest/float_eq-rs,MIT OR Apache-2.0,jtempest
 flume,https://github.com/zesterer/flume,Apache-2.0 OR MIT,Joshua Barretto <joshua.s.barretto@gmail.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foreign-types,https://github.com/sfackler/foreign-types,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>
-fs4,https://github.com/al8n/fs4-rs,MIT OR Apache-2.0,"Dan Burkert <dan@danburkert.com>, Al Liu <scygliu1@gmail.com>"
 fsevent-sys,https://github.com/octplane/fsevent-rust/tree/master/fsevent-sys,MIT,Pierre Baillet <pierre@baillet.name>
 fslock,https://github.com/brunoczim/fslock,MIT,The fslock Authors
 funty,https://github.com/myrrlyn/funty,MIT,myrrlyn <self@myrrlyn.dev>

--- a/changelog.d/19595_lock_data_dir.fix.md
+++ b/changelog.d/19595_lock_data_dir.fix.md
@@ -1,1 +1,0 @@
-Vector now acquires an exclusive lock to the data directory. This avoids two Vector processes accidentally using the same data directory.

--- a/regression/cases/http_elasticsearch/vector/vector.yaml
+++ b/regression/cases/http_elasticsearch/vector/vector.yaml
@@ -1,3 +1,5 @@
+data_dir: "/var/lib/vector"
+
 ##
 ## Sources
 ##

--- a/regression/cases/syslog_log2metric_humio_metrics/vector/vector.yaml
+++ b/regression/cases/syslog_log2metric_humio_metrics/vector/vector.yaml
@@ -1,3 +1,5 @@
+data_dir: "/var/lib/vector"
+
 ##
 ## Sources
 ##

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -207,7 +207,6 @@ impl From<Config> for ConfigBuilder {
             secret,
             graceful_shutdown_duration,
             hash: _,
-            ..
         } = config;
 
         let transforms = transforms

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,37 +1,9 @@
-// Workaround for a false positive. The function `create_data_dir_lock` cannot be const.
-#![allow(clippy::missing_const_for_fn)]
+use indexmap::IndexSet;
 
 use super::{
     builder::ConfigBuilder, graph::Graph, id::Inputs, transform::get_transform_output_ids,
     validation, Config, OutputId,
 };
-use std::fs::File;
-use std::path::PathBuf;
-
-use indexmap::IndexSet;
-
-#[cfg(not(test))]
-use fs4::FileExt;
-
-#[cfg(not(test))]
-fn create_data_dir_lock(data_dir: &Option<PathBuf>) -> Result<Option<File>, String> {
-    if let Some(data_dir) = data_dir {
-        let lock_path = data_dir.join(".lock");
-        let lock = File::create(&lock_path).map_err(|e| e.to_string())?;
-        match lock.try_lock_exclusive() {
-            Ok(()) => Ok(Some(lock)),
-            Err(e) => Err(format!("Couldn't lock {lock_path:?}. Error: {e}")),
-        }
-    } else {
-        Ok(None)
-    }
-}
-
-#[cfg(test)]
-fn create_data_dir_lock(_data_dir: &Option<PathBuf>) -> Result<Option<File>, String> {
-    // TODO: We should make all tests work with unique directories but this requires extensive changes.
-    Ok(None)
-}
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();
@@ -125,18 +97,9 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
         .map(|test| test.resolve_outputs(&graph))
         .collect::<Result<Vec<_>, Vec<_>>>()?;
 
-    let data_dir_lock = match create_data_dir_lock(&global.data_dir) {
-        Ok(lock) => lock,
-        Err(e) => {
-            errors.push(e);
-            None
-        }
-    };
-
     if errors.is_empty() {
         let mut config = Config {
             global,
-            data_dir_lock,
             #[cfg(feature = "api")]
             api,
             schema,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,4 @@
 #![allow(missing_docs)]
-use std::fs::File;
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Display, Formatter},
@@ -113,8 +112,6 @@ pub struct Config {
     #[cfg(feature = "enterprise")]
     pub enterprise: Option<enterprise::Options>,
     pub global: GlobalOptions,
-    #[serde(skip)]
-    pub data_dir_lock: Option<File>,
     pub healthchecks: HealthcheckOptions,
     sources: IndexMap<ComponentKey, SourceOuter>,
     sinks: IndexMap<ComponentKey, SinkOuter<OutputId>>,

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -10,7 +10,6 @@ use std::{
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use indexmap::IndexMap;
 use ordered_float::NotNan;
-use tempfile::TempDir;
 use tokio::sync::{
     oneshot::{self, Receiver},
     Mutex,
@@ -40,8 +39,6 @@ use crate::{
 
 pub struct UnitTest {
     pub name: String,
-    #[allow(dead_code)]
-    temp_dir: TempDir,
     config: Config,
     pieces: TopologyPieces,
     test_result_rxs: Vec<Receiver<UnitTestSinkResult>>,
@@ -425,15 +422,12 @@ async fn build_unit_test(
             .sinks
             .insert(ComponentKey::from(Uuid::new_v4().to_string()), sink);
     }
-    let temp_dir = TempDir::new().unwrap();
-    config_builder.set_data_dir(temp_dir.path());
     let config = config_builder.build()?;
     let diff = config::ConfigDiff::initial(&config);
     let pieces = TopologyPieces::build(&config, &diff, HashMap::new(), Default::default()).await?;
 
     Ok(UnitTest {
         name: test.name,
-        temp_dir,
         config,
         pieces,
         test_result_rxs,


### PR DESCRIPTION
Reverts vectordotdev/vector#19595

Causing test failures on `master`.