### PR TITLE
fix!(codecs): Use '\0' delimiter as default stream decode framer

### DIFF
--- a/changelog.d/20768-default_gelf_stream_framing.breaking.md
+++ b/changelog.d/20768-default_gelf_stream_framing.breaking.md
@@ -1,0 +1,31 @@
+Now the GELF codec with stream-based sources uses null byte (`\0`) as a messages delimiter by default instead of newline (`\n`) character.
+
+### Configuration changes
+
+In order to maintain the previous behavior, you must set the `framing.method` option to the `character_delimited` method and the `framing.character_delimited.delimiter` option to `\n` when using GELF codec with stream-based sources.
+
+### Example configuration change for socket source
+
+#### Previous
+
+```toml
+[sources.my_source_id]
+type = "socket"
+address = "0.0.0.0:9000"
+mode = "tcp"
+decoding.codec = "gelf"
+```
+
+#### Current
+
+```toml
+[sources.my_source_id]
+type = "socket"
+address = "0.0.0.0:9000"
+mode = "tcp"
+decoding.codec = "gelf"
+framing.method = "character_delimited"
+framing.character_delimited.delimiter = "\n"
+```
+
+authors: jorgehermo9

--- a/changelog.d/20768-default_gelf_stream_framing.breaking.md
+++ b/changelog.d/20768-default_gelf_stream_framing.breaking.md
@@ -8,24 +8,30 @@ In order to maintain the previous behavior, you must set the `framing.method` op
 
 #### Previous
 
-```toml
-[sources.my_source_id]
-type = "socket"
-address = "0.0.0.0:9000"
-mode = "tcp"
-decoding.codec = "gelf"
+```yaml
+sources:
+  my_source_id:
+    type: "socket"
+    address: "0.0.0.0:9000"
+    mode: "tcp"
+    decoding:
+      codec: "gelf"
 ```
 
 #### Current
 
-```toml
-[sources.my_source_id]
-type = "socket"
-address = "0.0.0.0:9000"
-mode = "tcp"
-decoding.codec = "gelf"
-framing.method = "character_delimited"
-framing.character_delimited.delimiter = "\n"
+```yaml
+sources:
+  my_source_id:
+    type: "socket"
+    address: "0.0.0.0:9000"
+    mode: "tcp"
+    decoding:
+      codec: "gelf"
+    framing:
+    method: "character_delimited"
+    character_delimited:
+      delimiter: "\n"
 ```
 
 authors: jorgehermo9

--- a/changelog.d/20768-default_gelf_stream_framing.breaking.md
+++ b/changelog.d/20768-default_gelf_stream_framing.breaking.md
@@ -1,4 +1,4 @@
-Now the GELF codec with stream-based sources uses null byte (`\0`) as a messages delimiter by default instead of newline (`\n`) character.
+Now the GELF codec with stream-based sources uses null byte (`\0`) by default as messages delimiter instead of newline (`\n`) character.
 
 ### Configuration changes
 

--- a/changelog.d/20768-default_gelf_stream_framing.breaking.md
+++ b/changelog.d/20768-default_gelf_stream_framing.breaking.md
@@ -1,4 +1,4 @@
-Now the GELF codec with stream-based sources uses null byte (`\0`) by default as messages delimiter instead of newline (`\n`) character.
+Now the GELF codec with stream-based sources uses null byte (`\0`) by default as messages delimiter instead of newline (`\n`) character. This better matches GELF server behavior.
 
 ### Configuration changes
 

--- a/changelog.d/20768-default_gelf_stream_framing.breaking.md
+++ b/changelog.d/20768-default_gelf_stream_framing.breaking.md
@@ -29,7 +29,7 @@ sources:
     decoding:
       codec: "gelf"
     framing:
