### PR TITLE
fix(config): Make config watcher recursive.

### DIFF
--- a/changelog.d/20996_recursive_config_watcher.fix.md
+++ b/changelog.d/20996_recursive_config_watcher.fix.md
@@ -1,0 +1,3 @@
+Fixes an issue where the configuration watcher did not properly handle recursive directories, ensuring configuration will be reloaded in the automatic-namespacing scenario. 
+
+authors: ifuryst

--- a/changelog.d/20996_recursive_config_watcher.fix.md
+++ b/changelog.d/20996_recursive_config_watcher.fix.md
@@ -1,3 +1,3 @@
-Fixes an issue where the configuration watcher did not properly handle recursive directories, ensuring configuration will be reloaded in the automatic-namespacing scenario. 
+Fixes an issue where the configuration watcher did not properly handle recursive directories, ensuring configuration will be reloaded in the automatic-namespacing scenario.
 
 authors: ifuryst


### PR DESCRIPTION
Close #20547, this problem is that the watcher doesn't watch dir recursively.

This easily changes the watcher to watch dir recursively. While this may not be the best solution, considering that `config::watcher::spawn_thread` is currently only used for watching config. IMHO, it seems intuitive to watch paths recursively.

Please let me know if you have any concerns about potential implications for users to upgrade the version.