### PR TITLE
chore(docs): Remove references to HTTP Content-Length from component spec

### DIFF
--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -160,8 +160,7 @@ the reception of Vector events from an upstream component.
   - `byte_size`
     - For UDP, TCP, and Unix protocols, the total number of bytes received from
       the socket excluding the delimiter.
-    - For HTTP-based protocols, the total number of bytes in the HTTP body, as
-      represented by the `Content-Length` header.
+    - For HTTP-based protocols, the total number of bytes in the HTTP body, afetr decompression
     - For files, the total number of bytes read from the file excluding the
       delimiter.
   - `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,
@@ -188,8 +187,7 @@ the reception of Vector events from an upstream component.
   - `byte_size`
     - For UDP, TCP, and Unix protocols, the total number of bytes placed on the
       socket excluding the delimiter.
-    - For HTTP-based protocols, the total number of bytes in the HTTP body, as
-      represented by the `Content-Length` header.
+    - For HTTP-based protocols, the total number of bytes in the HTTP body before compression
     - For files, the total number of bytes written to the file excluding the
       delimiter.
   - `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,

--- a/docs/specs/component.md
+++ b/docs/specs/component.md
@@ -160,7 +160,7 @@ the reception of Vector events from an upstream component.
   - `byte_size`
     - For UDP, TCP, and Unix protocols, the total number of bytes received from
       the socket excluding the delimiter.
-    - For HTTP-based protocols, the total number of bytes in the HTTP body, afetr decompression
+    - For HTTP-based protocols, the total number of bytes in the HTTP body, after decompression
     - For files, the total number of bytes read from the file excluding the
       delimiter.
   - `protocol` - The protocol used to send the bytes (i.e., `tcp`, `udp`,


### PR DESCRIPTION

This contradicts the statement that the bytes metrics should be before compression and after decompression.

Ref: https://github.com/vectordotdev/vector/issues/20610

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
