### PR TITLE
chore(api): Fix API address example

### DIFF
--- a/website/cue/reference/api.cue
+++ b/website/cue/reference/api.cue
@@ -29,7 +29,7 @@ api: {
 			required: false
 			type: string: {
 				default: "127.0.0.1:8686"
-				examples: ["0.0.0.0:8686", "localhost:1234"]
+				examples: ["0.0.0.0:8686", "127.0.0.1:1234"]
 			}
 			description: """
 				The network address to which the API should bind. If you're running


### PR DESCRIPTION
Only IP addresses can be used, not `localhost`.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
