### PR TITLE
chore(testing): only compile ValidatableComponent in test runs

### DIFF
--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -10,7 +10,6 @@ use vector_lib::codecs::{
 
 use crate::{
     codecs::{EncodingConfigWithFraming, SinkType},
-    components::validation::ComponentTestCaseConfig,
     http::{Auth, HttpClient, MaybeAuth},
     sinks::{
         prelude::*,
@@ -307,46 +306,52 @@ impl SinkConfig for HttpSinkConfig {
     }
 }
 
-impl ValidatableComponent for HttpSinkConfig {
-    fn validation_configuration() -> ValidationConfiguration {
-        use std::str::FromStr;
-        use vector_lib::codecs::{JsonSerializerConfig, MetricTagValues};
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::validation::prelude::*;
 
-        let config = HttpSinkConfig {
-            uri: UriSerde::from_str("http://127.0.0.1:9000/endpoint")
-                .expect("should never fail to parse"),
-            method: HttpMethod::Post,
-            encoding: EncodingConfigWithFraming::new(
-                None,
-                JsonSerializerConfig::new(MetricTagValues::Full).into(),
-                Transformer::default(),
-            ),
-            auth: None,
-            headers: None,
-            compression: Compression::default(),
-            batch: BatchConfig::default(),
-            request: RequestConfig::default(),
-            tls: None,
-            acknowledgements: AcknowledgementsConfig::default(),
-            payload_prefix: String::new(),
-            payload_suffix: String::new(),
-        };
+    impl ValidatableComponent for HttpSinkConfig {
+        fn validation_configuration() -> ValidationConfiguration {
+            use std::str::FromStr;
+            use vector_lib::codecs::{JsonSerializerConfig, MetricTagValues};
 
-        let external_resource = ExternalResource::new(
-            ResourceDirection::Push,
-            HttpResourceConfig::from_parts(config.uri.uri.clone(), Some(config.method.into())),
-            config.encoding.clone(),
-        );
+            let config = HttpSinkConfig {
+                uri: UriSerde::from_str("http://127.0.0.1:9000/endpoint")
+                    .expect("should never fail to parse"),
+                method: HttpMethod::Post,
+                encoding: EncodingConfigWithFraming::new(
+                    None,
+                    JsonSerializerConfig::new(MetricTagValues::Full).into(),
+                    Transformer::default(),
+                ),
+                auth: None,
+                headers: None,
+                compression: Compression::default(),
+                batch: BatchConfig::default(),
+                request: RequestConfig::default(),
+                tls: None,
+                acknowledgements: AcknowledgementsConfig::default(),
+                payload_prefix: String::new(),
+                payload_suffix: String::new(),
+            };
 
-        ValidationConfiguration::from_sink(
-            Self::NAME,
-            vec![ComponentTestCaseConfig::from_sink(
-                config,
-                None,
-                Some(external_resource),
-            )],
-        )
+            let external_resource = ExternalResource::new(
+                ResourceDirection::Push,
+                HttpResourceConfig::from_parts(config.uri.uri.clone(), Some(config.method.into())),
+                config.encoding.clone(),
+            );
+
+            ValidationConfiguration::from_sink(
+                Self::NAME,
+                vec![ComponentTestCaseConfig::from_sink(
+                    config,
+                    None,
+                    Some(external_resource),
+                )],
+            )
+        }
     }
-}
 
-register_validatable_component!(HttpSinkConfig);
+    register_validatable_component!(HttpSinkConfig);
+}

--- a/src/sinks/prelude.rs
+++ b/src/sinks/prelude.rs
@@ -25,7 +25,6 @@ pub use vector_lib::{
 
 pub use crate::{
     codecs::{Encoder, EncodingConfig, Transformer},
-    components::validation::prelude::*,
     config::{DataType, GenerateConfig, SinkConfig, SinkContext},
     event::{Event, LogEvent},
     internal_events::{SinkRequestBuildError, TemplateRenderingError},

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -10,6 +10,7 @@ use snafu::ResultExt;
 use std::{collections::HashMap, time::Duration};
 use tokio_util::codec::Decoder as _;
 
+use crate::sources::util::http_client;
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{SourceConfig, SourceContext},
@@ -26,7 +27,6 @@ use crate::{
     tls::{TlsConfig, TlsSettings},
     Result,
 };
-use crate::{components::validation::prelude::*, sources::util::http_client};
 use vector_lib::codecs::{
     decoding::{DeserializerConfig, FramingConfig},
     StreamDecodingError,
@@ -234,37 +234,6 @@ impl SourceConfig for HttpClientConfig {
         false
     }
 }
-
-impl ValidatableComponent for HttpClientConfig {
-    fn validation_configuration() -> ValidationConfiguration {
-        let uri = Uri::from_static("http://127.0.0.1:9898");
-
-        let config = Self {
-            endpoint: uri.to_string(),
-            interval: Duration::from_secs(1),
-            timeout: Duration::from_secs(1),
-            decoding: DeserializerConfig::Json(Default::default()),
-            ..Default::default()
-        };
-
-        let external_resource = ExternalResource::new(
-            ResourceDirection::Pull,
-            HttpResourceConfig::from_parts(uri, Some(config.method.into())),
-            config.get_decoding_config(None),
-        );
-
-        ValidationConfiguration::from_source(
-            Self::NAME,
-            vec![ComponentTestCaseConfig::from_source(
-                config,
-                None,
-                Some(external_resource),
-            )],
-        )
-    }
-}
-
-register_validatable_component!(HttpClientConfig);
 
 impl HttpClientConfig {
     pub fn get_decoding_config(&self, log_namespace: Option<LogNamespace>) -> DecodingConfig {

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -1,13 +1,15 @@
+use http::Uri;
 use std::collections::HashMap;
 use tokio::time::Duration;
-use vector_lib::codecs::CharacterDelimitedDecoderConfig;
 use warp::{http::HeaderMap, Filter};
 
+use crate::components::validation::prelude::*;
 use crate::sources::util::http::HttpMethod;
 use crate::{serde::default_decoding, serde::default_framing_message_based};
 use vector_lib::codecs::decoding::{
     CharacterDelimitedDecoderOptions, DeserializerConfig, FramingConfig,
 };
+use vector_lib::codecs::CharacterDelimitedDecoderConfig;
 use vector_lib::event::Event;
 
 use super::HttpClientConfig;
@@ -35,6 +37,37 @@ pub(crate) async fn run_compliance(config: HttpClientConfig) -> Vec<Event> {
 fn http_client_generate_config() {
     test_generate_config::<HttpClientConfig>();
 }
+
+impl ValidatableComponent for HttpClientConfig {
+    fn validation_configuration() -> ValidationConfiguration {
+        let uri = Uri::from_static("http://127.0.0.1:9898");
+
+        let config = Self {
+            endpoint: uri.to_string(),
+            interval: Duration::from_secs(1),
+            timeout: Duration::from_secs(1),
+            decoding: DeserializerConfig::Json(Default::default()),
+            ..Default::default()
+        };
+
+        let external_resource = ExternalResource::new(
+            ResourceDirection::Pull,
+            HttpResourceConfig::from_parts(uri, Some(config.method.into())),
+            config.get_decoding_config(None),
+        );
+
+        ValidationConfiguration::from_source(
+            Self::NAME,
+            vec![ComponentTestCaseConfig::from_source(
+                config,
+                None,
+                Some(external_resource),
+            )],
+        )
+    }
+}
+
+register_validatable_component!(HttpClientConfig);
 
 /// Bytes should be decoded and HTTP header set to text/plain.
 #[tokio::test]

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, net::SocketAddr};
 
 use bytes::{Bytes, BytesMut};
 use chrono::Utc;
-use http::{StatusCode, Uri};
+use http::StatusCode;
 use http_serde;
 use tokio_util::codec::Decoder as _;
 use vrl::value::{kind::Collection, Kind};
@@ -22,7 +22,6 @@ use vector_lib::{
 
 use crate::{
     codecs::{Decoder, DecodingConfig},
-    components::validation::prelude::*,
     config::{
         GenerateConfig, Resource, SourceAcknowledgementsConfig, SourceConfig, SourceContext,
         SourceOutput,
@@ -273,37 +272,6 @@ impl Default for SimpleHttpConfig {
 
 impl_generate_config_from_default!(SimpleHttpConfig);
 
-impl ValidatableComponent for SimpleHttpConfig {
-    fn validation_configuration() -> ValidationConfiguration {
-        let config = Self {
-            decoding: Some(DeserializerConfig::Json(Default::default())),
-            ..Default::default()
-        };
-
-        let listen_addr_http = format!("http://{}/", config.address);
-        let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
-
-        let external_resource = ExternalResource::new(
-            ResourceDirection::Push,
-            HttpResourceConfig::from_parts(uri, Some(config.method.into())),
-            config
-                .get_decoding_config()
-                .expect("should not fail to get decoding config"),
-        );
-
-        ValidationConfiguration::from_source(
-            Self::NAME,
-            vec![ComponentTestCaseConfig::from_source(
-                config,
-                None,
-                Some(external_resource),
-            )],
-        )
-    }
-}
-
-register_validatable_component!(SimpleHttpConfig);
-
 const fn default_http_method() -> HttpMethod {
     HttpMethod::Post
 }
@@ -549,7 +517,7 @@ mod tests {
         Compression,
     };
     use futures::Stream;
-    use http::{HeaderMap, Method, StatusCode};
+    use http::{HeaderMap, Method, StatusCode, Uri};
     use similar_asserts::assert_eq;
     use vector_lib::codecs::{
         decoding::{DeserializerConfig, FramingConfig},
@@ -564,6 +532,7 @@ mod tests {
 
     use crate::sources::http_server::HttpMethod;
     use crate::{
+        components::validation::prelude::*,
         config::{log_schema, SourceConfig, SourceContext},
         event::{Event, EventStatus, Value},
         test_util::{
@@ -1552,4 +1521,35 @@ mod tests {
             );
         }
     }
+
+    impl ValidatableComponent for SimpleHttpConfig {
+        fn validation_configuration() -> ValidationConfiguration {
+            let config = Self {
+                decoding: Some(DeserializerConfig::Json(Default::default())),
+                ..Default::default()
+            };
+
+            let listen_addr_http = format!("http://{}/", config.address);
+            let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
+
+            let external_resource = ExternalResource::new(
+                ResourceDirection::Push,
+                HttpResourceConfig::from_parts(uri, Some(config.method.into())),
+                config
+                    .get_decoding_config()
+                    .expect("should not fail to get decoding config"),
+            );
+
+            ValidationConfiguration::from_source(
+                Self::NAME,
+                vec![ComponentTestCaseConfig::from_source(
+                    config,
+                    None,
+                    Some(external_resource),
+                )],
+            )
+        }
+    }
+
+    register_validatable_component!(SimpleHttpConfig);
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -11,7 +11,7 @@ use bytes::{Buf, Bytes};
 use chrono::{DateTime, TimeZone, Utc};
 use flate2::read::MultiGzDecoder;
 use futures::FutureExt;
-use http::{StatusCode, Uri};
+use http::StatusCode;
 use hyper::{service::make_service_fn, Server};
 use serde::Serialize;
 use serde_json::{
@@ -22,16 +22,10 @@ use snafu::Snafu;
 use tokio::net::TcpStream;
 use tower::ServiceBuilder;
 use tracing::Span;
+use vector_lib::internal_event::{CountByteSize, InternalEventHandle as _, Registered};
 use vector_lib::lookup::lookup_v2::OptionalValuePath;
+use vector_lib::lookup::{self, event_path, owned_value_path};
 use vector_lib::sensitive_string::SensitiveString;
-use vector_lib::{
-    codecs::decoding::DeserializerConfig,
-    lookup::{self, event_path, owned_value_path},
-};
-use vector_lib::{
-    codecs::BytesDecoderConfig,
-    internal_event::{CountByteSize, InternalEventHandle as _, Registered},
-};
 use vector_lib::{
     config::{LegacyKey, LogNamespace},
     event::BatchNotifier,
@@ -50,8 +44,6 @@ use self::{
     splunk_response::{HecResponse, HecResponseMetadata, HecStatusCode},
 };
 use crate::{
-    codecs::DecodingConfig,
-    components::validation::prelude::*,
     config::{log_schema, DataType, Resource, SourceConfig, SourceContext, SourceOutput},
     event::{Event, LogEvent, Value},
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
@@ -1249,41 +1241,6 @@ fn response_json(code: StatusCode, body: impl Serialize) -> Response {
     warp::reply::with_status(warp::reply::json(&body), code).into_response()
 }
 
-impl ValidatableComponent for SplunkConfig {
-    fn validation_configuration() -> ValidationConfiguration {
-        let config = Self {
-            address: default_socket_address(),
-            ..Default::default()
-        };
-
-        let listen_addr_http = format!("http://{}/services/collector/event", config.address);
-        let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
-
-        let framing = BytesDecoderConfig::new().into();
-        let decoding = DeserializerConfig::Json(Default::default());
-
-        let external_resource = ExternalResource::new(
-            ResourceDirection::Push,
-            HttpResourceConfig::from_parts(uri, None).with_headers(HashMap::from([(
-                X_SPLUNK_REQUEST_CHANNEL.to_string(),
-                "channel".to_string(),
-            )])),
-            DecodingConfig::new(framing, decoding, false.into()),
-        );
-
-        ValidationConfiguration::from_source(
-            Self::NAME,
-            vec![ComponentTestCaseConfig::from_source(
-                config,
-                None,
-                Some(external_resource),
-            )],
-        )
-    }
-}
-
-register_validatable_component!(SplunkConfig);
-
 #[cfg(feature = "sinks-splunk_hec")]
 #[cfg(test)]
 mod tests {
@@ -1291,9 +1248,13 @@ mod tests {
 
     use chrono::{TimeZone, Utc};
     use futures_util::Stream;
+    use http::Uri;
     use reqwest::{RequestBuilder, Response};
     use serde::Deserialize;
-    use vector_lib::codecs::{JsonSerializerConfig, TextSerializerConfig};
+    use vector_lib::codecs::{
+        decoding::DeserializerConfig, BytesDecoderConfig, JsonSerializerConfig,
+        TextSerializerConfig,
+    };
     use vector_lib::sensitive_string::SensitiveString;
     use vector_lib::{event::EventStatus, schema::Definition};
     use vrl::path::PathPrefix;
@@ -1303,7 +1264,8 @@ mod tests {
         config_host_key_target_path, config_timestamp_key_target_path,
     };
     use crate::{
-        codecs::EncodingConfig,
+        codecs::{DecodingConfig, EncodingConfig},
+        components::validation::prelude::*,
         config::{log_schema, SinkConfig, SinkContext, SourceConfig, SourceContext},
         event::{Event, LogEvent},
         sinks::{
@@ -2650,4 +2612,39 @@ mod tests {
 
         assert_eq!(definitions, Some(expected_definition));
     }
+
+    impl ValidatableComponent for SplunkConfig {
+        fn validation_configuration() -> ValidationConfiguration {
+            let config = Self {
+                address: default_socket_address(),
+                ..Default::default()
+            };
+
+            let listen_addr_http = format!("http://{}/services/collector/event", config.address);
+            let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
+
+            let framing = BytesDecoderConfig::new().into();
+            let decoding = DeserializerConfig::Json(Default::default());
+
+            let external_resource = ExternalResource::new(
+                ResourceDirection::Push,
+                HttpResourceConfig::from_parts(uri, None).with_headers(HashMap::from([(
+                    X_SPLUNK_REQUEST_CHANNEL.to_string(),
+                    "channel".to_string(),
+                )])),
+                DecodingConfig::new(framing, decoding, false.into()),
+            );
+
+            ValidationConfiguration::from_source(
+                Self::NAME,
+                vec![ComponentTestCaseConfig::from_source(
+                    config,
+                    None,
+                    Some(external_resource),
+                )],
+            )
+        }
+    }
+
+    register_validatable_component!(SplunkConfig);
 }


### PR DESCRIPTION
This is some tech debt because it took me this long to realize that we had no reason to compile the implementation of `ValidatableComponent` outside of unit test runs.