### PR TITLE
chore(ci): peg `fakeintake` docker image

### DIFF
--- a/scripts/e2e/datadog-logs/compose.yaml
+++ b/scripts/e2e/datadog-logs/compose.yaml
@@ -84,12 +84,14 @@ services:
   # Receives log data from the `datadog-agent` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-agent:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
   # Receives log data from the `datadog-agent-vector` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-vector:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
 networks:
   default:

--- a/scripts/e2e/datadog-metrics/compose.yaml
+++ b/scripts/e2e/datadog-metrics/compose.yaml
@@ -67,12 +67,14 @@ services:
   # Receives metric data from the `datadog-agent` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-agent:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
   # Receives metric data from the `datadog-agent-vector` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-vector:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
 networks:
   default:


### PR DESCRIPTION
The `latest` tag is throwing errors on GET requests. Temporarily pegging to unblock PRs.