### PR TITLE
fix(file source): Set ignored_header_bytes default to `0`

### DIFF
--- a/changelog.d/file_ignored_header_bytes_default.fix.md
+++ b/changelog.d/file_ignored_header_bytes_default.fix.md
@@ -1,0 +1,1 @@
+The `fingerprint.ignored_header_bytes` option on the `file` source now has a default of `0`.

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -321,6 +321,7 @@ pub enum FingerprintConfig {
         /// The number of bytes to skip ahead (or ignore) when reading the data used for generating the checksum.
         ///
         /// This can be helpful if all files share a common header that should be skipped.
+        #[serde(default = "default_ignored_header_bytes")]
         #[configurable(metadata(docs::type_unit = "bytes"))]
         ignored_header_bytes: usize,
 
@@ -349,6 +350,10 @@ impl Default for FingerprintConfig {
             lines: default_lines(),
         }
     }
+}
+
+const fn default_ignored_header_bytes() -> usize {
+    0
 }
 
 const fn default_lines() -> usize {


### PR DESCRIPTION
To match the docs.

Fixes: #20072

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>