### PR TITLE
fix(ci): component features comment trigger one runner label

### DIFF
--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   check-component-features:
     # use free tier on schedule and 8 core to expedite results on demand invocation
-    runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || fromJSON('["linux", "ubuntu-20.04-8core"]') }}
+    runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || 'ubuntu-20.04-8core' }}
     if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     steps:
       - name: (PR comment) Get PR branch


### PR DESCRIPTION
Since GH only supports one runner label we [recently updated](https://github.com/vectordotdev/vector/pull/20210/files) our workflows but missed one- the component features when run on demand via comment trigger.


