### PR TITLE
enhancement(vrl): RFC for return expression

### DIFF
--- a/rfcs/2023-02-08-7496-vrl-return.md
+++ b/rfcs/2023-02-08-7496-vrl-return.md
@@ -1,0 +1,72 @@
+# RFC 7496 - 2023-02-02 - VRL Return Keyword
+
+Add return expression to the Vector Remap Language.
+
+## Context
+
+- #7496
+
+## Cross cutting concerns
+
+- None.
+
+## Scope
+
+### In scope
+
+- Adding a return expression to VRL.
+
+### Out of scope
+
+- Adding new keywords for similar purposes such as `drop`.
+- Defining semantics of keywords that are usually used for other purposes in other languages such as `break`.
+- Defining parameteized return, e.g. `return parse_json!(.message)`. The proposed return expression always passes current `.` to output and takes no input.
+
+## Pain
+
+- Aborting with changing the input cannot be easily done.
+- VRL code is often unnecessarily indented because of lack of early returns.
+
+## Proposal
+
+### User Experience
+
+- A `return` expression causes the VRL program to terminate, keeping any modifications made to the event.
+- The keyword is used by itself with no parameters and `.` will be sent to the output.
+
+### Implementation
+
+- Implementation will be largely the same as the current `abort` keyword when `drop_on_abort` is set to `false` and without the optional argument. The only differnece is that the returned value will be taken from `.` and not from original input.
+- `drop_on_abort` will have no effect on return calls and configuration such as `drop_on_return` will not be added.
+
+## Rationale
+
+- It will be possible to write VRL with less indentation making it more readable.
+- `return` is already a reserved word so it can be used without introducing a breaking change.
+
+## Drawbacks
+
+- The `return` keyword will be given a semantic meaning that will have to be supported going forward.
+
+## Prior Art
+
+- Most languages have a way to make early returns.
+- There was no prior attempted implementation of returns in VRL to my knowledge.
+
+## Alternatives
+
+- New keywords that are not currently a reserved keyword can be added to the language. This would, however, constitute a breaking change.
+- This feature can also be rejected as it does not add any functionality that cannot be currently expressed.
+
+## Outstanding Questions
+
+## Plan Of Attack
+
+Incremental steps to execute this change. These will be converted to issues after the RFC is approved:
+
+- [ ] Submit a PR with implementation.
+
+## Future Improvements
+
+- Adding a `drop` keyword for explicit drop as an alternative to pre-configured `abort` for full control over passing the events to output unchanged, passing them changed, or routing them to the dropped output.
+- Addition of positional arguments to `return`.

--- a/rfcs/2023-02-08-7496-vrl-return.md
+++ b/rfcs/2023-02-08-7496-vrl-return.md
@@ -15,14 +15,13 @@ Add return expression to the Vector Remap Language.
 ### In scope
 
 - Adding a return expression to VRL.
-- The `return` keyword can be used by itself to return implicitly `.`.
 - The `return` can optionally take an expression as an argument and the result of that expression will be returned.
 
 ### Out of scope
 
 - Adding new keywords for similar purposes such as `drop`.
 - Defining semantics of keywords that are usually used for other purposes in other languages such as `break`.
-- `return` expressions inside closures.
+- Implementation of `return` expressions inside closures.
 
 ## Pain
 
@@ -34,13 +33,12 @@ Add return expression to the Vector Remap Language.
 ### User Experience
 
 - A `return` expression causes the VRL program to terminate, keeping any modifications made to the event.
-- The keyword is used by itself with no parameters and `.` will be sent to the output or custom expression can be returned.
-- The keyword cannot be used inside a closure.
+- A `return` expression must be always followed by another expression, whose value will be used as the emitted event.
+- The keyword cannot be used inside a closure. Trying to do that will result in a compilation error.
 
 ### Implementation
 
-- Implementation will be largely the same as the current `abort` keyword when `drop_on_abort` is set to `false` and without the optional argument. The only difference is that the returned value will be taken from `.` and not from original input.
-- The implementation will then be extended with the optional argument, where the implementation may be as simple as lowering `return expr` into `. = expr ; return`.
+- Implementation will be similar to the current `abort` keyword when `drop_on_abort` is set to `false`. The only difference is that the returned value will be taken from the provided expression and not from original input.
 - `drop_on_abort` will have no effect on return calls and configuration such as `drop_on_return` will not be added.
 
 ## Rationale
