### PR TITLE
fix(socket source): fix socket source ignoring global log_namespace when computing outputs

### DIFF
--- a/changelog.d/socket-not-respecting-global-log-namespace.fix.md
+++ b/changelog.d/socket-not-respecting-global-log-namespace.fix.md
@@ -1,0 +1,3 @@
+The `socket` source now respects global log_namespace setting.
+
+authors: Zettroke

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -71,28 +71,12 @@ impl SocketConfig {
 
     fn log_namespace(&self, global_log_namespace: LogNamespace) -> LogNamespace {
         match &self.mode {
-            Mode::Tcp(config) => config
-                .log_namespace
-                .map(Into::into)
-                .unwrap_or(global_log_namespace)
-                .into(),
-            Mode::Udp(config) => config
-                .log_namespace
-                .map(Into::into)
-                .unwrap_or(global_log_namespace)
-                .into(),
+            Mode::Tcp(config) => global_log_namespace.merge(config.log_namespace),
+            Mode::Udp(config) => global_log_namespace.merge(config.log_namespace),
             #[cfg(unix)]
-            Mode::UnixDatagram(config) => config
-                .log_namespace
-                .map(Into::into)
-                .unwrap_or(global_log_namespace)
-                .into(),
+            Mode::UnixDatagram(config) => global_log_namespace.merge(config.log_namespace),
             #[cfg(unix)]
-            Mode::UnixStream(config) => config
-                .log_namespace
-                .map(Into::into)
-                .unwrap_or(global_log_namespace)
-                .into(),
+            Mode::UnixStream(config) => global_log_namespace.merge(config.log_namespace),
         }
     }
 }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -69,14 +69,30 @@ impl SocketConfig {
         }
     }
 
-    fn log_namespace(&self) -> LogNamespace {
+    fn log_namespace(&self, global_log_namespace: LogNamespace) -> LogNamespace {
         match &self.mode {
-            Mode::Tcp(config) => config.log_namespace.unwrap_or(false).into(),
-            Mode::Udp(config) => config.log_namespace.unwrap_or(false).into(),
+            Mode::Tcp(config) => config
+                .log_namespace
+                .map(Into::into)
+                .unwrap_or(global_log_namespace)
+                .into(),
+            Mode::Udp(config) => config
+                .log_namespace
+                .map(Into::into)
+                .unwrap_or(global_log_namespace)
+                .into(),
             #[cfg(unix)]
-            Mode::UnixDatagram(config) => config.log_namespace.unwrap_or(false).into(),
+            Mode::UnixDatagram(config) => config
+                .log_namespace
+                .map(Into::into)
+                .unwrap_or(global_log_namespace)
+                .into(),
             #[cfg(unix)]
-            Mode::UnixStream(config) => config.log_namespace.unwrap_or(false).into(),
+            Mode::UnixStream(config) => config
+                .log_namespace
+                .map(Into::into)
+                .unwrap_or(global_log_namespace)
+                .into(),
         }
     }
 }
@@ -202,7 +218,7 @@ impl SourceConfig for SocketConfig {
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        let log_namespace = global_log_namespace.merge(Some(self.log_namespace()));
+        let log_namespace = self.log_namespace(global_log_namespace);
 
         let schema_definition = self
             .decoding()


### PR DESCRIPTION
Socket source wasn't correctly merging log_namespace with global config.