### PR TITLE
feat(vrl): add `uuid_v7` function

### DIFF
--- a/lib/vector-vrl/tests/src/docs.rs
+++ b/lib/vector-vrl/tests/src/docs.rs
@@ -16,6 +16,7 @@ const SKIP_FUNCTION_EXAMPLES: &[&str] = &[
     "type_def", // Not supported on VM runtime
     "random_bytes",
     "uuid_v4",
+    "uuid_v7",
     "strip_ansi_escape_codes",
     "get_hostname",
     "now",

--- a/tests/behavior/transforms/remap.toml
+++ b/tests/behavior/transforms/remap.toml
@@ -529,6 +529,32 @@
         .b == "bar"
       '''
 
+[transforms.remap_function_uuid_v7]
+  inputs = []
+  type = "remap"
+  source = """
+    .a = uuid_v7()
+
+    if uuid_v7() != "" {
+      .b = "bar"
+    }
+  """
+[[tests]]
+  name = "remap_function_uuid_v7"
+  [tests.input]
+    insert_at = "remap_function_uuid_v7"
+    type = "log"
+    [tests.input.log_fields]
+      b = "foo"
+  [[tests.outputs]]
+    extract_from = "remap_function_uuid_v7"
+    [[tests.outputs.conditions]]
+      type = "vrl"
+      source = '''
+        match(string!(.a), r'(?i)^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$') &&
+        .b == "bar"
+      '''
+
 [transforms.remap_function_sha1]
   inputs = []
   type = "remap"

--- a/website/cue/reference/remap/functions/uuid_v7.cue
+++ b/website/cue/reference/remap/functions/uuid_v7.cue
@@ -1,0 +1,44 @@
+package metadata
+
+remap: functions: uuid_v7: {
+	category:    "Random"
+	description: """
+		Generates a random [UUIDv7](\(urls.uuidv7)) string.
+		"""
+
+	arguments: [
+		{
+			name:        "timestamp"
+			description: "The timestamp used to generate the UUIDv7."
+			required:    false
+			type: ["timestamp"]
+			default: "`now()`"
+		},
+	]
+	internal_failure_reasons: []
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Create a UUIDv7 with implicit `now()`"
+			source: #"""
+				uuid_v7()
+				"""#
+			return: "06338364-8305-7b74-8000-de4963503139"
+		},
+		{
+			title: "Create a UUIDv7 with explicit `now()`"
+			source: #"""
+				uuid_v7(now())
+				"""#
+			return: "018e29b3-0bea-7f78-8af3-d32ccb1b93c1"
+		},
+		{
+			title: "Create a UUIDv7 with custom timestamp"
+			source: #"""
+				uuid_v7(t'2020-12-30T22:20:53.824727Z')
+				"""#
+			return: "0176b5bd-5d19-7394-bb60-c21028c6152b"
+		},
+	]
+}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -527,6 +527,7 @@ urls: {
 	unix_timestamp:                             "\(wikipedia)/wiki/Unix_time"
 	utf8:                                       "\(wikipedia)/wiki/UTF-8"
 	uuidv4:                                     "\(wikipedia)/wiki/Universally_unique_identifier#Version_4_(random)"
+	uuidv7:                                     "https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#name-uuid-version-7"
 	url:                                        "\(wikipedia)/wiki/URL"
 	us_social_security_number:                  "https://www.ssa.gov/history/ssn/geocard.html"
 	user_agent:                                 "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent"


### PR DESCRIPTION
This PR introduces the following changes:

* add remap behavioral test for VRL `uuid_v7()` function
* provided cue website documentation for `uuid_v7()` function
* depends on vectordotdev/vrl/pull/738
