### PR TITLE
test(codecs): add missing assert in codec decoding tests

### DIFF
--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -498,7 +498,7 @@ mod tests {
     fn gelf_stream_default_framing_is_null_delimited() {
         let deserializer_config = DeserializerConfig::from(GelfDeserializerConfig::default());
         let framing_config = deserializer_config.default_stream_framing();
-        matches!(
+        assert!(matches!(
             framing_config,
             FramingConfig::CharacterDelimited(CharacterDelimitedDecoderConfig {
                 character_delimited: CharacterDelimitedDecoderOptions {
@@ -506,6 +506,6 @@ mod tests {
                     max_length: None,
                 }
             })
-        );
+        ));
     }
 }


### PR DESCRIPTION
Found a missing assert in a test that was done by myself.

the `matches` macro does not panic if the pattern does not match, it just returns false.