### PR TITLE
chore(testing): further adjustments to component validation framework

### DIFF
--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use bytes::BytesMut;
 use serde::Deserialize;
+use serde_json::Value;
 use snafu::Snafu;
 use tokio_util::codec::Encoder as _;
 
@@ -43,7 +44,7 @@ pub enum EventData {
     /// A simple log event.
     Log(String),
     /// A log event built from key-value pairs
-    LogBuilder(HashMap<String, String>),
+    LogBuilder(HashMap<String, Value>),
 }
 
 impl EventData {

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -240,21 +240,20 @@ fn spawn_input_http_client(
             debug!("Got event to send from runner.");
 
             let mut buffer = BytesMut::new();
-            if let (
-                Json(_),
-                Framer::CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' }),
-            ) = (encoder.serializer(), encoder.framer())
-            {
+
+            let is_json = matches!(encoder.serializer(), Json(_))
+                && matches!(
+                    encoder.framer(),
+                    Framer::CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' })
+                );
+
+            if is_json {
                 buffer.put_u8(b'[');
             }
 
             encode_test_event(&mut encoder, &mut buffer, event);
 
-            if let (
-                Json(_),
-                Framer::CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' }),
-            ) = (encoder.serializer(), encoder.framer())
-            {
+            if is_json {
                 if !buffer.is_empty() {
                     // remove trailing comma from last record
                     buffer.truncate(buffer.len() - 1);

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::{MethodFilter, MethodRouter},
     Router,
 };
-use bytes::BytesMut;
+use bytes::{BufMut as _, BytesMut};
 use http::{Method, Request, StatusCode, Uri};
 use hyper::{Body, Client, Server};
 use tokio::{
@@ -24,7 +24,10 @@ use crate::components::validation::{
     sync::{Configuring, TaskCoordinator},
     RunnerMetrics,
 };
-use vector_lib::{event::Event, EstimatedJsonEncodedSizeOf};
+use vector_lib::{
+    codecs::encoding::Framer, codecs::encoding::Serializer::Json,
+    codecs::CharacterDelimitedEncoder, event::Event, EstimatedJsonEncodedSizeOf,
+};
 
 use super::{encode_test_event, ResourceCodec, ResourceDirection, TestEvent};
 
@@ -65,7 +68,7 @@ impl HttpResourceConfig {
             }
             // We'll push data to the source.
             ResourceDirection::Push => {
-                spawn_input_http_client(self, codec, input_rx, task_coordinator)
+                spawn_input_http_client(self, codec, input_rx, task_coordinator, runner_metrics)
             }
         }
     }
@@ -213,12 +216,14 @@ fn spawn_input_http_client(
     codec: ResourceCodec,
     mut input_rx: mpsc::Receiver<TestEvent>,
     task_coordinator: &TaskCoordinator<Configuring>,
+    runner_metrics: &Arc<Mutex<RunnerMetrics>>,
 ) {
     // Spin up an HTTP client that will push the input data to the source on a
     // request-per-input-item basis. This runs serially and has no parallelism.
     let started = task_coordinator.track_started();
     let completed = task_coordinator.track_completed();
     let mut encoder = codec.into_encoder();
+    let runner_metrics = Arc::clone(runner_metrics);
 
     tokio::spawn(async move {
         // Mark ourselves as started. We don't actually do anything until we get our first input
@@ -235,7 +240,32 @@ fn spawn_input_http_client(
             debug!("Got event to send from runner.");
 
             let mut buffer = BytesMut::new();
+            if let (
+                Json(_),
+                Framer::CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' }),
+            ) = (encoder.serializer(), encoder.framer())
+            {
+                buffer.put_u8(b'[');
+            }
+
             encode_test_event(&mut encoder, &mut buffer, event);
+
+            if let (
+                Json(_),
+                Framer::CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' }),
+            ) = (encoder.serializer(), encoder.framer())
+            {
+                if !buffer.is_empty() {
+                    // remove trailing comma from last record
+                    buffer.truncate(buffer.len() - 1);
+                }
+                buffer.put_u8(b']');
+
+                // in this edge case we have removed the trailing comma (one byte) and added
+                // opening and closing braces (2 bytes) for a net add of one byte.
+                let mut runner_metrics = runner_metrics.lock().await;
+                runner_metrics.sent_bytes_total += 1;
+            }
 
             let mut request_builder = Request::builder()
                 .uri(request_uri.clone())

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -593,7 +593,7 @@ fn spawn_input_driver(
                 }
             }
 
-            let (failure_case, event) = input_event.clone().get();
+            let (failure_case, mut event) = input_event.clone().get();
 
             if let Some(encoder) = maybe_encoder.as_mut() {
                 let mut buffer = BytesMut::new();
@@ -613,6 +613,34 @@ fn spawn_input_driver(
 
             if !failure_case || component_type == ComponentType::Sink {
                 input_runner_metrics.sent_events_total += 1;
+
+                // Convert unix timestamp in input events to the Datetime string.
+                // This is necessary when a source expects the incoming event to have a
+                // unix timestamp but we convert it into a datetime string in the source.
+                // For example, the `datadog_agent` source. This only takes effect when
+                // the test case YAML file defining the event, constructs it with the log
+                // builder variant, and specifies an integer in milliseconds for the timestamp.
+                if component_type == ComponentType::Source {
+                    if let Event::Log(ref mut log) = event {
+                        if let Some(ts) = log.remove_timestamp() {
+                            match ts.as_integer() {
+                                Some(ts) => {
+                                    log.parse_path_and_insert(
+                                        "timestamp",
+                                        chrono::DateTime::from_timestamp_millis(ts).expect(
+                                            &format!("invalid timestamp in input test event {ts}"),
+                                        ),
+                                    )
+                                    .expect("failed to insert timestamp");
+                                }
+                                None => {
+                                    log.parse_path_and_insert("timestamp", ts)
+                                        .expect("failed to insert timestamp");
+                                }
+                            }
+                        }
+                    }
+                }
 
                 // This particular metric is tricky because a component can run the
                 // EstimatedJsonSizeOf calculation on a single event or an array of

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -623,21 +623,14 @@ fn spawn_input_driver(
                 if component_type == ComponentType::Source {
                     if let Event::Log(ref mut log) = event {
                         if let Some(ts) = log.remove_timestamp() {
-                            match ts.as_integer() {
-                                Some(ts) => {
-                                    log.parse_path_and_insert(
-                                        "timestamp",
-                                        chrono::DateTime::from_timestamp_millis(ts).expect(
-                                            &format!("invalid timestamp in input test event {ts}"),
-                                        ),
-                                    )
-                                    .expect("failed to insert timestamp");
-                                }
-                                None => {
-                                    log.parse_path_and_insert("timestamp", ts)
-                                        .expect("failed to insert timestamp");
-                                }
-                            }
+                            let ts = match ts.as_integer() {
+                                Some(ts) => chrono::DateTime::from_timestamp_millis(ts)
+                                    .expect(&format!("invalid timestamp in input test event {ts}"))
+                                    .into(),
+                                None => ts,
+                            };
+                            log.parse_path_and_insert("timestamp", ts)
+                                .expect("failed to insert timestamp");
                         }
                     }
                 }


### PR DESCRIPTION
This PR makes a few changes that became necessary when implementing the validation for the `datadog_agent` source (https://github.com/vectordotdev/vector/pull/20044)

- allow the log_builder test case event variant to define values that are non-strings
- in the HTTP External Resource for input driver- handle the case where we are dealing with character delimited JSON, by wrapping the event object in a JSON array and adjusting the runner's expected metric accordingly.
- and finally, a strange one- the `datadog_agent` component decodes the JSON fields into a custom structure, and then adds them to the log event. The only discrepancy is the timestamp, which the Agent sends (and thus the input driver must encode) as a unix timestamp (integer), but Vector converts that into a DateTime string when we build the Event.
    - my solution is to handle that in the input driver. I think it'd be a bit much to handle it in the component itself since we'd have to have some arguably ugly logic to keep track of the timestamp size separately and not count that. But it could be done.
    - it is a bit of a gray area since we are _technically_ doing enrichment with the timestamp conversion.


```
make test-component-validation
cargo nextest run --no-fail-fast --no-default-features --features component-validation-tests --status-level pass --test-threads 4 components::validation::tests
    Starting 6 tests across 3 binaries (432 skipped)
        PASS [  10.628s] vector components::validation::tests::validate_component_tests_validation_components_sources_http_client_yaml
        PASS [   5.499s] vector components::validation::tests::validate_component_tests_validation_components_sources_http_server_yaml
        PASS [  21.267s] vector components::validation::tests::validate_component_tests_validation_components_sinks_splunk_hec_logs_yaml
        PASS [  21.548s] vector components::validation::tests::validate_component_tests_validation_components_sinks_http_yaml
        PASS [   5.489s] vector components::validation::tests::validate_component_tests_validation_components_sources_splunk_hec_yaml
        PASS [  27.096s] vector components::validation::tests::validate_component_tests_validation_components_sinks_datadog_logs_yaml
```