### PR TITLE
fix(aws service): use http client when building assume role for AccessKey

### DIFF
--- a/changelog.d/20282_aws_access_key_id_and_assume_role_auth.fix.md
+++ b/changelog.d/20282_aws_access_key_id_and_assume_role_auth.fix.md
@@ -1,0 +1,5 @@
+Vector would panic when attempting to use a combination af `access_key_id` and
+`assume_role` authentication with the AWS components. This error has now been
+fixed.
+
+authors: StephenWakely

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -273,14 +273,21 @@ impl AwsAuthentication {
                 credentials_file,
                 profile,
             } => {
+                let connector = super::connector(proxy, tls_options)?;
+
                 // The SDK uses the default profile out of the box, but doesn't provide an optional
                 // type in the builder. We can just hardcode it so that everything works.
                 let profile_files = ProfileFiles::builder()
                     .with_file(ProfileFileKind::Credentials, credentials_file)
                     .build();
+
+                let provider_config = ProviderConfig::empty()
+                    .with_http_client(connector);
+
                 let profile_provider = ProfileFileCredentialsProvider::builder()
                     .profile_files(profile_files)
                     .profile_name(profile)
+                    .configure(&provider_config)
                     .build();
                 Ok(SharedCredentialsProvider::new(profile_provider))
             }

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -281,8 +281,7 @@ impl AwsAuthentication {
                     .with_file(ProfileFileKind::Credentials, credentials_file)
                     .build();
 
-                let provider_config = ProviderConfig::empty()
-                    .with_http_client(connector);
+                let provider_config = ProviderConfig::empty().with_http_client(connector);
 
                 let profile_provider = ProfileFileCredentialsProvider::builder()
                     .profile_files(profile_files)


### PR DESCRIPTION
Fixes #20282 

This fixes the error that we received when using both `access_key_id` and `assume_role` together. The builder used in that situation should have had a custom http client provided so it could use our TLS and proxy settings.

*Note:* I have tested this by running locally with that authentication scheme in the config. This gave me the same error in the issue. I fixed the bug and ran again. I now get the error `STS refused to grant assume role`, which is expected because I have not set up a valid client in AWS. I am pretty confident that this fixes the issue, but have not tested 100% to the end to save time having to setup a fairly complex authentication scheme in AWS.