### PR TITLE
feat(databend sink): add config missing_field_as for ndjson insert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,9 +2710,9 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "databend-client"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5c64ccaf4c765ee60cd3e47ea87a00371f74668e9b99d2d9e284171331ac4c"
+checksum = "32d42f932a3c2c5c1d5540579fe8c98bde9f95c8dc14e1d617bc87b583df2dce"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,7 +267,7 @@ chrono-tz = { version = "0.8.6", default-features = false }
 cidr-utils = { version = "0.6.1", default-features = false }
 colored = { version = "2.1.0", default-features = false }
 csv = { version = "1.3", default-features = false }
-databend-client ={ version = "0.16.1", default-features = false, features = ["rustls"], optional = true }
+databend-client ={ version = "0.17.0", default-features = false, features = ["rustls"], optional = true }
 derivative = { version = "2.2.0", default-features = false }
 dirs-next = { version = "2.0.0", default-features = false, optional = true }
 dyn-clone = { version = "1.0.17", default-features = false }

--- a/changelog.d/20331_databend_config_ndjson.enhancement.md
+++ b/changelog.d/20331_databend_config_ndjson.enhancement.md
@@ -1,0 +1,3 @@
+Added new config field `missing_field_as` as file format option for NDJSON encoding, default value is `NULL`.
+
+authors: everpcpc

--- a/changelog.d/20331_databend_config_ndjson.enhancement.md
+++ b/changelog.d/20331_databend_config_ndjson.enhancement.md
@@ -1,3 +1,3 @@
-Added new config field `missing_field_as` to the `databend` sink as file format option for NDJSON encoding, default value is `NULL`.
+Added a new config field `missing_field_as` to the `databend` sink to specify the behavior when fields are missing. Previously the behavior was the same as setting this new configuration option to `ERROR`. The new default value is `NULL`.
 
 authors: everpcpc

--- a/changelog.d/20331_databend_config_ndjson.enhancement.md
+++ b/changelog.d/20331_databend_config_ndjson.enhancement.md
@@ -1,3 +1,3 @@
-Added new config field `missing_field_as` as file format option for NDJSON encoding, default value is `NULL`.
+Added new config field `missing_field_as` to the `databend` sink as file format option for NDJSON encoding, default value is `NULL`.
 
 authors: everpcpc

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::{
     compression::DatabendCompression,
-    encoding::{DatabendEncodingConfig, DatabendSerializerConfig},
+    encoding::{DatabendEncodingConfig, DatabendMissingFieldAS, DatabendSerializerConfig},
     request_builder::DatabendRequestBuilder,
     service::{DatabendRetryLogic, DatabendService},
     sink::DatabendSink,
@@ -57,6 +57,10 @@ pub struct DatabendConfig {
     /// The table that data is inserted into.
     #[configurable(metadata(docs::examples = "mytable"))]
     pub table: String,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub missing_field_as: DatabendMissingFieldAS,
 
     #[configurable(derived)]
     #[serde(default)]
@@ -153,6 +157,7 @@ impl SinkConfig for DatabendConfig {
         let serializer = match self.encoding.config() {
             DatabendSerializerConfig::Json(_) => {
                 file_format_options.insert("type", "NDJSON");
+                file_format_options.insert("missing_field_as", self.missing_field_as.as_str());
                 encoding.build()?
             }
             DatabendSerializerConfig::Csv(_) => {

--- a/src/sinks/databend/encoding.rs
+++ b/src/sinks/databend/encoding.rs
@@ -66,3 +66,40 @@ impl DatabendEncodingConfig {
         &self.encoding
     }
 }
+
+/// Defines how missing fields are handled for NDJson.
+/// Refer to https://docs.databend.com/sql/sql-reference/file-format-options#null_field_as
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[configurable(metadata(docs::enum_tag_description = "How to handle missing fields for NDJson."))]
+pub enum DatabendMissingFieldAS {
+    /// Generates an error if a missing field is encountered.
+    Error,
+
+    /// Interprets missing fields as NULL values. An error will be generated for non-nullable fields.
+    Null,
+
+    /// Uses the default value of the field for missing fields.
+    FieldDefault,
+
+    /// Uses the default value of the field's data type for missing fields.
+    TypeDefault,
+}
+
+impl Default for DatabendMissingFieldAS {
+    fn default() -> Self {
+        Self::Null
+    }
+}
+
+impl DatabendMissingFieldAS {
+    pub(super) const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Error => "ERROR",
+            Self::Null => "NULL",
+            Self::FieldDefault => "FIELD_DEFAULT",
+            Self::TypeDefault => "TYPE_DEFAULT",
+        }
+    }
+}

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -276,6 +276,22 @@ base: components: sinks: databend: configuration: {
 		required:    true
 		type: string: examples: ["databend://localhost:8000/default?sslmode=disable"]
 	}
+	missing_field_as: {
+		description: """
+			Defines how missing fields are handled for NDJson.
+			Refer to https://docs.databend.com/sql/sql-reference/file-format-options#null_field_as
+			"""
+		required: false
+		type: string: {
+			default: "NULL"
+			enum: {
+				ERROR:         "Generates an error if a missing field is encountered."
+				FIELD_DEFAULT: "Uses the default value of the field for missing fields."
+				NULL:          "Interprets missing fields as NULL values. An error will be generated for non-nullable fields."
+				TYPE_DEFAULT:  "Uses the default value of the field's data type for missing fields."
+			}
+		}
+	}
 	request: {
 		description: """
 			Middleware settings for outbound requests.

--- a/website/cue/reference/components/sinks/databend.cue
+++ b/website/cue/reference/components/sinks/databend.cue
@@ -69,7 +69,7 @@ components: sinks: databend: {
 	support: {
 		requirements: [
 			"""
-				[Databend](\(urls.databend)) version `>= 0.9.0` is required.
+				[Databend](\(urls.databend)) version `>= 1.2.216` is required.
 				""",
 		]
 		warnings: []


### PR DESCRIPTION
Added new config field `missing_field_as` as file format option for `NDJSON` encoding, default value is `NULL`.