### PR TITLE
chore(ci): Replace usages of `docker-compose` with `docker compose`

### DIFF
--- a/scripts/environment/bootstrap-ubuntu-20.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-20.04.sh
@@ -105,12 +105,6 @@ if ! [ -x "$(command -v docker)" ]; then
     usermod --append --groups docker ubuntu || true
 fi
 
-# docker-compose
-if ! [ -x "$(command -v docker-compose)" ]; then
-  curl -fsSL "https://github.com/docker/compose/releases/download/v2.20.3/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
-  chmod +x /usr/local/bin/docker-compose
-fi
-
 bash scripts/environment/install-protoc.sh
 
 # Node.js, npm and yarn.

--- a/scripts/integration/README.md
+++ b/scripts/integration/README.md
@@ -3,7 +3,7 @@ This directory contains a set of integration test frameworks for vector which ar
 
 Each directory contains two files:
 
-1. A `compose.yaml` file containing the instructions to `docker-compose` or `podman-compose` for how
+1. A `compose.yaml` file containing the instructions to `docker compose` or `podman compose` for how
    to set up the containers in which to run the integrations, and
 2. A `test.yaml` file that describes how to run the integration tests, including a matrix of
    software versions or other parameters over which the tests will be run.

--- a/vdev/src/testing/config.rs
+++ b/vdev/src/testing/config.rs
@@ -126,8 +126,7 @@ pub struct ComposeTestConfig {
 #[serde(deny_unknown_fields)]
 pub struct IntegrationRunnerConfig {
     /// The set of environment variables to set in just the runner. This is used for settings that
-    /// might otherwise affect the operation of either docker or docker-compose but are needed in
-    /// the runner.
+    /// might otherwise affect the operation of docker but are needed in the runner.
     #[serde(default)]
     pub env: Environment,
     /// The set of volumes that need to be mounted into the runner.

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -276,9 +276,8 @@ impl Compose {
     }
 
     fn run(&self, action: &str, args: &[&'static str], config: Option<&Environment>) -> Result<()> {
-        let mut command = CONTAINER_TOOL.clone();
-        command.push(" compose");
-        let mut command = Command::new(command);
+        let mut command = Command::new(CONTAINER_TOOL.clone());
+        command.arg("compose");
         // When the integration test environment is already active, the tempfile path does not
         // exist because `Compose::new()` has not been called. In this case, the `stop` command
         // needs to use the calculated path from the integration name instead of the nonexistent

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -277,7 +277,7 @@ impl Compose {
 
     fn run(&self, action: &str, args: &[&'static str], config: Option<&Environment>) -> Result<()> {
         let mut command = CONTAINER_TOOL.clone();
-        command.push("-compose");
+        command.push(" compose");
         let mut command = Command::new(command);
         // When the integration test environment is already active, the tempfile path does not
         // exist because `Compose::new()` has not been called. In this case, the `stop` command

--- a/website/cue/reference/administration/management.cue
+++ b/website/cue/reference/administration/management.cue
@@ -124,7 +124,7 @@ administration: management: {
 						command to access Vector's logs:
 
 						```bash
-						docker-compose logs -f vector
+						docker compose logs -f vector
 						```
 
 						Replace `vector` with the name of Vector's service if you've named it something else.


### PR DESCRIPTION
`docker-compose` usage has been removed from GHA runners as of July 29th, 2024. See https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
