### PR TITLE
feat(dnsmsg_parser): add support for EDNS EDE fields

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -164,6 +164,7 @@ pront
 Proscan
 Qmobilevn
 RPZ
+RRSIGs
 Rackspace
 Rathi
 Regza
@@ -282,6 +283,7 @@ dnsutils
 dockercmd
 downsides
 downwardapi
+ede
 emoji
 esbuild
 etld

--- a/changelog.d/19937_edns_ede_support.feature.md
+++ b/changelog.d/19937_edns_ede_support.feature.md
@@ -1,0 +1,3 @@
+Added support for parsing EDNS EDE (Extended DNS errors) options
+
+authors: esensar

--- a/lib/dnsmsg-parser/src/dns_message.rs
+++ b/lib/dnsmsg-parser/src/dns_message.rs
@@ -1,5 +1,7 @@
 use hickory_proto::op::ResponseCode;
 
+use crate::ede::EDE;
+
 pub(super) const RTYPE_MB: u16 = 7;
 pub(super) const RTYPE_MG: u16 = 8;
 pub(super) const RTYPE_MR: u16 = 9;
@@ -81,6 +83,7 @@ pub struct OptPseudoSection {
     pub version: u8,
     pub dnssec_ok: bool,
     pub udp_max_payload_size: u16,
+    pub ede: Vec<EDE>,
     pub options: Vec<EdnsOptionEntry>,
 }
 

