### PR TITLE
feat(sources): add `permit_origin` config option for all tcp sources

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -442,6 +442,7 @@ solarwinds
 splunk
 ssh
 staticuser
+statsd
 symbian
 tanushri
 timeframe

--- a/changelog.d/20051_permit_origin_tcp.feature.md
+++ b/changelog.d/20051_permit_origin_tcp.feature.md
@@ -1,0 +1,3 @@
+Added support for `permit_origin` config option for all sources with TCP mode (`fluent`, `logstash`, `stastd`, `syslog`).
+
+authors: esensar

--- a/changelog.d/20051_permit_origin_tcp.feature.md
+++ b/changelog.d/20051_permit_origin_tcp.feature.md
@@ -1,3 +1,3 @@
-Added support for `permit_origin` config option for all sources with TCP mode (`fluent`, `logstash`, `stastd`, `syslog`).
+Added support for `permit_origin` config option for all sources with TCP mode (`fluent`, `logstash`, `statsd`, `syslog`).
 
 authors: esensar

--- a/lib/vector-core/src/ipallowlist.rs
+++ b/lib/vector-core/src/ipallowlist.rs
@@ -38,3 +38,9 @@ impl Configurable for IpNetConfig {
         Metadata::with_description("IP network")
     }
 }
+
+impl From<IpAllowlistConfig> for Vec<IpNet> {
+    fn from(value: IpAllowlistConfig) -> Self {
+        value.0.iter().map(|net| net.0).collect()
+    }
+}

--- a/lib/vector-core/src/ipallowlist.rs
+++ b/lib/vector-core/src/ipallowlist.rs
@@ -6,12 +6,22 @@ use ipnet::IpNet;
 use vector_config::{configurable_component, Configurable, Metadata, ToValue};
 use vector_config_common::schema::{InstanceType, SchemaGenerator, SchemaObject};
 
-/// List of allowed origin IP networks.
+/// List of allowed origin IP networks. IP addresses must be in CIDR notation.
 #[configurable_component]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, transparent)]
 #[configurable(metadata(docs::human_name = "Allowed IP network origins"))]
+#[configurable(metadata(docs::examples = "ip_allow_list_example()"))]
 pub struct IpAllowlistConfig(pub Vec<IpNetConfig>);
+
+const fn ip_allow_list_example() -> [&'static str; 4] {
+    [
+        "192.168.0.0/16",
+        "127.0.0.1/32",
+        "::1/128",
+        "9876:9ca3:99ab::23/128",
+    ]
+}
 
 /// IP network
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/lib/vector-core/src/ipallowlist.rs
+++ b/lib/vector-core/src/ipallowlist.rs
@@ -6,7 +6,7 @@ use ipnet::IpNet;
 use vector_config::{configurable_component, Configurable, Metadata, ToValue};
 use vector_config_common::schema::{InstanceType, SchemaGenerator, SchemaObject};
 
-/// IP network allowlist settings for network components
+/// List of allowed origin IP networks.
 #[configurable_component]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, transparent)]

--- a/src/sources/dnstap/tcp.rs
+++ b/src/sources/dnstap/tcp.rs
@@ -159,9 +159,7 @@ impl<T: FrameHandler + Clone> DnstapFrameHandler<T> {
             receive_buffer_bytes: config.receive_buffer_bytes,
             max_connection_duration_secs: config.max_connection_duration_secs,
             max_connections: config.connection_limit,
-            allowlist: config
-                .permit_origin
-                .map(|p| p.0.iter().map(|net| net.0).collect()),
+            allowlist: config.permit_origin.map(Into::into),
             log_namespace,
         }
     }

