### PR TITLE
fix(docs): Use correct how_it_works section for Vector sink

### DIFF
--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -77,7 +77,7 @@ components: sinks: vector: {
 
 	configuration: base.components.sinks.vector.configuration
 
-	how_it_works: components.sources.vector.how_it_works
+	how_it_works: components.sinks.vector.how_it_works
 
 	telemetry: metrics: {
 		protobuf_decode_errors_total: components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total


### PR DESCRIPTION
It was accidentally pulling the source's.

Fixes: #20092

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