-    method: "character_delimited"
+      method: "character_delimited"
     character_delimited:
       delimiter: "\n"
 ```

--- a/lib/codecs/src/decoding/framing/character_delimited.rs
+++ b/lib/codecs/src/decoding/framing/character_delimited.rs
@@ -15,6 +15,12 @@ pub struct CharacterDelimitedDecoderConfig {
 }
 
 impl CharacterDelimitedDecoderConfig {
+    /// Creates a `CharacterDelimitedDecoderConfig` with the specified delimiter and default max length.
+    pub const fn new(delimiter: u8) -> Self {
+        Self {
+            character_delimited: CharacterDelimitedDecoderOptions::new(delimiter, None),
+        }
+    }
     /// Build the `CharacterDelimitedDecoder` from this configuration.
     pub const fn build(&self) -> CharacterDelimitedDecoder {
         if let Some(max_length) = self.character_delimited.max_length {
@@ -53,7 +59,7 @@ pub struct CharacterDelimitedDecoderOptions {
 
 impl CharacterDelimitedDecoderOptions {
     /// Create a `CharacterDelimitedDecoderOptions` with a delimiter and optional max_length.
-    pub fn new(delimiter: u8, max_length: Option<usize>) -> Self {
+    pub const fn new(delimiter: u8, max_length: Option<usize>) -> Self {
         Self {
             delimiter,
             max_length,

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -478,12 +478,14 @@ mod tests {
     fn gelf_stream_default_framing_is_null_delimited() {
         let deserializer_config = DeserializerConfig::from(GelfDeserializerConfig::default());
         let framing_config = deserializer_config.default_stream_framing();
-        matches!(framing_config, FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig{
-            character_delimited: CharacterDelimitedDecoderOptions {
-                delimiter: 0,
-                max_length: None,
-            }
-        }));
-        })
+        matches!(
+            framing_config,
+            FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig {
+                character_delimited: CharacterDelimitedDecoderOptions {
+                    delimiter: 0,
+                    max_length: None,
+                }
+            })
+        );
     }
 }

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -334,7 +334,6 @@ impl DeserializerConfig {
             DeserializerConfig::Native => FramingConfig::LengthDelimited(Default::default()),
             DeserializerConfig::Bytes
             | DeserializerConfig::Json(_)
-            | DeserializerConfig::Gelf(_)
             | DeserializerConfig::NativeJson(_) => {
                 FramingConfig::NewlineDelimited(Default::default())
             }
@@ -342,6 +341,9 @@ impl DeserializerConfig {
             #[cfg(feature = "syslog")]
             DeserializerConfig::Syslog(_) => FramingConfig::NewlineDelimited(Default::default()),
             DeserializerConfig::Vrl(_) => FramingConfig::Bytes,
+            DeserializerConfig::Gelf(_) => {
+                FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig::new(0))
+            }
         }
     }
 

--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -469,3 +469,21 @@ impl format::Deserializer for Deserializer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gelf_stream_default_framing_is_null_delimited() {
+        let deserializer_config = DeserializerConfig::from(GelfDeserializerConfig::default());
+        let framing_config = deserializer_config.default_stream_framing();
+        matches!(framing_config, FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig{
+            character_delimited: CharacterDelimitedDecoderOptions {
+                delimiter: 0,
+                max_length: None,
+            }
+        }));
+        })
+    }
+}

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -362,12 +362,14 @@ impl SerializerConfig {
                 FramingConfig::LengthDelimited(LengthDelimitedEncoderConfig::default())
             }
             SerializerConfig::Csv(_)
-            | SerializerConfig::Gelf
             | SerializerConfig::Json(_)
             | SerializerConfig::Logfmt
             | SerializerConfig::NativeJson
             | SerializerConfig::RawMessage
             | SerializerConfig::Text(_) => FramingConfig::NewlineDelimited,
+            SerializerConfig::Gelf => {
+                FramingConfig::CharacterDelimited(CharacterDelimitedEncoderConfig::new(0))
+            }
         }
     }
 

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -164,7 +164,7 @@ mod tests {
             &Value::from("A short message")
         );
         assert_eq!(
-            event.get("additional_field").unwrap(),
+            event.get("_additional_field").unwrap(),
             &Value::from("additional_content")
         );
 

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -106,7 +106,7 @@ mod tests {
     use futures::{stream, StreamExt};
     use tokio_util::{codec::FramedRead, io::StreamReader};
     use vector_lib::codecs::{
-        decoding::{Deserializer,DeserializerConfig, Framer},
+        decoding::{Deserializer, DeserializerConfig, Framer, GelfDeserializerConfig},
         JsonDeserializer, NewlineDelimitedDecoder, StreamDecodingError,
     };
     use vrl::value::Value;
@@ -154,10 +154,7 @@ mod tests {
         let reader = StreamReader::new(stream);
         let deserializer_config = DeserializerConfig::from(GelfDeserializerConfig::default());
         let framing_config = deserializer_config.default_stream_framing();
-        let decoder = Decoder::new(
-            framing_config.build().unwrap(),
-            deserializer_config.build().unwrap(),
-        );
+        let decoder = Decoder::new(framing_config.build(), deserializer_config.build().unwrap());
         let mut stream = FramedRead::new(reader, decoder);
 
         let next = stream.next().await.unwrap();

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -163,5 +163,12 @@ mod tests {
             event.get("short_message").unwrap(),
             &Value::from("A short message")
         );
+
+        let next = stream.next().await.unwrap();
+        let event = next.unwrap().0.pop().unwrap().into_log();
+        assert_eq!(
+            event.get("short_message").unwrap(),
+            &Value::from("Another short message")
+        );
     }
 }

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -106,7 +106,7 @@ mod tests {
     use futures::{stream, StreamExt};
     use tokio_util::{codec::FramedRead, io::StreamReader};
     use vector_lib::codecs::{
-        decoding::{Deserializer, DeserializerConfig, Framer, GelfDeserializerConfig},
+        decoding::{Deserializer, Framer},
         JsonDeserializer, NewlineDelimitedDecoder, StreamDecodingError,
     };
     use vrl::value::Value;
@@ -137,42 +137,5 @@ mod tests {
         let next = stream.next().await.unwrap();
         let event = next.unwrap().0.pop().unwrap().into_log();
         assert_eq!(event.get("bar").unwrap(), &Value::from(2));
-    }
-
-    #[tokio::test]
-    async fn gelf_stream_decoding() {
-        let iter = stream::iter(
-            [
-                r#"{"version": "1.1", "host": "example.org", "short_message": "A short message", "timestamp": 1620000000, "level": 6, "_additional_field": "additional_content"}"#,
-                "\0",
-                r#"{"version": "1.1", "host": "example.org", "short_message": "Another short message", "timestamp": 1620000000, "level": 6}"#,
-            ]
-            .into_iter()
-            .map(Bytes::from),
-        );
-        let stream = iter.map(Ok::<_, std::io::Error>);
-        let reader = StreamReader::new(stream);
-        let deserializer_config = DeserializerConfig::from(GelfDeserializerConfig::default());
-        let framing_config = deserializer_config.default_stream_framing();
-        let decoder = Decoder::new(framing_config.build(), deserializer_config.build().unwrap());
-        let mut stream = FramedRead::new(reader, decoder);
-
-        let next = stream.next().await.unwrap();
-        let event = next.unwrap().0.pop().unwrap().into_log();
-        assert_eq!(
-            event.get("message").unwrap(),
-            &Value::from("A short message")
-        );
-        assert_eq!(
-            event.get("_additional_field").unwrap(),
-            &Value::from("additional_content")
-        );
-
-        let next = stream.next().await.unwrap();
-        let event = next.unwrap().0.pop().unwrap().into_log();
-        assert_eq!(
-            event.get("message").unwrap(),
-            &Value::from("Another short message")
-        );
     }
 }

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -143,7 +143,7 @@ mod tests {
     async fn gelf_stream_decoding() {
         let iter = stream::iter(
             [
-                r#"{"version": "1.1", "host": "example.org", "short_message": "A short message", "timestamp": 1620000000, "level": 6}"#,
+                r#"{"version": "1.1", "host": "example.org", "short_message": "A short message", "timestamp": 1620000000, "level": 6, "_additional_field": "additional_content"}"#,
                 "\0",
                 r#"{"version": "1.1", "host": "example.org", "short_message": "Another short message", "timestamp": 1620000000, "level": 6}"#,
             ]
@@ -162,6 +162,10 @@ mod tests {
         assert_eq!(
             event.get("message").unwrap(),
             &Value::from("A short message")
+        );
+        assert_eq!(
+            event.get("additional_field").unwrap(),
+            &Value::from("additional_content")
         );
 
         let next = stream.next().await.unwrap();

--- a/src/codecs/decoding/decoder.rs
+++ b/src/codecs/decoding/decoder.rs
@@ -140,7 +140,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gelf_streaming_decoding() {
+    async fn gelf_stream_decoding() {
         let iter = stream::iter(
             [
                 r#"{"version": "1.1", "host": "example.org", "short_message": "A short message", "timestamp": 1620000000, "level": 6}"#,
@@ -160,14 +160,14 @@ mod tests {
         let next = stream.next().await.unwrap();
         let event = next.unwrap().0.pop().unwrap().into_log();
         assert_eq!(
-            event.get("short_message").unwrap(),
+            event.get("message").unwrap(),
             &Value::from("A short message")
         );
 
         let next = stream.next().await.unwrap();
         let event = next.unwrap().0.pop().unwrap().into_log();
         assert_eq!(
-            event.get("short_message").unwrap(),
+            event.get("message").unwrap(),
             &Value::from("Another short message")
         );
     }


### PR DESCRIPTION
Closes #20768.

I think that in my local environment some test fail but has nothing to do with the changes I did. Could you trigger them here and if its fails too in the CI I review what could happen?

Thanks