### PR TITLE
fix(observability): propagate tracing span context in stream sink request building

### DIFF
--- a/changelog.d/19712_propagate_tracing_span_context_stream_sink_request_building.fix.md
+++ b/changelog.d/19712_propagate_tracing_span_context_stream_sink_request_building.fix.md
@@ -1,1 +1,36 @@
-Vector logs and internal metrics emitted while in the context of stream sink request building, now correctly contain the component's automatic tags (`component_kind`, `component_type`, `component_id`).
+The following metrics now correctly have the `component_kind`, `component_type`, and `component_id` tags:
+    - `component_errors_total`
+    - `component_discarded_events_total`
+
+For the following sinks:
+    - `splunk_hec`
+    - `clickhouse`
+    - `loki`
+    - `redis`
+    - `azure_blob`
+    - `azure_monitor_logs`
+    - `webhdfs`
+    - `appsignal`
+    - `amqp`
+    - `aws_kinesis`
+    - `statsd`
+    - `honeycomb`
+    - `gcp_stackdriver_metrics`
+    - `gcs_chronicle_unstructured`
+    - `gcp_stackdriver_logs`
+    - `gcp_pubsub`
+    - `gcp_cloud_storage`
+    - `nats`
+    - `http`
+    - `kafka`
+    - `new_relic`
+    - `datadog_metrics`
+    - `datadog_traces`
+    - `datadog_events`
+    - `databend`
+    - `prometheus_remote_write`
+    - `pulsar`
+    - `aws_s3`
+    - `aws_sqs`
+    - `aws_sns`
+    - `elasticsearch`

--- a/changelog.d/19712_propagate_tracing_span_context_stream_sink_request_building.fix.md
+++ b/changelog.d/19712_propagate_tracing_span_context_stream_sink_request_building.fix.md
@@ -1,0 +1,1 @@
+Vector logs and internal metrics emitted while in the context of stream sink request building, now correctly contain the component's automatic tags (`component_kind`, `component_type`, `component_id`).


### PR DESCRIPTION
Currently any vector logs or internal metrics that arise during the request building of stream sinks are missing automatic component tags.

This was discovered while implementing a sink validator for the component validation framework, for the internal metric  `component_discarded_events_total` (https://github.com/vectordotdev/vector/issues/16847)


before:

```

2024-01-25T21:59:37.955554Z ERROR vector::internal_events::codecs: Failed serializing frame. error=LogEvent does not contain required field: "host" error_code="encoder_serialize" error_type="encoder_failed" stage="sending" internal_log_rate_limit=true
2024-01-25T21:59:37.955678Z ERROR vector_common::internal_event::component_events_dropped: Events dropped intentional=false count=1 reason="Failed serializing frame." internal_log_rate_limit=true
2024-01-25T21:59:37.956047Z ERROR sink{component_kind="sink" component_id=test_sink component_type=http}: vector::internal_events::common: Failed to build request. error=unable to encode event error_type="encoder_failed" stage="processing" internal_log_rate_limit=true
```

after:

```
2024-01-25T22:18:24.972116Z ERROR sink{component_kind="sink" component_id=test_sink component_type=http}: vector::internal_events::codecs: Failed serializing frame. error=LogEvent does not contain required field: "host" error_code="encoder_serialize" error_type="encoder_failed" stage="sending" internal_log_rate_limit=true
2024-01-25T22:18:24.972213Z ERROR sink{component_kind="sink" component_id=test_sink component_type=http}: vector_common::internal_event::component_events_dropped: Events dropped intentional=false count=1 reason="Failed serializing frame." internal_log_rate_limit=true
2024-01-25T22:18:24.972405Z ERROR sink{component_kind="sink" component_id=test_sink component_type=http}: vector::internal_events::common: Failed to build request. error=unable to encode event error_type="encoder_failed" stage="processing" internal_log_rate_limit=true
```
