### PR TITLE
chore(ci): Add a timeout to all CI jobs

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -128,6 +128,7 @@ jobs:
   # Detects changes that are not specific to integration tests
   source:
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     if: ${{ inputs.source }}
     outputs:
       source: ${{ steps.filter.outputs.source }}
@@ -195,6 +196,7 @@ jobs:
   # Detects changes that are specific to integration tests
   int_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ inputs.int_tests }}
     outputs:
       all-tests: ${{ steps.filter.outputs.all-tests}}
@@ -252,6 +254,7 @@ jobs:
   # Detects changes that are specific to e2e tests
   e2e_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ inputs.e2e_tests }}
     outputs:
       all-tests: ${{ steps.filter.outputs.all-tests}}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test-cli:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -48,6 +48,7 @@ jobs:
   validate:
     name: Validate comment
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: |
       github.event.issue.pull_request && ( contains(github.event.comment.body, '/ci-run-all')
           || contains(github.event.comment.body, '/ci-run-cli')

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   create_preview_site:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
 
     # Get the artifacts with the PR number and branch name

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -7,6 +7,7 @@ jobs:
   cross-linux:
     name: Cross - ${{ matrix.target }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CARGO_INCREMENTAL: 0
     strategy:
@@ -79,6 +80,7 @@ jobs:
   update-pr-status:
     name: (PR comment) Signal result to PR
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     needs: cross-linux
     if: needs.cross-linux.result == 'success' && github.event_name == 'issue_comment'
     steps:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   test-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: [linux, ubuntu-20.04-8core]
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: changes
     if: always() && (
       github.event_name == 'schedule' || (
@@ -59,7 +59,6 @@ jobs:
             || needs.changes.outputs.e2e-datadog-metrics == 'true'
         )
       )
-    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: [linux, ubuntu-20.04-8core]
+    timeout-minutes: 30
     needs: changes
     if: always() && (
       github.event_name == 'schedule' || (
@@ -101,6 +102,7 @@ jobs:
   e2e-test-suite:
     name: E2E Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     needs: e2e-tests
     env:

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   publish-new-environment:
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - name: (PR comment) Get PR branch
         if: ${{ github.event_name == 'issue_comment' }}

--- a/.github/workflows/gardener_issue_comment.yml
+++ b/.github/workflows/gardener_issue_comment.yml
@@ -14,6 +14,7 @@ jobs:
   move-to-backlog:
     name: Move issues back to Gardener project board Triage
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ !github.event.issue.pull_request }}
     steps:
       - name: Generate authentication token

--- a/.github/workflows/gardener_open_issue.yml
+++ b/.github/workflows/gardener_open_issue.yml
@@ -10,6 +10,7 @@ jobs:
   add-to-project:
     name: Add issue to Gardener project board
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/add-to-project@v0.5.0
         with:

--- a/.github/workflows/gardener_open_pr.yml
+++ b/.github/workflows/gardener_open_pr.yml
@@ -11,6 +11,7 @@ jobs:
   add-contributor-to-project:
     name: Add contributor PR to Gardener project board
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Generate authentication token
@@ -33,6 +34,7 @@ jobs:
   add-dependabot-to-project:
     name: Add dependabot PR to Gardener project board
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/add-to-project@v0.5.0

--- a/.github/workflows/gardener_remove_waiting_author.yml
+++ b/.github/workflows/gardener_remove_waiting_author.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   remove_label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions-ecosystem/action-remove-labels@v1

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -8,6 +8,7 @@ jobs:
 
   sync-install:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     steps:
       - name: (PR comment) Get PR branch
         if: ${{ github.event_name == 'issue_comment' }}
@@ -51,6 +52,7 @@ jobs:
   test-install:
     needs: sync-install
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     steps:
       - run: sudo apt-get install --yes curl bc
       - run:  curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y

--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -48,6 +48,7 @@ jobs:
   prep-pr:
     name: (PR comment) Signal pending to PR
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: contains(github.event.comment.body, '/ci-run-integration') || contains(github.event.comment.body, '/ci-run-all')
     steps:
       - name: Generate authentication token
@@ -82,6 +83,7 @@ jobs:
   integration-tests:
     needs: prep-pr
     runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
         with:
@@ -459,6 +461,7 @@ jobs:
   e2e-tests:
     needs: prep-pr
     runs-on: [linux, ubuntu-20.04-8core]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:
@@ -490,6 +493,7 @@ jobs:
   update-pr-status:
     name: Signal result to PR
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - integration-tests
       - e2e-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -414,6 +414,7 @@ jobs:
   integration-test-suite:
     name: Integration Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     needs:
       - changes

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -60,6 +60,7 @@ jobs:
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu
     runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 45
     needs: changes
     # Run this job even if `changes` job is skipped (non- pull request trigger)
     if: ${{ !failure() && !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.k8s == 'true') }}
@@ -126,6 +127,7 @@ jobs:
   compute-k8s-test-plan:
     name: Compute K8s test plan
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: changes
     # Run this job even if `changes` job is skipped
     if: ${{ !failure() && !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.k8s == 'true') }}
