### PR TITLE
fix(kafka sink): Fix Kafka partition key on metric events

### DIFF
--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -43,13 +43,13 @@ pub struct KafkaSinkConfig {
     ))]
     pub topic: Template,
 
-    /// The log field name or tag key to use for the topic key.
+    /// A path expression to a field of the event to use for the topic key.
     ///
-    /// If the field does not exist in the log or in the tags, a blank value is used. If
-    /// unspecified, the key is not sent.
-    ///
+    /// If unspecified, or if the field does not exist in the log or metric, the key is not sent.
     /// Kafka uses a hash of the key to choose the partition or uses round-robin if the record has
     /// no key.
+    /// 
+    /// Metrics currently only support access to `name` and `tags`.
     #[configurable(metadata(docs::advanced))]
     #[configurable(metadata(docs::examples = "user_id"))]
     #[configurable(metadata(docs::examples = ".my_topic"))]

--- a/src/sinks/kafka/request_builder.rs
+++ b/src/sinks/kafka/request_builder.rs
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn kafka_get_key_from_metric_with_workaround() {
-        // Test to confirm the current work-around for parition keys does not break
+        // Confirm direct reference to dot-prefixed tag names does not break
         let event = Event::Metric(metric());
         let key_field = OwnedTargetPath::try_from(".workaround".to_string()).unwrap();
         let key_value = get_key(&event, Some(&key_field));

--- a/src/sinks/kafka/request_builder.rs
+++ b/src/sinks/kafka/request_builder.rs
@@ -156,7 +156,6 @@ mod tests {
         metric_tags!(
             "normal_tag" => "value1",
             ".workaround" => "value2",
-            "empty_tag" => "",
         )
     }
 
@@ -192,7 +191,6 @@ mod tests {
 
     #[test]
     fn kafka_get_key_from_metric_from_normal_tag() {
-        // Test to confirm the current work-around for parition keys does not break
         let event = Event::Metric(metric());
         let key_field = OwnedTargetPath::try_from(".tags.normal_tag".to_string()).unwrap();
         let key_value = get_key(&event, Some(&key_field));
@@ -201,18 +199,17 @@ mod tests {
     }
 
     #[test]
-    fn kafka_get_key_from_metric_from_empty_tag() {
-        // Test to confirm the current work-around for parition keys does not break
+    fn kafka_get_key_from_metric_from_missing_tag() {
         let event = Event::Metric(metric());
-        let key_field = OwnedTargetPath::try_from(".tags.empty_tag".to_string()).unwrap();
+        let key_field = OwnedTargetPath::try_from(".tags.missing_tag".to_string()).unwrap();
         let key_value = get_key(&event, Some(&key_field));
 
-        assert_eq!(key_value.unwrap().as_ref(), "".as_bytes());
+        assert_eq!(key_value, None);
     }
 
     #[test]
     fn kafka_get_key_from_metric_from_workaround_tag() {
-        // Test to confirm the current work-around for parition keys does not break
+        // Also test that explicitly referencing a workaround tag works as expected
         let event = Event::Metric(metric());
         let key_field = OwnedTargetPath::try_from(".tags.\".workaround\"".to_string()).unwrap();
         let key_value = get_key(&event, Some(&key_field));

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -339,13 +339,13 @@ base: components: sinks: kafka: configuration: {
 	}
 	key_field: {
 		description: """
-			The log field name or tag key to use for the topic key.
+			A path expression to a field of the event to use for the topic key.
 
-			If the field does not exist in the log or in the tags, a blank value is used. If
-			unspecified, the key is not sent.
-
+			If unspecified, or if the field does not exist in the log or metric, the key is not sent.
 			Kafka uses a hash of the key to choose the partition or uses round-robin if the record has
 			no key.
+
+			Metrics currently only support access to `name` and `tags`.
 			"""
 		required: false
 		type: string: examples: ["user_id", ".my_topic", "%my_topic"]


### PR DESCRIPTION
Currently, the Kafka sink implementation of `key_field` uses a simple lookup into `tags` for metrics. Unfortunately, this does not work because the round-trip through parsing the configuration results in a forced `.` prefix, which only works if the tag name also contains an explicit dot at the start.

Fixes: https://github.com/vectordotdev/vector/issues/20217

A workaround that I used in production:
```toml
[transforms.remap]
type = "remap"
input = [ "...some source..." ]
source = `.tags.".metric_name" = .name`

[sinks.kafka]
type = "kafka"
input = [ "remap" ]
key_field = ".metric_name"
...
```

This fix tries to improve the situation by:
- Supporting `.name` explicitly, so the hack above can be removed entirely
- Supporting `.tags.<tag-name>` explicitly, so that config can also be implemented in a way that will remain compatible when the Metric type structure eventually implements Value compatibility for VRL-style de-referencing.
- Supporting the current behaviour as a fall-through for anyone running an existing pipeline using `key_field` so there is at least one version that can be used as a graceful cross-over for deprecation of the previous behaviour.
- Implementing some unit-tests for these behaviours.