### PR TITLE
chore(dev): Bump Vector to 0.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10017,7 +10017,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "apache-avro",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"


### PR DESCRIPTION
Now that 0.37.0 has been released.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
