### PR TITLE
chore(docs): Document that AWS `endpoint` config needs to have a trailing `/`

### DIFF
--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -14,7 +14,9 @@ pub struct RegionOrEndpoint {
     pub region: Option<String>,
 
     /// Custom endpoint for use with AWS-compatible services.
-    #[configurable(metadata(docs::examples = "http://127.0.0.0:5000/path/to/service"))]
+    ///
+    /// Note: the trailing slash is required when building the locator.
+    #[configurable(metadata(docs::examples = "http://127.0.0.0:5000/path/to/service/"))]
     #[configurable(metadata(docs::advanced))]
     pub endpoint: Option<String>,
 }

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -476,8 +476,12 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	group_name: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -208,8 +208,12 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 		type: string: examples: ["service"]
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	region: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -455,8 +455,12 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	partition_key_field: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -455,8 +455,12 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	partition_key_field: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -564,8 +564,12 @@ base: components: sinks: aws_s3: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	filename_append_uuid: {

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -386,8 +386,12 @@ base: components: sinks: aws_sns: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	message_deduplication_id: {

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -386,8 +386,12 @@ base: components: sinks: aws_sqs: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	message_deduplication_id: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -186,8 +186,12 @@ base: components: sinks: elasticsearch: configuration: {
 		required:    false
 		type: object: options: {
 			endpoint: {
-				description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-				required:    false
+				description: """
+					Custom endpoint for use with AWS-compatible services.
+
+					Note: the trailing slash is required when building the locator.
+					"""
+				required: false
 				type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 			}
 			region: {

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -174,8 +174,12 @@ base: components: sinks: prometheus_remote_write: configuration: {
 		required:    false
 		type: object: options: {
 			endpoint: {
-				description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-				required:    false
+				description: """
+					Custom endpoint for use with AWS-compatible services.
+
+					Note: the trailing slash is required when building the locator.
+					"""
+				required: false
 				type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 			}
 			region: {

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -364,8 +364,12 @@ base: components: sources: aws_s3: configuration: {
 		}
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	framing: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -368,8 +368,12 @@ base: components: sources: aws_sqs: configuration: {
 		type: bool: default: true
 	}
 	endpoint: {
-		description: "Custom endpoint for use with AWS-compatible services. Note: the trailing slash is required when building the locator."
-		required:    false
+		description: """
+			Custom endpoint for use with AWS-compatible services.
+
+			Note: the trailing slash is required when building the locator.
+			"""
+		required: false
 		type: string: examples: ["http://127.0.0.0:5000/path/to/service/"]
 	}
 	framing: {


### PR DESCRIPTION
Recreates https://github.com/vectordotdev/vector/pull/20774

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
