### PR TITLE
fix(codecs): Enable float_roundtrip for serde_json to preserve precision of floats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ indexmap = { version = "2.2.5", default-features = false, features = ["serde", "
 pin-project = { version = "1.1.5", default-features = false }
 proptest = "1.4"
 proptest-derive = "0.4.0"
-serde_json = { version = "1.0.114", default-features = false, features = ["raw_value", "std"] }
+serde_json = { version = "1.0.114", default-features = false, features = ["raw_value", "std", "float_roundtrip"] }
 serde = { version = "1.0.197", default-features = false, features = ["alloc", "derive", "rc"] }
 toml = { version = "0.8.12", default-features = false, features = ["display", "parse"] }
 vrl = { version = "0.13.0", features = ["arbitrary", "cli", "test", "test_framework"] }


### PR DESCRIPTION
Pushing this up first just to measure performance impact.