### PR TITLE
feat(tap): Add duration flag to vector tap

### DIFF
--- a/changelog.d/vector_tap_duration_flag.enhancement.md
+++ b/changelog.d/vector_tap_duration_flag.enhancement.md
@@ -1,3 +1,3 @@
-The `vector tap` command now has an optional `duration` flag that allows you to specify the duration of the
+The `vector tap` command now has an optional `duration_ms` flag that allows you to specify the duration of the
 tap. By default, the tap will run indefinitely, but if a duration is specified (in milliseconds) the tap will
 automatically stop after that duration has elapsed.

--- a/changelog.d/vector_tap_duration_flag.enhancement.md
+++ b/changelog.d/vector_tap_duration_flag.enhancement.md
@@ -1,0 +1,3 @@
+The `vector tap` command now has an optional `duration` flag that allows you to specify the duration of the
+tap. By default, the tap will run indefinitely, but if a duration is specified (in milliseconds) the tap will
+automatically stop after that duration has elapsed.

--- a/changelog.d/vector_tap_duration_flag.enhancement.md
+++ b/changelog.d/vector_tap_duration_flag.enhancement.md
@@ -1,3 +1,5 @@
 The `vector tap` command now has an optional `duration_ms` flag that allows you to specify the duration of the
 tap. By default, the tap will run indefinitely, but if a duration is specified (in milliseconds) the tap will
 automatically stop after that duration has elapsed.
+
+authors: ArunPiduguDD

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -100,7 +100,8 @@ async fn run(
     };
 
     let start_time = Instant::now();
-    let stream_duration = opts.duration.map(Duration::from_millis).unwrap_or(Duration::MAX);
+    let stream_duration = 
+        opts.duration_ms.map(Duration::from_millis).unwrap_or(Duration::MAX);
 
     // Loop over the returned results, printing out tap events.
     #[allow(clippy::print_stdout)]
@@ -137,7 +138,7 @@ async fn run(
                 }
             Err(_) =>
                 // If the stream times out, that indicates the duration specified by the user
-                // has elapsed. We should exit gracefully. 
+                // has elapsed. We should exit gracefully.
                 return exitcode::OK,
             Ok(_) =>
                 return exitcode::TEMPFAIL,

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, collections::BTreeMap, time::Duration};
-use std::time::Instant;
 use colored::{ColoredString, Colorize};
+use std::time::Instant;
+use std::{borrow::Cow, collections::BTreeMap, time::Duration};
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use url::Url;
@@ -100,8 +100,10 @@ async fn run(
     };
 
     let start_time = Instant::now();
-    let stream_duration =
-        opts.duration_ms.map(Duration::from_millis).unwrap_or(Duration::MAX);
+    let stream_duration = opts
+        .duration_ms
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::MAX);
 
     // Loop over the returned results, printing out tap events.
     #[allow(clippy::print_stdout)]
@@ -112,10 +114,9 @@ async fn run(
             return exitcode::OK;
         }
 
-        let message =
-            timeout(stream_duration - time_elapsed, stream.next()).await;
+        let message = timeout(stream_duration - time_elapsed, stream.next()).await;
         match message {
-            Ok(Some(Some(res))) =>
+            Ok(Some(Some(res))) => {
                 if let Some(d) = res.data {
                     for tap_event in d.output_events_by_component_id_patterns.iter() {
                         match tap_event {
@@ -136,12 +137,14 @@ async fn run(
                         }
                     }
                 }
+            }
             Err(_) =>
-                // If the stream times out, that indicates the duration specified by the user
-                // has elapsed. We should exit gracefully.
-                return exitcode::OK,
-            Ok(_) =>
-                return exitcode::TEMPFAIL,
+            // If the stream times out, that indicates the duration specified by the user
+            // has elapsed. We should exit gracefully.
+            {
+                return exitcode::OK
+            }
+            Ok(_) => return exitcode::TEMPFAIL,
         }
     }
 }

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -100,7 +100,7 @@ async fn run(
     };
 
     let start_time = Instant::now();
-    let stream_duration = 
+    let stream_duration =
         opts.duration_ms.map(Duration::from_millis).unwrap_or(Duration::MAX);
 
     // Loop over the returned results, printing out tap events.

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -52,6 +52,10 @@ pub struct Opts {
     /// Whether to reconnect if the underlying API connection drops. By default, tap will attempt to reconnect if the connection drops.
     #[arg(short, long)]
     no_reconnect: bool,
+
+    /// Specifies a duration (in ms) to sample logs (e.g. specifying 10000 will sample logs for 10 seconds then exit)
+    #[arg(short, long)]
+    duration: Option<u64>,
 }
 
 impl Opts {

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -53,9 +53,9 @@ pub struct Opts {
     #[arg(short, long)]
     no_reconnect: bool,
 
-    /// Specifies a duration (in ms) to sample logs (e.g. specifying 10000 will sample logs for 10 seconds then exit)
-    #[arg(short, long)]
-    duration: Option<u64>,
+    /// Specifies a duration (in milliseconds) to sample logs (e.g. specifying 10000 will sample logs for 10 seconds then exit)
+    #[arg(short = 'd', long)]
+    duration_ms: Option<u64>,
 }
 
 impl Opts {

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -307,9 +307,9 @@ cli: {
 					_short:      "n"
 					description: "Whether to reconnect if the underlying Vector API connection drops. By default, tap will attempt to reconnect if the connection drops."
 				}
-				"duration": {
+				"duration_ms": {
 					_short:      "d"
-					description: "Specifies a duration (in ms) to sample logs (e.g. passing in 10000 will sample logs for 10 seconds then exit)."
+					description: "Specifies a duration (in milliseconds) to sample logs (e.g. passing in 10000 will sample logs for 10 seconds then exit)."
 				}
 			}
 

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -307,6 +307,10 @@ cli: {
 					_short:      "n"
 					description: "Whether to reconnect if the underlying Vector API connection drops. By default, tap will attempt to reconnect if the connection drops."
 				}
+				"duration": {
+					_short:      "d"
+					description: "Specifies a duration (in ms) to sample logs (e.g. passing in 10000 will sample logs for 10 seconds then exit)."
+				}
 			}
 
 			options: {


### PR DESCRIPTION
### Overview

Adds optional `duration` flag to `vector tap` command, which allows specifying how long to run `tap` before exiting (by default `tap` will run indefinitely)

### Testing

Tested by using `tap` on a `demo_logs` test pipeline (both with and without the duration flag)