### PR TITLE
fix(GcpAuthenticator): Improve token regeneration

### DIFF
--- a/changelog.d/19614_gcp_token_regeneration.enhancement.md
+++ b/changelog.d/19614_gcp_token_regeneration.enhancement.md
@@ -1,0 +1,3 @@
+Improves GcpAuthenticator token regeneration to avoid encountering 401 responses when a tick is missed.
+
+authors: garethpelly

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -210,7 +210,7 @@ impl GcpAuthenticator {
                         Ok(()) => {
                             sender.send_replace(());
                             let expires_in = inner.token.read().unwrap().expires_in() as u64;
-                            info!(Message = "expires_in.", %expires_in);
+                            debug!(Message = "expires_in.", %expires_in);
                             GcpAuthenticator::calculate_start_time_and_reset_interval(expires_in, &mut interval);
                         }
                         Err(error) => {

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -265,7 +265,7 @@ async fn fetch_token(creds: &Credentials, scope: &Scope) -> crate::Result<Token>
     let rsa_key = creds.rsa_key().context(InvalidRsaKeySnafu)?;
     let jwt = Jwt::new(claims, rsa_key, None);
 
-    info!(
+    debug!(
         message = "Fetching GCP authentication token.",
         project = ?creds.project(),
         iss = ?creds.iss(),

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -212,7 +212,7 @@ impl GcpAuthenticator {
                 let mut interval = tokio::time::interval_at(start, period);
                 loop {
                     interval.tick().await;
-                    info!("Renewing GCP authentication token.");
+                    debug!("Renewing GCP authentication token.");
                     match inner.regenerate_token().await {
                         Ok(()) => sender.send_replace(()),
                         Err(error) => {
@@ -255,7 +255,7 @@ async fn fetch_token(creds: &Credentials, scope: &Scope) -> crate::Result<Token>
     let rsa_key = creds.rsa_key().context(InvalidRsaKeySnafu)?;
     let jwt = Jwt::new(claims, rsa_key, None);
 
-    info!(
+    debug!(
         message = "Fetching GCP authentication token.",
         project = ?creds.project(),
         iss = ?creds.iss(),

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -210,7 +210,6 @@ impl GcpAuthenticator {
                         Ok(()) => {
                             sender.send_replace(());
                             let expires_in = inner.token.read().unwrap().expires_in() as u64;
-                            debug!(Message = "expires_in.", %expires_in);
                             GcpAuthenticator::calculate_start_time_and_reset_interval(expires_in, &mut interval);
                         }
                         Err(error) => {

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -200,13 +200,12 @@ impl GcpAuthenticator {
         match self {
             Self::Credentials(inner) => {
                 let expires_in = inner.token.read().unwrap().expires_in() as u64;
-                info!(message = "expires_in.", %expires_in);
                 let mut start = Instant::now();
                 // The first tick should occur during the known refresh window of the access token
                 if expires_in >= METADATA_TOKEN_CACHE_EXPIRY_SECS {
                     start = start
                         + Duration::from_secs(
-                            expires_in - METADATA_TOKEN_REFRESH_WINDOW_MIDPOINT_SECS
+                            expires_in - METADATA_TOKEN_REFRESH_WINDOW_MIDPOINT_SECS,
                         );
                 }
                 let period = Duration::from_secs(expires_in / 2);

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -16,7 +16,7 @@ use hyper::header::AUTHORIZATION;
 use once_cell::sync::Lazy;
 use smpl_jwt::Jwt;
 use snafu::{ResultExt, Snafu};
-use tokio::{sync::watch};
+use tokio::sync::watch;
 use vector_lib::configurable::configurable_component;
 use vector_lib::sensitive_string::SensitiveString;
 
@@ -200,7 +200,8 @@ impl GcpAuthenticator {
         match self {
             Self::Credentials(inner) => {
                 let expires_in = inner.token.read().unwrap().expires_in() as u64;
-                let mut deadline = Duration::from_secs(expires_in - METADATA_TOKEN_EXPIRY_MARGIN_SECS);
+                let mut deadline =
+                    Duration::from_secs(expires_in - METADATA_TOKEN_EXPIRY_MARGIN_SECS);
                 loop {
                     tokio::time::sleep(deadline).await;
                     debug!("Renewing GCP authentication token.");
@@ -208,8 +209,9 @@ impl GcpAuthenticator {
                         Ok(()) => {
                             sender.send_replace(());
                             let expires_in = inner.token.read().unwrap().expires_in() as u64;
-                            deadline = Duration::from_secs(expires_in - METADATA_TOKEN_EXPIRY_MARGIN_SECS);
-                        },
+                            deadline =
+                                Duration::from_secs(expires_in - METADATA_TOKEN_EXPIRY_MARGIN_SECS);
+                        }
                         Err(error) => {
                             error!(
                                 message = "Failed to update GCP authentication token.",

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -201,8 +201,8 @@ impl GcpAuthenticator {
             Self::Credentials(inner) => {
                 let expires_in = inner.token.read().unwrap().expires_in() as u64;
                 let mut deadline = Duration::from_secs(expires_in - METADATA_TOKEN_EXPIRY_MARGIN_SECS);
-                let mut _next_refresh = tokio::time::sleep(deadline);
-                _next_refresh.await;
+                let mut next_refresh = tokio::time::sleep(deadline);
+                next_refresh.await;
                 loop {
                     debug!("Renewing GCP authentication token.");
                     match inner.regenerate_token().await {
@@ -219,8 +219,8 @@ impl GcpAuthenticator {
                             deadline = Duration::from_secs(METADATA_TOKEN_ERROR_RETRY_SECS);
                         }
                     }
-                    _next_refresh = tokio::time::sleep(deadline);
-                    _next_refresh.await;
+                    next_refresh = tokio::time::sleep(deadline);
+                    next_refresh.await;
                 }
             }
             Self::ApiKey(_) | Self::None => {


### PR DESCRIPTION
Ref: https://github.com/vectordotdev/vector/issues/19614

**Summary:** This PR modifies the timing strategy used to regenerate the GCP authentication token.

I'm not a rust expert but when looking into the above GH Issue, it would seem that the 401 responses being returned from Google are likely as a result of a missed tick in the `token_regenerator` function.

Currently, the `expires_in` value (in seconds) is read from the token and divided by 2 in order to determine the Interval period to use as tick frequency.  If the `expires_in` value is 1000, there would be two ticks: one at 500 seconds in the future and another at 1000.  If the second tick is delayed for any reason, then Vector will send an out of date token to Google which will result in 401s.  Rust's default MissedTickBehaviour is [Burst](https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html#variant.Burst), and Vector will eventually trigger the tick resulting in it acquiring a new valid token. However, during this scenario events will be dropped.

Instead, this PR aims to ensure that the first tick lands at a midway point in the window (300 seconds remaining) when the Metadata server will [expire its cache](https://cloud.google.com/compute/docs/access/authenticate-workloads#applications:~:text=Access%20tokens%20expire%20after%20a%20short%20period%20of%20time.%20The%20metadata%20server%20caches%20access%20tokens%20until%20they%20have%205%20minutes%20of%20remaining%20time%20before%20they%20expire.) and provide a new valid token.  In order to prevent against any further drift with expiry and Interval ticks, the tick is reset using the expires_in value when a token is regenerated rather than relying on the start time + period calculated solely from the _first_ token acquired.

The period (expires_in / 2) calculation is maintained since its not clear to me why this strat was selected initially.

