### PR TITLE
chore(ci): Default env vars for enterprise_http_to_http regression case

### DIFF
--- a/regression/cases/enterprise_http_to_http/vector/vector.yaml
+++ b/regression/cases/enterprise_http_to_http/vector/vector.yaml
@@ -4,8 +4,8 @@ data_dir: "/var/lib/vector"
 ## Enterprise
 ##
 enterprise:
-  api_key:           "${DD_API_KEY}"
-  configuration_key: "${DD_CONFIGURATION_KEY}"
+  api_key:           "${DD_API_KEY-}"
+  configuration_key: "${DD_CONFIGURATION_KEY-}"
   endpoint:          "http://localhost:8080"
 
 ##


### PR DESCRIPTION
To unblock making unset env vars an error per https://github.com/vectordotdev/vector/pull/20062 since the regression tests use config from `master`.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
