### PR TITLE
test: Install dd-pkg in *-verify workflows and lint in verify-install.sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -347,6 +347,7 @@ jobs:
       - build-x86_64-unknown-linux-gnu-packages
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
+      DD_PKG_VERSION: "latest"
     strategy:
       matrix:
         container:
@@ -369,6 +370,9 @@ jobs:
           git \
           systemd \
           make
+      - name: Install dd-pkg for linting
+        run: |
+          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
       - name: Checkout Vector
@@ -393,6 +397,7 @@ jobs:
       - build-x86_64-unknown-linux-gnu-packages
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
+      DD_PKG_VERSION: "latest"
     strategy:
       matrix:
         container:
@@ -419,6 +424,9 @@ jobs:
           if ! command -v curl &> /dev/null ; then
             yum install -y curl
           fi
+      - name: Install dd-pkg for linting
+        run: |
+          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
       - name: Checkout Vector

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # SUMMARY
 #
-#   Verifies vector packages have been installed correctly
+#   Verifies vector packages have been built and installed correctly
 
 package="${1:?must pass package as argument}"
 
@@ -38,3 +38,5 @@ getent group vector || (echo "vector group  missing" && exit 1)
 vector --version || (echo "vector --version failed" && exit 1)
 grep -q "FOO=bar" "/etc/default/vector" || (echo "/etc/default/vector has incorrect contents" && exit 1)
 grep -q "foo: bar" "/etc/vector/vector.yaml" || (echo "/etc/vector/vector.yaml has incorrect contents" && exit 1)
+
+dd-pkg lint "$package"


### PR DESCRIPTION
Adds `dd-pkg` to CI for linting the produced DEB and RPM packages. Today this only checks that the package doesn't contain any world-writable files.

This lint was previously performed at the time of package promotion, so this is just shifting the check closer to the source.

Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
