### PR TITLE
chore: expose component test utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -850,6 +850,7 @@ webhdfs-integration-tests = ["sinks-webhdfs"]
 disable-resolv-conf = []
 shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-lua", "transforms-remap", "unix"]
 cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]
+component-test-utils = []
 
 # End-to-End testing-related features
 all-e2e-tests = [

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -53,7 +53,7 @@ const WAIT_FOR_SECS: u64 = 5; // The default time to wait in `wait_for`
 const WAIT_FOR_MIN_MILLIS: u64 = 5; // The minimum time to pause before retrying
 const WAIT_FOR_MAX_MILLIS: u64 = 500; // The maximum time to pause before retrying
 
-#[cfg(test)]
+#[cfg(any(test, feature = "component-test-utils"))]
 pub mod components;
 
 #[cfg(test)]


### PR DESCRIPTION
This enables users to write tests using `assert_source_compliance` etc. 