### PR TITLE
fix(journald source): correctly emit metadata to log namespace

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -5,10 +5,10 @@
 (?:^|/)amplify\.yml$
 (?:^|/)build_preview_sites\.yml$
 (?:^|/)create_preview_sites\.yml$
-(?:^|/)preview_site_trigger\.yml$
 (?:^|/)go\.sum$
 (?:^|/)package(?:-lock|)\.json$
 (?:^|/)Pipfile$
+(?:^|/)preview_site_trigger\.yml$
 (?:^|/)pyproject.toml
 (?:^|/)requirements(?:-dev|-doc|-test|)\.txt$
 (?:^|/)vendor/
@@ -82,6 +82,9 @@
 ^\Qbenches/transform/route.rs\E$
 ^\Qlib/codecs/tests/data/decoding/protobuf/test_protobuf.desc\E$
 ^\Qlib/codecs/tests/data/decoding/protobuf/test_protobuf3.desc\E$
+^\Qlib/codecs/tests/data/protobuf/protos/test.desc\E$
+^\Qlib/codecs/tests/data/protobuf/protos/test_protobuf.desc\E$
+^\Qlib/codecs/tests/data/protobuf/protos/test_protobuf3.desc\E$
 ^\Qlib/codecs/tests/data/protobuf/test.desc\E$
 ^\Qlib/codecs/tests/data/protobuf/test_protobuf.desc\E$
 ^\Qlib/codecs/tests/data/protobuf/test_protobuf3.desc\E$

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -21,7 +21,6 @@ andy
 ansicpg
 anumber
 anycondition
-anymap
 anypb
 apievent
 apipodspec
@@ -168,7 +167,6 @@ clibtype
 clickhouse
 clonable
 cloudresourcemanager
-cloudsmith
 cloudwatchlogs
 cmark
 CMK
@@ -222,6 +220,7 @@ customizability
 customtype
 cwl
 Dailywarehousing
+dalegaard
 daschl
 dashmap
 datadir
@@ -328,7 +327,6 @@ EOIG
 EOL'ed
 Err'ing
 errorf
-Errorsfor
 esb
 esque
 etheus
@@ -657,7 +655,6 @@ maybeanothertest
 mbean
 mcache
 mcr
-meh
 meln
 memfd
 memmap
@@ -1238,7 +1235,6 @@ wktpointer
 wmem
 woooooow
 woothee
-wor
 wordlist
 workdir
 workstreams

--- a/changelog.d/19812_journald_metadata_missing.fix.md
+++ b/changelog.d/19812_journald_metadata_missing.fix.md
@@ -1,0 +1,4 @@
+Fixed an issue where the `journald` source was not correctly emitting metadata when `log_namespace =
+True`.
+
+authors: @dalegaard


### PR DESCRIPTION
Fixes issues with incorrect metadata output when journald source is in `log_namespace` mode. The existing code assumed the metadata fields used to derive `host` and `timestamp` fields were available on the event itself, but in `log_namespace` mode these fields get put on the `%journald.metadata` field.

