### PR TITLE
fix(amqp source): fix crash when handling metrics

### DIFF
--- a/changelog.d/21141_fix_crash_when_handling_metrics.fix.md
+++ b/changelog.d/21141_fix_crash_when_handling_metrics.fix.md
@@ -1,0 +1,1 @@
+fixes the problem that amqp source crashes when handling metrics.

--- a/changelog.d/21141_fix_crash_when_handling_metrics.fix.md
+++ b/changelog.d/21141_fix_crash_when_handling_metrics.fix.md
@@ -1,1 +1,3 @@
-fixes the problem that amqp source crashes when handling metrics.
+The `amqp` source no longer panics when deserializing metrics (e.g. via the `native_json` codec).
+
+authors: kghost

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -27,7 +27,7 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::lookup::{lookup_v2::OptionalValuePath, metadata_path, owned_value_path, path};
 use vector_lib::{
     config::{log_schema, LegacyKey, LogNamespace, SourceAcknowledgementsConfig},
-    event::Event, event::LogEvent,
+    event::{Event, LogEvent},
     EstimatedJsonEncodedSizeOf,
 };
 use vector_lib::{

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -27,7 +27,7 @@ use vector_lib::configurable::configurable_component;
 use vector_lib::lookup::{lookup_v2::OptionalValuePath, metadata_path, owned_value_path, path};
 use vector_lib::{
     config::{log_schema, LegacyKey, LogNamespace, SourceAcknowledgementsConfig},
-    event::Event,
+    event::Event, event::LogEvent,
     EstimatedJsonEncodedSizeOf,
 };
 use vector_lib::{
@@ -236,14 +236,12 @@ struct Keys<'a> {
 }
 
 /// Populates the decoded event with extra metadata.
-fn populate_event(
-    event: &mut Event,
+fn populate_log_event(
+    log: &mut LogEvent,
     timestamp: Option<chrono::DateTime<Utc>>,
     keys: &Keys<'_>,
     log_namespace: LogNamespace,
 ) {
-    let log = event.as_mut_log();
-
     log_namespace.insert_source_metadata(
         AmqpSourceConfig::NAME,
         log,
@@ -348,10 +346,12 @@ async fn receive_event(
                     ));
 
                     for mut event in events {
-                        populate_event(&mut event,
-                                       timestamp,
-                                       &keys,
-                                       log_namespace);
+                        if let Event::Log(ref mut log) = event {
+                            populate_log_event(log,
+                                        timestamp,
+                                        &keys,
+                                        log_namespace);
+                        }
 
                         yield event;
                     }


### PR DESCRIPTION
amqp source crashes when handling metrics, this patch fixes the problem.


Here is my configuration to trigger the problem:
```
schema:
  log_namespace: true

api:
  enabled: true

sources:
  my_source_id:
    type: amqp
    connection_string: amqp://guest:guest@127.0.0.1:5672/%2f?timeout=10
    queue: "hello"
    decoding:
      codec: "native"

sinks:
  ...
  ...
```

And the crash log:

```
Aug 22 14:32:13 hostname vector[2541178]: 2024-08-22T06:32:13.882811Z  INFO vector::internal_events::api: API server running. address=127.0.0.1:8686 playground=http://127.0.0.1:8686/playground graphql=http://127.0.0.1:8686/graphql
Aug 22 14:32:13 hostname vector[2541178]: thread 'vector-worker' panicked at lib/vector-core/src/event/mod.rs:124:18:
Aug 22 14:32:13 hostname vector[2541178]: Failed type coercion, Metric(Metric { ... }) is not a log event
Aug 22 14:32:13 hostname vector[2541178]: stack backtrace:
Aug 22 14:32:13 hostname vector[2541178]:    0:     0x5effd9dc96b4 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h1e1a1972118942ad
Aug 22 14:32:13 hostname vector[2541178]:    1:     0x5effd92a26fb - core::fmt::write::hc090a2ffd6b28c4a
Aug 22 14:32:13 hostname vector[2541178]:    2:     0x5effd9d8bd5e - std::io::Write::write_fmt::h8898bac6ff039a23
Aug 22 14:32:13 hostname vector[2541178]:    3:     0x5effd9dcd749 - std::sys_common::backtrace::print::ha96650907276675e
Aug 22 14:32:13 hostname vector[2541178]:    4:     0x5effd9dcd069 - std::panicking::default_hook::{{closure}}::h215c2a0a8346e0e0
Aug 22 14:32:13 hostname vector[2541178]:    5:     0x5effd9dce15d - std::panicking::rust_panic_with_hook::hac8bdceee1e4fe2c
Aug 22 14:32:13 hostname vector[2541178]:    6:     0x5effd9dcdad2 - std::panicking::begin_panic_handler::{{closure}}::h00d785e82757ce3c
Aug 22 14:32:13 hostname vector[2541178]:    7:     0x5effd9dcda29 - std::sys_common::backtrace::__rust_end_short_backtrace::h1628d957bcd06996
Aug 22 14:32:13 hostname vector[2541178]:    8:     0x5effd9dcda16 - rust_begin_unwind
Aug 22 14:32:13 hostname vector[2541178]:    9:     0x5effd89f1802 - core::panicking::panic_fmt::hdc63834ffaaefae5
Aug 22 14:32:13 hostname vector[2541178]:   10:     0x5effdaffdf58 - <async_stream::async_stream::AsyncStream<T,U> as futures_core::stream::Stream>::poll_next::h5a23c9c168f01d30
Aug 22 14:32:13 hostname vector[2541178]:   11:     0x5effdaffa049 - vector::source_sender::SourceSender::send_event_stream::{{closure}}::h0ad79d975986d580
Aug 22 14:32:13 hostname vector[2541178]:   12:     0x5effdaff3ed2 - vector::sources::amqp::run_amqp_source::{{closure}}::hb7353edfdb2f380a
Aug 22 14:32:13 hostname vector[2541178]:   13:     0x5effdc79fb39 - vector::topology::builder::Builder::build_sources::{{closure}}::{{closure}}::h079b9608192a61db
Aug 22 14:32:13 hostname vector[2541178]:   14:     0x5effdc7289c4 - <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll::h3396e7ac2b3f2667
Aug 22 14:32:13 hostname vector[2541178]:   15:     0x5effdc7250c4 - tokio::runtime::task::raw::poll::h28a9b9cc41f7259f
Aug 22 14:32:13 hostname vector[2541178]:   16:     0x5effd9e1a41d - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::hfeeefbbcfc00d6b0
Aug 22 14:32:13 hostname vector[2541178]:   17:     0x5effd9e23684 - tokio::runtime::task::raw::poll::h46c7fec6a73d2699
Aug 22 14:32:13 hostname vector[2541178]:   18:     0x5effd9e023a1 - std::sys_common::backtrace::__rust_begin_short_backtrace::hbcbcf2d81647ecf2
Aug 22 14:32:13 hostname vector[2541178]:   19:     0x5effd9e020ff - core::ops::function::FnOnce::call_once{{vtable.shim}}::h3cea380f34720b52
Aug 22 14:32:13 hostname vector[2541178]:   20:     0x5effd9dd108b - std::sys::pal::unix::thread::Thread::new::thread_start::h522bc89a54da820a
Aug 22 14:32:13 hostname vector[2541178]:   21:     0x781db2a94ac3 - <unknown>
Aug 22 14:32:13 hostname vector[2541178]:   22:     0x781db2b26850 - <unknown>
Aug 22 14:32:13 hostname vector[2541178]:   23:                0x0 - <unknown>
Aug 22 14:32:13 hostname vector[2541178]: 2024-08-22T06:32:13.888194Z ERROR source{component_kind="source" component_id=my_source_id component_type=amqp}: vector::topology: An error occurred that Vector couldn't handle: the task panicked and was aborted.
Aug 22 14:32:13 hostname vector[2541178]: 2024-08-22T06:32:13.888273Z  INFO vector: Vector has stopped.
Aug 22 14:32:13 hostname vector[2541178]: 2024-08-22T06:32:13.889372Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="prometheus" time_remaining="59 seconds left"
```