### PR TITLE
feat(http_server): Add custom response header configuration

### DIFF
--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -70,6 +70,11 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         decode(encoding_header, body)
     }
 
+    // This function can be defined to enrich warp::Replies.
+    fn enrich_reply<T : warp::Reply>(&self, reply: T) -> T {
+        reply
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn run(
         self,
@@ -186,7 +191,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                     });
                     Err(r)
                 }
-            });
+            }).map(|reply| &self.enrich_reply(reply));
 
             let span = Span::current();
             let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {


### PR DESCRIPTION
Add a `custom_response_headers` option to `SimpleHttpConfig` to add the given headers to all Http responses.

Closes: #20395
