### PR TITLE
fix: Use ALPN and client cert in mqtt sink

### DIFF
--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -194,8 +194,14 @@ impl MqttSinkConfig {
         }
         if let Some(tls) = tls.tls() {
             let ca = tls.authorities_pem().flatten().collect();
-            let client_auth = None;
-            let alpn = Some(vec!["mqtt".into()]);
+            let client_auth = tls.identity_pem();
+            let alpn = match &self.tls {
+                  None => { None }
+                  Some(t) => match &t.options.alpn_protocols {
+                      None => { Some(vec!["mqtt".into()]) }
+                      Some(protos) => { Some(protos.into_iter().map(|p| p.clone().into_bytes()).collect()) }
+                  }
+            };
             options.set_transport(Transport::Tls(TlsConfiguration::Simple {
                 ca,
                 client_auth,


### PR DESCRIPTION
MQTT sink currently ignores ALPN list and client certs. This attempts to fix it, but I have not been able to confirm that this actually works. I am not able to connect to AWS IoT when I set these. This could be a mistake in my own environment though. I'm putting this up here in case anyone is trying to fix this in the future and wants to use this as a starting point.