### PR TITLE
chore(deps): Update lockfree-object-pool to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,9 +4931,9 @@ dependencies = [
 
 [[package]]
 name = "lockfree-object-pool"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee33defb27b106378a6efcfcde4dda6226dfdac8ba7a2904f5bc93363cb88557"
+checksum = "3a69c0481fc2424cb55795de7da41add33372ea75a94f9b6588ab6a2826dfebc"
 
 [[package]]
 name = "log"


### PR DESCRIPTION
We think this will fix #19627.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>