### PR TITLE
fix: disallow zero values for sink retry parameters

### DIFF
--- a/changelog.d/20891_disallow_zero_for_sink_retry_params.fix.md
+++ b/changelog.d/20891_disallow_zero_for_sink_retry_params.fix.md
@@ -1,0 +1,3 @@
+Fixes sink retry paramater validation to prevent panic at runtime.
+
+authors: dhable


### PR DESCRIPTION
Change `retry_initial_backoff_secs` and `retry_initial_backoff_secs` from `u64` to `NonZeroU64` to prevent divide by zero panic at runtime.

Fixes: #20890

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
