### PR TITLE
docs(dnstap source, releasing): Add breaking change note for dnstap source mode

### DIFF
--- a/website/content/en/highlights/2023-03-26-0-37-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-03-26-0-37-0-upgrade-guide.md
@@ -12,6 +12,7 @@ badges:
 Vector's 0.37.0 release includes **breaking changes**:
 
 1. [Vector defaults to requiring non-optional environment variables](#strict-env-vars)
+1. [The `dnstap` source now requires the `mode` parameter](#dnstap-mode)
 
 and **potentially impactful changes**:
 
@@ -38,6 +39,12 @@ The reasoning for this change is that users often miss the undefined variable wa
 confused by Vector not behaving as the expected. In particular, this happens when using `$1` in
 regex capture groups in VRL without realizing they need to be escaped as `$$1` to avoid
 interpolation.
+
+#### The `dnstap` source now requires the `mode` parameter {#dnstap-mode}
+
+The `dnstap` source now requires the `mode` paramater with the addition of support for reading
+events over a TCP socket. Set this to `unix` to continue reading from the Unix socket configured as
+`socket_path`.
 
 ### Potentially impactful changes
 

--- a/website/content/en/highlights/2023-03-26-0-37-0-upgrade-guide.md
+++ b/website/content/en/highlights/2023-03-26-0-37-0-upgrade-guide.md
@@ -42,7 +42,7 @@ interpolation.
 
 #### The `dnstap` source now requires the `mode` parameter {#dnstap-mode}
 
-The `dnstap` source now requires the `mode` paramater with the addition of support for reading
+The `dnstap` source now requires the `mode` parameter with the addition of support for reading
 events over a TCP socket. Set this to `unix` to continue reading from the Unix socket configured as
 `socket_path`.
 


### PR DESCRIPTION
`mode` is now a required parameter with no default. This was noticed by a user in Discord.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
