### PR TITLE
Draft: chore: Add an end-to-end batching benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -942,6 +942,8 @@ benches = [
   "sources-syslog",
   "transforms-lua",
   "transforms-sample",
+  "tracing/release_max_level_info",
+  "tracing/max_level_info",
 ]
 dnstap-benches = ["sources-dnstap"]
 language-benches = ["sinks-socket", "sources-socket", "transforms-lua", "transforms-remap"]
@@ -955,6 +957,12 @@ enrichment-tables-benches = ["enrichment-tables-geoip", "enrichment-tables-mmdb"
 
 [[bench]]
 name = "default"
+harness = false
+required-features = ["benches"]
+
+[[bench]]
+name = "integration"
+path = "benches/integration/mod.rs"
 harness = false
 required-features = ["benches"]
 

--- a/benches/integration/dummy_service.rs
+++ b/benches/integration/dummy_service.rs
@@ -1,0 +1,146 @@
+use bytes::Bytes;
+use std::io::Write;
+use std::task::{Context, Poll};
+use tower::Service;
+use vector::config::telemetry;
+use vector::event::{EstimatedJsonEncodedSizeOf, Event, EventFinalizers, EventStatus, Finalizable};
+use vector::sinks::prelude::{
+    BoxFuture, Compression, DriverResponse, EncodeResult, GroupedCountByteSize, MetaDescriptive,
+    RequestBuilder, RequestMetadata, RequestMetadataBuilder,
+};
+use vector::sinks::util::encoding::as_tracked_write;
+use vector::sinks::util::encoding::Encoder as SinkEncoder;
+
+use vector_lib::Error;
+
+// pub struct DummyRequest(ProcessedEvent<LogEvent, String>);
+pub struct DummyRequest {
+    bytes: Bytes,
+    request_metadata: RequestMetadata,
+    event_finalizers: EventFinalizers,
+}
+
+impl Finalizable for DummyRequest {
+    fn take_finalizers(&mut self) -> EventFinalizers {
+        std::mem::take(&mut self.event_finalizers)
+    }
+}
+
+impl MetaDescriptive for DummyRequest {
+    fn get_metadata(&self) -> &RequestMetadata {
+        &self.request_metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut RequestMetadata {
+        &mut self.request_metadata
+    }
+}
+
+pub struct DummyService {}
+
+impl Service<DummyRequest> for DummyService {
+    type Response = DummyServiceResponse;
+    type Error = Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: DummyRequest) -> Self::Future {
+        Box::pin(async move {
+            Ok(DummyServiceResponse {
+                byte_len: req.bytes.len(),
+                request_metadata: req.request_metadata,
+            })
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DummyLogsEncoder {}
+
+impl SinkEncoder<Vec<Event>> for DummyLogsEncoder {
+    fn encode_input(
+        &self,
+        input: Vec<Event>,
+        writer: &mut dyn Write,
+    ) -> std::io::Result<(usize, GroupedCountByteSize)> {
+        let mut byte_size = telemetry().create_request_count_byte_size();
+        for event in &input {
+            byte_size.add_event(event, event.estimated_json_encoded_size_of());
+        }
+        let written_bytes =
+            as_tracked_write::<_, _, std::io::Error>(writer, &input, |writer, value| {
+                for item in value {
+                    writer.write_all(item.as_log().get_message().unwrap().as_bytes().unwrap())?;
+                }
+                Ok(())
+            })?;
+        Ok((written_bytes, byte_size))
+    }
+}
+
+pub struct DummyRequestBuilder {
+    pub(crate) encoder: DummyLogsEncoder,
+}
+
+impl RequestBuilder<Vec<Event>> for DummyRequestBuilder {
+    type Metadata = EventFinalizers;
+    type Events = Vec<Event>;
+    type Encoder = DummyLogsEncoder;
+    type Payload = Bytes;
+    type Request = DummyRequest;
+    type Error = std::io::Error;
+
+    fn compression(&self) -> Compression {
+        Compression::None
+    }
+
+    fn encoder(&self) -> &Self::Encoder {
+        &self.encoder
+    }
+
+    fn split_input(
+        &self,
+        mut input: Vec<Event>,
+    ) -> (Self::Metadata, RequestMetadataBuilder, Self::Events) {
+        let finalizers = input.take_finalizers();
+        let builder = RequestMetadataBuilder::from_events(&input);
+        (finalizers, builder, input)
+    }
+
+    fn build_request(
+        &self,
+        metadata: Self::Metadata,
+        request_metadata: RequestMetadata,
+        payload: EncodeResult<Self::Payload>,
+    ) -> Self::Request {
+        let bytes = payload.into_payload();
+        DummyRequest {
+            bytes,
+            event_finalizers: metadata,
+            request_metadata,
+        }
+    }
+}
+
+pub struct DummyServiceResponse {
+    byte_len: usize,
+    request_metadata: RequestMetadata,
+}
+
+impl DriverResponse for DummyServiceResponse {
+    fn event_status(&self) -> EventStatus {
+        EventStatus::Delivered
+    }
+
+    fn events_sent(&self) -> &GroupedCountByteSize {
+        self.request_metadata
+            .events_estimated_json_encoded_byte_size()
+    }
+
+    fn bytes_sent(&self) -> Option<usize> {
+        Some(self.byte_len)
+    }
+}

--- a/benches/integration/dummy_sink.rs
+++ b/benches/integration/dummy_sink.rs
@@ -1,0 +1,86 @@
+use crate::dummy_service::{DummyLogsEncoder, DummyRequestBuilder, DummyService};
+
+use derivative::Derivative;
+use futures_util::{future, FutureExt, StreamExt};
+
+use tower::ServiceBuilder;
+use tracing::info;
+use vector::config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext};
+use vector::event::Event;
+use vector::sinks::prelude::{
+    default_request_builder_concurrency_limit, BatchConfig, BatcherSettings, BoxStream,
+};
+
+use vector::sinks::util::{RealtimeEventBasedDefaultBatchSettings, SinkBuilderExt};
+use vector::sinks::{Healthcheck, VectorSink};
+use vector_lib::configurable::configurable_component;
+use vector_lib::impl_generate_config_from_default;
+use vector_lib::sink::StreamSink;
+use vector_lib::Result as VectorResult;
+
+/// Configuration for the `unit_test` sink.
+#[configurable_component(sink("dummy_sink", "Unit test."))]
+#[derive(Clone, Default, Derivative)]
+#[derivative(Debug)]
+pub struct DummySinkConfig {
+    #[configurable(derived)]
+    #[serde(default)]
+    pub batch: BatchConfig<RealtimeEventBasedDefaultBatchSettings>,
+}
+
+impl_generate_config_from_default!(DummySinkConfig);
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "dummy_sink")]
+impl SinkConfig for DummySinkConfig {
+    async fn build(&self, _cx: SinkContext) -> VectorResult<(VectorSink, Healthcheck)> {
+        let batch_settings = self.batch.validate()?.into_batcher_settings()?;
+
+        let dummy_service = DummyService {};
+
+        let service = ServiceBuilder::new().service(dummy_service);
+
+        let sink = DummySink::new(batch_settings, service);
+        let healthcheck = future::ok(()).boxed();
+
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
+    }
+}
+
+pub struct DummySink {
+    batch_settings: BatcherSettings,
+    service: DummyService,
+}
+
+impl DummySink {
+    pub fn new(batch_settings: BatcherSettings, service: DummyService) -> Self {
+        Self {
+            batch_settings,
+            service,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamSink<Event> for DummySink {
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let request_builder = DummyRequestBuilder {
+            encoder: DummyLogsEncoder {},
+        };
+        input
+            .batched(self.batch_settings.as_byte_size_config())
+            .request_builder(default_request_builder_concurrency_limit(), request_builder)
+            .map(|r| r.unwrap())
+            .into_driver(self.service)
+            .run()
+            .await
+    }
+}

--- a/benches/integration/dummy_source.rs
+++ b/benches/integration/dummy_source.rs
@@ -1,0 +1,208 @@
+use bytes::Bytes;
+use derivative::Derivative;
+use serde_with::serde_as;
+use std::num::NonZeroUsize;
+use std::panic;
+use std::sync::Arc;
+
+use tokio::sync::Barrier;
+use tokio::{pin, select};
+
+use vector::codecs::Decoder;
+use vector::codecs::DecodingConfig;
+use vector::config::{LogNamespace, SourceConfig, SourceContext, SourceOutput};
+use vector::event::Event;
+use vector::shutdown::ShutdownSignal;
+use vector::sinks::prelude::FutureExt;
+use vector::sources::Source;
+use vector::SourceSender;
+
+use vector_lib::codecs::decoding::{DeserializerConfig, FramingConfig};
+use vector_lib::codecs::BytesDeserializerConfig;
+use vector_lib::configurable::configurable_component;
+use vector_lib::impl_generate_config_from_default;
+
+use vector_lib::Result as VectorResult;
+
+#[derive(Clone)]
+pub struct StartBarrier {
+    ready_barrier: Arc<Barrier>,
+    start_barrier: Arc<Barrier>,
+}
+
+impl StartBarrier {
+    pub fn new(workers: usize) -> Self {
+        Self {
+            ready_barrier: Arc::new(Barrier::new(workers + 1)),
+            start_barrier: Arc::new(Barrier::new(workers + 1)),
+        }
+    }
+
+    pub async fn worker_wait(&self) {
+        self.wait_ready().await;
+        self.wait_start().await;
+    }
+
+    pub async fn wait_ready(&self) {
+        self.ready_barrier.wait().await;
+    }
+
+    pub async fn wait_start(&self) {
+        self.start_barrier.wait().await;
+    }
+}
+
+pub fn default_decoding() -> DeserializerConfig {
+    BytesDeserializerConfig::new().into()
+}
+
+fn default_client_concurrency() -> NonZeroUsize {
+    NonZeroUsize::new(1).unwrap()
+}
+
+fn default_batch_size() -> NonZeroUsize {
+    NonZeroUsize::new(10).unwrap()
+}
+
+fn default_batch_count() -> NonZeroUsize {
+    NonZeroUsize::new(10).unwrap()
+}
+
+fn default_message_size() -> NonZeroUsize {
+    NonZeroUsize::new(1024).unwrap()
+}
+
+/// FooBar
+#[serde_as]
+#[configurable_component(source("dummy_source", "Generate dummy output"))]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default)]
+pub struct DummySourceConfig {
+    /// Number of tasks
+    #[serde(default = "default_client_concurrency")]
+    #[derivative(Default(value = "default_client_concurrency()"))]
+    pub client_concurrency: NonZeroUsize,
+
+    /// Number of message batches each task will send
+    #[serde(default = "default_batch_count")]
+    #[derivative(Default(value = "default_batch_count()"))]
+    pub batch_count: NonZeroUsize,
+
+    /// Size of each batch
+    #[serde(default = "default_batch_size")]
+    #[derivative(Default(value = "default_batch_size()"))]
+    pub batch_size: NonZeroUsize,
+
+    /// Size of each message
+    #[serde(default = "default_message_size")]
+    #[derivative(Default(value = "default_message_size()"))]
+    pub message_size: NonZeroUsize,
+
+    #[configurable(derived)]
+    #[derivative(Default(value = "default_decoding()"))]
+    #[serde(default = "default_decoding")]
+    pub decoding: DeserializerConfig,
+}
+
+impl_generate_config_from_default!(DummySourceConfig);
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "dummy_source")]
+impl SourceConfig for DummySourceConfig {
+    async fn build(&self, cx: SourceContext) -> VectorResult<Source> {
+        let log_namespace = cx.log_namespace(None);
+
+        let message_content: Bytes = (0..self.message_size.into())
+            .map(|_| rand::random::<u8>())
+            .collect();
+
+        let decoder =
+            DecodingConfig::new(FramingConfig::Bytes, self.decoding.clone(), log_namespace)
+                .build()?;
+
+        let barrier: StartBarrier = cx.extra_context.get().cloned().unwrap();
+
+        let source = DummySource {
+            concurrency: self.client_concurrency.into(),
+            batch_count: self.batch_count.into(),
+            batch_size: self.batch_size.into(),
+            message_content,
+            decoder,
+            barrier,
+        };
+
+        Ok(Box::pin(source.run(cx.out, cx.shutdown)))
+    }
+    fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
+        let schema_definition = self.decoding.schema_definition(global_log_namespace);
+
+        vec![SourceOutput::new_logs(
+            self.decoding.output_type(),
+            schema_definition,
+        )]
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone)]
+pub struct DummySource {
+    pub concurrency: usize,
+    pub batch_count: usize,
+    pub batch_size: usize,
+    pub message_content: Bytes,
+    pub decoder: Decoder,
+    pub barrier: StartBarrier,
+}
+
+impl DummySource {
+    pub async fn run(self, out: SourceSender, shutdown: ShutdownSignal) -> Result<(), ()> {
+        let mut task_handles: Vec<_> = (0..self.concurrency)
+            .map(|_| {
+                let source = self.clone();
+                let shutdown = shutdown.clone().fuse();
+                let mut out = out.clone();
+                let barrier = self.barrier.clone();
+
+                tokio::spawn(async move {
+                    pin!(shutdown);
+                    barrier.worker_wait().await;
+                    for _ in 0..source.batch_count {
+                        select! {
+                            _ = &mut shutdown => break,
+                            _ = source.send_single_batch(&mut out) => {},
+                        }
+                    }
+                })
+            })
+            .collect();
+        for task_handle in task_handles.drain(..) {
+            if let Err(e) = task_handle.await {
+                if e.is_panic() {
+                    panic::resume_unwind(e.into_panic());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_single_batch(
+        &self,
+        out: &mut SourceSender,
+        // finalizer: Option<&Arc<Finalizer>>,
+        // events_received: Registered<EventsReceived>,
+    ) {
+        let events: Vec<Event> = (0..self.batch_size)
+            .flat_map(|_| {
+                let (event, _) = self
+                    .decoder
+                    .deserializer_parse(self.message_content.clone())
+                    .unwrap();
+                event
+            })
+            .collect();
+        out.send_batch(events.into_iter()).await.unwrap();
+    }
+}

--- a/benches/integration/mod.rs
+++ b/benches/integration/mod.rs
@@ -1,0 +1,123 @@
+mod dummy_service;
+mod dummy_sink;
+mod dummy_source;
+
+use crate::dummy_source::StartBarrier;
+use criterion::{
+    criterion_group, criterion_main, BatchSize, Bencher, BenchmarkId, Criterion, Throughput,
+};
+use indoc::indoc;
+
+use tracing::info;
+use vector::config;
+use vector::extra_context::ExtraContext;
+use vector::test_util::runtime;
+use vector::topology::RunningTopology;
+
+criterion_group!(
+    name = benches;
+    // encapsulates inherent CI noise we saw in
+    // https://github.com/vectordotdev/vector/issues/5394
+    config = Criterion::default().noise_threshold(0.05);
+    targets = benchmark_update_parsing
+);
+
+criterion_main! {
+    benches,
+}
+
+fn run_benchmark(bench: &mut Bencher, params: &(usize, usize, usize, usize)) {
+    let (concurrency, batch_count, batch_size, message_size) = params.clone();
+    let config = format!(
+        indoc! {r#"
+            [sources.in]
+             type = "dummy_source"
+             client_concurrency = {}
+             batch_count = {}
+             batch_size = {}
+             message_size = {}
+
+            [sinks.out]
+             type = "dummy_sink"
+             inputs = ["in"]
+        "#},
+        concurrency, batch_count, batch_size, message_size
+    );
+
+    let rt = runtime();
+
+    bench.iter_batched(
+        || {
+            let mut config = config::load_from_str(&config, config::Format::Toml)
+                .expect(&format!("invalid TOML configuration: {}", &config));
+
+            let barrier = StartBarrier::new(concurrency);
+
+            let extra_context = ExtraContext::single_value(barrier.clone());
+
+            let topology = rt.block_on(async move {
+                config.healthchecks.set_require_healthy(false);
+                let (topology, _) = RunningTopology::start_init_validated(config, extra_context)
+                    .await
+                    .unwrap();
+                topology
+            });
+            rt.block_on(async {
+                info!("Waiting for tasks to be ready");
+                barrier.wait_ready().await;
+                info!("All tasks ready!");
+            });
+            (barrier, topology)
+        },
+        |(barrier, topology)| {
+            rt.block_on(async {
+                info!("Starting!");
+                barrier.wait_start().await;
+                info!("Started!");
+                topology.sources_finished().await;
+                info!("Stopping!");
+                topology.stop().await;
+                info!("Stopped!");
+            });
+        },
+        BatchSize::PerIteration,
+    );
+}
+
+fn benchmark_update_parsing(c: &mut Criterion) {
+    vector::test_util::trace_init();
+
+    let mut group = c.benchmark_group("integration/performance");
+
+    let concurrency_range = (50..=100).step_by(10);
+    let batch_count_range = (25..=25).step_by(1);
+    let batch_size_range = (10..=20).step_by(10);
+    let message_size_range = (512..=2048).step_by(512);
+
+    for concurrency in concurrency_range.clone() {
+        for batch_count in batch_count_range.clone() {
+            for batch_size in batch_size_range.clone() {
+                for message_size in message_size_range.clone() {
+                    let total_batches = concurrency * batch_count;
+                    let total_messages = total_batches * batch_size;
+                    let total_bytes = total_messages * message_size;
+                    group.throughput(Throughput::Bytes(total_bytes as u64));
+
+                    println!("Total batches: {}", total_batches);
+                    println!("Total messages: {}", total_messages);
+                    println!("Total megabytes: {}", total_bytes / 1024 / 1024);
+
+                    group.sample_size(100);
+                    let benchmark_id = format!("concurrency={concurrency}/batch_count={batch_count}/batch_size={batch_size}/msg_size={message_size}");
+                    group.bench_with_input(
+                        BenchmarkId::from_parameter(benchmark_id),
+                        &(concurrency, batch_count, batch_size, message_size),
+                        run_benchmark,
+                    );
+                }
+            }
+        }
+    }
+
+    group.finish();
+}


### PR DESCRIPTION
This is a bit of a weird PR, sorry. I have been playing a lot with the internals of Vector recently for a
project of mine [called pyvector](https://github.com/orf/pyvector) to integrate Vector as a Python library. Vector is a _really_ nicely structured project, and after a few wrong turns I was able to integrate it in-proces with Python as a library.

To explore how everything works (especially the service abstractions) I built the following dummy source and sink, and I figured I'd try and contribute it as a end-to-end Criterion benchmark for a couple of reasons:
1. I found it quite hard to find completely minimal/bare-bones non-test sources and sinks, so perhaps this could form an example for contributors?
2. An end-to-end benchmark involving producing and consuming might be an useful thing to include? 
   - I was curious about potential overhead incurred with having to repeatedly allocate `Vec`'s to call `SourceSender::send_batch` and I had no idea where to start profiling this.

Feel free to close this, but I figured it might be useful to someone in the future and I didn't want it to go to waste.