### PR TITLE
chore(ci): Marke file_to_blackhole soak as erratic

### DIFF
--- a/regression/cases/file_to_blackhole/experiment.yaml
+++ b/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,4 +1,5 @@
 optimization_goal: egress_throughput
+erratic: true
 
 target:
   name: vector


### PR DESCRIPTION
During the recent SMP upgrade it was observed that this soak test exhibits strange behavior and, anecdotally, seems to be resulting in a lot of false positives like the ones seen here: https://github.com/vectordotdev/vector/pull/20821

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
