### PR TITLE
fix(splunk_hec_logs sink): don't attempt to remove timestamp if auto extract is enabled

### DIFF
--- a/changelog.d/splunk_hec_logs_auto_extract_ts.fix.md
+++ b/changelog.d/splunk_hec_logs_auto_extract_ts.fix.md
@@ -1,0 +1,3 @@
+Previously, when the `auto_extract_timestamp` setting in the `splunk_hec_logs` Sink was enabled, the sink was attempting to remove the existing event timestamp. This would throw a warning that the timestamp type was invalid.
+
+This has been fixed to correctly not attempt to remove the timestamp from the event if `auto_extract_timestamp` is enabled, since this setting indicates that Vector should let Splunk do that.

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -274,6 +274,7 @@ impl HecLogsSinkConfig {
             timestamp_nanos_key: self.timestamp_nanos_key.clone(),
             timestamp_key: self.timestamp_key.path.clone(),
             endpoint_target: self.endpoint_target,
+            auto_extract_timestamp: self.auto_extract_timestamp.unwrap_or_default(),
         };
 
         Ok(VectorSink::from_event_streamsink(sink))

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -521,7 +521,7 @@ async fn splunk_auto_extracted_timestamp() {
 
         // we should not have removed the timestamp from the event in this case, because that only
         // happens when we set the `_time` field in the HEC metadata, which we do by extracting the
-        // timestamp from the event data in vector. Instead, when auto_extract_timetamp is true,
+        // timestamp from the event data in vector. Instead, when auto_extract_timestamp is true,
         // Splunk will determine the timestamp from the *message* field in the event.
         // Thus, we expect the `timestamp` field to still be present.
         assert_eq!(

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -519,8 +519,16 @@ async fn splunk_auto_extracted_timestamp() {
 
         let entry = find_entry(&message).await;
 
+        // we should not have removed the timestamp from the event in this case, because that only
+        // happens when we set the `_time` field in the HEC metadata, which we do by extracting the
+        // timestamp from the event data in vector. Instead, when auto_extract_timetamp is true,
+        // Splunk will determine the timestamp from the *message* field in the event.
+        // Thus, we expect the `timestamp` field to still be present.
         assert_eq!(
-            format!("{{\"message\":\"{}\"}}", message),
+            format!(
+                "{{\"message\":\"{}\",\"timestamp\":\"2020-03-05T00:00:00Z\"}}",
+                message
+            ),
             entry["_raw"].as_str().unwrap()
         );
         assert_eq!(

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -297,7 +297,7 @@ fn splunk_encode_log_event_json_timestamps() {
         get_hec_data_for_timestamp_test(None, Some(timestamp_key.clone()), dont_auto_extract);
     assert_eq!(hec_data.time, None);
 
-    // timestamp_key is provided and timstamp is valid
+    // timestamp_key is provided and timestamp is valid
     hec_data = get_hec_data_for_timestamp_test(
         Some(Value::Timestamp(Utc::now())),
         Some(timestamp_key.clone()),


### PR DESCRIPTION
ref: https://github.com/vectordotdev/vector/issues/19133

- Previously, when the `auto_extract_timestamp` setting in the `splunk_hec_logs` Sink was enabled, the sink was attempting to remove the existing event timestamp. This would throw a warning that the timestamp type was invalid.

- This has been fixed to correctly not attempt to remove the timestamp from the event if `auto_extract_timestamp` is enabled, since this setting indicates that Vector should let Splunk do that.