### PR TITLE
docs: Fix docs for `ignore_older_secs`

### DIFF
--- a/config/examples/environment_variables.yaml
+++ b/config/examples/environment_variables.yaml
@@ -15,7 +15,7 @@ sources:
     type: "file"
     include: [ "/var/log/apache2/*.log" ]
     # ignore files older than 1 day
-    ignore_older: 86400
+    ignore_older_secs: 86400
 
 # Add a field based on the value of the HOSTNAME env var
 # Docs: https://vector.dev/docs/reference/transforms/remap

--- a/config/examples/es_s3_hybrid.yaml
+++ b/config/examples/es_s3_hybrid.yaml
@@ -13,7 +13,7 @@ sources:
   apache_logs:
     type: "file"
     include: ["/var/log/*.log"]
-    ignore_older: 86400 # 1 day
+    ignore_older_secs: 86400 # 1 day
 
 # Optionally parse, structure and transform data here.
 # Docs: https://vector.dev/docs/reference/transforms

--- a/config/examples/namespacing/sources/apache_logs.yaml
+++ b/config/examples/namespacing/sources/apache_logs.yaml
@@ -2,4 +2,4 @@
 type: "file"
 include: # supports globbing
   - "/var/log/apache2/*.log"
-ignore_older: 86400 # 1 day
+ignore_older_secs: 86400 # 1 day

--- a/config/examples/wrapped_json.yaml
+++ b/config/examples/wrapped_json.yaml
@@ -13,7 +13,7 @@ sources:
   logs:
     type: "file"
     include: [ "/var/log/*.log" ]
-    ignore_older: 86400 # 1 day
+    ignore_older_secs: 86400 # 1 day
 
 # Parse the data as JSON
 # Docs: https://vector.dev/docs/reference/transforms/remap

--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -33,7 +33,7 @@ sources:
     type: "file"
     include:
       - "/var/log/apache2/*.log" # supports globbing
-    ignore_older: 86400          # 1 day
+    ignore_older_secs: 86400     # 1 day
 
 # Structure and parse via Vector's Remap Language
 transforms:
@@ -93,9 +93,9 @@ enabled = false
 
 # Ingest data by tailing one or more files
 [sources.apache_logs]
-type         = "file"
-include      = ["/var/log/apache2/*.log"]    # supports globbing
-ignore_older = 86400                         # 1 day
+type              = "file"
+include           = ["/var/log/apache2/*.log"]    # supports globbing
+ignore_older_secs = 86400                         # 1 day
 
 # Structure and parse via Vector's Remap Language
 [transforms.apache_parser]


### PR DESCRIPTION
As per file source docs, it only accepts a `ignore_older_secs`, not `ignore_older`, which is an undocumented alias. I think it's better to use only documented options in the examples.

Ref: https://vector.dev/docs/reference/configuration/sources/file/#ignore_older_secs