### PR TITLE
chore(enterprise): Deprecate the `enterprise` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fastrand 2.0.1",
  "http 0.2.9",
  "regex",

--- a/changelog.d/20437-enterprise.deprecation.md
+++ b/changelog.d/20437-enterprise.deprecation.md
@@ -1,0 +1,2 @@
+The `enterprise` feature has been deprecated and will be removed in a future
+version.

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -18,4 +18,4 @@ For example:
 
 ## To be removed
 
-* v0.39.0 enterprise_feature The `enterprise` feature has been deprecated and will be removed.
+- v0.39.0 enterprise_feature The `enterprise` feature has been deprecated and will be removed.

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -18,4 +18,4 @@ For example:
 
 ## To be removed
 
-* v0.40.0 enterprise_feature The `enterprise` feature has been deprecated and will be removed.
+* v0.39.0 enterprise_feature The `enterprise` feature has been deprecated and will be removed.

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -17,3 +17,5 @@ For example:
 ## To be migrated
 
 ## To be removed
+
+* v0.40.0 enterprise_feature The `enterprise` feature has been deprecated and will be removed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -540,7 +540,7 @@ fn build_enterprise(
     config_paths: Vec<ConfigPath>,
 ) -> Result<Option<EnterpriseReporter<BoxFuture<'static, ()>>>, ExitCode> {
     if config.enterprise.is_some() {
-        warn!("DEPRECATED: The `enterprise` feature has been deprecated and will be removed in a future version.");
+        warn!("DEPRECATED: The `enterprise` feature has been deprecated and will be removed in the next release.");
     }
 
     crate::ENTERPRISE_ENABLED

--- a/src/app.rs
+++ b/src/app.rs
@@ -539,9 +539,11 @@ fn build_enterprise(
     config: &mut Config,
     config_paths: Vec<ConfigPath>,
 ) -> Result<Option<EnterpriseReporter<BoxFuture<'static, ()>>>, ExitCode> {
-    use crate::ENTERPRISE_ENABLED;
+    if config.enterprise.is_some() {
+        warn!("DEPRECATED: The `enterprise` feature has been deprecated and will be removed in a future version.");
+    }
 
-    ENTERPRISE_ENABLED
+    crate::ENTERPRISE_ENABLED
         .set(
             config
                 .enterprise


### PR DESCRIPTION
Nobody is known to be using this feature, and it is adding complications to the code base. This change adds a warning if it is used and notes the deprecation state.