### PR TITLE
chore(ci): Validate PR author instead of repository

### DIFF
--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -49,8 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: |
-      github.event.issue.pull_request &&
-        github.repository == 'vectordotdev/vector' && (
+      github.event.issue.pull_request && (
           contains(github.event.comment.body, '/ci-run-all')
           || contains(github.event.comment.body, '/ci-run-cli')
           || contains(github.event.comment.body, '/ci-run-misc')
@@ -70,6 +69,13 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
           private_key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
+      - name: Get PR author
+        id: pr
+        uses: tspascoal/get-user-teams-membership@v3
+        with:
+          username: ${{ github.issue.user.login }}
+          team: 'Vector'
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Get PR comment author
         id: comment
         uses: tspascoal/get-user-teams-membership@v3
@@ -79,7 +85,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Validate author membership
-        if: steps.comment.outputs.isTeamMember == 'false'
+        if: steps.pr.outputs.isTeamMember == 'false' || steps.comment.outputs.isTeamMember == 'false'
         run: exit 1
 
   cli:


### PR DESCRIPTION
As repository is always `vectordotdev/vector` since this is a trigger on a comment.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
