### PR TITLE
fix(healthchecks): instrument healthchecks with component span

### DIFF
--- a/changelog.d/20356_component_tags_healthcheck.fix.md
+++ b/changelog.d/20356_component_tags_healthcheck.fix.md
@@ -1,0 +1,2 @@
+Any events emitted during the sink healthchecks now get tagged with the correct
+sink tags.

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -384,12 +384,9 @@ async fn s3_healthchecks() {
     create_bucket(&bucket, false).await;
 
     let config = config(&bucket, 1);
-    let service = config
-        .create_service(&ProxyConfig::from_env())
-        .await
-        .unwrap();
     config
-        .build_healthcheck(service.client())
+        .build_healthcheck(&ProxyConfig::from_env())
+        .await
         .unwrap()
         .await
         .unwrap();
@@ -398,12 +395,9 @@ async fn s3_healthchecks() {
 #[tokio::test]
 async fn s3_healthchecks_invalid_bucket() {
     let config = config("s3_healthchecks_invalid_bucket", 1);
-    let service = config
-        .create_service(&ProxyConfig::from_env())
-        .await
-        .unwrap();
     assert!(config
-        .build_healthcheck(service.client())
+        .build_healthcheck(&ProxyConfig::from_env())
+        .await
         .unwrap()
         .await
         .is_err());

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -252,6 +252,7 @@ impl AwsS3Config {
                     endpoint,
                     proxy,
                     &sqs.tls_options,
+                    true,
                 )
                 .await?;
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -664,8 +664,7 @@ impl<'a> Builder<'a> {
                     info!("Healthcheck disabled.");
                     Ok(TaskOutput::Healthcheck)
                 }
-            }
-            .instrument(span.clone());
+            };
 
             let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -664,7 +664,8 @@ impl<'a> Builder<'a> {
                     info!("Healthcheck disabled.");
                     Ok(TaskOutput::Healthcheck)
                 }
-            };
+            }
+            .instrument(span.clone());
 
             let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
 


### PR DESCRIPTION
Fixes #20356 

This instruments the healthcheck task with the sink component span. 

The aws s3 sink healthcheck sends a request to check the bucket can be written to. During the AWS upgrade a wrapper over the http connection was created that could instrument the bytes sent. Since the healthcheck was not being instrumented this resulted in an empty `component_sent_bytes_total` being emitted.

I am quite surprised that this error hasn't cropped up sooner, so it is well worth double checking that I am fixing this the correct way.