### PR TITLE
chore(dev): Update release instructions for deploying vector.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -49,6 +49,6 @@ On the day of release:
 - [ ] Add docker images to [https://github.com/DataDog/images](https://github.com/DataDog/images/tree/master/vector) to have them available internally.
 - [ ] Cherry-pick any release commits from the release branch that are not on `master`, to `master`
 - [ ] Bump the release number in the `Cargo.toml` on master to the next major release
-- [ ] Drop a note in the #websites Slack channel to request an update of the branch deployed
-      at https://vector.dev to the new release branch.
+- [ ] Reset the `website` branch to the `HEAD` of the release branch to update https://vector.dev
+  - [ ] `git checkout website && git reset --hard origin/v0.<new version number> && git push`
 - [ ] Kick-off post-mortems for any regressions resolved by the release

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -51,4 +51,6 @@ On the day of release:
 - [ ] Add docker images to [https://github.com/DataDog/images](https://github.com/DataDog/images/tree/master/vector) to have them available internally.
   - Follow the [instructions at the top of the mirror.yaml file](https://github.com/DataDog/images/blob/fbf12868e90d52e513ebca0389610dea8a3c7e1a/mirror.yaml#L33-L49).
 - [ ] Cherry-pick any release commits from the release branch that are not on `master`, to `master`
+- [ ] Reset the `website` branch to the `HEAD` of the release branch to update https://vector.dev
+  - [ ] `git checkout website && git reset --hard origin/v0.<current minor version>.<patch> && git push`
 - [ ] Kick-off post-mortems for any regressions resolved by the release


### PR DESCRIPTION
We've switched to having a long-running branch representing what to deploy to vector.dev to reduce coordination.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
