### PR TITLE
docs(setup): fix inconsistency in docker configuration example

### DIFF
--- a/website/content/en/docs/setup/installation/platforms/docker.md
+++ b/website/content/en/docs/setup/installation/platforms/docker.md
@@ -61,7 +61,7 @@ EOF
 ```shell
 docker run \
   -d \
-  -v $PWD/vector.toml:/etc/vector/vector.toml:ro \
+  -v $PWD/vector.yaml:/etc/vector/vector.yaml:ro \
   -p 8686:8686 \
   timberio/vector:{{< version >}}-debian
 ```


### PR DESCRIPTION
This changes the docker run command to refer to the correct configuration file created in previous command (YAML vs TOML).

---
>Sponsored by [Quad9](https://quad9.net/)