### PR TITLE
enhancement(enrichment_tables): allow union queries in enrichment tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -942,6 +942,7 @@ benches = [
   "sources-syslog",
   "transforms-lua",
   "transforms-sample",
+  "enrichment-tables-benches",
 ]
 dnstap-benches = ["sources-dnstap"]
 language-benches = ["sinks-socket", "sources-socket", "transforms-lua", "transforms-remap"]

--- a/Makefile
+++ b/Makefile
@@ -410,16 +410,6 @@ bench-dnsmsg-parser: ## Run dnsmsg-parser benches
 	${MAYBE_ENVIRONMENT_EXEC} CRITERION_HOME="$(CRITERION_HOME)" cargo bench --manifest-path lib/dnsmsg-parser/Cargo.toml ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
-.PHONY: bench-remap-functions
-bench-remap-functions: ## Run remap-functions benches
-	${MAYBE_ENVIRONMENT_EXEC} CRITERION_HOME="$(CRITERION_HOME)" cargo bench --manifest-path lib/vrl/stdlib/Cargo.toml ${CARGO_BENCH_FLAGS}
-	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
-
-.PHONY: bench-remap
-bench-remap: ## Run remap benches
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "remap-benches" --bench remap ${CARGO_BENCH_FLAGS}
-	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
-
 .PHONY: bench-transform
 bench-transform: ## Run transform benches
 	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "transform-benches" --bench transform ${CARGO_BENCH_FLAGS}
@@ -437,8 +427,7 @@ bench-metrics: ## Run metrics benches
 
 .PHONY: bench-all
 bench-all: ### Run all benches
-bench-all: bench-remap-functions
-	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches remap-benches  metrics-benches language-benches ${DNSTAP_BENCHES}" ${CARGO_BENCH_FLAGS}
+	${MAYBE_ENVIRONMENT_EXEC} cargo bench --no-default-features --features "benches metrics-benches language-benches ${DNSTAP_BENCHES}" ${CARGO_BENCH_FLAGS}
 	${MAYBE_ENVIRONMENT_COPY_ARTIFACTS}
 
 ##@ Checking

