### PR TITLE
enhancement(datadog_agent source): add `parse_ddtags` config setting to parse the `ddtags` log event field into an object

### DIFF
--- a/changelog.d/datadog_agent_ddtags_parsing.enhancement.md
+++ b/changelog.d/datadog_agent_ddtags_parsing.enhancement.md
@@ -1,0 +1,4 @@
+The `datadog_agent` source now contains a configuration setting `parse_ddtags`, which is disabeled by default.
+
+When enabled, the `ddtags` field (a comma separated list of key-value strings) is parsed and expanded into an
+object in the event.

--- a/changelog.d/datadog_agent_ddtags_parsing.enhancement.md
+++ b/changelog.d/datadog_agent_ddtags_parsing.enhancement.md
@@ -1,4 +1,4 @@
-The `datadog_agent` source now contains a configuration setting `parse_ddtags`, which is disabeled by default.
+The `datadog_agent` source now contains a configuration setting `parse_ddtags`, which is disabled by default.
 
 When enabled, the `ddtags` field (a comma separated list of key-value strings) is parsed and expanded into an
 object in the event.

--- a/src/sources/datadog_agent/logs.rs
+++ b/src/sources/datadog_agent/logs.rs
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn ddtags_parse_multi() {
-        let raw = Bytes::from(String::from("filename:driver.log,Gandalf:the_grey"));
+        let raw = Bytes::from(String::from("filename:driver.log,wizard:the_grey"));
         let obj = parse_ddtags(&raw);
 
         assert!(
@@ -262,7 +262,7 @@ mod tests {
                     "driver.log".to_string().into()
                 ),
                 (
-                    KeyString::from("Gandalf".to_string()),
+                    KeyString::from("wizard".to_string()),
                     "the_grey".to_string().into()
                 ),
             ])

--- a/src/sources/datadog_agent/logs.rs
+++ b/src/sources/datadog_agent/logs.rs
@@ -251,8 +251,8 @@ mod tests {
     }
 
     #[test]
