### PR TITLE
chore(dev): Ensure changelog fragment author doesn't start with @

### DIFF
--- a/changelog.d/10304_add_prometheus_pushgateway_source.feature.md
+++ b/changelog.d/10304_add_prometheus_pushgateway_source.feature.md
@@ -2,4 +2,4 @@ Vector can now emulate a [Prometheus Pushgateway](https://github.com/prometheus/
 
 There are some caveats, which are listed [here](https://github.com/Sinjo/vector/blob/0d4fc20091ddae7f3562bfdf07c9095c0c7223e0/src/sources/prometheus/pushgateway.rs#L8-L12).
 
-authors: @Sinjo
+authors: Sinjo

--- a/changelog.d/19711_add_s3_source_delete_configuration.feature.md
+++ b/changelog.d/19711_add_s3_source_delete_configuration.feature.md
@@ -1,3 +1,3 @@
 Added a configuration option for the `aws_s3` source that prevents deletion of messages which failed to be delivered to a sink.
 
-authors: @tanushri-sundar
+authors: tanushri-sundar

--- a/scripts/check_changelog_fragments.sh
+++ b/scripts/check_changelog_fragments.sh
@@ -61,7 +61,10 @@ while IFS= read -r fname; do
   # used for external contributor PRs.
   if [[ $1 == "--authors" ]]; then
     last=$( tail -n 1 "${CHANGELOG_DIR}/${fname}" )
-    if ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
+    if [[ "${last}" =~ ^(authors: @.*)$ ]]; then
+      echo "invalid fragment contents: author should not be prefixed with @"
+      exit 1
+    elif ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
       echo "invalid fragment contents: author option was specified but fragment ${fname} contains no authors."
       exit 1
     fi


### PR DESCRIPTION
This breaks the linking to the user profile

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
