### PR TITLE
feat(new sink): Add possibility to use nats jetstream in nats sink

### DIFF
--- a/changelog.d/20834_nats_jetstream_sink.feature.md
+++ b/changelog.d/20834_nats_jetstream_sink.feature.md
@@ -16,3 +16,5 @@ sinks:
     encoding:
       codec: json
 ```
+
+authors: whatcouldbepizza

--- a/changelog.d/20834_nats_jetstream_sink.feature.md
+++ b/changelog.d/20834_nats_jetstream_sink.feature.md
@@ -1,0 +1,18 @@
+Add possibility to use NATS JetStream in NATS sink. Can be turned on/off via `jetstream` option (default is false).
+
+### Example
+
+#### Config
+
+```
+sinks:
+  nats:
+    type: nats
+    inputs:
+      - in
+    subject: nork
+    url: "nats://localhost:4222"
+    jetstream: true
+    encoding:
+      codec: json
+```

--- a/changelog.d/20834_nats_jetstream_sink.feature.md
+++ b/changelog.d/20834_nats_jetstream_sink.feature.md
@@ -1,20 +1,3 @@
 Add possibility to use NATS JetStream in NATS sink. Can be turned on/off via `jetstream` option (default is false).
 
-### Example
-
-#### Config
-
-```
-sinks:
-  nats:
-    type: nats
-    inputs:
-      - in
-    subject: nork
-    url: "nats://localhost:4222"
-    jetstream: true
-    encoding:
-      codec: json
-```
-
 authors: whatcouldbepizza

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -80,6 +80,8 @@ pub struct NatsSinkConfig {
 
     /// Send messages using [Jetstream][jetstream].
     ///
+    /// If set, the `subject` must belong to an existing JetStream stream.
+    ///
     /// [jetstream]: https://docs.nats.io/nats-concepts/jetstream
     #[serde(default)]
     pub(super) jetstream: bool,

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -176,7 +176,14 @@ impl NatsPublisher {
                     .await
                     .map_err(|e| NatsError::PublishError {
                         source: Box::new(e),
+                    })?;
+                client
+                    .flush()
+                    .map_ok(|_| ())
+                    .map_err(|e| NatsError::PublishError {
+                        source: Box::new(e),
                     })
+                    .await
             }
             NatsPublisher::JetStream(jetstream) => {
                 let ack = jetstream.publish(subject, payload).await.map_err(|e| {
@@ -189,12 +196,5 @@ impl NatsPublisher {
                 })
             }
         }
-    }
-
-    pub(super) async fn flush(&self) -> Result<(), ()> {
-        if let NatsPublisher::Core(client) = self {
-            return client.flush().map_err(|_| ()).await;
-        }
-        Ok(())
     }
 }

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -190,4 +190,11 @@ impl NatsPublisher {
             }
         }
     }
+
+    pub(super) async fn flush(&self) -> Result<(), ()> {
+        if let NatsPublisher::Core(client) = self {
+            return client.flush().map_err(|_| ()).await;
+        }
+        Ok(())
+    }
 }

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -155,21 +155,7 @@ impl NatsSinkConfig {
 }
 
 async fn healthcheck(config: NatsSinkConfig) -> crate::Result<()> {
-    let connection = config.connect().await?;
-    if !config.jetstream {
-        return Ok(());
-    }
-
-    async_nats::jetstream::new(connection)
-        .get_stream(config.subject.to_string())
-        .map_ok(|_| ())
-        .map_err(|e| {
-            NatsError::ServerError {
-                source: Box::new(e),
-            }
-            .into()
-        })
-        .await
+    config.connect().map_ok(|_| ()).map_err(|e| e.into()).await
 }
 
 pub enum NatsPublisher {

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -78,7 +78,9 @@ pub struct NatsSinkConfig {
     #[serde(default)]
     pub(super) request: TowerRequestConfig<NatsTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
+    /// Send messages using [Jetstream][jetstream].
+    ///
+    /// [jetstream]: https://docs.nats.io/nats-concepts/jetstream
     #[serde(default)]
     pub(super) jetstream: bool,
 }
@@ -140,11 +142,12 @@ impl NatsSinkConfig {
     pub(super) async fn publisher(&self) -> Result<NatsPublisher, NatsError> {
         let connection = self.connect().await?;
 
-        match self.jetstream {
-            true => Ok(NatsPublisher::JetStream(async_nats::jetstream::new(
+        if self.jetstream {
+            Ok(NatsPublisher::JetStream(async_nats::jetstream::new(
                 connection,
-            ))),
-            false => Ok(NatsPublisher::Core(connection)),
+            )))
+        } else {
+            Ok(NatsPublisher::Core(connection))
         }
     }
 }

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -171,10 +171,7 @@ impl NatsPublisher {
                     .await
                     .map_err(|e| NatsError::PublishError {
                         source: Box::new(e),
-                    })?;
-                client.flush().await.map_err(|e| NatsError::PublishError {
-                    source: Box::new(e),
-                })
+                    })
             }
             NatsPublisher::JetStream(jetstream) => {
                 let ack = jetstream.publish(subject, payload).await.map_err(|e| {

--- a/src/sinks/nats/integration_tests.rs
+++ b/src/sinks/nats/integration_tests.rs
@@ -78,6 +78,7 @@ async fn nats_no_auth() {
         tls: None,
         auth: None,
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -110,6 +111,7 @@ async fn nats_userpass_auth_valid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     publish_and_check(conf)
@@ -139,6 +141,7 @@ async fn nats_userpass_auth_invalid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -170,6 +173,7 @@ async fn nats_token_auth_valid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -201,6 +205,7 @@ async fn nats_token_auth_invalid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -233,6 +238,7 @@ async fn nats_nkey_auth_valid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -265,6 +271,7 @@ async fn nats_nkey_auth_invalid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -298,6 +305,7 @@ async fn nats_tls_valid() {
         }),
         auth: None,
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -325,6 +333,7 @@ async fn nats_tls_invalid() {
         tls: None,
         auth: None,
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -360,6 +369,7 @@ async fn nats_tls_client_cert_valid() {
         }),
         auth: None,
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -393,6 +403,7 @@ async fn nats_tls_client_cert_invalid() {
         }),
         auth: None,
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -430,6 +441,7 @@ async fn nats_tls_jwt_auth_valid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;
@@ -467,6 +479,7 @@ async fn nats_tls_jwt_auth_invalid() {
             },
         }),
         request: Default::default(),
+        jetstream: false,
     };
 
     let r = publish_and_check(conf).await;

--- a/src/sinks/nats/mod.rs
+++ b/src/sinks/nats/mod.rs
@@ -27,4 +27,6 @@ enum NatsError {
     Connect { source: async_nats::ConnectError },
     #[snafu(display("NATS Server Error: {}", source))]
     ServerError { source: async_nats::Error },
+    #[snafu(display("NATS Publish Error: {}", source))]
+    PublishError { source: async_nats::Error },
 }

--- a/src/sinks/nats/sink.rs
+++ b/src/sinks/nats/sink.rs
@@ -74,7 +74,7 @@ impl NatsSink {
                 publisher: Arc::clone(&self.publisher),
             });
 
-        input
+        let result = input
             .filter_map(|event| std::future::ready(self.make_nats_event(event)))
             .request_builder(default_request_builder_concurrency_limit(), request_builder)
             .filter_map(|request| async move {
@@ -89,7 +89,10 @@ impl NatsSink {
             .into_driver(service)
             .protocol("nats")
             .run()
-            .await
+            .await;
+
+        self.publisher.flush().await?;
+        return result;
     }
 }
 

--- a/src/sinks/nats/sink.rs
+++ b/src/sinks/nats/sink.rs
@@ -74,7 +74,7 @@ impl NatsSink {
                 publisher: Arc::clone(&self.publisher),
             });
 
-        let result = input
+        input
             .filter_map(|event| std::future::ready(self.make_nats_event(event)))
             .request_builder(default_request_builder_concurrency_limit(), request_builder)
             .filter_map(|request| async move {
@@ -89,10 +89,7 @@ impl NatsSink {
             .into_driver(service)
             .protocol("nats")
             .run()
-            .await;
-
-        self.publisher.flush().await?;
-        return result;
+            .await
     }
 }
 

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -383,6 +383,15 @@ base: components: sinks: nats: configuration: {
 			}
 		}
 	}
+	jetstream: {
+		description: """
+			Send messages using [Jetstream][jetstream].
+
+			[jetstream]: https://docs.nats.io/nats-concepts/jetstream
+			"""
+		required: false
+		type: bool: default: false
+	}
 	request: {
 		description: """
 			Middleware settings for outbound requests.

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -387,6 +387,8 @@ base: components: sinks: nats: configuration: {
 		description: """
 			Send messages using [Jetstream][jetstream].
 
+			If set, the `subject` must belong to an existing JetStream stream.
+
 			[jetstream]: https://docs.nats.io/nats-concepts/jetstream
 			"""
 		required: false


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Add new option `jetstream` to nats sink configuration that allows using jetstream to sink into nats