### PR TITLE
chore(dev): Update sasl2-sys to fix building on GCC 14+ / CLang environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8077,9 +8077,9 @@ dependencies = [
 
 [[package]]
 name = "sasl2-sys"
-version = "0.1.20+2.1.28"
+version = "0.1.22+2.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e645bd98535fc8fd251c43ba7c7c1f9be1e0369c99b6a5ea719052a773e655c"
+checksum = "05f2a7f7efd9fc98b3a9033272df10709f5ee3fa0eabbd61a527a3a1ed6bd3c6"
 dependencies = [
  "cc",
  "duct",

--- a/changelog.d/20478_update_sasl2.fix.md
+++ b/changelog.d/20478_update_sasl2.fix.md
@@ -1,0 +1,1 @@
+This update to sasl2-sys fixes building on GCC 14+ and Clang environments (e.g. Fedora 40 and others), which fail building due to those compilers now treating various warnings as errors.

--- a/changelog.d/20478_update_sasl2.fix.md
+++ b/changelog.d/20478_update_sasl2.fix.md
@@ -1,1 +1,0 @@
-This update to sasl2-sys fixes building on GCC 14+ and Clang environments (e.g. Fedora 40 and others), which fail building due to those compilers now treating various warnings as errors.


### PR DESCRIPTION
This is a minor update to `Cargo.lock` updating `sasl2-sys` to the 0.1.22 release. This fixes building on GCC 14+ and Clang environments (e.g. Fedora 40 and others), which fail building due to those compilers now treating various warnings as errors.

See original thread in #20478

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
