### PR TITLE
enhancement(topology): Speed up vector startup with big remap transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,6 +4472,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "rayon",
  "serde",
 ]
 
@@ -7335,9 +7336,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -7345,9 +7346,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -10183,6 +10184,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "ratatui",
+ "rayon",
  "rdkafka",
  "redis",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ members = [
 [workspace.dependencies]
 chrono = { version = "0.4.37", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5.4", default-features = false, features = ["derive", "error-context", "env", "help", "std", "string", "usage", "wrap_help"] }
-indexmap = { version = "2.2.6", default-features = false, features = ["serde", "std"] }
+indexmap = { version = "2.2.6", default-features = false, features = ["serde", "std", "rayon"] }
 pin-project = { version = "1.1.5", default-features = false }
 proptest = "1.4"
 proptest-derive = "0.4.0"
@@ -319,6 +319,7 @@ postgres-openssl = { version = "0.5.0", default-features = false, features = ["r
 pulsar = { version = "6.2.0", default-features = false, features = ["tokio-runtime", "auth-oauth2", "flate2", "lz4", "snap", "zstd"], optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rand_distr = { version = "0.4.3", default-features = false }
+rayon = "1.10.0"
 rdkafka = { version = "0.35.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd"], optional = true }
 redis = { version = "0.24.0", default-features = false, features = ["connection-manager", "tokio-comp", "tokio-native-tls-comp"], optional = true }
 regex = { version = "1.10.4", default-features = false, features = ["std", "perf"] }

--- a/lib/enrichment/src/tables.rs
+++ b/lib/enrichment/src/tables.rs
@@ -53,7 +53,10 @@ pub struct TableRegistry {
 impl PartialEq for TableRegistry {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.tables, &other.tables) && Arc::ptr_eq(&self.loading, &other.loading)
-            || self.tables.load().is_none() && other.tables.load().is_none() && self.loading.lock().unwrap().is_none() && other.loading.lock().unwrap().is_none()
+            || self.tables.load().is_none()
+                && other.tables.load().is_none()
+                && self.loading.lock().unwrap().is_none()
+                && other.loading.lock().unwrap().is_none()
     }
 }
 impl Eq for TableRegistry {}

--- a/lib/enrichment/src/tables.rs
+++ b/lib/enrichment/src/tables.rs
@@ -49,6 +49,15 @@ pub struct TableRegistry {
     tables: Arc<ArcSwap<Option<TableMap>>>,
 }
 
+/// Pessimistic Eq implementation for caching purposes
+impl PartialEq for TableRegistry {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.tables, &other.tables) && Arc::ptr_eq(&self.loading, &other.loading)
+            || self.tables.load().is_none() && other.tables.load().is_none() && self.loading.lock().unwrap().is_none() && other.loading.lock().unwrap().is_none()
+    }
+}
+impl Eq for TableRegistry {}
+
 impl TableRegistry {
     /// Load the given Enrichment Tables into the registry. This can be new tables
     /// loaded from the config, or tables that need to be reloaded because the

--- a/src/api/schema/components/mod.rs
+++ b/src/api/schema/components/mod.rs
@@ -289,7 +289,7 @@ pub fn update_config(config: &Config) {
                 component_type: transform.inner.get_component_name().to_string(),
                 inputs: transform.inputs.clone(),
                 outputs: get_transform_output_ids(
-                    transform.inner.as_ref(),
+                    transform,
                     "".into(),
                     config.schema.log_namespace(),
                 )

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -22,7 +22,7 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
         errors.extend(name_errors);
     }
 
-    // precache remap transforms outputs in parallel
+    // pre cache remap transforms outputs in parallel
     builder.transforms.par_iter()
         .filter(|(_, t)| t.inner.get_component_name() == "remap")
         .for_each(|(k, t)| { get_transform_outputs(t, k.clone(), builder.schema.log_namespace()); } );

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,5 +1,8 @@
 use super::{
-    builder::ConfigBuilder, graph::Graph, id::Inputs, transform::{get_transform_outputs, get_transform_output_ids},
+    builder::ConfigBuilder,
+    graph::Graph,
+    id::Inputs,
+    transform::{get_transform_output_ids, get_transform_outputs},
     validation, Config, OutputId,
 };
 
@@ -23,9 +26,13 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
     }
 
     // pre cache remap transforms outputs in parallel
-    builder.transforms.par_iter()
+    builder
+        .transforms
+        .par_iter()
         .filter(|(_, t)| t.inner.get_component_name() == "remap")
-        .for_each(|(k, t)| { get_transform_outputs(t, k.clone(), builder.schema.log_namespace()); } );
+        .for_each(|(k, t)| {
+            get_transform_outputs(t, k.clone(), builder.schema.log_namespace());
+        });
 
     expand_globs(&mut builder);
 

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -1,10 +1,8 @@
 use indexmap::{set::IndexSet, IndexMap};
 use std::collections::{HashMap, HashSet, VecDeque};
+use crate::config::transform::get_transform_outputs;
 
-use super::{
-    schema, ComponentKey, DataType, OutputId, SinkOuter, SourceOuter, SourceOutput, TransformOuter,
-    TransformOutput,
-};
+use super::{schema, ComponentKey, DataType, OutputId, SinkOuter, SourceOuter, SourceOutput, TransformOuter, TransformOutput};
 
 #[derive(Debug, Clone)]
 pub enum Node {
@@ -76,11 +74,7 @@ impl Graph {
                 id.clone(),
                 Node::Transform {
                     in_ty: transform.inner.input().data_type(),
-                    outputs: transform.inner.outputs(
-                        vector_lib::enrichment::TableRegistry::default(),
-                        &[(id.into(), schema::Definition::any())],
-                        schema.log_namespace(),
-                    ),
+                    outputs: get_transform_outputs(transform, id.clone(), schema.log_namespace())
                 },
             );
         }

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -1,8 +1,11 @@
+use crate::config::transform::get_transform_outputs;
 use indexmap::{set::IndexSet, IndexMap};
 use std::collections::{HashMap, HashSet, VecDeque};
-use crate::config::transform::get_transform_outputs;
 
-use super::{schema, ComponentKey, DataType, OutputId, SinkOuter, SourceOuter, SourceOutput, TransformOuter, TransformOutput};
+use super::{
+    schema, ComponentKey, DataType, OutputId, SinkOuter, SourceOuter, SourceOutput, TransformOuter,
+    TransformOutput,
+};
 
 #[derive(Debug, Clone)]
 pub enum Node {
@@ -74,7 +77,7 @@ impl Graph {
                 id.clone(),
                 Node::Transform {
                     in_ty: transform.inner.input().data_type(),
-                    outputs: get_transform_outputs(transform, id.clone(), schema.log_namespace())
+                    outputs: get_transform_outputs(transform, id.clone(), schema.log_namespace()),
                 },
             );
         }

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -252,12 +252,11 @@ pub fn get_transform_outputs<T: Configurable + Serialize + 'static>(
     key: ComponentKey,
     global_log_namespace: LogNamespace,
 ) -> Vec<TransformOutput> {
-    transform.inner
-        .outputs(
-            vector_lib::enrichment::TableRegistry::default(),
-            &[(key.clone().into(), schema::Definition::any())],
-            global_log_namespace,
-        )
+    transform.inner.outputs(
+        vector_lib::enrichment::TableRegistry::default(),
+        &[(key.clone().into(), schema::Definition::any())],
+        global_log_namespace,
+    )
 }
 
 /// Often we want to call outputs just to retrieve the OutputId's without needing

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -184,11 +184,7 @@ impl UnitTestBuildMetadata {
             .transforms
             .iter()
             .flat_map(|(key, transform)| {
-                get_transform_output_ids(
-                    transform,
-                    key.clone(),
-                    builder.schema.log_namespace(),
-                )
+                get_transform_output_ids(transform, key.clone(), builder.schema.log_namespace())
             })
             .collect::<HashSet<_>>();
 
@@ -455,13 +451,9 @@ async fn build_unit_test(
 fn get_loose_end_outputs_sink(config: &ConfigBuilder) -> Option<SinkOuter<String>> {
     let config = config.clone();
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
-        get_transform_output_ids(
-            transform,
-            key.clone(),
-            config.schema.log_namespace(),
-        )
-        .map(|output| output.to_string())
-        .collect::<Vec<_>>()
+        get_transform_output_ids(transform, key.clone(), config.schema.log_namespace())
+            .map(|output| output.to_string())
+            .collect::<Vec<_>>()
     });
 
     let mut loose_end_outputs = Vec::new();

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -185,7 +185,7 @@ impl UnitTestBuildMetadata {
             .iter()
             .flat_map(|(key, transform)| {
                 get_transform_output_ids(
-                    transform.inner.as_ref(),
+                    transform,
                     key.clone(),
                     builder.schema.log_namespace(),
                 )
@@ -456,7 +456,7 @@ fn get_loose_end_outputs_sink(config: &ConfigBuilder) -> Option<SinkOuter<String
     let config = config.clone();
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
         get_transform_output_ids(
-            transform.inner.as_ref(),
+            transform,
             key.clone(),
             config.schema.log_namespace(),
         )

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -175,7 +175,7 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
         }
 
         if get_transform_output_ids(
-            transform.inner.as_ref(),
+            transform,
             key.clone(),
             config.schema.log_namespace(),
         )
@@ -341,7 +341,7 @@ pub fn warnings(config: &Config) -> Vec<String> {
     });
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
         get_transform_output_ids(
-            transform.inner.as_ref(),
+            transform,
             key.clone(),
             config.schema.log_namespace(),
         )

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -174,12 +174,8 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
             errors.extend(errs.into_iter().map(|msg| format!("Transform {key} {msg}")));
         }
 
-        if get_transform_output_ids(
-            transform,
-            key.clone(),
-            config.schema.log_namespace(),
-        )
-        .any(|output| matches!(output.port, Some(output) if output == DEFAULT_OUTPUT))
+        if get_transform_output_ids(transform, key.clone(), config.schema.log_namespace())
+            .any(|output| matches!(output.port, Some(output) if output == DEFAULT_OUTPUT))
         {
             errors.push(format!(
                 "Transform {key} cannot have a named output with reserved name: `{DEFAULT_OUTPUT}`"
@@ -340,13 +336,9 @@ pub fn warnings(config: &Config) -> Vec<String> {
             .collect::<Vec<_>>()
     });
     let transform_ids = config.transforms.iter().flat_map(|(key, transform)| {
-        get_transform_output_ids(
-            transform,
-            key.clone(),
-            config.schema.log_namespace(),
-        )
-        .map(|output| ("transform", output))
-        .collect::<Vec<_>>()
+        get_transform_output_ids(transform, key.clone(), config.schema.log_namespace())
+            .map(|output| ("transform", output))
+            .collect::<Vec<_>>()
     });
 
     for (input_type, id) in transform_ids.chain(source_ids) {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1,3 +1,4 @@
+use std::ops::DerefMut;
 use std::{
     collections::HashMap,
     future::ready,
@@ -5,7 +6,6 @@ use std::{
     sync::{Arc, Mutex},
     time::Instant,
 };
-use std::ops::DerefMut;
 
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt, TryStreamExt};
 use futures_util::stream::FuturesUnordered;
@@ -417,110 +417,109 @@ impl<'a> Builder<'a> {
         let tasks = Mutex::new(&mut self.tasks);
         let rt = tokio::runtime::Handle::current();
         let span = tracing::Span::current();
-        self.config.transforms()
+        self.config
+            .transforms()
             .par_bridge()
             .filter(|(key, _)| diff.transforms.contains_new(key))
             .for_each(|(key, transform)| {
-                rt.block_on(
-                    async {
+                rt.block_on(async {
+                    let _span = span.enter();
+                    debug!(component = %key, "Building new transform.");
+
+                    let input_definitions = match schema::input_definitions(
+                        &transform.inputs,
+                        config,
+                        enrichment_tables.clone(),
+                        definition_cache.lock().unwrap().deref_mut(),
+                    ) {
+                        Ok(definitions) => definitions,
+                        Err(_) => {
+                            // We have received an error whilst retrieving the definitions,
+                            // there is no point in continuing.
+
+                            return;
+                        }
+                    };
+
+                    let merged_definition: Definition = input_definitions
+                        .iter()
+                        .map(|(_output_id, definition)| definition.clone())
+                        .reduce(Definition::merge)
+                        // We may not have any definitions if all the inputs are from metrics sources.
+                        .unwrap_or_else(Definition::any);
+
+                    let span = error_span!(
+                        "transform",
+                        component_kind = "transform",
+                        component_id = %key.id(),
+                        component_type = %transform.inner.get_component_name(),
+                    );
+
+                    let transform_outputs = transform.inner.outputs(
+                        enrichment_tables.clone(),
+                        &input_definitions,
+                        config.schema.log_namespace(),
+                    );
+
+                    // Create a map of the outputs to the list of possible definitions from those outputs.
+                    let schema_definitions = transform_outputs
+                        .clone()
+                        .into_iter()
+                        .map(|output| {
+                            let definitions = output.schema_definitions(config.schema.enabled);
+                            (output.port, definitions)
+                        })
+                        .collect::<HashMap<_, _>>();
+
+                    let context = TransformContext {
+                        key: Some(key.clone()),
+                        globals: config.global.clone(),
+                        enrichment_tables: enrichment_tables.clone(),
+                        schema_definitions,
+                        merged_schema_definition: merged_definition.clone(),
+                        schema: config.schema,
+                        extra_context: extra_context.clone(),
+                    };
+
+                    let node = TransformNode::from_parts(key.clone(), transform, transform_outputs);
+
+                    let transform = match transform
+                        .inner
+                        .build(&context)
+                        .instrument(span.clone())
+                        .await
+                    {
+                        Err(error) => {
+                            errors
+                                .lock()
+                                .unwrap()
+                                .push(format!("Transform \"{}\": {}", key, error));
+
+                            return;
+                        }
+                        Ok(transform) => transform,
+                    };
+
+                    let (input_tx, input_rx) = TopologyBuilder::standalone_memory(
+                        TOPOLOGY_BUFFER_SIZE,
+                        WhenFull::Block,
+                        &span,
+                    )
+                    .await;
+
+                    inputs
+                        .lock()
+                        .unwrap()
+                        .insert(key.clone(), (input_tx, node.inputs.clone()));
+
+                    let (transform_task, transform_outputs) = {
                         let _span = span.enter();
-                        debug!(component = %key, "Building new transform.");
+                        build_transform(transform, node, input_rx)
+                    };
 
-                        let input_definitions = match schema::input_definitions(
-                            &transform.inputs,
-                            config,
-                            enrichment_tables.clone(),
-                            definition_cache.lock().unwrap().deref_mut(),
-                        ) {
-                            Ok(definitions) => definitions,
-                            Err(_) => {
-                                // We have received an error whilst retrieving the definitions,
-                                // there is no point in continuing.
-
-                                return;
-                            }
-                        };
-
-                        let merged_definition: Definition = input_definitions
-                            .iter()
-                            .map(|(_output_id, definition)| definition.clone())
-                            .reduce(Definition::merge)
-                            // We may not have any definitions if all the inputs are from metrics sources.
-                            .unwrap_or_else(Definition::any);
-
-                        let span = error_span!(
-                            "transform",
-                            component_kind = "transform",
-                            component_id = %key.id(),
-                            component_type = %transform.inner.get_component_name(),
-                        );
-
-                        let transform_outputs = transform
-                            .inner
-                            .outputs(
-                                enrichment_tables.clone(),
-                                &input_definitions,
-                                config.schema.log_namespace(),
-                            );
-
-                        // Create a map of the outputs to the list of possible definitions from those outputs.
-                        let schema_definitions =
-                            transform_outputs.clone().into_iter()
-                            .map(|output| {
-                                let definitions = output.schema_definitions(config.schema.enabled);
-                                (output.port, definitions)
-                            })
-                            .collect::<HashMap<_, _>>();
-
-
-                        let context = TransformContext {
-                            key: Some(key.clone()),
-                            globals: config.global.clone(),
-                            enrichment_tables: enrichment_tables.clone(),
-                            schema_definitions,
-                            merged_schema_definition: merged_definition.clone(),
-                            schema: config.schema,
-                            extra_context: extra_context.clone(),
-                        };
-
-                        let node = TransformNode::from_parts(
-                            key.clone(),
-                            transform,
-                            transform_outputs
-                        );
-
-                        let transform = match transform
-                            .inner
-                            .build(&context)
-                            .instrument(span.clone())
-                            .await
-                        {
-                            Err(error) => {
-                                errors.lock().unwrap()
-                                    .push(format!("Transform \"{}\": {}", key, error));
-
-                                return;
-                            }
-                            Ok(transform) => transform,
-                        };
-
-
-                        let (input_tx, input_rx) =
-                            TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block, &span)
-                                .await;
-
-                        inputs.lock().unwrap()
-                            .insert(key.clone(), (input_tx, node.inputs.clone()));
-
-                        let (transform_task, transform_outputs) = {
-                            let _span = span.enter();
-                            build_transform(transform, node, input_rx)
-                        };
-
-                        outputs.lock().unwrap().extend(transform_outputs);
-                        tasks.lock().unwrap().insert(key.clone(), transform_task);
-                    }
-                );
+                    outputs.lock().unwrap().extend(transform_outputs);
+                    tasks.lock().unwrap().insert(key.clone(), transform_task);
+                });
             });
     }
 
@@ -756,7 +755,7 @@ impl TransformNode {
     pub fn from_parts(
         key: ComponentKey,
         transform: &TransformOuter<OutputId>,
-        transform_outputs: Vec<TransformOutput>
+        transform_outputs: Vec<TransformOutput>,
     ) -> Self {
         Self {
             key,

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -822,13 +822,17 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
 
-            let got = expanded_definitions(
+            let mut got = expanded_definitions(
                 vector_lib::enrichment::TableRegistry::default(),
                 &inputs,
                 &case,
                 &mut HashMap::default(),
             )
             .unwrap();
+
+            got.sort_by(|v1, v2| v1.0.component.id().cmp(v2.0.component.id()));
+            let mut want = case.want.clone();
+            want.sort_by(|v1, v2| v1.0.component.id().cmp(v2.0.component.id()));
             assert_eq!(got, case.want, "{}", title);
         }
     }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -5,19 +5,21 @@ use std::{
     io::{self, Read},
     path::PathBuf,
 };
+use std::sync::Mutex;
 
 use snafu::{ResultExt, Snafu};
 use vector_lib::codecs::MetricTagValues;
 use vector_lib::compile_vrl;
 use vector_lib::config::LogNamespace;
 use vector_lib::configurable::configurable_component;
+use vector_lib::enrichment::TableRegistry;
 use vector_lib::lookup::{metadata_path, owned_value_path, PathPrefix};
 use vector_lib::schema::Definition;
 use vector_lib::TimeZone;
 use vector_vrl_functions::set_semantic_meaning::MeaningList;
 use vrl::compiler::runtime::{Runtime, Terminate};
 use vrl::compiler::state::ExternalEnv;
-use vrl::compiler::{CompileConfig, ExpressionError, Function, Program, TypeState, VrlRuntime};
+use vrl::compiler::{CompileConfig, ExpressionError, Program, TypeState, VrlRuntime};
 use vrl::diagnostic::{DiagnosticMessage, Formatter, Note};
 use vrl::path;
 use vrl::path::ValuePath;
@@ -43,9 +45,9 @@ const DROPPED: &str = "dropped";
     "remap",
     "Modify your observability data as it passes through your topology using Vector Remap Language (VRL)."
 ))]
-#[derive(Clone, Debug, Derivative)]
+#[derive(Derivative)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[derivative(Default, Debug)]
 pub struct RemapConfig {
     /// The [Vector Remap Language][vrl] (VRL) program to execute for each event.
     ///
@@ -133,14 +135,39 @@ pub struct RemapConfig {
     #[configurable(derived, metadata(docs::hidden))]
     #[serde(default)]
     pub runtime: VrlRuntime,
+
+    #[configurable(derived, metadata(docs::hidden))]
+    #[serde(skip)]
+    #[derivative(Debug="ignore")]
+    pub cache: Mutex<Vec<((TableRegistry, schema::Definition), std::result::Result<(Program, String, MeaningList), String>)>>,
+}
+
+impl Clone for RemapConfig {
+    fn clone(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+            file: self.file.clone(),
+            metric_tag_values: self.metric_tag_values,
+            timezone: self.timezone,
+            drop_on_error: self.drop_on_error,
+            drop_on_abort: self.drop_on_abort,
+            reroute_dropped: self.reroute_dropped,
+            runtime: self.runtime,
+            cache: Mutex::new(Default::default()),
+        }
+    }
 }
 
 impl RemapConfig {
     fn compile_vrl_program(
         &self,
-        enrichment_tables: vector_lib::enrichment::TableRegistry,
+        enrichment_tables: TableRegistry,
         merged_schema_definition: schema::Definition,
-    ) -> Result<(Program, String, Vec<Box<dyn Function>>, CompileConfig)> {
+    ) -> Result<(Program, String, MeaningList)> {
+        if let Some((_, res)) = self.cache.lock().unwrap().iter().find(|v| v.0.0 == enrichment_tables && v.0.1 == merged_schema_definition) {
+            return res.clone().map_err(Into::into);
+        }
+
         let source = match (&self.source, &self.file) {
             (Some(source), None) => source.to_owned(),
             (None, Some(path)) => {
@@ -169,24 +196,27 @@ impl RemapConfig {
         };
         let mut config = CompileConfig::default();
 
-        config.set_custom(enrichment_tables);
+        config.set_custom(enrichment_tables.clone());
         config.set_custom(MeaningList::default());
 
-        compile_vrl(&source, &functions, &state, config)
+        let res = compile_vrl(&source, &functions, &state, config)
             .map_err(|diagnostics| {
                 Formatter::new(&source, diagnostics)
                     .colored()
                     .to_string()
-                    .into()
             })
             .map(|result| {
                 (
                     result.program,
                     Formatter::new(&source, result.warnings).to_string(),
-                    functions,
-                    result.config,
+                    result.config.get_custom::<MeaningList>().unwrap().clone(),
                 )
-            })
+            });
+
+
+        self.cache.lock().unwrap().push(((enrichment_tables, merged_schema_definition), res.clone()));
+
+        res.map_err(Into::into)
     }
 }
 
@@ -235,14 +265,10 @@ impl TransformConfig for RemapConfig {
         // step.
         let compiled = self
             .compile_vrl_program(enrichment_tables, merged_definition)
-            .map(|(program, _, _, external_context)| {
+            .map(|(program, _, meaning_list)| {
                 (
                     program.final_type_info().state,
-                    external_context
-                        .get_custom::<MeaningList>()
-                        .cloned()
-                        .expect("context exists")
-                        .0,
+                    meaning_list.0,
                 )
             })
             .map_err(|_| ());
@@ -388,7 +414,7 @@ impl Remap<AstRunner> {
         config: RemapConfig,
         context: &TransformContext,
     ) -> crate::Result<(Self, String)> {
-        let (program, warnings, _, _) = config.compile_vrl_program(
+        let (program, warnings, _) = config.compile_vrl_program(
             context.enrichment_tables.clone(),
             context.merged_schema_definition.clone(),
         )?;


### PR DESCRIPTION
We have pretty big vrl transforms in our pipeline and we started to encounter issues with how long vector takes to startup.
Startup time was reaching of up to 10 minutes, which was troublesome.

The optimization consists of 2 thing.
1. Cache vrl compilation results for remap, as it's `outputs` method is requiring to compile vrl and called many times. In the end it results in vrl compilation happening around 8 times for each remap.
2. Parallelizing topology building.

### Results
| Test | Baseline | 1 thread | 16 threads |
|--------|--------|--------|--------|
| big_conf_clean-single.yaml | 11.40s | 4.50s | 4.47s |
| big_conf_clean-6.yaml | 67.18s | 27.24s | 5.01s |
| big_conf_clean-chain.yaml | 120.38s | 31.75s | 16.69s | 

Attaching this configs. (Yes, we really have 2kloc vrl 😂)
[big_conf_clean-single.yaml.txt](https://github.com/vectordotdev/vector/files/15288561/big_conf_clean-single.yaml.txt)
[big_conf_clean-6.yaml.txt](https://github.com/vectordotdev/vector/files/15288562/big_conf_clean-6.yaml.txt)
[big_conf_clean-chain.yaml.txt](https://github.com/vectordotdev/vector/files/15288565/big_conf_clean-chain.yaml.txt) 

But there is few questions/problems I have with current implementation:
* I'm not so keen on keeping cache in `RemapConfig`, as it feels kinda hacky, but I'm not sure
* I've added rayon as a dependency, I thought about hiding it behind a feature flag, but it would be really annoying.
* I don't like pre-cache step in `compile`, but I don't want to introduce `par_iter` into every method either.
* Maybe there should be a cli option for limiting thread count

While startup time is not the most important metric, it's troubling when it takes minutes.
This optimization is extremely helpful for heavy use of vrl transforms and huge topologies, like my company's use case.

Hope we can resolve questions/problems and merge it.
