### PR TITLE
chore(ci): Restrict integration comment workflow to PRs from maintainers

### DIFF
--- a/.github/workflows/integration-comment.yml
+++ b/.github/workflows/integration-comment.yml
@@ -57,6 +57,13 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
           private_key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
+      - name: Get PR author
+        id: pr
+        uses: tspascoal/get-user-teams-membership@v3
+        with:
+          username: ${{ github.event.issue.user.login }}
+          team: 'Vector'
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Get PR comment author
         id: comment
         uses: tspascoal/get-user-teams-membership@v3
@@ -66,7 +73,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Validate author membership
-        if: steps.comment.outputs.isTeamMember == 'false'
+        if: steps.pr.outputs.isTeamMember == 'false' || steps.comment.outputs.isTeamMember == 'false'
         run: exit 1
 
       - name: (PR comment) Get PR branch


### PR DESCRIPTION
Same fix as introduced to other comment workflow in https://github.com/vectordotdev/vector/commit/37e0c1dc5c532d8dc3b4c175566663c057158c2a

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
