### PR TITLE
feat(codecs): add options to `length_delimited` framing

### DIFF
--- a/changelog.d/20154_length_delimited_framing_options.feature.md
+++ b/changelog.d/20154_length_delimited_framing_options.feature.md
@@ -1,0 +1,3 @@
+Added support for additional config options for `length_delimited` framing.
+
+authors: esensar

--- a/lib/codecs/src/common/length_delimited.rs
+++ b/lib/codecs/src/common/length_delimited.rs
@@ -1,0 +1,66 @@
+use tokio_util::codec::LengthDelimitedCodec;
+use vector_config::configurable_component;
+
+/// Options for building a `LengthDelimitedDecoder` or `LengthDelimitedEncoder`.
+#[configurable_component]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LengthDelimitedCoderOptions {
+    /// Maximum frame length
+    #[serde(default = "default_max_frame_length")]
+    pub max_frame_length: usize,
+
+    /// Number of bytes representing the field length
+    #[serde(default = "default_length_field_length")]
+    pub length_field_length: usize,
+
+    /// Number of bytes in the header before the length field
+    #[serde(default = "default_length_field_offset")]
+    pub length_field_offset: usize,
+
+    /// Length field byte order (little or big endian)
+    #[serde(default = "default_length_field_is_big_endian")]
+    pub length_field_is_big_endian: bool,
+}
+
+const fn default_max_frame_length() -> usize {
+    8 * 1_024 * 1_024
+}
+
+const fn default_length_field_length() -> usize {
+    4
+}
+
+const fn default_length_field_offset() -> usize {
+    0
+}
+
+const fn default_length_field_is_big_endian() -> bool {
+    true
+}
+
+impl Default for LengthDelimitedCoderOptions {
+    fn default() -> Self {
+        Self {
+            max_frame_length: default_max_frame_length(),
+            length_field_length: default_length_field_length(),
+            length_field_offset: default_length_field_offset(),
+            length_field_is_big_endian: default_length_field_is_big_endian(),
+        }
+    }
+}
+
+impl LengthDelimitedCoderOptions {
+    pub fn build_codec(&self) -> LengthDelimitedCodec {
+        let mut builder = tokio_util::codec::LengthDelimitedCodec::builder()
+            .length_field_length(self.length_field_length)
+            .length_field_offset(self.length_field_offset)
+            .max_frame_length(self.max_frame_length)
+            .to_owned();
+        if self.length_field_is_big_endian {
+            builder.big_endian();
+        } else {
+            builder.little_endian();
+        };
+        builder.new_codec()
+    }
+}

--- a/lib/codecs/src/common/mod.rs
+++ b/lib/codecs/src/common/mod.rs
@@ -1,3 +1,4 @@
 //! A collection of common utility features used by both encoding and decoding logic.
 
