### PR TITLE
chore(ci): Only use one label for selecting GHA runner

### DIFF
--- a/.github/workflows/compilation-timings.yml
+++ b/.github/workflows/compilation-timings.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   release-build-optimized:
     name: "Release Build (optimized)"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
 
   release-build-normal:
     name: "Release Build (normal)"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     env:
       # We're not actually doing a debug build, we're just turning off the logic
       # in release-flags.sh so that we don't override the Cargo "release" profile
@@ -40,7 +40,7 @@ jobs:
 
   debug-build:
     name: "Debug Build"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
 
   debug-rebuild:
     name: "Debug Rebuild"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
 
   check:
     name: "Cargo Check"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 45
     needs: changes
     if: always() && (

--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -82,7 +82,7 @@ jobs:
 
   integration-tests:
     needs: prep-pr
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
@@ -460,7 +460,7 @@ jobs:
 
   e2e-tests:
     needs: prep-pr
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   test-integration:
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 40
     if: inputs.if || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     needs: changes
     if: always() && (
       github.event_name == 'merge_group' || (

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 45
     needs: changes
     # Run this job even if `changes` job is skipped (non- pull request trigger)
@@ -181,7 +181,7 @@ jobs:
 
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 45
     needs:
       - build-x86_64-unknown-linux-gnu

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-misc:
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 45
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
   build-x86_64-unknown-linux-musl-packages:
     name: Build Vector for x86_64-unknown-linux-musl (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -71,7 +71,7 @@ jobs:
 
   build-x86_64-unknown-linux-gnu-packages:
     name: Build Vector for x86_64-unknown-linux-gnu (.tar.gz, DEB, RPM)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     needs: generate-publish-metadata
     timeout-minutes: 60
     env:
@@ -97,7 +97,7 @@ jobs:
 
   build-aarch64-unknown-linux-musl-packages:
     name: Build Vector for aarch64-unknown-linux-musl (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -125,7 +125,7 @@ jobs:
 
   build-aarch64-unknown-linux-gnu-packages:
     name: Build Vector for aarch64-unknown-linux-gnu (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -153,7 +153,7 @@ jobs:
 
   build-armv7-unknown-linux-gnueabihf-packages:
     name: Build Vector for armv7-unknown-linux-gnueabihf (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -181,7 +181,7 @@ jobs:
 
   build-armv7-unknown-linux-musleabihf-packages:
     name: Build Vector for armv7-unknown-linux-musleabihf (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -209,7 +209,7 @@ jobs:
 
   build-arm-unknown-linux-gnueabi-packages:
     name: Build Vector for arm-unknown-linux-gnueabi (.tar.gz)
-    runs-on: [ linux, release-builder ]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -237,7 +237,7 @@ jobs:
 
   build-arm-unknown-linux-musleabi-packages:
     name: Build Vector for arm-unknown-linux-musleabi (.tar.gz)
-    runs-on: [ linux, release-builder ]
+    runs-on: release-builder-linux
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -293,7 +293,7 @@ jobs:
 
   build-x86_64-pc-windows-msvc-packages:
     name: Build Vector for x86_64-pc-windows-msvc (.zip)
-    runs-on: [windows, release-builder]
+    runs-on: release-builder-windows
     timeout-minutes: 90
     needs: generate-publish-metadata
     env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -287,7 +287,7 @@ jobs:
 
   build-baseline:
     name: Build baseline Vector container
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 30
     needs:
       - compute-metadata
@@ -325,7 +325,7 @@ jobs:
 
   build-comparison:
     name: Build comparison Vector container
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 30
     needs:
       - compute-metadata

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
   checks:
     name: Checks
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 45
     needs: changes
     env:

--- a/.github/workflows/unit_windows.yml
+++ b/.github/workflows/unit_windows.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   test-windows:
-    runs-on: [windows, windows-2019-8core]
+    runs-on: windows-2019-8core
     timeout-minutes: 60
     steps:
       - name: (PR comment) Get PR branch


### PR DESCRIPTION
GHA is deprecating multi-label runners at the end of April.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
