### PR TITLE
enhancement(remap): do not filter out file contents from error logs

### DIFF
--- a/changelog.d/remove_remap_file_filter.enhancement.md
+++ b/changelog.d/remove_remap_file_filter.enhancement.md
@@ -1,0 +1,2 @@
+The `remap` component no longer filters out the file contents from error messages when the VRL
+program is passed in via the `file` option.


### PR DESCRIPTION
Reverts vectordotdev/vector#19356. After some more consideration we've decided to revert this until we can come up with a better long term solution.

Fixes: #20124