### PR TITLE
fix(vrl): Mark set_secret and remove_secret as impure

### DIFF
--- a/changelog.d/vrl-secrets-impure.fix.md
+++ b/changelog.d/vrl-secrets-impure.fix.md
@@ -1,0 +1,2 @@
+The `set_secret` and `remove_secret` VRL functions no longer complain about their return value not
+being consumed. These functions don't return any value.

--- a/lib/vector-vrl/functions/src/remove_secret.rs
+++ b/lib/vector-vrl/functions/src/remove_secret.rs
@@ -54,6 +54,6 @@ impl FunctionExpression for RemoveSecretFn {
     }
 
     fn type_def(&self, _: &TypeState) -> TypeDef {
-        TypeDef::null().infallible()
+        TypeDef::null().infallible().impure()
     }
 }

--- a/lib/vector-vrl/functions/src/set_secret.rs
+++ b/lib/vector-vrl/functions/src/set_secret.rs
@@ -70,6 +70,6 @@ impl FunctionExpression for SetSecretFn {
     }
 
     fn type_def(&self, _: &TypeState) -> TypeDef {
-        TypeDef::null().infallible()
+        TypeDef::null().infallible().impure()
     }
 }


### PR DESCRIPTION
Otherwise the VRL compiler complains that the return value isn't consumed.

Fixes: #20809

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
