### PR TITLE
fix(splunk_hec source): calculate `EstimatedJsonSizeOf` for `component_received_event_bytes_total` before enrichment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -898,7 +898,7 @@ enterprise-tests = [
 component-validation-runner = ["dep:tonic", "sources-internal_logs", "sources-internal_metrics", "sources-vector", "sinks-vector"]
 # For now, only include components that implement ValidatableComponent.
 # In the future, this can change to simply reference the targets `sources`, `transforms`, `sinks`
-component-validation-tests = ["component-validation-runner", "sources-http_client", "sources-http_server", "sinks-http"]
+component-validation-tests = ["component-validation-runner", "sources-http_client", "sources-http_server", "sinks-http", "sources-splunk_hec"]
 
 # Grouping together features for benchmarks. We exclude the API client due to it causing the build process to run out
 # of memory when those additional dependencies are built in CI.

--- a/changelog.d/splunk_hec_received_event_bytes.fix.md
+++ b/changelog.d/splunk_hec_received_event_bytes.fix.md
@@ -1,0 +1,3 @@
+We now correctly calculate the estimated JSON size in bytes for the metric `component_received_event_bytes_total` for the `splunk_hec` source.
+
+Previously this was being calculated after event enrichment. It is now calculated before enrichment, for both `raw` and `event` endpoints.

--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -10,6 +10,7 @@ use crate::config::{BoxedSink, BoxedSource, BoxedTransform};
 
 /// For components implementing `ValidatableComponent`
 pub mod prelude {
+    pub use super::ComponentTestCaseConfig;
     pub use super::ExternalResource;
     pub use super::HttpResourceConfig;
     pub use super::ResourceDirection;

--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -8,6 +8,16 @@ mod validators;
 
 use crate::config::{BoxedSink, BoxedSource, BoxedTransform};
 
+/// For components implementing `ValidatableComponent`
+pub mod prelude {
+    pub use super::ExternalResource;
+    pub use super::HttpResourceConfig;
+    pub use super::ResourceDirection;
+    pub use super::ValidatableComponent;
+    pub use super::ValidationConfiguration;
+    pub use crate::register_validatable_component;
+}
+
 pub use self::resources::*;
 #[cfg(feature = "component-validation-runner")]
 pub use self::runner::*;
@@ -272,6 +282,7 @@ mod tests {
     #[test_resources("tests/validation/components/**/*.yaml")]
     fn validate_component(test_case_data_path: &str) {
         let test_case_data_path = PathBuf::from(test_case_data_path.to_string());
+
         if !test_case_data_path.exists() {
             panic!("Component validation test invoked with path to test case data that could not be found: {}", test_case_data_path.to_string_lossy());
         }

--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -38,7 +38,7 @@ pub enum RawTestEvent {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(untagged)]
+#[serde(rename_all = "snake_case")]
 pub enum EventData {
     /// A simple log event.
     Log(String),

--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bytes::BytesMut;
 use serde::Deserialize;
 use snafu::Snafu;
@@ -38,8 +40,10 @@ pub enum RawTestEvent {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum EventData {
-    /// A log event.
+    /// A simple log event.
     Log(String),
+    /// A log event built from key-value pairs
+    LogBuilder(HashMap<String, String>),
 }
 
 impl EventData {
@@ -47,6 +51,13 @@ impl EventData {
     pub fn into_event(self) -> Event {
         match self {
             Self::Log(message) => Event::Log(LogEvent::from_bytes_legacy(&message.into())),
+            Self::LogBuilder(data) => {
+                let mut log_event = LogEvent::default();
+                for (k, v) in data {
+                    log_event.parse_path_and_insert(k, v).unwrap();
+                }
+                Event::Log(log_event)
+            }
         }
     }
 }

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     future::Future,
     net::{IpAddr, SocketAddr},
     str::FromStr,
@@ -33,11 +33,21 @@ use super::{encode_test_event, ResourceCodec, ResourceDirection, TestEvent};
 pub struct HttpResourceConfig {
     uri: Uri,
     method: Option<Method>,
+    headers: Option<HashMap<String, String>>,
 }
 
 impl HttpResourceConfig {
     pub const fn from_parts(uri: Uri, method: Option<Method>) -> Self {
-        Self { uri, method }
+        Self {
+            uri,
+            method,
+            headers: None,
+        }
+    }
+
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = Some(headers);
+        self
     }
 
     pub fn spawn_as_input(
@@ -219,6 +229,7 @@ fn spawn_input_http_client(
         let client = Client::builder().build_http::<Body>();
         let request_uri = config.uri;
         let request_method = config.method.unwrap_or(Method::POST);
+        let headers = config.headers.unwrap_or_default();
 
         while let Some(event) = input_rx.recv().await {
             debug!("Got event to send from runner.");
@@ -226,9 +237,15 @@ fn spawn_input_http_client(
             let mut buffer = BytesMut::new();
             encode_test_event(&mut encoder, &mut buffer, event);
 
-            let request = Request::builder()
+            let mut request_builder = Request::builder()
                 .uri(request_uri.clone())
-                .method(request_method.clone())
+                .method(request_method.clone());
+
+            for header in &headers {
+                request_builder = request_builder.header(header.0, header.1);
+            }
+
+            let request = request_builder
                 .body(buffer.freeze().into())
                 .expect("should not fail to build request");
 

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -634,10 +634,15 @@ fn spawn_input_driver(
             if !failure_case || component_type == ComponentType::Sink {
                 input_runner_metrics.sent_events_total += 1;
 
-                // The event is wrapped in a Vec to match the actual event storage in
-                // the real topology
-                // input_runner_metrics.sent_event_bytes_total +=
-                //     vec![event].estimated_json_encoded_size_of().get() as u64;
+                // This particular metric is tricky because a component can run the
+                // EstimatedJsonSizeOf calculation on a single event or an array of
+                // events. If it's an array of events, the size calculation includes
+                // the size of bracket ('[', ']') characters... But we have no way
+                // of knowing which case it will be. Indeed, there are even components
+                // where BOTH scenarios are possible, depending on how the component
+                // is configured.
+                // This is handled in the component spec validator code where we compare
+                // the actual to the expected.
                 input_runner_metrics.sent_event_bytes_total +=
                     event.estimated_json_encoded_size_of().get() as u64;
             }

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -205,6 +205,14 @@ impl Runner {
 
         let test_cases = load_component_test_cases(&self.test_case_data_path)?;
         for test_case in test_cases {
+            println!("");
+            println!("");
+            info!(
+                "Running test '{}' case for component '{}' (type: {:?})...",
+                test_case.name,
+                self.configuration.component_name,
+                self.configuration.component_type()
+            );
             // Create a task coordinator for each relevant phase of the test.
             //
             // This provides us the granularity to know when the tasks associated with each phase

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -636,8 +636,10 @@ fn spawn_input_driver(
 
                 // The event is wrapped in a Vec to match the actual event storage in
                 // the real topology
+                // input_runner_metrics.sent_event_bytes_total +=
+                //     vec![event].estimated_json_encoded_size_of().get() as u64;
                 input_runner_metrics.sent_event_bytes_total +=
-                    vec![event].estimated_json_encoded_size_of().get() as u64;
+                    event.estimated_json_encoded_size_of().get() as u64;
             }
         }
         info!("Input driver sent all events.");

--- a/src/components/validation/validators/component_spec/mod.rs
+++ b/src/components/validation/validators/component_spec/mod.rs
@@ -30,6 +30,8 @@ impl Validator for ComponentSpecValidator {
         telemetry_events: &[Event],
         runner_metrics: &RunnerMetrics,
     ) -> Result<Vec<String>, Vec<String>> {
+        let expect_received_events = inputs.iter().filter(|te| *te.should_fail()).count();
+
         for input in inputs {
             info!("Validator observed input event: {:?}", input);
         }
@@ -79,7 +81,12 @@ impl Validator for ComponentSpecValidator {
             format!("received {} telemetry events", telemetry_events.len()),
         ];
 
-        let out = validate_telemetry(component_type, telemetry_events, runner_metrics)?;
+        let out = validate_telemetry(
+            component_type,
+            telemetry_events,
+            runner_metrics,
+            expect_received_events,
+        )?;
         run_out.extend(out);
 
         Ok(run_out)
@@ -90,6 +97,7 @@ fn validate_telemetry(
     component_type: ComponentType,
     telemetry_events: &[Event],
     runner_metrics: &RunnerMetrics,
+    expect_received_events: u64,
 ) -> Result<Vec<String>, Vec<String>> {
     let mut out: Vec<String> = Vec::new();
     let mut errs: Vec<String> = Vec::new();
@@ -111,6 +119,7 @@ fn validate_telemetry(
             runner_metrics,
             metric_type,
             component_type,
+            expect_received_events,
         ) {
             Err(e) => errs.extend(e),
             Ok(m) => out.extend(m),
@@ -129,6 +138,7 @@ fn validate_metric(
     runner_metrics: &RunnerMetrics,
     metric_type: &ComponentMetricType,
     component_type: ComponentType,
+    expect_received_events: u64,
 ) -> Result<Vec<String>, Vec<String>> {
     let component_id = match component_type {
         ComponentType::Source => TEST_SOURCE_NAME,
@@ -179,7 +189,13 @@ fn validate_metric(
         ComponentMetricType::DiscardedEventsTotal => runner_metrics.discarded_events_total,
     };
 
-    compare_actual_to_expected(telemetry_events, metric_type, component_id, expected)
+    compare_actual_to_expected(
+        telemetry_events,
+        metric_type,
+        component_id,
+        expected,
+        expect_received_events,
+    )
 }
 
 fn filter_events_by_metric_and_component<'a>(
@@ -253,6 +269,7 @@ fn compare_actual_to_expected(
     metric_type: &ComponentMetricType,
     component_id: &str,
     expected: u64,
+    expect_received_events: u64,
 ) -> Result<Vec<String>, Vec<String>> {
     let mut errs: Vec<String> = Vec::new();
 
@@ -263,7 +280,15 @@ fn compare_actual_to_expected(
 
     info!("{}: expected {}, actual {}.", metric_type, expected, actual,);
 
-    if actual != expected {
+    if actual != expected
+        // This is a bit messy. The issue is that EstimatedJsonSizeOf can be called by a component
+        // on an event array, or on a single event. And we have no way of knowing which that is.
+        // By default the input driver for the framework is not assuming it is an array, so we
+        // check here if it matches what the array scenario would be, which is to add the size of
+        // the brackets, for each event.
+        || (metric_type == ComponentMetricType::EventsReceivedBytes
+            && actual == expected + (expect_received_events * 2))
+    {
         errs.push(format!(
             "{}: expected {}, but received {}",
             metric_type, expected, actual

--- a/src/components/validation/validators/mod.rs
+++ b/src/components/validation/validators/mod.rs
@@ -52,6 +52,7 @@ impl From<StandardValidators> for Box<dyn Validator> {
     }
 }
 
+#[derive(PartialEq)]
 pub enum ComponentMetricType {
     EventsReceived,
     EventsReceivedBytes,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -158,7 +158,14 @@ impl ValidatableComponent for SplunkConfig {
             DecodingConfig::new(framing, decoding, false.into()),
         );
 
-        ValidationConfiguration::from_source(Self::NAME, config, Some(external_resource))
+        ValidationConfiguration::from_source(
+            Self::NAME,
+            vec![ComponentTestCaseConfig::from_source(
+                config,
+                None,
+                Some(external_resource),
+            )],
+        )
     }
 }
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -147,7 +147,7 @@ impl ValidatableComponent for SplunkConfig {
         let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
 
         let framing = BytesDecoderConfig::new().into();
-        let decoding = BytesDeserializerConfig::default().into();
+        let decoding = BytesDeserializerConfig.into();
 
         let external_resource = ExternalResource::new(
             ResourceDirection::Push,
@@ -680,6 +680,7 @@ struct EventIterator<'de, R: JsonRead<'de>> {
 }
 
 impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         deserializer: serde_json::StreamDeserializer<'de, R, JsonValue>,
         channel: Option<String>,

--- a/tests/validation/components/sinks/http.yaml
+++ b/tests/validation/components/sinks/http.yaml
@@ -1,10 +1,11 @@
 - name: happy path
   expectation: success
   events:
-    - simple message 1
-    - simple message 2
-    - simple message 3
+    - log: simple message 1
+    - log: simple message 2
+    - log: simple message 3
 - name: sad path
   expectation: failure
   events:
-    - external_resource_rejects: simple message downstream rejects
+    - external_resource_rejects:
+        log: simple message downstream rejects

--- a/tests/validation/components/sources/http_client.yaml
+++ b/tests/validation/components/sources/http_client.yaml
@@ -1,12 +1,13 @@
 - name: happy path
   expectation: success
   events:
-    - simple message 1
-    - simple message 2
-    - simple message 3
+    - log: simple message 1
+    - log: simple message 2
+    - log: simple message 3
 - name: sad path
   expectation: partial_success
   events:
-    - simple message 1
-    - simple message 2
-    - fail_encoding_of: simple message with the wrong encoding
+    - log: simple message 1
+    - log: simple message 2
+    - fail_encoding_of:
+        log: simple message with the wrong encoding

--- a/tests/validation/components/sources/http_server.yaml
+++ b/tests/validation/components/sources/http_server.yaml
@@ -1,12 +1,13 @@
 - name: happy path
   expectation: success
   events:
-    - simple message 1
-    - simple message 2
-    - simple message 3
+    - log: simple message 1
+    - log: simple message 2
+    - log: simple message 3
 - name: sad path
   expectation: partial_success
   events:
-    - simple message 1
-    - simple message 2
-    - fail_encoding_of: simple message with the wrong encoding
+    - log: simple message 1
+    - log: simple message 2
+    - fail_encoding_of:
+        log: simple message with the wrong encoding

--- a/tests/validation/components/sources/splunk_hec.yaml
+++ b/tests/validation/components/sources/splunk_hec.yaml
@@ -1,13 +1,19 @@
 - name: happy path
   expectation: success
   events:
-    - event: simple message 1
-    - event: simple message 2
-    - event: simple message 3
+    - log_builder:
+        event: simple message 1
+    - log_builder:
+        event: simple message 2
+    - log_builder:
+        event: simple message 3
 - name: sad path
   expectation: partial_success
   events:
-    - event: simple message 1
-    - event: simple message 2
+    - log_builder:
+        event: simple message 1
+    - log_builder:
+        event: simple message 2
     - fail_encoding_of:
-        event: "simple message with wrong encoding"
+        log_builder:
+          event: "simple message with wrong encoding"

--- a/tests/validation/components/sources/splunk_hec.yaml
+++ b/tests/validation/components/sources/splunk_hec.yaml
@@ -1,0 +1,13 @@
+- name: happy path
+  expectation: success
+  events:
+    - simple message 1
+    - simple message 2
+    - simple message 3
+# - name: sad path
+#   expectation: partial_success
+#   events:
+#     - simple message 1
+#     - simple message 2
+#     - modified: true
+#       event: simple message with the wrong encoding

--- a/tests/validation/components/sources/splunk_hec.yaml
+++ b/tests/validation/components/sources/splunk_hec.yaml
@@ -1,13 +1,13 @@
 - name: happy path
   expectation: success
   events:
-    - simple message 1
-    - simple message 2
-    - simple message 3
-# - name: sad path
-#   expectation: partial_success
-#   events:
-#     - simple message 1
-#     - simple message 2
-#     - modified: true
-#       event: simple message with the wrong encoding
+    - event: simple message 1
+    - event: simple message 2
+    - event: simple message 3
+- name: sad path
+  expectation: partial_success
+  events:
+    - event: simple message 1
+    - event: simple message 2
+    - fail_encoding_of:
+        event: "simple message with wrong encoding"


### PR DESCRIPTION
Primarily this change implements `ValidatableComponent` for the `splunk_hec` source, validating both happy path and error path internal metrics are in line with the Component Specification.

The framework identified a bug- that we were calculating the size in bytes of the received events _after_ enriching them, which is wrong. It should occur before enrichment. So this change also fixes that for both the `raw` and `event` endpoints.

Changes to the testing framework:
- Added a way to construct the test case log events from the YAML definition on a per-field basis (before we were always injecting into the `message` field). This was necessary in order to construct events in a way that the HEC protocol expects.
- This component requires a specific HTTP header. As such, the external resource configuration for Http resources, was extended to allow specifying custom headers to add to events.
- Removed the assumption that all components would be handling events in a `Vec` . This is significant because some components only operate on a per-event basis. And the `EstimatedJsonEncodedSizeOf` calculation on a `Vec` , includes 2 bytes per bracket character... thus the testing framework needs to handle this. The solution I created for this is to allow a value for this metric that either matches within a Vec or without. We could alternatively try encoding this information into the `ComponentTestCaseConfiguration`.


```
$  make test-component-validation
cargo nextest run --no-fail-fast --no-default-features --features component-validation-tests --status-level pass --test-threads 4 components::validation::tests
    Starting 4 tests across 3 binaries (333 skipped)
        PASS [   5.849s] vector components::validation::tests::validate_component_tests_validation_components_sources_splunk_hec_yaml
        PASS [   6.118s] vector components::validation::tests::validate_component_tests_validation_components_sources_http_server_yaml
        PASS [   9.710s] vector components::validation::tests::validate_component_tests_validation_components_sources_http_client_yaml
        PASS [  11.642s] vector components::validation::tests::validate_component_tests_validation_components_sinks_http_yaml
------------
     Summary [  11.643s] 4 tests run: 4 passed, 333 skipped
 ```


```
2024-02-23T21:21:32.993513Z  INFO vector::components::validation::tests: Successfully validated component 'splunk_hec':
  test case 'happy path': passed
    - sent 3 inputs and received 3 outputs
    - received 1247 telemetry events
    - component_received_events_total: 3
    - component_received_event_bytes_total: 90
    - component_received_bytes_total: 84
    - component_sent_events_total: 3
    - component_sent_event_bytes_total: 384
    - component_sent_bytes_total: 0
    - component_errors_total: 0
    - component_discarded_events_total: 0
  test case 'sad path': passed
    - sent 3 inputs and received 2 outputs
    - received 1261 telemetry events
    - component_received_events_total: 2
    - component_received_event_bytes_total: 60
    - component_received_bytes_total: 102
    - component_sent_events_total: 2
    - component_sent_event_bytes_total: 256
    - component_sent_bytes_total: 0
    - component_errors_total: 1
    - component_discarded_events_total: 0
```