### PR TITLE
chore(releasing): Prepare v0.37.1 release

### DIFF
--- a/.github/workflows/compilation-timings.yml
+++ b/.github/workflows/compilation-timings.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   release-build-optimized:
     name: "Release Build (optimized)"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
 
   release-build-normal:
     name: "Release Build (normal)"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     env:
       # We're not actually doing a debug build, we're just turning off the logic
       # in release-flags.sh so that we don't override the Cargo "release" profile
@@ -40,7 +40,7 @@ jobs:
 
   debug-build:
     name: "Debug Build"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
 
   debug-rebuild:
     name: "Debug Rebuild"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
 
   check:
     name: "Cargo Check"
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: colpal/actions-clean@v1
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 45
     needs: changes
     if: always() && (

--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -82,7 +82,7 @@ jobs:
 
   integration-tests:
     needs: prep-pr
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
@@ -460,7 +460,7 @@ jobs:
 
   e2e-tests:
     needs: prep-pr
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   test-integration:
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 40
     if: inputs.if || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     needs: changes
     if: always() && (
       github.event_name == 'merge_group' || (

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 45
     needs: changes
     # Run this job even if `changes` job is skipped (non- pull request trigger)
@@ -181,7 +181,7 @@ jobs:
 
   test-e2e-kubernetes:
     name: K8s ${{ matrix.kubernetes_version.version }} / ${{ matrix.container_runtime }} (${{ matrix.kubernetes_version.role }})
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 45
     needs:
       - build-x86_64-unknown-linux-gnu

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-misc:
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 45
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
   build-x86_64-unknown-linux-musl-packages:
     name: Build Vector for x86_64-unknown-linux-musl (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -71,7 +71,7 @@ jobs:
 
   build-x86_64-unknown-linux-gnu-packages:
     name: Build Vector for x86_64-unknown-linux-gnu (.tar.gz, DEB, RPM)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     needs: generate-publish-metadata
     timeout-minutes: 60
     env:
@@ -97,7 +97,7 @@ jobs:
 
   build-aarch64-unknown-linux-musl-packages:
     name: Build Vector for aarch64-unknown-linux-musl (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -125,7 +125,7 @@ jobs:
 
   build-aarch64-unknown-linux-gnu-packages:
     name: Build Vector for aarch64-unknown-linux-gnu (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -153,7 +153,7 @@ jobs:
 
   build-armv7-unknown-linux-gnueabihf-packages:
     name: Build Vector for armv7-unknown-linux-gnueabihf (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -181,7 +181,7 @@ jobs:
 
   build-armv7-unknown-linux-musleabihf-packages:
     name: Build Vector for armv7-unknown-linux-musleabihf (.tar.gz)
-    runs-on: [linux, release-builder]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -209,7 +209,7 @@ jobs:
 
   build-arm-unknown-linux-gnueabi-packages:
     name: Build Vector for arm-unknown-linux-gnueabi (.tar.gz)
-    runs-on: [ linux, release-builder ]
+    runs-on: release-builder-linux
     timeout-minutes: 60
     needs: generate-publish-metadata
     env:
@@ -237,7 +237,7 @@ jobs:
 
   build-arm-unknown-linux-musleabi-packages:
     name: Build Vector for arm-unknown-linux-musleabi (.tar.gz)
-    runs-on: [ linux, release-builder ]
+    runs-on: release-builder-linux
     needs: generate-publish-metadata
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -293,7 +293,7 @@ jobs:
 
   build-x86_64-pc-windows-msvc-packages:
     name: Build Vector for x86_64-pc-windows-msvc (.zip)
-    runs-on: [windows, release-builder]
+    runs-on: release-builder-windows
     timeout-minutes: 90
     needs: generate-publish-metadata
     env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -287,7 +287,7 @@ jobs:
 
   build-baseline:
     name: Build baseline Vector container
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 30
     needs:
       - compute-metadata
@@ -325,7 +325,7 @@ jobs:
 
   build-comparison:
     name: Build comparison Vector container
-    runs-on: [linux, ubuntu-20.04-4core]
+    runs-on: ubuntu-20.04-4core
     timeout-minutes: 30
     needs:
       - compute-metadata

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
   checks:
     name: Checks
-    runs-on: [linux, ubuntu-20.04-8core]
+    runs-on: ubuntu-20.04-8core
     timeout-minutes: 45
     needs: changes
     env:

--- a/.github/workflows/unit_windows.yml
+++ b/.github/workflows/unit_windows.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   test-windows:
-    runs-on: [windows, windows-2019-8core]
+    runs-on: windows-2019-8core
     timeout-minutes: 60
     steps:
       - name: (PR comment) Get PR branch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes 1.5.0",
  "fastrand 2.0.1",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -3747,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -3766,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -4210,14 +4210,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing 0.1.40",
@@ -7515,7 +7515,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -9371,7 +9371,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
  "flate2",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -10083,7 +10083,7 @@ dependencies = [
  "governor",
  "greptimedb-client",
  "grok",
- "h2 0.4.3",
+ "h2 0.4.4",
  "hash_hasher",
  "hashbrown 0.14.3",
  "headers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10017,7 +10017,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "apache-avro",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.37.0"
+version = "0.37.1"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"

--- a/changelog.d/20192_geoip_geolite_city_support.fix.md
+++ b/changelog.d/20192_geoip_geolite_city_support.fix.md
@@ -1,3 +1,0 @@
-Fixed an issue where `GeoLite2-City` MMDB database type was not supported.
-
-authors: esensar

--- a/changelog.d/20192_geoip_geolite_city_support.fix.md
+++ b/changelog.d/20192_geoip_geolite_city_support.fix.md
@@ -1,0 +1,3 @@
+Fixed an issue where `GeoLite2-City` MMDB database type was not supported.
+
+authors: esensar

--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -13,7 +13,7 @@ set -u
 # If PACKAGE_ROOT is unset or empty, default it.
 PACKAGE_ROOT="${PACKAGE_ROOT:-"https://packages.timber.io/vector"}"
 # If VECTOR_VERSION is unset or empty, default it.
-VECTOR_VERSION="${VECTOR_VERSION:-"0.37.0"}"
+VECTOR_VERSION="${VECTOR_VERSION:-"0.37.1"}"
 _divider="--------------------------------------------------------------------------------"
 _prompt=">>>"
 _indent="   "

--- a/scripts/e2e/datadog-logs/compose.yaml
+++ b/scripts/e2e/datadog-logs/compose.yaml
@@ -84,12 +84,14 @@ services:
   # Receives log data from the `datadog-agent` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-agent:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
   # Receives log data from the `datadog-agent-vector` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-vector:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
 networks:
   default:

--- a/scripts/e2e/datadog-metrics/compose.yaml
+++ b/scripts/e2e/datadog-metrics/compose.yaml
@@ -67,12 +67,14 @@ services:
   # Receives metric data from the `datadog-agent` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-agent:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
   # Receives metric data from the `datadog-agent-vector` service. Is queried by the test runner
   # which does the validation of consistency with the other fakeintake service.
   fakeintake-vector:
-    image: docker.io/datadog/fakeintake:latest
+    # TODO: temporarily pegging the image as latest results in failures
+    image: docker.io/datadog/fakeintake:v77a06f2b
 
 networks:
   default:

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -39,7 +39,6 @@ apt-get install --yes --no-install-recommends \
     llvm \
     locales \
     pkg-config \
-    python3-pip \
     rename \
     rpm \
     ruby-bundler \

--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -20,8 +20,6 @@ apt-get install --yes \
   apt-utils \
   apt-transport-https
 
-apt-get upgrade --yes
-
 # Deps
 apt-get install --yes --no-install-recommends \
     awscli \

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -29,8 +29,5 @@ fi
 sudo npm -g install markdownlint-cli@0.30
 sudo npm -g install @datadog/datadog-ci
 
-pip3 install jsonschema==3.2.0
-pip3 install remarshal==0.11.2
-
 # Make sure our release build settings are present.
 . scripts/environment/release-flags.sh

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -36,7 +36,7 @@ impl TryFrom<&str> for DatabaseKind {
             "GeoLite2-ASN" => Ok(Self::Asn),
             "GeoIP2-ISP" => Ok(Self::Isp),
             "GeoIP2-Connection-Type" => Ok(Self::ConnectionType),
-            "GeoIP2-City" => Ok(Self::City),
+            "GeoIP2-City" | "GeoLite2-City" => Ok(Self::City),
             _ => Err(()),
         }
     }

--- a/website/content/en/releases/0.37.1.md
+++ b/website/content/en/releases/0.37.1.md
@@ -1,0 +1,4 @@
+---
+title: Vector v0.37.1 release notes
+weight: 21
+---

--- a/website/cue/reference/releases/0.37.0.cue
+++ b/website/cue/reference/releases/0.37.0.cue
@@ -33,7 +33,12 @@ releases: "0.37.0": {
 
 	known_issues: [
 		"""
-			The `parse_ddtags` setting added to the `datadog_agent` Source incorrectly parses the tags into an object instead of an array.
+			The `geoip2` enrichment table type stopped handling `GeoLite2-City` mmdb types. This is fixed in v0.37.1.
+			""",
+		"""
+			The `parse_ddtags` setting added to the `datadog_agent` source incorrectly parses the
+			tags into an object instead of an array. The `datadog_logs` sink also failed to
+			reconstruct the parsed tags. This will be fixed in v0.38.0.
 			""",
 	]
 

--- a/website/cue/reference/releases/0.37.0.cue
+++ b/website/cue/reference/releases/0.37.0.cue
@@ -37,7 +37,7 @@ releases: "0.37.0": {
 			""",
 		"""
 			The `parse_ddtags` setting added to the `datadog_agent` source incorrectly parses the
-			tags into an object instead of an array. The `datadog_logs` sink also failed to
+			tags into an object instead of an array. The `datadog_logs` sink also fails to
 			reconstruct the parsed tags. This will be fixed in v0.38.0.
 			""",
 	]

--- a/website/cue/reference/releases/0.37.1.cue
+++ b/website/cue/reference/releases/0.37.1.cue
@@ -36,5 +36,7 @@ releases: "0.37.1": {
 		{sha: "1cb0b96459ba23aa821fee2725680a42146944c6", date: "2024-03-30 05:14:41 UTC", description: "Only use one label for selecting GHA runner", pr_number:                              20210, scopes: ["ci"], type:                         "chore", breaking_change: false, author: "Jesse Szwedko", files_count:            11, insertions_count: 26, deletions_count:  26},
 		{sha: "8c99fd31e51934647b1e7e4e341992b4edee4070", date: "2024-03-29 05:32:26 UTC", description: "align `ddtags` parsing with DD logs intake", pr_number:                               20184, scopes: ["datadog_agent"], type:              "fix", breaking_change:   true, author:  "neuronull", files_count:                5, insertions_count:  16, deletions_count:  37},
 		{sha: "e3831a86e77057acfb4ecccb1625d7a5c381fd8c", date: "2024-04-02 21:45:46 UTC", description: "reconstruct `ddtags` if not already in format expected by DD logs intake", pr_number: 20198, scopes: ["datadog_logs sink"], type:          "fix", breaking_change:   false, author: "neuronull", files_count:                5, insertions_count:  195, deletions_count: 28},
+		{sha: "7f0dc8fc63ec982a16682a462fc10584f21cdbba", date: "2024-04-05 21:31:59 UTC", description: "Update h2", pr_number:                                                                20236, scopes: ["deps"], type:                       "chore", breaking_change: false, author: "Jesse Szwedko", files_count:            1, insertions_count:  10, deletions_count:  10},
+
 	]
 }

--- a/website/cue/reference/releases/0.37.1.cue
+++ b/website/cue/reference/releases/0.37.1.cue
@@ -1,0 +1,40 @@
+package metadata
+
+releases: "0.37.1": {
+	date:     "2024-04-08"
+	codename: ""
+
+	whats_next: []
+
+	description: """
+		This patch release contains fixes for regressions in 0.37.0.
+
+		**Note:** Please see the release notes for [`v0.37.0`](/releases/0.37.0/) for additional
+		changes if upgrading from `v0.36.X`. In particular, see the upgrade guide for breaking
+		changes.
+		"""
+
+	changelog: [
+		{
+			type: "fix"
+			description: """
+				Fixed an issue where `GeoLite2-City` MMDB database type was not supported.
+				"""
+			contributors: ["esensar"]
+		},
+	]
+
+	commits: [
+		{sha: "dd984ea225b453c5a22f59cbff87f1fa6919237a", date: "2024-03-29 03:48:25 UTC", description: "note for 0.37 about incorrect ddtags parsing behavior", pr_number:                    20186, scopes: ["docs"], type:                       "chore", breaking_change: false, author: "neuronull", files_count:                3, insertions_count:  12, deletions_count:  0},
+		{sha: "716160dba256255bd43a897ec57ca8359ec44f0c", date: "2024-03-27 00:51:35 UTC", description: "Remove package deprecation banner", pr_number:                                        20181, scopes: ["docs"], type:                       "chore", breaking_change: false, author: "Jesse Szwedko", files_count:            1, insertions_count:  1, deletions_count:   1},
+		{sha: "a81f3b3c5039e818989d425ed787e885304c8df1", date: "2024-03-29 04:16:51 UTC", description: "Add breaking change note for dnstap source mode", pr_number:                          20202, scopes: ["dnstap source", "releasing"], type: "docs", breaking_change:  false, author: "Jesse Szwedko", files_count:            1, insertions_count:  7, deletions_count:   0},
+		{sha: "3f4859f86cb345149a167c0aaef38b8bda2ec912", date: "2024-04-02 08:34:02 UTC", description: "fix type cardinality docs", pr_number:                                                20209, scopes: [], type:                             "docs", breaking_change:  false, author: "Michael サイトー 中村 Bashurov", files_count: 3, insertions_count:  7, deletions_count:   9},
+		{sha: "17fb71c10950357fbcfff818458b6cbd4fe6e0fa", date: "2024-03-28 08:18:40 UTC", description: "bring back support for `GeoLite2-City` db", pr_number:                                20192, scopes: ["enrichment_tables"], type:          "fix", breaking_change:   false, author: "Ensar Sarajčić", files_count:           2, insertions_count:  4, deletions_count:   1},
+		{sha: "b7495c271be5138dfb677ea05cbbfad0ce623584", date: "2024-03-28 05:35:54 UTC", description: "peg `fakeintake` docker image", pr_number:                                            20196, scopes: ["ci"], type:                         "chore", breaking_change: false, author: "neuronull", files_count:                2, insertions_count:  8, deletions_count:   4},
+		{sha: "4496b3dba977444e39d8fdfbba56574ea5fecb7a", date: "2024-03-28 23:46:26 UTC", description: "Drop `apt-get upgrade`", pr_number:                                                   20203, scopes: ["ci"], type:                         "chore", breaking_change: false, author: "Jesse Szwedko", files_count:            1, insertions_count:  0, deletions_count:   2},
+		{sha: "2cb35f197f322daec498fd763706577b224a09c4", date: "2024-03-29 02:31:59 UTC", description: "Remove pip install of modules", pr_number:                                            20204, scopes: ["ci"], type:                         "chore", breaking_change: false, author: "Jesse Szwedko", files_count:            2, insertions_count:  0, deletions_count:   4},
+		{sha: "1cb0b96459ba23aa821fee2725680a42146944c6", date: "2024-03-30 05:14:41 UTC", description: "Only use one label for selecting GHA runner", pr_number:                              20210, scopes: ["ci"], type:                         "chore", breaking_change: false, author: "Jesse Szwedko", files_count:            11, insertions_count: 26, deletions_count:  26},
+		{sha: "8c99fd31e51934647b1e7e4e341992b4edee4070", date: "2024-03-29 05:32:26 UTC", description: "align `ddtags` parsing with DD logs intake", pr_number:                               20184, scopes: ["datadog_agent"], type:              "fix", breaking_change:   true, author:  "neuronull", files_count:                5, insertions_count:  16, deletions_count:  37},
+		{sha: "e3831a86e77057acfb4ecccb1625d7a5c381fd8c", date: "2024-04-02 21:45:46 UTC", description: "reconstruct `ddtags` if not already in format expected by DD logs intake", pr_number: 20198, scopes: ["datadog_logs sink"], type:          "fix", breaking_change:   false, author: "neuronull", files_count:                5, insertions_count:  195, deletions_count: 28},
+	]
+}

--- a/website/cue/reference/versions.cue
+++ b/website/cue/reference/versions.cue
@@ -2,6 +2,7 @@ package metadata
 
 // This has to be maintained manually because there's currently no way to sort versions programmatically
 versions: [string, ...string] & [
+	"0.37.1",
 	"0.37.0",
 	"0.36.1",
 	"0.36.0",


### PR DESCRIPTION
Checklist: https://github.com/vectordotdev/vector/issues/20258

Only one actual fix, the rest are build pipeline fixes picked over from `master`.