### PR TITLE
chore(testing): support LogNamespace in Component Validation Framework

### DIFF
--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -188,7 +188,7 @@ impl ValidationConfiguration {
         self.component_configurations.clone()
     }
 
-    /// Gets the LogNamespace the that the component is using.
+    /// Gets the LogNamespace that the component is using.
     pub const fn log_namespace(&self) -> LogNamespace {
         self.log_namespace
     }

--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -6,6 +6,8 @@ mod test_case;
 pub mod util;
 mod validators;
 
+use vector_lib::config::LogNamespace;
+
 use crate::config::{BoxedSink, BoxedSource, BoxedTransform};
 
 /// For components implementing `ValidatableComponent`
@@ -125,42 +127,49 @@ pub struct ValidationConfiguration {
     /// There may be only one `ComponentTestCaseConfig` necessary to execute all test cases, but some cases
     /// require more advanced configuration in order to hit the code path desired.
     component_configurations: Vec<ComponentTestCaseConfig>,
+    log_namespace: LogNamespace,
 }
 
 impl ValidationConfiguration {
     /// Creates a new `ValidationConfiguration` for a source.
     pub fn from_source(
         component_name: &'static str,
+        log_namespace: LogNamespace,
         component_configurations: Vec<ComponentTestCaseConfig>,
     ) -> Self {
         Self {
             component_name,
             component_type: ComponentType::Source,
             component_configurations,
+            log_namespace,
         }
     }
 
     /// Creates a new `ValidationConfiguration` for a transform.
     pub fn from_transform(
         component_name: &'static str,
+        log_namespace: LogNamespace,
         component_configurations: Vec<ComponentTestCaseConfig>,
     ) -> Self {
         Self {
             component_name,
             component_type: ComponentType::Transform,
             component_configurations,
+            log_namespace,
         }
     }
 
     /// Creates a new `ValidationConfiguration` for a sink.
     pub fn from_sink(
         component_name: &'static str,
+        log_namespace: LogNamespace,
         component_configurations: Vec<ComponentTestCaseConfig>,
     ) -> Self {
         Self {
             component_name,
             component_type: ComponentType::Sink,
             component_configurations,
+            log_namespace,
         }
     }
 
@@ -177,6 +186,11 @@ impl ValidationConfiguration {
     /// Gets the configuration of the component.
     pub fn component_configurations(&self) -> Vec<ComponentTestCaseConfig> {
         self.component_configurations.clone()
+    }
+
+    /// Gets the LogNamespace the that the component is using.
+    pub const fn log_namespace(&self) -> LogNamespace {
+        self.log_namespace
     }
 
     fn get_comp_test_case(&self, test_case: Option<&String>) -> Option<ComponentTestCaseConfig> {

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -503,7 +503,7 @@ where
 
         let router = Router::new().route(&request_path, method_router).fallback(
             |req: Request<Body>| async move {
-                error!(?req, "Component sent request the server could not route");
+                error!(?req, "Component sent request the server could not route.");
                 StatusCode::NOT_FOUND
             },
         );

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -74,26 +74,14 @@ impl HttpResourceConfig {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn spawn_as_output(self, ctx: HttpResourceOutputContext) -> vector_lib::Result<()> {
         match ctx.direction {
             // We'll pull data from the sink.
-            ResourceDirection::Pull => Ok(spawn_output_http_client(self, ctx)),
+            ResourceDirection::Pull => Ok(ctx.spawn_output_http_client(self)),
             // The sink will push data to us.
-            ResourceDirection::Push => spawn_output_http_server(self, ctx),
+            ResourceDirection::Push => ctx.spawn_output_http_server(self),
         }
     }
-}
-
-/// Anything that the output side HTTP external resource needs
-pub struct HttpResourceOutputContext<'a> {
-    pub direction: ResourceDirection,
-    pub codec: ResourceCodec,
-    pub output_tx: mpsc::Sender<Vec<Event>>,
-    pub task_coordinator: &'a TaskCoordinator<Configuring>,
-    pub input_events: Vec<TestEvent>,
-    pub runner_metrics: &'a Arc<Mutex<RunnerMetrics>>,
-    pub log_namespace: LogNamespace,
 }
 
 /// Spawns an HTTP server that a source will make requests to in order to get events.
@@ -290,129 +278,141 @@ fn spawn_input_http_client(
     });
 }
 
