### PR TITLE
<enhancement>(administration config): New --skip-healthchecks option for vector validate

### DIFF
--- a/changelog.d/validate_skip_healthchecks.enhancement.md
+++ b/changelog.d/validate_skip_healthchecks.enhancement.md
@@ -1,0 +1,5 @@
+New Option `--skip-healthchecks` for `vector validate` validates config
+including VRL, but skips health checks for sinks.
+
+Usesful to validate configuration before deploying it remotely.
+authors: MartinEmrich

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -21,6 +21,10 @@ pub struct Opts {
     #[arg(long)]
     pub no_environment: bool,
 
+    /// Disables health checks during validation.
+    #[arg(long)]
+    pub skip_healthchecks: bool,
+
     /// Fail validation on warnings that are probably a mistake in the configuration
     /// or are recommended to be fixed.
     #[arg(short, long)]
@@ -178,8 +182,7 @@ async fn validate_environment(opts: &Opts, config: &Config, fmt: &mut Formatter)
     } else {
         return false;
     };
-
-    validate_healthchecks(opts, config, &diff, &mut pieces, fmt).await
+    opts.skip_healthchecks || validate_healthchecks(opts, config, &diff, &mut pieces, fmt).await
 }
 
 async fn validate_components(

--- a/website/content/en/docs/administration/validating.md
+++ b/website/content/en/docs/administration/validating.md
@@ -55,6 +55,18 @@ These environment checks can be disabled using the [`--no-environment`][no_envir
 vector validate --no-environment /etc/vector/vector.yaml
 ```
 
+#### Skipping health checks
+
+To validate the vector configuration even if the health-checked endpoints are not reachable
+(i.e. from a local workstation), but still run all other environment checks, use the
+[`--skip-healthchecks`][skip_healthchecks] flag:
+
+```bash
+vector validate --skip-healthchecks /etc/vector/vector.yaml
+```
+
+Note that the configured `data_dir` must still be writeable.
+
 [components]: /components
 [no_environment]: /docs/reference/cli/#validate-no-environment
 [sinks]: /sinks

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -413,6 +413,12 @@ cli: {
 						checks and health checks
 						"""
 				}
+				"skip-healthchecks": {
+					_short: "ne"
+					description: """
+						Disables health checks during validation.
+						"""
+				}
 				"deny-warnings": {
 					_short:      "d"
 					description: "Fail validation on warnings"


### PR DESCRIPTION
Runs full validation including VRL remaps, but skips health check connection attempts to remote sinks.

It sits in the middle between `vector validate --no-environment` (does not validate VRL remap transforms, thus does not catch VRL errors) and plain `vector validate` (which also fails if the config is valid, but health check targets fail).

I use/need this to validate my VRL heavy configuration file before deploying it to a remote system. From my local system, the targets are not reachable, so health checks would fail.

I believe this could be useful for many people authoring VRL scripts/rules, e.g. as a Git pre-commit hook.
