### PR TITLE
chore(core): Rename `severity` meaning to `status`

### DIFF
--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -7,13 +7,13 @@ use std::borrow::Cow;
 use syslog_loose::{IncompleteDate, Message, ProcId, Protocol, Variant};
 use vector_config::configurable_component;
 use vector_core::config::{LegacyKey, LogNamespace};
+use vector_core::schema::meaning;
 use vector_core::{
     config::{log_schema, DataType},
     event::{Event, LogEvent, ObjectMap, Value},
     schema,
 };
 use vrl::value::{kind::Collection, Kind};
-use vector_core::schema::meaning;
 
 use super::{default_lossy, Deserializer};
 

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -13,6 +13,7 @@ use vector_core::{
     schema,
 };
 use vrl::value::{kind::Collection, Kind};
+use vector_core::schema::meaning;
 
 use super::{default_lossy, Deserializer};
 

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -85,7 +85,7 @@ impl SyslogDeserializerConfig {
                     .optional_field(
                         &owned_value_path!("severity"),
                         Kind::bytes(),
-                        Some("severity"),
+                        Some("status"),
                     )
                     .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                     .optional_field(&owned_value_path!("version"), Kind::integer(), None)
@@ -130,7 +130,7 @@ impl SyslogDeserializerConfig {
                 .optional_field(
                     &owned_value_path!("severity"),
                     Kind::bytes(),
-                    Some("severity"),
+                    Some("status"),
                 )
                 .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                 .optional_field(&owned_value_path!("version"), Kind::integer(), None)
@@ -177,7 +177,7 @@ impl SyslogDeserializerConfig {
                         None,
                         &owned_value_path!("severity"),
                         Kind::bytes().or_undefined(),
-                        Some("severity"),
+                        Some("status"),
                     )
                     .with_source_metadata(
                         source,

--- a/lib/codecs/src/decoding/format/syslog.rs
+++ b/lib/codecs/src/decoding/format/syslog.rs
@@ -85,7 +85,7 @@ impl SyslogDeserializerConfig {
                     .optional_field(
                         &owned_value_path!("severity"),
                         Kind::bytes(),
-                        Some("status"),
+                        Some(meaning::STATUS),
                     )
                     .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                     .optional_field(&owned_value_path!("version"), Kind::integer(), None)
@@ -130,7 +130,7 @@ impl SyslogDeserializerConfig {
                 .optional_field(
                     &owned_value_path!("severity"),
                     Kind::bytes(),
-                    Some("status"),
+                    Some(meaning::STATUS),
                 )
                 .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                 .optional_field(&owned_value_path!("version"), Kind::integer(), None)
@@ -177,7 +177,7 @@ impl SyslogDeserializerConfig {
                         None,
                         &owned_value_path!("severity"),
                         Kind::bytes().or_undefined(),
-                        Some("status"),
+                        Some(meaning::STATUS),
                     )
                     .with_source_metadata(
                         source,

--- a/lib/vector-core/src/schema/meaning.rs
+++ b/lib/vector-core/src/schema/meaning.rs
@@ -16,5 +16,6 @@ pub const HOST: &str = "host";
 pub const TAGS: &str = "tags";
 
 pub const SOURCE: &str = "source";
-pub const SEVERITY: &str = "severity";
+pub const STATUS: &str = "status";
 pub const TRACE_ID: &str = "trace_id";
+pub const SPAN_ID: &str = "span_id";

--- a/src/common/datadog.rs
+++ b/src/common/datadog.rs
@@ -18,7 +18,7 @@ pub const DDTAGS: &str = "ddtags";
 /// to the field name that Datadog intake expects.
 // https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/?s=severity#reserved-attributes
 pub const DD_RESERVED_SEMANTIC_ATTRS: [(&str, &str); 6] = [
-    (meaning::STATUS, "status"), // status is intentionally semantically defined as severity
+    (meaning::STATUS, "status"),
     (meaning::TIMESTAMP, "timestamp"),
     (meaning::HOST, "hostname"),
     (meaning::SERVICE, "service"),

--- a/src/common/datadog.rs
+++ b/src/common/datadog.rs
@@ -18,7 +18,7 @@ pub const DDTAGS: &str = "ddtags";
 /// to the field name that Datadog intake expects.
 // https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/?s=severity#reserved-attributes
 pub const DD_RESERVED_SEMANTIC_ATTRS: [(&str, &str); 6] = [
-    (meaning::SEVERITY, "status"), // status is intentionally semantically defined as severity
+    (meaning::STATUS, "status"), // status is intentionally semantically defined as severity
     (meaning::TIMESTAMP, "timestamp"),
     (meaning::HOST, "hostname"),
     (meaning::SERVICE, "service"),

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -168,7 +168,7 @@ impl SinkConfig for DatadogLogsConfig {
             .optional_meaning(meaning::TIMESTAMP, Kind::timestamp())
             .optional_meaning(meaning::HOST, Kind::bytes())
             .optional_meaning(meaning::SOURCE, Kind::bytes())
-            .optional_meaning(meaning::SEVERITY, Kind::bytes())
+            .optional_meaning(meaning::STATUS, Kind::bytes())
             .optional_meaning(meaning::SERVICE, Kind::bytes())
             .optional_meaning(meaning::TRACE_ID, Kind::bytes());
 

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -476,7 +476,7 @@ mod tests {
                 Some(LegacyKey::InsertIfEmpty(owned_value_path!("severity"))),
                 &owned_value_path!("severity"),
                 Kind::bytes(),
-                Some(meaning::SEVERITY),
+                Some(meaning::STATUS),
             )
             .with_source_metadata(
                 "datadog_agent",
@@ -549,7 +549,7 @@ mod tests {
                     Some(LegacyKey::InsertIfEmpty(owned_value_path!("severity"))),
                     &owned_value_path!("severity"),
                     Kind::bytes(),
-                    Some(meaning::SEVERITY),
+                    Some(meaning::STATUS),
                 )
                 .with_source_metadata(
                     "datadog_agent",

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -247,7 +247,7 @@ impl SourceConfig for DatadogAgentConfig {
                 Some(LegacyKey::InsertIfEmpty(owned_value_path!("status"))),
                 &owned_value_path!("status"),
                 Kind::bytes(),
-                Some(meaning::SEVERITY),
+                Some(meaning::STATUS),
             )
             .with_source_metadata(
                 Self::NAME,

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1630,7 +1630,7 @@ fn test_config_outputs() {
                             .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes(),
-                                Some("severity"),
+                                Some("status"),
                             )
                             .with_event_field(
                                 &owned_value_path!("timestamp"),
@@ -1683,7 +1683,7 @@ fn test_config_outputs() {
                             .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes(),
-                                Some("severity"),
+                                Some("status"),
                             )
                             .with_event_field(
                                 &owned_value_path!("timestamp"),
@@ -1737,7 +1737,7 @@ fn test_config_outputs() {
                                 .with_event_field(
                                     &owned_value_path!("status"),
                                     Kind::bytes(),
-                                    Some("severity"),
+                                    Some("status"),
                                 )
                                 .with_event_field(
                                     &owned_value_path!("timestamp"),
@@ -1870,7 +1870,7 @@ fn test_config_outputs() {
                             .optional_field(
                                 &owned_value_path!("severity"),
                                 Kind::bytes(),
-                                Some("severity"),
+                                Some("status"),
                             )
                             .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                             .optional_field(&owned_value_path!("version"), Kind::integer(), None)
@@ -1946,7 +1946,7 @@ fn test_config_outputs() {
                                 .optional_field(
                                     &owned_value_path!("severity"),
                                     Kind::bytes(),
-                                    Some("severity"),
+                                    Some("status"),
                                 )
                                 .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                                 .optional_field(
@@ -2338,7 +2338,7 @@ fn test_output_schema_definition_json_vector_namespace() {
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "status"),
                     Kind::bytes(),
-                    Some("severity")
+                    Some("status")
                 )
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "timestamp"),
@@ -2397,7 +2397,7 @@ fn test_output_schema_definition_bytes_vector_namespace() {
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "status"),
                     Kind::bytes(),
-                    Some("severity")
+                    Some("status")
                 )
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "timestamp"),
@@ -2488,7 +2488,7 @@ fn test_output_schema_definition_bytes_legacy_namespace() {
             .with_event_field(
                 &owned_value_path!("status"),
                 Kind::bytes(),
-                Some("severity")
+                Some("status")
             )
             .with_event_field(
                 &owned_value_path!("timestamp"),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1630,7 +1630,7 @@ fn test_config_outputs() {
                             .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes(),
-                                Some("status"),
+                                Some(meaning::STATUS),
                             )
                             .with_event_field(
                                 &owned_value_path!("timestamp"),
@@ -1683,7 +1683,7 @@ fn test_config_outputs() {
                             .with_event_field(
                                 &owned_value_path!("status"),
                                 Kind::bytes(),
-                                Some("status"),
+                                Some(meaning::STATUS),
                             )
                             .with_event_field(
                                 &owned_value_path!("timestamp"),
@@ -1737,7 +1737,7 @@ fn test_config_outputs() {
                                 .with_event_field(
                                     &owned_value_path!("status"),
                                     Kind::bytes(),
-                                    Some("status"),
+                                    Some(meaning::STATUS),
                                 )
                                 .with_event_field(
                                     &owned_value_path!("timestamp"),
@@ -1870,7 +1870,7 @@ fn test_config_outputs() {
                             .optional_field(
                                 &owned_value_path!("severity"),
                                 Kind::bytes(),
-                                Some("status"),
+                                Some(meaning::STATUS),
                             )
                             .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                             .optional_field(&owned_value_path!("version"), Kind::integer(), None)
@@ -1946,7 +1946,7 @@ fn test_config_outputs() {
                                 .optional_field(
                                     &owned_value_path!("severity"),
                                     Kind::bytes(),
-                                    Some("status"),
+                                    Some(meaning::STATUS),
                                 )
                                 .optional_field(&owned_value_path!("facility"), Kind::bytes(), None)
                                 .optional_field(
@@ -2338,7 +2338,7 @@ fn test_output_schema_definition_json_vector_namespace() {
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "status"),
                     Kind::bytes(),
-                    Some("status")
+                    Some(meaning::STATUS)
                 )
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "timestamp"),
@@ -2397,7 +2397,7 @@ fn test_output_schema_definition_bytes_vector_namespace() {
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "status"),
                     Kind::bytes(),
-                    Some("status")
+                    Some(meaning::STATUS)
                 )
                 .with_metadata_field(
                     &owned_value_path!("datadog_agent", "timestamp"),
@@ -2485,7 +2485,11 @@ fn test_output_schema_definition_bytes_legacy_namespace() {
                 Some("service")
             )
             .with_event_field(&owned_value_path!("source_type"), Kind::bytes(), None)
-            .with_event_field(&owned_value_path!("status"), Kind::bytes(), Some("status"))
+            .with_event_field(
+                &owned_value_path!("status"),
+                Kind::bytes(),
+                Some(meaning::STATUS)
+            )
             .with_event_field(
                 &owned_value_path!("timestamp"),
                 Kind::timestamp(),

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2485,11 +2485,7 @@ fn test_output_schema_definition_bytes_legacy_namespace() {
                 Some("service")
             )
             .with_event_field(&owned_value_path!("source_type"), Kind::bytes(), None)
-            .with_event_field(
-                &owned_value_path!("status"),
-                Kind::bytes(),
-                Some("status")
-            )
+            .with_event_field(&owned_value_path!("status"), Kind::bytes(), Some("status"))
             .with_event_field(
                 &owned_value_path!("timestamp"),
                 Kind::timestamp(),

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -217,7 +217,7 @@ impl SourceConfig for OpentelemetryConfig {
                 Some(LegacyKey::Overwrite(owned_value_path!(SEVERITY_TEXT_KEY))),
                 &owned_value_path!(SEVERITY_TEXT_KEY),
                 Kind::bytes().or_undefined(),
-                Some("severity"),
+                Some("status"),
             )
             .with_source_metadata(
                 Self::NAME,

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -217,7 +217,7 @@ impl SourceConfig for OpentelemetryConfig {
                 Some(LegacyKey::Overwrite(owned_value_path!(SEVERITY_TEXT_KEY))),
                 &owned_value_path!(SEVERITY_TEXT_KEY),
                 Kind::bytes().or_undefined(),
-                Some("status"),
+                Some(meaning::STATUS),
             )
             .with_source_metadata(
                 Self::NAME,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -535,7 +535,7 @@ mod test {
                 .with_metadata_field(
                     &owned_value_path!("syslog", "severity"),
                     Kind::bytes().or_undefined(),
-                    Some("severity"),
+                    Some("status"),
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "facility"),
@@ -614,7 +614,7 @@ mod test {
         .with_event_field(
             &owned_value_path!("severity"),
             Kind::bytes().or_undefined(),
-            Some("severity"),
+            Some("status"),
         )
         .with_event_field(
             &owned_value_path!("facility"),

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -535,7 +535,7 @@ mod test {
                 .with_metadata_field(
                     &owned_value_path!("syslog", "severity"),
                     Kind::bytes().or_undefined(),
-                    Some("status"),
+                    Some(meaning::STATUS),
                 )
                 .with_metadata_field(
                     &owned_value_path!("syslog", "facility"),
@@ -614,7 +614,7 @@ mod test {
         .with_event_field(
             &owned_value_path!("severity"),
             Kind::bytes().or_undefined(),
-            Some("status"),
+            Some(meaning::STATUS),
         )
         .with_event_field(
             &owned_value_path!("facility"),


### PR DESCRIPTION
- Renames "severity" to "status" to align with Datadog [reserved attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
- Adds a common "span_id" meaning.

Note: it shouldn't break any components using "severity" meaning, since it's just a constant change.