### PR TITLE
fix(tap): Don't send events if output is empty

### DIFF
--- a/lib/vector-tap/src/lib.rs
+++ b/lib/vector-tap/src/lib.rs
@@ -182,6 +182,9 @@ impl<'a> TapRunner<'a> {
                                 )
                             })
                             .collect();
+                        if output_events.is_empty() {
+                            continue
+                        }
 
                         match &self.output_channel {
                             OutputChannel::Stdout(formatter) => {


### PR DESCRIPTION
### Overview

When sending output events via `tap`, we can run into issues with the async channel output type if the output is empty. Add a check to see if the output is empty before attempting to send events.

### Testing

Tested with `demo_logs`, unit tests

