### PR TITLE
docs: fix type cardinality docs

### DIFF
--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -47,7 +47,7 @@ pub enum Mode {
     /// This mode has lower memory requirements than `exact`, but may occasionally allow metric
     /// events to pass through the transform even when they contain new tags that exceed the
     /// configured limit. The rate at which this happens can be controlled by changing the value of
-    /// `cache_size_per_tag`.
+    /// `cache_size_per_key`.
     Probabilistic(BloomFilterConfig),
 }
 

--- a/website/cue/reference/components/transforms/base/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/base/tag_cardinality_limit.cue
@@ -42,7 +42,7 @@ base: components: transforms: tag_cardinality_limit: configuration: {
 				This mode has lower memory requirements than `exact`, but may occasionally allow metric
 				events to pass through the transform even when they contain new tags that exceed the
 				configured limit. The rate at which this happens can be controlled by changing the value of
-				`cache_size_per_tag`.
+				`cache_size_per_key`.
 				"""
 		}
 	}

--- a/website/cue/reference/components/transforms/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/tag_cardinality_limit.cue
@@ -61,10 +61,8 @@ components: transforms: tag_cardinality_limit: {
 				because it exceeded the `value_limit`.
 				"""
 			configuration: {
-				fields: {
-					value_limit:           1
-					limit_exceeded_action: "drop_tag"
-				}
+				value_limit:           1
+				limit_exceeded_action: "drop_tag"
 			}
 			input: [
 				{metric: {
@@ -150,15 +148,15 @@ components: transforms: tag_cardinality_limit: {
 				```text
 				(number of distinct field names in the tags for your metrics * average length of
 				the field names for the tags) + (number of distinct field names in the tags of
-				-your metrics * `cache_size_per_tag`)
+				-your metrics * `cache_size_per_key`)
 				```
 
-				The `cache_size_per_tag` option controls the size of the bloom filter used
+				The `cache_size_per_key` option controls the size of the bloom filter used
 				for storing the set of acceptable values for any single key. The larger the
 				bloom filter the lower the false positive rate, which in our case means the less
 				likely we are to allow a new tag value that would otherwise violate a
 				configured limit. If you want to know the exact false positive rate for a given
-				`cache_size_per_tag` and `value_limit`, there are many free on-line bloom filter
+				`cache_size_per_key` and `value_limit`, there are many free on-line bloom filter
 				calculators that can answer this. The formula is generally presented in terms of
 				'n', 'p', 'k', and 'm' where 'n' is the number of items in the filter
 				(`value_limit` in our case), 'p' is the probability of false positives (what we


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

- Renamed `cache_size_per_tag` mentions to `cache_size_per_key`. This references are more than 2 years old, so I assume it was initially a typo
- Removed `fields` key from example of this transform configuration. Also looks like a oversight rather than something deliberate