### PR TITLE
enhancement(aws provider): Add ability to disable request signing

### DIFF
--- a/changelog.d/allow_disabling_aws_request_signing.enhancement.md
+++ b/changelog.d/allow_disabling_aws_request_signing.enhancement.md
@@ -1,0 +1,2 @@
+AWS components can now have request signing disabled by setting `auth.sign: false` on AWS
+components. This can be useful, for example, when sending anonymous requests to AWS S3.

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -175,6 +175,14 @@ pub enum AwsAuthentication {
         /// [aws_region]: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
         #[configurable(metadata(docs::examples = "us-west-2"))]
         region: Option<String>,
+
+        /// Whether to sign requests.
+        ///
+        /// Setting this to false can be useful when writing to an AWS S3 bucket that allows
+        /// anonymous requests.
+        #[serde(default = "crate::serde::default_true")]
+        #[derivative(Default(value = "true"))]
+        sign: bool,
     },
 }
 
@@ -239,7 +247,7 @@ impl AwsAuthentication {
         service_region: Region,
         proxy: &ProxyConfig,
         tls_options: &Option<TlsConfig>,
-    ) -> crate::Result<SharedCredentialsProvider> {
+    ) -> crate::Result<Option<SharedCredentialsProvider>> {
         match self {
             Self::AccessKey {
                 access_key_id,
@@ -265,9 +273,9 @@ impl AwsAuthentication {
 
                     let provider = builder.build_from_provider(provider).await;
 
-                    return Ok(SharedCredentialsProvider::new(provider));
+                    return Ok(Some(SharedCredentialsProvider::new(provider)));
                 }
-                Ok(provider)
+                Ok(Some(provider))
             }
             AwsAuthentication::File {
                 credentials_file,
@@ -288,7 +296,7 @@ impl AwsAuthentication {
                     .profile_name(profile)
                     .configure(&provider_config)
                     .build();
-                Ok(SharedCredentialsProvider::new(profile_provider))
+                Ok(Some(SharedCredentialsProvider::new(profile_provider)))
             }
             AwsAuthentication::Role {
                 assume_role,
@@ -313,9 +321,15 @@ impl AwsAuthentication {
                     )
                     .await;
 
-                Ok(SharedCredentialsProvider::new(provider))
+                Ok(Some(SharedCredentialsProvider::new(provider)))
             }
-            AwsAuthentication::Default { imds, region, .. } => Ok(SharedCredentialsProvider::new(
+            AwsAuthentication::Default { sign: false, .. } => Ok(None),
+            AwsAuthentication::Default {
+                sign: true,
+                imds,
+                region,
+                ..
+            } => Ok(Some(SharedCredentialsProvider::new(
                 default_credentials_provider(
                     region.clone().map(Region::new).unwrap_or(service_region),
                     proxy,
@@ -323,7 +337,7 @@ impl AwsAuthentication {
                     *imds,
                 )
                 .await?,
-            )),
+            ))),
         }
     }
 
@@ -672,6 +686,42 @@ mod tests {
             } => {
                 assert_eq!(&credentials_file, "/path/to/file");
                 assert_eq!(profile, "default".to_string());
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parsing_none() {
+        let config = toml::from_str::<ComponentConfig>(
+            r#"
+            auth.credentials_file = "/path/to/file"
+            auth.profile = "foo"
+        "#,
+        )
+        .unwrap();
+
+        match config.auth {
+            AwsAuthentication::File {
+                credentials_file,
+                profile,
+            } => {
+                assert_eq!(&credentials_file, "/path/to/file");
+                assert_eq!(&profile, "foo");
+            }
+            _ => panic!(),
+        }
+
+        let config = toml::from_str::<ComponentConfig>(
+            r#"
+            auth.no_sign = true
+        "#,
+        )
+        .unwrap();
+
+        match config.auth {
+            AwsAuthentication::None { no_sign } => {
+                assert_eq!(&no_sign, true);
             }
             _ => panic!(),
         }

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -269,10 +269,14 @@ impl ElasticsearchCommon {
 #[cfg(feature = "aws-core")]
 pub async fn sign_request(
     request: &mut http::Request<Bytes>,
-    credentials_provider: &aws_credential_types::provider::SharedCredentialsProvider,
+    credentials_provider: &Option<aws_credential_types::provider::SharedCredentialsProvider>,
     region: &Option<aws_types::region::Region>,
 ) -> crate::Result<()> {
-    crate::aws::sign_request("es", request, credentials_provider, region).await
+    if let Some(credentials_provider) = credentials_provider {
+        crate::aws::sign_request("es", request, credentials_provider, region).await
+    } else {
+        Ok(())
+    }
 }
 
 async fn get_version(

--- a/src/sinks/prometheus/remote_write/service.rs
+++ b/src/sinks/prometheus/remote_write/service.rs
@@ -94,10 +94,14 @@ impl Service<RemoteWriteRequest> for RemoteWriteService {
 #[cfg(feature = "aws-core")]
 async fn sign_request(
     request: &mut http::Request<Bytes>,
-    credentials_provider: &SharedCredentialsProvider,
+    credentials_provider: &Option<SharedCredentialsProvider>,
     region: &Option<Region>,
 ) -> crate::Result<()> {
-    crate::aws::sign_request("aps", request, credentials_provider, region).await
+    if let Some(credentials_provider) = credentials_provider {
+        crate::aws::sign_request("aps", request, credentials_provider, region).await
+    } else {
+        Ok(())
+    }
 }
 
 pub(super) async fn build_request(

--- a/src/sinks/util/auth.rs
+++ b/src/sinks/util/auth.rs
@@ -3,7 +3,7 @@ pub enum Auth {
     Basic(crate::http::Auth),
     #[cfg(feature = "aws-core")]
     Aws {
-        credentials_provider: aws_credential_types::provider::SharedCredentialsProvider,
+        credentials_provider: Option<aws_credential_types::provider::SharedCredentialsProvider>,
         region: aws_types::region::Region,
     },
 }

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -127,6 +127,16 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	batch: {

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -127,6 +127,16 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	batch: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -127,6 +127,16 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	batch: {

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -127,6 +127,16 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	batch: {

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -202,6 +202,16 @@ base: components: sinks: aws_s3: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	batch: {

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -127,6 +127,16 @@ base: components: sinks: aws_sns: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	encoding: {

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -127,6 +127,16 @@ base: components: sinks: aws_sqs: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	encoding: {

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -165,6 +165,17 @@ base: components: sinks: elasticsearch: configuration: {
 				required:      true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: bool: default: true
+			}
 			strategy: {
 				description: "The authentication strategy to use."
 				required:    true

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -142,6 +142,17 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				required:      true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				relevant_when: "strategy = \"aws\""
+				required:      false
+				type: bool: default: true
+			}
 			strategy: {
 				description: "The authentication strategy to use."
 				required:    true

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -122,6 +122,16 @@ base: components: sources: aws_s3: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	compression: {

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -122,6 +122,16 @@ base: components: sources: aws_sqs: configuration: {
 				required:    true
 				type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
 			}
+			sign: {
+				description: """
+					Whether to sign requests.
+
+					Setting this to false can be useful when writing to an AWS S3 bucket that allows
+					anonymous requests.
+					"""
+				required: false
+				type: bool: default: true
+			}
 		}
 	}
 	client_concurrency: {


### PR DESCRIPTION
This can be useful when sending anonymous requests to AWS S3. Potentially it could be useful in other situations as well (e.g. sending to AWS API compatible endpoints that don't support signing).

I'd really have liked to introduce this as a new "strategy" for AWS authentication configuration since it is mutually exclusive with the others, but given the way AWS authentication configuration is currently implemented as an untagged enum, adding it to the default config enum seemed like the best option.

If/when we refactor this to follow
https://github.com/vectordotdev/vector/blob/master/docs/specs/configuration.md#polymorphism then we can move it.

Prompted by a user in discord: https://discord.com/channels/742820443487993987/1267892632319692802/1267892632319692802

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
