### PR TITLE
docs(kubernetes platform): fix example kustomization file

### DIFF
--- a/website/content/en/docs/setup/installation/platforms/kubernetes.md
+++ b/website/content/en/docs/setup/installation/platforms/kubernetes.md
@@ -53,7 +53,7 @@ namespace: vector
 
 bases:
   # Include Vector recommended base (from git).
-  - github.com/vectordotdev/vector/tree/master/distribution/kubernetes/vector-agent
+  - github.com/vectordotdev/vector/distribution/kubernetes/vector-agent?ref=master
 
 images:
   # Override the Vector image to pin the version used.


### PR DESCRIPTION
This example kustomization file is rejected, with the following error:
```
error: accumulating resources: accumulation err='accumulating resources from 'git@github.com:vectordotdev/vector.git/tree/master/distribution/kubernetes/vector-agent': evalsymlink failure on '/home/user/Documents/workspace-kube/bug-free-broccoli/vector/git@github.com:vectordotdev/vector.git/tree/master/distribution/kubernetes/vector-agent' : lstat /home/user/Documents/workspace-kube/bug-free-broccoli/vector/git@github.com:vectordotdev: no such file or directory': evalsymlink failure on '/tmp/kustomize-1831957474/tree/master/distribution/kubernetes/vector-agent' : lstat /tmp/kustomize-1831957474/tree: no such file or directory
```

This is because the url is recognized as a github link, and gives an erroneous path.
more info: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/resource/