### PR TITLE
enhancement(demo_logs source): Add `host` to emitted logs

### DIFF
--- a/changelog.d/demo_logs_host.enhancement.md
+++ b/changelog.d/demo_logs_host.enhancement.md
@@ -1,0 +1,2 @@
+The `demo_logs` source now adds `host` (or the configured `log_schema.host_key`) with the value of
+`localhost` to emitted logs.


### PR DESCRIPTION
I think it's reasonable for this field to be set by default.

Closes: https://github.com/vectordotdev/vector/issues/20726

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
