### PR TITLE
chore(core): Switch to JSON value in component config generators

### DIFF
--- a/docs/tutorials/sinks/1_basic_sink.md
+++ b/docs/tutorials/sinks/1_basic_sink.md
@@ -66,7 +66,7 @@ our struct:
 
 ```rust
 impl GenerateConfig for BasicConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str("").unwrap()
     }
 }

--- a/lib/vector-config/src/component/description.rs
+++ b/lib/vector-config/src/component/description.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, marker::PhantomData};
 
+use serde_json::Value;
 use snafu::Snafu;
-use toml::Value;
 use vector_config_common::{attributes::CustomAttribute, constants};
 
 use super::{ComponentMarker, GenerateConfig};

--- a/lib/vector-config/src/component/generate.rs
+++ b/lib/vector-config/src/component/generate.rs
@@ -1,14 +1,14 @@
 /// A component that can generate a default configuration for itself.
 pub trait GenerateConfig {
-    fn generate_config() -> toml::Value;
+    fn generate_config() -> serde_json::Value;
 }
 
 #[macro_export]
 macro_rules! impl_generate_config_from_default {
     ($type:ty) => {
         impl $crate::component::GenerateConfig for $type {
-            fn generate_config() -> toml::value::Value {
-                toml::value::Value::try_from(&Self::default()).unwrap()
+            fn generate_config() -> serde_json::Value {
+                serde_json::to_value(&Self::default()).unwrap()
             }
         }
     };

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -335,8 +335,8 @@ pub struct SimpleSourceConfig {
 }
 
 impl GenerateConfig for SimpleSourceConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             listen_addr: default_simple_source_listen_addr(),
             timeout: default_simple_source_timeout(),
         })
@@ -381,8 +381,8 @@ pub struct SimpleSinkConfig {
 }
 
 impl GenerateConfig for SimpleSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoint: default_simple_sink_endpoint(),
             batch: default_simple_sink_batch(),
             encoding: default_simple_sink_encoding(),
@@ -463,8 +463,8 @@ pub enum TagConfig {
 }
 
 impl GenerateConfig for AwsBleepBloopSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             auth: AwsAuthentication::default(),
             folder_id: String::from("foo12"),
             batch: default_aws_bleep_bloop_sink_batch(),
@@ -523,8 +523,8 @@ pub mod vector_v2 {
     }
 
     impl GenerateConfig for VectorConfig {
-        fn generate_config() -> toml::Value {
-            toml::Value::try_from(Self {
+        fn generate_config() -> serde_json::Value {
+            serde_json::to_value(Self {
                 address: "0.0.0.0:6000".parse().unwrap(),
                 shutdown_timeout_secs: default_shutdown_timeout_secs(),
             })
@@ -563,12 +563,10 @@ pub enum VectorSourceConfig {
 }
 
 impl GenerateConfig for VectorSourceConfig {
-    fn generate_config() -> toml::Value {
-        let config = toml::Value::try_into::<self::vector_v2::VectorConfig>(
-            self::vector_v2::VectorConfig::generate_config(),
-        )
-        .unwrap();
-        toml::Value::try_from(VectorConfigV2 {
+    fn generate_config() -> serde_json::Value {
+        let config: self::vector_v2::VectorConfig =
+            serde_json::from_value(self::vector_v2::VectorConfig::generate_config()).unwrap();
+        serde_json::to_value(VectorConfigV2 {
             version: Some(V2::V2),
             config,
         })

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -80,8 +80,8 @@ fn default_locale() -> String {
 }
 
 impl GenerateConfig for GeoipConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             path: "/path/to/GeoLite2-City.mmdb".to_string(),
             locale: default_locale(),
         })

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use colored::*;
 use indexmap::IndexMap;
 use serde::Serialize;
-use toml::{map::Map, Value};
+use serde_json::Value;
 use vector_lib::configurable::component::{
     ExampleError, SinkDescription, SourceDescription, TransformDescription,
 };
@@ -164,12 +164,12 @@ pub(crate) fn generate_example(
                             source_type, err
                         ));
                     }
-                    Value::Table(Map::new())
+                    Value::Object(Default::default())
                 }
             };
             example
-                .as_table_mut()
-                .expect("examples are always tables")
+                .as_object_mut()
+                .expect("examples are always objects")
                 .insert("type".into(), source_type.to_owned().into());
 
             sources.insert(name, example);
@@ -227,12 +227,12 @@ pub(crate) fn generate_example(
                             transform_type, err
                         ));
                     }
-                    Value::Table(Map::new())
+                    Value::Object(Default::default())
                 }
             };
             example
-                .as_table_mut()
-                .expect("examples are always tables")
+                .as_object_mut()
+                .expect("examples are always objects")
                 .insert("type".into(), transform_type.to_owned().into());
 
             transforms.insert(
@@ -276,12 +276,12 @@ pub(crate) fn generate_example(
                     if err != ExampleError::MissingExample {
                         errs.push(format!("failed to generate sink '{}': {}", sink_type, err));
                     }
-                    Value::Table(Map::new())
+                    Value::Object(Default::default())
                 }
             };
             example
-                .as_table_mut()
-                .expect("examples are always tables")
+                .as_object_mut()
+                .expect("examples are always objects")
                 .insert("type".into(), sink_type.to_owned().into());
 
             sinks.insert(

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -25,8 +25,8 @@ pub struct ExecBackend {
 }
 
 impl GenerateConfig for ExecBackend {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(ExecBackend {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(ExecBackend {
             command: vec![String::from("/path/to/script")],
             timeout: 5,
         })

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -80,7 +80,7 @@ impl Default for AmqpSinkConfig {
 }
 
 impl GenerateConfig for AmqpSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"connection_string = "amqp://localhost:5672/%2f"
             routing_key = "user_id"

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -225,8 +225,8 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 }
 
 impl GenerateConfig for CloudwatchLogsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(default_config(JsonSerializerConfig::default().into())).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(default_config(JsonSerializerConfig::default().into())).unwrap()
     }
 }
 

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -155,7 +155,7 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
 }
 
 impl GenerateConfig for KinesisFirehoseSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"stream_name = "my-stream"
             encoding.codec = "json""#,

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -157,7 +157,7 @@ impl SinkConfig for KinesisStreamsSinkConfig {
 }
 
 impl GenerateConfig for KinesisStreamsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"partition_key_field = "foo"
             stream_name = "my-stream"

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -150,8 +150,8 @@ pub(super) fn default_filename_time_format() -> String {
 }
 
 impl GenerateConfig for S3SinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             bucket: "".to_owned(),
             key_prefix: default_key_prefix(),
             filename_time_format: default_filename_time_format(),

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -35,7 +35,7 @@ pub(super) struct SnsSinkConfig {
 }
 
 impl GenerateConfig for SnsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"topic_arn = "arn:aws:sns:us-east-2:123456789012:MyTopic"
             region = "us-east-2"

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -36,7 +36,7 @@ pub(super) struct SqsSinkConfig {
 }
 
 impl GenerateConfig for SqsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"queue_url = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
             region = "us-east-2"

--- a/src/sinks/axiom.rs
+++ b/src/sinks/axiom.rs
@@ -65,7 +65,7 @@ pub struct AxiomConfig {
 }
 
 impl GenerateConfig for AxiomConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"token = "${AXIOM_TOKEN}"
             dataset = "${AXIOM_DATASET}"

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -155,8 +155,8 @@ pub fn default_blob_prefix() -> Template {
 }
 
 impl GenerateConfig for AzureBlobSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             connection_string: Some(String::from("DefaultEndpointsProtocol=https;AccountName=some-account-name;AccountKey=some-account-key;").into()),
             storage_account: Some(String::from("some-account-name")),
             container_name: String::from("logs"),

--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -68,8 +68,8 @@ impl SinkConfig for BlackholeConfig {
 }
 
 impl GenerateConfig for BlackholeConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -61,8 +61,8 @@ const fn default_target() -> Target {
 }
 
 impl GenerateConfig for ConsoleSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             target: Target::Stdout,
             encoding: (None::<FramingConfig>, JsonSerializerConfig::default()).into(),
             acknowledgements: Default::default(),

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -79,7 +79,7 @@ pub struct DatabendConfig {
 }
 
 impl GenerateConfig for DatabendConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "http://localhost:8000"
             table = "default"

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -40,7 +40,7 @@ pub struct DatadogEventsConfig {
 }
 
 impl GenerateConfig for DatadogEventsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
         "#})

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -71,7 +71,7 @@ pub struct DatadogLogsConfig {
 }
 
 impl GenerateConfig for DatadogLogsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
         "#})

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -73,7 +73,7 @@ pub struct DatadogTracesConfig {
 }
 
 impl GenerateConfig for DatadogTracesConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
         "#})

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -92,8 +92,8 @@ pub struct FileSinkConfig {
 }
 
 impl GenerateConfig for FileSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             path: Template::try_from("/tmp/vector-%Y-%m-%d.log").unwrap(),
             idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),

--- a/src/sinks/gcp/chronicle_unstructured.rs
+++ b/src/sinks/gcp/chronicle_unstructured.rs
@@ -163,7 +163,7 @@ pub struct ChronicleUnstructuredConfig {
 }
 
 impl GenerateConfig for ChronicleUnstructuredConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             credentials_path = "/path/to/credentials.json"
             customer_id = "customer_id"

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -205,7 +205,7 @@ fn default_config(encoding: EncodingConfigWithFraming) -> GcsSinkConfig {
 }
 
 impl GenerateConfig for GcsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             bucket = "my-bucket"
             credentials_path = "/path/to/credentials.json"

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -103,7 +103,7 @@ fn default_endpoint() -> String {
 }
 
 impl GenerateConfig for PubsubConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             project = "my-project"
             topic = "my-topic"

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -78,7 +78,7 @@ impl SinkBatchSettings for HoneycombDefaultBatchSettings {
 }
 
 impl GenerateConfig for HoneycombConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"api_key = "${HONEYCOMB_API_KEY}"
             dataset = "my-honeycomb-dataset""#,

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -164,7 +164,7 @@ impl HttpSinkConfig {
 }
 
 impl GenerateConfig for HttpSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"uri = "https://10.22.212.22:9000/endpoint"
             encoding.codec = "json""#,

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -145,8 +145,8 @@ pub fn timestamp_nanos_key() -> Option<String> {
 }
 
 impl GenerateConfig for HumioLogsConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             token: "${HUMIO_TOKEN}".to_owned().into(),
             endpoint: default_endpoint(),
             source: None,

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -142,7 +142,7 @@ fn default_endpoint() -> String {
 }
 
 impl GenerateConfig for HumioMetricsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
                 host_key = "hostname"
                 token = "${HUMIO_TOKEN}"

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -143,7 +143,7 @@ struct InfluxDbLogsSink {
 }
 
 impl GenerateConfig for InfluxDbLogsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             endpoint = "http://localhost:8086/"
             namespace = "my-namespace"

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -237,8 +237,8 @@ impl KafkaSinkConfig {
 }
 
 impl GenerateConfig for KafkaSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             bootstrap_servers: "10.14.22.123:9092,10.14.23.332:9092".to_owned(),
             topic: Template::try_from("topic-1234".to_owned()).unwrap(),
             key_field: Some(ConfigTargetPath::try_from("user_id".to_owned()).unwrap()),

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -159,7 +159,7 @@ pub enum OutOfOrderAction {
 }
 
 impl GenerateConfig for LokiConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "http://localhost:3100"
             encoding.codec = "json"

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -34,7 +34,7 @@ const PATH: &str = "/logs/ingest";
 pub struct LogdnaConfig(MezmoConfig);
 
 impl GenerateConfig for LogdnaConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         <MezmoConfig as GenerateConfig>::generate_config()
     }
 }
@@ -144,7 +144,7 @@ fn default_env() -> String {
 }
 
 impl GenerateConfig for MezmoConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"hostname = "hostname"
             api_key = "${LOGDNA_API_KEY}""#,

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -83,8 +83,8 @@ fn default_name() -> String {
 }
 
 impl GenerateConfig for NatsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             acknowledgements: Default::default(),
             auth: None,
             connection_name: "vector".into(),

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -55,7 +55,7 @@ fn default_process() -> Template {
 }
 
 impl GenerateConfig for PapertrailConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "logs.papertrailapp.com:12345"
             encoding.codec = "json""#,

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -185,8 +185,8 @@ const fn default_suppress_timestamp() -> bool {
 }
 
 impl GenerateConfig for PrometheusExporterConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -275,8 +275,8 @@ impl PulsarSinkConfig {
 }
 
 impl GenerateConfig for PulsarSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -117,7 +117,7 @@ pub struct RedisSinkConfig {
 }
 
 impl GenerateConfig for RedisSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"
             url = "redis://127.0.0.1:6379/0"

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -64,7 +64,7 @@ pub struct SematextLogsConfig {
 }
 
 impl GenerateConfig for SematextLogsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             token = "${SEMATEXT_TOKEN}"
         "#})

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -91,7 +91,7 @@ pub struct SematextMetricsConfig {
 }
 
 impl GenerateConfig for SematextMetricsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_namespace = "vector"
             token = "${SEMATEXT_TOKEN}"

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -80,7 +80,7 @@ pub struct UnixMode {
 }
 
 impl GenerateConfig for SocketSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"address = "92.12.333.224:5000"
             mode = "tcp"

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -162,8 +162,8 @@ const fn default_endpoint_target() -> EndpointTarget {
 }
 
 impl GenerateConfig for HecLogsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             default_token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned().into(),
             endpoint: "endpoint".to_owned(),
             host_key: config_host_key_target_path(),

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -122,8 +122,8 @@ pub struct HecMetricsSinkConfig {
 }
 
 impl GenerateConfig for HecMetricsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             default_namespace: None,
             default_token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned().into(),
             endpoint: "http://localhost:8088".to_owned(),

--- a/src/sinks/statsd/config.rs
+++ b/src/sinks/statsd/config.rs
@@ -104,10 +104,10 @@ const fn default_address() -> SocketAddr {
 }
 
 impl GenerateConfig for StatsdSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let address = default_address();
 
-        toml::Value::try_from(Self {
+        serde_json::to_value(Self {
             default_namespace: None,
             mode: Mode::Udp(UdpConnectorConfig::from_address(
                 address.ip().to_string(),

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -88,8 +88,8 @@ impl VectorConfig {
 }
 
 impl GenerateConfig for VectorConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(default_config("127.0.0.1:6000")).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(default_config("127.0.0.1:6000")).unwrap()
     }
 }
 

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -76,8 +76,8 @@ pub struct WebHdfsConfig {
 }
 
 impl GenerateConfig for WebHdfsConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             root: "/".to_string(),
             prefix: "%F/".to_string(),
             endpoint: "http://127.0.0.1:9870".to_string(),

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -66,8 +66,8 @@ pub struct WebSocketSinkConfig {
 }
 
 impl GenerateConfig for WebSocketSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             uri: "ws://127.0.0.1:9000/endpoint".into(),
             tls: None,
             encoding: JsonSerializerConfig::default().into(),

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -58,8 +58,8 @@ pub fn default_namespace() -> String {
 }
 
 impl GenerateConfig for ApacheMetricsConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoints: vec!["http://localhost:8080/server-status/?auto".to_owned()],
             scrape_interval_secs: default_scrape_interval_secs(),
             namespace: default_namespace(),

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -135,8 +135,8 @@ impl AwsEcsMetricsSourceConfig {
 }
 
 impl GenerateConfig for AwsEcsMetricsSourceConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoint: default_endpoint(),
             version: default_version(),
             scrape_interval_secs: default_scrape_interval_secs(),

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -248,8 +248,8 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
 }
 
 impl GenerateConfig for AwsKinesisFirehoseConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "0.0.0.0:443".parse().unwrap(),
             access_key: None,
             access_keys: None,

--- a/src/sources/datadog_agent/integration_tests.rs
+++ b/src/sources/datadog_agent/integration_tests.rs
@@ -80,7 +80,8 @@ async fn wait_for_message() {
     ]);
     let context = SourceContext::new_test(sender, Some(schema_definitions));
     tokio::spawn(async move {
-        let config: DatadogAgentConfig = DatadogAgentConfig::generate_config().try_into().unwrap();
+        let config: DatadogAgentConfig =
+            serde_json::from_value(DatadogAgentConfig::generate_config()).unwrap();
         config.build(context).await.unwrap().await.unwrap()
     });
     let events = spawn_collect_n(

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -136,8 +136,8 @@ pub struct DatadogAgentConfig {
 }
 
 impl GenerateConfig for DatadogAgentConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "0.0.0.0:8080".parse().unwrap(),
             tls: None,
             store_api_key: true,

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -66,7 +66,7 @@ impl FileDescriptorConfig for FileDescriptorSourceConfig {
 }
 
 impl GenerateConfig for FileDescriptorSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             fd = 10
         "#})

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -71,8 +71,8 @@ pub struct FluentConfig {
 }
 
 impl GenerateConfig for FluentConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: SocketListenAddr::SocketAddr("0.0.0.0:24224".parse().unwrap()),
             keepalive: None,
             tls: None,

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -157,8 +157,8 @@ impl Default for LogplexConfig {
 }
 
 impl GenerateConfig for LogplexConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(LogplexConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(LogplexConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -45,7 +45,7 @@ use crate::{
 pub struct HttpConfig(SimpleHttpConfig);
 
 impl GenerateConfig for HttpConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         <SimpleHttpConfig as GenerateConfig>::generate_config()
     }
 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -261,8 +261,8 @@ const fn default_read_from() -> ReadFromConfig {
 }
 
 impl GenerateConfig for Config {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             self_node_name: default_self_node_name_env_template(),
             auto_partial_merge: true,
             ..Default::default()

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -127,8 +127,8 @@ impl Default for LogstashConfig {
 }
 
 impl GenerateConfig for LogstashConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(LogstashConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(LogstashConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -120,7 +120,7 @@ const fn default_subscription_capacity() -> usize {
 }
 
 impl GenerateConfig for NatsSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"
             connection_name = "vector"

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -118,8 +118,8 @@ fn example_http_config() -> HttpConfig {
 }
 
 impl GenerateConfig for OpentelemetryConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             grpc: example_grpc_config(),
             http: example_http_config(),
             acknowledgements: Default::default(),

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -73,8 +73,8 @@ pub struct PrometheusPushgatewayConfig {
 }
 
 impl GenerateConfig for PrometheusPushgatewayConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "127.0.0.1:9091".parse().unwrap(),
             tls: None,
             auth: None,

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -66,8 +66,8 @@ impl PrometheusRemoteWriteConfig {
 }
 
 impl GenerateConfig for PrometheusRemoteWriteConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "127.0.0.1:9090".parse().unwrap(),
             tls: None,
             auth: None,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -120,8 +120,8 @@ fn query_example() -> serde_json::Value {
 }
 
 impl GenerateConfig for PrometheusScrapeConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoints: vec!["http://localhost:9090/metrics".to_string()],
             interval: default_interval(),
             timeout: default_timeout(),

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -140,7 +140,7 @@ pub struct RedisSourceConfig {
 }
 
 impl GenerateConfig for RedisSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"
             url = "redis://127.0.0.1:6379/0"

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -98,7 +98,7 @@ impl From<udp::UdpConfig> for SocketConfig {
 }
 
 impl GenerateConfig for SocketConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"mode = "tcp"
             address = "0.0.0.0:9000""#,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -130,8 +130,8 @@ const fn default_shutdown_timeout_secs() -> Duration {
 }
 
 impl GenerateConfig for StatsdConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::Udp(UdpConfig::from_address(
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::Udp(UdpConfig::from_address(
             SocketListenAddr::SocketAddr(SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::LOCALHOST,
                 8125,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -153,8 +153,8 @@ impl Default for SyslogConfig {
 }
 
 impl GenerateConfig for SyslogConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(SyslogConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(SyslogConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -163,8 +163,8 @@ impl Default for VectorConfig {
 }
 
 impl GenerateConfig for VectorConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(VectorConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(VectorConfig::default()).unwrap()
     }
 }
 

--- a/src/test_util/mock/sources/backpressure.rs
+++ b/src/test_util/mock/sources/backpressure.rs
@@ -28,11 +28,11 @@ pub struct BackpressureSourceConfig {
 }
 
 impl GenerateConfig for BackpressureSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let config = Self {
             counter: Arc::new(AtomicUsize::new(0)),
         };
-        toml::Value::try_from(&config).unwrap()
+        serde_json::to_value(&config).unwrap()
     }
 }
 

--- a/src/test_util/mock/sources/tripwire.rs
+++ b/src/test_util/mock/sources/tripwire.rs
@@ -22,11 +22,11 @@ pub struct TripwireSourceConfig {
 }
 
 impl GenerateConfig for TripwireSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let config = Self {
             tripwire: Arc::new(Mutex::new(None)),
         };
-        toml::Value::try_from(&config).unwrap()
+        serde_json::to_value(&config).unwrap()
     }
 }
 

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -24,8 +24,8 @@ pub struct NoopTransformConfig {
 }
 
 impl GenerateConfig for NoopTransformConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(&Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(&Self {
             transform_type: TransformType::Function,
         })
         .unwrap()

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -138,8 +138,8 @@ pub struct Dedupe {
 }
 
 impl GenerateConfig for DedupeConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             fields: None,
             cache: default_cache_config(),
         })

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -33,7 +33,7 @@ impl From<AnyCondition> for FilterConfig {
 }
 
 impl GenerateConfig for FilterConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(r#"condition = ".message = \"value\"""#).unwrap()
     }
 }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -173,8 +173,8 @@ pub struct LogToMetric {
 }
 
 impl GenerateConfig for LogToMetricConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             metrics: vec![MetricConfig {
                 field: "field_name".try_into().expect("Fixed template"),
                 name: None,

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -77,7 +77,7 @@ pub enum LuaConfig {
 }
 
 impl GenerateConfig for LuaConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"version = "2"
             hooks.process = """#,

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -75,8 +75,8 @@ impl MetricToLogConfig {
 }
 
 impl GenerateConfig for MetricToLogConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             host_tag: Some("host-tag".to_string()),
             timezone: None,
             log_namespace: None,

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -87,8 +87,8 @@ pub struct RouteConfig {
 }
 
 impl GenerateConfig for RouteConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             reroute_unmatched: true,
             route: IndexMap::new(),
         })

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -49,8 +49,8 @@ pub struct SampleConfig {
 }
 
 impl GenerateConfig for SampleConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             rate: 10,
             key_field: None,
             exclude: None::<AnyCondition>,

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -90,8 +90,8 @@ pub(crate) const fn default_cache_size() -> usize {
 }
 
 impl GenerateConfig for TagCardinalityLimitConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             mode: Mode::Exact,
             value_limit: default_value_limit(),
             limit_exceeded_action: default_limit_exceeded_action(),


### PR DESCRIPTION
As discussed in #19963, this is part of moving from TOML to JSON values internally.

This part ended up being much simpler and more mechanical than I had expected. Mostly this is just a straight swap of `toml::Value` and `try_from` for `serde_json::Value` and `serde_json::to_value` in component descriptions and config generators.