--- a/lib/dnsmsg-parser/src/ede.rs
+++ b/lib/dnsmsg-parser/src/ede.rs
@@ -1,0 +1,98 @@
+use hickory_proto::{
+    error::ProtoResult,
+    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder},
+};
+
+pub const EDE_OPTION_CODE: u16 = 15u16;
+
+#[derive(Debug, Clone)]
+pub struct EDE {
+    info_code: u16,
+    extra_text: Option<String>,
+}
+
+impl EDE {
+    pub fn new(info_code: u16, extra_text: Option<String>) -> Self {
+        Self {
+            info_code,
+            extra_text,
+        }
+    }
+
+    /// Returns the length in bytes of the EdnsOption
+    pub fn len(&self) -> u16 {
+        2 + self.extra_text.as_ref().map(|s| s.len()).unwrap_or(0) as u16
+    }
+
+    // https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes
+    pub fn purpose(&self) -> Option<&str> {
+        match self.info_code {
+            0 => Some("Other Error"),
+            1 => Some("Unsupported DNSKEY Algorithm"),
+            2 => Some("Unsupported DS Digest Type"),
+            3 => Some("Stale Answer"),
+            4 => Some("Forged Answer"),
+            5 => Some("DNSSEC Indeterminate"),
+            6 => Some("DNSSEC Bogus"),
+            7 => Some("Signature Expired"),
+            8 => Some("Signature Not Yet Valid"),
+            9 => Some("DNSKEY Missing"),
+            10 => Some("RRSIGs Missing"),
+            11 => Some("No Zone Key Bit Set"),
+            12 => Some("NSEC Missing"),
+            13 => Some("Cached Error"),
+            14 => Some("Not Ready"),
+            15 => Some("Blocked"),
+            16 => Some("Censored"),
+            17 => Some("Filtered"),
+            18 => Some("Prohibited"),
+            19 => Some("Stale NXDomain Answer"),
+            20 => Some("Not Authoritative"),
+            21 => Some("Not Supported"),
+            22 => Some("No Reachable Authority"),
+            23 => Some("Network Error"),
+            24 => Some("Invalid Data"),
+            25 => Some("Signature Expired before Valid"),
+            26 => Some("Too Early"),
+            27 => Some("Unsupported NSEC3 Interations Value"),
+            28 => Some("Unable to conform to policy"),
+            29 => Some("Synthesized"),
+            _ => None,
+        }
+    }
+
+    pub fn info_code(&self) -> u16 {
+        self.info_code
+    }
+
+    pub fn extra_text(&self) -> Option<String> {
+        self.extra_text.clone()
+    }
+}
+
+impl BinEncodable for EDE {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        encoder.emit_u16(self.info_code)?;
+        if let Some(extra_text) = &self.extra_text {
+            encoder.emit_vec(extra_text.as_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> BinDecodable<'a> for EDE {
+    fn read(decoder: &mut BinDecoder<'a>) -> ProtoResult<Self> {
+        let info_code = decoder.read_u16()?.unverified();
+        if decoder.len() == 0 {
+            return Ok(Self {
+                info_code,
+                extra_text: None,
+            });
+        }
+        let extra_text = String::from_utf8(decoder.read_vec(decoder.len())?.unverified())?;
+        Ok(Self {
+            info_code,
+            extra_text: Some(extra_text),
+        })
+    }
+}

--- a/lib/dnsmsg-parser/src/ede.rs
+++ b/lib/dnsmsg-parser/src/ede.rs
@@ -19,15 +19,6 @@ impl EDE {
         }
     }
 
-    /// Returns the length in bytes of the EdnsOption
-    pub fn len(&self) -> u16 {
-        2 + self.extra_text.as_ref().map(|s| s.len()).unwrap_or(0) as u16
-    }
-
-    pub fn is_empty(&self) -> bool {
-        false
-    }
-
     // https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes
     pub fn purpose(&self) -> Option<&str> {
         match self.info_code {

--- a/lib/dnsmsg-parser/src/ede.rs
+++ b/lib/dnsmsg-parser/src/ede.rs
@@ -54,7 +54,7 @@ impl EDE {
             24 => Some("Invalid Data"),
             25 => Some("Signature Expired before Valid"),
             26 => Some("Too Early"),
-            27 => Some("Unsupported NSEC3 Interations Value"),
+            27 => Some("Unsupported NSEC3 Iterations Value"),
             28 => Some("Unable to conform to policy"),
             29 => Some("Synthesized"),
             _ => None,

--- a/lib/dnsmsg-parser/src/ede.rs
+++ b/lib/dnsmsg-parser/src/ede.rs
@@ -83,16 +83,16 @@ impl BinEncodable for EDE {
 impl<'a> BinDecodable<'a> for EDE {
     fn read(decoder: &mut BinDecoder<'a>) -> ProtoResult<Self> {
         let info_code = decoder.read_u16()?.unverified();
-        if decoder.len() == 0 {
-            return Ok(Self {
-                info_code,
-                extra_text: None,
-            });
-        }
-        let extra_text = String::from_utf8(decoder.read_vec(decoder.len())?.unverified())?;
+        let extra_text = if decoder.len() == 0 {
+            None
+        } else {
+            Some(String::from_utf8(
+                decoder.read_vec(decoder.len())?.unverified(),
+            )?)
+        };
         Ok(Self {
             info_code,
-            extra_text: Some(extra_text),
+            extra_text,
         })
     }
 }

--- a/lib/dnsmsg-parser/src/ede.rs
+++ b/lib/dnsmsg-parser/src/ede.rs
@@ -24,6 +24,10 @@ impl EDE {
         2 + self.extra_text.as_ref().map(|s| s.len()).unwrap_or(0) as u16
     }
 
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
     // https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes
     pub fn purpose(&self) -> Option<&str> {
         match self.info_code {
@@ -83,7 +87,7 @@ impl BinEncodable for EDE {
 impl<'a> BinDecodable<'a> for EDE {
     fn read(decoder: &mut BinDecoder<'a>) -> ProtoResult<Self> {
         let info_code = decoder.read_u16()?.unverified();
-        let extra_text = if decoder.len() == 0 {
+        let extra_text = if decoder.is_empty() {
             None
         } else {
             Some(String::from_utf8(

--- a/lib/dnsmsg-parser/src/lib.rs
+++ b/lib/dnsmsg-parser/src/lib.rs
@@ -9,3 +9,4 @@
 
 pub mod dns_message;
 pub mod dns_message_parser;
+pub mod ede;

--- a/src/sources/dnstap/schema.rs
+++ b/src/sources/dnstap/schema.rs
@@ -254,7 +254,13 @@ pub struct DnstapPaths {
     pub version: OwnedValuePath,
     pub do_flag: OwnedValuePath,
     pub udp_max_payload_size: OwnedValuePath,
+    pub ede: OwnedValuePath,
     pub options: OwnedValuePath,
+
+    // DnsMessageEdeOptionSchema
+    pub info_code: OwnedValuePath,
+    pub purpose: OwnedValuePath,
+    pub extra_text: OwnedValuePath,
 
     // DnsMessageOptionSchema
     pub opt_code: OwnedValuePath,
@@ -336,7 +342,11 @@ pub(crate) static DNSTAP_VALUE_PATHS: Lazy<DnstapPaths> = Lazy::new(|| DnstapPat
     version: owned_value_path!("ednsVersion"),
     do_flag: owned_value_path!("do"),
     udp_max_payload_size: owned_value_path!("udpPayloadSize"),
+    ede: owned_value_path!("ede"),
     options: owned_value_path!("options"),
+    info_code: owned_value_path!("infoCode"),
+    purpose: owned_value_path!("purpose"),
+    extra_text: owned_value_path!("extraText"),
     opt_code: owned_value_path!("optCode"),
     opt_name: owned_value_path!("optName"),
     opt_data: owned_value_path!("optValue"),
@@ -412,6 +422,20 @@ impl DnsMessageOptPseudoSectionSchema {
             DNSTAP_VALUE_PATHS.options.to_string() => Kind::array(
                 Collection::from_unknown(Kind::object(DnsMessageOptionSchema::schema_definition()))
             ).or_undefined(),
+        }
+        .into()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DnsMessageEdeOptionSchema;
+
+impl DnsMessageEdeOptionSchema {
+    pub fn schema_definition() -> Collection<Field> {
+        btreemap! {
+            DNSTAP_VALUE_PATHS.info_code.to_string() => Kind::integer(),
+            DNSTAP_VALUE_PATHS.purpose.to_string() => Kind::bytes(),
+            DNSTAP_VALUE_PATHS.extra_text.to_string() => Kind::bytes(),
         }
         .into()
     }

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -809,8 +809,47 @@ components: sources: dnstap: {
 										]
 										"udpPayloadSize": 4096
 									},
+									{
+										"do":            false
+										"ednsVersion":   0
+										"extendedRcode": 0
+										"options": [
+											{
+												"optCode":  10
+												"optName":  "Cookie"
+												"optValue": "hbbDFmHUM9wBAAAAX1q1McL4KhalWTS3"
+											},
+										]
+										"ede": [
+											{
+												"infoCode":  9
+												"purpose":   "DNSKEY Missing"
+												"extraText": "Additional description"
+											},
+										]
+										"udpPayloadSize": 4096
+									},
 								]
-								options: {}
+								options: {
+									ede: {
+										required:    false
+										description: """
+										Extended DNS errors. Provides additional information about
+										the DNS failure. See [RFC 8914](\(urls.rfc_8914)) for
+										detailed information.
+										"""
+										type: array: items: type: object: {
+											examples: [
+												{
+													"infoCode":  9
+													"purpose":   "DNSKEY Missing"
+													"extraText": "Additional description"
+												},
+											]
+											options: {}
+										}
+									}
+								}
 							}
 						}
 						zone: {

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -444,6 +444,7 @@ urls: {
 	rfc_4180:                                   "https://tools.ietf.org/html/rfc4180"
 	rfc_6587_3_4_1:                             "https://tools.ietf.org/html/rfc6587#section-3.4.1"
 	rfc_6891:                                   "https://tools.ietf.org/html/rfc6891"
+	rfc_8914:                                   "https://tools.ietf.org/html/rfc8914"
 	rhel:                                       "https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux"
 	rpm:                                        "https://rpm.org/"
 	rust:                                       "https://www.rust-lang.org/"


### PR DESCRIPTION
This adds support for EDNS extended DNS errors. This implementation is slightly different compared to original proposal in #19871, in that it does not return `ede` as a direct child of `responseData`, but rather in `opt` field of `responseData`, since that is where other EDNS options are located.

Fixes: #19871