-/// Spawns an HTTP server that accepts events sent by a sink.
-#[allow(clippy::missing_const_for_fn)]
-fn spawn_output_http_server(
-    config: HttpResourceConfig,
-    context: HttpResourceOutputContext,
-) -> vector_lib::Result<()> {
-    // This HTTP server will wait for events to be sent by a sink, and collect them and send them on
-    // via an output sender. We accept/collect events until we're told to shutdown.
+/// Anything that the output side HTTP external resource needs
+pub struct HttpResourceOutputContext<'a> {
+    pub direction: ResourceDirection,
+    pub codec: ResourceCodec,
+    pub output_tx: mpsc::Sender<Vec<Event>>,
+    pub task_coordinator: &'a TaskCoordinator<Configuring>,
+    pub input_events: Vec<TestEvent>,
+    pub runner_metrics: &'a Arc<Mutex<RunnerMetrics>>,
+    pub log_namespace: LogNamespace,
+}
 
-    // First, we'll build and spawn our HTTP server.
-    let decoder = context.codec.into_decoder(context.log_namespace)?;
+impl HttpResourceOutputContext<'_> {
+    /// Spawns an HTTP server that accepts events sent by a sink.
+    #[allow(clippy::missing_const_for_fn)]
+    fn spawn_output_http_server(&self, config: HttpResourceConfig) -> vector_lib::Result<()> {
+        // This HTTP server will wait for events to be sent by a sink, and collect them and send them on
+        // via an output sender. We accept/collect events until we're told to shutdown.
 
-    // Note that we currently don't differentiate which events should and shouldn't be rejected-
-    // we reject all events in this server if any are marked for rejection.
-    // In the future it might be useful to be able to select which to reject. That will involve
-    // adding logic to the test case which is passed down here, and to the event itself. Since
-    // we can't guarantee the order of events, we'd need a way to flag which ones need to be
-    // rejected.
-    let should_reject = context
-        .input_events
-        .iter()
-        .filter(|te| te.should_reject())
-        .count()
-        > 0;
+        // First, we'll build and spawn our HTTP server.
+        let decoder = self.codec.into_decoder(self.log_namespace)?;
 
-    let (_, http_server_shutdown_tx) = spawn_http_server(
-        context.task_coordinator,
-        &config,
-        context.runner_metrics,
-        move |request, output_runner_metrics| {
-            let output_tx = context.output_tx.clone();
-            let mut decoder = decoder.clone();
+        // Note that we currently don't differentiate which events should and shouldn't be rejected-
+        // we reject all events in this server if any are marked for rejection.
+        // In the future it might be useful to be able to select which to reject. That will involve
+        // adding logic to the test case which is passed down here, and to the event itself. Since
+        // we can't guarantee the order of events, we'd need a way to flag which ones need to be
+        // rejected.
+        let should_reject = self
+            .input_events
+            .iter()
+            .filter(|te| te.should_reject())
+            .count()
+            > 0;
 
-            async move {
-                match hyper::body::to_bytes(request.into_body()).await {
-                    Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-                    Ok(body) => {
-                        let mut body = BytesMut::from(&body[..]);
-                        loop {
-                            match decoder.decode_eof(&mut body) {
-                                Ok(Some((events, byte_size))) => {
-                                    if should_reject {
-                                        info!("HTTP server external output resource decoded {byte_size} bytes but test case configured to reject.");
-                                    } else {
-                                        let mut output_runner_metrics =
-                                            output_runner_metrics.lock().await;
-                                        info!("HTTP server external output resource decoded {byte_size} bytes.");
+        let output_tx = self.output_tx.clone();
+        let (_, http_server_shutdown_tx) = spawn_http_server(
+            self.task_coordinator,
+            &config,
+            self.runner_metrics,
+            move |request, output_runner_metrics| {
+                let output_tx = output_tx.clone();
+                let mut decoder = decoder.clone();
 
-                                        // Update the runner metrics for the received events. This will later
-                                        // be used in the Validators, as the "expected" case.
-                                        output_runner_metrics.received_bytes_total +=
-                                            byte_size as u64;
+                async move {
+                    match hyper::body::to_bytes(request.into_body()).await {
+                        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                        Ok(body) => {
+                            let mut body = BytesMut::from(&body[..]);
+                            loop {
+                                match decoder.decode_eof(&mut body) {
+                                    Ok(Some((events, byte_size))) => {
+                                        if should_reject {
+                                            info!("HTTP server external output resource decoded {byte_size} bytes but test case configured to reject.");
+                                        } else {
+                                            let mut output_runner_metrics =
+                                                output_runner_metrics.lock().await;
+                                            info!("HTTP server external output resource decoded {byte_size} bytes.");
 
-                                        output_runner_metrics.received_events_total +=
-                                            events.len() as u64;
+                                            // Update the runner metrics for the received events. This will later
+                                            // be used in the Validators, as the "expected" case.
+                                            output_runner_metrics.received_bytes_total +=
+                                                byte_size as u64;
 
-                                        events.iter().for_each(|event| {
-                                            output_runner_metrics.received_event_bytes_total +=
-                                                event.estimated_json_encoded_size_of().get() as u64;
-                                        });
+                                            output_runner_metrics.received_events_total +=
+                                                events.len() as u64;
 
-                                        output_tx
-                                            .send(events.to_vec())
-                                            .await
-                                            .expect("should not fail to send output event");
+                                            events.iter().for_each(|event| {
+                                                output_runner_metrics.received_event_bytes_total +=
+                                                    event.estimated_json_encoded_size_of().get()
+                                                        as u64;
+                                            });
+
+                                            output_tx
+                                                .send(events.to_vec())
+                                                .await
+                                                .expect("should not fail to send output event");
+                                        }
                                     }
-                                }
-                                Ok(None) => {
-                                    if should_reject {
-                                        // This status code is not retried and should result in the component under test
-                                        // emitting error events
-                                        return StatusCode::BAD_REQUEST.into_response();
-                                    } else {
-                                        return StatusCode::OK.into_response();
+                                    Ok(None) => {
+                                        if should_reject {
+                                            // This status code is not retried and should result in the component under test
+                                            // emitting error events
+                                            return StatusCode::BAD_REQUEST.into_response();
+                                        } else {
+                                            return StatusCode::OK.into_response();
+                                        }
                                     }
-                                }
-                                Err(_) => {
-                                    error!(
-                                        "HTTP server failed to decode {:?}",
-                                        String::from_utf8_lossy(&body)
-                                    );
-                                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                                    Err(_) => {
+                                        error!(
+                                            "HTTP server failed to decode {:?}",
+                                            String::from_utf8_lossy(&body)
+                                        );
+                                        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-        },
-    );
+            },
+        );
 
-    // Now we'll create and spawn the resource's core logic loop which simply waits for the runner
-    // to instruct us to shutdown, and when that happens, cascades to shutting down the HTTP server.
-    let resource_started = context.task_coordinator.track_started();
-    let resource_completed = context.task_coordinator.track_completed();
-    let mut resource_shutdown_rx = context.task_coordinator.register_for_shutdown();
+        // Now we'll create and spawn the resource's core logic loop which simply waits for the runner
+        // to instruct us to shutdown, and when that happens, cascades to shutting down the HTTP server.
+        let resource_started = self.task_coordinator.track_started();
+        let resource_completed = self.task_coordinator.track_completed();
+        let mut resource_shutdown_rx = self.task_coordinator.register_for_shutdown();
 
-    tokio::spawn(async move {
-        resource_started.mark_as_done();
-        info!("HTTP server external output resource started.");
+        tokio::spawn(async move {
+            resource_started.mark_as_done();
+            info!("HTTP server external output resource started.");
 
-        // Wait for the runner to tell us to shutdown
-        resource_shutdown_rx.wait().await;
+            // Wait for the runner to tell us to shutdown
+            resource_shutdown_rx.wait().await;
 
-        // signal the server to shutdown
-        let _ = http_server_shutdown_tx.send(());
+            // signal the server to shutdown
+            let _ = http_server_shutdown_tx.send(());
 
-        // mark ourselves as done
-        resource_completed.mark_as_done();
+            // mark ourselves as done
+            resource_completed.mark_as_done();
 
-        info!("HTTP server external output resource completed.");
-    });
+            info!("HTTP server external output resource completed.");
+        });
 
-    Ok(())
-}
+        Ok(())
+    }
 
-/// Spawns an HTTP client that pulls events by making requests to an HTTP server driven by a sink.
-#[allow(clippy::missing_const_for_fn)]
-fn spawn_output_http_client(_config: HttpResourceConfig, _ctx: HttpResourceOutputContext) {
-    // TODO: The `prometheus_exporter` sink is the only sink that exposes an HTTP server which must be
-    // scraped... but since we need special logic to aggregate/deduplicate scraped metrics, we can't
-    // use this generically for that purpose.
-    todo!()
+    /// Spawns an HTTP client that pulls events by making requests to an HTTP server driven by a sink.
+    #[allow(clippy::missing_const_for_fn)]
+    fn spawn_output_http_client(&self, _config: HttpResourceConfig) {
+        // TODO: The `prometheus_exporter` sink is the only sink that exposes an HTTP server which must be
+        // scraped... but since we need special logic to aggregate/deduplicate scraped metrics, we can't
+        // use this generically for that purpose.
+        todo!()
+    }
 }
 
 fn spawn_http_server<H, F, R>(

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -21,6 +21,7 @@ use crate::codecs::{Decoder, DecodingConfig, Encoder, EncodingConfig, EncodingCo
 
 pub use self::event::{encode_test_event, TestEvent};
 pub use self::http::HttpResourceConfig;
+use self::http::HttpResourceOutputContext;
 
 use super::{
     sync::{Configuring, TaskCoordinator},
@@ -349,15 +350,17 @@ impl ExternalResource {
         log_namespace: LogNamespace,
     ) -> vector_lib::Result<()> {
         match self.definition {
-            ResourceDefinition::Http(http_config) => http_config.spawn_as_output(
-                self.direction,
-                self.codec,
-                output_tx,
-                task_coordinator,
-                input_events,
-                runner_metrics,
-                log_namespace,
-            ),
+            ResourceDefinition::Http(http_config) => {
+                http_config.spawn_as_output(HttpResourceOutputContext {
+                    direction: self.direction,
+                    codec: self.codec,
+                    output_tx,
+                    task_coordinator,
+                    input_events,
+                    runner_metrics,
+                    log_namespace,
+                })
+            }
         }
     }
 }

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -322,6 +322,7 @@ impl Runner {
                 &runner_metrics,
                 maybe_runner_encoder.as_ref().cloned(),
                 self.configuration.component_type,
+                self.configuration.log_namespace(),
             );
 
             // the number of events we expect to receive from the output.
@@ -498,6 +499,7 @@ fn build_external_resource(
                 output_task_coordinator,
                 test_case.events.clone(),
                 runner_metrics,
+                configuration.log_namespace(),
             )?;
 
             Ok((
@@ -567,10 +569,10 @@ fn spawn_input_driver(
     runner_metrics: &Arc<Mutex<RunnerMetrics>>,
     mut maybe_encoder: Option<Encoder<encoding::Framer>>,
     component_type: ComponentType,
+    log_namespace: LogNamespace,
 ) -> JoinHandle<()> {
     let input_runner_metrics = Arc::clone(runner_metrics);
 
-    let log_namespace = LogNamespace::Legacy;
     let now = Utc::now();
 
     tokio::spawn(async move {

--- a/src/components/validation/validators/component_spec/mod.rs
+++ b/src/components/validation/validators/component_spec/mod.rs
@@ -281,7 +281,7 @@ fn compare_actual_to_expected(
 
     let actual = sum_counters(metric_type, &metrics)?;
 
-    info!("{}: expected {}, actual {}.", metric_type, expected, actual,);
+    info!("{metric_type}: expected {expected}, actual {actual}.");
 
     if actual != expected &&
         // This is a bit messy. The issue is that EstimatedJsonSizeOf can be called by a component
@@ -293,8 +293,7 @@ fn compare_actual_to_expected(
             || (actual != (expected + (expect_received_events * 2))))
     {
         errs.push(format!(
-            "{}: expected {}, actual {}",
-            metric_type, expected, actual
+            "{metric_type}: expected {expected}, actual {actual}",
         ));
     }
 

--- a/src/components/validation/validators/component_spec/mod.rs
+++ b/src/components/validation/validators/component_spec/mod.rs
@@ -293,7 +293,7 @@ fn compare_actual_to_expected(
             || (actual != (expected + (expect_received_events * 2))))
     {
         errs.push(format!(
-            "{}: expected {}, but received {}",
+            "{}: expected {}, actual {}",
             metric_type, expected, actual
         ));
     }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -185,7 +185,10 @@ mod test {
     use super::*;
     use crate::codecs::EncodingConfigWithFraming;
     use crate::components::validation::prelude::*;
-    use vector_lib::codecs::{JsonSerializerConfig, MetricTagValues};
+    use vector_lib::{
+        codecs::{JsonSerializerConfig, MetricTagValues},
+        config::LogNamespace,
+    };
 
     #[test]
     fn generate_config() {
@@ -223,6 +226,7 @@ mod test {
 
             ValidationConfiguration::from_sink(
                 Self::NAME,
+                LogNamespace::Legacy,
                 vec![ComponentTestCaseConfig::from_sink(
                     config,
                     None,

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -315,6 +315,7 @@ mod tests {
         fn validation_configuration() -> ValidationConfiguration {
             use std::str::FromStr;
             use vector_lib::codecs::{JsonSerializerConfig, MetricTagValues};
+            use vector_lib::config::LogNamespace;
 
             let config = HttpSinkConfig {
                 uri: UriSerde::from_str("http://127.0.0.1:9000/endpoint")
@@ -344,6 +345,7 @@ mod tests {
 
             ValidationConfiguration::from_sink(
                 Self::NAME,
+                LogNamespace::Legacy,
                 vec![ComponentTestCaseConfig::from_sink(
                     config,
                     None,

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -284,7 +284,10 @@ impl HecLogsSinkConfig {
 mod tests {
     use super::*;
     use crate::components::validation::prelude::*;
-    use vector_lib::codecs::{JsonSerializerConfig, MetricTagValues};
+    use vector_lib::{
+        codecs::{JsonSerializerConfig, MetricTagValues},
+        config::LogNamespace,
+    };
 
     #[test]
     fn generate_config() {
@@ -341,6 +344,7 @@ mod tests {
 
             ValidationConfiguration::from_sink(
                 Self::NAME,
+                LogNamespace::Legacy,
                 vec![ComponentTestCaseConfig::from_sink(
                     config,
                     None,

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2532,7 +2532,7 @@ impl ValidatableComponent for DatadogAgentConfig {
             keepalive: Default::default(),
         };
 
-        let log_namespace: LogNamespace = config.log_namespace.unwrap_or(false).into();
+        let log_namespace: LogNamespace = config.log_namespace.unwrap_or_default().into();
 
         // TODO set up separate test cases for metrics and traces endpoints
 

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -50,7 +50,7 @@ impl ValidatableComponent for HttpClientConfig {
             decoding: DeserializerConfig::Json(Default::default()),
             ..Default::default()
         };
-        let log_namespace: LogNamespace = config.log_namespace.unwrap_or(false).into();
+        let log_namespace: LogNamespace = config.log_namespace.unwrap_or_default().into();
 
         let external_resource = ExternalResource::new(
             ResourceDirection::Pull,

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -1,6 +1,7 @@
 use http::Uri;
 use std::collections::HashMap;
 use tokio::time::Duration;
+use vector_lib::config::LogNamespace;
 use warp::{http::HeaderMap, Filter};
 
 use crate::components::validation::prelude::*;
@@ -49,6 +50,7 @@ impl ValidatableComponent for HttpClientConfig {
             decoding: DeserializerConfig::Json(Default::default()),
             ..Default::default()
         };
+        let log_namespace: LogNamespace = config.log_namespace.unwrap_or(false).into();
 
         let external_resource = ExternalResource::new(
             ResourceDirection::Pull,
@@ -58,6 +60,7 @@ impl ValidatableComponent for HttpClientConfig {
 
         ValidationConfiguration::from_source(
             Self::NAME,
+            log_namespace,
             vec![ComponentTestCaseConfig::from_source(
                 config,
                 None,

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -1529,6 +1529,8 @@ mod tests {
                 ..Default::default()
             };
 
+            let log_namespace: LogNamespace = config.log_namespace.unwrap_or(false).into();
+
             let listen_addr_http = format!("http://{}/", config.address);
             let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
 
@@ -1542,6 +1544,7 @@ mod tests {
 
             ValidationConfiguration::from_source(
                 Self::NAME,
+                log_namespace,
                 vec![ComponentTestCaseConfig::from_source(
                     config,
                     None,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2623,7 +2623,7 @@ mod tests {
             let listen_addr_http = format!("http://{}/services/collector/event", config.address);
             let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
 
-            let log_namespace: LogNamespace = config.log_namespace.unwrap_or(false).into();
+            let log_namespace: LogNamespace = config.log_namespace.unwrap_or_default().into();
             let framing = BytesDecoderConfig::new().into();
             let decoding = DeserializerConfig::Json(Default::default());
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2623,6 +2623,7 @@ mod tests {
             let listen_addr_http = format!("http://{}/services/collector/event", config.address);
             let uri = Uri::try_from(&listen_addr_http).expect("should not fail to parse URI");
 
+            let log_namespace: LogNamespace = config.log_namespace.unwrap_or(false).into();
             let framing = BytesDecoderConfig::new().into();
             let decoding = DeserializerConfig::Json(Default::default());
 
@@ -2637,6 +2638,7 @@ mod tests {
 
             ValidationConfiguration::from_source(
                 Self::NAME,
+                log_namespace,
                 vec![ComponentTestCaseConfig::from_source(
                     config,
                     None,

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -137,7 +137,7 @@ pub struct VectorConfig {
     /// The namespace to use for logs. This overrides the global setting.
     #[serde(default)]
     #[configurable(metadata(docs::hidden))]
-    log_namespace: Option<bool>,
+    pub log_namespace: Option<bool>,
 }
 
 impl VectorConfig {


### PR DESCRIPTION
This enables support in the Component Validation Framework for setting the LogNamespace used within the input edge when transforms and sinks are under test, which is necessary when the Vector namespace is being used, in order for required semantic meanings to be defined.

Includes a couple small error handling improvements to the HTTP external resource as well, for debugging purposes. 
