### PR TITLE
fix(metrics): normalizer doesn't handle mix of absolute and incremental metrics

### DIFF
--- a/changelog.d/prometheus_mixed_gauges.fix.md
+++ b/changelog.d/prometheus_mixed_gauges.fix.md
@@ -1,0 +1,4 @@
+The `prometheus_exporter` sink is now able to correctly handle a mix of both incremental and
+absolute valued gauges arriving for the same metric series.
+
+authors: RussellRollins

--- a/src/sinks/util/buffer/metrics/normalize.rs
+++ b/src/sinks/util/buffer/metrics/normalize.rs
@@ -120,17 +120,7 @@ impl MetricSet {
     /// to absolute if incremental.
     pub fn make_absolute(&mut self, metric: Metric) -> Option<Metric> {
         match metric.kind() {
-            MetricKind::Absolute => {
-                // Even if passing through as-is, track the absolute value so that we are able to
-                // correctly calculate any later incremental values that come through for the same
-                // series.
-                self.0.insert(
-                    metric.series().clone(),
-                    (metric.data().clone(), EventMetadata::default()),
-                );
-
-                Some(metric)
-            }
+            MetricKind::Absolute => Some(metric),
             MetricKind::Incremental => Some(self.incremental_to_absolute(metric)),
         }
     }

--- a/src/sinks/util/buffer/metrics/normalize.rs
+++ b/src/sinks/util/buffer/metrics/normalize.rs
@@ -120,7 +120,17 @@ impl MetricSet {
     /// to absolute if incremental.
     pub fn make_absolute(&mut self, metric: Metric) -> Option<Metric> {
         match metric.kind() {
-            MetricKind::Absolute => Some(metric),
+            MetricKind::Absolute => {
+                // Even if passing through as-is, track the absolute value so that we are able to
+                // correctly calculate any later incremental values that come through for the same
+                // series.
+                self.0.insert(
+                    metric.series().clone(),
+                    (metric.data().clone(), EventMetadata::default()),
+                );
+
+                Some(metric)
+            }
             MetricKind::Incremental => Some(self.incremental_to_absolute(metric)),
         }
     }


### PR DESCRIPTION
Big thank you to @RussellRollins for writing the failing test here! That was very helpful to narrow down the issue.

This simple fix here comes with some unfortunate downsides that we're going to need to consider before merging.

The root cause here is that we didn't really expect to need to handle a mix of incremental and absolute values for the same series. Concretely, this means the metrics normalizer only maintains state when it sees an incremental metrics that it needs to convert to absolute. If it sees an absolute metric, it assumes it will always be absolute and does not bother to store any state. That is why the failing test shows that incremental values "reset" the metric and don't take into account the previous absolute value.

To handle this case, we need to maintain state for all metrics that flow through the normalizer, just in case we see an incremental version later. Depending on the workload, this could be a relatively dramatic shift in load for this part of the component. For example, previous workloads that sent only absolute values would not need to maintain any state in the normalizer at all but now will need to maintain the full state of every metric that flows through. This is especially unfortunate because the normalizer is being used as part of the prometheus exporter which already by its nature maintains the current state of every metric, deals with expiration, etc. It's far from ideal to duplicate this logic and resource use twice in the same component.

It's possible that it's fine to move forward with this fix in the short term, depending on the impact to performance and resource use, but it points pretty strongly towards the correct solution being to move this absolute/incremental handling into the state of the prom exporter itself, where we already have all the necessary state.