### PR TITLE
enhancement(gcp_cloud_storage): Make API endpoint configurable

### DIFF
--- a/changelog.d/21137_configurable_gcs_sink_endpoint.enhancement.md
+++ b/changelog.d/21137_configurable_gcs_sink_endpoint.enhancement.md
@@ -1,1 +1,3 @@
-Adds support for configuring `gcp_cloud_storage` sink API endpoint.
+Adds support for configuring `gcp_cloud_storage` sink API `endpoint`.
+
+authors: movinfinex

--- a/changelog.d/21137_configurable_gcs_sink_endpoint.enhancement.md
+++ b/changelog.d/21137_configurable_gcs_sink_endpoint.enhancement.md
@@ -1,0 +1,1 @@
+Adds support for configuring `gcp_cloud_storage` sink API endpoint.

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -203,6 +203,7 @@ fn default_config(encoding: EncodingConfigWithFraming) -> GcsSinkConfig {
         encoding,
         compression: Compression::gzip_default(),
         batch: Default::default(),
+        endpoint: Default::default(),
         request: Default::default(),
         auth: Default::default(),
         tls: Default::default(),

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -26,7 +26,8 @@ use crate::{
     sinks::{
         gcs_common::{
             config::{
-                build_healthcheck, GcsPredefinedAcl, GcsRetryLogic, GcsStorageClass, BASE_URL,
+                build_healthcheck, default_endpoint, GcsPredefinedAcl, GcsRetryLogic,
+                GcsStorageClass,
             },
             service::{GcsRequest, GcsRequestSettings, GcsService},
             sink::GcsSink,
@@ -155,6 +156,12 @@ pub struct GcsSinkConfig {
     #[serde(default)]
     batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
 
+    /// API endpoint for Google Cloud Storage
+    #[configurable(metadata(docs::examples = "http://localhost:9000"))]
+    #[configurable(validation(format = "uri"))]
+    #[serde(default = "default_endpoint")]
+    endpoint: String,
+
     #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig<GcsTowerRequestConfigDefaults>,
@@ -221,7 +228,7 @@ impl GenerateConfig for GcsSinkConfig {
 impl SinkConfig for GcsSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let auth = self.auth.build(Scope::DevStorageReadWrite).await?;
-        let base_url = format!("{}{}/", BASE_URL, self.bucket);
+        let base_url = format!("{}/{}/", self.endpoint, self.bucket);
         let tls = TlsSettings::from_options(&self.tls)?;
         let client = HttpClient::new(tls, cx.proxy())?;
         let healthcheck = build_healthcheck(

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -14,7 +14,9 @@ use crate::{
     },
 };
 
-pub const BASE_URL: &str = "https://storage.googleapis.com/";
+pub fn default_endpoint() -> String {
+    "https://storage.googleapis.com".to_string()
+}
 
 /// GCS Predefined ACLs.
 ///

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -441,6 +441,14 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 			}
 		}
 	}
+	endpoint: {
+		description: "API endpoint for Google Cloud Storage"
+		required: false
+		type: string: {
+			default: "https://storage.googleapis.com"
+			examples: ["http://localhost:9000"]
+		}
+	}
 	filename_append_uuid: {
 		description: """
 			Whether or not to append a UUID v4 token to the end of the object key.

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -443,7 +443,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 	}
 	endpoint: {
 		description: "API endpoint for Google Cloud Storage"
-		required: false
+		required:    false
 		type: string: {
 			default: "https://storage.googleapis.com"
 			examples: ["http://localhost:9000"]


### PR DESCRIPTION
Closes https://github.com/vectordotdev/vector/issues/21137

Adds an `endpoint` config parameter, following the same pattern as other sources/sinks.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
