### PR TITLE
enhancement(source metrics): Adding a histogram for event byte size

### DIFF
--- a/changelog.d/19686_element_size_histogram.enhancement.md
+++ b/changelog.d/19686_element_size_histogram.enhancement.md
@@ -1,9 +1,7 @@
 Added a new histogram metric, `component_received_bytes`, that measures the byte-size of individual events received by the following sources:
 
-- `http_client`
-- `nginx_metrics`
-- `aws_sqs`
-- `apache_metrics`
-- `mongodb_metrics`
+- `socket`
+- `statsd`
+- `syslog`
 
-authors: pabloem
+authors: Pablo E.

--- a/changelog.d/19686_element_size_histogram.enhancement.md
+++ b/changelog.d/19686_element_size_histogram.enhancement.md
@@ -1,0 +1,2 @@
+Added a new histogram-type metric measuring the byte-size of individual elements received by endpoint sources.
+authors: pabloem

--- a/changelog.d/19686_element_size_histogram.enhancement.md
+++ b/changelog.d/19686_element_size_histogram.enhancement.md
@@ -4,4 +4,4 @@ Added a new histogram metric, `component_received_bytes`, that measures the byte
 - `statsd`
 - `syslog`
 
-authors: Pablo E.
+authors: pabloem

--- a/changelog.d/19686_element_size_histogram.enhancement.md
+++ b/changelog.d/19686_element_size_histogram.enhancement.md
@@ -1,2 +1,9 @@
-Added a new histogram-type metric measuring the byte-size of individual elements received by endpoint sources.
+Added a new histogram metric, `component_received_bytes`, that measures the byte-size of individual events received by the following sources:
+
+- `http_client`
+- `nginx_metrics`
+- `aws_sqs`
+- `apache_metrics`
+- `mongodb_metrics`
+
 authors: pabloem

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -26,7 +26,7 @@ impl InternalEvent for EndpointBytesReceived<'_> {
             "endpoint" => self.endpoint.to_owned(),
         );
         histogram!(
-            "component_received_event_size_bytes", self.byte_size as u64,
+            "component_received_bytes", self.byte_size as f64,
             "protocol" => self.protocol.to_owned(),
             "endpoint" => self.endpoint.to_owned(),
         );

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -25,6 +25,11 @@ impl InternalEvent for EndpointBytesReceived<'_> {
             "protocol" => self.protocol.to_owned(),
             "endpoint" => self.endpoint.to_owned(),
         );
+        histogram!(
+            "component_received_event_size_bytes", self.byte_size as u64,
+            "protocol" => self.protocol.to_owned(),
+            "endpoint" => self.endpoint.to_owned(),
+        );
     }
 }
 

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -26,9 +26,7 @@ impl InternalEvent for EndpointBytesReceived<'_> {
             "endpoint" => self.endpoint.to_owned(),
         );
         histogram!(
-            "component_received_bytes", self.byte_size as f64,
-            "protocol" => self.protocol.to_owned(),
-            "endpoint" => self.endpoint.to_owned(),
+            "component_received_bytes", self.byte_size as f64
         );
     }
 }

--- a/src/internal_events/common.rs
+++ b/src/internal_events/common.rs
@@ -25,9 +25,6 @@ impl InternalEvent for EndpointBytesReceived<'_> {
             "protocol" => self.protocol.to_owned(),
             "endpoint" => self.endpoint.to_owned(),
         );
-        histogram!(
-            "component_received_bytes", self.byte_size as f64
-        );
     }
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -40,9 +40,7 @@ impl InternalEvent for SocketBytesReceived {
             "component_received_bytes_total", self.byte_size as u64,
             "protocol" => protocol,
         );
-        histogram!(
-            "component_received_bytes", self.byte_size as f64
-        );
+        histogram!("component_received_bytes", self.byte_size as f64);
     }
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -40,6 +40,9 @@ impl InternalEvent for SocketBytesReceived {
             "component_received_bytes_total", self.byte_size as u64,
             "protocol" => protocol,
         );
+        histogram!(
+            "component_received_bytes", self.byte_size as f64
+        );
     }
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -64,6 +64,7 @@ impl InternalEvent for SocketEventsReceived {
         );
         counter!("component_received_events_total", self.count as u64, "mode" => mode);
         counter!("component_received_event_bytes_total", self.byte_size.get() as u64, "mode" => mode);
+        histogram!("component_received_bytes", self.byte_size.get() as f64, "mode" => mode);
     }
 }
 

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -1,4 +1,4 @@
-use metrics::counter;
+use metrics::{counter, histogram};
 use vector_lib::internal_event::{ComponentEventsDropped, InternalEvent, UNINTENTIONAL};
 use vector_lib::{
     internal_event::{error_stage, error_type},

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -370,6 +370,12 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              component_received_events_total.tags
 		}
+		component_received_bytes: {
+			description:       string | *"The size in bytes of each event received by the source."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              component_received_events_total.tags
+		}
 		component_received_events_total: {
 			description: """
 				The number of events accepted by this component either from tagged

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -114,5 +114,6 @@ components: sources: socket: {
 		connection_established_total: components.sources.internal_metrics.output.metrics.connection_established_total
 		connection_send_errors_total: components.sources.internal_metrics.output.metrics.connection_send_errors_total
 		connection_shutdown_total:    components.sources.internal_metrics.output.metrics.connection_shutdown_total
+		component_received_bytes:     components.sources.internal_metrics.output.metrics.component_received_bytes
 	}
 }

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -85,6 +85,6 @@ components: sources: statsd: {
 		}
 	}
 	telemetry: metrics: {
-		component_received_bytes:     components.sources.internal_metrics.output.metrics.component_received_bytes
+		component_received_bytes: components.sources.internal_metrics.output.metrics.component_received_bytes
 	}
 }

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -84,4 +84,7 @@ components: sources: statsd: {
 				"""
 		}
 	}
+	telemetry: metrics: {
+		component_received_bytes:     components.sources.internal_metrics.output.metrics.component_received_bytes
+	}
 }

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -213,5 +213,6 @@ components: sources: syslog: {
 	telemetry: metrics: {
 		connection_read_errors_total: components.sources.internal_metrics.output.metrics.connection_read_errors_total
 		utf8_convert_errors_total:    components.sources.internal_metrics.output.metrics.utf8_convert_errors_total
+		component_received_bytes:     components.sources.internal_metrics.output.metrics.component_received_bytes
 	}
 }


### PR DESCRIPTION
Useful when debugging low-level sources like UDP, TCP sockets

If this metric looks good, I can add docs and we can prepare to merge. Thanks!