### PR TITLE
docs(vrl): make `parse_etld` fallible in docs

### DIFF
--- a/website/cue/reference/remap/functions/parse_etld.cue
+++ b/website/cue/reference/remap/functions/parse_etld.cue
@@ -25,7 +25,9 @@ remap: functions: parse_etld: {
 			default: false
 		},
 	]
-	internal_failure_reasons: []
+	internal_failure_reasons: [
+		"unable to determine eTLD for `value`"
+	]
 	return: types: ["object"]
 
 	examples: [

--- a/website/cue/reference/remap/functions/parse_etld.cue
+++ b/website/cue/reference/remap/functions/parse_etld.cue
@@ -26,7 +26,7 @@ remap: functions: parse_etld: {
 		},
 	]
 	internal_failure_reasons: [
-		"unable to determine eTLD for `value`"
+		"unable to determine eTLD for `value`",
 	]
 	return: types: ["object"]
 


### PR DESCRIPTION
Missed in #19795