### PR TITLE
chore(api): Move host_metrics feature gate

### DIFF
--- a/src/api/schema/metrics/mod.rs
+++ b/src/api/schema/metrics/mod.rs
@@ -15,7 +15,7 @@ mod uptime;
 mod host;
 
 pub use allocated_bytes::{AllocatedBytes, ComponentAllocatedBytes};
-use async_graphql::{Interface, Object, Subscription};
+use async_graphql::{Interface, Subscription};
 use chrono::{DateTime, Utc};
 pub use errors::{ComponentErrorsTotal, ErrorsTotal};
 pub use filter::*;
@@ -45,9 +45,9 @@ pub enum MetricType {
 #[derive(Default)]
 pub struct MetricsQuery;
 
-#[Object]
+#[cfg(feature = "sources-host_metrics")]
+#[async_graphql::Object]
 impl MetricsQuery {
-    #[cfg(feature = "sources-host_metrics")]
     /// Vector host metrics
     async fn host_metrics(&self) -> host::HostMetrics {
         host::HostMetrics::new()

--- a/src/api/schema/mod.rs
+++ b/src/api/schema/mod.rs
@@ -13,7 +13,7 @@ use async_graphql::{EmptyMutation, MergedObject, MergedSubscription, Schema, Sch
 pub struct Query(
     health::HealthQuery,
     components::ComponentsQuery,
-    metrics::MetricsQuery,
+    #[cfg(feature = "sources-host_metrics")] metrics::MetricsQuery,
     meta::MetaQuery,
 );
 


### PR DESCRIPTION
https://github.com/vectordotdev/vector/commit/80f63bb6b52561ae4a9f98783ae98472c0798845 caused a failure when enabling just the `api` feature and not `host_metrics`. This seems to be due to the fact that `MetricsQuery` is empty when there `host_metrics` is disabled. To remedy this, I moved the feature gate so that `MetricsQuery` itself is not included when `host_metrics` is disabled.