### PR TITLE
chore(config): Add configurable support for `http::Uri`

### DIFF
--- a/lib/vector-config/src/external/http.rs
+++ b/lib/vector-config/src/external/http.rs
@@ -1,0 +1,28 @@
+use std::cell::RefCell;
+
+use serde_json::Value;
+use vector_config_common::validation::{Format, Validation};
+
+use crate::{
+    schema::{generate_string_schema, SchemaGenerator, SchemaObject},
+    Configurable, GenerateError, Metadata, ToValue,
+};
+
+impl Configurable for http::Uri {
+    fn metadata() -> Metadata {
+        let mut metadata = Metadata::default();
+        metadata.set_description("A uniform resource indicator (URI).");
+        metadata.add_validation(Validation::KnownFormat(Format::Uri));
+        metadata
+    }
+
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for http::Uri {
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}

--- a/lib/vector-config/src/external/mod.rs
+++ b/lib/vector-config/src/external/mod.rs
@@ -1,6 +1,7 @@
 mod chrono;
 mod datetime;
 mod encoding_rs;
+mod http;
 mod indexmap;
 mod no_proxy;
 mod serde_with;


### PR DESCRIPTION
Copied from the support for `url::Url`.