### PR TITLE
fix(kafka source): consumer subscribe in main kafka source task

### DIFF
--- a/changelog.d/20687-kafka_source_validate_deadlock.fix.md
+++ b/changelog.d/20687-kafka_source_validate_deadlock.fix.md
@@ -1,0 +1,3 @@
+The kafka source does not deadlock or cause consumer group rebalancing during `vector validate`.
+
+authors: jches

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -446,7 +446,7 @@ async fn kafka_source(
     let topics: Vec<&str> = config.topics.iter().map(|s| s.as_str()).collect();
     if let Err(e) = consumer.subscribe(&topics).context(SubscribeSnafu) {
         error!("{}", e);
-        return Err(())
+        return Err(());
     }
 
     let coordination_task = {


### PR DESCRIPTION
This moves the `consumer.subscribe(topics)` call into the main kafka source loop, to ensure that callback handlers will be set up whenever the consumer is subscribed.

In `vector validate` mode for example, the consumer sometimes receives partition assignments, and the consumer invokes pre_rebalance handlers. The main consumer task is not polled in that scenario, so callback messages sent to the coordination task are never handled and the pre_rebalance handler deadlocks. Moving the subscribe call into the main loop means that the consumer will not join the group and will not get a partition assignment unless the main source task is being polled.

Closes https://github.com/vectordotdev/vector/issues/20687