-    fn ddtags_parse_mutli() {
-        let raw = Bytes::from(String::from("filename:driver.log,gandalf:the_grey"));
+    fn ddtags_parse_multi() {
+        let raw = Bytes::from(String::from("filename:driver.log,Gandalf:the_grey"));
         let obj = parse_ddtags(&raw);
 
         assert!(
@@ -262,7 +262,7 @@ mod tests {
                     "driver.log".to_string().into()
                 ),
                 (
-                    KeyString::from("gandalf".to_string()),
+                    KeyString::from("Gandalf".to_string()),
                     "the_grey".to_string().into()
                 ),
             ])

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -112,7 +112,7 @@ pub struct DatadogAgentConfig {
     multiple_outputs: bool,
 
     /// If this is set to `true`, when log events contain the field `ddtags`, the string value that
-    /// containins a list of key:value pairs set by the Agent is parsed and expanded into an object.
+    /// contains a list of key:value pairs set by the Agent is parsed and expanded into an object.
     #[configurable(metadata(docs::advanced))]
     #[serde(default = "crate::serde::default_false")]
     parse_ddtags: bool,

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -42,6 +42,7 @@ use vector_lib::internal_event::{EventsReceived, Registered};
 use vector_lib::lookup::owned_value_path;
 use vector_lib::tls::MaybeTlsIncomingStream;
 use vrl::path::OwnedTargetPath;
+use vrl::value::kind::Collection;
 use vrl::value::Kind;
 use warp::{filters::BoxedFilter, reject::Rejection, reply::Response, Filter, Reply};
 
@@ -110,6 +111,12 @@ pub struct DatadogAgentConfig {
     #[serde(default = "crate::serde::default_false")]
     multiple_outputs: bool,
 
+    /// If this is set to `true`, when log events contain the field `ddtags`, the string value that
+    /// containins a list of key:value pairs set by the Agent is parsed and expanded into an object.
+    #[configurable(metadata(docs::advanced))]
+    #[serde(default = "crate::serde::default_false")]
+    parse_ddtags: bool,
+
     /// The namespace to use for logs. This overrides the global setting.
     #[serde(default)]
     #[configurable(metadata(docs::hidden))]
@@ -148,6 +155,7 @@ impl GenerateConfig for DatadogAgentConfig {
             disable_metrics: false,
             disable_traces: false,
             multiple_outputs: false,
+            parse_ddtags: false,
             log_namespace: Some(false),
             keepalive: KeepaliveConfig::default(),
         })
@@ -178,6 +186,7 @@ impl SourceConfig for DatadogAgentConfig {
             tls.http_protocol_name(),
             logs_schema_definition,
             log_namespace,
+            self.parse_ddtags,
         );
         let listener = tls.bind(&self.address).await?;
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
@@ -268,7 +277,11 @@ impl SourceConfig for DatadogAgentConfig {
                 Self::NAME,
                 Some(LegacyKey::InsertIfEmpty(owned_value_path!("ddtags"))),
                 &owned_value_path!("ddtags"),
-                Kind::bytes(),
+                if self.parse_ddtags {
+                    Kind::object(Collection::empty().with_unknown(Kind::bytes())).or_undefined()
+                } else {
+                    Kind::bytes()
+                },
                 Some("tags"),
             )
             .with_standard_vector_source_metadata();
@@ -325,6 +338,7 @@ pub(crate) struct DatadogAgentSource {
     protocol: &'static str,
     logs_schema_definition: Option<Arc<schema::Definition>>,
     events_received: Registered<EventsReceived>,
+    parse_ddtags: bool,
 }
 
 #[derive(Clone)]
@@ -361,6 +375,7 @@ impl DatadogAgentSource {
         protocol: &'static str,
         logs_schema_definition: Option<schema::Definition>,
         log_namespace: LogNamespace,
+        parse_ddtags: bool,
     ) -> Self {
         Self {
             api_key_extractor: ApiKeyExtractor {
@@ -381,6 +396,7 @@ impl DatadogAgentSource {
             logs_schema_definition: logs_schema_definition.map(Arc::new),
             log_namespace,
             events_received: register!(EventsReceived),
+            parse_ddtags,
         }
     }
 

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -136,7 +136,7 @@ fn test_decode_log_body_parse_ddtags() {
         hostname: Bytes::from(String::from("host")),
         service: Bytes::from(String::from("service")),
         ddsource: Bytes::from(String::from("ddsource")),
-        ddtags: Bytes::from(String::from("wizard:the_grey")),
+        ddtags: Bytes::from(String::from("wizard:the_grey,env:staging")),
     }];
 
     let body = Bytes::from(serde_json::to_string(&log_msgs).unwrap());
@@ -172,10 +172,16 @@ fn test_decode_log_body_parse_ddtags() {
 
     assert_eq!(
         log["ddtags"],
-        ObjectMap::from([(
-            KeyString::from("wizard".to_string()),
-            "the_grey".to_string().into()
-        )])
+        ObjectMap::from([
+            (
+                KeyString::from("wizard".to_string()),
+                "the_grey".to_string().into()
+            ),
+            (
+                KeyString::from("env".to_string()),
+                "staging".to_string().into()
+            )
+        ])
         .into()
     );
 }

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -136,7 +136,7 @@ fn test_decode_log_body_parse_ddtags() {
         hostname: Bytes::from(String::from("host")),
         service: Bytes::from(String::from("service")),
         ddsource: Bytes::from(String::from("ddsource")),
-        ddtags: Bytes::from(String::from("gandalf:the_grey")),
+        ddtags: Bytes::from(String::from("Gandalf:the_grey")),
     }];
 
     let body = Bytes::from(serde_json::to_string(&log_msgs).unwrap());
@@ -173,7 +173,7 @@ fn test_decode_log_body_parse_ddtags() {
     assert_eq!(
         log["ddtags"],
         ObjectMap::from([(
-            KeyString::from("gandalf".to_string()),
+            KeyString::from("Gandalf".to_string()),
             "the_grey".to_string().into()
         )])
         .into()

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -27,8 +27,9 @@ use vector_lib::{
     event::{metric::TagValue, MetricTags},
     metric_tags,
 };
+use vrl::compiler::value::Collection;
+use vrl::value;
 use vrl::value::{Kind, ObjectMap};
-use vrl::{compiler::value::Collection, value::KeyString};
 
 use crate::schema::Definition;
 use crate::{
@@ -172,17 +173,7 @@ fn test_decode_log_body_parse_ddtags() {
 
     assert_eq!(
         log["ddtags"],
-        ObjectMap::from([
-            (
-                KeyString::from("wizard".to_string()),
-                "the_grey".to_string().into()
-            ),
-            (
-                KeyString::from("env".to_string()),
-                "staging".to_string().into()
-            )
-        ])
-        .into()
+        value!({"env": "staging", "wizard": "the_grey"})
     );
 }
 

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -136,7 +136,7 @@ fn test_decode_log_body_parse_ddtags() {
         hostname: Bytes::from(String::from("host")),
         service: Bytes::from(String::from("service")),
         ddsource: Bytes::from(String::from("ddsource")),
-        ddtags: Bytes::from(String::from("Gandalf:the_grey")),
+        ddtags: Bytes::from(String::from("wizard:the_grey")),
     }];
 
     let body = Bytes::from(serde_json::to_string(&log_msgs).unwrap());
@@ -173,7 +173,7 @@ fn test_decode_log_body_parse_ddtags() {
     assert_eq!(
         log["ddtags"],
         ObjectMap::from([(
-            KeyString::from("Gandalf".to_string()),
+            KeyString::from("wizard".to_string()),
             "the_grey".to_string().into()
         )])
         .into()

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -404,7 +404,7 @@ base: components: sources: datadog_agent: configuration: {
 	parse_ddtags: {
 		description: """
 			If this is set to `true`, when log events contain the field `ddtags`, the string value that
-			containins a list of key:value pairs set by the Agent is parsed and expanded into an object.
+			contains a list of key:value pairs set by the Agent is parsed and expanded into an object.
 			"""
 		required: false
 		type: bool: default: false

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -401,6 +401,14 @@ base: components: sources: datadog_agent: configuration: {
 		required: false
 		type: bool: default: false
 	}
+	parse_ddtags: {
+		description: """
+			If this is set to `true`, when log events contain the field `ddtags`, the string value that
+			containins a list of key:value pairs set by the Agent is parsed and expanded into an object.
+			"""
+		required: false
+		type: bool: default: false
+	}
 	store_api_key: {
 		description: """
 			If this is set to `true`, when incoming events contain a Datadog API key, it is


### PR DESCRIPTION
`ddtags` is a log event field set by the Agent, which is a string containing a comma separated list of tags (which can be either bare tags or key:value pairs). 

The new option `parse_ddtags` is disabled by default but when enabled, results in this string event field being parsed and expanded into an Object.

In addition to the unit tests, I validated this change manually with the Agent.