### PR TITLE
fix(proxy): support url-encoded auth values

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -459,6 +459,7 @@ upstreaminfo
 useragents
 usergroups
 userguide
+urlencoding
 webhdfs
 winapi
 workarounds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10662,6 +10662,7 @@ dependencies = [
  "tracing-subscriber",
  "typetag",
  "url",
+ "urlencoding",
  "vector-buffers",
  "vector-common",
  "vector-config",

--- a/changelog.d/17125_proxy_auth_url_encoded.fix.md
+++ b/changelog.d/17125_proxy_auth_url_encoded.fix.md
@@ -1,0 +1,1 @@
+Proxy configuration now supports URL-encoded values.

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -58,6 +58,7 @@ tracing-core = { version = "0.1.26", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std"] }
 typetag = { version = "0.2.16", default-features = false }
 url = { version = "2", default-features = false }
+urlencoding = { version = "2.1.3", default-features = false }
 vector-buffers = { path = "../vector-buffers", default-features = false }
 vector-common = { path = "../vector-common" }
 vector-config = { path = "../vector-config" }

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -164,9 +164,9 @@ impl ProxyConfig {
                     if let Ok(authority) = Url::parse(url) {
                         if let Some(password) = authority.password() {
                             let decoded_user = urlencoding::decode(authority.username())
-                                .expect("username is valid UTF-8 because already URI parsed.");
+                                .expect("username must be valid UTF-8.");
                             let decoded_pw = urlencoding::decode(password)
-                                .expect("Password is valid UTF-8 because URI already parsed.");
+                                .expect("Password must be valid UTF-8.");
                             proxy.set_authorization(Authorization::basic(
                                 &decoded_user,
                                 &decoded_pw,

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -163,9 +163,13 @@ impl ProxyConfig {
                     let mut proxy = Proxy::new(self.interceptor().intercept(proxy_scheme), parsed);
                     if let Ok(authority) = Url::parse(url) {
                         if let Some(password) = authority.password() {
+                            let decoded_user = urlencoding::decode(authority.username())
+                                .expect("username is valid UTF-8 because already URI parsed.");
+                            let decoded_pw = urlencoding::decode(password)
+                                .expect("Password is valid UTF-8 because URI already parsed.");
                             proxy.set_authorization(Authorization::basic(
-                                authority.username(),
-                                password,
+                                &decoded_user,
+                                &decoded_pw,
                             ));
                         }
                     }
@@ -397,7 +401,6 @@ mod tests {
         }
     }
 
-    #[ignore]
     #[test]
     fn build_proxy_with_special_chars_url_encoded() {
         let config = ProxyConfig {


### PR DESCRIPTION
fixes: #17125

its common for proxy authorization to contain special characters as URL-encoded values. Vector previously did not decode these but does now with this change.

Note that a unit test was previously added to repro the issue. Its now been un-ignored and passes.