### PR TITLE
fix(sources): annotation suppression failed when log_namespace is enabled in kubernetes_logs

### DIFF
--- a/changelog.d/20682_consistent_annotation_suppression.fix.md
+++ b/changelog.d/20682_consistent_annotation_suppression.fix.md
@@ -1,0 +1,3 @@
+Fixes an issue where annotation suppression failed when `log_namespace` was set to `true` in kubernetes_logs.
+
+authors: ifuryst

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -427,11 +427,14 @@ impl LogNamespace {
         value: impl Into<Value>,
     ) {
         match self {
-            LogNamespace::Vector => {
-                log.metadata_mut()
-                    .value_mut()
-                    .insert(path!(source_name).concat(metadata_key), value);
-            }
+            LogNamespace::Vector => match legacy_key {
+                None => { /* don't insert */ }
+                _ => {
+                    log.metadata_mut()
+                        .value_mut()
+                        .insert(path!(source_name).concat(metadata_key), value);
+                }
+            },
             LogNamespace::Legacy => match legacy_key {
                 None => { /* don't insert */ }
                 Some(LegacyKey::Overwrite(key)) => {

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -991,6 +991,64 @@ mod tests {
     }
 
     #[test]
+    fn test_suppress_annotation_fields() {
+        let cases = vec![
+            (
+                FieldsSpec {
+                    container_id: OptionalTargetPath::none(),
+                    ..FieldsSpec::default()
+                },
+                ContainerStatus {
+                    container_id: Some("container_id_foo".to_owned()),
+                    image_id: "test_image_id".to_owned(),
+                    ..ContainerStatus::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert(
+                        event_path!("kubernetes", "container_image_id"),
+                        "test_image_id",
+                    );
+                    log
+                },
+                LogNamespace::Legacy,
+            ),
+            (
+                FieldsSpec {
+                    container_id: OptionalTargetPath::none(),
+                    ..FieldsSpec::default()
+                },
+                ContainerStatus {
+                    container_id: Some("container_id_foo".to_owned()),
+                    image_id: "test_image_id".to_owned(),
+                    ..ContainerStatus::default()
+                },
+                {
+                    let mut log = LogEvent::default();
+                    log.insert(
+                        metadata_path!("kubernetes_logs", "container_image_id"),
+                        "test_image_id",
+                    );
+                    log
+                },
+                LogNamespace::Vector,
+            ),
+        ];
+        for (fields_spec, container_status, expected, log_namespace) in cases.into_iter() {
+            let mut log = LogEvent::default();
+            annotate_from_container_status(
+                &mut log,
+                &fields_spec,
+                &container_status,
+                log_namespace,
+            );
+            println!("{:?}", log);
+            println!("{:?}", expected);
+            assert_eq!(log, expected);
+        }
+    }
+
+    #[test]
     fn test_annotate_from_container() {
         let cases = vec![
             (


### PR DESCRIPTION
Close #20682

Before:
<img width="1030" alt="Xnip2024-08-11_23-16-04" src="https://github.com/user-attachments/assets/7756cbfd-1baf-4f38-8e86-e0800e04736b">

After:
<img width="817" alt="Xnip2024-08-11_23-16-23" src="https://github.com/user-attachments/assets/6417cc58-2057-4564-aa6f-23d2c4f60eb7">

Config:
```yaml
schema:
    log_namespace: true

sources:
    source_kubernetes:
      type: kubernetes_logs
      self_node_name: "abc123"
      pod_annotation_fields:
        container_id: ""
        container_image_id: ""
      #   pod_labels: ""
      #   pod_owner: ""

transforms:
  transform_namespace:
    type: remap
    inputs:
      - source_kubernetes
    source: |
      .event_data = .
      .meta_data = %

sinks:
  console:
    type: console
    inputs:
      - transform_namespace
    encoding:
      codec: json
```

