### PR TITLE
chore(docs): Regenerate component docs

### DIFF
--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -476,9 +476,9 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	group_name: {
 		description: """

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -208,9 +208,9 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 		type: string: examples: ["service"]
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	region: {
 		description: """

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -455,9 +455,9 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	partition_key_field: {
 		description: """

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -455,9 +455,9 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	partition_key_field: {
 		description: """

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -564,9 +564,9 @@ base: components: sinks: aws_s3: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	filename_append_uuid: {
 		description: """

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -386,9 +386,9 @@ base: components: sinks: aws_sns: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	message_deduplication_id: {
 		description: """

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -386,9 +386,9 @@ base: components: sinks: aws_sqs: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	message_deduplication_id: {
 		description: """

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -186,9 +186,9 @@ base: components: sinks: elasticsearch: configuration: {
 		required:    false
 		type: object: options: {
 			endpoint: {
-				description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+				description: "Custom endpoint for use with AWS-compatible services."
 				required:    false
-				type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+				type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 			}
 			region: {
 				description: """

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -174,9 +174,9 @@ base: components: sinks: prometheus_remote_write: configuration: {
 		required:    false
 		type: object: options: {
 			endpoint: {
-				description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+				description: "Custom endpoint for use with AWS-compatible services."
 				required:    false
-				type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+				type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 			}
 			region: {
 				description: """

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -364,9 +364,9 @@ base: components: sources: aws_s3: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	framing: {
 		description: """

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -368,9 +368,9 @@ base: components: sources: aws_sqs: configuration: {
 		type: bool: default: true
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
+		description: "Custom endpoint for use with AWS-compatible services."
 		required:    false
-		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
+		type: string: examples: ["http://127.0.0.0:5000/path/to/service"]
 	}
 	framing: {
 		description: """


### PR DESCRIPTION
Was missed in https://github.com/vectordotdev/vector/pull/20774 because the check didn't run.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
