### PR TITLE
fix(website): Update action for previews

### DIFF
--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -67,7 +67,7 @@ jobs:
         ENDPOINT: ${{ secrets.ENDPOINT }}
       run: |
         sleep 20
-        HMAC_KEY=$(echo -n $REQUEST_MESSAGE | openssl dgst -sha256 -hmac "$REQUEST_TOKEN" -binary | od -An -tx1 | tr -d ' \n'; echo)
+        HMAC_KEY=$(echo -n $REQUEST_MESSAGE | openssl dgst -sha256 -hmac "$REQUEST_TOKEN" | cut -d" " -f2)
         SIGNATURE="sha256=$HMAC_KEY"
         RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
              -H "Content-Type: application/json" \

--- a/.github/workflows/preview_site_trigger.yml
+++ b/.github/workflows/preview_site_trigger.yml
@@ -8,7 +8,7 @@ jobs:
   approval_check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ ! contains(github.head_ref, 'dependabot*') && ! contains(github.head_ref, 'gh-readonly-queue*') }}
+    if: ${{ contains(github.head_ref, 'website') }}
     steps:
       - name: Echo approval
         run: |


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
- Fixes the way the key is hashed
- Updates the workflow trigger to only run if the branch contains the word `website`

The branch creation settings on the apps was updated as well, for now only vector.dev will deploy via the workflow, the rust-doc and playground will also work after some cleanup in the app that doesn't happen via this PR