### PR TITLE
fix(datadog sinks): Compute proper validate endpoint

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -273,6 +273,7 @@ datacenter
 datadog
 datadoghq
 datanode
+ddog
 debian
 demuxing
 dfs

--- a/changelog.d/datadog-api-endpoint.fix.md
+++ b/changelog.d/datadog-api-endpoint.fix.md
@@ -1,0 +1,3 @@
+The `endpoint` is the Datadog sinks is rewritten the same was as the Datadog
+Agent does to produce the API validation endpoint to avoid a HTTP 404 Not Found
+error when running the health check.

--- a/changelog.d/datadog-api-endpoint.fix.md
+++ b/changelog.d/datadog-api-endpoint.fix.md
@@ -1,3 +1,3 @@
-The `endpoint` is the Datadog sinks is rewritten the same was as the Datadog
-Agent does to produce the API validation endpoint to avoid a HTTP 404 Not Found
-error when running the health check.
+The `endpoint` in the Datadog sinks is rewritten the same as the Datadog Agent
+does to produce the API validation endpoint to avoid a HTTP 404 Not Found error
+when running the health check.

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -5,18 +5,16 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::schema;
 use vrl::value::Kind;
 
+use super::{
+    service::{DatadogEventsResponse, DatadogEventsService},
+    sink::DatadogEventsSink,
+};
 use crate::{
     common::datadog,
     config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
     http::HttpClient,
     sinks::{
-        datadog::{
-            events::{
-                service::{DatadogEventsResponse, DatadogEventsService},
-                sink::DatadogEventsSink,
-            },
-            get_api_base_endpoint, DatadogCommonConfig, LocalDatadogCommonConfig,
-        },
+        datadog::{DatadogCommonConfig, LocalDatadogCommonConfig},
         util::{http::HttpStatusRetryLogic, ServiceBuilderExt, TowerRequestConfig},
         Healthcheck, VectorSink,
     },
@@ -49,14 +47,6 @@ impl GenerateConfig for DatadogEventsConfig {
 }
 
 impl DatadogEventsConfig {
-    fn get_api_events_endpoint(&self, dd_common: &DatadogCommonConfig) -> http::Uri {
-        let api_base_endpoint =
-            get_api_base_endpoint(dd_common.endpoint.as_ref(), dd_common.site.as_str());
-
-        // We know this URI will be valid since we have just built it up ourselves.
-        http::Uri::try_from(format!("{}/api/v1/events", api_base_endpoint)).expect("URI not valid")
-    }
-
     fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
         let tls = MaybeTlsSettings::from_config(&self.dd_common.tls, false)?;
         let client = HttpClient::new(tls, proxy)?;
@@ -69,7 +59,7 @@ impl DatadogEventsConfig {
         client: HttpClient,
     ) -> crate::Result<VectorSink> {
         let service = DatadogEventsService::new(
-            self.get_api_events_endpoint(dd_common),
+            dd_common.get_api_endpoint("/api/v1/events")?,
             dd_common.default_api_key.clone(),
             client,
         );

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -7,13 +7,12 @@ use vector_lib::{
     sensitive_string::SensitiveString, tls::TlsEnableableConfig,
 };
 
+use super::Healthcheck;
 use crate::{
-    common::datadog::{self, get_api_base_endpoint},
+    common::datadog,
     http::{HttpClient, HttpError},
     sinks::HealthcheckError,
 };
-
-use super::Healthcheck;
 
 #[cfg(feature = "sinks-datadog_events")]
 pub mod events;
@@ -139,12 +138,19 @@ impl DatadogCommonConfig {
     /// Returns a `Healthcheck` which is a future that will be used to ensure the
     /// `<site>/api/v1/validate` endpoint is reachable.
     pub fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
-        let validate_endpoint =
-            get_api_validate_endpoint(self.endpoint.as_ref(), self.site.as_str())?;
+        let validate_endpoint = self.get_api_endpoint("/api/v1/validate")?;
 
         let api_key: String = self.default_api_key.clone().into();
 
         Ok(build_healthcheck_future(client, validate_endpoint, api_key).boxed())
+    }
+
+    /// Gets the API endpoint with a given suffix path.
+    ///
+    /// If `endpoint` is not specified, we fallback to `site`.
+    fn get_api_endpoint(&self, path: &str) -> crate::Result<Uri> {
+        let base = datadog::get_api_base_endpoint(self.endpoint.as_deref(), self.site.as_str());
+        [&base, path].join("").parse().map_err(Into::into)
     }
 }
 
@@ -165,15 +171,6 @@ async fn build_healthcheck_future(
         StatusCode::OK => Ok(()),
         other => Err(HealthcheckError::UnexpectedStatus { status: other }.into()),
     }
-}
-
-/// Gets the API endpoint for validating credentials.
-///
-/// If `endpoint` is not specified, we fallback to `site`.
-fn get_api_validate_endpoint(endpoint: Option<&String>, site: &str) -> crate::Result<Uri> {
-    let base = get_api_base_endpoint(endpoint, site);
-    let validate = format!("{}{}", base, "/api/v1/validate");
-    validate.parse::<Uri>().map_err(Into::into)
 }
 
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
When no `endpoint` is configured in the `datadog_*` sinks, they use the `site` instead to compute separate endpoints for the API key validation and for the actual service. However, when an `endpoint` _is_ configured, that URI is used for both, leading to a HTTP 404 Not Found error when trying to run the health check.

This change pulls in the API endpoint computation used by the Datadog Agent to rewrite the `endpoint` URI when it is detected as a valid Datadog domain.