### PR TITLE
docs(remap transform): Fix `drop_on_abort` docs

### DIFF
--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -105,11 +105,9 @@ pub struct RemapConfig {
 
     /// Drops any event that is manually aborted during processing.
     ///
-    /// Normally, if a VRL program is manually aborted (using [`abort`][vrl_docs_abort]) when
-    /// processing an event, the original, unmodified event is sent downstream. In some cases,
-    /// you may not wish to send the event any further, such as if certain transformation or
-    /// enrichment is strictly required. Setting `drop_on_abort` to `true` allows you to ensure
-    /// these events do not get processed any further.
+    /// If a VRL program is manually aborted (using [`abort`][vrl_docs_abort]) when
+    /// processing an event, this option controls whether the original, unmodified event is sent
+    /// downstream without any modifications or if it is dropped.
     ///
     /// Additionally, dropped events can potentially be diverted to a specially-named output for
     /// further logging and analysis by setting `reroute_dropped`.

--- a/website/cue/reference/components/transforms/base/remap.cue
+++ b/website/cue/reference/components/transforms/base/remap.cue
@@ -5,11 +5,9 @@ base: components: transforms: remap: configuration: {
 		description: """
 			Drops any event that is manually aborted during processing.
 
-			Normally, if a VRL program is manually aborted (using [`abort`][vrl_docs_abort]) when
-			processing an event, the original, unmodified event is sent downstream. In some cases,
-			you may not wish to send the event any further, such as if certain transformation or
-			enrichment is strictly required. Setting `drop_on_abort` to `true` allows you to ensure
-			these events do not get processed any further.
+			If a VRL program is manually aborted (using [`abort`][vrl_docs_abort]) when
+			processing an event, this option controls whether the original, unmodified event is sent
+			downstream without any modifications or if it is dropped.
 
 			Additionally, dropped events can potentially be diverted to a specially-named output for
 			further logging and analysis by setting `reroute_dropped`.


### PR DESCRIPTION
The docs assumed the default was `false` when it is actually `true`. I slimmed them down so that
they don't refer to the default.

Fixes: #19916

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
