### PR TITLE
chore: Update issue templates to point to GH discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Support
-    url: https://discussions.vector.dev
+    url: https://github.com/vectordotdev/vector/discussions
     about: Get help! Ask questions, get support, and share ideas.
 
   - name: Chat


### PR DESCRIPTION
The discussions.vector.dev domain no longer exists. Just point directly to GH discussions.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
