### PR TITLE
feat(config): Support loading secrets from AWS Secrets Manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faea24d86bcabc65048014abd3ee5763a5e8877f678d9cd688a12e086ebe2dbd"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.5.0",
+ "fastrand 2.0.1",
+ "http 0.2.9",
+ "regex",
+ "tracing 0.1.40",
+]
+
+[[package]]
 name = "aws-sdk-sns"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10101,6 +10124,7 @@ dependencies = [
  "aws-sdk-firehose",
  "aws-sdk-kinesis",
  "aws-sdk-s3",
+ "aws-sdk-secretsmanager",
  "aws-sdk-sns",
  "aws-sdk-sqs",
  "aws-sdk-sts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ aws-sdk-cloudwatchlogs = { version = "1.3.0", default-features = false, features
 aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
+aws-sdk-secretsmanager = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
 # The sts crate is needed despite not being referred to anywhere in the code because we need to set the
 # `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication
 # is configured.
@@ -402,9 +403,9 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
+default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "secrets"]
 # Default features for `cargo docs`. The same as `default` but without `rdkafka?/gssapi-vendored` which would require installing libsasl in our doc build environment.
-docs = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
+docs = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
 # Default features for *-pc-windows-msvc
@@ -490,6 +491,11 @@ enrichment-tables-mmdb = ["dep:maxminddb"]
 
 # Codecs
 codecs-syslog = ["vector-lib/syslog"]
+
+# Secrets
+secrets = ["secrets-aws-secrets-manager"]
+
+secrets-aws-secrets-manager = ["aws-core", "dep:aws-sdk-secretsmanager"]
 
 # Sources
 sources = ["sources-logs", "sources-metrics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,13 +407,13 @@ default = ["api", "api-client", "enrichment-tables", "sinks", "sources", "source
 # Default features for `cargo docs`. The same as `default` but without `rdkafka?/gssapi-vendored` which would require installing libsasl in our doc build environment.
 docs = ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
+default-cmake = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "secrets"]
 # Default features for *-pc-windows-msvc
 # TODO: Enable SASL https://github.com/vectordotdev/vector/pull/3081#issuecomment-659298042
-default-msvc = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "transforms", "enterprise"]
-default-musl = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
-default-no-api-client = ["api", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
-default-no-vrl-cli = ["api", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
+default-msvc = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "transforms", "enterprise", "secrets"]
+default-musl = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "secrets"]
+default-no-api-client = ["api", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "secrets"]
+default-no-vrl-cli = ["api", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "secrets"]
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 # Enables the binary secret-backend-example
@@ -425,18 +425,18 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics", "enterp
 # Target specific release features.
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
-target-aarch64-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
-target-aarch64-unknown-linux-musl = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
-target-armv7-unknown-linux-gnueabihf = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
-target-armv7-unknown-linux-musleabihf = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "enterprise"]
-target-arm-unknown-linux-gnueabi = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
-target-arm-unknown-linux-musleabi = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "enterprise"]
-target-x86_64-unknown-linux-gnu = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise"]
-target-x86_64-unknown-linux-musl = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
+target-aarch64-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
+target-aarch64-unknown-linux-musl = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
+target-armv7-unknown-linux-gnueabihf = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
+target-armv7-unknown-linux-musleabihf = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "enterprise", "secrets"]
+target-arm-unknown-linux-gnueabi = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
+target-arm-unknown-linux-musleabi = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "enterprise", "secrets"]
+target-x86_64-unknown-linux-gnu = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "enterprise", "secrets"]
+target-x86_64-unknown-linux-musl = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
 # Does not currently build
-target-powerpc64le-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
+target-powerpc64le-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
 # Currently doesn't build due to lack of support for 64-bit atomics
-target-powerpc-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise"]
+target-powerpc-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "enterprise", "secrets"]
 
 # Enables features that work only on systems providing `cfg(unix)`
 unix = ["tikv-jemallocator", "allocation-tracing"]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -54,6 +54,7 @@ aws-sdk-cloudwatchlogs,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS R
 aws-sdk-firehose,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-sdk-kinesis,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-sdk-s3,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
