### PR TITLE
refactor(tap): Refactor vector tap into library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10681,6 +10681,7 @@ dependencies = [
  "vector-core",
  "vector-lookup",
  "vector-stream",
+ "vector-tap",
 ]
 
 [[package]]
@@ -10713,6 +10714,20 @@ dependencies = [
  "twox-hash",
  "vector-common",
  "vector-core",
+]
+
+[[package]]
+name = "vector-tap"
+version = "0.1.0"
+dependencies = [
+ "colored",
+ "serde_yaml 0.9.34+deprecated",
+ "snafu 0.7.5",
+ "tokio",
+ "tokio-stream",
+ "tracing 0.1.40",
+ "url",
+ "vector-api-client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ members = [
   "lib/vector-lib",
   "lib/vector-lookup",
   "lib/vector-stream",
+  "lib/vector-tap",
   "lib/vector-vrl/cli",
   "lib/vector-vrl/functions",
   "lib/vector-vrl/tests",

--- a/changelog.d/refactor_vector_tap_to_library.md
+++ b/changelog.d/refactor_vector_tap_to_library.md
@@ -1,0 +1,6 @@
+Adding a new use case which will re-use the logic used to implement the `vector tap` command to retrieve a live view of events flowing through Vector. Refactoring out the relevant logic to a general library.
+
+authors: ArunPiduguDD
+
+
+

--- a/changelog.d/refactor_vector_tap_to_library.md
+++ b/changelog.d/refactor_vector_tap_to_library.md
@@ -1,4 +1,0 @@
-Adding a new use case which will re-use the logic used to implement the `vector tap` command to retrieve a live view of events flowing through Vector. Refactoring out the relevant logic to a general library.
-
-
-

--- a/changelog.d/refactor_vector_tap_to_library.md
+++ b/changelog.d/refactor_vector_tap_to_library.md
@@ -1,6 +1,4 @@
 Adding a new use case which will re-use the logic used to implement the `vector tap` command to retrieve a live view of events flowing through Vector. Refactoring out the relevant logic to a general library.
 
-authors: ArunPiduguDD
-
 
 

--- a/lib/vector-lib/Cargo.toml
+++ b/lib/vector-lib/Cargo.toml
@@ -18,6 +18,7 @@ vector-config = { path = "../vector-config" }
 vector-core = { path = "../vector-core", default-features = false }
 vector-lookup = { path = "../vector-lookup", features = ["test"] }
 vector-stream = { path = "../vector-stream" }
+vector-tap = { path = "../vector-tap" }
 
 [features]
 api = ["vector-core/api"]

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -24,6 +24,7 @@ pub use vector_core::{
 };
 pub use vector_lookup as lookup;
 pub use vector_stream as stream;
+pub use vector_tap as tap;
 
 pub mod config {
     pub use vector_common::config::ComponentKey;

--- a/lib/vector-tap/Cargo.toml
+++ b/lib/vector-tap/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vector-tap"
+version = "0.1.0"
+authors = ["Vector Contributors <vector@datadoghq.com>"]
+edition = "2021"
+publish = false
+license = "MPL-2.0"
+
+[dependencies]
+colored = { version = "2.1.0", default-features = false }
+serde_yaml = { version = "0.9.34", default-features = false }
+snafu = { version = "0.7.5", default-features = false }
+tokio = { version = "1.38.0", default-features = false, features = ["time"] }
+tokio-stream = { version = "0.1.15", default-features = false, features = ["sync"] }
+tracing = { version = "0.1.34", default-features = false }
+url = { version = "2.5.2", default-features = false }
+vector-api-client = {path = "../vector-api-client" }

--- a/lib/vector-tap/src/lib.rs
+++ b/lib/vector-tap/src/lib.rs
@@ -22,7 +22,7 @@ use vector_api_client::{
     },
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EventFormatter {
     meta: bool,
     format: TapEncodingFormat,
@@ -98,6 +98,7 @@ impl EventFormatter {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum OutputChannel {
     Stdout(EventFormatter),
     AsyncChannel(tokio_mpsc::Sender<Vec<GraphQLTapOutputEvents>>),

--- a/lib/vector-tap/src/lib.rs
+++ b/lib/vector-tap/src/lib.rs
@@ -2,8 +2,8 @@
 
 extern crate tracing;
 
-use std::{borrow::Cow, collections::BTreeMap};
 use std::time::{Duration, Instant};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use colored::{ColoredString, Colorize};
 use snafu::Snafu;
@@ -15,8 +15,7 @@ use vector_api_client::{
     connect_subscription_client,
     gql::{
         output_events_by_component_id_patterns_subscription::OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns as GraphQLTapOutputEvent,
-        TapEncodingFormat,
-        TapSubscriptionExt,
+        TapEncodingFormat, TapSubscriptionExt,
     },
 };
 
@@ -59,7 +58,7 @@ impl EventFormatter {
                     component_type.green(),
                     event
                 )
-                    .into(),
+                .into(),
                 TapEncodingFormat::Yaml => {
                     let mut value: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
                     value.insert("event".to_string(), serde_yaml::from_str(event).unwrap());
@@ -76,7 +75,7 @@ impl EventFormatter {
                         self.component_type_label,
                         component_type.green()
                     )
-                        .into()
+                    .into()
                 }
                 TapEncodingFormat::Logfmt => format!(
                     "{}={} {}={} {}={} {}",
@@ -88,7 +87,7 @@ impl EventFormatter {
                     component_type.green(),
                     event
                 )
-                    .into(),
+                .into(),
             }
         } else {
             event.into()
@@ -157,10 +156,9 @@ impl<'a> TapRunner<'a> {
         }
 
         let start_time = Instant::now();
-        let stream_duration =
-            duration_ms
-                .map(Duration::from_millis)
-                .unwrap_or(Duration::MAX);
+        let stream_duration = duration_ms
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::MAX);
 
         // Loop over the returned results, printing out tap events.
         loop {
@@ -176,13 +174,37 @@ impl<'a> TapRunner<'a> {
                         for tap_event in d.output_events_by_component_id_patterns.iter() {
                             match tap_event {
                                 GraphQLTapOutputEvent::Log(ev) => {
-                                    println!("{}", self.formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
+                                    println!(
+                                        "{}",
+                                        self.formatter.format(
+                                            ev.component_id.as_ref(),
+                                            ev.component_kind.as_ref(),
+                                            ev.component_type.as_ref(),
+                                            ev.string.as_ref()
+                                        )
+                                    );
                                 }
                                 GraphQLTapOutputEvent::Metric(ev) => {
-                                    println!("{}", self.formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
+                                    println!(
+                                        "{}",
+                                        self.formatter.format(
+                                            ev.component_id.as_ref(),
+                                            ev.component_kind.as_ref(),
+                                            ev.component_type.as_ref(),
+                                            ev.string.as_ref()
+                                        )
+                                    );
                                 }
                                 GraphQLTapOutputEvent::Trace(ev) => {
-                                    println!("{}", self.formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
+                                    println!(
+                                        "{}",
+                                        self.formatter.format(
+                                            ev.component_id.as_ref(),
+                                            ev.component_kind.as_ref(),
+                                            ev.component_type.as_ref(),
+                                            ev.string.as_ref()
+                                        )
+                                    );
                                 }
                                 GraphQLTapOutputEvent::EventNotification(ev) => {
                                     if !quiet {
@@ -196,9 +218,9 @@ impl<'a> TapRunner<'a> {
                 Err(_) => {
                     // If the stream times out, that indicates the duration specified by the user
                     // has elapsed. We should exit gracefully.
-                    return Ok(())
+                    return Ok(());
                 }
-                Ok(_) => return Err(TapExecutorError::GraphQLError)
+                Ok(_) => return Err(TapExecutorError::GraphQLError),
             }
         }
     }

--- a/lib/vector-tap/src/lib.rs
+++ b/lib/vector-tap/src/lib.rs
@@ -1,0 +1,205 @@
+#![deny(warnings)]
+
+#[macro_use]
+extern crate tracing;
+
+use std::{borrow::Cow, collections::BTreeMap};
+use std::time::{Duration, Instant};
+
+use colored::{ColoredString, Colorize};
+use snafu::Snafu;
+use tokio::sync::mpsc as tokio_mpsc;
+use tokio::time::timeout;
+use tokio_stream::StreamExt;
+use url::Url;
+
+use vector_api_client::{
+    connect_subscription_client,
+    gql::{
+        output_events_by_component_id_patterns_subscription::OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns as GraphQLTapOutputEvents,
+        TapEncodingFormat,
+        TapSubscriptionExt,
+    },
+};
+
+#[derive(Clone)]
+pub struct EventFormatter {
+    meta: bool,
+    format: TapEncodingFormat,
+    component_id_label: ColoredString,
+    component_kind_label: ColoredString,
+    component_type_label: ColoredString,
+}
+
+impl EventFormatter {
+    pub fn new(meta: bool, format: TapEncodingFormat) -> Self {
+        Self {
+            meta,
+            format,
+            component_id_label: "component_id".green(),
+            component_kind_label: "component_kind".green(),
+            component_type_label: "component_type".green(),
+        }
+    }
+
+    pub fn format<'a>(
+        &self,
+        component_id: &str,
+        component_kind: &str,
+        component_type: &str,
+        event: &'a str,
+    ) -> Cow<'a, str> {
+        if self.meta {
+            match self.format {
+                TapEncodingFormat::Json => format!(
+                    r#"{{"{}":"{}","{}":"{}","{}":"{}","event":{}}}"#,
+                    self.component_id_label,
+                    component_id.green(),
+                    self.component_kind_label,
+                    component_kind.green(),
+                    self.component_type_label,
+                    component_type.green(),
+                    event
+                )
+                    .into(),
+                TapEncodingFormat::Yaml => {
+                    let mut value: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
+                    value.insert("event".to_string(), serde_yaml::from_str(event).unwrap());
+                    // We interpolate to include component_id rather than
+                    // include it in the map to correctly preserve color
+                    // formatting
+                    format!(
+                        "{}{}: {}\n{}: {}\n{}: {}\n",
+                        serde_yaml::to_string(&value).unwrap(),
+                        self.component_id_label,
+                        component_id.green(),
+                        self.component_kind_label,
+                        component_kind.green(),
+                        self.component_type_label,
+                        component_type.green()
+                    )
+                        .into()
+                }
+                TapEncodingFormat::Logfmt => format!(
+                    "{}={} {}={} {}={} {}",
+                    self.component_id_label,
+                    component_id.green(),
+                    self.component_kind_label,
+                    component_kind.green(),
+                    self.component_type_label,
+                    component_type.green(),
+                    event
+                )
+                    .into(),
+            }
+        } else {
+            event.into()
+        }
+    }
+}
+
+pub enum OutputChannel {
+    Stdout(EventFormatter),
+    AsyncChannel(tokio_mpsc::Sender<Vec<GraphQLTapOutputEvents>>),
+}
+
+/// Error type for DNS message parsing
+#[derive(Debug, Snafu)]
+pub enum TapExecutorError {
+    #[snafu(display("[tap] Couldn't connect to API via WebSockets"))]
+    ConnectionFailure,
+    NoEventsFound,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn exec_tap(
+    url: Url,
+    interval: i64,
+    limit: i64,
+    duration_ms: Option<u64>,
+    input_patterns: Vec<String>,
+    output_patterns: Vec<String>,
+    format: TapEncodingFormat,
+    output_channel: OutputChannel,
+    quiet: bool,
+) -> Result<(), TapExecutorError> {
+    let subscription_client = match connect_subscription_client(url.clone()).await {
+        Ok(c) => c,
+        Err(e) => {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("[tap] Couldn't connect to API via WebSockets: {}", e);
+            }
+            return Err(TapExecutorError::ConnectionFailure);
+        }
+    };
+
+    tokio::pin! {
+        let stream = subscription_client.output_events_by_component_id_patterns_subscription(
+            output_patterns.clone(),
+            input_patterns.clone(),
+            format,
+            limit,
+            interval,
+        );
+    }
+
+    let start_time = Instant::now();
+    let stream_duration =
+        duration_ms
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::MAX);
+
+    // Loop over the returned results, printing out tap events.
+    #[allow(clippy::print_stdout)]
+    #[allow(clippy::print_stderr)]
+    loop {
+        let time_elapsed = start_time.elapsed();
+        if time_elapsed >= stream_duration {
+            return Ok(());
+        }
+
+        let message = timeout(stream_duration - time_elapsed, stream.next()).await;
+        match message {
+            Ok(Some(Some(res))) => {
+                if let Some(d) = res.data {
+                    match &output_channel {
+                        OutputChannel::Stdout(formatter) => {
+                            for tap_event in d.output_events_by_component_id_patterns.iter() {
+                                match tap_event {
+                                    GraphQLTapOutputEvents::Log(ev) => {
+                                        println!("{}", formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
+                                    }
+                                    GraphQLTapOutputEvents::Metric(ev) => {
+                                        println!("{}", formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
+                                    }
+                                    GraphQLTapOutputEvents::Trace(ev) => {
+                                        println!("{}", formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
+                                    }
+                                    GraphQLTapOutputEvents::EventNotification(ev) => {
+                                        if !quiet {
+                                            eprintln!("{}", ev.message);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        OutputChannel::AsyncChannel (sender_tx) => {
+                            if sender_tx.send(d.output_events_by_component_id_patterns).await.is_err() {
+                                debug!("Could not send events");
+                            }
+                        }
+                    }
+                }
+            }
+            Err(_) =>
+            // If the stream times out, that indicates the duration specified by the user
+            // has elapsed. We should exit gracefully.
+                {
+                    return Ok(())
+                }
+            Ok(_) => return Err(TapExecutorError::NoEventsFound)
+        }
+    }
+}
+

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -1,17 +1,6 @@
-use colored::{ColoredString, Colorize};
-use std::time::Instant;
-use std::{borrow::Cow, collections::BTreeMap, time::Duration};
-use tokio::time::timeout;
-use tokio_stream::StreamExt;
-use url::Url;
-use vector_lib::api_client::{
-    connect_subscription_client,
-    gql::{
-        output_events_by_component_id_patterns_subscription::OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns,
-        TapEncodingFormat, TapSubscriptionExt,
-    },
-    Client,
-};
+use std::{time::Duration};
+use vector_lib::api_client::Client;
+use vector_lib::tap::{exec_tap, EventFormatter, TapExecutorError};
 
 use crate::signal::{SignalRx, SignalTo};
 
@@ -55,172 +44,37 @@ pub async fn tap(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitC
         tokio::select! {
             biased;
             Ok(SignalTo::Shutdown(_) | SignalTo::Quit) = signal_rx.recv() => break,
-            status = run(subscription_url.clone(), opts, outputs_patterns.clone(), formatter.clone()) => {
-                if status == exitcode::UNAVAILABLE || status == exitcode::TEMPFAIL && !opts.no_reconnect {
-                    #[allow(clippy::print_stderr)]
-                    {
-                        eprintln!("[tap] Connection failed. Reconnecting in {:?} seconds.", RECONNECT_DELAY / 1000);
+            exec_result = exec_tap(
+                opts.url(),
+                opts.interval as i64,
+                opts.limit as i64,
+                opts.duration_ms,
+                opts.inputs_of.clone(),
+                outputs_patterns.clone(),
+                opts.format,
+                formatter.clone(),
+                opts.quiet,
+            ) => {
+                match exec_result {
+                    Ok(_) => {
+                        break;
                     }
-                    tokio::time::sleep(Duration::from_millis(RECONNECT_DELAY)).await;
-                } else {
-                    break;
+                    Err(TapExecutorError::ConnectionFailure) | Err(TapExecutorError::NoEventsFound) => {
+                        if !opts.no_reconnect {
+                            #[allow(clippy::print_stderr)]
+                            {
+                                eprintln!("[tap] Connection failed. Reconnecting in {:?} seconds.", RECONNECT_DELAY / 1000);
+                            }
+                            tokio::time::sleep(Duration::from_millis(RECONNECT_DELAY)).await;
+                        }
+                        else {
+                            break;
+                        }
+                    }
                 }
             }
         }
     }
 
     exitcode::OK
-}
-
-async fn run(
-    url: Url,
-    opts: &super::Opts,
-    outputs_patterns: Vec<String>,
-    formatter: EventFormatter,
-) -> exitcode::ExitCode {
-    let subscription_client = match connect_subscription_client(url).await {
-        Ok(c) => c,
-        Err(e) => {
-            #[allow(clippy::print_stderr)]
-            {
-                eprintln!("[tap] Couldn't connect to API via WebSockets: {}", e);
-            }
-            return exitcode::UNAVAILABLE;
-        }
-    };
-
-    tokio::pin! {
-        let stream = subscription_client.output_events_by_component_id_patterns_subscription(
-            outputs_patterns,
-            opts.inputs_of.clone(),
-            opts.format,
-            opts.limit as i64,
-            opts.interval as i64,
-        );
-    };
-
-    let start_time = Instant::now();
-    let stream_duration = opts
-        .duration_ms
-        .map(Duration::from_millis)
-        .unwrap_or(Duration::MAX);
-
-    // Loop over the returned results, printing out tap events.
-    #[allow(clippy::print_stdout)]
-    #[allow(clippy::print_stderr)]
-    loop {
-        let time_elapsed = start_time.elapsed();
-        if time_elapsed >= stream_duration {
-            return exitcode::OK;
-        }
-
-        let message = timeout(stream_duration - time_elapsed, stream.next()).await;
-        match message {
-            Ok(Some(Some(res))) => {
-                if let Some(d) = res.data {
-                    for tap_event in d.output_events_by_component_id_patterns.iter() {
-                        match tap_event {
-                            OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns::Log(ev) => {
-                                println!("{}", formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
-                            },
-                            OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns::Metric(ev) => {
-                                println!("{}", formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
-                            },
-                            OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns::Trace(ev) => {
-                                println!("{}", formatter.format(ev.component_id.as_ref(), ev.component_kind.as_ref(), ev.component_type.as_ref(), ev.string.as_ref()));
-                            },
-                            OutputEventsByComponentIdPatternsSubscriptionOutputEventsByComponentIdPatterns::EventNotification(ev) => {
-                                if !opts.quiet {
-                                    eprintln!("{}", ev.message);
-                                }
-                            },
-                        }
-                    }
-                }
-            }
-            Err(_) =>
-            // If the stream times out, that indicates the duration specified by the user
-            // has elapsed. We should exit gracefully.
-            {
-                return exitcode::OK
-            }
-            Ok(_) => return exitcode::TEMPFAIL,
-        }
-    }
-}
-
-#[derive(Clone)]
-struct EventFormatter {
-    meta: bool,
-    format: TapEncodingFormat,
-    component_id_label: ColoredString,
-    component_kind_label: ColoredString,
-    component_type_label: ColoredString,
-}
-
-impl EventFormatter {
-    fn new(meta: bool, format: TapEncodingFormat) -> Self {
-        Self {
-            meta,
-            format,
-            component_id_label: "component_id".green(),
-            component_kind_label: "component_kind".green(),
-            component_type_label: "component_type".green(),
-        }
-    }
-
-    fn format<'a>(
-        &self,
-        component_id: &str,
-        component_kind: &str,
-        component_type: &str,
-        event: &'a str,
-    ) -> Cow<'a, str> {
-        if self.meta {
-            match self.format {
-                TapEncodingFormat::Json => format!(
-                    r#"{{"{}":"{}","{}":"{}","{}":"{}","event":{}}}"#,
-                    self.component_id_label,
-                    component_id.green(),
-                    self.component_kind_label,
-                    component_kind.green(),
-                    self.component_type_label,
-                    component_type.green(),
-                    event
-                )
-                .into(),
-                TapEncodingFormat::Yaml => {
-                    let mut value: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
-                    value.insert("event".to_string(), serde_yaml::from_str(event).unwrap());
-                    // We interpolate to include component_id rather than
-                    // include it in the map to correctly preserve color
-                    // formatting
-                    format!(
-                        "{}{}: {}\n{}: {}\n{}: {}\n",
-                        serde_yaml::to_string(&value).unwrap(),
-                        self.component_id_label,
-                        component_id.green(),
-                        self.component_kind_label,
-                        component_kind.green(),
-                        self.component_type_label,
-                        component_type.green()
-                    )
-                    .into()
-                }
-                TapEncodingFormat::Logfmt => format!(
-                    "{}={} {}={} {}={} {}",
-                    self.component_id_label,
-                    component_id.green(),
-                    self.component_kind_label,
-                    component_kind.green(),
-                    self.component_type_label,
-                    component_type.green(),
-                    event
-                )
-                .into(),
-            }
-        } else {
-            event.into()
-        }
-    }
 }

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -44,7 +44,7 @@ pub async fn tap(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitC
         opts.inputs_of.clone(),
         opts.outputs_patterns().clone(),
         &formatter,
-        opts.format
+        opts.format,
     );
 
     loop {

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -1,6 +1,6 @@
 use std::{time::Duration};
 use vector_lib::api_client::Client;
-use vector_lib::tap::{exec_tap, EventFormatter, OutputChannel, TapExecutorError};
+use vector_lib::tap::{exec_tap, EventFormatter, TapExecutorError};
 
 use crate::signal::{SignalRx, SignalTo};
 
@@ -37,7 +37,7 @@ pub(crate) async fn cmd(opts: &super::Opts, signal_rx: SignalRx) -> exitcode::Ex
 /// Observe event flow from specified components
 pub async fn tap(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitCode {
     let subscription_url = opts.web_socket_url();
-    let output_channel = OutputChannel::Stdout(EventFormatter::new(opts.meta, opts.format));
+    let formatter = EventFormatter::new(opts.meta, opts.format);
     let outputs_patterns = opts.outputs_patterns();
 
     loop {
@@ -45,21 +45,21 @@ pub async fn tap(opts: &super::Opts, mut signal_rx: SignalRx) -> exitcode::ExitC
             biased;
             Ok(SignalTo::Shutdown(_) | SignalTo::Quit) = signal_rx.recv() => break,
             exec_result = exec_tap(
-                subscription_url.clone(),
+                &subscription_url,
                 opts.interval as i64,
                 opts.limit as i64,
                 opts.duration_ms,
                 opts.inputs_of.clone(),
                 outputs_patterns.clone(),
                 opts.format,
-                output_channel.clone(),
+                &formatter,
                 opts.quiet,
             ) => {
                 match exec_result {
                     Ok(_) => {
                         break;
                     }
-                    Err(TapExecutorError::ConnectionFailure) | Err(TapExecutorError::NoEventsFound) => {
+                    Err(TapExecutorError::ConnectionFailure) | Err(TapExecutorError::GraphQLError) => {
                         if !opts.no_reconnect {
                             #[allow(clippy::print_stderr)]
                             {


### PR DESCRIPTION
### Overview

Adding a new use case which will re-use the logic used to implement the `vector tap` command to retrieve a live view of events flowing through Vector. This PR refactors out the required logic to a general library.

Will publish a follow-up PR that adds additional functionality for new use case.

### Testing
Tested by using tap on a demo_logs test pipeline 
