### PR TITLE
chore(ci): increase timeout for `cross` workflow

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -7,7 +7,7 @@ jobs:
   cross-linux:
     name: Cross - ${{ matrix.target }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       CARGO_INCREMENTAL: 0
     strategy:


### PR DESCRIPTION
This workflow timed out recently when it was apparently not hanging.