### PR TITLE
chore(sample transform): make containing module pub

### DIFF
--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use snafu::Snafu;
 
-mod sample;
+pub mod sample;
 
 #[cfg(feature = "transforms-aggregate")]
 pub mod aggregate;


### PR DESCRIPTION
This was overlooked in https://github.com/vectordotdev/vector/pull/19806