### PR TITLE
chore(ci): Update versions of OSes used for testing the RPM package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -401,13 +401,11 @@ jobs:
     strategy:
       matrix:
         container:
-          - "quay.io/centos/centos:stream8"
           - "quay.io/centos/centos:stream9"
-          - "amazonlinux:1"
           - "amazonlinux:2"
-          - "fedora:37"
-          - "fedora:38"
+          - "amazonlinux:2023"
           - "fedora:39"
+          - "fedora:40"
     container:
       image: ${{ matrix.container }}
     steps:


### PR DESCRIPTION
Prompted because centos:stream8 repos disappeared due to it being EOL. I removed other EOL versions and added newer versions we weren't currently testing.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
