### PR TITLE
fix(elasticsearch sink): Readd error log for elasticsearch sink

### DIFF
--- a/src/internal_events/elasticsearch.rs
+++ b/src/internal_events/elasticsearch.rs
@@ -1,0 +1,32 @@
+use http::Response;
+use vector_lib::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct ElasticsearchResponseError<'a> {
+    response: &'a Response<bytes::Bytes>,
+    message: &'static str,
+    error_code: String,
+}
+
+#[cfg(feature = "sinks-elasticsearch")]
+impl<'a> ElasticsearchResponseError<'a> {
+    pub fn new(message: &'static str, response: &'a Response<bytes::Bytes>) -> Self {
+        let error_code = super::prelude::http_error_code(response.status().as_u16());
+        Self {
+            message,
+            response,
+            error_code,
+        }
+    }
+}
+
+impl<'a> InternalEvent for ElasticsearchResponseError<'a> {
+    fn emit(self) {
+        // Emission of Error internal event and metrics is handled upstream by the caller.
+        error!(
+            message = %self.message,
+            error_code = %self.error_code,
+            response = ?self.response,
+        );
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -42,6 +42,7 @@ mod demo_logs;
 mod dnstap;
 #[cfg(feature = "sources-docker_logs")]
 mod docker_logs;
+mod elasticsearch;
 mod encoding_transcode;
 #[cfg(feature = "sources-eventstoredb_metrics")]
 mod eventstoredb_metrics;
@@ -175,6 +176,8 @@ pub(crate) use self::demo_logs::*;
 pub(crate) use self::dnstap::*;
 #[cfg(feature = "sources-docker_logs")]
 pub(crate) use self::docker_logs::*;
+#[cfg(feature = "sinks-elasticsearch")]
+pub(crate) use self::elasticsearch::*;
 #[cfg(feature = "sources-eventstoredb_metrics")]
 pub(crate) use self::eventstoredb_metrics::*;
 #[cfg(feature = "sources-exec")]

--- a/src/internal_events/prelude.rs
+++ b/src/internal_events/prelude.rs
@@ -2,6 +2,7 @@
     feature = "sources-apache_metrics",
     feature = "sources-aws_ecs_metrics",
     feature = "sources-aws_kinesis_firehose",
+    feature = "sinks-elasticsearch",
     feature = "sources-http-client",
     feature = "sources-utils-http",
 ))]


### PR DESCRIPTION
Users were depending on this log to determine the number of failed events. Ideally these failed
events could be routed from the sink and counted that way, but until then re-adding the log unblocks
users from upgrading.

Fixes: #15886

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
