### PR TITLE
feat(dnsmsg_parser): add support for parsing HTTPS and SVCB records

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -422,6 +422,7 @@ servlet
 Sinjo
 sublocation
 sundar
+svcb
 snyk
 socketaddr
 solarwinds

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -5,10 +5,10 @@
 (?:^|/)amplify\.yml$
 (?:^|/)build_preview_sites\.yml$
 (?:^|/)create_preview_sites\.yml$
-(?:^|/)preview_site_trigger\.yml$
 (?:^|/)go\.sum$
 (?:^|/)package(?:-lock|)\.json$
 (?:^|/)Pipfile$
+(?:^|/)preview_site_trigger\.yml$
 (?:^|/)pyproject.toml
 (?:^|/)requirements(?:-dev|-doc|-test|)\.txt$
 (?:^|/)vendor/
@@ -82,6 +82,9 @@
 ^\Qbenches/transform/route.rs\E$
 ^\Qlib/codecs/tests/data/decoding/protobuf/test_protobuf.desc\E$
 ^\Qlib/codecs/tests/data/decoding/protobuf/test_protobuf3.desc\E$
+^\Qlib/codecs/tests/data/protobuf/protos/test.desc\E$
+^\Qlib/codecs/tests/data/protobuf/protos/test_protobuf.desc\E$
+^\Qlib/codecs/tests/data/protobuf/protos/test_protobuf3.desc\E$
 ^\Qlib/codecs/tests/data/protobuf/test.desc\E$
 ^\Qlib/codecs/tests/data/protobuf/test_protobuf.desc\E$
 ^\Qlib/codecs/tests/data/protobuf/test_protobuf3.desc\E$

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -21,7 +21,6 @@ andy
 ansicpg
 anumber
 anycondition
-anymap
 anypb
 apievent
 apipodspec
@@ -168,7 +167,6 @@ clibtype
 clickhouse
 clonable
 cloudresourcemanager
-cloudsmith
 cloudwatchlogs
 cmark
 CMK
@@ -328,8 +326,8 @@ EOIG
 EOL'ed
 Err'ing
 errorf
-Errorsfor
 esb
+esensar
 esque
 etheus
 etl
@@ -657,7 +655,6 @@ maybeanothertest
 mbean
 mcache
 mcr
-meh
 meln
 memfd
 memmap
@@ -1238,7 +1235,6 @@ wktpointer
 wmem
 woooooow
 woothee
-wor
 wordlist
 workdir
 workstreams

--- a/changelog.d/19785_https_svcb_record_types_support.enhancement.md
+++ b/changelog.d/19785_https_svcb_record_types_support.enhancement.md
@@ -1,1 +1,2 @@
 Added support for parsing HTTPS (type 65) and SVCB (type 64) resource records from DNS messages
+authors: @esensar

--- a/changelog.d/19785_https_svcb_record_types_support.enhancement.md
+++ b/changelog.d/19785_https_svcb_record_types_support.enhancement.md
@@ -1,0 +1,1 @@
+Added support for parsing HTTPS (type 65) and SVCB (type 64) resource records from DNS messages


### PR DESCRIPTION
Since these record types are supported by `hickory_proto` crate, it was just a matter of formatting them. This also adds tests based on the data from #19785.

Fixes: #19785
