### PR TITLE
chore(deps): Update fork of tokio-util to 0.7.11 (latest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9440,8 +9440,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
-source = "git+https://github.com/vectordotdev/tokio?branch=tokio-util-0.7.8-framed-read-continue-on-error#3747655f8f0443e13fe20da3f613ea65c23347c2"
+version = "0.7.11"
+source = "git+https://github.com/vectordotdev/tokio?branch=tokio-util-0.7.11-framed-read-continue-on-error#156dcaacdfa53f530a39eb91b1ceb731a9908986"
 dependencies = [
  "bytes 1.7.1",
  "futures-core",
@@ -9450,7 +9450,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
- "tracing 0.1.40",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,7 @@ zstd = { version = "0.13.0", default-features = false }
 
 [patch.crates-io]
 # The upgrade for `tokio-util` >= 0.6.9 is blocked on https://github.com/vectordotdev/vector/issues/11257.
-tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-util-0.7.8-framed-read-continue-on-error" }
+tokio-util = { git = "https://github.com/vectordotdev/tokio", branch = "tokio-util-0.7.11-framed-read-continue-on-error" }
 nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/musl" }
 # The `heim` crates depend on `ntapi` 0.3.7 on Windows, but that version has an
 # unaligned access bug fixed in the following revision.


### PR DESCRIPTION
Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
