### PR TITLE
fix(enrichment_tables): bring back support for `GeoLite2-City` db

### DIFF
--- a/changelog.d/20192_geoip_geolite_city_support.fix.md
+++ b/changelog.d/20192_geoip_geolite_city_support.fix.md
@@ -1,0 +1,3 @@
+Fixed an issue where `GeoLite2-City` MMDB database type was not supported.
+
+authors: esensar

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -36,7 +36,7 @@ impl TryFrom<&str> for DatabaseKind {
             "GeoLite2-ASN" => Ok(Self::Asn),
             "GeoIP2-ISP" => Ok(Self::Isp),
             "GeoIP2-Connection-Type" => Ok(Self::ConnectionType),
-            "GeoIP2-City" => Ok(Self::City),
+            "GeoIP2-City" | "GeoLite2-City" => Ok(Self::City),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
Brings back support for `GeoLite2-City` DB after adding custom `mmdb` type. The issue was that previously any unknown DB type was treated as a City DB, which covered the case of `GeoLite2-City`. This now explicitly adds it as a supported type.

Fixes: #20191
Related: #20054