### PR TITLE
fix(config): allow usage of metrics-only decoders in log sources

### DIFF
--- a/changelog.d/21039_allow-usage-of-metrics-only-decoders.fix.md
+++ b/changelog.d/21039_allow-usage-of-metrics-only-decoders.fix.md
@@ -1,1 +1,3 @@
 Log sources can now use metrics-only decoders such as the recently added `influxdb` decoder.
+
+authors: jorgehermo9

--- a/changelog.d/21039_allow-usage-of-metrics-only-decoders.fix.md
+++ b/changelog.d/21039_allow-usage-of-metrics-only-decoders.fix.md
@@ -1,0 +1,1 @@
+Log sources can now use metrics-only decoders such as the recently added `influxdb` decoder.

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -671,4 +671,18 @@ mod test {
         new_definition.assert_valid_for_event(&valid_event);
         new_definition.assert_valid_for_event(&invalid_event);
     }
+
+    #[test]
+    fn test_new_log_source_ignores_definition_when_metric_only_data_type() {
+        let definition = schema::Definition::any();
+        let output = SourceOutput::new_maybe_logs(DataType::Metric, definition);
+        assert_eq!(output.schema_definition(true), None);
+    }
+
+    #[test]
+    fn test_new_log_source_uses_definition_when_log_data_type() {
+        let definition = schema::Definition::any();
+        let output = SourceOutput::new_maybe_logs(DataType::Log, definition.clone());
+        assert_eq!(output.schema_definition(true), Some(definition));
+    }
 }

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -673,14 +673,14 @@ mod test {
     }
 
     #[test]
