### PR TITLE
chore(ci): Bump timeouts for test-misc and integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -89,7 +89,7 @@ jobs:
             || needs.changes.outputs.webhdfs == 'true'
         )
       )
-    timeout-minutes: 75
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-misc:
     runs-on: ubuntu-20.04-4core
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       CARGO_INCREMENTAL: 0
     steps:


### PR DESCRIPTION
A recent PR was bumping into these:
https://github.com/vectordotdev/vector/pull/20429

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
