### PR TITLE
docs(remap transform): Fix example syntax

### DIFF
--- a/website/cue/reference/remap/errors/305_divide_by_zero_error.cue
+++ b/website/cue/reference/remap/errors/305_divide_by_zero_error.cue
@@ -16,7 +16,7 @@ remap: errors: "305": {
 
 		```coffee
 		result, err = 27 / .some_value
-		if err != nil {
+		if err != null {
 			# Handle error
 		}
 		```


### PR DESCRIPTION
As far as I can tell, VRL uses "null", not "nil", so this example is not correct. On the errors page, a bit down from the fixed example, you can see `null` used: https://vector.dev/docs/reference/vrl/errors/#handling 👍 
