### PR TITLE
chore(releasing)!: Update the base image used for x86_64 artifacts to Ubuntu 16.04

### DIFF
--- a/changelog.d/update-x86-64-cross-base.breaking.md
+++ b/changelog.d/update-x86-64-cross-base.breaking.md
@@ -1,0 +1,1 @@
+Vector no longer supports running on CentOS 7 since it is now end-of-life

--- a/scripts/cross/bootstrap-centos.sh
+++ b/scripts/cross/bootstrap-centos.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -o errexit
-
-yum install -y unzip centos-release-scl
-yum install -y llvm-toolset-7
-
-# needed to compile openssl
-yum install -y perl-IPC-Cmd
-

--- a/scripts/cross/entrypoint-centos.sh
+++ b/scripts/cross/entrypoint-centos.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# shellcheck source=/dev/null
-source scl_source enable llvm-toolset-7
-exec "$@"

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -2,5 +2,3 @@ FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5
 
 COPY scripts/cross/bootstrap-ubuntu.sh scripts/environment/install-protoc.sh /
 RUN /bootstrap-ubuntu.sh && bash /install-protoc.sh
-
-ENTRYPOINT [ "/entrypoint-centos.sh" ]

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5-centos
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5
 
 COPY scripts/cross/bootstrap-centos.sh scripts/cross/entrypoint-centos.sh scripts/environment/install-protoc.sh /
 RUN /bootstrap-centos.sh && bash /install-protoc.sh

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5
 
-COPY scripts/cross/bootstrap-centos.sh scripts/cross/entrypoint-centos.sh scripts/environment/install-protoc.sh /
-RUN /bootstrap-centos.sh && bash /install-protoc.sh
+COPY scripts/cross/bootstrap-ubuntu.sh scripts/environment/install-protoc.sh /
+RUN /bootstrap-ubuntu.sh && bash /install-protoc.sh
 
 ENTRYPOINT [ "/entrypoint-centos.sh" ]


### PR DESCRIPTION
The previous base, CentOS 7, is now EOL as of 2024-06-30 so the mirrors are no longer responsive.
This drops support for the x86_64 build of Vector running on CentOS 7 (since Ubuntu 16.04 has
a newer glibc).

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