@@ -180,6 +182,7 @@ jobs:
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
     runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 45
     needs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
@@ -233,6 +236,7 @@ jobs:
   final-result:
     name: K8s E2E Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - changes
       - build-x86_64-unknown-linux-gnu

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   label:
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/master_merge_queue.yml
+++ b/.github/workflows/master_merge_queue.yml
@@ -105,6 +105,7 @@ jobs:
     # Always run this so that pull_request triggers are marked as success.
     if: always()
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     needs:
       - changes
       - test-cli

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test-misc:
     runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 45
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   check-msrv:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - run: sudo -E bash scripts/environment/bootstrap-ubuntu-20.04.sh

--- a/.github/workflows/preview_site_trigger.yml
+++ b/.github/workflows/preview_site_trigger.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   approval_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ ! contains(github.head_ref, 'dependabot*') && ! contains(github.head_ref, 'gh-readonly-queue*') }}
     steps:
       - name: Echo approval

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   validate-protos:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # Run `git checkout`
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
   generate-publish-metadata:
     name: Generate Publish-related Metadata
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     outputs:
       vector_version: ${{ steps.generate-publish-metadata.outputs.vector_version }}
       vector_build_desc: ${{ steps.generate-publish-metadata.outputs.vector_build_desc }}
@@ -45,6 +46,7 @@ jobs:
   build-x86_64-unknown-linux-musl-packages:
     name: Build Vector for x86_64-unknown-linux-musl (.tar.gz)
     runs-on: [linux, release-builder]
+    timeout-minutes: 60
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -71,6 +73,7 @@ jobs:
     name: Build Vector for x86_64-unknown-linux-gnu (.tar.gz, DEB, RPM)
     runs-on: [linux, release-builder]
     needs: generate-publish-metadata
+    timeout-minutes: 60
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       VECTOR_BUILD_DESC: ${{ needs.generate-publish-metadata.outputs.vector_build_desc }}
@@ -95,6 +98,7 @@ jobs:
   build-aarch64-unknown-linux-musl-packages:
     name: Build Vector for aarch64-unknown-linux-musl (.tar.gz)
     runs-on: [linux, release-builder]
+    timeout-minutes: 60
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -122,6 +126,7 @@ jobs:
   build-aarch64-unknown-linux-gnu-packages:
     name: Build Vector for aarch64-unknown-linux-gnu (.tar.gz)
     runs-on: [linux, release-builder]
+    timeout-minutes: 60
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -149,6 +154,7 @@ jobs:
   build-armv7-unknown-linux-gnueabihf-packages:
     name: Build Vector for armv7-unknown-linux-gnueabihf (.tar.gz)
     runs-on: [linux, release-builder]
+    timeout-minutes: 60
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -176,6 +182,7 @@ jobs:
   build-armv7-unknown-linux-musleabihf-packages:
     name: Build Vector for armv7-unknown-linux-musleabihf (.tar.gz)
     runs-on: [linux, release-builder]
+    timeout-minutes: 60
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -203,6 +210,7 @@ jobs:
   build-x86_64-apple-darwin-packages:
     name: Build Vector for x86_64-apple-darwin (.tar.gz)
     runs-on: macos-latest-xl
+    timeout-minutes: 90
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -231,6 +239,7 @@ jobs:
   build-x86_64-pc-windows-msvc-packages:
     name: Build Vector for x86_64-pc-windows-msvc (.zip)
     runs-on: [windows, release-builder]
+    timeout-minutes: 90
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -277,6 +286,7 @@ jobs:
   deb-verify:
     name: Verify DEB Packages
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages
@@ -322,6 +332,7 @@ jobs:
   rpm-verify:
     name: Verify RPM Packages
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages
@@ -371,6 +382,7 @@ jobs:
   macos-verify:
     name: Verify macOS Package
     runs-on: macos-12
+    timeout-minutes: 5
     needs:
       - generate-publish-metadata
       - build-x86_64-apple-darwin-packages
