### PR TITLE
chore: Adds a trailing newline escape for smp job submit

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -474,7 +474,7 @@ jobs:
             --baseline-sha ${{ needs.compute-metadata.outputs.baseline-sha }} \
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
             --target-config-dir ${{ github.workspace }}/regression/ \
-            --warmup-seconds ${{ env.SMP_WARMUP_SECONDS }}
+            --warmup-seconds ${{ env.SMP_WARMUP_SECONDS }} \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Small fix that was missed in #20828 