### PR TITLE
docs(external docs): Emphasize the $$ rather than $ in config file.

### DIFF
--- a/website/cue/reference/remap/functions/replace.cue
+++ b/website/cue/reference/remap/functions/replace.cue
@@ -62,7 +62,7 @@ remap: functions: replace: {
 			return: "Pineapples and Bananas"
 		},
 		{
-			title: "Replace with capture groups"
+			title: "Replace with capture groups (NOTE: Use `$$num` in config files)"
 			source: #"""
 				replace("foo123bar", r'foo(?P<num>\d+)bar', "$num")
 				"""#

--- a/website/cue/reference/remap/functions/replace.cue
+++ b/website/cue/reference/remap/functions/replace.cue
@@ -62,7 +62,7 @@ remap: functions: replace: {
 			return: "Pineapples and Bananas"
 		},
 		{
-			title: "Replace with capture groups (NOTE: Use `$$num` in config files)"
+			title: "Replace with capture groups (Note: Use `$$num` in config files)"
 			source: #"""
 				replace("foo123bar", r'foo(?P<num>\d+)bar', "$num")
 				"""#


### PR DESCRIPTION

<img width="928" alt="image" src="https://github.com/user-attachments/assets/d9bc1dae-b879-498f-91ad-94d648b1478d">

<img width="911" alt="image" src="https://github.com/user-attachments/assets/40e76a91-f185-46b2-803e-efee230b4b56">


Even though the [replace function](https://vector.dev/docs/reference/vrl/functions/#replace) documentation already states that $$ should be used instead of $ in configuration files, the [specific use case example](https://vector.dev/docs/reference/vrl/functions/#replace-examples-replace-with-capture-groups) does not emphasize this distinction. This can easily lead to misunderstandings, especially for newcomers. Since many people will use this in configuration files, I believe it is necessary to explicitly clarify the different usage in the specific use case example.

related issue: #20988
