### PR TITLE
chore(ci): Download SHA256SUMS to correct location

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -698,6 +698,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-SHA256SUMS
+          path: target/artifacts
       - name: Download staged package artifacts (arm-unknown-linux-gnueabi)
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This was accidentally dropped in e9815e1f328 resulting in the SHA256SUMS not being uploaded to the GitHub releases.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
