### PR TITLE
chore(vdev): Drop dependency on `cached` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,39 +1715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
-name = "cached"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19d1059a4bedbc76b73980269f4195a0f54e046a113affdbbdd7184cef62745"
-dependencies = [
- "ahash 0.8.6",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "hashbrown 0.14.3",
- "instant",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702122b4ca80256cfde5dfa743b9ffee02896be8b193b75d1e5970edaf78af3"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
-
-[[package]]
 name = "cargo_toml"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,16 +2518,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
@@ -2574,20 +2531,6 @@ name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2618,17 +2561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
  "quote 1.0.35",
  "syn 1.0.109",
 ]
@@ -9696,7 +9628,6 @@ name = "vdev"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cached",
  "chrono",
  "clap 4.4.18",
  "clap-verbosity-flag",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.79"
-cached = "0.48.0"
 chrono = { version = "0.4.31", default-features = false, features = ["serde", "clock"] }
 clap.workspace = true
 clap-verbosity-flag = "2.1.2"

--- a/vdev/src/platform.rs
+++ b/vdev/src/platform.rs
@@ -1,8 +1,8 @@
-use cached::proc_macro::once;
 use directories::ProjectDirs;
 
 use std::env::consts::ARCH;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 pub fn canonicalize_path(path: impl AsRef<Path>) -> String {
     let path = path.as_ref();
@@ -12,12 +12,16 @@ pub fn canonicalize_path(path: impl AsRef<Path>) -> String {
         .to_string()
 }
 
-#[once]
-pub fn data_dir() -> PathBuf {
-    _project_dirs().data_local_dir().to_path_buf()
+pub fn data_dir() -> &'static Path {
+    static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
+    DATA_DIR.get_or_init(|| {
+        ProjectDirs::from("", "vector", "vdev")
+            .expect("Could not determine the project directory")
+            .data_local_dir()
+            .to_path_buf()
+    })
 }
 
-#[once]
 pub fn default_target() -> String {
     if cfg!(windows) {
         format!("{ARCH}-pc-windows-msvc")
@@ -34,9 +38,4 @@ pub fn default_features() -> &'static str {
     } else {
         "default"
     }
-}
-
-#[once]
-fn _project_dirs() -> ProjectDirs {
-    ProjectDirs::from("", "vector", "vdev").expect("Could not determine the project directory")
 }

--- a/vdev/src/testing/state.rs
+++ b/vdev/src/testing/state.rs
@@ -9,7 +9,7 @@ use super::config::Environment;
 use crate::{platform, util};
 
 static DATA_DIR: Lazy<PathBuf> = Lazy::new(|| {
-    [platform::data_dir().as_path(), Path::new("integration")]
+    [platform::data_dir(), Path::new("integration")]
         .into_iter()
         .collect()
 });


### PR DESCRIPTION
The uses of this crate are pretty trivial and not worth pulling an extra dependency.

Replaces #19689 