### PR TITLE
chore: Add future deprecation note for `component_(sent|received)_bytes_total` metrics

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -126,6 +126,8 @@ of these events:
 
 #### ComponentEventsReceived
 
+**Note**: Will be deprecated once `SourceNetworkBytesReceived` exists.
+
 _All components_ MUST emit a `ComponentEventsReceived` event that represents
 the reception of Vector events from an upstream component.
 
@@ -146,6 +148,8 @@ the reception of Vector events from an upstream component.
   - MUST NOT be rate limited.
 
 #### ComponentBytesReceived
+
+**Note**: Will be deprecated once `SourceNetworkBytesSent` exists.
 
 *Sources* MUST emit a `ComponentBytesReceived` event that represent the reception of bytes.
 


### PR DESCRIPTION
Vector originally published two component bytes metrics:

- `component_sent_bytes_total` the number of serialized bytes successfully sent by sinks (before
  compression)
- `component_received_bytes_total` the number of serialized bytes successfully received by sources
  (after decompression and filtering)

These were intended to be used by users to understand the volume of data flowing in/out of sources
and sinks. However, they were dependent on the exact serialization format such that the same event
going into the `socket` source vs. `vector` source might be measured differently. To have
a consistent metric we then added:

- `component_sent_event_bytes_total` the number of "estimated JSON event" bytes successfully sent by a components
- `component_received_event_bytes_total` the number of "estimated JSON event" bytes successfully received by a components

This is a metric that is able to be compared between any two components. This removed a use-case of
`component_(sent|received)_bytes_total`. The remaining use-case users seemed to use this metric for
was as a proxy for network bytes, but what they really are interested in is the _actual_ network
bytes. So we proposed two new metrics:

- `component_sent_network_bytes_total` the total number of bytes sent out on the network by a
  component
- `component_received_network_bytes_total` the total number of bytes received on the network by a
  component

Once those metrics exist, it isn't clear what use-case remains for
`component_(sent|received)_bytes_total` and so it would make sense to deprecate and remove them.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
