### PR TITLE
chore(deps): Group dependabot tower updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,10 @@ updates:
         patterns:
         - "tonic"
         - "tonic-*"
+      tower:
+        patterns:
+        - "tower"
+        - "tower-*"
       wasm-bindgen:
         patterns:
         - "wasm-bindgen-*"


### PR DESCRIPTION
Ran into issue in https://github.com/vectordotdev/vector/pull/21069 because they weren't updated together.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
