### PR TITLE
enhancement(amqp sink): add expiration option to AMQP messages

### DIFF
--- a/changelog.d/20214_amqp_expiration.enhancement.md
+++ b/changelog.d/20214_amqp_expiration.enhancement.md
@@ -1,0 +1,3 @@
+added support for `expiration_ms` on AMQP sink, to set an expiration on messages sent
+
+authors: sonnens

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -12,16 +12,13 @@ use super::sink::AmqpSink;
 #[derive(Clone, Debug, Default)]
 pub struct AmqpPropertiesConfig {
     /// Content-Type for the AMQP messages.
-    #[configurable(derived)]
     pub(crate) content_type: Option<String>,
 
     /// Content-Encoding for the AMQP messages.
-    #[configurable(derived)]
     pub(crate) content_encoding: Option<String>,
 
     /// Expiration for AMQP messages (in milliseconds)
-    #[configurable(derived)]
-    pub(crate) expiration: Option<u64>,
+    pub(crate) expiration_ms: Option<u64>,
 }
 
 impl AmqpPropertiesConfig {
@@ -33,8 +30,8 @@ impl AmqpPropertiesConfig {
         if let Some(content_encoding) = &self.content_encoding {
             prop = prop.with_content_encoding(ShortString::from(content_encoding.clone()));
         }
-        if let Some(expiration) = &self.expiration {
-            prop = prop.with_expiration(ShortString::from(expiration.clone()));
+        if let Some(expiration_ms) = &self.expiration_ms {
+            prop = prop.with_expiration(ShortString::from(expiration_ms.to_string()));
         }
         prop
     }

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -21,7 +21,7 @@ pub struct AmqpPropertiesConfig {
 
     /// Expiration for AMQP messages (in milliseconds)
     #[configurable(derived)]
-    pub(crate) expiration: Option<String>,
+    pub(crate) expiration: Option<u64>,
 }
 
 impl AmqpPropertiesConfig {

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -18,6 +18,10 @@ pub struct AmqpPropertiesConfig {
     /// Content-Encoding for the AMQP messages.
     #[configurable(derived)]
     pub(crate) content_encoding: Option<String>,
+
+    /// Expiration for AMQP messages (in milliseconds)
+    #[configurable(derived)]
+    pub(crate) expiration: Option<String>,
 }
 
 impl AmqpPropertiesConfig {
@@ -28,6 +32,9 @@ impl AmqpPropertiesConfig {
         }
         if let Some(content_encoding) = &self.content_encoding {
             prop = prop.with_content_encoding(ShortString::from(content_encoding.clone()));
+        }
+        if let Some(expiration) = &self.expiration {
+            prop = prop.with_expiration(ShortString::from(expiration.clone()));
         }
         prop
     }

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -312,6 +312,11 @@ base: components: sinks: amqp: configuration: {
 				required:    false
 				type: string: {}
 			}
+			expiration_ms: {
+				description: "Expiration for AMQP messages (in milliseconds)"
+				required:    false
+				type: uint: {}
+			}
 		}
 	}
 	routing_key: {


### PR DESCRIPTION
AMQP messages can be sent with an expiration by exposing the Lapin `with_expiration` option. This PR does that in the `properties` subsection of config

I filed an issue to attach to this PR https://github.com/vectordotdev/vector/issues/20214