### PR TITLE
chore(ci): Use gzip compression for datadog_logs regression tests

### DIFF
--- a/regression/cases/datadog_agent_remap_datadog_logs/vector/vector.yaml
+++ b/regression/cases/datadog_agent_remap_datadog_logs/vector/vector.yaml
@@ -42,6 +42,7 @@ sinks:
     inputs: [ "parse_message" ]
     endpoint:        "http://localhost:8080"
     default_api_key: "DEADBEEF"
+    compression: "gzip"
     healthcheck:
       enabled: false
     buffer:

--- a/regression/cases/datadog_agent_remap_datadog_logs_acks/vector/vector.yaml
+++ b/regression/cases/datadog_agent_remap_datadog_logs_acks/vector/vector.yaml
@@ -42,6 +42,7 @@ sinks:
     inputs: [ "parse_message" ]
     endpoint:        "http://localhost:8080"
     default_api_key: "DEADBEEF"
+    compression: "gzip"
     healthcheck:
       enabled: false
     buffer:


### PR DESCRIPTION
This seems to be closer to what real-world usage would look like given customers would likely want
to compress egress traffic to reduce bandwidth costs.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>