### PR TITLE
fix(config api): emit graphql field of api config

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -142,7 +142,8 @@ impl ApplicationConfig {
                 Ok(api_server) => {
                     emit!(ApiStarted {
                         addr: self.api.address.unwrap(),
-                        playground: self.api.playground
+                        playground: self.api.playground,
+                        graphql: self.api.graphql
                     });
 
                     Some(api_server)

--- a/src/internal_events/api.rs
+++ b/src/internal_events/api.rs
@@ -7,15 +7,19 @@ use vector_lib::internal_event::InternalEvent;
 pub struct ApiStarted {
     pub addr: SocketAddr,
     pub playground: bool,
+    pub graphql: bool,
 }
 
 impl InternalEvent for ApiStarted {
     fn emit(self) {
         let playground = &*format!("http://{}:{}/playground", self.addr.ip(), self.addr.port());
+        let graphql = &*format!("http://{}:{}/graphql", self.addr.ip(), self.addr.port());
         info!(
             message="API server running.",
             address = ?self.addr,
-            playground = %if self.playground { playground } else { "off" }
+            playground = %if self.playground { playground } else { "off" },
+            graphql = %if self.graphql { graphql } else { "off" }
+
         );
         counter!("api_started_total", 1);
     }

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -121,7 +121,8 @@ impl TopologyController {
                 Ok(api_server) => {
                     emit!(ApiStarted {
                         addr: new_config.api.address.unwrap(),
-                        playground: new_config.api.playground
+                        playground: new_config.api.playground,
+                        graphql: new_config.api.graphql,
                     });
 
                     Some(api_server)


### PR DESCRIPTION
Following up on https://github.com/vectordotdev/vector/pull/19645, this PR emits the new graphql field on app startup and reload