@@ -68,9 +66,9 @@ Add return expression to the Vector Remap Language.
 
 Incremental steps to execute this change. These will be converted to issues after the RFC is approved:
 
-- [ ] Submit a PR with implementation of returns without positional arguments.
-- [ ] Submit a PR with addition of optional arguments to the `return` expression.
+- [ ] Submit a PR with implementation of returns.
 
 ## Future Improvements
 
 - Adding a `drop` keyword for explicit drop as an alternative to pre-configured `abort` for full control over passing the events to output unchanged, passing them changed, or routing them to the dropped output.
+- Adding `return` to closures.

--- a/rfcs/2023-02-08-7496-vrl-return.md
+++ b/rfcs/2023-02-08-7496-vrl-return.md
@@ -15,12 +15,14 @@ Add return expression to the Vector Remap Language.
 ### In scope
 
 - Adding a return expression to VRL.
+- The `return` keyword can be used by itself to return implicitly `.`.
+- The `return` can optionally take an expression as an argument and the result of that expression will be returned.
 
 ### Out of scope
 
 - Adding new keywords for similar purposes such as `drop`.
 - Defining semantics of keywords that are usually used for other purposes in other languages such as `break`.
-- Defining parameterized return, e.g. `return parse_json!(.message)`. The proposed return expression always passes current `.` to output and takes no input.
+- `return` expressions inside closures.
 
 ## Pain
 
@@ -32,11 +34,13 @@ Add return expression to the Vector Remap Language.
 ### User Experience
 
 - A `return` expression causes the VRL program to terminate, keeping any modifications made to the event.
-- The keyword is used by itself with no parameters and `.` will be sent to the output.
+- The keyword is used by itself with no parameters and `.` will be sent to the output or custom expression can be returned.
+- The keyword cannot be used inside a closure.
 
 ### Implementation
 
 - Implementation will be largely the same as the current `abort` keyword when `drop_on_abort` is set to `false` and without the optional argument. The only difference is that the returned value will be taken from `.` and not from original input.
+- The implementation will then be extended with the optional argument, where the implementation may be as simple as lowering `return expr` into `. = expr ; return`.
 - `drop_on_abort` will have no effect on return calls and configuration such as `drop_on_return` will not be added.
 
 ## Rationale
@@ -64,9 +68,9 @@ Add return expression to the Vector Remap Language.
 
 Incremental steps to execute this change. These will be converted to issues after the RFC is approved:
 
-- [ ] Submit a PR with implementation.
+- [ ] Submit a PR with implementation of returns without positional arguments.
+- [ ] Submit a PR with addition of optional arguments to the `return` expression.
 
 ## Future Improvements
 
 - Adding a `drop` keyword for explicit drop as an alternative to pre-configured `abort` for full control over passing the events to output unchanged, passing them changed, or routing them to the dropped output.
-- Addition of positional arguments to `return`.

--- a/rfcs/2023-02-08-7496-vrl-return.md
+++ b/rfcs/2023-02-08-7496-vrl-return.md
@@ -20,7 +20,7 @@ Add return expression to the Vector Remap Language.
 
 - Adding new keywords for similar purposes such as `drop`.
 - Defining semantics of keywords that are usually used for other purposes in other languages such as `break`.
-- Defining parameteized return, e.g. `return parse_json!(.message)`. The proposed return expression always passes current `.` to output and takes no input.
+- Defining parameterized return, e.g. `return parse_json!(.message)`. The proposed return expression always passes current `.` to output and takes no input.
 
 ## Pain
 
@@ -36,7 +36,7 @@ Add return expression to the Vector Remap Language.
 
 ### Implementation
 
-- Implementation will be largely the same as the current `abort` keyword when `drop_on_abort` is set to `false` and without the optional argument. The only differnece is that the returned value will be taken from `.` and not from original input.
+- Implementation will be largely the same as the current `abort` keyword when `drop_on_abort` is set to `false` and without the optional argument. The only difference is that the returned value will be taken from `.` and not from original input.
 - `drop_on_abort` will have no effect on return calls and configuration such as `drop_on_return` will not be added.
 
 ## Rationale


### PR DESCRIPTION
Partly based on #7496 but closer to a subset from #19766 which does not include any breaking changes such as adding a new reserved keyword to VRL.

<!--
**Your PR title must conform to the conventional commit spec!**
  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