--- a/benches/enrichment_tables.rs
+++ b/benches/enrichment_tables.rs
@@ -60,7 +60,7 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
         let (condition, index, result_offset) = if date_range {
             // Search on the first and last field.
             (
-                vec![
+                vec![vec![
                     Condition::Equals {
                         field: "field-0",
                         value: Value::from(format!("data-0-{}", (size - 1) / 10 * 10)),
@@ -76,13 +76,13 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
                             .single()
                             .expect("invalid timestamp"),
                     },
-                ],
+                ]],
                 file.add_index(case, &["field-0"]).unwrap(),
                 5,
             )
         } else {
             (
-                vec![
+                vec![vec![
                     Condition::Equals {
                         field: "field-2",
                         value: Value::from(format!("data-2-{}", size - 1)),
@@ -91,7 +91,7 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
                         field: "field-9",
                         value: Value::from(format!("data-9-{}", size - 1)),
                     },
-                ],
+                ]],
                 file.add_index(case, &["field-2", "field-9"]).unwrap(),
                 1,
             )
@@ -112,11 +112,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_date_10", |b| {
         let (file, index, condition, expected) = setup(10, true, Case::Sensitive);
         b.iter_batched(
-            || (&file, condition.clone(), expected.clone()),
+            || (&file, &condition, expected.clone()),
             |(file, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -126,11 +126,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_hashindex_sensitive_10", |b| {
         let (file, index, condition, expected) = setup(10, false, Case::Sensitive);
         b.iter_batched(
-            || (&file, index, condition.clone(), expected.clone()),
+            || (&file, index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -140,11 +140,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_hashindex_insensitive_10", |b| {
         let (file, index, condition, expected) = setup(10, false, Case::Insensitive);
         b.iter_batched(
-            || (&file, index, condition.clone(), expected.clone()),
+            || (&file, index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Insensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Insensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -154,11 +154,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_date_1_000", |b| {
         let (file, index, condition, expected) = setup(1_000, true, Case::Sensitive);
         b.iter_batched(
-            || (&file, condition.clone(), expected.clone()),
+            || (&file, &condition, expected.clone()),
             |(file, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -168,11 +168,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_hashindex_sensitive_1_000", |b| {
         let (file, index, condition, expected) = setup(1_000, false, Case::Sensitive);
         b.iter_batched(
-            || (&file, index, condition.clone(), expected.clone()),
+            || (&file, index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -182,11 +182,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_hashindex_insensitive_1_000", |b| {
         let (file, index, condition, expected) = setup(1_000, false, Case::Insensitive);
         b.iter_batched(
-            || (&file, index, condition.clone(), expected.clone()),
+            || (&file, index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Insensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Insensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -196,11 +196,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function("enrichment_tables/file_date_1_000_000", |b| {
         let (file, index, condition, expected) = setup(1_000_000, true, Case::Sensitive);
         b.iter_batched(
-            || (&file, condition.clone(), expected.clone()),
+            || (&file, &condition, expected.clone()),
             |(file, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &[condition], None, &[index])
+                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
                 )
             },
             BatchSize::SmallInput,
@@ -212,11 +212,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
         |b| {
             let (file, index, condition, expected) = setup(1_000_000, false, Case::Sensitive);
             b.iter_batched(
-                || (&file, index, condition.clone(), expected.clone()),
+                || (&file, index, &condition, expected.clone()),
                 |(file, index, condition, expected)| {
                     assert_eq!(
                         Ok(expected),
-                        file.find_table_row(Case::Sensitive, &[condition], None, &[index])
+                        file.find_table_row(Case::Sensitive, &condition, None, &[index])
                     )
                 },
                 BatchSize::SmallInput,
@@ -229,11 +229,11 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
         |b| {
             let (file, index, condition, expected) = setup(1_000_000, false, Case::Insensitive);
             b.iter_batched(
-                || (&file, index, condition.clone(), expected.clone()),
+                || (&file, index, &condition, expected.clone()),
                 |(file, index, condition, expected)| {
                     assert_eq!(
                         Ok(expected),
-                        file.find_table_row(Case::Insensitive, &[condition], None, &[index])
+                        file.find_table_row(Case::Insensitive, &condition, None, &[index])
                     )
                 },
                 BatchSize::SmallInput,

--- a/benches/enrichment_tables.rs
+++ b/benches/enrichment_tables.rs
@@ -36,10 +36,16 @@ fn column(col: usize, row: usize) -> Value {
     }
 }
 
+enum ConditionType {
+    Equals,
+    BetweenDates,
+    Multiple,
+}
+
 fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     let mut group = c.benchmark_group("enrichment_tables_file");
 
-    let setup = |size, date_range, case| {
+    let setup = |size, condition_type, case| {
         let data = (0..size)
             .map(|row| {
                 // Add 8 columns.
@@ -57,31 +63,32 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
                 .collect::<Vec<_>>(),
         );
 
-        let (condition, index, result_offset) = if date_range {
-            // Search on the first and last field.
-            (
-                vec![vec![
-                    Condition::Equals {
-                        field: "field-0",
-                        value: Value::from(format!("data-0-{}", (size - 1) / 10 * 10)),
-                    },
-                    Condition::BetweenDates {
-                        field: "field-1",
-                        from: Utc
-                            .with_ymd_and_hms(2013, 6, 1, 0, 0, 0)
-                            .single()
-                            .expect("invalid timestamp"),
-                        to: Utc
-                            .with_ymd_and_hms(2013, 7, 1, 0, 0, 0)
-                            .single()
-                            .expect("invalid timestamp"),
-                    },
-                ]],
-                file.add_index(case, &["field-0"]).unwrap(),
-                5,
-            )
-        } else {
-            (
+        let (condition, index, result_offset) = match condition_type {
+            ConditionType::BetweenDates => {
+                // Search on the first and last field.
+                (
+                    vec![vec![
+                        Condition::Equals {
+                            field: "field-0",
+                            value: Value::from(format!("data-0-{}", (size - 1) / 10 * 10)),
+                        },
+                        Condition::BetweenDates {
+                            field: "field-1",
+                            from: Utc
+                                .with_ymd_and_hms(2013, 6, 1, 0, 0, 0)
+                                .single()
+                                .expect("invalid timestamp"),
+                            to: Utc
+                                .with_ymd_and_hms(2013, 7, 1, 0, 0, 0)
+                                .single()
+                                .expect("invalid timestamp"),
+                        },
+                    ]],
+                    vec![file.add_index(case, &["field-0"]).unwrap()],
+                    5,
+                )
+            }
+            ConditionType::Equals => (
                 vec![vec![
                     Condition::Equals {
                         field: "field-2",
@@ -92,9 +99,32 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
                         value: Value::from(format!("data-9-{}", size - 1)),
                     },
                 ]],
-                file.add_index(case, &["field-2", "field-9"]).unwrap(),
+                vec![file.add_index(case, &["field-2", "field-9"]).unwrap()],
                 1,
-            )
+            ),
+            ConditionType::Multiple => (
+                vec![
+                    vec![
+                        Condition::Equals {
+                            field: "field-2",
+                            value: Value::from(format!("data-2-{}", size - 1)),
+                        },
+                        Condition::Equals {
+                            field: "field-9",
+                            value: Value::from(format!("data-9-{}", size - 1)),
+                        },
+                    ],
+                    vec![Condition::Equals {
+                        field: "field-3",
+                        value: Value::from(format!("data-3-{}", size - 1)),
+                    }],
+                ],
+                vec![
+                    file.add_index(case, &["field-2", "field-9"]).unwrap(),
+                    file.add_index(case, &["field-3"]).unwrap(),
+                ],
+                1,
+            ),
         };
 
         let result = (0..10)
@@ -110,13 +140,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     };
 
     group.bench_function("enrichment_tables/file_date_10", |b| {
-        let (file, index, condition, expected) = setup(10, true, Case::Sensitive);
+        let (file, index, condition, expected) =
+            setup(10, ConditionType::BetweenDates, Case::Sensitive);
         b.iter_batched(
-            || (&file, &condition, expected.clone()),
-            |(file, condition, expected)| {
+            || (&file, &condition, &index, expected.clone()),
+            |(file, condition, index, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Sensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -124,13 +155,13 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_sensitive_10", |b| {
-        let (file, index, condition, expected) = setup(10, false, Case::Sensitive);
+        let (file, index, condition, expected) = setup(10, ConditionType::Equals, Case::Sensitive);
         b.iter_batched(
-            || (&file, index, &condition, expected.clone()),
+            || (&file, &index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Sensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -138,13 +169,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_insensitive_10", |b| {
-        let (file, index, condition, expected) = setup(10, false, Case::Insensitive);
+        let (file, index, condition, expected) =
+            setup(10, ConditionType::Equals, Case::Insensitive);
         b.iter_batched(
-            || (&file, index, &condition, expected.clone()),
+            || (&file, &index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Insensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Insensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -152,13 +184,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_date_1_000", |b| {
-        let (file, index, condition, expected) = setup(1_000, true, Case::Sensitive);
+        let (file, index, condition, expected) =
+            setup(1_000, ConditionType::BetweenDates, Case::Sensitive);
         b.iter_batched(
-            || (&file, &condition, expected.clone()),
-            |(file, condition, expected)| {
+            || (&file, &index, &condition, expected.clone()),
+            |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Sensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -166,13 +199,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_sensitive_1_000", |b| {
-        let (file, index, condition, expected) = setup(1_000, false, Case::Sensitive);
+        let (file, index, condition, expected) =
+            setup(1_000, ConditionType::Equals, Case::Sensitive);
         b.iter_batched(
-            || (&file, index, &condition, expected.clone()),
+            || (&file, &index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Sensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -180,13 +214,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_insensitive_1_000", |b| {
-        let (file, index, condition, expected) = setup(1_000, false, Case::Insensitive);
+        let (file, index, condition, expected) =
+            setup(1_000, ConditionType::Equals, Case::Insensitive);
         b.iter_batched(
-            || (&file, index, &condition, expected.clone()),
+            || (&file, &index, &condition, expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Insensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Insensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -194,13 +229,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_date_1_000_000", |b| {
-        let (file, index, condition, expected) = setup(1_000_000, true, Case::Sensitive);
+        let (file, index, condition, expected) =
+            setup(1_000_000, ConditionType::BetweenDates, Case::Sensitive);
         b.iter_batched(
-            || (&file, &condition, expected.clone()),
-            |(file, condition, expected)| {
+            || (&file, &index, &condition, expected.clone()),
+            |(file, index, condition, expected)| {
                 assert_eq!(
                     Ok(expected),
-                    file.find_table_row(Case::Sensitive, &condition, None, &[index])
+                    file.find_table_row(Case::Sensitive, condition, None, index)
                 )
             },
             BatchSize::SmallInput,
@@ -210,13 +246,14 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function(
         "enrichment_tables/file_hashindex_sensitive_1_000_000",
         |b| {
-            let (file, index, condition, expected) = setup(1_000_000, false, Case::Sensitive);
+            let (file, index, condition, expected) =
+                setup(1_000_000, ConditionType::Equals, Case::Sensitive);
             b.iter_batched(
-                || (&file, index, &condition, expected.clone()),
+                || (&file, &index, &condition, expected.clone()),
                 |(file, index, condition, expected)| {
                     assert_eq!(
                         Ok(expected),
-                        file.find_table_row(Case::Sensitive, &condition, None, &[index])
+                        file.find_table_row(Case::Sensitive, condition, None, index)
                     )
                 },
                 BatchSize::SmallInput,
@@ -227,19 +264,35 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     group.bench_function(
         "enrichment_tables/file_hashindex_insensitive_1_000_000",
         |b| {
-            let (file, index, condition, expected) = setup(1_000_000, false, Case::Insensitive);
+            let (file, index, condition, expected) =
+                setup(1_000_000, ConditionType::Equals, Case::Insensitive);
             b.iter_batched(
-                || (&file, index, &condition, expected.clone()),
+                || (&file, &index, &condition, expected.clone()),
                 |(file, index, condition, expected)| {
                     assert_eq!(
                         Ok(expected),
-                        file.find_table_row(Case::Insensitive, &condition, None, &[index])
+                        file.find_table_row(Case::Insensitive, condition, None, index)
                     )
                 },
                 BatchSize::SmallInput,
             );
         },
     );
+
+    group.bench_function("enrichment_tables/file_hashindex_union_1_000_000", |b| {
+        let (file, index, condition, expected) =
+            setup(1_000_000, ConditionType::Multiple, Case::Sensitive);
+        b.iter_batched(
+            || (&file, &index, &condition, expected.clone()),
+            |(file, index, condition, expected)| {
+                assert_eq!(
+                    Ok(vec![expected]),
+                    file.find_table_rows(Case::Insensitive, condition, None, index)
+                )
+            },
+            BatchSize::SmallInput,
+        );
+    });
 }
 
 fn benchmark_enrichment_tables_geoip(c: &mut Criterion) {

--- a/lib/enrichment/src/find_enrichment_table_records.rs
+++ b/lib/enrichment/src/find_enrichment_table_records.rs
@@ -133,7 +133,7 @@ impl Function for FindEnrichmentTableRecords {
         let index = condition
             .iter()
             .map(|condition| {
-                add_index(registry, &table, case_sensitive, &condition)
+                add_index(registry, &table, case_sensitive, condition)
                     .map_err(|err| Box::new(err) as Box<_>)
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/lib/enrichment/src/get_enrichment_table_record.rs
+++ b/lib/enrichment/src/get_enrichment_table_record.rs
@@ -124,7 +124,7 @@ impl Function for GetEnrichmentTableRecord {
         let index = condition
             .iter()
             .map(|condition| {
-                add_index(registry, &table, case_sensitive, &condition)
+                add_index(registry, &table, case_sensitive, condition)
                     .map_err(|err| Box::new(err) as Box<_>)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -184,7 +184,7 @@ impl FunctionExpression for GetEnrichmentTableRecordFn {
             table,
             case_sensitive,
             &condition,
-            &index,
+            index,
         )
     }
 
@@ -209,10 +209,10 @@ mod tests {
         let registry = get_table_registry();
         let func = GetEnrichmentTableRecordFn {
             table: "dummy1".to_string(),
-            condition: BTreeMap::from([(
+            condition: vec![BTreeMap::from([(
                 "field".into(),
                 expression::Literal::from("value").into(),
-            )]),
+            )])],
             index: vec![IndexHandle(999)],
             select: None,
             case_sensitive: Case::Sensitive,

--- a/lib/enrichment/src/lib.rs
+++ b/lib/enrichment/src/lib.rs
@@ -16,6 +16,8 @@ use vrl::value::{ObjectMap, Value};
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct IndexHandle(pub usize);
 
+pub type Conditions<'a> = [&'a [Condition<'a>]];
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Condition<'a> {
     /// Condition exactly matches the field value.
@@ -45,9 +47,9 @@ pub trait Table: DynClone {
     fn find_table_row<'a>(
         &self,
         case: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        index: Option<IndexHandle>,
+        index: &[IndexHandle],
     ) -> Result<ObjectMap, String>;
 
     /// Search the enrichment table data with the given condition.
@@ -56,9 +58,9 @@ pub trait Table: DynClone {
     fn find_table_rows<'a>(
         &self,
         case: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        index: Option<IndexHandle>,
+        index: &[IndexHandle],
     ) -> Result<Vec<ObjectMap>, String>;
 
     /// Hints to the enrichment table what data is going to be searched to allow it to index the

--- a/lib/enrichment/src/lib.rs
+++ b/lib/enrichment/src/lib.rs
@@ -16,7 +16,7 @@ use vrl::value::{ObjectMap, Value};
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct IndexHandle(pub usize);
 
-pub type Conditions<'a> = [&'a [Condition<'a>]];
+pub type Conditions<'a> = [Vec<Condition<'a>>];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Condition<'a> {

--- a/lib/enrichment/src/tables.rs
+++ b/lib/enrichment/src/tables.rs
@@ -37,7 +37,7 @@ use std::{
 use arc_swap::ArcSwap;
 use vrl::value::ObjectMap;
 
-use super::{Condition, IndexHandle, Table};
+use super::{Conditions, IndexHandle, Table};
 use crate::Case;
 
 /// A hashmap of name => implementation of an enrichment table.
@@ -202,9 +202,9 @@ impl TableSearch {
         &self,
         table: &str,
         case: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        index: Option<IndexHandle>,
+        index: &[IndexHandle],
     ) -> Result<ObjectMap, String> {
         let tables = self.0.load();
         if let Some(ref tables) = **tables {
@@ -224,9 +224,9 @@ impl TableSearch {
         &self,
         table: &str,
         case: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        index: Option<IndexHandle>,
+        index: &[IndexHandle],
     ) -> Result<Vec<ObjectMap>, String> {
         let tables = self.0.load();
         if let Some(ref tables) = **tables {
@@ -273,7 +273,7 @@ fn fmt_enrichment_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::DummyEnrichmentTable;
+    use crate::{test_util::DummyEnrichmentTable, Condition};
     use vrl::value::Value;
 
     #[test]
@@ -320,12 +320,12 @@ mod tests {
             tables.find_table_row(
                 "dummy1",
                 Case::Sensitive,
-                &[Condition::Equals {
+                &[&[Condition::Equals {
                     field: "thing",
                     value: Value::from("thang"),
-                }],
+                }]],
                 None,
-                None
+                &[]
             )
         );
     }
@@ -361,12 +361,12 @@ mod tests {
             tables_search.find_table_row(
                 "dummy1",
                 Case::Sensitive,
-                &[Condition::Equals {
+                &[&[Condition::Equals {
                     field: "thing",
                     value: Value::from("thang"),
-                }],
+                }]],
                 None,
-                None
+                &[]
             )
         );
     }
@@ -430,7 +430,7 @@ mod tests {
             tables
                 .get("dummy1")
                 .unwrap()
-                .find_table_row(Case::Sensitive, &Vec::new(), None, None)
+                .find_table_row(Case::Sensitive, &[], None, &[])
                 .unwrap()
                 .get("field")
                 .cloned()
@@ -443,7 +443,7 @@ mod tests {
             tables
                 .get("dummy2")
                 .unwrap()
-                .find_table_row(Case::Sensitive, &Vec::new(), None, None)
+                .find_table_row(Case::Sensitive, &[], None, &[])
                 .unwrap()
                 .get("thing")
                 .cloned()

--- a/lib/enrichment/src/tables.rs
+++ b/lib/enrichment/src/tables.rs
@@ -320,7 +320,7 @@ mod tests {
             tables.find_table_row(
                 "dummy1",
                 Case::Sensitive,
-                &[&[Condition::Equals {
+                &[vec![Condition::Equals {
                     field: "thing",
                     value: Value::from("thang"),
                 }]],
@@ -361,7 +361,7 @@ mod tests {
             tables_search.find_table_row(
                 "dummy1",
                 Case::Sensitive,
-                &[&[Condition::Equals {
+                &[vec![Condition::Equals {
                     field: "thing",
                     value: Value::from("thang"),
                 }]],

--- a/lib/enrichment/src/test_util.rs
+++ b/lib/enrichment/src/test_util.rs
@@ -5,7 +5,7 @@ use std::{
 
 use vrl::value::{ObjectMap, Value};
 
-use crate::{Case, Condition, IndexHandle, Table, TableRegistry};
+use crate::{Case, Conditions, IndexHandle, Table, TableRegistry};
 
 #[derive(Debug, Clone)]
 pub(crate) struct DummyEnrichmentTable {
@@ -37,9 +37,9 @@ impl Table for DummyEnrichmentTable {
     fn find_table_row(
         &self,
         _case: Case,
-        _condition: &[Condition],
+        _condition: &Conditions,
         _select: Option<&[String]>,
-        _index: Option<IndexHandle>,
+        _index: &[IndexHandle],
     ) -> Result<ObjectMap, String> {
         Ok(self.data.clone())
     }
@@ -47,9 +47,9 @@ impl Table for DummyEnrichmentTable {
     fn find_table_rows(
         &self,
         _case: Case,
-        _condition: &[Condition],
+        _condition: &Conditions,
         _select: Option<&[String]>,
-        _index: Option<IndexHandle>,
+        _index: &[IndexHandle],
     ) -> Result<Vec<ObjectMap>, String> {
         Ok(vec![self.data.clone()])
     }

--- a/lib/vector-vrl/tests/src/test_enrichment.rs
+++ b/lib/vector-vrl/tests/src/test_enrichment.rs
@@ -8,9 +8,9 @@ impl enrichment::Table for TestEnrichmentTable {
     fn find_table_row<'a>(
         &self,
         _case: enrichment::Case,
-        _condition: &'a [enrichment::Condition<'a>],
+        _condition: &'a enrichment::Conditions<'a>,
         _select: Option<&[String]>,
-        _index: Option<enrichment::IndexHandle>,
+        _index: &[enrichment::IndexHandle],
     ) -> Result<ObjectMap, String> {
         let mut result = ObjectMap::new();
         result.insert("id".into(), Value::from(1));
@@ -23,9 +23,9 @@ impl enrichment::Table for TestEnrichmentTable {
     fn find_table_rows<'a>(
         &self,
         _case: enrichment::Case,
-        _condition: &'a [enrichment::Condition<'a>],
+        _condition: &'a enrichment::Conditions<'a>,
         _select: Option<&[String]>,
-        _index: Option<enrichment::IndexHandle>,
+        _index: &[enrichment::IndexHandle],
     ) -> Result<Vec<ObjectMap>, String> {
         let mut result1 = ObjectMap::new();
         result1.insert("id".into(), Value::from(1));

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -1185,6 +1185,58 @@ mod tests {
     }
 
     #[test]
+    fn finds_union_with_multiple_indexes() {
+        let mut file = File::new(
+            Default::default(),
+            SystemTime::now(),
+            vec![
+                vec!["zip".into(), "zup".into()],
+                vec!["zirp".into(), "zurp".into()],
+                vec!["zirp".into(), "zoop".into()],
+                vec!["zip".into(), "zoop".into()],
+            ],
+            vec!["field1".to_string(), "field2".to_string()],
+        );
+
+        let handle1 = file.add_index(Case::Sensitive, &["field1"]).unwrap();
+        let handle2 = file.add_index(Case::Sensitive, &["field2"]).unwrap();
+
+        let condition1 = vec![Condition::Equals {
+            field: "field1",
+            value: Value::from("zip"),
+        }];
+
+        let condition2 = vec![Condition::Equals {
+            field: "field2",
+            value: Value::from("zurp"),
+        }];
+
+        assert_eq!(
+            Ok(vec![
+                ObjectMap::from([
+                    ("field1".into(), Value::from("zip")),
+                    ("field2".into(), Value::from("zup")),
+                ]),
+                ObjectMap::from([
+                    ("field1".into(), Value::from("zirp")),
+                    ("field2".into(), Value::from("zurp")),
+                ]),
+                ObjectMap::from([
+                    ("field1".into(), Value::from("zip")),
+                    ("field2".into(), Value::from("zoop")),
+                ]),
+            ]),
+            file.find_table_rows(
+                Case::Sensitive,
+                &[condition1, condition2],
+                None,
+                &[handle1, handle2]
+            )
+        );
+    }
+
+
+    #[test]
     fn merge_sorted_merges() {
         assert_eq!(
             vec![1, 2, 3, 4, 5, 6, 7, 8, 9],

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -611,9 +611,6 @@ fn merge_sorted<T>(left: &[T], right: &[T]) -> Vec<T>
 where
     T: PartialOrd + Copy + core::fmt::Debug,
 {
-    dbg!(left);
-    dbg!(right);
-
     let mut result = Vec::new();
     let mut leftidx = 0;
     let mut rightidx = 0;
@@ -625,7 +622,7 @@ where
                     result.push(*leftval);
                     leftidx += 1;
                     rightidx += 1;
-                } else if left < right {
+                } else if leftval < rightval {
                     result.push(*leftval);
                     leftidx += 1;
                 } else {
@@ -642,7 +639,6 @@ where
                 rightidx += 1;
             }
             (None, None) => {
-                dbg!(&result);
                 return result;
             }
         }
@@ -781,7 +777,7 @@ mod tests {
                 ("field1".into(), Value::from("zirp")),
                 ("field2".into(), Value::from("zurp")),
             ])),
-            file.find_table_row(Case::Sensitive, &[&[condition]], None, &[])
+            file.find_table_row(Case::Sensitive, &[vec![condition]], None, &[])
         );
     }
 
@@ -849,7 +845,7 @@ mod tests {
                 ("field1".into(), Value::from("zirp")),
                 ("field2".into(), Value::from("zurp")),
             ])),
-            file.find_table_row(Case::Sensitive, &[&[condition]], None, &[handle])
+            file.find_table_row(Case::Sensitive, &[vec![condition]], None, &[handle])
         );
     }
 
@@ -881,7 +877,7 @@ mod tests {
             ]),
             file.find_table_rows(
                 Case::Sensitive,
-                &[&[Condition::Equals {
+                &[vec![Condition::Equals {
                     field: "field1",
                     value: Value::from("zip"),
                 }]],
@@ -894,7 +890,7 @@ mod tests {
             Ok(vec![]),
             file.find_table_rows(
                 Case::Sensitive,
-                &[&[Condition::Equals {
+                &[vec![Condition::Equals {
                     field: "field1",
                     value: Value::from("ZiP"),
                 }]],
@@ -941,7 +937,7 @@ mod tests {
             ]),
             file.find_table_rows(
                 Case::Sensitive,
-                &[&[condition]],
+                &[vec![condition]],
                 Some(&["field1".to_string(), "field3".to_string()]),
                 &[handle]
             )
@@ -976,7 +972,7 @@ mod tests {
             ]),
             file.find_table_rows(
                 Case::Insensitive,
-                &[&[Condition::Equals {
+                &[vec![Condition::Equals {
                     field: "field1",
                     value: Value::from("zip"),
                 }]],
@@ -998,7 +994,7 @@ mod tests {
             ]),
             file.find_table_rows(
                 Case::Insensitive,
-                &[&[Condition::Equals {
+                &[vec![Condition::Equals {
                     field: "field1",
                     value: Value::from("ZiP"),
                 }]],
@@ -1038,7 +1034,7 @@ mod tests {
 
         let handle = file.add_index(Case::Sensitive, &["field1"]).unwrap();
 
-        let conditions = [
+        let conditions = vec![
             Condition::Equals {
                 field: "field1",
                 value: "zip".into(),
@@ -1069,7 +1065,7 @@ mod tests {
                     )
                 )
             ])),
-            file.find_table_row(Case::Sensitive, &[&conditions], None, &[handle])
+            file.find_table_row(Case::Sensitive, &[conditions], None, &[handle])
         );
     }
 
@@ -1092,7 +1088,7 @@ mod tests {
 
         assert_eq!(
             Err("no rows found".to_string()),
-            file.find_table_row(Case::Sensitive, &[&[condition]], None, &[])
+            file.find_table_row(Case::Sensitive, &[vec![condition]], None, &[])
         );
     }
 
@@ -1117,7 +1113,7 @@ mod tests {
 
         assert_eq!(
             Err("no rows found in index".to_string()),
-            file.find_table_row(Case::Sensitive, &[&[condition]], None, &[handle])
+            file.find_table_row(Case::Sensitive, &[vec![condition]], None, &[handle])
         );
     }
 
@@ -1159,10 +1155,31 @@ mod tests {
             ]),
             file.find_table_rows(
                 Case::Sensitive,
-                &[condition1.as_slice(), condition2.as_slice()],
+                &[condition1, condition2],
                 None,
                 &[handle, handle]
             )
+        );
+    }
+
+    #[test]
+    fn merge_sorted_merges() {
+        assert_eq!(
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            merge_sorted(&[1, 3, 5, 7, 9], &[2, 4, 6, 8])
+        );
+    }
+
+    #[test]
+    fn merge_sorted_removes_dedupes() {
+        assert_eq!(
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            merge_sorted(&[1, 2, 3, 4, 5, 6, 7, 8, 9], &[2, 4, 6, 8])
+        );
+
+        assert_eq!(
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            merge_sorted(&[2, 4, 6, 8], &[1, 2, 3, 4, 5, 6, 7, 8, 9])
         );
     }
 }

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -12,7 +12,7 @@ use maxminddb::{
 };
 use ordered_float::NotNan;
 use vector_lib::configurable::configurable_component;
-use vector_lib::enrichment::{Case, Condition, IndexHandle, Table};
+use vector_lib::enrichment::{Case, Condition, Conditions, IndexHandle, Table};
 use vrl::value::{ObjectMap, Value};
 
 use crate::config::{EnrichmentTableConfig, GenerateConfig};
@@ -249,9 +249,9 @@ impl Table for Geoip {
     fn find_table_row<'a>(
         &self,
         case: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        index: Option<IndexHandle>,
+        index:&[IndexHandle],
     ) -> Result<ObjectMap, String> {
         let mut rows = self.find_table_rows(case, condition, select, index)?;
 
@@ -268,11 +268,11 @@ impl Table for Geoip {
     fn find_table_rows<'a>(
         &self,
         _: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        _: Option<IndexHandle>,
+        _: &[IndexHandle],
     ) -> Result<Vec<ObjectMap>, String> {
-        match condition.first() {
+        match condition.first().unwrap().first() {
             Some(_) if condition.len() > 1 => Err("Only one condition is allowed".to_string()),
             Some(Condition::Equals { value, .. }) => {
                 let ip = value
@@ -474,12 +474,12 @@ mod tests {
         .unwrap()
         .find_table_rows(
             Case::Insensitive,
-            &[Condition::Equals {
+            &[&[Condition::Equals {
                 field: "ip",
                 value: ip.into(),
-            }],
+            }]],
             select,
-            None,
+            &[],
         )
         .unwrap()
         .pop()

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -474,7 +474,7 @@ mod tests {
         .unwrap()
         .find_table_rows(
             Case::Insensitive,
-            &[&[Condition::Equals {
+            &[vec![Condition::Equals {
                 field: "ip",
                 value: ip.into(),
             }]],

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -6,7 +6,7 @@ use std::{fs, net::IpAddr, sync::Arc, time::SystemTime};
 
 use maxminddb::{MaxMindDBError, Reader};
 use vector_lib::configurable::configurable_component;
-use vector_lib::enrichment::{Case, Condition, IndexHandle, Table};
+use vector_lib::enrichment::{Case, Condition, Conditions, IndexHandle, Table};
 use vrl::value::{ObjectMap, Value};
 
 use crate::config::{EnrichmentTableConfig, GenerateConfig};
@@ -96,9 +96,9 @@ impl Table for Mmdb {
     fn find_table_row<'a>(
         &self,
         case: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        index: Option<IndexHandle>,
+        index: &[IndexHandle],
     ) -> Result<ObjectMap, String> {
         let mut rows = self.find_table_rows(case, condition, select, index)?;
 
@@ -115,11 +115,11 @@ impl Table for Mmdb {
     fn find_table_rows<'a>(
         &self,
         _: Case,
-        condition: &'a [Condition<'a>],
+        condition: &'a Conditions<'a>,
         select: Option<&[String]>,
-        _: Option<IndexHandle>,
+        _: &[IndexHandle],
     ) -> Result<Vec<ObjectMap>, String> {
-        match condition.first() {
+        match condition.first().unwrap().first() {
             Some(_) if condition.len() > 1 => Err("Only one condition is allowed".to_string()),
             Some(Condition::Equals { value, .. }) => {
                 let ip = value
@@ -264,12 +264,12 @@ mod tests {
         .unwrap()
         .find_table_rows(
             Case::Insensitive,
-            &[Condition::Equals {
+            &[&[Condition::Equals {
                 field: "ip",
                 value: ip.into(),
-            }],
+            }]],
             select,
-            None,
+            &[],
         )
         .unwrap()
         .pop()

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -264,7 +264,7 @@ mod tests {
         .unwrap()
         .find_table_rows(
             Case::Insensitive,
-            &[&[Condition::Equals {
+            &[vec![Condition::Equals {
                 field: "ip",
                 value: ip.into(),
             }]],


### PR DESCRIPTION
This enhances the enrichment table queries to allow multiple criteria to be specified. The results from these are ORed together.

To do this the condition can now be an array, each item of the array specifies a separate condition.

For example:

```
      .zog = find_enrichment_table_records!("nug", [{ "id": .thing }, { "zog": .thung }])
```

`zog` will contain all rows where `id` is `.thing` OR where `zog` is `.thung`.


It is not possible to specify complex combinations of ANDs and ORs. eg.. `this = that AND (that = thing OR thung = thong)`, such queries go beyond the complexity we want for these tables, and could also lead to a number of performance footguns.


This change doesn't break backward compatibility. It is still possible to pass an object representing a single collection of conditions that are ANDed together.

--- 

There is still a bug in here  that needs fixing. Keeping in draft until then..

