### PR TITLE
chore(splunk_hec_logs sink): support log namespaced host and timestamp attributes

### DIFF
--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -188,7 +188,7 @@ impl HumioLogsConfig {
         HecLogsSinkConfig {
             default_token: self.token.clone(),
             endpoint: self.endpoint.clone(),
-            host_key: self.host_key.clone(),
+            host_key: self.host_key.path.map(|p| p.to_string()),
             indexed_fields: self.indexed_fields.clone(),
             index: self.index.clone(),
             sourcetype: self.event_type.clone(),
@@ -203,7 +203,7 @@ impl HumioLogsConfig {
                 indexer_acknowledgements_enabled: false,
                 ..Default::default()
             },
-            timestamp_key: config_timestamp_key_target_path(),
+            timestamp_key: None,
             endpoint_target: EndpointTarget::Event,
             auto_extract_timestamp: None,
         }

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -3,8 +3,6 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::lookup::lookup_v2::{ConfigValuePath, OptionalTargetPath};
 use vector_lib::sensitive_string::SensitiveString;
 
-use super::config_host_key_target_path;
-use crate::sinks::splunk_hec::common::config_timestamp_key_target_path;
 use crate::{
     codecs::EncodingConfig,
     config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
@@ -74,8 +72,8 @@ pub struct HumioLogsConfig {
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    #[serde(default = "config_host_key_target_path")]
-    pub(super) host_key: OptionalTargetPath,
+    #[serde(default)]
+    pub(super) host_key: Option<OptionalTargetPath>,
 
     /// Event fields to be added to Humio’s extra fields.
     ///
@@ -132,8 +130,8 @@ pub struct HumioLogsConfig {
     /// By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
     ///
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
-    #[serde(default = "config_timestamp_key_target_path")]
-    pub(super) timestamp_key: OptionalTargetPath,
+    #[serde(default)]
+    pub(super) timestamp_key: Option<OptionalTargetPath>,
 }
 
 fn default_endpoint() -> String {
@@ -154,14 +152,14 @@ impl GenerateConfig for HumioLogsConfig {
             event_type: None,
             indexed_fields: vec![],
             index: None,
-            host_key: config_host_key_target_path(),
+            host_key: None,
             compression: Compression::default(),
             request: TowerRequestConfig::default(),
             batch: BatchConfig::default(),
             tls: None,
             timestamp_nanos_key: None,
             acknowledgements: Default::default(),
-            timestamp_key: config_timestamp_key_target_path(),
+            timestamp_key: None,
         })
         .unwrap()
     }
@@ -188,7 +186,7 @@ impl HumioLogsConfig {
         HecLogsSinkConfig {
             default_token: self.token.clone(),
             endpoint: self.endpoint.clone(),
-            host_key: self.host_key.path.as_ref().map(|p| p.to_string()),
+            host_key: self.host_key.clone(),
             indexed_fields: self.indexed_fields.clone(),
             index: self.index.clone(),
             sourcetype: self.event_type.clone(),
@@ -203,7 +201,7 @@ impl HumioLogsConfig {
                 indexer_acknowledgements_enabled: false,
                 ..Default::default()
             },
-            timestamp_key: None,
+            timestamp_key: self.timestamp_key.clone(),
             endpoint_target: EndpointTarget::Event,
             auto_extract_timestamp: None,
         }

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -71,7 +71,8 @@ pub struct HumioLogsConfig {
 
     /// Overrides the name of the log field used to retrieve the hostname to send to Humio.
     ///
-    /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
+    /// By default, the [global `log_schema.host_key` option][global_host_key] is used if log
+    /// events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[serde(default = "config_host_key_target_path")]
@@ -128,8 +129,10 @@ pub struct HumioLogsConfig {
     pub acknowledgements: AcknowledgementsConfig,
 
     /// Overrides the name of the log field used to retrieve the timestamp to send to Humio.
+    /// When set to `“”`, a timestamp is not set in the events sent to Humio.
     ///
-    /// By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+    /// By default, either the [global `log_schema.timestamp_key` option][global_timestamp_key] is used
+    /// if log events are Legacy namespaced, or the semantic meaning of "timestamp" is used, if defined.
     ///
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[serde(default = "config_timestamp_key_target_path")]

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -206,7 +206,7 @@ impl HumioLogsConfig {
                 indexer_acknowledgements_enabled: false,
                 ..Default::default()
             },
-            timestamp_key: Some(self.timestamp_key.clone()),
+            timestamp_key: Some(config_timestamp_key_target_path()),
             endpoint_target: EndpointTarget::Event,
             auto_extract_timestamp: None,
         }

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -188,7 +188,7 @@ impl HumioLogsConfig {
         HecLogsSinkConfig {
             default_token: self.token.clone(),
             endpoint: self.endpoint.clone(),
-            host_key: self.host_key.path.map(|p| p.to_string()),
+            host_key: self.host_key.path.as_ref().map(|p| p.to_string()),
             indexed_fields: self.indexed_fields.clone(),
             index: self.index.clone(),
             sourcetype: self.event_type.clone(),

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -3,6 +3,7 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::lookup::lookup_v2::{ConfigValuePath, OptionalTargetPath};
 use vector_lib::sensitive_string::SensitiveString;
 
+use super::config_host_key_target_path;
 use crate::sinks::splunk_hec::common::config_timestamp_key_target_path;
 use crate::{
     codecs::EncodingConfig,
@@ -21,8 +22,6 @@ use crate::{
     template::Template,
     tls::TlsConfig,
 };
-
-use super::config_host_key_target_path;
 
 pub(super) const HOST: &str = "https://cloud.humio.com";
 

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -84,7 +84,8 @@ pub struct HumioMetricsConfig {
 
     /// Overrides the name of the log field used to retrieve the hostname to send to Humio.
     ///
-    /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
+    /// By default, the [global `log_schema.host_key` option][global_host_key] is used if log
+    /// events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[serde(default = "config_host_key")]

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -9,8 +9,10 @@ use vector_lib::lookup::lookup_v2::{ConfigValuePath, OptionalTargetPath, Optiona
 use vector_lib::sensitive_string::SensitiveString;
 use vector_lib::sink::StreamSink;
 
-use super::config_host_key;
-use super::logs::{HumioLogsConfig, HOST};
+use super::{
+    config_host_key,
+    logs::{HumioLogsConfig, HOST},
+};
 use crate::{
     config::{
         AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, TransformContext,

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -161,6 +161,10 @@ pub fn config_timestamp_key() -> OptionalValuePath {
     }
 }
 
+pub const fn config_no_target_path() -> OptionalTargetPath {
+    OptionalTargetPath { path: None }
+}
+
 pub fn render_template_string<'a>(
     template: &Template,
     event: impl Into<EventRef<'a>>,

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -135,12 +135,6 @@ pub fn build_uri(
     uri.parse::<Uri>()
 }
 
-pub fn config_host_key_target_path() -> OptionalTargetPath {
-    OptionalTargetPath {
-        path: crate::config::log_schema().host_key_target_path().cloned(),
-    }
-}
-
 pub fn config_host_key() -> OptionalValuePath {
     OptionalValuePath {
         path: crate::config::log_schema().host_key().cloned(),
@@ -153,16 +147,6 @@ pub fn config_timestamp_key_target_path() -> OptionalTargetPath {
             .timestamp_key_target_path()
             .cloned(),
     }
-}
-
-pub fn config_timestamp_key() -> OptionalValuePath {
-    OptionalValuePath {
-        path: crate::config::log_schema().timestamp_key().cloned(),
-    }
-}
-
-pub const fn config_no_target_path() -> OptionalTargetPath {
-    OptionalTargetPath { path: None }
 }
 
 pub fn render_template_string<'a>(

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -12,8 +12,7 @@ use crate::{
         prelude::*,
         splunk_hec::common::{
             acknowledgements::HecClientAcknowledgementsConfig,
-            build_healthcheck, build_http_batch_service, config_host_key_target_path,
-            config_timestamp_key_target_path, create_client,
+            build_healthcheck, build_http_batch_service, config_no_target_path, create_client,
             service::{HecService, HttpRequestBuilder},
             EndpointTarget, SplunkHecDefaultBatchSettings,
         },
@@ -57,7 +56,7 @@ pub struct HecLogsSinkConfig {
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[configurable(metadata(docs::advanced))]
-    #[serde(default = "config_host_key_target_path")]
+    #[serde(default = "config_no_target_path")]
     pub host_key: OptionalTargetPath,
 
     /// Fields to be [added to Splunk index][splunk_field_index_docs].
@@ -128,7 +127,7 @@ pub struct HecLogsSinkConfig {
     ///
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[configurable(metadata(docs::advanced))]
-    #[serde(default = "crate::sinks::splunk_hec::common::config_timestamp_key_target_path")]
+    #[serde(default = "config_no_target_path")]
     #[configurable(metadata(docs::examples = "timestamp", docs::examples = ""))]
     pub timestamp_key: OptionalTargetPath,
 
@@ -158,7 +157,7 @@ impl GenerateConfig for HecLogsSinkConfig {
         toml::Value::try_from(Self {
             default_token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned().into(),
             endpoint: "endpoint".to_owned(),
-            host_key: config_host_key_target_path(),
+            host_key: config_no_target_path(),
             indexed_fields: vec![],
             index: None,
             sourcetype: None,
@@ -170,7 +169,7 @@ impl GenerateConfig for HecLogsSinkConfig {
             tls: None,
             acknowledgements: Default::default(),
             timestamp_nanos_key: None,
-            timestamp_key: config_timestamp_key_target_path(),
+            timestamp_key: config_no_target_path(),
             auto_extract_timestamp: None,
             endpoint_target: EndpointTarget::Event,
         })
@@ -301,7 +300,7 @@ mod tests {
             let config = Self {
                 endpoint: endpoint.clone(),
                 default_token: "i_am_an_island".to_string().into(),
-                host_key: config_host_key_target_path(),
+                host_key: config_no_target_path(),
                 indexed_fields: vec![],
                 index: None,
                 sourcetype: None,
@@ -323,7 +322,7 @@ mod tests {
                     ..Default::default()
                 },
                 timestamp_nanos_key: None,
-                timestamp_key: config_timestamp_key_target_path(),
+                timestamp_key: config_no_target_path(),
                 auto_extract_timestamp: None,
                 endpoint_target: EndpointTarget::Raw,
             };

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -52,7 +52,8 @@ pub struct HecLogsSinkConfig {
 
     /// Overrides the name of the log field used to retrieve the hostname to send to Splunk HEC.
     ///
-    /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
+    /// By default, the [global `log_schema.host_key` option][global_host_key] is used if log
+    /// events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[configurable(metadata(docs::advanced))]
@@ -122,7 +123,8 @@ pub struct HecLogsSinkConfig {
     /// Overrides the name of the log field used to retrieve the timestamp to send to Splunk HEC.
     /// When set to `“”`, a timestamp is not set in the events sent to Splunk HEC.
     ///
-    /// By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+    /// By default, either the [global `log_schema.timestamp_key` option][global_timestamp_key] is used
+    /// if log events are Legacy namespaced, or the semantic meaning of "timestamp" is used, if defined.
     ///
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[configurable(metadata(docs::advanced))]

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use vector_lib::{
-    codecs::TextSerializerConfig, lookup::lookup_v2::ConfigValuePath,
+    codecs::TextSerializerConfig,
+    lookup::lookup_v2::{ConfigValuePath, OptionalTargetPath},
     sensitive_string::SensitiveString,
 };
 
@@ -55,7 +56,7 @@ pub struct HecLogsSinkConfig {
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[configurable(metadata(docs::advanced))]
-    pub host_key: Option<String>,
+    pub host_key: Option<OptionalTargetPath>,
 
     /// Fields to be [added to Splunk index][splunk_field_index_docs].
     ///
@@ -126,7 +127,7 @@ pub struct HecLogsSinkConfig {
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[configurable(metadata(docs::advanced))]
     #[configurable(metadata(docs::examples = "timestamp", docs::examples = ""))]
-    pub timestamp_key: Option<String>,
+    pub timestamp_key: Option<OptionalTargetPath>,
 
     /// Passes the `auto_extract_timestamp` option to Splunk.
     ///

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -49,13 +49,13 @@ pub struct HecLogsSinkConfig {
     #[configurable(validation(format = "uri"))]
     pub endpoint: String,
 
-    /// Overrides the path to the log field used to retrieve the hostname to send to Splunk HEC.
+    /// Overrides the name of the log field used to retrieve the hostname to send to Splunk HEC.
     ///
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[configurable(metadata(docs::advanced))]
-    pub host_path: Option<String>,
+    pub host_key: Option<String>,
 
     /// Fields to be [added to Splunk index][splunk_field_index_docs].
     ///
@@ -118,7 +118,7 @@ pub struct HecLogsSinkConfig {
     #[serde(skip)]
     pub timestamp_nanos_key: Option<String>,
 
-    /// Overrides the path to the log field used to retrieve the timestamp to send to Splunk HEC.
+    /// Overrides the name of the log field used to retrieve the timestamp to send to Splunk HEC.
     /// When set to `“”`, a timestamp is not set in the events sent to Splunk HEC.
     ///
     /// By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
@@ -126,7 +126,7 @@ pub struct HecLogsSinkConfig {
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[configurable(metadata(docs::advanced))]
     #[configurable(metadata(docs::examples = "timestamp", docs::examples = ""))]
-    pub timestamp_path: Option<String>,
+    pub timestamp_key: Option<String>,
 
     /// Passes the `auto_extract_timestamp` option to Splunk.
     ///
@@ -154,7 +154,7 @@ impl GenerateConfig for HecLogsSinkConfig {
         toml::Value::try_from(Self {
             default_token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned().into(),
             endpoint: "endpoint".to_owned(),
-            host_path: None,
+            host_key: None,
             indexed_fields: vec![],
             index: None,
             sourcetype: None,
@@ -166,7 +166,7 @@ impl GenerateConfig for HecLogsSinkConfig {
             tls: None,
             acknowledgements: Default::default(),
             timestamp_nanos_key: None,
-            timestamp_path: None,
+            timestamp_key: None,
             auto_extract_timestamp: None,
             endpoint_target: EndpointTarget::Event,
         })
@@ -266,9 +266,9 @@ impl HecLogsSinkConfig {
                 .iter()
                 .map(|config_path| config_path.0.clone())
                 .collect(),
-            host_path: self.host_path.clone(),
+            host_key: self.host_key.clone(),
             timestamp_nanos_key: self.timestamp_nanos_key.clone(),
-            timestamp_path: self.timestamp_path.clone(),
+            timestamp_key: self.timestamp_key.clone(),
             endpoint_target: self.endpoint_target,
         };
 
@@ -297,7 +297,7 @@ mod tests {
             let config = Self {
                 endpoint: endpoint.clone(),
                 default_token: "i_am_an_island".to_string().into(),
-                host_path: None,
+                host_key: None,
                 indexed_fields: vec![],
                 index: None,
                 sourcetype: None,
@@ -319,7 +319,7 @@ mod tests {
                     ..Default::default()
                 },
                 timestamp_nanos_key: None,
-                timestamp_path: None,
+                timestamp_key: None,
                 auto_extract_timestamp: None,
                 endpoint_target: EndpointTarget::Raw,
             };

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -56,6 +56,9 @@ pub struct HecLogsSinkConfig {
     /// events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
+    // NOTE: The `OptionalTargetPath` is wrapped in an `Option` in order to distinguish between a true
+    //       `None` type and an empty string. This is necessary because `OptionalTargetPath` deserializes an
+    //       empty string to a `None` path internally.
     #[configurable(metadata(docs::advanced))]
     pub host_key: Option<OptionalTargetPath>,
 
@@ -129,6 +132,9 @@ pub struct HecLogsSinkConfig {
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[configurable(metadata(docs::advanced))]
     #[configurable(metadata(docs::examples = "timestamp", docs::examples = ""))]
+    // NOTE: The `OptionalTargetPath` is wrapped in an `Option` in order to distinguish between a true
+    //       `None` type and an empty string. This is necessary because `OptionalTargetPath` deserializes an
+    //       empty string to a `None` path internally.
     pub timestamp_key: Option<OptionalTargetPath>,
 
     /// Passes the `auto_extract_timestamp` option to Splunk.

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -5,13 +5,11 @@ use futures::{future::ready, stream};
 use serde_json::Value as JsonValue;
 use tokio::time::{sleep, Duration};
 use vector_lib::codecs::{JsonSerializerConfig, TextSerializerConfig};
-use vector_lib::lookup::lookup_v2::{ConfigValuePath, OptionalTargetPath};
+use vector_lib::lookup::lookup_v2::ConfigValuePath;
 use vector_lib::{
     config::{init_telemetry, Tags, Telemetry},
     event::{BatchNotifier, BatchStatus, Event, LogEvent},
-    lookup,
 };
-use vrl::path::OwnedTargetPath;
 
 use crate::{
     codecs::EncodingConfig,
@@ -118,7 +116,7 @@ async fn config(
     HecLogsSinkConfig {
         default_token: get_token().await.into(),
         endpoint: splunk_hec_address(),
-        host_key: OptionalTargetPath::event("host"),
+        host_key: Some("host".to_string()),
         indexed_fields,
         index: None,
         sourcetype: None,
@@ -130,7 +128,7 @@ async fn config(
         tls: None,
         acknowledgements: Default::default(),
         timestamp_nanos_key: None,
-        timestamp_key: Default::default(),
+        timestamp_key: None,
         auto_extract_timestamp: None,
         endpoint_target: EndpointTarget::Event,
     }
@@ -409,7 +407,7 @@ async fn splunk_configure_hostname() {
     let cx = SinkContext::default();
 
     let config = HecLogsSinkConfig {
-        host_key: OptionalTargetPath::event("roast"),
+        host_key: Some("roast".to_string()),
         ..config(JsonSerializerConfig::default().into(), vec!["asdf".into()]).await
     };
 
@@ -488,11 +486,7 @@ async fn splunk_auto_extracted_timestamp() {
 
         let config = HecLogsSinkConfig {
             auto_extract_timestamp: Some(true),
-            timestamp_key: OptionalTargetPath {
-                path: Some(OwnedTargetPath::event(lookup::owned_value_path!(
-                    "timestamp"
-                ))),
-            },
+            timestamp_key: Some("timestamp".to_string()),
             ..config(JsonSerializerConfig::default().into(), vec![]).await
         };
 
@@ -543,11 +537,7 @@ async fn splunk_non_auto_extracted_timestamp() {
 
         let config = HecLogsSinkConfig {
             auto_extract_timestamp: Some(false),
-            timestamp_key: OptionalTargetPath {
-                path: Some(OwnedTargetPath::event(lookup::owned_value_path!(
-                    "timestamp"
-                ))),
-            },
+            timestamp_key: Some("timestamp".to_string()),
             ..config(JsonSerializerConfig::default().into(), vec![]).await
         };
 

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -20,6 +20,9 @@ use vector_lib::{
 };
 use vrl::path::OwnedTargetPath;
 
+// NOTE: The `OptionalTargetPath`s are wrapped in an `Option` in order to distinguish between a true
+//       `None` type and an empty string. This is necessary because `OptionalTargetPath` deserializes an
+//       empty string to a `None` path internally.
 pub struct HecLogsSink<S> {
     pub context: SinkContext,
     pub service: S,

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -226,7 +226,7 @@ fn user_or_namespaced_path(
 ) -> Option<OwnedTargetPath> {
     // When the user provides an empty string, we won't set this field in the outgoing event data
     if let Some(key) = user_key {
-        if key == "" {
+        if key.is_empty() {
             None
         } else {
             Some(OwnedTargetPath::event(owned_value_path!(key)))

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -224,19 +224,12 @@ fn user_or_namespaced_path(
     user_key: Option<&OptionalTargetPath>,
     semantic: &str,
 ) -> Option<OwnedTargetPath> {
-    match user_key {
-        Some(k) => {
-            if k.path.is_some() {
-                k.path.clone()
-            } else {
-                None
-            }
-        }
-        None => match log.namespace() {
+    user_key
+        .and_then(|key| key.path.clone())
+        .or_else(|| match log.namespace() {
             LogNamespace::Vector => log.find_key_by_meaning(semantic).cloned(),
             LogNamespace::Legacy => crate::config::log_schema().host_key_target_path().cloned(),
-        },
-    }
+        })
 }
 
 pub fn process_log(event: Event, data: &HecLogData) -> HecProcessedEvent {

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -342,7 +342,7 @@ fn splunk_encode_log_event_semantic_meanings() {
             source: None,
             index: None,
             host_key: None,
-            indexed_fields: &vec![],
+            indexed_fields: &[],
             timestamp_nanos_key: None,
             timestamp_key: None,
             endpoint_target: EndpointTarget::Event,

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -284,8 +284,10 @@ fn splunk_encode_log_event_json_timestamps() {
         path: Some(OwnedTargetPath::event(owned_value_path!("timestamp"))),
     });
 
+    let no_timestamp = Some(OptionalTargetPath::none());
+
     // no timestamp_key is provided
-    let mut hec_data = get_hec_data_for_timestamp_test(None, None);
+    let mut hec_data = get_hec_data_for_timestamp_test(None, no_timestamp);
     assert_eq!(hec_data.time, None);
 
     // timestamp_key is provided but timestamp is not valid type
@@ -295,12 +297,6 @@ fn splunk_encode_log_event_json_timestamps() {
 
     // timestamp_key is provided but no timestamp in the event
     let hec_data = get_hec_data_for_timestamp_test(None, timestamp);
-    assert_eq!(hec_data.time, None);
-
-    let no_timestamp = Some(OptionalTargetPath::none());
-
-    // timestamp_key is provided as an empty string
-    let hec_data = get_hec_data_for_timestamp_test(Some(Utc::now().into()), no_timestamp);
     assert_eq!(hec_data.time, None);
 }
 

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -284,4 +284,13 @@ fn splunk_encode_log_event_json_timestamps() {
     // timestamp_key is provided but no timestamp in the event
     let hec_data = get_hec_data_for_timestamp_test(None, timestamp);
     assert_eq!(hec_data.time, None);
+
+    // timestamp_key is provided as an empty string
+    let hec_data = get_hec_data_for_timestamp_test(Some(Utc::now().into()), Some("".to_string()));
+    assert_eq!(hec_data.time, None);
+}
+
+#[test]
+fn splunk_encode_log_event_semantic_meanings() {
+    // TODO
 }

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -83,14 +83,15 @@ fn get_processed_event_timestamp(
     event.as_mut_log().insert("key", "value");
     event.as_mut_log().insert("int_val", 123);
 
-    if let Some(timestamp_key) = &timestamp_key {
+    if let Some(OptionalTargetPath {
+        path: Some(ts_path),
+    }) = &timestamp_key
+    {
         if timestamp.is_some() {
-            if let Some(ts_path) = &timestamp_key.path {
-                event
-                    .as_mut_log()
-                    .insert(&OwnedTargetPath::event(ts_path.path.clone()), timestamp);
-            }
-        } else if let Some(ts_path) = &timestamp_key.path {
+            event
+                .as_mut_log()
+                .insert(&OwnedTargetPath::event(ts_path.path.clone()), timestamp);
+        } else {
             event
                 .as_mut_log()
                 .remove(&OwnedTargetPath::event(ts_path.path.clone()));

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -89,12 +89,10 @@ fn get_processed_event_timestamp(
                     .as_mut_log()
                     .insert(&OwnedTargetPath::event(ts_path.path.clone()), timestamp);
             }
-        } else {
-            if let Some(ts_path) = &timestamp_key.path {
-                event
-                    .as_mut_log()
-                    .remove(&OwnedTargetPath::event(ts_path.path.clone()));
-            }
+        } else if let Some(ts_path) = &timestamp_key.path {
+            event
+                .as_mut_log()
+                .remove(&OwnedTargetPath::event(ts_path.path.clone()));
         }
     }
 

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -50,7 +50,7 @@ struct HecEventText {
 
 fn get_processed_event_timestamp(
     timestamp: Option<Value>,
-    timestamp_path: Option<String>,
+    timestamp_key: Option<String>,
 ) -> HecProcessedEvent {
     let mut event = Event::Log(LogEvent::from("hello world"));
     event
@@ -64,16 +64,16 @@ fn get_processed_event_timestamp(
     event.as_mut_log().insert("key", "value");
     event.as_mut_log().insert("int_val", 123);
 
-    if let Some(timestamp_path) = &timestamp_path {
+    if let Some(timestamp_key) = &timestamp_key {
         if timestamp.is_some() {
             event.as_mut_log().insert(
-                &OwnedTargetPath::event(owned_value_path!(timestamp_path)),
+                &OwnedTargetPath::event(owned_value_path!(timestamp_key)),
                 timestamp,
             );
         } else {
             event
                 .as_mut_log()
-                .remove(&OwnedTargetPath::event(owned_value_path!(timestamp_path)));
+                .remove(&OwnedTargetPath::event(owned_value_path!(timestamp_key)));
         }
     }
 
@@ -92,10 +92,10 @@ fn get_processed_event_timestamp(
             sourcetype: sourcetype.as_ref(),
             source: source.as_ref(),
             index: index.as_ref(),
-            host_path: Some(&String::from("host_key")),
+            host_key: Some(&String::from("host_key")),
             indexed_fields: indexed_fields.as_slice(),
             timestamp_nanos_key: timestamp_nanos_key.as_ref(),
-            timestamp_path: timestamp_path.as_ref(),
+            timestamp_key: timestamp_key.as_ref(),
             endpoint_target: EndpointTarget::Event,
         },
     )
@@ -205,7 +205,7 @@ async fn splunk_passthrough_token() {
     let config = HecLogsSinkConfig {
         default_token: "token".to_string().into(),
         endpoint: format!("http://{}", addr),
-        host_path: None,
+        host_key: None,
         indexed_fields: Vec::new(),
         index: None,
         sourcetype: None,
@@ -217,7 +217,7 @@ async fn splunk_passthrough_token() {
         tls: None,
         acknowledgements: Default::default(),
         timestamp_nanos_key: None,
-        timestamp_path: None,
+        timestamp_key: None,
         auto_extract_timestamp: None,
         endpoint_target: EndpointTarget::Event,
     };

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1260,9 +1260,6 @@ mod tests {
     use vrl::path::PathPrefix;
 
     use super::*;
-    use crate::sinks::splunk_hec::common::{
-        config_host_key_target_path, config_timestamp_key_target_path,
-    };
     use crate::{
         codecs::{DecodingConfig, EncodingConfig},
         components::validation::prelude::*,
@@ -1340,7 +1337,7 @@ mod tests {
         HecLogsSinkConfig {
             default_token: TOKEN.to_owned().into(),
             endpoint: format!("http://{}", address),
-            host_key: config_host_key_target_path(),
+            host_key: None,
             indexed_fields: vec![],
             index: None,
             sourcetype: None,
@@ -1352,7 +1349,7 @@ mod tests {
             tls: None,
             acknowledgements: Default::default(),
             timestamp_nanos_key: None,
-            timestamp_key: config_timestamp_key_target_path(),
+            timestamp_key: None,
             auto_extract_timestamp: None,
             endpoint_target: Default::default(),
         }

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -370,7 +370,8 @@ base: components: sinks: humio_logs: configuration: {
 		description: """
 			Overrides the name of the log field used to retrieve the hostname to send to Humio.
 
-			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+			By default, the [global `log_schema.host_key` option][global_host_key] is used if log
+			events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
@@ -609,8 +610,10 @@ base: components: sinks: humio_logs: configuration: {
 	timestamp_key: {
 		description: """
 			Overrides the name of the log field used to retrieve the timestamp to send to Humio.
+			When set to `“”`, a timestamp is not set in the events sent to Humio.
 
-			By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+			By default, either the [global `log_schema.timestamp_key` option][global_timestamp_key] is used
+			if log events are Legacy namespaced, or the semantic meaning of "timestamp" is used, if defined.
 
 			[global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
 			"""

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -124,7 +124,8 @@ base: components: sinks: humio_metrics: configuration: {
 		description: """
 			Overrides the name of the log field used to retrieve the hostname to send to Humio.
 
-			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+			By default, the [global `log_schema.host_key` option][global_host_key] is used if log
+			events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -432,12 +432,13 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		description: """
 			Overrides the name of the log field used to retrieve the hostname to send to Splunk HEC.
 
-			By default, the [global `log_schema.host_key` option][global_host_key] is used.
+			By default, the [global `log_schema.host_key` option][global_host_key] is used if log
+			events are Legacy namespaced, or the semantic meaning of "host" is used, if defined.
 
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
 		required: false
-		type: string: default: ".host"
+		type: string: {}
 	}
 	index: {
 		description: """
@@ -680,15 +681,13 @@ base: components: sinks: splunk_hec_logs: configuration: {
 			Overrides the name of the log field used to retrieve the timestamp to send to Splunk HEC.
 			When set to `“”`, a timestamp is not set in the events sent to Splunk HEC.
 
-			By default, the [global `log_schema.timestamp_key` option][global_timestamp_key] is used.
+			By default, either the [global `log_schema.timestamp_key` option][global_timestamp_key] is used
+			if log events are Legacy namespaced, or the semantic meaning of "timestamp" is used, if defined.
 
 			[global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
 			"""
 		required: false
-		type: string: {
-			default: ".timestamp"
-			examples: ["timestamp", ""]
-		}
+		type: string: examples: ["timestamp", ""]
 	}
 	tls: {
 		description: "TLS configuration."


### PR DESCRIPTION
- Currently the splunk hec logs sink has default paths for the `timestamp_key` and `host_key` configurable settings which statically point to the global log namespace location for these keys.
- In order to support log namespacing for these settings, the logic for determining the default case is moved from the configuration serialization down into the sink's encoding of the event. That is necessary because we must determine at runtime if each event received is namespaced or not.
- Note that this necessitated a small change to the Humio sinks as well simply due to those sinks being wrappers over Splunk HEC, to preserve existing behavior.