### PR TITLE
docs: Fix link to commit scopes in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ format. Vector performs a pull request check to verify the pull request title
 in case you forget.
 
 A list of allowed sub-categories is defined
-[here](https://github.com/vectordotdev/vector/tree/master/.github).
+[here](https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L21).
 
 The following are all good examples of pull request titles:
 


### PR DESCRIPTION
The link pointed to the directory containing the right file, but is more convenient as a link to the file itself.