### PR TITLE
fix(aws provider): Enable `credentials-process` for `aws-config`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["be
 aws-sdk-sts = { version = "1.3.1", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-types = { version = "1.1.7", default-features = false, optional = true }
 aws-sigv4 = { version = "1.1.7", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "1.0.1", default-features = false, features = ["behavior-version-latest"], optional = true }
+aws-config = { version = "1.0.1", default-features = false, features = ["behavior-version-latest", "credentials-process"], optional = true }
 aws-credential-types = { version = "1.1.7", default-features = false, features = ["hardcoded-credentials"], optional = true }
 aws-smithy-http = { version = "0.60", default-features = false, features = ["event-stream"], optional = true }
 aws-smithy-types = { version = "1.1.7", default-features = false, optional = true }

--- a/changelog.d/aws_credentials_process.fix.md
+++ b/changelog.d/aws_credentials_process.fix.md
@@ -1,0 +1,2 @@
+AWS components again support the use of `credential_process` in AWS config files to load AWS
+credentials from an external process. This was a regression in v0.36.0.


### PR DESCRIPTION
Otherwise it outputs this warning:

```
2024-03-07T11:59:25.573521Z  WARN provide_credentials{provider=default_chain}: aws_config::meta::credentials::chain: provider failed to provide credentials provider=Profile error=the credentials provider was not properly configured: ProfileFile provider could not be built: This behavior requires following cargo feature(s) enabled: credentials-process. In order to spawn a subprocess, the credentials-process feature must be enabled. (InvalidConfiguration(InvalidConfiguration { source: "ProfileFile provider could not be built: This behavior requires following cargo feature(s) enabled: credentials-process. In order to spawn a subprocess, the credentials-process feature must be enabled."
```

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
