### PR TITLE
chore(ci): Pin EventstoreDB to 24.2

### DIFF
--- a/scripts/integration/eventstoredb/test.yaml
+++ b/scripts/integration/eventstoredb/test.yaml
@@ -4,7 +4,7 @@ features:
 test_filter: '::eventstoredb_metrics::'
 
 matrix:
-  version: [latest]
+  version: ["24.2"]
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch


### PR DESCRIPTION
I think 24.6 is causing an integration test failure.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
