### PR TITLE
fix(gcs): replace // with / when merging base url and object key

### DIFF
--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -112,9 +112,9 @@ impl Service<GcsRequest> for GcsService {
         let settings = request.settings;
         let metadata = request.metadata;
 
-        let uri = format!("{}{}", self.base_url, request.key)
-            .parse::<Uri>()
-            .unwrap();
+        let uri = merge_url_and_key(&self.base_url, &request.key);
+
+        let uri = uri.parse::<Uri>().unwrap();
 
         let mut builder = Request::put(uri);
         let headers = builder.headers_mut().unwrap();
@@ -140,5 +140,43 @@ impl Service<GcsRequest> for GcsService {
             let result = client.call(http_request).await;
             result.map(|inner| GcsResponse { inner, metadata })
         })
+    }
+}
+
+/// converts // to / between the base url and the key if necessary
+fn merge_url_and_key(base_url: &str, key: &str) -> String {
+    let key = if base_url.ends_with("/") {
+        key.strip_prefix('/').unwrap_or_else(|| key)
+    } else if !key.starts_with('/') {
+        &format!("/{}", key)
+    } else {
+        key
+    };
+
+    format!("{}{}", base_url, key)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sinks::gcs_common::service::merge_url_and_key;
+
+    #[test]
+    fn merge_base_url_and_key() {
+        assert_eq!(
+            "https://baseurl/key",
+            merge_url_and_key("https://baseurl/", "/key")
+        );
+        assert_eq!(
+            "https://baseurl/key",
+            merge_url_and_key("https://baseurl/", "key")
+        );
+        assert_eq!(
+            "https://baseurl/key",
+            merge_url_and_key("https://baseurl", "/key")
+        );
+        assert_eq!(
+            "https://baseurl/key",
+            merge_url_and_key("https://baseurl", "key")
+        );
     }
 }

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -148,8 +148,6 @@ fn merge_url_and_key(base_url: &str, key: &str) -> String {
     let base_url = base_url.strip_suffix('/').unwrap_or(base_url);
     let key = key.strip_prefix('/').unwrap_or(key);
     format!("{base_url}/{key}")
-
-    format!("{}{}", base_url, key)
 }
 
 #[cfg(test)]

--- a/src/sinks/gcs_common/service.rs
+++ b/src/sinks/gcs_common/service.rs
@@ -145,13 +145,9 @@ impl Service<GcsRequest> for GcsService {
 
 /// converts // to / between the base url and the key if necessary
 fn merge_url_and_key(base_url: &str, key: &str) -> String {
-    let key = if base_url.ends_with("/") {
-        key.strip_prefix('/').unwrap_or_else(|| key)
-    } else if !key.starts_with('/') {
-        &format!("/{}", key)
-    } else {
-        key
-    };
+    let base_url = base_url.strip_suffix('/').unwrap_or(base_url);
+    let key = key.strip_prefix('/').unwrap_or(key);
+    format!("{base_url}/{key}")
 
     format!("{}{}", base_url, key)
 }


### PR DESCRIPTION
Replaces `//` with `/` when merging base url and object keys to avoid creating "/" root folder.