+aws-sdk-secretsmanager,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-sdk-sns,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-sdk-sqs,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"
 aws-sdk-sts,https://github.com/awslabs/aws-sdk-rust,Apache-2.0,"AWS Rust SDK Team <aws-sdk-rust@amazon.com>, Russell Cohen <rcoh@amazon.com>"

--- a/changelog.d/19990_support_loading_secrets_from_aws_secrets_manager.feature.md
+++ b/changelog.d/19990_support_loading_secrets_from_aws_secrets_manager.feature.md
@@ -1,0 +1,3 @@
+Added support for loading secrets from AWS Secrets Manager.
+
+authors: DarkAtra

--- a/src/secrets/aws_secrets_manager.rs
+++ b/src/secrets/aws_secrets_manager.rs
@@ -1,0 +1,110 @@
+use std::collections::{HashMap, HashSet};
+
+use aws_sdk_secretsmanager::{config, Client};
+use futures::executor;
+use vector_lib::configurable::{component::GenerateConfig, configurable_component};
+
+use crate::aws::{create_client, AwsAuthentication, ClientBuilder, RegionOrEndpoint};
+use crate::config::ProxyConfig;
+use crate::tls::TlsConfig;
+use crate::{config::SecretBackend, signal};
+
+pub(crate) struct SecretsManagerClientBuilder;
+
+impl ClientBuilder for SecretsManagerClientBuilder {
+    type Client = Client;
+
+    fn build(config: &aws_types::SdkConfig) -> Self::Client {
+        let config = config::Builder::from(config).build();
+        Client::from_conf(config)
+    }
+}
+
+/// Configuration for the `aws_secrets_manager` secrets backend.
+#[configurable_component(secrets("aws_secrets_manager"))]
+#[derive(Clone, Debug)]
+pub struct AwsSecretsManagerBackend {
+    /// ID of the secret to resolve.
+    pub secret_id: String,
+
+    #[serde(flatten)]
+    #[configurable(derived)]
+    pub region: RegionOrEndpoint,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub auth: AwsAuthentication,
+
+    #[configurable(derived)]
+    pub tls: Option<TlsConfig>,
+}
+
+impl GenerateConfig for AwsSecretsManagerBackend {
+    fn generate_config() -> toml::Value {
+        toml::Value::try_from(AwsSecretsManagerBackend {
+            secret_id: String::from("secret-id"),
+            region: Default::default(),
+            auth: Default::default(),
+            tls: None,
+        })
+        .unwrap()
+    }
+}
+
+impl SecretBackend for AwsSecretsManagerBackend {
+    fn retrieve(
+        &mut self,
+        secret_keys: HashSet<String>,
+        _: &mut signal::SignalRx,
+    ) -> crate::Result<HashMap<String, String>> {
+        let client: Client = executor::block_on(async {
+            return create_client::<SecretsManagerClientBuilder>(
+                &self.auth,
+                self.region.region(),
+                self.region.endpoint(),
+                &ProxyConfig::default(),
+                &self.tls,
+            )
+            .await;
+        })?;
+
+        let get_secret_value_response = executor::block_on(async {
+            return client
+                .get_secret_value()
+                .secret_id(&self.secret_id)
+                .send()
+                .await;
+        })?;
+
+        let secret_string = get_secret_value_response.secret_string.ok_or::<String>(
+            format!(
+                "secret for secret-id '{}' could not be retrieved",
+                &self.secret_id
+            )
+            .into(),
+        )?;
+
+        let output = serde_json::from_str::<HashMap<String, String>>(secret_string.as_str())?;
+
+        let mut secrets = HashMap::new();
+        for k in secret_keys.into_iter() {
+            if let Some(secret) = output.get(&k) {
+                if secret.is_empty() {
+                    return Err(format!(
+                        "value for key '{}' in secret with id '{}' was empty",
+                        k, &self.secret_id
+                    )
+                    .into());
+                }
+                secrets.insert(k.to_string(), secret.to_string());
+            } else {
+                return Err(format!(
+                    "key '{}' in secret with id '{}' does not exist",
+                    k, &self.secret_id
+                )
+                .into());
+            }
+        }
+        return Ok(secrets);
+    }
+}

