### PR TITLE
chore(cli)!: Update default for --strict-env-vars to true

### DIFF
--- a/changelog.d/deprecate_strict_env_vars.breaking.md
+++ b/changelog.d/deprecate_strict_env_vars.breaking.md
@@ -1,0 +1,4 @@
+The default of `--strict-env-vars` has been changed to `true`. This option has been deprecated. In
+a future version it will be removed and Vector will have the behavior it currently has when set
+to `true` which is that missing environment variables will cause Vector to fail to start up with an
+error instead of a warning.

--- a/changelog.d/deprecate_strict_env_vars.breaking.md
+++ b/changelog.d/deprecate_strict_env_vars.breaking.md
@@ -1,4 +1,4 @@
 The default of `--strict-env-vars` has been changed to `true`. This option has been deprecated. In
 a future version it will be removed and Vector will have the behavior it currently has when set
 to `true` which is that missing environment variables will cause Vector to fail to start up with an
-error instead of a warning.
+error instead of a warning. Set `--strict-env-vars=false` to opt into deprecated behavior.

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -16,7 +16,7 @@ For example:
 
 ## To be migrated
 
-- v0.37.0 strict_env_vars Change the default for missing environment variable interpolation from
-  warning to erroring.
-
 ## To be removed
+
+- v0.38.0 strict_env_vars Remove option for configuring missing environment variable interpolation
+  to be a warning rather than an error

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -213,11 +213,12 @@ pub struct RootOpts {
     #[arg(long, env = "VECTOR_ALLOW_EMPTY_CONFIG", default_value = "false")]
     pub allow_empty_config: bool,
 
-    /// Turn on strict mode for environment variable interpolation. When set, interpolation of a
-    /// missing environment variable in configuration files will cause an error instead of a
-    /// warning, which will result in a failure to load any such configuration file. This defaults
-    /// to false, but that default is deprecated and will be changed to strict in future versions.
-    #[arg(long, env = "VECTOR_STRICT_ENV_VARS", default_value = "false")]
+    /// Turn on strict mode for environment variable interpolation. When set, interpolation of
+    /// a missing environment variable in configuration files will cause an error instead of
+    /// a warning, which will result in a failure to load any such configuration file. This option
+    /// is deprecated and will be removed in a future version to remove the ability to downgrade
+    /// missing environment variables to warnings.
+    #[arg(long, env = "VECTOR_STRICT_ENV_VARS", default_value = "true")]
     pub strict_env_vars: bool,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,7 +218,15 @@ pub struct RootOpts {
     /// a warning, which will result in a failure to load any such configuration file. This option
     /// is deprecated and will be removed in a future version to remove the ability to downgrade
     /// missing environment variables to warnings.
-    #[arg(long, env = "VECTOR_STRICT_ENV_VARS", default_value = "true")]
+    #[arg(
+        long,
+        env = "VECTOR_STRICT_ENV_VARS",
+        default_value = "true",
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        action = ArgAction::Set
+    )]
     pub strict_env_vars: bool,
 }
 

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -658,9 +658,13 @@ cli: {
 		}
 		VECTOR_STRICT_ENV_VARS: {
 			description: """
-				Turn on strict mode for environment variable interpolation. When set, interpolation of a missing environment variable in configuration files will cause an error instead of a warning, which will result in a failure to load any such configuration file. This defaults to false, but that default is deprecated and will be changed to strict in future versions.
+				Turn on strict mode for environment variable interpolation. When set, interpolation of a missing
+				environment variable in configuration files will cause an error instead of a warning, which will
+				result in a failure to load any such configuration file. This option is deprecated and will be
+				removed in a future version to remove the ability to downgrade missing environment variables to
+				warnings.
 				"""
-			type: bool: default: false
+			type: bool: default: true
 		}
 	}
 


### PR DESCRIPTION
This deprecates this option.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
