### PR TITLE
 Kubernetes_logs. Add delimiters for different OS in path_helper. Issue#18521

### DIFF
--- a/src/sources/kubernetes_logs/path_helpers.rs
+++ b/src/sources/kubernetes_logs/path_helpers.rs
@@ -12,6 +12,10 @@ const K8S_LOGS_DIR: &str = "/var/log/pods";
 /// The delimiter used in the log path.
 const LOG_PATH_DELIMITER: &str = "_";
 
+/// Delimiters for for different OS
+const WINDOWS_DELIMITER: &str = "\\";
+const LINUX_DELIMITER: &str = "/";
+
 /// Builds absolute log directory path for a pod sandbox.
 ///
 /// Based on <https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L178>
@@ -34,7 +38,15 @@ pub(super) fn build_pod_logs_directory(
 ///
 /// Inspired by <https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L186>
 pub(super) fn parse_log_file_path(path: &str) -> Option<LogFileInfo<'_>> {
-    let mut components = path.rsplit('/');
+    let delimiter;
+
+    if path.chars().nth(4) == Some('/') {
+        delimiter = LINUX_DELIMITER;
+    } else {
+        delimiter = WINDOWS_DELIMITER;
+    }
+
+    let mut components = path.rsplit(&delimiter);
 
     let _log_file_name = components.next()?;
     let container_name = components.next()?;


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