--- a/src/secrets/aws_secrets_manager.rs
+++ b/src/secrets/aws_secrets_manager.rs
@@ -57,32 +57,31 @@ impl SecretBackend for AwsSecretsManagerBackend {
         secret_keys: HashSet<String>,
         _: &mut signal::SignalRx,
     ) -> crate::Result<HashMap<String, String>> {
-        let client: Client = executor::block_on(async {
-            return create_client::<SecretsManagerClientBuilder>(
+        let client = executor::block_on(async {
+            create_client::<SecretsManagerClientBuilder>(
                 &self.auth,
                 self.region.region(),
                 self.region.endpoint(),
                 &ProxyConfig::default(),
                 &self.tls,
             )
-            .await;
+            .await
         })?;
 
         let get_secret_value_response = executor::block_on(async {
-            return client
+            client
                 .get_secret_value()
                 .secret_id(&self.secret_id)
                 .send()
-                .await;
+                .await
         })?;
 
-        let secret_string = get_secret_value_response.secret_string.ok_or::<String>(
-            format!(
+        let secret_string = get_secret_value_response
+            .secret_string
+            .ok_or::<String>(format!(
                 "secret for secret-id '{}' could not be retrieved",
                 &self.secret_id
-            )
-            .into(),
-        )?;
+            ))?;
 
         let output = serde_json::from_str::<HashMap<String, String>>(secret_string.as_str())?;
 
@@ -105,6 +104,6 @@ impl SecretBackend for AwsSecretsManagerBackend {
                 .into());
             }
         }
-        return Ok(secrets);
+        Ok(secrets)
     }
 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -6,6 +6,7 @@ use vector_lib::configurable::{configurable_component, NamedComponent};
 
 use crate::{config::SecretBackend, signal};
 
+mod aws_secrets_manager;
 mod exec;
 mod test;
 
@@ -18,6 +19,9 @@ pub enum SecretBackends {
     /// Exec.
     Exec(exec::ExecBackend),
 
+    /// AWS Secrets Manager.
+    AwsSecretsManager(aws_secrets_manager::AwsSecretsManagerBackend),
+
     /// Test.
     #[configurable(metadata(docs::hidden))]
     Test(test::TestBackend),
@@ -28,6 +32,7 @@ impl NamedComponent for SecretBackends {
     fn get_component_name(&self) -> &'static str {
         match self {
             Self::Exec(config) => config.get_component_name(),
+            Self::AwsSecretsManager(config) => config.get_component_name(),
             Self::Test(config) => config.get_component_name(),
         }
     }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -11,6 +11,7 @@ mod exec;
 mod test;
 
 /// Configurable secret backends in Vector.
+#[allow(clippy::large_enum_variant)]
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[enum_dispatch(SecretBackend)]

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -6,6 +6,7 @@ use vector_lib::configurable::{configurable_component, NamedComponent};
 
 use crate::{config::SecretBackend, signal};
 
+#[cfg(feature = "secrets-aws-secrets-manager")]
 mod aws_secrets_manager;
 mod exec;
 mod test;
@@ -21,6 +22,7 @@ pub enum SecretBackends {
     Exec(exec::ExecBackend),
 
     /// AWS Secrets Manager.
+    #[cfg(feature = "secrets-aws-secrets-manager")]
     AwsSecretsManager(aws_secrets_manager::AwsSecretsManagerBackend),
 
     /// Test.
@@ -33,6 +35,7 @@ impl NamedComponent for SecretBackends {
     fn get_component_name(&self) -> &'static str {
         match self {
             Self::Exec(config) => config.get_component_name(),
+            #[cfg(feature = "secrets-aws-secrets-manager")]
             Self::AwsSecretsManager(config) => config.get_component_name(),
             Self::Test(config) => config.get_component_name(),
         }

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -473,8 +473,7 @@ configuration: {
 			common: false
 			description: """
 				Configuration options to retrieve secrets from external backend in order to avoid storing secrets in plaintext
-				in Vector config. Multiple backends can be configured. To signify Vector that it should look for a secret to
-				retrieve use the `SECRET[<backend_name>.<secret_key>]`. This placeholder will then be replaced by the secret
+				in Vector config. Multiple backends can be configured. Use `SECRET[<backend_name>.<secret_key>]` to tell Vector to retrieve the secret. This placeholder is replaced by the secret
 				retrieved from the relevant backend.
 				"""
 			required: false
@@ -503,7 +502,7 @@ configuration: {
 						If an `error` is returned for any secrets, or if the command exits with a non-zero status code,
 						Vector will log the errors and exit.
 
-						Secrets will be loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
+						Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
 						configuration reload process.
 						"""
 					type: object: options: {
@@ -533,7 +532,7 @@ configuration: {
 					description: """
 						Retrieve secrets from AWS Secrets Manager.
 
-						The secret is expected to be a JSON text string with key/value pairs, e.g.:
+						The secret must be a JSON text string with key/value pairs. For example:
 						```json
 						{
                           "username": "test",
@@ -541,15 +540,15 @@ configuration: {
                         }
 						```
 
-						Vector will log and exit if an error occurred retrieving the secrets.
+						If an error occurred retrieving the secrets, Vector logs the error and exits.
 
-						Secrets will be loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
+						Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
 						configuration reload process.
 						"""
 					type: object: options: {
 						secret_id: {
 							description: """
-								The id of the secret to be retrieved.
+								The ID of the secret to be retrieved.
 								"""
 							required: true
 							type: string: {

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -473,9 +473,9 @@ configuration: {
 			common: false
 			description: """
 				Configuration options to retrieve secrets from external backend in order to avoid storing secrets in plaintext
-				in Vector config. Currently, only the exec backend is supported. Multiple backends can be configured. To signify
-				Vector that it should look for a secret to retrieve use the `SECRET[<backend_name>.<secret_key>]`. This placeholder
-				will then be replaced by the secret retrieved from the relevant backend.
+				in Vector config. Multiple backends can be configured. To signify Vector that it should look for a secret to
+				retrieve use the `SECRET[<backend_name>.<secret_key>]`. This placeholder will then be replaced by the secret
+				retrieved from the relevant backend.
 				"""
 			required: false
 			type: object: options: {
@@ -524,6 +524,36 @@ configuration: {
 							type: uint: {
 								default: 5
 								unit:    "seconds"
+							}
+						}
+					}
+				}
+				aws_secrets_manager: {
+					required: true
+					description: """
+						Retrieve secrets from AWS Secrets Manager.
+
+						The secret is expected to be a JSON text string with key/value pairs, e.g.:
+						```json
+						{
+                          "username": "test",
+                          "password": "example-password"
+                        }
+						```
+
+						Vector will log and exit if an error occurred retrieving the secrets.
+
+						Secrets will be loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
+						configuration reload process.
+						"""
+					type: object: options: {
+						secret_id: {
+							description: """
+								The id of the secret to be retrieved.
+								"""
+							required: true
+							type: string: {
+								examples: ["/secret/foo-bar"]
 							}
 						}
 					}

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -535,9 +535,9 @@ configuration: {
 						The secret must be a JSON text string with key/value pairs. For example:
 						```json
 						{
-                          "username": "test",
-                          "password": "example-password"
-                        }
+							"username": "test",
+							"password": "example-password"
+						}
 						```
 
 						If an error occurred retrieving the secrets, Vector logs the error and exits.


### PR DESCRIPTION
Adds an option to resolve secrets from AWS Secrets Manager - e.g.:
```yaml
secret:
  loki:
    type: "aws_secrets_manager"
    secret_id: "/secret/my-fancy-secret"
# [...] other stuff here
sinks:
  loki_application_logs:
    auth:
      strategy: basic
      # secret usage
      user: 'SECRET[loki.username]'
      password: 'SECRET[loki.password]'
```

with the secret containg key/value pairs:
```
{
  "username": "test",
  "password": "example-password"
}
```

Fixes https://github.com/vectordotdev/vector/issues/19990