### PR TITLE
chore(ci): Reinstall rustup in MacOS bootstrap

### DIFF
--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -49,8 +49,6 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - run: bash scripts/environment/bootstrap-macos-10.sh
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make test

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -1,7 +1,6 @@
 name: Unit - Mac
 
 on:
-  pull_request:
   workflow_call:
 
 jobs:

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -1,6 +1,7 @@
 name: Unit - Mac
 
 on:
+  pull_request:
   workflow_call:
 
 jobs:
@@ -48,6 +49,8 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - run: bash scripts/environment/bootstrap-macos-10.sh
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - run: bash scripts/environment/prepare.sh
       - run: echo "::add-matcher::.github/matchers/rust.json"
       - run: make test

--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -12,11 +12,11 @@ brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; b
 
 brew install ruby@3 coreutils cue-lang/tap/cue protobuf
 
-# rustup-init (renamed to rustup) is preinstalled on CI, but seems to be lacking the rustup binary
+# rustup-init (renamed to rustup) is already installed in GHA, but seems to be lacking the rustup binary
 # Reinstalling seems to fix it
 # TODO(jszwedko): It's possible GHA just needs to update its images and this won't be needed in the
 # future
-brew install --reinstall rustup
+brew reinstall rustup
 
 gem install bundler
 

--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -10,7 +10,7 @@ brew update
 # https://github.com/actions/setup-python/issues/577
 brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
 
-brew install rustup ruby@3 coreutils cue-lang/tap/cue protobuf
+brew install ruby@3 coreutils cue-lang/tap/cue protobuf
 
 gem install bundler
 
@@ -18,4 +18,5 @@ echo "export PATH=\"/usr/local/opt/ruby/bin:\$PATH\"" >> "$HOME/.bash_profile"
 
 if [ -n "${CI-}" ] ; then
   echo "/usr/local/opt/ruby/bin" >> "$GITHUB_PATH"
+  echo "/opt/homebrew/opt/rustup/bin" >> "$GITHUB_PATH"
 fi

--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -10,7 +10,7 @@ brew update
 # https://github.com/actions/setup-python/issues/577
 brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
 
-brew install ruby@3 coreutils cue-lang/tap/cue protobuf
+brew install rustup ruby@3 coreutils cue-lang/tap/cue protobuf
 
 gem install bundler
 

--- a/scripts/environment/bootstrap-macos-10.sh
+++ b/scripts/environment/bootstrap-macos-10.sh
@@ -12,11 +12,16 @@ brew list -1 | grep python | while read -r formula; do brew unlink "$formula"; b
 
 brew install ruby@3 coreutils cue-lang/tap/cue protobuf
 
+# rustup-init (renamed to rustup) is preinstalled on CI, but seems to be lacking the rustup binary
+# Reinstalling seems to fix it
+# TODO(jszwedko): It's possible GHA just needs to update its images and this won't be needed in the
+# future
+brew install --reinstall rustup
+
 gem install bundler
 
 echo "export PATH=\"/usr/local/opt/ruby/bin:\$PATH\"" >> "$HOME/.bash_profile"
 
 if [ -n "${CI-}" ] ; then
   echo "/usr/local/opt/ruby/bin" >> "$GITHUB_PATH"
-  echo "/opt/homebrew/opt/rustup/bin" >> "$GITHUB_PATH"
 fi


### PR DESCRIPTION
The package was renamed from rustup-init to rustup which seems to be causing some issues in CI where the package is already installed (because `rustup-init` was renamed to it) but `rustup` doesn't have the actual `rustup` binaries downloaded. Reinstalling seems to fix this.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
