### PR TITLE
chore(config): Drop support for missing example configs

### DIFF
--- a/lib/vector-config/src/component/description.rs
+++ b/lib/vector-config/src/component/description.rs
@@ -10,9 +10,6 @@ use crate::{schema, Configurable, ConfigurableRef, GenerateError, Metadata};
 
 #[derive(Debug, Snafu, Clone, PartialEq, Eq)]
 pub enum ExampleError {
-    #[snafu(display("unable to create an example for this component"))]
-    MissingExample,
-
     #[snafu(display("component '{}' does not exist", component_name))]
     DoesNotExist { component_name: String },
 }
@@ -23,7 +20,7 @@ pub struct ComponentDescription<T: ComponentMarker + Sized> {
     description: &'static str,
     label: &'static str,
     logical_name: &'static str,
-    example_value: fn() -> Option<Value>,
+    example_value: fn() -> Value,
     config: ConfigurableRef,
     _component_type: PhantomData<T>,
 }
@@ -53,7 +50,7 @@ where
             description,
             label,
             logical_name,
-            example_value: || Some(C::generate_config()),
+            example_value: C::generate_config,
             config: ConfigurableRef::new::<C>(),
             _component_type: PhantomData,
         }
@@ -72,7 +69,7 @@ where
             .ok_or_else(|| ExampleError::DoesNotExist {
                 component_name: component_name.to_owned(),
             })
-            .and_then(|t| (t.example_value)().ok_or(ExampleError::MissingExample))
+            .map(|t| (t.example_value)())
     }
 
     /// Gets a sorted list of all registered components of the given component type.

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use serde::Serialize;
 use toml::{map::Map, Value};
 use vector_lib::configurable::component::{
-    ExampleError, SinkDescription, SourceDescription, TransformDescription,
+    SinkDescription, SourceDescription, TransformDescription,
 };
 use vector_lib::{buffers::BufferConfig, config::GlobalOptions, default_data_dir};
 
@@ -158,12 +158,10 @@ pub(crate) fn generate_example(
             let mut example = match SourceDescription::example(&source_type) {
                 Ok(example) => example,
                 Err(err) => {
-                    if err != ExampleError::MissingExample {
-                        errs.push(format!(
-                            "failed to generate source '{}': {}",
-                            source_type, err
-                        ));
-                    }
+                    errs.push(format!(
+                        "failed to generate source '{}': {}",
+                        source_type, err
+                    ));
                     Value::Table(Map::new())
                 }
             };
@@ -221,12 +219,10 @@ pub(crate) fn generate_example(
             let mut example = match TransformDescription::example(&transform_type) {
                 Ok(example) => example,
                 Err(err) => {
-                    if err != ExampleError::MissingExample {
-                        errs.push(format!(
-                            "failed to generate transform '{}': {}",
-                            transform_type, err
-                        ));
-                    }
+                    errs.push(format!(
+                        "failed to generate transform '{}': {}",
+                        transform_type, err
+                    ));
                     Value::Table(Map::new())
                 }
             };
@@ -273,9 +269,7 @@ pub(crate) fn generate_example(
             let mut example = match SinkDescription::example(&sink_type) {
                 Ok(example) => example,
                 Err(err) => {
-                    if err != ExampleError::MissingExample {
-                        errs.push(format!("failed to generate sink '{}': {}", sink_type, err));
-                    }
+                    errs.push(format!("failed to generate sink '{}': {}", sink_type, err));
                     Value::Table(Map::new())
                 }
             };


### PR DESCRIPTION
The example value field in component descriptions is wrapped in an `Option`, but all uses of it set it to `Some`. This removes the optionality and drops the resulting unreachable error case.