### PR TITLE
chore(ci): Bump timeout for publishing new environment

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   publish-new-environment:
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: (PR comment) Get PR branch
         if: ${{ github.event_name == 'issue_comment' }}


### PR DESCRIPTION
p95 is 18 minutes which is a bit close for comfort. I've seen some timeouts recently.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
