### PR TITLE
fix(config): Avoid parsing configuration files without interpolating secrets

### DIFF
--- a/changelog.d/defer-log-schema-defaults.fix.md
+++ b/changelog.d/defer-log-schema-defaults.fix.md
@@ -1,0 +1,1 @@
+Vector no longer panics during configuration loading if a secret is used for a configuration option that has additional validation (e.g. URIs).

--- a/src/app.rs
+++ b/src/app.rs
@@ -489,9 +489,6 @@ pub async fn load_configs(
         paths = ?config_paths.iter().map(<&PathBuf>::from).collect::<Vec<_>>()
     );
 
-    // config::init_log_schema should be called before initializing sources.
-    config::init_log_schema(&config_paths, true).map_err(handle_config_errors)?;
-
     let mut config = config::load_from_paths_with_provider_and_secrets(
         &config_paths,
         signal_handler,
@@ -500,6 +497,7 @@ pub async fn load_configs(
     .await
     .map_err(handle_config_errors)?;
 
+    config::init_log_schema(config.global.log_schema.clone(), true);
     config::init_telemetry(config.global.telemetry.clone(), true);
 
     if !config.healthchecks.enabled {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,18 +64,8 @@ pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
 pub use vars::{interpolate, ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX};
 pub use vector_lib::config::{
-    init_telemetry, log_schema, proxy::ProxyConfig, telemetry, LogSchema, OutputId,
+    init_log_schema, init_telemetry, log_schema, proxy::ProxyConfig, telemetry, LogSchema, OutputId,
 };
-
-/// Loads Log Schema from configurations and sets global schema.
-/// Once this is done, configurations can be correctly loaded using
-/// configured log schema defaults.
-/// If deny is set, will panic if schema has already been set.
-pub fn init_log_schema(config_paths: &[ConfigPath], deny_if_set: bool) -> Result<(), Vec<String>> {
-    let builder = load_builder_from_paths(config_paths)?;
-    vector_lib::config::init_log_schema(builder.global.log_schema, deny_if_set);
-    Ok(())
-}
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum ConfigPath {

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -83,11 +83,24 @@ impl UnitTest {
     }
 }
 
+/// Loads Log Schema from configurations and sets global schema.
+/// Once this is done, configurations can be correctly loaded using
+/// configured log schema defaults.
+/// If deny is set, will panic if schema has already been set.
+fn init_log_schema_from_paths(
+    config_paths: &[ConfigPath],
+    deny_if_set: bool,
+) -> Result<(), Vec<String>> {
+    let builder = config::loading::load_builder_from_paths(config_paths)?;
+    vector_lib::config::init_log_schema(builder.global.log_schema, deny_if_set);
+    Ok(())
+}
+
 pub async fn build_unit_tests_main(
     paths: &[ConfigPath],
     signal_handler: &mut signal::SignalHandler,
 ) -> Result<Vec<UnitTest>, Vec<String>> {
-    config::init_log_schema(paths, false)?;
+    init_log_schema_from_paths(paths, false)?;
     let mut secrets_backends_loader = loading::load_secret_backends_from_paths(paths)?;
     let config_builder = if secrets_backends_loader.has_secrets_to_retrieve() {
         let resolved_secrets = secrets_backends_loader

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -70,8 +70,7 @@ pub struct DockerLogsConfig {
     /// By default, the [global `log_schema.host_key` option][global_host_key] is used.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    #[serde(default = "default_host_key")]
-    host_key: OptionalValuePath,
+    host_key: Option<OptionalValuePath>,
 
     /// Docker host to connect to.
     ///
@@ -171,7 +170,7 @@ pub struct DockerLogsConfig {
 impl Default for DockerLogsConfig {
     fn default() -> Self {
         Self {
-            host_key: default_host_key(),
+            host_key: None,
             docker_host: None,
             tls: None,
             exclude_containers: None,
@@ -185,10 +184,6 @@ impl Default for DockerLogsConfig {
             log_namespace: None,
         }
     }
-}
-
-fn default_host_key() -> OptionalValuePath {
-    log_schema().host_key().cloned().into()
 }
 
 fn default_partial_event_marker_field() -> Option<String> {
@@ -273,7 +268,12 @@ impl SourceConfig for DockerLogsConfig {
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        let host_key = self.host_key.clone().path.map(LegacyKey::Overwrite);
+        let host_key = self
+            .host_key
+            .clone()
+            .unwrap_or(log_schema().host_key().cloned().into())
+            .path
+            .map(LegacyKey::Overwrite);
 
         let schema_definition = BytesDeserializerConfig
             .schema_definition(global_log_namespace.merge(self.log_namespace))
@@ -465,7 +465,10 @@ impl DockerLogsSource {
     ) -> crate::Result<DockerLogsSource> {
         let backoff_secs = config.retry_backoff_secs;
 
-        let host_key = config.host_key.clone();
+        let host_key = config
+            .host_key
+            .clone()
+            .unwrap_or(log_schema().host_key().cloned().into());
         let hostname = crate::get_hostname().ok();
 
         // Only logs created at, or after this moment are logged.

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -35,8 +35,7 @@ pub struct InternalLogsConfig {
     /// Set to `""` to suppress this key.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    #[serde(default = "default_host_key")]
-    host_key: OptionalValuePath,
+    host_key: Option<OptionalValuePath>,
 
     /// Overrides the name of the log field used to add the current process ID to each event.
     ///
@@ -52,10 +51,6 @@ pub struct InternalLogsConfig {
     log_namespace: Option<bool>,
 }
 
-fn default_host_key() -> OptionalValuePath {
-    log_schema().host_key().cloned().into()
-}
-
 fn default_pid_key() -> OptionalValuePath {
     OptionalValuePath::from(owned_value_path!("pid"))
 }
@@ -65,7 +60,7 @@ impl_generate_config_from_default!(InternalLogsConfig);
 impl Default for InternalLogsConfig {
     fn default() -> InternalLogsConfig {
         InternalLogsConfig {
-            host_key: default_host_key(),
+            host_key: None,
             pid_key: default_pid_key(),
             log_namespace: None,
         }
@@ -75,7 +70,12 @@ impl Default for InternalLogsConfig {
 impl InternalLogsConfig {
     /// Generates the `schema::Definition` for this component.
     fn schema_definition(&self, log_namespace: LogNamespace) -> Definition {
-        let host_key = self.host_key.clone().path.map(LegacyKey::Overwrite);
+        let host_key = self
+            .host_key
+            .clone()
+            .unwrap_or(log_schema().host_key().cloned().into())
+            .path
+            .map(LegacyKey::Overwrite);
         let pid_key = self.pid_key.clone().path.map(LegacyKey::Overwrite);
 
         // There is a global and per-source `log_namespace` config.
@@ -104,7 +104,11 @@ impl InternalLogsConfig {
 #[typetag::serde(name = "internal_logs")]
 impl SourceConfig for InternalLogsConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let host_key = self.host_key.clone().path;
+        let host_key = self
+            .host_key
+            .clone()
+            .unwrap_or(log_schema().host_key().cloned().into())
+            .path;
         let pid_key = self.pid_key.clone().path;
 
         let subscription = TraceSubscription::subscribe();

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -211,7 +211,7 @@ impl SourceConfig for SocketConfig {
 
         let schema_definition = match &self.mode {
             Mode::Tcp(config) => {
-                let legacy_host_key = config.host_key().clone().path.map(LegacyKey::InsertIfEmpty);
+                let legacy_host_key = config.host_key().path.map(LegacyKey::InsertIfEmpty);
 
                 let legacy_port_key = config.port_key().clone().path.map(LegacyKey::InsertIfEmpty);
 
@@ -247,7 +247,7 @@ impl SourceConfig for SocketConfig {
                     )
             }
             Mode::Udp(config) => {
-                let legacy_host_key = config.host_key().clone().path.map(LegacyKey::InsertIfEmpty);
+                let legacy_host_key = config.host_key().path.map(LegacyKey::InsertIfEmpty);
 
                 let legacy_port_key = config.port_key().clone().path.map(LegacyKey::InsertIfEmpty);
 

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -46,8 +46,7 @@ pub struct TcpConfig {
     /// Set to `""` to suppress this key.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    #[serde(default = "default_host_key")]
-    host_key: OptionalValuePath,
+    host_key: Option<OptionalValuePath>,
 
     /// Overrides the name of the log field used to add the peer host's port to each event.
     ///
@@ -106,7 +105,7 @@ impl TcpConfig {
             address,
             keepalive: None,
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
-            host_key: default_host_key(),
+            host_key: None,
             port_key: default_port_key(),
             permit_origin: None,
             tls: None,
@@ -119,8 +118,8 @@ impl TcpConfig {
         }
     }
 
-    pub const fn host_key(&self) -> &OptionalValuePath {
-        &self.host_key
+    pub(super) fn host_key(&self) -> OptionalValuePath {
+        self.host_key.clone().unwrap_or(default_host_key())
     }
 
     pub const fn port_key(&self) -> &OptionalValuePath {
@@ -228,7 +227,12 @@ impl TcpSource for RawTcpSource {
                     now,
                 );
 
-                let legacy_host_key = self.config.host_key.clone().path;
+                let legacy_host_key = self
+                    .config
+                    .host_key
+                    .clone()
+                    .unwrap_or(default_host_key())
+                    .path;
 
                 self.log_namespace.insert_source_metadata(
                     SocketConfig::NAME,

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -1,3 +1,4 @@
+use super::default_host_key;
 use bytes::BytesMut;
 use chrono::Utc;
 use futures::StreamExt;
@@ -17,7 +18,6 @@ use vector_lib::{
 
 use crate::{
     codecs::Decoder,
-    config::log_schema,
     event::Event,
     internal_events::{
         SocketBindError, SocketEventsReceived, SocketMode, SocketReceiveError, StreamClosedError,
@@ -57,8 +57,7 @@ pub struct UdpConfig {
     /// Set to `""` to suppress this key.
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
-    #[serde(default = "default_host_key")]
-    host_key: OptionalValuePath,
+    host_key: Option<OptionalValuePath>,
 
     /// Overrides the name of the log field used to add the peer host's port to each event.
     ///
@@ -88,10 +87,6 @@ pub struct UdpConfig {
     pub log_namespace: Option<bool>,
 }
 
-fn default_host_key() -> OptionalValuePath {
-    log_schema().host_key().cloned().into()
-}
-
 fn default_port_key() -> OptionalValuePath {
     OptionalValuePath::from(owned_value_path!("port"))
 }
@@ -101,8 +96,8 @@ fn default_max_length() -> usize {
 }
 
 impl UdpConfig {
-    pub(super) const fn host_key(&self) -> &OptionalValuePath {
-        &self.host_key
+    pub(super) fn host_key(&self) -> OptionalValuePath {
+        self.host_key.clone().unwrap_or(default_host_key())
     }
 
     pub const fn port_key(&self) -> &OptionalValuePath {
@@ -125,7 +120,7 @@ impl UdpConfig {
         Self {
             address,
             max_length: default_max_length(),
-            host_key: default_host_key(),
+            host_key: None,
             port_key: default_port_key(),
             receive_buffer_bytes: None,
             framing: default_framing_message_based(),
@@ -245,7 +240,11 @@ pub(super) fn udp(
                                             now,
                                         );
 
-                                        let legacy_host_key = config.host_key.clone().path;
+                                        let legacy_host_key = config
+                                            .host_key
+                                            .clone()
+                                            .unwrap_or(default_host_key())
+                                            .path;
 
                                         log_namespace.insert_source_metadata(
                                             SocketConfig::NAME,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -141,12 +141,10 @@ pub fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
         fmt.title(format!("Failed to load {:?}", &paths_list));
         fmt.sub_error(errors);
     };
-    config::init_log_schema(&paths, true)
-        .map_err(&mut report_error)
-        .ok()?;
     let builder = config::load_builder_from_paths(&paths)
         .map_err(&mut report_error)
         .ok()?;
+    config::init_log_schema(builder.global.log_schema.clone(), true);
 
     // Build
     let (config, warnings) = builder

--- a/website/cue/reference/components/sources/base/docker_logs.cue
+++ b/website/cue/reference/components/sources/base/docker_logs.cue
@@ -45,7 +45,7 @@ base: components: sources: docker_logs: configuration: {
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
 		required: false
-		type: string: default: "host"
+		type: string: {}
 	}
 	include_containers: {
 		description: """

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -169,10 +169,7 @@ base: components: sources: file: configuration: {
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
 		required: false
-		type: string: {
-			default: "host"
-			examples: ["hostname"]
-		}
+		type: string: examples: ["hostname"]
 	}
 	ignore_checkpoints: {
 		description: """

--- a/website/cue/reference/components/sources/base/internal_logs.cue
+++ b/website/cue/reference/components/sources/base/internal_logs.cue
@@ -12,7 +12,7 @@ base: components: sources: internal_logs: configuration: {
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
 		required: false
-		type: string: default: "host"
+		type: string: {}
 	}
 	pid_key: {
 		description: """

--- a/website/cue/reference/components/sources/base/internal_metrics.cue
+++ b/website/cue/reference/components/sources/base/internal_metrics.cue
@@ -31,7 +31,7 @@ base: components: sources: internal_metrics: configuration: {
 					[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 					"""
 				required: false
-				type: string: default: "host"
+				type: string: {}
 			}
 			pid_key: {
 				description: """

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -386,7 +386,7 @@ base: components: sources: socket: configuration: {
 			[global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
 			"""
 		required: false
-		type: string: default: "host"
+		type: string: {}
 	}
 	keepalive: {
 		description:   "TCP keepalive settings for socket-based components."


### PR DESCRIPTION
Closes: https://github.com/vectordotdev/vector/issues/20974

Reverts https://github.com/vectordotdev/vector/pull/17759 and solves the issue fixed by that PR by, instead of deserializing configuration twice, to set the global `log_schema`, defer fetching values from the `log_schema` until _after_ deserialization (previously some config structs would attempt to fetch during deserialization, but the `log_schema` may not have been deserialized by that point).

Attempting to pull from `log_schema` during deserialization is an easy bug to reintroduce, but I don't see an easy way to prohibit it.

I think it is easiest to review the first two commits independently.