### PR TITLE
enhancement(http-sink): Add automatic bearer token acquisition for http-sink

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -3,8 +3,8 @@ use std::{
     fmt,
     net::SocketAddr,
     task::{Context, Poll},
-    time::Duration,
 };
+use serde::Deserialize;
 use std::sync::{Arc, Mutex};
 use futures::future::BoxFuture;
 use headers::{Authorization, HeaderMapExt};
@@ -17,6 +17,8 @@ use hyper::{
     client,
     client::{Client, HttpConnector},
 };
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use bytes::Buf;
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
 use rand::Rng;
@@ -359,6 +361,102 @@ impl Auth {
             },
             Auth::OAuth2 { .. } => todo!(),
         }
+    }
+
+    pub async fn apply_async<B>(&self, req: &mut Request<B>, client: HttpClient, mut bearer_state: BearerTokenState) {
+        let map = req.headers_mut();
+        match &self {
+            Auth::Basic { user, password } => {
+                let auth = Authorization::basic(user.as_str(), password.inner());
+                map.typed_insert(auth);
+            }
+            Auth::Bearer { token } => match Authorization::bearer(token.inner()) {
+                Ok(auth) => map.typed_insert(auth),
+                Err(error) => error!(message = "Invalid bearer token.", token = %token, %error),
+            },
+            Auth::OAuth2 { token_endpoint, client_id, client_secret } => {
+                let token = bearer_state.get_token(client.clone(), token_endpoint, client_id, client_secret).await;
+                let temp_auth = Auth::Bearer{ token: SensitiveString::from(token)};
+                temp_auth.apply(req);
+            },
+        }
+    }
+
+
+}
+
+#[derive(Clone, Debug)]
+pub struct BearerTokenState {
+    token: Arc<Mutex<Option<ExpirableToken>>>
+} 
+
+#[derive(Debug, Deserialize)]
+struct Token {
+    access_token: String,
+    expires_in: u32 
+}
+
+#[derive(Debug)]
+struct ExpirableToken {
+    access_token: String,
+    expires_after_ms: u128
+}
+
+impl BearerTokenState {
+    
+    pub fn new() -> BearerTokenState {
+        let empty_token = Arc::new(Mutex::new(None));
+        BearerTokenState { token: empty_token }
+    }
+
+    async fn get_token(&mut self, client: HttpClient, token_endpoint: &String, client_id: &String, client_secret: &SensitiveString) -> String {
+        
+        let now = SystemTime::now();
+        let since_the_epoch = now
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+
+        //first lets try to return already acquired token
+        {
+            let maybe_token = self.token.lock().unwrap();
+            match &*maybe_token {
+                Some(token) => {
+                    if since_the_epoch.as_millis() < token.expires_after_ms {
+                        //we have token, token is valud for at least 1min, we can use it.
+                        return token.access_token.clone();
+                    }
+                },
+                None => {},
+            }
+        }
+
+        //we need to acquire new
+        let request_body = format!("client_secret={}&grant_type=client_credentials&response_type=token&client_id={}", client_secret.inner(), client_id);
+        println!("{}", request_body);
+
+        let builder = Request::post(token_endpoint.clone());
+        let builder = builder.header("Content-Type", "application/x-www-form-urlencoded");
+        let request = builder.body(Body::from(request_body)).expect("error creating request");
+        let response = client.send(request).await.unwrap();
+
+        println!("BODY {:?}", response);
+
+        let body = hyper::body::aggregate(response).await.unwrap();
+        let token: Token = serde_json::from_reader(body.reader()).unwrap();
+        let token_to_return = token.access_token.clone();
+
+        //expires_in means, in seconds, for how long it will be valid, lets say 5min, 
+        //to not cause some random 4xx, because token expired in the meantime, we will make some
+        //room for token refreshing, this room is 1min (60seconds)
+        let token_is_valid_for_ms = (token.expires_in - 60) * 1000;
+        let token_will_expire_after_ms = since_the_epoch.as_millis() + (token_is_valid_for_ms as u128);
+
+
+        {
+            let _ = self.token.lock().unwrap().replace(ExpirableToken{access_token:token.access_token, expires_after_ms: token_will_expire_after_ms});
+        }
+
+        token_to_return
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-
+use std::sync::{Arc, Mutex};
 use futures::future::BoxFuture;
 use headers::{Authorization, HeaderMapExt};
 use http::{
@@ -33,9 +33,7 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::sensitive_string::SensitiveString;
 
 use crate::{
-    config::ProxyConfig,
-    internal_events::{http_client, HttpServerRequestReceived, HttpServerResponseSent},
-    tls::{tls_connector_builder, MaybeTlsSettings, TlsError},
+    config::ProxyConfig, internal_events::{http_client, HttpServerRequestReceived, HttpServerResponseSent}, tls::{tls_connector_builder, MaybeTlsSettings, TlsError}
 };
 
 pub mod status {
@@ -293,6 +291,27 @@ pub enum Auth {
         password: SensitiveString,
     },
 
+    /// Lorem ipsum dolor sit amet.
+    ///
+    /// Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
+    OAuth2 {
+        /// Temporibus autem quibusdam et aut officiis debitis.
+        #[configurable(metadata(docs::examples = "${TOKEN_ENDPOINT}"))]
+        #[configurable(metadata(docs::examples = "token_endpoint"))]
+        token_endpoint: String,
+
+        /// Nam libero tempore, cum soluta nobis.
+        #[configurable(metadata(docs::examples = "${CLIENT_ID}"))]
+        #[configurable(metadata(docs::examples = "client_id"))]
+        client_id: String,
+
+        /// At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium.
+        #[configurable(metadata(docs::examples = "${CLIENT_SECRET}"))]
+        #[configurable(metadata(docs::examples = "client_secret"))]
+        client_secret: SensitiveString,
+    },
+
+
     /// Bearer authentication.
     ///
     /// The bearer token value (OAuth2, JWT, etc.) is passed as-is.
@@ -338,6 +357,7 @@ impl Auth {
                 Ok(auth) => map.typed_insert(auth),
                 Err(error) => error!(message = "Invalid bearer token.", token = %token, %error),
             },
+            Auth::OAuth2 { .. } => todo!(),
         }
     }
 }

--- a/src/sinks/clickhouse/service.rs
+++ b/src/sinks/clickhouse/service.rs
@@ -69,8 +69,9 @@ pub(super) struct ClickhouseServiceRequestBuilder {
     pub(super) compression: Compression,
 }
 
+#[async_trait]
 impl HttpServiceRequestBuilder<PartitionKey> for ClickhouseServiceRequestBuilder {
-    fn build(
+    async fn build(
         &self,
         mut request: HttpRequest<PartitionKey>,
     ) -> Result<Request<Bytes>, crate::Error> {

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -130,6 +130,9 @@ impl SinkConfig for DatabendConfig {
             Some(Auth::Bearer { .. }) => {
                 return Err("Bearer authentication is not supported currently".into());
             }
+            Some(Auth::OAuth2 { .. }) => {
+                todo!()
+            }
             None => {}
         }
         if let Some(database) = &self.database {

--- a/src/sinks/gcp/stackdriver/logs/service.rs
+++ b/src/sinks/gcp/stackdriver/logs/service.rs
@@ -11,6 +11,7 @@ use crate::{
     },
 };
 use snafu::ResultExt;
+use async_trait::async_trait;
 
 #[derive(Debug, Clone)]
 pub(super) struct StackdriverLogsServiceRequestBuilder {
@@ -18,8 +19,9 @@ pub(super) struct StackdriverLogsServiceRequestBuilder {
     pub(super) auth: GcpAuthenticator,
 }
 
+#[async_trait]
 impl HttpServiceRequestBuilder<()> for StackdriverLogsServiceRequestBuilder {
-    fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
+    async fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
         let builder = Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/json");
 
         let mut request = builder

--- a/src/sinks/gcp/stackdriver/metrics/config.rs
+++ b/src/sinks/gcp/stackdriver/metrics/config.rs
@@ -159,8 +159,9 @@ pub(super) struct StackdriverMetricsServiceRequestBuilder {
     pub(super) auth: GcpAuthenticator,
 }
 
+#[async_trait]
 impl HttpServiceRequestBuilder<()> for StackdriverMetricsServiceRequestBuilder {
-    fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
+    async fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
         let builder = Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/json");
 
         let mut request = builder

--- a/src/sinks/honeycomb/service.rs
+++ b/src/sinks/honeycomb/service.rs
@@ -9,6 +9,7 @@ use crate::sinks::{
     HTTPRequestBuilderSnafu,
 };
 use snafu::ResultExt;
+use async_trait::async_trait;
 
 use super::config::HTTP_HEADER_HONEYCOMB;
 
@@ -18,8 +19,9 @@ pub(super) struct HoneycombSvcRequestBuilder {
     pub(super) api_key: SensitiveString,
 }
 
+#[async_trait]
 impl HttpServiceRequestBuilder<()> for HoneycombSvcRequestBuilder {
-    fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
+    async fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
         let builder = Request::post(&self.uri).header(HTTP_HEADER_HONEYCOMB, self.api_key.inner());
 
         builder

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -10,7 +10,7 @@ use vector_lib::codecs::{
 
 use crate::{
     codecs::{EncodingConfigWithFraming, SinkType},
-    http::{Auth, HttpClient, MaybeAuth},
+    http::{Auth, BearerTokenState, HttpClient, MaybeAuth},
     sinks::{
         prelude::*,
         util::{
@@ -276,8 +276,11 @@ impl SinkConfig for HttpSinkConfig {
         });
 
         println!("XOXOXOXO CONFIG HttpSinkConfig");
+        let bearer_state = BearerTokenState::new();
 
         let http_sink_request_builder = HttpSinkRequestBuilder::new(
+            client.clone(),
+            bearer_state,
             self.uri.with_default_parts(),
             self.method,
             self.auth.choose_one(&self.uri.auth)?,

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -275,6 +275,8 @@ impl SinkConfig for HttpSinkConfig {
                 .to_string()
         });
 
+        println!("XOXOXOXO CONFIG HttpSinkConfig");
+
         let http_sink_request_builder = HttpSinkRequestBuilder::new(
             self.uri.with_default_parts(),
             self.method,

--- a/src/sinks/http/service.rs
+++ b/src/sinks/http/service.rs
@@ -20,6 +20,7 @@ use crate::{
 use snafu::ResultExt;
 
 use super::config::HttpMethod;
+use async_trait::async_trait;
 
 #[derive(Debug, Clone)]
 pub(super) struct HttpSinkRequestBuilder {
@@ -51,9 +52,12 @@ impl HttpSinkRequestBuilder {
         }
     }
 }
-
+#[async_trait]
 impl HttpServiceRequestBuilder<()> for HttpSinkRequestBuilder {
-    fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
+    async fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
+
+        println!("XOXOXOX HttpServiceRequestBuilder::build");
+
         let method: Method = self.method.into();
         let uri: Uri = self.uri.uri.clone();
         let mut builder = Request::builder().method(method).uri(uri);

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -323,6 +323,7 @@ fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
                 Auth::Bearer { token } => {
                     HeaderValue::from_str(format!("Bearer {}", token.inner()).as_str())
                 }
+                Auth::OAuth2 { .. } => todo!(),
             };
 
             if let Ok(encoded_credentials) = encoded_credentials {


### PR DESCRIPTION
This PR intend to be a proof-of-concept for https://github.com/vectordotdev/vector/issues/20635. 
Because I have little knowledge about vector and not much more experience in Rust, I started with minimal working implementation to just verify concept (for example, where code responsible for token acquisition should be placed :)), if shape of this change will be more or less ok, I will take care for test, docs and code quality :) 

example configuration I used to test this solution.
```yaml
sources:
  my_source_id:
    scrape_interval_secs: 1
    type: http_client
    endpoint: http://127.0.0.1:9898/logs

sinks:
  my_sink_id:
    auth:
      strategy: "o_auth2"
      client_id: "some_client_id"
      client_secret: "client_secret"
      token_endpoint: "https://some.url/oauth/token"
    type: http
    encoding:
      codec: raw_message
    inputs:
      - my_source_id
    uri: http://127.0.0.1:9091/output
```

And, initial question to vector's owners is: does this PR makes sense from your point of view ? 

thanks.