### PR TITLE
fix(docs, http_server source): Update docs for disabling `max_connection_age_secs`

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -402,8 +402,8 @@ pub struct KeepaliveConfig {
     /// by sending a `Connection: close` header on the HTTP response.
     ///
     ///
-    /// Set this to a large value to disable this feature (in the future setting this to `null`
-    /// should be possible).
+    /// Set this to a large value like `100000000` to disable this feature (in the future setting
+    /// this to `null` should be possible).
     ///
     /// A random jitter configured by `max_connection_age_jitter_factor` is added
     /// to the specified duration to spread out connection storms.

--- a/src/http.rs
+++ b/src/http.rs
@@ -402,8 +402,7 @@ pub struct KeepaliveConfig {
     /// by sending a `Connection: close` header on the HTTP response.
     ///
     ///
-    /// Set this to a large value like `100000000` to disable this feature (in the future, setting
-    /// this to `null` should be possible).
+    /// Set this to a large value like `100000000` to "disable" this feature
     ///
     /// A random jitter configured by `max_connection_age_jitter_factor` is added
     /// to the specified duration to spread out connection storms.

--- a/src/http.rs
+++ b/src/http.rs
@@ -402,7 +402,7 @@ pub struct KeepaliveConfig {
     /// by sending a `Connection: close` header on the HTTP response.
     ///
     ///
-    /// Set this to a large value like `100000000` to disable this feature (in the future setting
+    /// Set this to a large value like `100000000` to disable this feature (in the future, setting
     /// this to `null` should be possible).
     ///
     /// A random jitter configured by `max_connection_age_jitter_factor` is added

--- a/src/http.rs
+++ b/src/http.rs
@@ -402,7 +402,7 @@ pub struct KeepaliveConfig {
     /// by sending a `Connection: close` header on the HTTP response.
     ///
     ///
-    /// Set this to a high number to disable this feature (in the future setting this to `null`
+    /// Set this to a large value to disable this feature (in the future setting this to `null`
     /// should be possible).
     ///
     /// A random jitter configured by `max_connection_age_jitter_factor` is added

--- a/src/http.rs
+++ b/src/http.rs
@@ -401,6 +401,10 @@ pub struct KeepaliveConfig {
     /// The maximum amount of time a connection may exist before it is closed
     /// by sending a `Connection: close` header on the HTTP response.
     ///
+    ///
+    /// Set this to a high number to disable this feature (in the future setting this to `null`
+    /// should be possible).
+    ///
     /// A random jitter configured by `max_connection_age_jitter_factor` is added
     /// to the specified duration to spread out connection storms.
     #[serde(default = "default_max_connection_age")]

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -83,9 +83,9 @@ interpolation.
 HTTP server-based sources include a new `keepalive.max_connection_age_secs` configuration option, which defaults to 5 minutes (300 seconds).
 When enabled, this closes incoming TCP connections that reach the maximum age by sending a `Connection: close` header in the response.
 While this parameter is crucial for managing the lifespan of persistent, incoming connections to Vector and for effective load balancing, it
-can be disabled by setting `keepalive.max_connection_age_secs` to a very large number (ideally you
-could set it to `null` but Vector currently requires all values to be valid TOML values, of which
-`null` is not).
+can be disabled by setting `keepalive.max_connection_age_secs` to a very large number like
+`100000000` (ideally you could set it to `null` but Vector currently requires all values to be valid
+TOML values, of which `null` is not).
 
 #### Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks {#component-sent-bytes-total}
 

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -83,7 +83,7 @@ interpolation.
 HTTP server-based sources include a new `keepalive.max_connection_age_secs` configuration option, which defaults to 5 minutes (300 seconds).
 When enabled, this closes incoming TCP connections that reach the maximum age by sending a `Connection: close` header in the response.
 While this parameter is crucial for managing the lifespan of persistent, incoming connections to Vector and for effective load balancing, it
-can be disabled by setting `keepalive.max_connection_age_secs` to a very high number (ideally you
+can be disabled by setting `keepalive.max_connection_age_secs` to a very large number (ideally you
 could set it to `null` but Vector currently requires all values to be valid TOML values, of which
 `null` is not).
 

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -84,7 +84,7 @@ HTTP server-based sources include a new `keepalive.max_connection_age_secs` conf
 When enabled, this closes incoming TCP connections that reach the maximum age by sending a `Connection: close` header in the response.
 While this parameter is crucial for managing the lifespan of persistent, incoming connections to Vector and for effective load balancing, it
 can be disabled by setting `keepalive.max_connection_age_secs` to a very large number like
-`100000000` (ideally you could set it to `null` but Vector currently requires all values to be valid
+`100000000` (ideally you could set it to `null`, but Vector currently requires all values to be valid
 TOML values, of which `null` is not).
 
 #### Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks {#component-sent-bytes-total}

--- a/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-12-19-0-35-0-upgrade-guide.md
@@ -83,7 +83,9 @@ interpolation.
 HTTP server-based sources include a new `keepalive.max_connection_age_secs` configuration option, which defaults to 5 minutes (300 seconds).
 When enabled, this closes incoming TCP connections that reach the maximum age by sending a `Connection: close` header in the response.
 While this parameter is crucial for managing the lifespan of persistent, incoming connections to Vector and for effective load balancing, it
-can be disabled by setting `keepalive.max_connection_age_secs` to `null`.
+can be disabled by setting `keepalive.max_connection_age_secs` to a very high number (ideally you
+could set it to `null` but Vector currently requires all values to be valid TOML values, of which
+`null` is not).
 
 #### Update `component_sent_bytes_total` to correctly report uncompressed bytes for all sinks {#component-sent-bytes-total}
 

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -342,8 +342,8 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -342,6 +342,9 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -342,8 +342,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -339,8 +339,8 @@ base: components: sources: datadog_agent: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -339,6 +339,9 @@ base: components: sources: datadog_agent: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -339,8 +339,7 @@ base: components: sources: datadog_agent: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -336,8 +336,7 @@ base: components: sources: heroku_logs: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -336,6 +336,9 @@ base: components: sources: heroku_logs: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -336,8 +336,8 @@ base: components: sources: heroku_logs: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -364,6 +364,9 @@ base: components: sources: http: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -364,8 +364,8 @@ base: components: sources: http: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -364,8 +364,7 @@ base: components: sources: http: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -364,8 +364,7 @@ base: components: sources: http_server: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -364,6 +364,9 @@ base: components: sources: http_server: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -364,8 +364,8 @@ base: components: sources: http_server: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -177,8 +177,8 @@ base: components: sources: opentelemetry: configuration: {
 																The maximum amount of time a connection may exist before it is closed
 																by sending a `Connection: close` header on the HTTP response.
 
-																Set this to a high number to disable this feature (in the future setting this to `null`
-																should be possible).
+																Set this to a large value like `100000000` to disable this feature (in the future setting
+																this to `null` should be possible).
 
 																A random jitter configured by `max_connection_age_jitter_factor` is added
 																to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -177,8 +177,7 @@ base: components: sources: opentelemetry: configuration: {
 																The maximum amount of time a connection may exist before it is closed
 																by sending a `Connection: close` header on the HTTP response.
 
-																Set this to a large value like `100000000` to disable this feature (in the future setting
-																this to `null` should be possible).
+																Set this to a large value like `100000000` to "disable" this feature
 
 																A random jitter configured by `max_connection_age_jitter_factor` is added
 																to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -177,6 +177,9 @@ base: components: sources: opentelemetry: configuration: {
 																The maximum amount of time a connection may exist before it is closed
 																by sending a `Connection: close` header on the HTTP response.
 
+																Set this to a high number to disable this feature (in the future setting this to `null`
+																should be possible).
+
 																A random jitter configured by `max_connection_age_jitter_factor` is added
 																to the specified duration to spread out connection storms.
 																"""

--- a/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
@@ -76,8 +76,7 @@ base: components: sources: prometheus_pushgateway: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
@@ -76,8 +76,8 @@ base: components: sources: prometheus_pushgateway: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
@@ -76,6 +76,9 @@ base: components: sources: prometheus_pushgateway: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -66,8 +66,8 @@ base: components: sources: prometheus_remote_write: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -66,6 +66,9 @@ base: components: sources: prometheus_remote_write: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -66,8 +66,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -91,8 +91,8 @@ base: components: sources: splunk_hec: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a high number to disable this feature (in the future setting this to `null`
-					should be possible).
+					Set this to a large value like `100000000` to disable this feature (in the future setting
+					this to `null` should be possible).
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -91,8 +91,7 @@ base: components: sources: splunk_hec: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
-					Set this to a large value like `100000000` to disable this feature (in the future setting
-					this to `null` should be possible).
+					Set this to a large value like `100000000` to "disable" this feature
 
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -91,6 +91,9 @@ base: components: sources: splunk_hec: configuration: {
 					The maximum amount of time a connection may exist before it is closed
 					by sending a `Connection: close` header on the HTTP response.
 
+					Set this to a high number to disable this feature (in the future setting this to `null`
+					should be possible).
+
 					A random jitter configured by `max_connection_age_jitter_factor` is added
 					to the specified duration to spread out connection storms.
 					"""


### PR DESCRIPTION
Ideally you could set this to `null`, but Vector requires all config values to be valid TOML, of
which `null` is not.

Closes: https://github.com/vectordotdev/vector/issues/19644

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
