### PR TITLE
fix(datadog_logs sink): relax required input semantic meanings

### DIFF
--- a/changelog.d/dd_logs_semantic_meaning.fix.md
+++ b/changelog.d/dd_logs_semantic_meaning.fix.md
@@ -1,0 +1,7 @@
+The `datadog_logs` source now does not require a semantic meaning input definition for `message` and `timestamp` fields.
+
+While the Datadog logs intake does handle these fields if they are present, they aren't required.
+
+If the are present (such as in the default, Legacy namespace), the behavior is unchanged.
+
+The only impact is that configurations which enable the Log Namespace feature, no longer need to manually set the semantic meaning for these two fields through a remap transform if the source did not already set them.

--- a/changelog.d/dd_logs_semantic_meaning.fix.md
+++ b/changelog.d/dd_logs_semantic_meaning.fix.md
@@ -2,6 +2,6 @@ The `datadog_logs` source now does not require a semantic meaning input definiti
 
 While the Datadog logs intake does handle these fields if they are present, they aren't required.
 
-If the are present (such as in the default, Legacy namespace), the behavior is unchanged.
+The only impact is that configurations which enable the Log Namespace feature and use a Source input to this sink which does not itself define a semantic meaning for `message` and `timestamp`, no longer need to manually set the semantic meaning for these two fields through a remap transform.
 
-The only impact is that configurations which enable the Log Namespace feature, no longer need to manually set the semantic meaning for these two fields through a remap transform if the source did not already set them.
+Existing configurations that utilize the Legacy namespace are unaffected.

--- a/changelog.d/dd_logs_semantic_meaning.fix.md
+++ b/changelog.d/dd_logs_semantic_meaning.fix.md
@@ -1,4 +1,4 @@
-The `datadog_logs` source now does not require a semantic meaning input definition for `message` and `timestamp` fields.
+The `datadog_logs` sink now does not require a semantic meaning input definition for `message` and `timestamp` fields.
 
 While the Datadog logs intake does handle these fields if they are present, they aren't required.
 

--- a/changelog.d/dd_logs_semantic_meaning.fix.md
+++ b/changelog.d/dd_logs_semantic_meaning.fix.md
@@ -1,7 +1,7 @@
-The `datadog_logs` sink now does not require a semantic meaning input definition for `message` and `timestamp` fields.
+The `datadog_logs` sink no longer requires  a semantic meaning input definition for `message` and `timestamp` fields.
 
 While the Datadog logs intake does handle these fields if they are present, they aren't required.
 
-The only impact is that configurations which enable the Log Namespace feature and use a Source input to this sink which does not itself define a semantic meaning for `message` and `timestamp`, no longer need to manually set the semantic meaning for these two fields through a remap transform.
+The only impact is that configurations which enable the [Log Namespace](https://vector.dev/blog/log-namespacing/) feature and use a Source input to this sink which does not itself define a semantic meaning for `message` and `timestamp`, no longer need to manually set the semantic meaning for these two fields through a remap transform.
 
-Existing configurations that utilize the Legacy namespace are unaffected.
+Existing configurations that utilize the Legacy namespace are unaffected, as are configurations using the Vector namespace where the input source has defined the `message` and `timestamp` semantic meanings.

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -164,8 +164,8 @@ impl SinkConfig for DatadogLogsConfig {
 
     fn input(&self) -> Input {
         let requirement = schema::Requirement::empty()
-            .required_meaning(meaning::MESSAGE, Kind::bytes())
-            .required_meaning(meaning::TIMESTAMP, Kind::timestamp())
+            .optional_meaning(meaning::MESSAGE, Kind::bytes())
+            .optional_meaning(meaning::TIMESTAMP, Kind::timestamp())
             .optional_meaning(meaning::HOST, Kind::bytes())
             .optional_meaning(meaning::SOURCE, Kind::bytes())
             .optional_meaning(meaning::SEVERITY, Kind::bytes())


### PR DESCRIPTION
The `datadog_logs` sink now does not require a semantic meaning input definition for `message` and `timestamp` fields.

While the Datadog logs intake does handle these fields if they are present, they aren't required.

The only impact is that configurations which enable the Log Namespace feature and use a Source input to this sink which does not itself define a semantic meaning for `message` and `timestamp`, no longer need to manually set the semantic meaning for these two fields through a remap transform.

Existing configurations that utilize the Legacy namespace are unaffected.