### PR TITLE
fix(aws region): remove cfg test attribute

### DIFF
--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -20,7 +20,6 @@ pub struct RegionOrEndpoint {
 }
 
 impl RegionOrEndpoint {
-    #[cfg(test)]
     /// Creates with the given region.
     pub const fn with_region(region: String) -> Self {
         Self {
@@ -29,7 +28,6 @@ impl RegionOrEndpoint {
         }
     }
 
-    #[cfg(test)]
     /// Creates with both a region and an endpoint.
     pub fn with_both(region: impl Into<String>, endpoint: impl Into<String>) -> Self {
         Self {


### PR DESCRIPTION
This change removes the conditional compilation attribute `#[cfg(test)]` from the `RegionOrEndpoint` methods

Unfortunately, although the invocation is wrapped in a tokio::test, the reference to `with_region` is still not found.

I have removed the attribute from method `with_both` for consistency