### PR TITLE
fix(aws service): determine region using our http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9864,6 +9864,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sns",
  "aws-sdk-sqs",
+ "aws-sdk-sts",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ aws-sdk-cloudwatchlogs = { version = "1.3.0", default-features = false, features
 aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
+aws-sdk-sts = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-types = { version = "1.1.5", default-features = false, optional = true }
 aws-sigv4 = { version = "1.1.5", default-features = false, features = ["sign-http"], optional = true }
 aws-config = { version = "1.0.1", default-features = false, features = ["behavior-version-latest"], optional = true }
@@ -464,6 +465,7 @@ aws-core = [
   "dep:aws-smithy-types",
   "dep:aws-smithy-runtime",
   "dep:aws-smithy-runtime-api",
+  "dep:aws-sdk-sts",
 ]
 
 # Anything that requires Protocol Buffers.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,9 @@ aws-sdk-cloudwatchlogs = { version = "1.3.0", default-features = false, features
 aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
+# The sts crate is needed despite not being referred to anywhere in the code because we need to set the
+# `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication
+# is configured.
 aws-sdk-sts = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-types = { version = "1.1.6", default-features = false, optional = true }
 aws-sigv4 = { version = "1.1.6", default-features = false, features = ["sign-http"], optional = true }

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -14,14 +14,11 @@ use aws_config::{
 };
 use aws_credential_types::{provider::SharedCredentialsProvider, Credentials};
 use aws_smithy_async::time::SystemTimeSource;
-use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use aws_smithy_runtime_api::client::identity::SharedIdentityCache;
 use aws_types::{region::Region, SdkConfig};
 use serde_with::serde_as;
+use vector_lib::configurable::configurable_component;
 use vector_lib::{config::proxy::ProxyConfig, sensitive_string::SensitiveString, tls::TlsConfig};
-use vector_lib::{configurable::configurable_component, tls::MaybeTlsSettings};
-
-use crate::http::{build_proxy_connector, build_tls_connector};
 
 // matches default load timeout from the SDK as of 0.10.1, but lets us confidently document the
 // default rather than relying on the SDK default to not change
@@ -267,11 +264,7 @@ impl AwsAuthentication {
                 ..
             } => {
                 let auth_region = region.clone().map(Region::new).unwrap_or(service_region);
-
-                let tls_settings = MaybeTlsSettings::tls_client(tls_options)?;
-                let tls_connector = build_tls_connector(tls_settings)?;
-
-                let connector = HyperClientBuilder::new().build(tls_connector);
+                let connector = super::connector(proxy, tls_options)?;
                 let config = SdkConfig::builder()
                     .http_client(connector)
                     .region(auth_region.clone())
@@ -326,14 +319,7 @@ async fn default_credentials_provider(
     tls_options: &Option<TlsConfig>,
     imds: ImdsAuthentication,
 ) -> crate::Result<SharedCredentialsProvider> {
-    let tls_settings = MaybeTlsSettings::tls_client(tls_options)?;
-    let connector = if proxy.enabled {
-        let proxy = build_proxy_connector(tls_settings, proxy)?;
-        HyperClientBuilder::new().build(proxy)
-    } else {
-        let tls_connector = build_tls_connector(tls_settings)?;
-        HyperClientBuilder::new().build(tls_connector)
-    };
+    let connector = super::connector(proxy, tls_options)?;
 
     let provider_config = ProviderConfig::empty()
         .with_region(Some(region.clone()))

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -3,7 +3,6 @@ pub mod auth;
 pub mod region;
 
 pub use auth::{AwsAuthentication, ImdsAuthentication};
-// use aws_config::{meta::region::ProvideRegion, retry::RetryConfig, Region, SdkConfig};
 use aws_config::{meta::region::ProvideRegion, retry::RetryConfig, Region, SdkConfig};
 use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
 use aws_sigv4::{

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -99,7 +99,7 @@ fn check_response(res: &HttpResponse) -> bool {
 /// Creates the http connector that has been configured to use the given proxy and TLS settings.
 /// All AWS requests should use this connector as the aws crates by default use RustTLS which we
 /// have turned off as we want to consistently use openssl.
-pub(self) fn connector(
+fn connector(
     proxy: &ProxyConfig,
     tls_options: &Option<TlsConfig>,
 ) -> crate::Result<SharedHttpClient> {

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod region;
 
 pub use auth::{AwsAuthentication, ImdsAuthentication};
+// use aws_config::{meta::region::ProvideRegion, retry::RetryConfig, Region, SdkConfig};
 use aws_config::{meta::region::ProvideRegion, retry::RetryConfig, Region, SdkConfig};
 use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
 use aws_sigv4::{
@@ -21,6 +22,7 @@ use aws_smithy_runtime_api::client::{
     runtime_components::RuntimeComponents,
 };
 use aws_smithy_types::body::SdkBody;
+use aws_types::sdk_config::SharedHttpClient;
 use bytes::Bytes;
 use futures_util::FutureExt;
 use http::HeaderMap;
@@ -94,6 +96,24 @@ fn check_response(res: &HttpResponse) -> bool {
         || (status.is_client_error() && re.is_match(response_body.as_ref()))
 }
 
+/// Creates the http connector that has been configured to use the given proxy and TLS settings.
+/// All AWS requests should use this connector as the aws crates by default use RustTLS which we
+/// have turned off as we want to consistently use openssl.
+pub(self) fn connector(
+    proxy: &ProxyConfig,
+    tls_options: &Option<TlsConfig>,
+) -> crate::Result<SharedHttpClient> {
+    let tls_settings = MaybeTlsSettings::tls_client(tls_options)?;
+
+    if proxy.enabled {
+        let proxy = build_proxy_connector(tls_settings, proxy)?;
+        Ok(HyperClientBuilder::new().build(proxy))
+    } else {
+        let tls_connector = build_tls_connector(tls_settings)?;
+        Ok(HyperClientBuilder::new().build(tls_connector))
+    }
+}
+
 /// Implement for each AWS service to create the appropriate AWS sdk client.
 pub trait ClientBuilder {
     /// The type of the client in the SDK.
@@ -145,15 +165,7 @@ pub async fn create_client_and_region<T: ClientBuilder>(
     let provider_config =
         aws_config::provider_config::ProviderConfig::empty().with_region(Some(region.clone()));
 
-    let tls_settings = MaybeTlsSettings::tls_client(tls_options)?;
-
-    let connector = if proxy.enabled {
-        let proxy = build_proxy_connector(tls_settings, proxy)?;
-        HyperClientBuilder::new().build(proxy)
-    } else {
-        let tls_connector = build_tls_connector(tls_settings)?;
-        HyperClientBuilder::new().build(tls_connector)
-    };
+    let connector = connector(proxy, tls_options)?;
 
     // Create a custom http connector that will emit the required metrics for us.
     let connector = AwsHttpClient {


### PR DESCRIPTION
Previously if a region wasn't specified, in the config the Region resolver over IMDS would use the AWS connector which uses `rustls`. Since we don't use `rustls` this would error.

So this sets it up so the region resolver uses our http client. The `default_provider` doesn't seem to let us setup our own connector, so I have had to configure a new provider chain.

I have tested this manually on ec2 with imds.