### PR TITLE
fix(host_metrics source): Include cgroups2 root memory metrics

### DIFF
--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -116,7 +116,7 @@ impl<'a> CGroupRecurser<'a> {
             if self.load_cpu {
                 self.load_cpu(&cgroup, &tags).await;
             }
-            if self.load_memory && !cgroup.is_root() {
+            if self.load_memory {
                 self.load_memory(&cgroup, &tags).await;
             }
 
@@ -271,10 +271,6 @@ struct CGroup {
 }
 
 impl CGroup {
-    fn is_root(&self) -> bool {
-        self.name == Path::new("/")
-    }
-
     fn tags(&self) -> MetricTags {
         metric_tags! {
             "cgroup" => self.name.to_string_lossy(),
@@ -599,11 +595,11 @@ mod tests {
             );
             assert_eq!(
                 count_name(&metrics, "cgroup_memory_anon_bytes"),
-                SUBDIRS.len() - 1
+                SUBDIRS.len()
             );
             assert_eq!(
                 count_name(&metrics, "cgroup_memory_file_bytes"),
-                SUBDIRS.len() - 1
+                SUBDIRS.len()
             );
         }
 


### PR DESCRIPTION
* `cgroup_memory_anon_bytes` and `cgroup_memory_file_bytes` are no longer zero on cgroups v2 systems
* test `sources::host_metrics::cgroups::tests::generates_cgroups_metrics` should no longer flap

I'm not sure why the `is_root` check was there for cgroups v2. Memory is only in the root cgroup dir. No child dirs exist in cgroup root on my machine.

Fixes https://github.com/vectordotdev/vector/issues/18697