### PR TITLE
fix(codecs): Ensure that batches using newline delimited framing end in a newline

### DIFF
--- a/changelog.d/batch-newline.fix.md
+++ b/changelog.d/batch-newline.fix.md
@@ -1,0 +1,1 @@
+Batches encoded using newline delimited framing now end with a trailing newline.


### PR DESCRIPTION
Fixes: #21086

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
