### PR TITLE
enhancement(aws_s3 source): Adds an option `max_number_of_messages` for the aws_s3 source

### DIFF
--- a/changelog.d/20172_max_number_of_messages.enhancement.md
+++ b/changelog.d/20172_max_number_of_messages.enhancement.md
@@ -1,0 +1,3 @@
+Adds a `max_number_of_messages` to the sqs configuration of the `aws_s3` source
+
+authors: fdamstra

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -800,6 +800,7 @@ mod integration_tests {
             sqs: Some(sqs::Config {
                 queue_url: queue_url.to_string(),
                 poll_secs: 1,
+                max_number_of_messages: 10,
                 visibility_timeout_secs: 0,
                 client_concurrency: None,
                 ..Default::default()

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -165,9 +165,7 @@ pub(super) enum IngestorNewError {
         timeout: u64,
     },
     #[snafu(display("Invalid value for max_number_of_messages {}", messages))]
-    InvalidNumberOfMessages {
-        messages: u32,
-    },
+    InvalidNumberOfMessages { messages: u32 },
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -252,7 +250,7 @@ impl Ingestor {
     ) -> Result<Ingestor, IngestorNewError> {
         if config.max_number_of_messages < 1 || config.max_number_of_messages > 10 {
             return Err(IngestorNewError::InvalidNumberOfMessages {
-                messages: config.max_number_of_messages
+                messages: config.max_number_of_messages,
             });
         }
         let state = Arc::new(State {

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -605,6 +605,21 @@ base: components: sources: aws_s3: configuration: {
 				required: false
 				type: bool: default: true
 			}
+			max_number_of_messages: {
+				description: """
+					Maximum number of messages to poll from sqs in a batch
+
+					Defaults to 10
+
+					Should be set to smaller numbers when the files are larger to help prevent large ingestions
+					from causing other files to exceed the visibility_timeout. Valid values are 1 - 10
+					"""
+				required: false
+				type: uint: {
+					default: 10
+					examples: [1]
+				}
+			}
 			poll_secs: {
 				description: """
 					How long to wait while polling the queue for new messages, in seconds.

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -607,12 +607,12 @@ base: components: sources: aws_s3: configuration: {
 			}
 			max_number_of_messages: {
 				description: """
-					Maximum number of messages to poll from sqs in a batch
+					Maximum number of messages to poll from SQS in a batch
 
 					Defaults to 10
 
-					Should be set to smaller numbers when the files are larger to help prevent large ingestions
-					from causing other files to exceed the visibility_timeout. Valid values are 1 - 10
+					Should be set to a smaller value when the files are large to help prevent the ingestion of
+					one file from causing the other files to exceed the visibility_timeout. Valid values are 1 - 10
 					"""
 				required: false
 				type: uint: {


### PR DESCRIPTION
Implements #20172

Allows for selection of maximum number of messages to pull from the S3 queue.

Compiled and tested for functionality.