### PR TITLE
chore(deps): Bump MSRV to reduce usage of `async_trait`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10210,7 +10210,6 @@ name = "vector-api-client"
 version = "0.1.2"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "clap 4.5.3",
  "futures 0.3.30",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "vector"
 autobenches = false # our benchmarks are not runnable on their own either way
 # Minimum supported rust version
 # See docs/DEVELOPING.md for policy
-rust-version = "1.75"
+rust-version = "1.77"
 
 [[bin]]
 name = "vector"

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -16,7 +16,6 @@ serde_json.workspace = true
 anyhow = { version = "1.0.81", default-features = false, features = ["std"] }
 
 # Tokio / Futures
-async-trait = { version = "0.1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["compat", "io-compat"] }
 tokio = { version = "1.36.0", default-features = false, features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1.15", default-features = false, features = ["sync"] }

--- a/lib/vector-api-client/src/gql/components.rs
+++ b/lib/vector-api-client/src/gql/components.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use async_trait::async_trait;
 use graphql_client::GraphQLQuery;
 
 use crate::{BoxedSubscription, QueryResult};
@@ -32,12 +31,10 @@ pub struct ComponentAddedSubscription;
 )]
 pub struct ComponentRemovedSubscription;
 
-#[async_trait]
 pub trait ComponentsQueryExt {
     async fn components_query(&self, first: i64) -> crate::QueryResult<ComponentsQuery>;
 }
 
