### PR TITLE
fix(docs): Use `component_kind` rather than `kind` for Hugo

### DIFF
--- a/website/content/en/docs/reference/configuration/sinks/amqp.md
+++ b/website/content/en/docs/reference/configuration/sinks/amqp.md
@@ -1,7 +1,7 @@
 ---
 title: AMQP
 description: Send events to [AMQP 0.9.1](https://www.amqp.org/specification/0-9-1/amqp-org-download) compatible brokers like RabbitMQ
-kind: sink
+component_kind: sink
 layout: component
 tags: ["amqp", "rabbitmq", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/appsignal.md
+++ b/website/content/en/docs/reference/configuration/sinks/appsignal.md
@@ -1,7 +1,7 @@
 ---
 title: AppSignal
 description: Deliver events to [AppSignal](https://www.appsignal.com/)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["appsignal", "component", "sink", "logs", "metrics"]
 aliases: ["/docs/reference/configuration/sinks/appsignal"]

--- a/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_logs.md
@@ -1,7 +1,7 @@
 ---
 title: AWS Cloudwatch logs
 description: Publish log events to [AWS Cloudwatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "cloudwatch", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_cloudwatch_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: AWS Cloudwatch metrics
 description: Publish metric events to [AWS Cloudwatch Metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "cloudwatch", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/aws_kinesis_firehose.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_kinesis_firehose.md
@@ -1,7 +1,7 @@
 ---
 title: AWS Kinesis Data Firehose logs
 description: Publish logs to [AWS Kinesis Data Firehose](https://aws.amazon.com/kinesis/data-firehose) topics
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "kinesis", "firehose", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/aws_kinesis_streams.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_kinesis_streams.md
@@ -1,7 +1,7 @@
 ---
 title: AWS Kinesis Streams logs
 description: Publish logs to [AWS Kinesis Streams](https://aws.amazon.com/kinesis/data-streams) topics
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "kinesis", "streams", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/aws_s3.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_s3.md
@@ -1,7 +1,7 @@
 ---
 title: AWS S3
 description: Store observability events in the [AWS S3](https://aws.amazon.com/s3/) object storage system
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "s3", "component", "sink", "storage"]
 aliases: ["/docs/reference/sinks/s3"]

--- a/website/content/en/docs/reference/configuration/sinks/aws_sns.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_sns.md
@@ -1,7 +1,7 @@
 ---
 title: AWS SNS
 description: Publish observability events to [Simple Notification Service](https://aws.amazon.com/sns/) topics
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "sns", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/aws_sqs.md
+++ b/website/content/en/docs/reference/configuration/sinks/aws_sqs.md
@@ -1,7 +1,7 @@
 ---
 title: AWS SQS
 description: Publish observability events to [Simple Queue Service](https://aws.amazon.com/sqs/) topics
-kind: sink
+component_kind: sink
 layout: component
 tags: ["aws", "sqs", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/axiom.md
+++ b/website/content/en/docs/reference/configuration/sinks/axiom.md
@@ -1,7 +1,7 @@
 ---
 title: Axiom
 description: Deliver log events to [Axiom](https://axiom.co)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["axiom", "component", "sink", "logs", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/azure_blob.md
+++ b/website/content/en/docs/reference/configuration/sinks/azure_blob.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Blob Storage
 description: Store your observability data in [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["azure", "blob", "storage", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/azure_monitor_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/azure_monitor_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Monitor Logs
 description: Publish log events to the [Azure Monitor Logs](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs) service
-kind: sink
+component_kind: sink
 layout: component
 tags: ["azure", "monitor", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/blackhole.md
+++ b/website/content/en/docs/reference/configuration/sinks/blackhole.md
@@ -1,7 +1,7 @@
 ---
 title: Blackhole
 description: Send observability events nowhere, which can be useful for debugging purposes
-kind: sink
+component_kind: sink
 layout: component
 tags: ["blackhole", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/clickhouse.md
+++ b/website/content/en/docs/reference/configuration/sinks/clickhouse.md
@@ -1,7 +1,7 @@
 ---
 title: ClickHouse
 description: Deliver log data to the [ClickHouse](https://clickhouse.com) database
-kind: sink
+component_kind: sink
 layout: component
 tags: ["clickhouse", "component", "sink", "storage", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/console.md
+++ b/website/content/en/docs/reference/configuration/sinks/console.md
@@ -1,7 +1,7 @@
 ---
 title: Console
 description: Display observability events in the console, which can be useful for debugging purposes
-kind: sink
+component_kind: sink
 layout: component
 tags: ["console", "component", "sink", "debug"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/databend.md
+++ b/website/content/en/docs/reference/configuration/sinks/databend.md
@@ -1,7 +1,7 @@
 ---
 title: Databend
 description: Deliver log data to the [Databend](https://databend.rs) database
-kind: sink
+component_kind: sink
 layout: component
 tags: ["datafuselabs", "databend", "component", "sink", "storage", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/datadog_events.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_events.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog events
 description: Publish observability events to the [Datadog](https://docs.datadoghq.com) [Events API](https://docs.datadoghq.com/api/latest/events)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["datadog", "component", "sink", "events"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/datadog_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog logs
 description: Publish log events to [Datadog](https://docs.datadoghq.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["datadog", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/datadog_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog metrics
 description: Publish metric events to [Datadog](https://docs.datadoghq.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["datadog", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/datadog_traces.md
+++ b/website/content/en/docs/reference/configuration/sinks/datadog_traces.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog traces
 description: Publish traces to [Datadog](https://docs.datadoghq.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["datadog", "component", "sink", "traces"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/elasticsearch.md
+++ b/website/content/en/docs/reference/configuration/sinks/elasticsearch.md
@@ -1,7 +1,7 @@
 ---
 title: Elasticsearch
 description: Index observability events in [Elasticsearch](https://www.elastic.co/elasticsearch)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["elasticsearch", "component", "sink", "search", "storage"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/file.md
+++ b/website/content/en/docs/reference/configuration/sinks/file.md
@@ -1,7 +1,7 @@
 ---
 title: File
 description: Output observability events into files
-kind: sink
+component_kind: sink
 layout: component
 tags: ["file", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/gcp_chronicle_unstructured.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_chronicle_unstructured.md
@@ -2,7 +2,7 @@
 title: GCP Chronicle Unstructured
 description: Store unstructured log events in [Google Chronicle](https://cloud.google.com/chronicle/docs/overview)
 short: GCP Chronicle Unstructured
-kind: sink
+component_kind: sink
 layout: component
 tags: ["gcp", "chronicle", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/gcp_cloud_storage.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_cloud_storage.md
@@ -2,7 +2,7 @@
 title: GCP Cloud Storage (GCS)
 description: Store observability events in GCP [Cloud Storage](https://cloud.google.com/storage)
 short: GCP Cloud Storage
-kind: sink
+component_kind: sink
 layout: component
 tags: ["gcp", "gcs", "cloud storage", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/gcp_pubsub.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_pubsub.md
@@ -1,7 +1,7 @@
 ---
 title: GCP PubSub
 description: Publish observability events to GCP's [PubSub](https://cloud.google.com/pubsub) messaging system
-kind: sink
+component_kind: sink
 layout: component
 tags: ["gcp", "pubsub", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_logs.md
@@ -2,7 +2,7 @@
 title: GCP Operations (formerly Stackdriver) logs
 description: Deliver logs to GCP's [Cloud Operations](https://cloud.google.com/products/operations) suite
 short: GCP Stackdriver
-kind: sink
+component_kind: sink
 layout: component
 tags: ["gcp", "stackdriver", "operations", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/gcp_stackdriver_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: GCP Cloud Monitoring (formerly Stackdriver)
 description: Deliver metrics to GCP's [Cloud Monitoring](https://cloud.google.com/monitoring) system
-kind: sink
+component_kind: sink
 layout: component
 tags: ["gcp", "stackdriver", "operations", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/greptimedb.md
+++ b/website/content/en/docs/reference/configuration/sinks/greptimedb.md
@@ -1,7 +1,7 @@
 ---
 title: GreptimeDB
 description: Writes metric data to [GreptimeDB](https://github.com/greptimeteam/greptimedb)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["greptimedb", "component", "sink", "storage", "time-series", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/honeycomb.md
+++ b/website/content/en/docs/reference/configuration/sinks/honeycomb.md
@@ -1,7 +1,7 @@
 ---
 title: Honeycomb
 description: Deliver log events to [Honeycomb](https://www.honeycomb.io)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["honeycomb", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/http.md
+++ b/website/content/en/docs/reference/configuration/sinks/http.md
@@ -1,7 +1,7 @@
 ---
 title: HTTP
 description: Deliver observability data to an [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) server
-kind: sink
+component_kind: sink
 layout: component
 tags: ["http", "client", "component", "sink", "logs", "metrics", "traces"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/humio_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/humio_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Humio logs
 description: Deliver log event data to [Humio](https://humio.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["humio", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/humio_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/humio_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Humio metrics
 description: Deliver metric event data to [Humio](https://humio.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["humio", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/influxdb_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/influxdb_logs.md
@@ -1,7 +1,7 @@
 ---
 title: InfluxDB logs
 description: Deliver log event data to [InfluxDB](https://influxdata.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["influxdb", "influx", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/influxdb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/influxdb_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: InfluxDB metrics
 description: Deliver metric event data to [InfluxDB](https://influxdata.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["influxdb", "influx", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/kafka.md
+++ b/website/content/en/docs/reference/configuration/sinks/kafka.md
@@ -1,7 +1,7 @@
 ---
 title: Kafka
 description: Publish observability data to [Apache Kafka](https://kafka.apache.org) topics
-kind: sink
+component_kind: sink
 layout: component
 tags: ["kafka", "apache", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/loki.md
+++ b/website/content/en/docs/reference/configuration/sinks/loki.md
@@ -1,7 +1,7 @@
 ---
 title: Loki
 description: Deliver log event data to the [Loki](https://grafana.com/oss/loki) aggregation system
-kind: sink
+component_kind: sink
 layout: component
 tags: ["loki", "grafana", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/mezmo.md
+++ b/website/content/en/docs/reference/configuration/sinks/mezmo.md
@@ -1,7 +1,7 @@
 ---
 title: Mezmo (formerly LogDNA)
 description: Deliver log event data to [Mezmo](https://mezmo.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["logdna", "mezmo", "component", "sink", "logs"]
 aliases: ["/docs/reference/configuration/sinks/logdna"]

--- a/website/content/en/docs/reference/configuration/sinks/mqtt.md
+++ b/website/content/en/docs/reference/configuration/sinks/mqtt.md
@@ -1,7 +1,7 @@
 ---
 title: MQTT
 description: Deliver observability event data to an [MQTT](https://mqtt.org) broker
-kind: sink
+component_kind: sink
 layout: component
 tags: ["mqtt", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/nats.md
+++ b/website/content/en/docs/reference/configuration/sinks/nats.md
@@ -1,7 +1,7 @@
 ---
 title: NATS
 description: Publish observability data to subjects on the [NATS](https://nats.io) messaging system
-kind: sink
+component_kind: sink
 layout: component
 tags: ["nats", "pubsub", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/new_relic.md
+++ b/website/content/en/docs/reference/configuration/sinks/new_relic.md
@@ -1,7 +1,7 @@
 ---
 title: New Relic
 description: Deliver events to [New Relic](https://newrelic.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["new relic", "newrelic", "component", "sink", "logs", "metrics"]
 aliases: ["/docs/reference/configuration/sinks/new_relic_logs"]

--- a/website/content/en/docs/reference/configuration/sinks/papertrail.md
+++ b/website/content/en/docs/reference/configuration/sinks/papertrail.md
@@ -1,7 +1,7 @@
 ---
 title: Papertrail
 description: Deliver log events to [Papertrail](https://www.solarwinds.com/papertrail) from SolarWinds
-kind: sink
+component_kind: sink
 layout: component
 tags: ["papertrail", "solarwinds", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/prometheus_exporter.md
+++ b/website/content/en/docs/reference/configuration/sinks/prometheus_exporter.md
@@ -1,7 +1,7 @@
 ---
 title: Prometheus Exporter
 description: Output metric events to a [Prometheus exporter](https://prometheus.io/docs/instrumenting/exporters) running on the host
-kind: sink
+component_kind: sink
 layout: component
 tags: ["prometheus", "exporter", "component", "sink", "metrics"]
 aliases: ["/docs/reference/sinks/prometheus"]

--- a/website/content/en/docs/reference/configuration/sinks/prometheus_remote_write.md
+++ b/website/content/en/docs/reference/configuration/sinks/prometheus_remote_write.md
@@ -1,7 +1,7 @@
 ---
 title: Prometheus remote write
 description: Deliver metric data to a [Prometheus remote write](https://prometheus.io/docs/practices/remote_write) endpoint
-kind: sink
+component_kind: sink
 layout: component
 tags: ["prometheus", "remote write", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/pulsar.md
+++ b/website/content/en/docs/reference/configuration/sinks/pulsar.md
@@ -1,7 +1,7 @@
 ---
 title: Pulsar
 description: Publish observability events to [Apache Pulsar](https://pulsar.apache.org) topics
-kind: sink
+component_kind: sink
 layout: component
 tags: ["pulsar", "apache", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/redis.md
+++ b/website/content/en/docs/reference/configuration/sinks/redis.md
@@ -1,7 +1,7 @@
 ---
 title: Redis
 description: Publish observability data to [Redis](https://redis.io).
-kind: sink
+component_kind: sink
 layout: component
 tags: ["redis", "pubsub", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/sematext_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/sematext_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Sematext logs
 description: Publish log events to [Sematext](https://sematext.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["sematext", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/sematext_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/sematext_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Sematext metrics
 description: Publish metric events to [Sematext](https://sematext.com)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["sematext", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/socket.md
+++ b/website/content/en/docs/reference/configuration/sinks/socket.md
@@ -1,7 +1,7 @@
 ---
 title: Socket
 description: Deliver logs to a remote socket endpoint
-kind: sink
+component_kind: sink
 layout: component
 tags: ["socket", "remote", "component", "sink", "logs"]
 aliases: ["/docs/reference/sinks/tcp"]

--- a/website/content/en/docs/reference/configuration/sinks/splunk_hec_logs.md
+++ b/website/content/en/docs/reference/configuration/sinks/splunk_hec_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Splunk HEC logs
 description: Deliver log data to Splunk's [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["splunk", "hec", "http event collector", "component", "sink", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/splunk_hec_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/splunk_hec_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Splunk HEC metrics
 description: Deliver metric data to Splunk's [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector)
-kind: sink
+component_kind: sink
 layout: component
 tags: ["splunk", "hec", "http event collector", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/statsd.md
+++ b/website/content/en/docs/reference/configuration/sinks/statsd.md
@@ -1,7 +1,7 @@
 ---
 title: StatsD
 description: Deliver metric data to a [StatsD](https://github.com/statsd/statsd) aggregator
-kind: sink
+component_kind: sink
 layout: component
 tags: ["statsd", "component", "sink", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/vector.md
+++ b/website/content/en/docs/reference/configuration/sinks/vector.md
@@ -1,7 +1,7 @@
 ---
 title: Vector
 description: Relay observability data to another Vector instance
-kind: sink
+component_kind: sink
 layout: component
 tags: ["vector", "instance", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/webhdfs.md
+++ b/website/content/en/docs/reference/configuration/sinks/webhdfs.md
@@ -1,7 +1,7 @@
 ---
 title: WebHDFS
 description: Output observability events into WebHDFS
-kind: sink
+component_kind: sink
 layout: component
 tags: ["webhdfs", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sinks/websocket.md
+++ b/website/content/en/docs/reference/configuration/sinks/websocket.md
@@ -1,7 +1,7 @@
 ---
 title: Websocket
 description: Deliver observability event data to a websocket listener
-kind: sink
+component_kind: sink
 layout: component
 tags: ["websocket", "component", "sink"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/amqp.md
+++ b/website/content/en/docs/reference/configuration/sources/amqp.md
@@ -1,7 +1,7 @@
 ---
 title: AMQP
 description: Collect events from [AMQP 0.9.1](https://www.amqp.org/specification/0-9-1/amqp-org-download) compatible brokers like RabbitMQ
-kind: source
+component_kind: source
 layout: component
 tags: ["amqp", "rabbitmq", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/apache_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/apache_metrics.md
@@ -2,7 +2,7 @@
 title: Apache HTTP server (HTTPD) metrics
 description: Collect metrics from Apache's [HTTPD](https://httpd.apache.org) server
 short: Apache Metrics
-kind: source
+component_kind: source
 layout: component
 tags: ["apache", "http", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/aws_ecs_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_ecs_metrics.md
@@ -3,7 +3,7 @@ title: AWS ECS metrics
 description: >
   Collect Docker container stats for tasks running in [AWS ECS](https://aws.amazon.com/ecs) and
   [AWS Fargate](https://aws.amazon.com/fargate)
-kind: source
+component_kind: source
 layout: component
 tags: ["aws", "ecs", "docker", "fargate", "container", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/aws_kinesis_firehose.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_kinesis_firehose.md
@@ -1,7 +1,7 @@
 ---
 title: AWS Kinesis Firehose
 description: Collect logs from [AWS Kinesis Firehose](https://aws.amazon.com/kinesis/data-firehose)
-kind: source
+component_kind: source
 layout: component
 tags: ["aws", "kinesis", "firehose", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/aws_s3.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_s3.md
@@ -1,7 +1,7 @@
 ---
 title: AWS S3
 description: Collect logs from [AWS S3](https://aws.amazon.com/s3)
-kind: source
+component_kind: source
 layout: component
 tags: ["aws", "s3", "storage", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/aws_sqs.md
+++ b/website/content/en/docs/reference/configuration/sources/aws_sqs.md
@@ -1,7 +1,7 @@
 ---
 title: AWS SQS
 description: Collect logs from [AWS SQS](https://aws.amazon.com/sqs)
-kind: source
+component_kind: source
 layout: component
 tags: ["aws", "sqs", "queue", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/datadog_agent.md
+++ b/website/content/en/docs/reference/configuration/sources/datadog_agent.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog agent
 description: Receive logs, metrics, and traces collected by a [Datadog Agent](https://docs.datadoghq.com/agent)
-kind: source
+component_kind: source
 layout: component
 tags: ["datadog", "agent", "component", "source", "logs", "metrics", "traces"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/demo_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/demo_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Demo Logs
 description: Generate fake log events, which can be useful for testing and demos
-kind: source
+component_kind: source
 layout: component
 tags: ["demo", "random", "fake", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/dnstap.md
+++ b/website/content/en/docs/reference/configuration/sources/dnstap.md
@@ -1,7 +1,7 @@
 ---
 title: dnstap
 description: Collect DNS logs from a [dnstap](https://dnstap.info)-compatible server
-kind: source
+component_kind: source
 layout: component
 tags: ["dnstap", "dns", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/docker_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/docker_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Docker logs
 description: Collect logs from [Docker](https://docker.com)
-kind: source
+component_kind: source
 layout: component
 tags: ["docker", "container", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/eventstoredb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/eventstoredb_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: EventStoreDB metrics
 description: Receive metrics from collected by a [EventStoreDB](https://www.eventstore.com/)
-kind: source
+component_kind: source
 layout: component
 tags: ["eventstore", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/exec.md
+++ b/website/content/en/docs/reference/configuration/sources/exec.md
@@ -1,7 +1,7 @@
 ---
 title: Exec
 description: Collect output from a process running on the host
-kind: source
+component_kind: source
 layout: component
 tags: ["exec", "process", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/file.md
+++ b/website/content/en/docs/reference/configuration/sources/file.md
@@ -1,7 +1,7 @@
 ---
 title: File
 description: Collect logs from [files](https://en.wikipedia.org/wiki/File_system)
-kind: source
+component_kind: source
 layout: component
 tags: ["file", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/file_descriptor.md
+++ b/website/content/en/docs/reference/configuration/sources/file_descriptor.md
@@ -1,7 +1,7 @@
 ---
 title: File Descriptor
 description: Collect logs from a [file descriptor](https://en.wikipedia.org/wiki/File_descriptor)
-kind: source
+component_kind: source
 layout: component
 tags: ["file_descriptor", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/fluent.md
+++ b/website/content/en/docs/reference/configuration/sources/fluent.md
@@ -1,7 +1,7 @@
 ---
 title: Fluent
 description: Collect logs from a [Fluentd](https://www.fluentd.org) or [Fluent Bit](https://fluentbit.io) agent
-kind: source
+component_kind: source
 layout: component
 tags: ["fluentd", "fluent", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/gcp_pubsub.md
+++ b/website/content/en/docs/reference/configuration/sources/gcp_pubsub.md
@@ -1,7 +1,7 @@
 ---
 title: GCP PubSub
 description: Fetch observability events from GCP's [PubSub](https://cloud.google.com/pubsub) messaging system
-kind: source
+component_kind: source
 layout: component
 tags: ["gcp", "pubsub", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/heroku_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/heroku_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Heroku Logplex
 description: Collect logs from Heroku's [Logplex](https://devcenter.heroku.com/articles/logplex), the router responsible for receiving logs from your Heroku apps
-kind: source
+component_kind: source
 layout: component
 tags: ["heroku", "logplex", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/host_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/host_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Host metrics
 description: Collect metric data from the local system
-kind: source
+component_kind: source
 layout: component
 tags: ["vector", "host", "local", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/http_client.md
+++ b/website/content/en/docs/reference/configuration/sources/http_client.md
@@ -1,7 +1,7 @@
 ---
 title: HTTP Client
 description: Pull observability data from an [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) server at a configured interval
-kind: source
+component_kind: source
 layout: component
 tags: ["http", "client", "scrape", "component", "source", "logs", "metrics", "traces"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/http_server.md
+++ b/website/content/en/docs/reference/configuration/sources/http_server.md
@@ -1,7 +1,7 @@
 ---
 title: HTTP Server
 description: Receive observability data from an [HTTP client request](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Client_request)
-kind: source
+component_kind: source
 layout: component
 tags: ["http", "server", "component", "source", "logs", "metrics", "traces"]
 aliases: ["/docs/reference/configuration/sources/http"]

--- a/website/content/en/docs/reference/configuration/sources/internal_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/internal_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Internal logs
 description: Expose all log and trace messages emitted by the running Vector instance
-kind: source
+component_kind: source
 layout: component
 tags: ["vector", "instance", "local", "internal", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/internal_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/internal_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Internal metrics
 description: Access to the metrics produced by Vector itself and process them in your Vector pipeline
-kind: source
+component_kind: source
 layout: component
 tags: ["vector", "instance", "local", "internal", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/journald.md
+++ b/website/content/en/docs/reference/configuration/sources/journald.md
@@ -1,7 +1,7 @@
 ---
 title: JournalD
 description: Collect logs from [JournalD](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html)
-kind: source
+component_kind: source
 layout: component
 tags: ["journald", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/kafka.md
+++ b/website/content/en/docs/reference/configuration/sources/kafka.md
@@ -1,7 +1,7 @@
 ---
 title: Kafka
 description: Collect observability data from [Apache Kafka](https://kafka.apache.org) topics
-kind: source
+component_kind: source
 layout: component
 tags: ["kafka", "apache", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/kubernetes_logs.md
+++ b/website/content/en/docs/reference/configuration/sources/kubernetes_logs.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes logs
 description: Collect logs from [Kubernetes](https://kubernetes.io) Nodes
-kind: source
+component_kind: source
 layout: component
 tags: ["kubernetes", "k8s", "node", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/logstash.md
+++ b/website/content/en/docs/reference/configuration/sources/logstash.md
@@ -1,7 +1,7 @@
 ---
 title: Logstash
 description: Collect logs from a [Logstash](https://www.elastic.co/logstash) agent
-kind: source
+component_kind: source
 layout: component
 tags: ["logstash", "elastic", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/mongodb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/mongodb_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: MongoDB metrics
 description: Collect metrics from the [MongoDB](https://mongodb.com) database
-kind: source
+component_kind: source
 layout: component
 tags: ["mongodb", "mongo", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/nats.md
+++ b/website/content/en/docs/reference/configuration/sources/nats.md
@@ -1,7 +1,7 @@
 ---
 title: NATS
 description: Read observability data from subjects on the [NATS](https://nats.io) messaging system
-kind: source
+component_kind: source
 layout: component
 tags: ["nats", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/nginx_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/nginx_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: NGINX metrics
 description: Collect metrics from [NGINX](https://nginx.com)
-kind: source
+component_kind: source
 layout: component
 tags: ["nginx", "http", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/opentelemetry.md
+++ b/website/content/en/docs/reference/configuration/sources/opentelemetry.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry
 description: Receive [OTLP](https://opentelemetry.io/docs/reference/specification/protocol/otlp/) data through gRPC or HTTP.
-kind: source
+component_kind: source
 layout: component
 tags: ["opentelemetry", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/postgresql_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/postgresql_metrics.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL metrics
 description: Collect metrics from the [PostgreSQL](https://postgresql.org) database
-kind: source
+component_kind: source
 layout: component
 tags: ["postgresql", "postgres", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/prometheus_pushgateway.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_pushgateway.md
@@ -1,7 +1,7 @@
 ---
 title: Prometheus Pushgateway
 description: Collect metrics from [Prometheus](https://prometheus.io)
-kind: source
+component_kind: source
 layout: component
 tags: ["prometheus", "pushgateway", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/prometheus_remote_write.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_remote_write.md
@@ -1,7 +1,7 @@
 ---
 title: Prometheus remote write
 description: Collect metrics from [Prometheus](https://prometheus.io)
-kind: source
+component_kind: source
 layout: component
 tags: ["prometheus", "remote write", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/prometheus_scrape.md
+++ b/website/content/en/docs/reference/configuration/sources/prometheus_scrape.md
@@ -1,7 +1,7 @@
 ---
 title: Prometheus scrape
 description: Collect metrics via the [Prometheus](https://prometheus.io) client
-kind: source
+component_kind: source
 layout: component
 tags: ["prometheus", "scrape", "component", "source", "metrics"]
 aliases: ["/docs/reference/sources/prometheus"]

--- a/website/content/en/docs/reference/configuration/sources/pulsar.md
+++ b/website/content/en/docs/reference/configuration/sources/pulsar.md
@@ -1,7 +1,7 @@
 ---
 title: Pulsar
 description: Collect observability events from [Apache Pulsar](https://pulsar.apache.org) topics
-kind: source
+component_kind: source
 layout: component
 tags: ["pulsar", "apache", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/redis.md
+++ b/website/content/en/docs/reference/configuration/sources/redis.md
@@ -1,7 +1,7 @@
 ---
 title: Redis
 description: Collect observability data from Redis.
-kind: source
+component_kind: source
 layout: component
 tags: ["redis", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/socket.md
+++ b/website/content/en/docs/reference/configuration/sources/socket.md
@@ -1,7 +1,7 @@
 ---
 title: Socket
 description: Collect logs using the [socket](https://en.wikipedia.org/wiki/Network_socket) client
-kind: source
+component_kind: source
 layout: component
 tags: ["socket", "component", "source", "logs"]
 aliases: ["/docs/reference/sources/tcp", "/docs/reference/sources/udp"]

--- a/website/content/en/docs/reference/configuration/sources/splunk_hec.md
+++ b/website/content/en/docs/reference/configuration/sources/splunk_hec.md
@@ -2,7 +2,7 @@
 title: Splunk HTTP Event Collector (HEC)
 description: Receive logs from [Splunk](https://splunk.com)
 short: Splunk HEC
-kind: source
+component_kind: source
 layout: component
 tags: ["splunk", "hec", "http event collector", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/statsd.md
+++ b/website/content/en/docs/reference/configuration/sources/statsd.md
@@ -1,7 +1,7 @@
 ---
 title: StatsD
 description: Collect metrics emitted via [StatsD](https://github.com/statsd/statsd) protocol
-kind: source
+component_kind: source
 layout: component
 tags: ["statsd", "component", "source", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/stdin.md
+++ b/website/content/en/docs/reference/configuration/sources/stdin.md
@@ -1,7 +1,7 @@
 ---
 title: stdin
 description: Collect logs sent via [stdin](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin))
-kind: source
+component_kind: source
 layout: component
 tags: ["stdin", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/syslog.md
+++ b/website/content/en/docs/reference/configuration/sources/syslog.md
@@ -1,7 +1,7 @@
 ---
 title: Syslog
 description: Collect logs sent via [Syslog](https://en.wikipedia.org/wiki/Syslog)
-kind: source
+component_kind: source
 layout: component
 tags: ["syslog", "component", "source", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/sources/vector.md
+++ b/website/content/en/docs/reference/configuration/sources/vector.md
@@ -1,7 +1,7 @@
 ---
 title: Vector
 description: Collect observability data from another Vector instance
-kind: source
+component_kind: source
 layout: component
 tags: ["vector", "instance", "component", "source"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/aggregate.md
+++ b/website/content/en/docs/reference/configuration/transforms/aggregate.md
@@ -1,7 +1,7 @@
 ---
 title: Aggregate
 description: Aggregate metrics passing through a topology
-kind: transform
+component_kind: transform
 layout: component
 tags: ["aggregate", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/aws_ec2_metadata.md
+++ b/website/content/en/docs/reference/configuration/transforms/aws_ec2_metadata.md
@@ -1,7 +1,7 @@
 ---
 title: AWS EC2 metadata
 description: Parse metadata emitted by [AWS EC2](https://aws.amazon.com/ec2) instances
-kind: transform
+component_kind: transform
 layout: component
 tags: ["aws", "ec2", "metadata", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/dedupe.md
+++ b/website/content/en/docs/reference/configuration/transforms/dedupe.md
@@ -2,7 +2,7 @@
 title: Dedupe events
 description: Deduplicate logs passing through a topology
 short: Dedupe
-kind: transform
+component_kind: transform
 layout: component
 tags: ["dedupe", "deduplicate", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/filter.md
+++ b/website/content/en/docs/reference/configuration/transforms/filter.md
@@ -1,7 +1,7 @@
 ---
 title: Filter
 description: Filter events based on a set of conditions
-kind: transform
+component_kind: transform
 layout: component
 tags: ["filter", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/log_to_metric.md
+++ b/website/content/en/docs/reference/configuration/transforms/log_to_metric.md
@@ -1,7 +1,7 @@
 ---
 title: Log to metric
 description: Convert log events to metric events
-kind: transform
+component_kind: transform
 layout: component
 tags: ["log to metric", "convert", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/lua.md
+++ b/website/content/en/docs/reference/configuration/transforms/lua.md
@@ -1,7 +1,7 @@
 ---
 title: Lua
 description: Modify event data using the [Lua](https://lua.org) programming language
-kind: transform
+component_kind: transform
 layout: component
 tags: ["lua", "runtime", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/metric_to_log.md
+++ b/website/content/en/docs/reference/configuration/transforms/metric_to_log.md
@@ -1,7 +1,7 @@
 ---
 title: Metric to log
 description: Convert metric events to log events
-kind: transform
+component_kind: transform
 layout: component
 tags: ["metric to log", "convert", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/reduce.md
+++ b/website/content/en/docs/reference/configuration/transforms/reduce.md
@@ -1,7 +1,7 @@
 ---
 title: Reduce
 description: Collapse multiple log events into a single event based on a set of conditions and merge strategies
-kind: transform
+component_kind: transform
 layout: component
 tags: ["filter", "multiline", "component", "transform", "logs"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/remap.md
+++ b/website/content/en/docs/reference/configuration/transforms/remap.md
@@ -2,7 +2,7 @@
 title: Remap with VRL
 description: >
   Modify your observability data as it passes through your topology using [Vector Remap Language](/docs/reference/vrl) (VRL)
-kind: transform
+component_kind: transform
 featured: true
 layout: component
 weight: 1

--- a/website/content/en/docs/reference/configuration/transforms/route.md
+++ b/website/content/en/docs/reference/configuration/transforms/route.md
@@ -1,7 +1,7 @@
 ---
 title: Route
 description: Split a stream of events into multiple sub-streams based on user-supplied conditions
-kind: transform
+component_kind: transform
 layout: component
 tags: ["route", "swimlanes", "split", "component", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/sample.md
+++ b/website/content/en/docs/reference/configuration/transforms/sample.md
@@ -1,7 +1,7 @@
 ---
 title: Sample
 description: Sample events from an event stream based on supplied criteria and at a configurable rate
-kind: transform
+component_kind: transform
 layout: component
 tags: ["sample", "component", "log", "trace", "transform"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/tag_cardinality_limit.md
+++ b/website/content/en/docs/reference/configuration/transforms/tag_cardinality_limit.md
@@ -1,7 +1,7 @@
 ---
 title: Tag cardinality limit
 description: Limit the cardinality of tags on metrics events as a safeguard against cardinality explosion
-kind: transform
+component_kind: transform
 layout: component
 tags: ["tag", "cardinality", "component", "transform", "metrics"]
 ---

--- a/website/content/en/docs/reference/configuration/transforms/throttle.md
+++ b/website/content/en/docs/reference/configuration/transforms/throttle.md
@@ -1,7 +1,7 @@
 ---
 title: Throttle
 description: Rate limit logs passing through a topology
-kind: transform
+component_kind: transform
 layout: component
 tags: ["throttle", "component", "transform"]
 ---

--- a/website/layouts/shortcodes/components.html
+++ b/website/layouts/shortcodes/components.html
@@ -1,8 +1,8 @@
-{{ $kind := .Get 0 }}
-{{ $componentsOfType := where site.RegularPages ".Params.kind" $kind }}
+{{ $componentKind:= .Get 0 }}
+{{ $componentsOfKind := where site.RegularPages ".Params.component_kind" $componentKind}}
 <div class="mt-3">
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1.5 md:gap-2">
-    {{ range $componentsOfType }}
+    {{ range $componentsOfKind }}
     {{ .Render "component-card" }}
     {{ end }}
   </div>


### PR DESCRIPTION
`kind` is a reserved attribute: https://gohugo.io/templates/section-templates/#page-kinds. Newer versions of hugo (>= 0.122.0) start returning errors like:

```
sinks/mqtt.md:1:1": unknown kind "sink" in front matter
```

Ref: https://github.com/vectordotdev/vector/pull/20048#discussion_r1520134528

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
