### PR TITLE
fix(kafka source): fix source span instrumentation

### DIFF
--- a/changelog.d/20224_kafka_source_event_instrumentation.fix.md
+++ b/changelog.d/20224_kafka_source_event_instrumentation.fix.md
@@ -1,3 +1,3 @@
-The Kafka source emits received bytes and event counts corerctly.
+The Kafka source emits received bytes and event counts correctly.
 
 authors: jches

--- a/changelog.d/20224_kafka_source_event_instrumentation.fix.md
+++ b/changelog.d/20224_kafka_source_event_instrumentation.fix.md
@@ -1,0 +1,3 @@
+The Kafka source emits reveived bytes and event counts corerctly.
+
+authors: jches

--- a/changelog.d/20224_kafka_source_event_instrumentation.fix.md
+++ b/changelog.d/20224_kafka_source_event_instrumentation.fix.md
@@ -1,3 +1,3 @@
-The Kafka source emits reveived bytes and event counts corerctly.
+The Kafka source emits received bytes and event counts corerctly.
 
 authors: jches

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -612,15 +612,13 @@ impl ConsumerStateInner<Consuming> {
                             _ => emit!(KafkaReadError { error }),
                         },
                         Some(Ok(msg)) => {
-                            let e = span.enter();
                             emit!(KafkaBytesReceived {
                                 byte_size: msg.payload_len(),
                                 protocol: "tcp",
                                 topic: msg.topic(),
                                 partition: msg.partition(),
                             });
-                            drop(e);
-                            parse_message(msg, decoder.clone(), &keys, &mut out, acknowledgements, &finalizer, log_namespace).instrument(span.clone()).await;
+                            parse_message(msg, decoder.clone(), &keys, &mut out, acknowledgements, &finalizer, log_namespace).await;
                         }
                     },
 
@@ -643,7 +641,7 @@ impl ConsumerStateInner<Consuming> {
                 )
             }
             (tp, status)
-        });
+        }.instrument(span));
         (end_tx, handle)
     }
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -716,7 +716,9 @@ impl ConsumerStateInner<Draining> {
                     decoder: self.decoder,
                     out: self.out,
                     log_namespace: self.log_namespace,
-                    consumer_state: Consuming { span: self.consumer_state.span },
+                    consumer_state: Consuming {
+                        span: self.consumer_state.span,
+                    },
                 }),
             )
         }


### PR DESCRIPTION
This ensures the source `span` is passed through to the kafka consumer tasks so that metrics can be correctly instrumented.

Fixes: https://github.com/vectordotdev/vector/issues/20224