### PR TITLE
chore(deps): Allow unicode-3 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
   "ISC",
   "MIT",
   "OpenSSL",
+  "Unicode-3.0",
   "Unicode-DFS-2016",
   "Zlib"
 ]


### PR DESCRIPTION
Required by https://github.com/vectordotdev/vector/pull/20642

License text: https://opensource.org/license/unicode-license-v3

We are already complying with the terms which are similar to `Unicode-DFS-2016`.