### PR TITLE
chore(dev): Update changelog generation script to handle authors and whitespace

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -74,7 +74,7 @@ the authors specified.
 
 The process for adding this is simply to have the last line of the file be in this format:
 
-    authors: <author1_gh_username>, <author2_gh_username>, <...>
+    authors: <author1_gh_username> <author2_gh_username> <...>
 
 Do not include a leading `@` when specifying your username.
 

--- a/changelog.d/pulsar_source2.feature.md
+++ b/changelog.d/pulsar_source2.feature.md
@@ -1,3 +1,0 @@
-A new source has been added that can receive logs from Apache Pulsar.
-
-authors: zamazan4ik, WarmSnowy

--- a/changelog.d/pulsar_source2.feature.md
+++ b/changelog.d/pulsar_source2.feature.md
@@ -1,0 +1,3 @@
+A new source has been added that can receive logs from Apache Pulsar.
+
+authors: zamazan4ik, WarmSnowy

--- a/scripts/check_changelog_fragments.sh
+++ b/scripts/check_changelog_fragments.sh
@@ -61,8 +61,11 @@ while IFS= read -r fname; do
   # used for external contributor PRs.
   if [[ $1 == "--authors" ]]; then
     last=$( tail -n 1 "${CHANGELOG_DIR}/${fname}" )
-    if [[ "${last}" =~ ^(authors: @.*)$ ]]; then
+    if [[ "${last}" == "authors: "*@* ]]; then
       echo "invalid fragment contents: author should not be prefixed with @"
+      exit 1
+    elif [[ "${last}" == "authors: "*,* ]]; then
+      echo "invalid fragment contents: authors should be space delimited, not comma delimited."
       exit 1
     elif ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
       echo "invalid fragment contents: author option was specified but fragment ${fname} contains no authors."

--- a/scripts/generate-release-cue.rb
+++ b/scripts/generate-release-cue.rb
@@ -145,16 +145,13 @@ def generate_changelog!(new_version)
     contributors = Array.new
 
     if last.start_with?("authors: ")
-      authors_str = last[9..]
-      authors_str = authors_str.delete(" \t\r\n")
-      authors_arr = authors_str.split(",")
-      authors_arr.each { |author| contributors.push(author) }
+      contributors = last[9..].split(" ").map(&:strip)
 
       # remove that line from the description
       lines.pop()
     end
 
-    description = lines.join("")
+    description = lines.join("").strip()
 
     # get the PR number of the changelog fragment.
     # the fragment type is not used in the Vector release currently.
@@ -195,7 +192,7 @@ def generate_changelog!(new_version)
     entry = "{\n" +
       "type: #{type.to_json}\n" +
       "description: \"\"\"\n" +
-      "#{description}" +
+      "#{description}\n" +
       "\"\"\"\n"
 
     if contributors.length() > 0


### PR DESCRIPTION
This:

- Assumes contributors are space delimited, as we have been doing in practice
- Normalizes the description field so that it always terminates in a single newline. Previously, if
  there were contributors, it would have an extra blank line

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>