### PR TITLE
enhancement(http-sink): Add automatic bearer token acquisition for http-sink

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -293,6 +293,26 @@ pub enum Auth {
         password: SensitiveString,
     },
 
+    /// Lorem ipsum dolor sit amet.
+    ///
+    /// Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
+    OAuth2 {
+        /// Temporibus autem quibusdam et aut officiis debitis.
+        #[configurable(metadata(docs::examples = "${TOKEN_ENDPOINT}"))]
+        #[configurable(metadata(docs::examples = "token_endpoint"))]
+        token_endpoint: String,
+
+        /// Nam libero tempore, cum soluta nobis.
+        #[configurable(metadata(docs::examples = "${CLIENT_ID}"))]
+        #[configurable(metadata(docs::examples = "client_id"))]
+        client_id: String,
+
+        /// At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium.
+        #[configurable(metadata(docs::examples = "${CLIENT_SECRET}"))]
+        #[configurable(metadata(docs::examples = "client_secret"))]
+        client_secret: SensitiveString,
+    },
+
     /// Bearer authentication.
     ///
     /// The bearer token value (OAuth2, JWT, etc.) is passed as-is.
@@ -337,6 +357,9 @@ impl Auth {
             Auth::Bearer { token } => match Authorization::bearer(token.inner()) {
                 Ok(auth) => map.typed_insert(auth),
                 Err(error) => error!(message = "Invalid bearer token.", token = %token, %error),
+            },
+            Auth::OAuth2 { ..} => {
+                panic!("Operation not supporter for this type of authorization.")
             },
         }
     }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -130,6 +130,9 @@ impl SinkConfig for DatabendConfig {
             Some(Auth::Bearer { .. }) => {
                 return Err("Bearer authentication is not supported currently".into());
             }
+            Some(Auth::OAuth2 { .. }) => {
+                return Err("OAuth2 authentication is not supported currently".into());
+            }
             None => {}
         }
         if let Some(database) = &self.database {

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -322,6 +322,9 @@ fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
                 ),
                 Auth::Bearer { token } => {
                     HeaderValue::from_str(format!("Bearer {}", token.inner()).as_str())
+                },
+                Auth::OAuth2 { .. } => {
+                    panic!("Operation not supporter for this type of authorization.")
                 }
             };
 


### PR DESCRIPTION
This PR intend to be a proof-of-concept for https://github.com/vectordotdev/vector/issues/20635. 
Because I have little knowledge about vector and not much more experience in Rust, I started with minimal working implementation to just verify concept (for example, where code responsible for token acquisition should be placed :)), if shape of this change will be more or less ok, I will take care for test, docs and code quality :) 

example configuration I used to test this solution.
```yaml
sources:
  my_source_id:
    scrape_interval_secs: 1
    type: http_client
    endpoint: http://127.0.0.1:9898/logs
    auth:
      strategy: "o_auth2"
      client_id: "some.client.id"
      client_secret: "some.client.secret"
      token_endpoint: "https://some.oauth.system/oauth/token"

sinks:
  out:
    inputs:
      - "my_source_id"
    type: "console"
    encoding:
      codec: "text" 
```