### PR TITLE
chore(ci): Fix and reenable eventstoredb integration test

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -74,8 +74,8 @@ on:
         value: ${{ jobs.int_tests.outputs.docker-logs }}
       elasticsearch:
         value: ${{ jobs.int_tests.outputs.elasticsearch }}
-      #eventstoredb:
-        #value: ${{ jobs.int_tests.outputs.eventstoredb }}
+      eventstoredb:
+        value: ${{ jobs.int_tests.outputs.eventstoredb }}
       fluent:
         value: ${{ jobs.int_tests.outputs.fluent }}
       gcp:
@@ -215,7 +215,7 @@ jobs:
       dnstap: ${{ steps.filter.outputs.dnstap }}
       docker-logs: ${{ steps.filter.outputs.docker-logs }}
       elasticsearch: ${{ steps.filter.outputs.elasticsearch }}
-      #eventstoredb: ${{ steps.filter.outputs.eventstoredb }}
+      eventstoredb: ${{ steps.filter.outputs.eventstoredb }}
       fluent: ${{ steps.filter.outputs.fluent }}
       gcp: ${{ steps.filter.outputs.gcp }}
       greptimedb: ${{ steps.filter.outputs.greptimedb }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,6 +67,7 @@ jobs:
             || needs.changes.outputs.dnstap == 'true'
             || needs.changes.outputs.docker-logs == 'true'
             || needs.changes.outputs.elasticsearch == 'true'
+            || needs.changes.outputs.eventstoredb == 'true'
             || needs.changes.outputs.fluent == 'true'
             || needs.changes.outputs.gcp == 'true'
             || needs.changes.outputs.greptimedb == 'true'
@@ -230,13 +231,13 @@ jobs:
           max_attempts: 3
           command: bash scripts/ci-int-e2e-test.sh int  elasticsearch
 
-      #- if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.eventstoredb == 'true' }}
-        #name: eventstoredb
-        #uses: nick-fields/retry@v3
-        #with:
-          #timeout_minutes: 30
-          #max_attempts: 3
-          #command: bash scripts/ci-int-e2e-test.sh int  eventstoredb
+      - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.eventstoredb == 'true' }}
+        name: eventstoredb
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: bash scripts/ci-int-e2e-test.sh int  eventstoredb
 
       - if: ${{ github.event_name == 'merge_group' || needs.changes.outputs.all-int == 'true' || needs.changes.outputs.fluent == 'true' }}
         name: fluent

--- a/scripts/integration/eventstoredb/test.yaml
+++ b/scripts/integration/eventstoredb/test.yaml
@@ -4,7 +4,7 @@ features:
 test_filter: '::eventstoredb_metrics::'
 
 matrix:
-  version: [latest]
+  version: ["24.2", "24.6", "latest"]
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch

--- a/src/sources/eventstoredb_metrics/mod.rs
+++ b/src/sources/eventstoredb_metrics/mod.rs
@@ -124,6 +124,7 @@ fn eventstoredb(
                         };
                         bytes_received.emit(ByteSize(bytes.len()));
 
+                        dbg!(std::str::from_utf8(&bytes.to_vec()).unwrap());
                         match serde_json::from_slice::<Stats>(bytes.as_ref()) {
                             Err(error) => {
                                 emit!(EventStoreDbStatsParsingError { error });

--- a/src/sources/eventstoredb_metrics/mod.rs
+++ b/src/sources/eventstoredb_metrics/mod.rs
@@ -124,7 +124,6 @@ fn eventstoredb(
                         };
                         bytes_received.emit(ByteSize(bytes.len()));
 
-                        dbg!(std::str::from_utf8(&bytes.to_vec()).unwrap());
                         match serde_json::from_slice::<Stats>(bytes.as_ref()) {
                             Err(error) => {
                                 emit!(EventStoreDbStatsParsingError { error });

--- a/src/sources/eventstoredb_metrics/types.rs
+++ b/src/sources/eventstoredb_metrics/types.rs
@@ -207,6 +207,8 @@ impl<'de> Deserialize<'de> for Drive {
 pub struct DriveStats {
     pub available_bytes: usize,
     pub total_bytes: usize,
+    // EventstoreDB v24.2 has the value as an string representing the percent like 30%
+    // v24.6 has it as integer value like 30. Here we handle both.
     #[serde(deserialize_with = "percent_or_integer")]
     pub usage: usize,
     pub used_bytes: usize,

--- a/src/sources/eventstoredb_metrics/types.rs
+++ b/src/sources/eventstoredb_metrics/types.rs
@@ -1,5 +1,7 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{
-    de::{MapAccess, Visitor},
+    de::{self, Error, MapAccess, Unexpected, Visitor},
     Deserialize, Deserializer,
 };
 
@@ -205,7 +207,8 @@ impl<'de> Deserialize<'de> for Drive {
 pub struct DriveStats {
     pub available_bytes: usize,
     pub total_bytes: usize,
-    pub usage: String,
+    #[serde(deserialize_with = "percent_or_integer")]
+    pub usage: usize,
     pub used_bytes: usize,
 }
 
@@ -231,4 +234,53 @@ impl<'de> Visitor<'de> for DriveVisitor {
 
         Err(serde::de::Error::missing_field("<Drive path>"))
     }
+}
+
+// Can be either an integer or a string like 30%
+fn percent_or_integer<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct PercentOrInteger;
+    static PERCENT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\d+)%").unwrap());
+
+    impl<'de> Visitor<'de> for PercentOrInteger {
+        type Value = usize;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if let Some(caps) = PERCENT_REGEX.captures(value) {
+                caps[1].parse::<usize>().map_err(|err| {
+                    Error::custom(format!("could not parse percent value into usize: {}", err))
+                })
+            } else {
+                Err(de::Error::invalid_value(
+                    Unexpected::Str(value),
+                    &"string did not contain a percent value like 30%",
+                ))
+            }
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            usize::try_from(v).map_err(Error::custom)
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            usize::try_from(v).map_err(Error::custom)
+        }
+    }
+
+    deserializer.deserialize_any(PercentOrInteger)
 }


### PR DESCRIPTION
The integration test started failing because v26.4 of EventstoreDB switched the disk usage metric from a string like 30% to an integer. I updated the deserialization to handle both and added both versions to the integration test matrix.