--- a/src/sources/dnstap/tcp.rs
+++ b/src/sources/dnstap/tcp.rs
@@ -46,9 +46,7 @@ pub struct TcpConfig {
     #[serde(default = "default_port_key")]
     pub port_key: OptionalValuePath,
 
-    /// List of allowed origin IP networks
-    ///
-    /// By default, all origins are allowed
+    #[configurable(derived)]
     permit_origin: Option<IpAllowlistConfig>,
 
     #[configurable(derived)]

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -51,9 +51,7 @@ pub struct FluentConfig {
     #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    /// List of allowed origin IP networks
-    ///
-    /// By default, all origins are allowed
+    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
     /// The size of the receive buffer used for each connection.

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -115,9 +115,7 @@ impl SourceConfig for FluentConfig {
             cx,
             self.acknowledgements,
             self.connection_limit,
-            self.permit_origin
-                .clone()
-                .map(|p| p.0.iter().map(|net| net.0).collect()),
+            self.permit_origin.clone().map(Into::into),
             FluentConfig::NAME,
             log_namespace,
         )

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -5,6 +5,7 @@ use std::{
     convert::TryFrom,
     io::{self, Read},
 };
+use vector_lib::ipallowlist::IpAllowlistConfig;
 
 use bytes::{Buf, Bytes, BytesMut};
 use flate2::read::ZlibDecoder;
@@ -44,6 +45,11 @@ pub struct LogstashConfig {
     #[configurable(derived)]
     #[configurable(metadata(docs::advanced))]
     keepalive: Option<TcpKeepaliveConfig>,
+
+    /// List of allowed origin IP networks
+    ///
+    /// By default, all origins are allowed
+    pub permit_origin: Option<IpAllowlistConfig>,
 
     #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
@@ -117,6 +123,7 @@ impl Default for LogstashConfig {
         Self {
             address: SocketListenAddr::SocketAddr("0.0.0.0:5044".parse().unwrap()),
             keepalive: None,
+            permit_origin: None,
             tls: None,
             receive_buffer_bytes: None,
             acknowledgements: Default::default(),
@@ -162,7 +169,9 @@ impl SourceConfig for LogstashConfig {
             cx,
             self.acknowledgements,
             self.connection_limit,
-            None,
+            self.permit_origin
+                .clone()
+                .map(|p| p.0.iter().map(|net| net.0).collect()),
             LogstashConfig::NAME,
             log_namespace,
         )
@@ -717,6 +726,7 @@ mod test {
             let source = LogstashConfig {
                 address: address.into(),
                 tls: None,
+                permit_origin: None,
                 keepalive: None,
                 receive_buffer_bytes: None,
                 acknowledgements: true.into(),
@@ -960,6 +970,7 @@ mod integration_tests {
                 address: address.into(),
                 tls: Some(tls_config),
                 keepalive: None,
+                permit_origin: None,
                 receive_buffer_bytes: None,
                 acknowledgements: false.into(),
                 connection_limit: None,

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -46,9 +46,7 @@ pub struct LogstashConfig {
     #[configurable(metadata(docs::advanced))]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    /// List of allowed origin IP networks
-    ///
-    /// By default, all origins are allowed
+    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
     #[configurable(derived)]

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -167,9 +167,7 @@ impl SourceConfig for LogstashConfig {
             cx,
             self.acknowledgements,
             self.connection_limit,
-            self.permit_origin
-                .clone()
-                .map(|p| p.0.iter().map(|net| net.0).collect()),
+            self.permit_origin.clone().map(Into::into),
             LogstashConfig::NAME,
             log_namespace,
         )

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -145,9 +145,7 @@ impl SourceConfig for SocketConfig {
                     cx,
                     false.into(),
                     config.connection_limit,
-                    config
-                        .permit_origin
-                        .map(|p| p.0.iter().map(|net| net.0).collect()),
+                    config.permit_origin.map(Into::into),
                     SocketConfig::NAME,
                     log_namespace,
                 )

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -59,9 +59,7 @@ pub struct TcpConfig {
     #[serde(default = "default_port_key")]
     port_key: OptionalValuePath,
 
-    /// List of allowed origin IP networks
-    ///
-    /// By default, all origins are allowed
+    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
     #[configurable(derived)]

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -93,9 +93,7 @@ pub struct TcpConfig {
     #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    /// List of allowed origin IP networks
-    ///
-    /// By default, all origins are allowed
+    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
     #[configurable(derived)]

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -173,10 +173,7 @@ impl SourceConfig for StatsdConfig {
                     cx,
                     false.into(),
                     config.connection_limit,
-                    config
-                        .permit_origin
-                        .clone()
-                        .map(|p| p.0.iter().map(|net| net.0).collect()),
+                    config.permit_origin.clone().map(Into::into),
                     StatsdConfig::NAME,
                     LogNamespace::Legacy,
                 )

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -207,7 +207,7 @@ impl SourceConfig for SyslogConfig {
                     cx,
                     false.into(),
                     connection_limit,
-                    permit_origin.map(|p| p.0.iter().map(|net| net.0).collect()),
+                    permit_origin.map(Into::into),
                     SyslogConfig::NAME,
                     log_namespace,
                 )

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -81,9 +81,7 @@ pub enum Mode {
         #[configurable(derived)]
         keepalive: Option<TcpKeepaliveConfig>,
 
-        /// List of allowed origin IP networks
-        ///
-        /// By default, all origins are allowed
+        #[configurable(derived)]
         permit_origin: Option<IpAllowlistConfig>,
 
         #[configurable(derived)]

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1,6 +1,7 @@
 #[cfg(unix)]
 use std::path::PathBuf;
 use std::{net::SocketAddr, time::Duration};
+use vector_lib::ipallowlist::IpAllowlistConfig;
 
 use bytes::Bytes;
 use chrono::Utc;
@@ -70,6 +71,7 @@ pub struct SyslogConfig {
 #[derive(Clone, Debug)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 #[configurable(metadata(docs::enum_tag_description = "The type of socket to use."))]
+#[allow(clippy::large_enum_variant)]
 pub enum Mode {
     /// Listen on TCP.
     Tcp {
@@ -78,6 +80,11 @@ pub enum Mode {
 
         #[configurable(derived)]
         keepalive: Option<TcpKeepaliveConfig>,
+
+        /// List of allowed origin IP networks
+        ///
+        /// By default, all origins are allowed
+        permit_origin: Option<IpAllowlistConfig>,
 
         #[configurable(derived)]
         tls: Option<TlsSourceConfig>,
@@ -141,6 +148,7 @@ impl Default for SyslogConfig {
             mode: Mode::Tcp {
                 address: SocketListenAddr::SocketAddr("0.0.0.0:514".parse().unwrap()),
                 keepalive: None,
+                permit_origin: None,
                 tls: None,
                 receive_buffer_bytes: None,
                 connection_limit: None,
@@ -173,6 +181,7 @@ impl SourceConfig for SyslogConfig {
             Mode::Tcp {
                 address,
                 keepalive,
+                permit_origin,
                 tls,
                 receive_buffer_bytes,
                 connection_limit,
@@ -200,7 +209,7 @@ impl SourceConfig for SyslogConfig {
                     cx,
                     false.into(),
                     connection_limit,
-                    None,
+                    permit_origin.map(|p| p.0.iter().map(|net| net.0).collect()),
                     SyslogConfig::NAME,
                     log_namespace,
                 )
@@ -1115,6 +1124,7 @@ mod test {
             // Create and spawn the source.
             let config = SyslogConfig::from_mode(Mode::Tcp {
                 address: in_addr.into(),
+                permit_origin: None,
                 keepalive: None,
                 tls: None,
                 receive_buffer_bytes: None,
@@ -1258,6 +1268,7 @@ mod test {
             // Create and spawn the source.
             let config = SyslogConfig::from_mode(Mode::Tcp {
                 address: in_addr.into(),
+                permit_origin: None,
                 keepalive: None,
                 tls: None,
                 receive_buffer_bytes: None,

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -87,11 +87,7 @@ base: components: sources: dnstap: configuration: {
 		type: bool: {}
 	}
 	permit_origin: {
-		description: """
-			List of allowed origin IP networks
-
-			By default, all origins are allowed
-			"""
+		description:   "List of allowed origin IP networks."
 		relevant_when: "mode = \"tcp\""
 		required:      false
 		type: array: items: type: string: {}

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -87,10 +87,10 @@ base: components: sources: dnstap: configuration: {
 		type: bool: {}
 	}
 	permit_origin: {
-		description:   "List of allowed origin IP networks."
+		description:   "List of allowed origin IP networks. IP addresses must be in CIDR notation."
 		relevant_when: "mode = \"tcp\""
 		required:      false
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["192.168.0.0/16", "127.0.0.1/32", "::1/128", "9876:9ca3:99ab::23/128"]
 	}
 	port_key: {
 		description: """

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -46,6 +46,15 @@ base: components: sources: fluent: configuration: {
 			type: uint: unit: "seconds"
 		}
 	}
+	permit_origin: {
+		description: """
+			List of allowed origin IP networks
+
+			By default, all origins are allowed
+			"""
+		required: false
+		type: array: items: type: string: {}
+	}
 	receive_buffer_bytes: {
 		description: """
 			The size of the receive buffer used for each connection.

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -47,12 +47,8 @@ base: components: sources: fluent: configuration: {
 		}
 	}
 	permit_origin: {
-		description: """
-			List of allowed origin IP networks
-
-			By default, all origins are allowed
-			"""
-		required: false
+		description: "List of allowed origin IP networks."
+		required:    false
 		type: array: items: type: string: {}
 	}
 	receive_buffer_bytes: {

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -47,9 +47,9 @@ base: components: sources: fluent: configuration: {
 		}
 	}
 	permit_origin: {
-		description: "List of allowed origin IP networks."
+		description: "List of allowed origin IP networks. IP addresses must be in CIDR notation."
 		required:    false
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["192.168.0.0/16", "127.0.0.1/32", "::1/128", "9876:9ca3:99ab::23/128"]
 	}
 	receive_buffer_bytes: {
 		description: """

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -47,12 +47,8 @@ base: components: sources: logstash: configuration: {
 		}
 	}
 	permit_origin: {
-		description: """
-			List of allowed origin IP networks
-
-			By default, all origins are allowed
-			"""
-		required: false
+		description: "List of allowed origin IP networks."
+		required:    false
 		type: array: items: type: string: {}
 	}
 	receive_buffer_bytes: {

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -46,6 +46,15 @@ base: components: sources: logstash: configuration: {
 			type: uint: unit: "seconds"
 		}
 	}
+	permit_origin: {
+		description: """
+			List of allowed origin IP networks
+
+			By default, all origins are allowed
+			"""
+		required: false
+		type: array: items: type: string: {}
+	}
 	receive_buffer_bytes: {
 		description: "The size of the receive buffer used for each connection."
 		required:    false

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -47,9 +47,9 @@ base: components: sources: logstash: configuration: {
 		}
 	}
 	permit_origin: {
-		description: "List of allowed origin IP networks."
+		description: "List of allowed origin IP networks. IP addresses must be in CIDR notation."
 		required:    false
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["192.168.0.0/16", "127.0.0.1/32", "::1/128", "9876:9ca3:99ab::23/128"]
 	}
 	receive_buffer_bytes: {
 		description: "The size of the receive buffer used for each connection."

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -394,10 +394,10 @@ base: components: sources: socket: configuration: {
 		type: string: examples: ["/path/to/socket"]
 	}
 	permit_origin: {
-		description:   "List of allowed origin IP networks."
+		description:   "List of allowed origin IP networks. IP addresses must be in CIDR notation."
 		relevant_when: "mode = \"tcp\""
 		required:      false
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["192.168.0.0/16", "127.0.0.1/32", "::1/128", "9876:9ca3:99ab::23/128"]
 	}
 	port_key: {
 		description: """

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -394,11 +394,7 @@ base: components: sources: socket: configuration: {
 		type: string: examples: ["/path/to/socket"]
 	}
 	permit_origin: {
-		description: """
-			List of allowed origin IP networks
-
-			By default, all origins are allowed
-			"""
+		description:   "List of allowed origin IP networks."
 		relevant_when: "mode = \"tcp\""
 		required:      false
 		type: array: items: type: string: {}

--- a/website/cue/reference/components/sources/base/statsd.cue
+++ b/website/cue/reference/components/sources/base/statsd.cue
@@ -48,11 +48,7 @@ base: components: sources: statsd: configuration: {
 		type: string: examples: ["/path/to/socket"]
 	}
 	permit_origin: {
-		description: """
-			List of allowed origin IP networks
-
-			By default, all origins are allowed
-			"""
+		description:   "List of allowed origin IP networks."
 		relevant_when: "mode = \"tcp\""
 		required:      false
 		type: array: items: type: string: {}

--- a/website/cue/reference/components/sources/base/statsd.cue
+++ b/website/cue/reference/components/sources/base/statsd.cue
@@ -48,10 +48,10 @@ base: components: sources: statsd: configuration: {
 		type: string: examples: ["/path/to/socket"]
 	}
 	permit_origin: {
-		description:   "List of allowed origin IP networks."
+		description:   "List of allowed origin IP networks. IP addresses must be in CIDR notation."
 		relevant_when: "mode = \"tcp\""
 		required:      false
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["192.168.0.0/16", "127.0.0.1/32", "::1/128", "9876:9ca3:99ab::23/128"]
 	}
 	receive_buffer_bytes: {
 		description:   "The size of the receive buffer used for each connection."

--- a/website/cue/reference/components/sources/base/statsd.cue
+++ b/website/cue/reference/components/sources/base/statsd.cue
@@ -47,6 +47,16 @@ base: components: sources: statsd: configuration: {
 		required:      true
 		type: string: examples: ["/path/to/socket"]
 	}
+	permit_origin: {
+		description: """
+			List of allowed origin IP networks
+
+			By default, all origins are allowed
+			"""
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: array: items: type: string: {}
+	}
 	receive_buffer_bytes: {
 		description:   "The size of the receive buffer used for each connection."
 		relevant_when: "mode = \"tcp\" or mode = \"udp\""

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -78,10 +78,10 @@ base: components: sources: syslog: configuration: {
 		type: string: examples: ["/path/to/socket"]
 	}
 	permit_origin: {
-		description:   "List of allowed origin IP networks."
+		description:   "List of allowed origin IP networks. IP addresses must be in CIDR notation."
 		relevant_when: "mode = \"tcp\""
 		required:      false
-		type: array: items: type: string: {}
+		type: array: items: type: string: examples: ["192.168.0.0/16", "127.0.0.1/32", "::1/128", "9876:9ca3:99ab::23/128"]
 	}
 	receive_buffer_bytes: {
 		description: """

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -77,6 +77,16 @@ base: components: sources: syslog: configuration: {
 		required:      true
 		type: string: examples: ["/path/to/socket"]
 	}
+	permit_origin: {
+		description: """
+			List of allowed origin IP networks
+
+			By default, all origins are allowed
+			"""
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: array: items: type: string: {}
+	}
 	receive_buffer_bytes: {
 		description: """
 			The size of the receive buffer used for each connection.

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -78,11 +78,7 @@ base: components: sources: syslog: configuration: {
 		type: string: examples: ["/path/to/socket"]
 	}
 	permit_origin: {
-		description: """
-			List of allowed origin IP networks
-
-			By default, all origins are allowed
-			"""
+		description:   "List of allowed origin IP networks."
 		relevant_when: "mode = \"tcp\""
 		required:      false
 		type: array: items: type: string: {}


### PR DESCRIPTION
Adds `permit_origin` config option to all sources that have a TCP mode (introduced in https://github.com/vectordotdev/vector/pull/19892).

Related: https://github.com/vectordotdev/vector/pull/19892