-#[async_trait]
 impl ComponentsQueryExt for crate::Client {
     async fn components_query(&self, first: i64) -> QueryResult<ComponentsQuery> {
         let request_body = ComponentsQuery::build_query(components_query::Variables { first });
@@ -50,7 +47,6 @@ pub trait ComponentsSubscriptionExt {
     fn component_removed(&self) -> crate::BoxedSubscription<ComponentRemovedSubscription>;
 }
 
-#[async_trait]
 impl ComponentsSubscriptionExt for crate::SubscriptionClient {
     /// Subscription for when a component has been added
     fn component_added(&self) -> BoxedSubscription<ComponentAddedSubscription> {

--- a/lib/vector-api-client/src/gql/health.rs
+++ b/lib/vector-api-client/src/gql/health.rs
@@ -1,6 +1,5 @@
 //! Health queries/subscriptions, for asserting a GraphQL API server is alive.
 
-use async_trait::async_trait;
 use graphql_client::GraphQLQuery;
 
 /// Shorthand for a Chrono datetime, set to UTC.
@@ -29,13 +28,11 @@ pub struct HealthQuery;
 pub struct HeartbeatSubscription;
 
 /// Extension methods for health queries.
-#[async_trait]
 pub trait HealthQueryExt {
     /// Executes a health query.
     async fn health_query(&self) -> crate::QueryResult<HealthQuery>;
 }
 
-#[async_trait]
 impl HealthQueryExt for crate::Client {
     /// Executes a health query.
     async fn health_query(&self) -> crate::QueryResult<HealthQuery> {

--- a/lib/vector-api-client/src/gql/meta.rs
+++ b/lib/vector-api-client/src/gql/meta.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use graphql_client::GraphQLQuery;
 
 /// MetaVersionStringQuery returns the version string of the queried Vector instance.
@@ -11,13 +10,11 @@ use graphql_client::GraphQLQuery;
 pub struct MetaVersionStringQuery;
 
 /// Extension methods for meta queries.
-#[async_trait]
 pub trait MetaQueryExt {
     /// Executes a meta version string query.
     async fn meta_version_string(&self) -> crate::QueryResult<MetaVersionStringQuery>;
 }
 
-#[async_trait]
 impl MetaQueryExt for crate::Client {
     /// Executes a meta version string query.
     async fn meta_version_string(&self) -> crate::QueryResult<MetaVersionStringQuery> {

--- a/lib/vector-api-client/src/lib.rs
+++ b/lib/vector-api-client/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![deny(warnings)]
 #![deny(missing_debug_implementations, missing_copy_implementations)]
+#![allow(async_fn_in_trait)]
 
 mod client;
 /// GraphQL queries

--- a/lib/vector-api-client/src/test/mod.rs
+++ b/lib/vector-api-client/src/test/mod.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use graphql_client::GraphQLQuery;
 
 use crate::{BoxedSubscription, QueryResult};
@@ -48,7 +47,6 @@ pub struct ComponentByComponentKeyQuery;
 )]
 pub struct ComponentsConnectionQuery;
 
-#[async_trait]
 pub trait TestQueryExt {
     async fn component_links_query(
         &self,
@@ -77,7 +75,6 @@ pub trait TestQueryExt {
     ) -> crate::QueryResult<ComponentsConnectionQuery>;
 }
 
-#[async_trait]
 impl TestQueryExt for crate::Client {
     async fn component_links_query(
         &self,

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::type_complexity)] // long-types happen, especially in async code
 #![allow(clippy::must_use_candidate)]
+#![allow(async_fn_in_trait)]
 
 #[macro_use]
 extern crate tracing;

--- a/lib/vector-buffers/src/variants/disk_v2/io.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/io.rs
@@ -1,6 +1,5 @@
 use std::{io, path::Path};
 
-use async_trait::async_trait;
 use tokio::{
     fs::OpenOptions,
     io::{AsyncRead, AsyncWrite},
@@ -22,7 +21,6 @@ impl Metadata {
 }
 
 /// Generalized interface for opening and deleting files from a filesystem.
-#[async_trait]
 pub trait Filesystem: Send + Sync {
     type File: AsyncFile;
     type MemoryMap: ReadableMemoryMap;
@@ -89,7 +87,6 @@ pub trait Filesystem: Send + Sync {
     async fn delete_file(&self, path: &Path) -> io::Result<()>;
 }
 
-#[async_trait]
 pub trait AsyncFile: AsyncRead + AsyncWrite + Send + Sync {
     /// Queries metadata about the underlying file.
     ///
@@ -128,7 +125,6 @@ pub trait WritableMemoryMap: ReadableMemoryMap {
 #[derive(Clone, Debug)]
 pub struct ProductionFilesystem;
 
-#[async_trait]
 impl Filesystem for ProductionFilesystem {
     type File = tokio::fs::File;
     type MemoryMap = memmap2::Mmap;
@@ -217,7 +213,6 @@ fn open_readable_file_options() -> OpenOptions {
     open_options
 }
 
-#[async_trait]
 impl AsyncFile for tokio::fs::File {
     async fn metadata(&self) -> io::Result<Metadata> {
         let metadata = self.metadata().await?;

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use async_trait::async_trait;
 use tokio::{
     fs::OpenOptions,
     io::{AsyncWriteExt, DuplexStream},
@@ -32,7 +31,6 @@ mod model;
 mod record;
 mod size_limits;
 
-#[async_trait]
 impl AsyncFile for DuplexStream {
     async fn metadata(&self) -> io::Result<Metadata> {
         Ok(Metadata { len: 0 })
@@ -43,7 +41,6 @@ impl AsyncFile for DuplexStream {
     }
 }
 
-#[async_trait]
 impl AsyncFile for Cursor<Vec<u8>> {
     async fn metadata(&self) -> io::Result<Metadata> {
         Ok(Metadata { len: 0 })

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
@@ -8,7 +8,6 @@ use std::{
     task::{Context, Poll},
 };
 
-use async_trait::async_trait;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::variants::disk_v2::{
@@ -206,7 +205,6 @@ impl AsyncWrite for TestFile {
     }
 }
 
-#[async_trait]
 impl AsyncFile for TestFile {
     #[instrument(skip(self), level = "debug")]
     async fn metadata(&self) -> io::Result<Metadata> {
@@ -304,7 +302,6 @@ impl Default for TestFilesystem {
     }
 }
 
-#[async_trait]
 impl Filesystem for TestFilesystem {
     type File = TestFile;
     type MemoryMap = TestMmap;

--- a/lib/vector-core/src/sink.rs
+++ b/lib/vector-core/src/sink.rs
@@ -1,6 +1,5 @@
 use std::{fmt, iter::IntoIterator, pin::Pin};
 
-use async_trait::async_trait;
 use futures::{stream, task::Context, task::Poll, Sink, SinkExt, Stream, StreamExt};
 
 use crate::event::{into_event_stream, Event, EventArray, EventContainer};
@@ -86,7 +85,7 @@ impl fmt::Debug for VectorSink {
 
 // === StreamSink ===
 
-#[async_trait]
+#[async_trait::async_trait]
 pub trait StreamSink<T> {
     async fn run(self: Box<Self>, input: stream::BoxStream<'_, T>) -> Result<(), ()>;
 }
@@ -172,7 +171,7 @@ struct EventStream<T> {
     sink: Box<T>,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl<T: StreamSink<Event> + Send> StreamSink<EventArray> for EventStream<T> {
     async fn run(self: Box<Self>, input: stream::BoxStream<'_, EventArray>) -> Result<(), ()> {
         let input = Box::pin(input.flat_map(into_event_stream));

--- a/src/config/enrichment_table.rs
+++ b/src/config/enrichment_table.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use vector_lib::config::GlobalOptions;
 use vector_lib::configurable::{configurable_component, NamedComponent};
@@ -22,7 +21,6 @@ impl EnrichmentTableOuter {
 }
 
 /// Generalized interface for describing and building enrichment table components.
-#[async_trait]
 #[enum_dispatch]
 pub trait EnrichmentTableConfig: NamedComponent + core::fmt::Debug + Send + Sync {
     /// Builds the enrichment table with the given globals.

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -1,11 +1,9 @@
-use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use vector_lib::configurable::NamedComponent;
 
 use crate::{providers::BuildResult, signal};
 
 /// Generalized interface for constructing a configuration from a provider.
-#[async_trait]
 #[enum_dispatch]
 pub trait ProviderConfig: NamedComponent + core::fmt::Debug + Send + Sync {
     /// Builds a configuration.

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -230,7 +230,6 @@ impl FileConfig {
     }
 }
 
-#[async_trait::async_trait]
 impl EnrichmentTableConfig for FileConfig {
     async fn build(
         &self,

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -92,7 +92,6 @@ impl GenerateConfig for GeoipConfig {
     }
 }
 
-#[async_trait::async_trait]
 impl EnrichmentTableConfig for GeoipConfig {
     async fn build(
         &self,

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -30,7 +30,6 @@ impl GenerateConfig for MmdbConfig {
     }
 }
 
-#[async_trait::async_trait]
 impl EnrichmentTableConfig for MmdbConfig {
     async fn build(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![allow(async_fn_in_trait)]
 #![allow(clippy::approx_constant)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wild_err_arm)]

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -169,7 +169,6 @@ fn poll_http(
     }
 }
 
-#[async_trait::async_trait]
 impl ProviderConfig for HttpConfig {
     async fn build(&mut self, signal_handler: &mut signal::SignalHandler) -> BuildResult {
         let url = self

--- a/src/sinks/aws_kinesis/firehose/record.rs
+++ b/src/sinks/aws_kinesis/firehose/record.rs
@@ -41,7 +41,6 @@ pub struct KinesisFirehoseClient {
     pub client: KinesisClient,
 }
 
-#[async_trait::async_trait]
 impl SendRecord for KinesisFirehoseClient {
     type T = KinesisRecord;
     type E = KinesisError;

--- a/src/sinks/aws_kinesis/record.rs
+++ b/src/sinks/aws_kinesis/record.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkError};
 use bytes::Bytes;
 
@@ -19,15 +20,14 @@ pub trait Record {
 }
 
 /// Capable of sending records.
-#[async_trait]
 pub trait SendRecord {
     type T;
     type E;
 
     /// Sends the records.
-    async fn send(
+    fn send(
         &self,
         records: Vec<Self::T>,
         stream_name: String,
-    ) -> Result<KinesisResponse, SdkError<Self::E, HttpResponse>>;
+    ) -> impl Future<Output = Result<KinesisResponse, SdkError<Self::E, HttpResponse>>> + Send;
 }

--- a/src/sinks/aws_kinesis/streams/record.rs
+++ b/src/sinks/aws_kinesis/streams/record.rs
@@ -51,7 +51,6 @@ pub struct KinesisStreamClient {
     pub client: KinesisClient,
 }
 
-#[async_trait::async_trait]
 impl SendRecord for KinesisStreamClient {
     type T = KinesisRecord;
     type E = KinesisError;

--- a/src/sinks/aws_s_s/client.rs
+++ b/src/sinks/aws_s_s/client.rs
@@ -1,15 +1,16 @@
+use std::future::Future;
+
 use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkError};
 
 use super::{request_builder::SendMessageEntry, service::SendMessageResponse};
 
-#[async_trait::async_trait]
 pub(super) trait Client<R>
 where
     R: std::fmt::Debug + std::fmt::Display + std::error::Error,
 {
-    async fn send_message(
+    fn send_message(
         &self,
         entry: SendMessageEntry,
         byte_size: usize,
-    ) -> Result<SendMessageResponse, SdkError<R, HttpResponse>>;
+    ) -> impl Future<Output = Result<SendMessageResponse, SdkError<R, HttpResponse>>> + Send;
 }

--- a/src/sinks/aws_s_s/sns/client.rs
+++ b/src/sinks/aws_s_s/sns/client.rs
@@ -16,7 +16,6 @@ impl SnsMessagePublisher {
     }
 }
 
-#[async_trait::async_trait]
 impl Client<PublishError> for SnsMessagePublisher {
     async fn send_message(
         &self,

--- a/src/sinks/aws_s_s/sqs/client.rs
+++ b/src/sinks/aws_s_s/sqs/client.rs
@@ -16,7 +16,6 @@ impl SqsMessagePublisher {
     }
 }
 
-#[async_trait::async_trait]
 impl Client<SendMessageError> for SqsMessagePublisher {
     async fn send_message(
         &self,

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -206,7 +206,6 @@ impl HttpEventEncoder<Value> for PubSubSinkEventEncoder {
     }
 }
 
-#[async_trait::async_trait]
 impl HttpSink for PubsubSink {
     type Input = Value;
     type Output = Vec<BoxedRawValue>;

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -320,7 +320,6 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
     }
 }
 
-#[async_trait::async_trait]
 impl HttpSink for InfluxDbLogsSink {
     type Input = BytesMut;
     type Output = BytesMut;

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -295,7 +295,6 @@ impl HttpEventEncoder<PartitionInnerBuffer<serde_json::Value, PartitionKey>> for
     }
 }
 
-#[async_trait::async_trait]
 impl HttpSink for MezmoConfig {
     type Input = PartitionInnerBuffer<serde_json::Value, PartitionKey>;
     type Output = PartitionInnerBuffer<Vec<BoxedRawValue>, PartitionKey>;

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -41,14 +41,16 @@ pub trait HttpEventEncoder<Output> {
     fn encode_event(&mut self, event: Event) -> Option<Output>;
 }
 
-#[async_trait::async_trait]
 pub trait HttpSink: Send + Sync + 'static {
     type Input;
     type Output;
     type Encoder: HttpEventEncoder<Self::Input>;
 
     fn build_encoder(&self) -> Self::Encoder;
-    async fn build_request(&self, events: Self::Output) -> crate::Result<http::Request<Bytes>>;
+    fn build_request(
+        &self,
+        events: Self::Output,
+    ) -> impl Future<Output = crate::Result<http::Request<Bytes>>> + Send;
 }
 
 /// Provides a simple wrapper around internal tower and

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{FutureExt, TryFutureExt};
 use hyper::{service::make_service_fn, Server};
@@ -45,7 +44,6 @@ use super::{
     error::ErrorMessage,
 };
 
-#[async_trait]
 pub trait HttpSource: Clone + Send + Sync + 'static {
     // This function can be defined to enrich events with additional HTTP
     // metadata. This function should be used rather than internal enrichment so


### PR DESCRIPTION
There are several uses that still require the use of `async_trait`, namely those where the resulting trait must be object safe (i.e. is used in a `Box<dyn Future>` construct). The `async_trait` macro handles this by boxing the resulting future, so we _could_ work around this ourselves, but only by manually expanding the boxing ourselves, which is not a win over just using the macro.