### PR TITLE
chore: Increases default warmup duration for Regression Detector jobs

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -41,6 +41,7 @@ concurrency:
 
 env:
   SINGLE_MACHINE_PERFORMANCE_API: ${{ secrets.SINGLE_MACHINE_PERFORMANCE_API }}
+  SMP_WARMUP_SECONDS: 70 # default is 45 seconds
 
 jobs:
 
@@ -473,6 +474,7 @@ jobs:
             --baseline-sha ${{ needs.compute-metadata.outputs.baseline-sha }} \
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
             --target-config-dir ${{ github.workspace }}/regression/ \
+            --warmup-seconds ${{ env.SMP_WARMUP_SECONDS }}
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Vector has been seeing some unusual false positive results, and looking into the detailed data, we observe a "spike" in egress throughput at the beginning of the job.

By increasing the warmup duration, we should effectively ignore this early spike, which should give cleaner data for analysis.

Example:
![image](https://github.com/vectordotdev/vector/assets/996472/42f33888-4be0-46c0-a4d3-5255f52bc19b)
