### PR TITLE
docs: Fix link to remap event data model

### DIFF
--- a/website/cue/reference/remap/concepts/metrics.cue
+++ b/website/cue/reference/remap/concepts/metrics.cue
@@ -3,7 +3,7 @@ remap: concepts: metrics: {
 	description: """
 		VRL enables you to transform [log events](\(urls.vector_log)) with very few restrictions but is much more
 		restrictive when it comes to how you can transform [metrics](\(urls.vector_metric)). See the [event data
-		model](\(urls.vector_remap_transform)/#event-data-model) documentation for a field-by-field breakdown of changes
+		model](\(urls.vector_remap_transform)#event-data-model) documentation for a field-by-field breakdown of changes
 		you can and can't make to metric events.
 		"""
 }


### PR DESCRIPTION
Reported in discord

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
