### PR TITLE
chore(core): Allow arbitrary data types in `registered_event!`

### DIFF
--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -216,7 +216,7 @@ macro_rules! registered_event {
             $( $field:ident: $type:ty = $value:expr, )*
         }
 
-        fn emit(&$slf:ident, $data_name:ident: $data:ident)
+        fn emit(&$slf:ident, $data_name:ident: $data_type:ty)
             $emit_body:block
 
         $(fn register($fixed_name:ident: $fixed_tags:ty, $tags_name:ident: $tags:ty)
@@ -243,9 +243,9 @@ macro_rules! registered_event {
             }
 
             impl $crate::internal_event::InternalEventHandle for [<$event Handle>] {
-                type Data = $data;
+                type Data = $data_type;
 
-                fn emit(&$slf, $data_name: $data)
+                fn emit(&$slf, $data_name: $data_type)
                     $emit_body
             }
 


### PR DESCRIPTION
The data type parameter for the `emit` event function in the `registered_event!` macro is specified as an `ident`. This restricts the possible values to named types like tuples and newtype wrappers, which is the desired pattern, but that presents problems for passing in references. This change loosens the type in the macro to `ty` which allows for arbitrary types to be used.