### PR TITLE
feat(greptimedb sink): improve tls support for greptimedb sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "greptimedb-client"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptimedb-ingester-rust.git?rev=4cb19ec47eeaf634c451d9ae438dac445a8a3dce#4cb19ec47eeaf634c451d9ae438dac445a8a3dce"
+source = "git+https://github.com/GreptimeTeam/greptimedb-ingester-rust.git?rev=d21dbcff680139ed2065b62100bac3123da7c789#d21dbcff680139ed2065b62100bac3123da7c789"
 dependencies = [
  "dashmap",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ hex = { version = "0.4.3", default-features = false, optional = true }
 sha2 = { version = "0.10.8", default-features = false, optional = true }
 
 # GreptimeDB
-greptimedb-client = { git = "https://github.com/GreptimeTeam/greptimedb-ingester-rust.git", rev = "4cb19ec47eeaf634c451d9ae438dac445a8a3dce", optional = true }
+greptimedb-client = { git = "https://github.com/GreptimeTeam/greptimedb-ingester-rust.git", rev = "d21dbcff680139ed2065b62100bac3123da7c789", optional = true }
 
 # External libs
 arc-swap = { version = "1.6", default-features = false, optional = true }

--- a/changelog.d/20006_improve_greptimedb_tls.enhancement.md
+++ b/changelog.d/20006_improve_greptimedb_tls.enhancement.md
@@ -1,1 +1,3 @@
 Improves TLS support for greptimedb sink. `tls.ca_file` is no longer required for enabling TLS. Just use `tls = {}` in toml configuration when your server is hosting a public CA.
+
+authors: sunng87

--- a/changelog.d/20006_improve_greptimedb_tls.enhancement.md
+++ b/changelog.d/20006_improve_greptimedb_tls.enhancement.md
@@ -1,0 +1,1 @@
+Improves TLS support for greptimedb sink. `tls.ca_file` is no longer required for enabling TLS. Just use `tls = {}` in toml configuration when your server is hosting a public CA.

--- a/src/sinks/greptimedb/mod.rs
+++ b/src/sinks/greptimedb/mod.rs
@@ -19,7 +19,6 @@
 //! - Distribution, Histogram and Summary, Sketch: Statistical attributes like
 //! `sum`, `count`, "max", "min", quantiles and buckets are stored as columns.
 //!
-use greptimedb_client::Client;
 use vector_lib::sensitive_string::SensitiveString;
 
 use crate::sinks::prelude::*;
@@ -138,8 +137,7 @@ impl SinkConfig for GreptimeDBConfig {
 }
 
 fn healthcheck(config: &GreptimeDBConfig) -> crate::Result<super::Healthcheck> {
-    // FIXME: TLS support
-    let client = Client::with_urls(vec![&config.endpoint]);
+    let client = service::new_client_from_config(config)?;
 
     Ok(async move { client.health_check().await.map_err(|error| error.into()) }.boxed())
 }

--- a/src/sinks/greptimedb/mod.rs
+++ b/src/sinks/greptimedb/mod.rs
@@ -20,7 +20,6 @@
 //! `sum`, `count`, "max", "min", quantiles and buckets are stored as columns.
 //!
 use greptimedb_client::Client;
-use snafu::Snafu;
 use vector_lib::sensitive_string::SensitiveString;
 
 use crate::sinks::prelude::*;
@@ -139,17 +138,10 @@ impl SinkConfig for GreptimeDBConfig {
 }
 
 fn healthcheck(config: &GreptimeDBConfig) -> crate::Result<super::Healthcheck> {
+    // FIXME: TLS support
     let client = Client::with_urls(vec![&config.endpoint]);
 
     Ok(async move { client.health_check().await.map_err(|error| error.into()) }.boxed())
-}
-
-#[derive(Debug, Snafu)]
-pub enum GreptimeDBConfigError {
-    #[snafu(display("greptimedb TLS Config Error: missing key"))]
-    TlsMissingKey,
-    #[snafu(display("greptimedb TLS Config Error: missing cert"))]
-    TlsMissingCert,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This patch improves TLS support for greptimedb sink, by updating the client sdk, and improving how we parse the configuration.

Before this patch, we will need to configure a custom server ca certificate to use TLS. However, for those hosting greptimedb using public ca, like letsencrypt, this server ca file is not required. So with change, we make server certificate completely optional for enable TLS.

This has been verified against greptimedb's hosted service.