### PR TITLE
chore(docs): suggest make generate-component-docs

### DIFF
--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -61,7 +61,7 @@ Much of Vector's reference documentation is automatically compiled from source c
 To regenerate this content, run:
 
 ```bash
-cargo vdev build component-docs
+make generate-component-docs
 ```
 
 ### Formatting

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Whether you're a Vector team member, or an outside contributor, this is the best
 place to start. This folder contains internal documentation to help with the
 development of Vector and ensuring your change gets approved in a timely manner.
 
-1. **[CONTRIBUTING.md](CONTRIBUTING.md)** - Start here, contributor basics and workflow
+1. **[CONTRIBUTING.md](../CONTRIBUTING.md)** - Start here, contributor basics and workflow
 2. **[DEVELOPING.md](DEVELOPING.md)** - Everything necessary to develop
 3. **[DOCUMENTING.md](DOCUMENTING.md)** - Preparing your change for Vector users
 


### PR DESCRIPTION
- Fix `CONTRIBUTING.md` path, it's located in the parent directory of `docs`
- Suggest command `make generate-component-docs`. The command `cargo vdev build component-docs` fails with the following error:
```
usage: extract-component-schema.rb <configuration schema path>
Error: command: cd "/home/gabriel/temp/vector" && "/home/gabriel/temp/vector/scripts/generate-component-docs.rb"
  failed with exit code: 1
```