-    fn test_new_log_source_ignores_definition_when_metric_only_data_type() {
+    fn test_new_log_source_ignores_definition_with_metric_data_type() {
         let definition = schema::Definition::any();
         let output = SourceOutput::new_maybe_logs(DataType::Metric, definition);
         assert_eq!(output.schema_definition(true), None);
     }
 
     #[test]
-    fn test_new_log_source_uses_definition_when_log_data_type() {
+    fn test_new_log_source_uses_definition_with_log_data_type() {
         let definition = schema::Definition::any();
         let output = SourceOutput::new_maybe_logs(DataType::Log, definition.clone());
         assert_eq!(output.schema_definition(true), Some(definition));

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -121,11 +121,10 @@ impl SourceOutput {
     /// Designed for use in log sources.
     #[must_use]
     pub fn new_maybe_logs(ty: DataType, schema_definition: schema::Definition) -> Self {
-        let schema_definition = if ty.contains(DataType::Log) {
-            Some(Arc::new(schema_definition))
-        } else {
-            None
-        };
+        let schema_definition = ty
+            .contains(DataType::Log)
+            .then(|| Arc::new(schema_definition));
+
         Self {
             port: None,
             ty,

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -379,7 +379,7 @@ mod test {
                     outputs: vec![match ty {
                         DataType::Metric => SourceOutput::new_metrics(),
                         DataType::Trace => SourceOutput::new_traces(),
-                        _ => SourceOutput::new_logs(ty, Definition::any()),
+                        _ => SourceOutput::new_maybe_logs(ty, Definition::any()),
                     }],
                 },
             );
@@ -639,7 +639,7 @@ mod test {
         graph.nodes.insert(
             ComponentKey::from("foo.bar"),
             Node::Source {
-                outputs: vec![SourceOutput::new_logs(
+                outputs: vec![SourceOutput::new_maybe_logs(
                     DataType::all_bits(),
                     Definition::any(),
                 )],
@@ -648,7 +648,7 @@ mod test {
         graph.nodes.insert(
             ComponentKey::from("foo.bar"),
             Node::Source {
-                outputs: vec![SourceOutput::new_logs(
+                outputs: vec![SourceOutput::new_maybe_logs(
                     DataType::all_bits(),
                     Definition::any(),
                 )],
@@ -676,7 +676,7 @@ mod test {
         graph.nodes.insert(
             ComponentKey::from("baz.errors"),
             Node::Source {
-                outputs: vec![SourceOutput::new_logs(
+                outputs: vec![SourceOutput::new_maybe_logs(
                     DataType::all_bits(),
                     Definition::any(),
                 )],

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -46,7 +46,7 @@ impl SourceConfig for UnitTestSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::all_bits(),
             schema::Definition::default_legacy_namespace(),
         )]
@@ -103,7 +103,7 @@ impl SourceConfig for UnitTestStreamSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::all_bits(),
             schema::Definition::default_legacy_namespace(),
         )]

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -178,7 +178,7 @@ impl SourceConfig for AmqpSourceConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -232,7 +232,7 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -210,7 +210,7 @@ impl SourceConfig for AwsS3Config {
             schema_definition = schema_definition.unknown_fields(Kind::bytes());
         }
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -147,7 +147,7 @@ impl SourceConfig for AwsSqsConfig {
                 Some("timestamp"),
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -294,7 +294,7 @@ impl SourceConfig for DatadogAgentConfig {
 
         if self.multiple_outputs {
             if !self.disable_logs {
-                output.push(SourceOutput::new_logs(DataType::Log, definition).with_port(LOGS))
+                output.push(SourceOutput::new_maybe_logs(DataType::Log, definition).with_port(LOGS))
             }
             if !self.disable_metrics {
                 output.push(SourceOutput::new_metrics().with_port(METRICS))
@@ -303,7 +303,10 @@ impl SourceConfig for DatadogAgentConfig {
                 output.push(SourceOutput::new_traces().with_port(TRACES))
             }
         } else {
-            output.push(SourceOutput::new_logs(DataType::all_bits(), definition))
+            output.push(SourceOutput::new_maybe_logs(
+                DataType::all_bits(),
+                definition,
+            ))
         }
         output
     }

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -329,7 +329,7 @@ impl SourceConfig for DemoLogsConfig {
                 Some("service"),
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -209,7 +209,10 @@ impl SourceConfig for DnstapConfig {
         let schema_definition = self
             .schema_definition(log_namespace)
             .with_standard_vector_source_metadata();
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -349,7 +349,10 @@ impl SourceConfig for DockerLogsConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -335,7 +335,7 @@ impl SourceConfig for ExecConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -486,7 +486,10 @@ impl SourceConfig for FileConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -222,7 +222,7 @@ fn outputs(
         )
         .with_standard_vector_source_metadata();
 
-    vec![SourceOutput::new_logs(
+    vec![SourceOutput::new_maybe_logs(
         decoding.output_type(),
         schema_definition,
     )]

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -125,7 +125,10 @@ impl SourceConfig for FluentConfig {
         let log_namespace = global_log_namespace.merge(self.log_namespace);
         let schema_definition = self.schema_definition(log_namespace);
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn resources(&self) -> Vec<Resource> {

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -353,7 +353,10 @@ impl SourceConfig for PubsubConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -196,7 +196,7 @@ impl SourceConfig for LogplexConfig {
         // There is a global and per-source `log_namespace` config.
         // The source config overrides the global setting and is merged here.
         let schema_def = self.schema_definition(global_log_namespace.merge(self.log_namespace));
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_def,
         )]

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -224,7 +224,7 @@ impl SourceConfig for HttpClientConfig {
             .schema_definition(log_namespace)
             .with_standard_vector_source_metadata();
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -382,7 +382,7 @@ impl SourceConfig for SimpleHttpConfig {
 
         let schema_definition = self.schema_definition(log_namespace);
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding
                 .as_ref()
                 .map(|d| d.output_type())

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -129,7 +129,10 @@ impl SourceConfig for InternalLogsConfig {
         let schema_definition =
             self.schema_definition(global_log_namespace.merge(self.log_namespace));
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -397,7 +397,10 @@ impl SourceConfig for JournaldConfig {
         let schema_definition =
             self.schema_definition(global_log_namespace.merge(self.log_namespace));
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -409,7 +409,7 @@ impl SourceConfig for KafkaSourceConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -518,7 +518,10 @@ impl SourceConfig for Config {
             )
             .with_standard_vector_source_metadata();
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn can_acknowledge(&self) -> bool {

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -176,7 +176,7 @@ impl SourceConfig for LogstashConfig {
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
         // There is a global and per-source `log_namespace` config.
         // The source config overrides the global setting and is merged here.
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::Log,
             self.schema_definition(global_log_namespace.merge(self.log_namespace)),
         )]

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -171,7 +171,7 @@ impl SourceConfig for NatsSourceConfig {
                 None,
             );
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -287,7 +287,7 @@ impl SourceConfig for OpentelemetryConfig {
         };
 
         vec![
-            SourceOutput::new_logs(DataType::Log, schema_definition).with_port(LOGS),
+            SourceOutput::new_maybe_logs(DataType::Log, schema_definition).with_port(LOGS),
             SourceOutput::new_traces().with_port(TRACES),
         ]
     }

--- a/src/sources/pulsar.rs
+++ b/src/sources/pulsar.rs
@@ -230,7 +230,7 @@ impl SourceConfig for PulsarSourceConfig {
                 Kind::bytes(),
                 Some("producer_name"),
             );
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -217,7 +217,7 @@ impl SourceConfig for RedisSourceConfig {
             )
             .with_standard_vector_source_metadata();
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
             schema_definition,
         )]

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -293,7 +293,7 @@ impl SourceConfig for SocketConfig {
             }
         };
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.decoding().output_type(),
             schema_definition,
         )]

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -271,7 +271,10 @@ impl SourceConfig for SplunkConfig {
             None,
         );
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn resources(&self) -> Vec<Resource> {

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -256,7 +256,10 @@ impl SourceConfig for SyslogConfig {
             .schema_definition(log_namespace)
             .with_standard_vector_source_metadata();
 
-        vec![SourceOutput::new_logs(DataType::Log, schema_definition)]
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
     }
 
     fn resources(&self) -> Vec<Resource> {

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -200,7 +200,7 @@ impl SourceConfig for VectorConfig {
             .schema_definition(log_namespace)
             .with_standard_vector_source_metadata();
 
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::all_bits(),
             schema_definition,
         )]

--- a/src/test_util/mock/sources/backpressure.rs
+++ b/src/test_util/mock/sources/backpressure.rs
@@ -64,7 +64,7 @@ impl SourceConfig for BackpressureSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::all_bits(),
             Definition::default_legacy_namespace(),
         )]

--- a/src/test_util/mock/sources/basic.rs
+++ b/src/test_util/mock/sources/basic.rs
@@ -136,7 +136,7 @@ impl SourceConfig for BasicSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             self.data_type.unwrap(),
             Definition::default_legacy_namespace(),
         )]

--- a/src/test_util/mock/sources/error.rs
+++ b/src/test_util/mock/sources/error.rs
@@ -28,7 +28,7 @@ impl SourceConfig for ErrorSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::Log,
             Definition::default_legacy_namespace(),
         )]

--- a/src/test_util/mock/sources/panic.rs
+++ b/src/test_util/mock/sources/panic.rs
@@ -27,7 +27,7 @@ impl SourceConfig for PanicSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::Log,
             Definition::default_legacy_namespace(),
         )]

--- a/src/test_util/mock/sources/tripwire.rs
+++ b/src/test_util/mock/sources/tripwire.rs
@@ -67,7 +67,7 @@ impl SourceConfig for TripwireSourceConfig {
     }
 
     fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
-        vec![SourceOutput::new_logs(
+        vec![SourceOutput::new_maybe_logs(
             DataType::Log,
             Definition::default_legacy_namespace(),
         )]

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -497,7 +497,7 @@ mod tests {
                     inputs: vec![("foo", None)],
                     sources: IndexMap::from([(
                         "foo",
-                        vec![SourceOutput::new_logs(
+                        vec![SourceOutput::new_maybe_logs(
                             DataType::all_bits(),
                             Definition::default_legacy_namespace(),
                         )],
@@ -512,7 +512,7 @@ mod tests {
                     inputs: vec![("source-foo", None)],
                     sources: IndexMap::from([(
                         "source-foo",
-                        vec![SourceOutput::new_logs(
+                        vec![SourceOutput::new_maybe_logs(
                             DataType::all_bits(),
                             Definition::empty_legacy_namespace().with_event_field(
                                 &owned_value_path!("foo"),
@@ -539,7 +539,7 @@ mod tests {
                     sources: IndexMap::from([
                         (
                             "source-foo",
-                            vec![SourceOutput::new_logs(
+                            vec![SourceOutput::new_maybe_logs(
                                 DataType::all_bits(),
                                 Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
@@ -550,7 +550,7 @@ mod tests {
                         ),
                         (
                             "source-bar",
-                            vec![SourceOutput::new_logs(
+                            vec![SourceOutput::new_maybe_logs(
                                 DataType::all_bits(),
                                 Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
@@ -588,7 +588,7 @@ mod tests {
                     sources: IndexMap::from([
                         (
                             "source-foo",
-                            vec![SourceOutput::new_logs(
+                            vec![SourceOutput::new_maybe_logs(
                                 DataType::all_bits(),
                                 Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("foo"),
@@ -599,7 +599,7 @@ mod tests {
                         ),
                         (
                             "source-bar",
-                            vec![SourceOutput::new_logs(
+                            vec![SourceOutput::new_maybe_logs(
                                 DataType::all_bits(),
                                 Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("bar"),
@@ -662,7 +662,7 @@ mod tests {
                     sources: IndexMap::from([
                         (
                             "Source 1",
-                            vec![SourceOutput::new_logs(
+                            vec![SourceOutput::new_maybe_logs(
                                 DataType::all_bits(),
                                 Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("source-1"),
@@ -673,7 +673,7 @@ mod tests {
                         ),
                         (
                             "Source 2",
-                            vec![SourceOutput::new_logs(
+                            vec![SourceOutput::new_maybe_logs(
                                 DataType::all_bits(),
                                 Definition::empty_legacy_namespace().with_event_field(
                                     &owned_value_path!("source-2"),


### PR DESCRIPTION
Closes #21039 

Now this works:
### Configuration
```yaml
sources:
  file:
    type: exec
    command: ["cat", "test.txt"]
    decoding:
      codec: "influxdb"
    mode: streaming
    streaming:
      respawn_on_exit: false
sinks:
  console:
    type: console
    inputs: ["file"]
    encoding:
      codec: "native_json"
```

### Input `test.txt`
```txt
weather,location=us-midwest temperature=82 1465839830100400200
```

### Output
```json
{"metric":{"name":"weather_temperature","tags":{"location":"us-midwest"},"timestamp":"+48420-08-12T18:35:00.400200Z","kind":"absolute","gauge":{"value":82.0}}}
```


Although, I would like to add some more tests, like for example, integration test for some source with an influxdb decoder config similar to the former. Where should I create those tests? Or isn't that needed?
It would be nice to have this kind of test so we verify that log sources with this codec can really output metrics to a metric sink and this feature doesn't get broken in a future.