### PR TITLE
chore(tests): expose test utilities

### DIFF
--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -20,7 +20,7 @@ pub mod snappy;
 pub mod socket_bytes_sink;
 pub mod statistic;
 pub mod tcp;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test;
 pub mod udp;
 #[cfg(all(any(feature = "sinks-socket", feature = "sinks-statsd"), unix))]

--- a/src/sinks/util/test.rs
+++ b/src/sinks/util/test.rs
@@ -1,13 +1,18 @@
-use std::net::SocketAddr;
-
-use bytes::Bytes;
-use futures::{channel::mpsc, FutureExt, SinkExt, TryFutureExt};
+use bytes::{Buf, Bytes};
+use flate2::read::MultiGzDecoder;
+use futures::{channel::mpsc, stream, FutureExt, SinkExt, TryFutureExt};
+use futures_util::StreamExt;
+use http::request::Parts;
 use hyper::{
     body::HttpBody,
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
 };
 use serde::Deserialize;
+use std::{
+    io::{BufRead, BufReader},
+    net::SocketAddr,
+};
 use stream_cancel::{Trigger, Tripwire};
 
 use crate::{
@@ -105,4 +110,21 @@ where
         .map_err(|error| panic!("Server error: {}", error));
 
     (rx, trigger, server)
+}
+
+pub async fn get_received(
+    rx: mpsc::Receiver<(Parts, Bytes)>,
+    assert_parts: impl Fn(Parts),
+) -> Vec<String> {
+    rx.flat_map(|(parts, body)| {
+        assert_parts(parts);
+        stream::iter(BufReader::new(MultiGzDecoder::new(body.reader())).lines())
+    })
+    .map(Result::unwrap)
+    .map(|line| {
+        let val: serde_json::Value = serde_json::from_str(&line).unwrap();
+        val.get("message").unwrap().as_str().unwrap().to_owned()
+    })
+    .collect::<Vec<_>>()
+    .await
 }

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -53,6 +53,7 @@ pub const FILE_SOURCE_TAGS: [&str; 1] = ["file"];
 /// The most basic set of tags for sinks, regardless of whether or not they push data or have it pulled out.
 pub const SINK_TAGS: [&str; 1] = ["protocol"];
 
+///
 pub const DATA_VOLUME_SINK_TAGS: [&str; 2] = ["source", "service"];
 
 /// The standard set of tags for all sinks that write a file.
@@ -117,6 +118,7 @@ pub static SINK_TESTS: Lazy<ComponentTests> = Lazy::new(|| {
     }
 });
 
+///
 pub static DATA_VOLUME_SINK_TESTS: Lazy<ComponentTests> = Lazy::new(|| {
     ComponentTests {
         events: &["BytesSent", "EventsSent"], // EventsReceived is emitted in the topology
@@ -339,6 +341,7 @@ where
     run_and_assert_source_advanced(source, setup, timeout, event_count, &SOURCE_TESTS, tags).await
 }
 
+/// Runs and asserts source test specifcations with configurations.
 pub async fn run_and_assert_source_advanced<SC>(
     source: SC,
     setup: impl FnOnce(&mut SourceContext),
@@ -407,6 +410,7 @@ where
     .await
 }
 
+/// Runs and asserts compliance for transforms.
 pub async fn assert_transform_compliance<T>(f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -428,6 +432,7 @@ pub async fn assert_sink_compliance<T>(tags: &[&str], f: impl Future<Output = T>
     result
 }
 
+/// Runs and asserts sink compliance.
 pub async fn run_and_assert_sink_compliance<S, I>(sink: VectorSink, events: S, tags: &[&str])
 where
     S: Stream<Item = I> + Send,
@@ -451,6 +456,7 @@ pub async fn assert_data_volume_sink_compliance<T>(tags: &[&str], f: impl Future
     result
 }
 
+/// Runs data volume sink tests and asserts compliance.
 pub async fn run_and_assert_data_volume_sink_compliance<S, I>(
     sink: VectorSink,
     events: S,
@@ -466,6 +472,7 @@ pub async fn run_and_assert_data_volume_sink_compliance<S, I>(
     .await;
 }
 
+/// Asserts compliance for nonsending sink tests.
 pub async fn assert_nonsending_sink_compliance<T>(tags: &[&str], f: impl Future<Output = T>) -> T {
     init_test();
 
@@ -476,6 +483,7 @@ pub async fn assert_nonsending_sink_compliance<T>(tags: &[&str], f: impl Future<
     result
 }
 
+/// Runs and asserts compliance for nonsending sink tests.
 pub async fn run_and_assert_nonsending_sink_compliance<S, I>(
     sink: VectorSink,
     events: S,
@@ -502,6 +510,7 @@ pub async fn assert_sink_error<T>(tags: &[&str], f: impl Future<Output = T>) -> 
     result
 }
 
+/// Runs and asserts sink error compliance.
 pub async fn run_and_assert_sink_error<S, I>(sink: VectorSink, events: S, tags: &[&str])
 where
     S: Stream<Item = I> + Send,


### PR DESCRIPTION
- Exposes more test utilities
- Moves `get_received` to test utility folder
- Adds missing docs due to linting error