@@ -393,6 +405,7 @@ jobs:
   publish-docker:
     name: Publish to Docker
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     needs:
       - generate-publish-metadata
       - build-aarch64-unknown-linux-gnu-packages
@@ -465,6 +478,7 @@ jobs:
   publish-s3:
     name: Publish to S3
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages
@@ -537,6 +551,7 @@ jobs:
     # We only publish to GitHub for versioned releases, not nightlies.
     if: inputs.channel == 'release'
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages
@@ -613,6 +628,7 @@ jobs:
     # We only publish to Homebrew for versioned releases, not nightlies.
     if: inputs.channel == 'release'
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     needs:
       - generate-publish-metadata
       - publish-s3
@@ -631,6 +647,7 @@ jobs:
   generate-sha256sum:
     name: Generate SHA256 checksums
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     needs:
       - generate-publish-metadata
       - build-x86_64-unknown-linux-gnu-packages

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -47,6 +47,7 @@ jobs:
   # Only run this workflow if files changed in areas that could possibly introduce a regression
   should-run:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name != 'pull_request'
     outputs:
       source_changed: ${{ steps.filter.outputs.SOURCE_CHANGED }}
@@ -110,6 +111,7 @@ jobs:
   compute-metadata:
     name: Compute metadata
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     needs: should-run
     if: github.event_name != 'merge_group' || needs.should-run.outputs.source_changed == 'true'
     outputs:
@@ -286,6 +288,7 @@ jobs:
   build-baseline:
     name: Build baseline Vector container
     runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 30
     needs:
       - compute-metadata
     steps:
@@ -323,6 +326,7 @@ jobs:
   build-comparison:
     name: Build comparison Vector container
     runs-on: [linux, ubuntu-20.04-4core]
+    timeout-minutes: 30
     needs:
       - compute-metadata
     steps:
@@ -360,6 +364,7 @@ jobs:
   confirm-valid-credentials:
     name: Confirm AWS credentials are minimally valid
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     needs:
       - compute-metadata
     steps:
@@ -381,6 +386,7 @@ jobs:
   upload-baseline-image-to-ecr:
     name: Upload baseline images to ECR
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     needs:
       - compute-metadata
       - confirm-valid-credentials
@@ -419,6 +425,7 @@ jobs:
   upload-comparison-image-to-ecr:
     name: Upload comparison images to ECR
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     needs:
       - compute-metadata
       - confirm-valid-credentials
@@ -457,6 +464,7 @@ jobs:
   submit-job:
     name: Submit regression job
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     needs:
       - compute-metadata
       - upload-baseline-image-to-ecr
@@ -593,6 +601,7 @@ jobs:
   detect-regression:
     name: Determine regression status
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     needs:
       - submit-job
       - compute-metadata
@@ -669,6 +678,7 @@ jobs:
   analyze-experiment:
     name: Download regression analysis & upload report
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     needs:
       - submit-job
       - compute-metadata
@@ -782,6 +792,7 @@ jobs:
   regression-detection-suite:
     name: Regression Detection Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     needs:
       - compute-metadata

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -78,6 +78,7 @@ jobs:
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: "contains(github.event_name, 'pull_request') || github.event_name == 'push'"
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
   checks:
     name: Checks
     runs-on: [linux, ubuntu-20.04-8core]
+    timeout-minutes: 45
     needs: changes
     env:
       CARGO_INCREMENTAL: 0
@@ -122,6 +123,7 @@ jobs:
   all-checks:
     name: Test Suite
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     if: always()
     needs: [changes, checks]
     env:

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   unit-mac:
     runs-on: macos-13
+    timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: 0
     steps:

--- a/.github/workflows/unit_windows.yml
+++ b/.github/workflows/unit_windows.yml
@@ -7,6 +7,7 @@ jobs:
 
   test-windows:
     runs-on: [windows, windows-2019-8core]
+    timeout-minutes: 60
     steps:
       - name: (PR comment) Get PR branch
         if: ${{ github.event_name == 'issue_comment' }}

--- a/.github/workflows/workload_checks.yml
+++ b/.github/workflows/workload_checks.yml
@@ -30,6 +30,7 @@ jobs:
   compute-metadata:
     name: Compute metadata
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       replicas: ${{ steps.experimental-meta.outputs.REPLICAS }}
       warmup-seconds: ${{ steps.experimental-meta.outputs.WARMUP_SECONDS }}
@@ -81,6 +82,7 @@ jobs:
   submit-job:
     name: Submit workload checks job
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs:
       - compute-metadata
     steps:


### PR DESCRIPTION
To override the default of 6 hours. This'll let us bump up the merge queue timeout.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
