### PR TITLE
fix(docs): Use `component_kind` rather than `kind` in templates

### DIFF
--- a/website/layouts/_default/component-card-selectable.html
+++ b/website/layouts/_default/component-card-selectable.html
@@ -16,7 +16,7 @@
 <a href="{{ .RelPermalink }}">
   <div class="component-card is-hoverable" x-data="{ tags: {{ $tags | jsonify }} }">
     <header class="component-card-header">
-      {{ .Title }} {{ .Params.kind }}
+      {{ .Title }} {{ .Params.component_kind }}
     </header>
 
     {{ with $desc }}

--- a/website/layouts/_default/component-card.html
+++ b/website/layouts/_default/component-card.html
@@ -1,6 +1,6 @@
 {{ $title := .Params.short | default .Title }}
 {{ $componentTag := .File.BaseFileName }}
-{{ $kind := .Params.kind }}
+{{ $kind := .Params.component_kind }}
 <div>
   <a href="{{ .RelPermalink }}">
     <div class="no-prose border hover:border-4 rounded dark:border-gray-700 p-4 shadow-sm hover:border-secondary dark:hover:border-primary">

--- a/website/layouts/partials/meta.html
+++ b/website/layouts/partials/meta.html
@@ -5,7 +5,7 @@
 {{ $img := site.Params.site_logo | absURL }}
 {{ $imgAlt := printf "Logo for %s" site.Title }}
 {{ $twitter := printf "@%s" site.Params.social.twitter_handle }}
-{{ $title := cond (eq .Layout "component") (printf "%s %s" .Title .Params.kind) .Title }}
+{{ $title := cond (eq .Layout "component") (printf "%s %s" .Title .Params.component_kind) .Title }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 <meta http-equiv="x-ua-compatible" content="id=edge">


### PR DESCRIPTION
I missed a few spots in https://github.com/vectordotdev/vector/pull/20058

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