+pub mod length_delimited;
 pub mod protobuf;

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -89,7 +89,7 @@ pub enum FramingConfig {
     CharacterDelimited(CharacterDelimitedDecoderConfig),
 
     /// Byte frames which are prefixed by an unsigned big-endian 32-bit integer indicating the length.
-    LengthDelimited,
+    LengthDelimited(LengthDelimitedDecoderConfig),
 
     /// Byte frames which are delimited by a newline character.
     NewlineDelimited(NewlineDelimitedDecoderConfig),
@@ -113,8 +113,8 @@ impl From<CharacterDelimitedDecoderConfig> for FramingConfig {
 }
 
 impl From<LengthDelimitedDecoderConfig> for FramingConfig {
-    fn from(_: LengthDelimitedDecoderConfig) -> Self {
-        Self::LengthDelimited
+    fn from(config: LengthDelimitedDecoderConfig) -> Self {
+        Self::LengthDelimited(config)
     }
 }
 
@@ -136,9 +136,7 @@ impl FramingConfig {
         match self {
             FramingConfig::Bytes => Framer::Bytes(BytesDecoderConfig.build()),
             FramingConfig::CharacterDelimited(config) => Framer::CharacterDelimited(config.build()),
-            FramingConfig::LengthDelimited => {
-                Framer::LengthDelimited(LengthDelimitedDecoderConfig.build())
-            }
+            FramingConfig::LengthDelimited(config) => Framer::LengthDelimited(config.build()),
             FramingConfig::NewlineDelimited(config) => Framer::NewlineDelimited(config.build()),
             FramingConfig::OctetCounting(config) => Framer::OctetCounting(config.build()),
         }
@@ -333,7 +331,7 @@ impl DeserializerConfig {
     pub fn default_stream_framing(&self) -> FramingConfig {
         match self {
             DeserializerConfig::Avro { .. } => FramingConfig::Bytes,
-            DeserializerConfig::Native => FramingConfig::LengthDelimited,
+            DeserializerConfig::Native => FramingConfig::LengthDelimited(Default::default()),
             DeserializerConfig::Bytes
             | DeserializerConfig::Json(_)
             | DeserializerConfig::Gelf(_)

--- a/lib/codecs/src/encoding/framing/length_delimited.rs
+++ b/lib/codecs/src/encoding/framing/length_delimited.rs
@@ -1,59 +1,43 @@
 use bytes::BytesMut;
-use serde::{Deserialize, Serialize};
+use derivative::Derivative;
 use tokio_util::codec::{Encoder, LengthDelimitedCodec};
+use vector_config::configurable_component;
+
+use crate::common::length_delimited::LengthDelimitedCoderOptions;
 
 use super::BoxedFramingError;
 
 /// Config used to build a `LengthDelimitedEncoder`.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct LengthDelimitedEncoderConfig;
+#[configurable_component]
+#[derive(Debug, Clone, Derivative, Eq, PartialEq)]
+#[derivative(Default)]
+pub struct LengthDelimitedEncoderConfig {
+    /// Options for the length delimited decoder.
+    #[serde(skip_serializing_if = "vector_core::serde::is_default")]
+    pub length_delimited: LengthDelimitedCoderOptions,
+}
 
 impl LengthDelimitedEncoderConfig {
-    /// Creates a `LengthDelimitedEncoderConfig`.
-    pub const fn new() -> Self {
-        Self
-    }
-
     /// Build the `LengthDelimitedEncoder` from this configuration.
     pub fn build(&self) -> LengthDelimitedEncoder {
-        LengthDelimitedEncoder::new()
+        LengthDelimitedEncoder::new(&self.length_delimited)
     }
 }
 
 /// An encoder for handling bytes that are delimited by a length header.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LengthDelimitedEncoder(LengthDelimitedCodec);
 
 impl LengthDelimitedEncoder {
-    /// Creates a `LengthDelimitedEncoder`.
-    pub fn new() -> Self {
-        Self(LengthDelimitedCodec::new())
+    /// Creates a new `LengthDelimitedEncoder`.
+    pub fn new(config: &LengthDelimitedCoderOptions) -> Self {
+        Self(config.build_codec())
     }
 }
 
 impl Default for LengthDelimitedEncoder {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Clone for LengthDelimitedEncoder {
-    fn clone(&self) -> Self {
-        // This has been fixed with https://github.com/tokio-rs/tokio/pull/4089,
-        // however we are blocked on upgrading to a new release of `tokio-util`
-        // that includes the `Clone` implementation:
-        // https://github.com/vectordotdev/vector/issues/11257.
-        //
-        // This is an awful implementation for `Clone` since it resets the
-        // internal state. However, it works for our use case because we
-        // generally only clone a codec that has not been mutated yet.
-        //
-        // Ideally, `tokio_util::codec::LengthDelimitedCodec` should implement
-        // `Clone` and it doesn't look like it was a deliberate decision to
-        // leave out the implementation. All of its internal fields implement
-        // `Clone`, so adding an implementation for `Clone` could be contributed
-        // to the upstream repo easily by adding it to the `derive` macro.
-        Self::new()
+        Self(LengthDelimitedCodec::new())
     }
 }
 
@@ -73,11 +57,24 @@ mod tests {
 
     #[test]
     fn encode() {
-        let mut codec = LengthDelimitedEncoder::new();
+        let mut codec = LengthDelimitedEncoder::default();
 
         let mut buffer = BytesMut::from("abc");
         codec.encode((), &mut buffer).unwrap();
 
         assert_eq!(&buffer[..], b"\0\0\0\x03abc");
+    }
+
+    #[test]
+    fn encode_2byte_length() {
+        let mut codec = LengthDelimitedEncoder::new(&LengthDelimitedCoderOptions {
+            length_field_length: 2,
+            ..Default::default()
+        });
+
+        let mut buffer = BytesMut::from("abc");
+        codec.encode((), &mut buffer).unwrap();
+
+        assert_eq!(&buffer[..], b"\0\x03abc");
     }
 }

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -67,7 +67,7 @@ pub enum FramingConfig {
     /// Event data is prefixed with its length in bytes.
     ///
     /// The prefix is a 32-bit unsigned integer, little endian.
-    LengthDelimited,
+    LengthDelimited(LengthDelimitedEncoderConfig),
 
     /// Event data is delimited by a newline (LF) character.
     NewlineDelimited,
@@ -86,8 +86,8 @@ impl From<CharacterDelimitedEncoderConfig> for FramingConfig {
 }
 
 impl From<LengthDelimitedEncoderConfig> for FramingConfig {
-    fn from(_: LengthDelimitedEncoderConfig) -> Self {
-        Self::LengthDelimited
+    fn from(config: LengthDelimitedEncoderConfig) -> Self {
+        Self::LengthDelimited(config)
     }
 }
 
@@ -103,9 +103,7 @@ impl FramingConfig {
         match self {
             FramingConfig::Bytes => Framer::Bytes(BytesEncoderConfig.build()),
             FramingConfig::CharacterDelimited(config) => Framer::CharacterDelimited(config.build()),
-            FramingConfig::LengthDelimited => {
-                Framer::LengthDelimited(LengthDelimitedEncoderConfig.build())
-            }
+            FramingConfig::LengthDelimited(config) => Framer::LengthDelimited(config.build()),
             FramingConfig::NewlineDelimited => {
                 Framer::NewlineDelimited(NewlineDelimitedEncoderConfig.build())
             }
@@ -360,7 +358,9 @@ impl SerializerConfig {
             // [1]: https://avro.apache.org/docs/1.11.1/specification/_print/#message-framing
             SerializerConfig::Avro { .. }
             | SerializerConfig::Native
-            | SerializerConfig::Protobuf(_) => FramingConfig::LengthDelimited,
+            | SerializerConfig::Protobuf(_) => {
+                FramingConfig::LengthDelimited(LengthDelimitedEncoderConfig::default())
+            }
             SerializerConfig::Csv(_)
             | SerializerConfig::Gelf
             | SerializerConfig::Json(_)

--- a/src/codecs/encoding/config.rs
+++ b/src/codecs/encoding/config.rs
@@ -105,7 +105,7 @@ impl EncodingConfigWithFraming {
                 SinkType::MessageBased => CharacterDelimitedEncoder::new(b',').into(),
             },
             (None, Serializer::Avro(_) | Serializer::Native(_)) => {
-                LengthDelimitedEncoder::new().into()
+                LengthDelimitedEncoder::default().into()
             }
             (None, Serializer::Gelf(_)) => {
                 // Graylog/GELF always uses null byte delimiter on TCP, see
@@ -115,7 +115,7 @@ impl EncodingConfigWithFraming {
             (None, Serializer::Protobuf(_)) => {
                 // Protobuf uses length-delimited messages, see:
                 // https://developers.google.com/protocol-buffers/docs/techniques#streaming
-                LengthDelimitedEncoder::new().into()
+                LengthDelimitedEncoder::default().into()
             }
             (
                 None,

--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -173,7 +173,7 @@ pub fn encode_test_event(
             // versa.
             let mut alt_encoder = if encoder.serializer().supports_json() {
                 Encoder::<encoding::Framer>::new(
-                    LengthDelimitedEncoder::new().into(),
+                    LengthDelimitedEncoder::default().into(),
                     LogfmtSerializer::new().into(),
                 )
             } else {

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -182,7 +182,11 @@ fn decoder_framing_to_encoding_framer(framing: &decoding::FramingConfig) -> enco
                 },
             })
         }
-        decoding::FramingConfig::LengthDelimited => encoding::FramingConfig::LengthDelimited,
+        decoding::FramingConfig::LengthDelimited(config) => {
+            encoding::FramingConfig::LengthDelimited(encoding::LengthDelimitedEncoderConfig {
+                length_delimited: config.length_delimited.clone(),
+            })
+        }
         decoding::FramingConfig::NewlineDelimited(_) => encoding::FramingConfig::NewlineDelimited,
         // TODO: There's no equivalent octet counting framer for encoding... although
         // there's no particular reason that would make it hard to write.
@@ -228,7 +232,11 @@ fn encoder_framing_to_decoding_framer(framing: encoding::FramingConfig) -> decod
                 },
             })
         }
-        encoding::FramingConfig::LengthDelimited => decoding::FramingConfig::LengthDelimited,
+        encoding::FramingConfig::LengthDelimited(config) => {
+            decoding::FramingConfig::LengthDelimited(decoding::LengthDelimitedDecoderConfig {
+                length_delimited: config.length_delimited.clone(),
+            })
+        }
         encoding::FramingConfig::NewlineDelimited => {
             decoding::FramingConfig::NewlineDelimited(Default::default())
         }

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -619,6 +619,33 @@ base: components: sinks: aws_s3: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -436,6 +436,33 @@ base: components: sinks: azure_blob: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -287,6 +287,33 @@ base: components: sinks: console: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -307,6 +307,33 @@ base: components: sinks: file: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -490,6 +490,33 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -400,6 +400,33 @@ base: components: sinks: http: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -300,6 +300,33 @@ base: components: sinks: socket: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -369,6 +369,33 @@ base: components: sinks: webhdfs: configuration: {
 					type: uint: {}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -309,6 +309,33 @@ base: components: sources: amqp: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -307,6 +307,33 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -407,6 +407,33 @@ base: components: sources: aws_s3: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -411,6 +411,33 @@ base: components: sources: aws_sqs: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -304,6 +304,33 @@ base: components: sources: datadog_agent: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/demo_logs.cue
+++ b/website/cue/reference/components/sources/base/demo_logs.cue
@@ -300,6 +300,33 @@ base: components: sources: demo_logs: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/exec.cue
+++ b/website/cue/reference/components/sources/base/exec.cue
@@ -288,6 +288,33 @@ base: components: sources: exec: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sources/base/file_descriptor.cue
+++ b/website/cue/reference/components/sources/base/file_descriptor.cue
@@ -266,6 +266,33 @@ base: components: sources: file_descriptor: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -343,6 +343,33 @@ base: components: sources: gcp_pubsub: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -301,6 +301,33 @@ base: components: sources: heroku_logs: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -316,6 +316,33 @@ base: components: sources: http: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -304,6 +304,33 @@ base: components: sources: http_client: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -316,6 +316,33 @@ base: components: sources: http_server: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -337,6 +337,33 @@ base: components: sources: kafka: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -356,6 +356,33 @@ base: components: sources: nats: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/pulsar.cue
+++ b/website/cue/reference/components/sources/base/pulsar.cue
@@ -367,6 +367,33 @@ base: components: sources: pulsar: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/redis.cue
+++ b/website/cue/reference/components/sources/base/redis.cue
@@ -274,6 +274,33 @@ base: components: sources: redis: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    false

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -276,6 +276,33 @@ base: components: sources: socket: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true

--- a/website/cue/reference/components/sources/base/stdin.cue
+++ b/website/cue/reference/components/sources/base/stdin.cue
@@ -259,6 +259,33 @@ base: components: sources: stdin: configuration: {
 					}
 				}
 			}
+			length_delimited: {
+				description:   "Options for the length delimited decoder."
+				relevant_when: "method = \"length_delimited\""
+				required:      true
+				type: object: options: {
+					length_field_is_big_endian: {
+						description: "Length field byte order (little or big endian)"
+						required:    false
+						type: bool: default: true
+					}
+					length_field_length: {
+						description: "Number of bytes representing the field length"
+						required:    false
+						type: uint: default: 4
+					}
+					length_field_offset: {
+						description: "Number of bytes in the header before the length field"
+						required:    false
+						type: uint: default: 0
+					}
+					max_frame_length: {
+						description: "Maximum frame length"
+						required:    false
+						type: uint: default: 8388608
+					}
+				}
+			}
 			method: {
 				description: "The framing method."
 				required:    true


### PR DESCRIPTION
Adds options for `length_delimited` framing to enable configuring length of the length field, as well as some other options supported by `LengthDelimitedCodec`. This adds that support for both encoding and decoding.

Fixes: #19323