### PR TITLE
chore(deps): Ensure prometheus::remote_write::Errors is appropriately gated

### DIFF
--- a/src/sinks/prometheus/remote_write/mod.rs
+++ b/src/sinks/prometheus/remote_write/mod.rs
@@ -5,7 +5,6 @@
 //!
 //! [remote_write]: https://prometheus.io/docs/concepts/remote_write_spec/
 
-use snafu::prelude::*;
 use vector_lib::event::Metric;
 
 use crate::sinks::{
@@ -27,9 +26,9 @@ mod integration_tests;
 #[cfg(all(test, feature = "sources-prometheus-remote-write"))]
 pub use config::RemoteWriteConfig;
 
-#[derive(Debug, Snafu)]
+#[cfg(feature = "aws-core")]
+#[derive(Debug, snafu::Snafu)]
 enum Errors {
-    #[cfg(feature = "aws-core")]
     #[snafu(display("aws.region required when AWS authentication is in use"))]
     AwsRegionRequired,
 }


### PR DESCRIPTION
Only used when AWS configuration (`aws-core`) is enabled.

This was exposed by the Rust 1.78.0 upgrade in 58114f1345c1fe33807d14f0c8f8ae9087919d19

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
