### PR TITLE
fix(log_to_metric transform): set not working in log-to-metric transform when all_metrics=true

### DIFF
--- a/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
+++ b/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
@@ -1,3 +1,3 @@
 Fixed an issue where the log_to_metric transform with all_metrics=true config failed to convert properly-formatted 'set'-type events into metrics.
 
-author: pabloem
+author: Pablo E.

--- a/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
+++ b/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
@@ -1,3 +1,3 @@
 Fixed an issue where the log_to_metric transform with all_metrics=true config failed to convert properly-formatted 'set'-type events into metrics.
 
-author: Pablo E.
+author: pabloem

--- a/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
+++ b/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
@@ -1,0 +1,3 @@
+Fixed an issue where the log_to_metric transform with all_metrics=true config failed to convert properly-formatted 'set'-type events into metrics.
+
+author: pabloem

--- a/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
+++ b/changelog.d/20228_fix-log-to-metric-set-supported.fix.md
@@ -1,3 +1,3 @@
 Fixed an issue where the log_to_metric transform with all_metrics=true config failed to convert properly-formatted 'set'-type events into metrics.
 
-author: pabloem
+authors: pabloem

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1962,4 +1962,43 @@ mod tests {
             .with_timestamp(Some(ts()))
         );
     }
+
+    #[tokio::test]
+    async fn transform_set() {
+        let config = parse_yaml_config(
+            r#"
+            metrics: []
+            all_metrics: true
+            "#,
+        );
+
+        let json_str = r#"{
+          "set": {
+            "values": ["990.0", "1234"]
+          },
+          "kind": "incremental",
+          "name": "test.transform.set",
+          "tags": {
+            "env": "test_env",
+            "host": "localhost"
+          }
+        }"#;
+        let log = create_log_event(json_str);
+        let metric = do_transform(config, log.clone()).await.unwrap();
+        assert_eq!(
+            *metric.as_metric(),
+            Metric::new_with_metadata(
+                "test.transform.set",
+                MetricKind::Incremental,
+                MetricValue::Set { values: vec!["990.0".into(), "1234".into()].into_iter().collect() },
+                metric.metadata().clone(),
+            )
+            .with_namespace(Some("test_namespace"))
+            .with_tags(Some(metric_tags!(
+                "env" => "test_env",
+                "host" => "localhost",
+            )))
+            .with_timestamp(Some(ts()))
+        );
+    }
 }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1990,7 +1990,9 @@ mod tests {
             Metric::new_with_metadata(
                 "test.transform.set",
                 MetricKind::Incremental,
-                MetricValue::Set { values: vec!["990.0".into(), "1234".into()].into_iter().collect() },
+                MetricValue::Set {
+                    values: vec!["990.0".into(), "1234".into()].into_iter().collect()
+                },
                 metric.metadata().clone(),
             )
             .with_namespace(Some("test_namespace"))

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -516,9 +516,10 @@ fn get_set_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
         values.push(String::from_utf8_lossy(value).to_string());
     }
 
-    Ok(MetricValue::Set { values })
+    Ok(MetricValue::Set {
+        values: values.into_iter().collect(),
+    })
 }
-
 
 fn get_distribution_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
     let event_samples = log

--- a/testing/github-20228/config.toml
+++ b/testing/github-20228/config.toml
@@ -1,0 +1,46 @@
+
+[[tests]]
+name = "Test log_to_metric conversion of sets"
+
+# The inputs for the test
+[[tests.inputs]]
+insert_at = "parse_json"
+type = "log"
+
+[tests.inputs.log_fields]
+message = '{"name": "sample.set.metric", "tags": {"host": "my-host", "region": "us-west"}, "kind": "incremental", "values": [1, 2, 3, 4, 5]}'
+
+[[tests.outputs]]
+extract_from = "convert_metrics"
+
+# We just validate that the values are the same
+[[tests.outputs.conditions]]
+type = "vrl"
+source = '''
+assert!(.name == "sample.set.metric")
+assert!(.tags.host == "my-host")
+assert!(.tags.region == "us-west")
+assert!(.kind == "incremental")
+'''
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.stdout]
+inputs = ["convert_metrics"]
+type = "console"
+encoding.codec = "json"
+
+[transforms.parse_json]
+inputs = ["stdin"]
+type = "remap"
+source = '''
+. = parse_json!(.message)
+'''
+
+[transforms.convert_metrics]
+inputs = ["parse_json"]
+type = "log_to_metric"
+all_metrics = true
+metrics = []
+


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->


I am pretty sure this is a bug. I was not able to make this work. I submit a test case that fails on current released versions. How could I set up this test case to run continuously?
