### PR TITLE
chore(ci): Reduce test timeout to 2 minutes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,9 @@ failure-output = "immediate-final"
 # don't cancel the test run on the first failure
 fail-fast = false
 
+# timeout tests after 2 minutes
+slow-timeout = { period = "30s", terminate-after = 4 }
+
 [profile.default.junit]
 # output test results at target/nextest/default/junit.xml
 path = "junit.xml"


### PR DESCRIPTION
The default is 30 minutes. We saw this timeout recently hit by `vector
sources::kafka::integration_test::handles_one_negative_acknowledgement`.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
