### PR TITLE
enhancement(filtering) Avoid clonning when checking conditions

### DIFF
--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -19,7 +19,7 @@ use vector_common::{
 };
 pub use vrl::value::{KeyString, ObjectMap, Value};
 #[cfg(feature = "vrl")]
-pub use vrl_target::{TargetEvents, VrlTarget, ImmutableVrlTarget};
+pub use vrl_target::{ImmutableVrlTarget, TargetEvents, VrlTarget};
 
 use crate::config::LogNamespace;
 use crate::config::OutputId;

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -19,7 +19,7 @@ use vector_common::{
 };
 pub use vrl::value::{KeyString, ObjectMap, Value};
 #[cfg(feature = "vrl")]
-pub use vrl_target::{TargetEvents, VrlTarget};
+pub use vrl_target::{TargetEvents, VrlTarget, ImmutableVrlTarget};
 
 use crate::config::LogNamespace;
 use crate::config::OutputId;

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -457,6 +457,88 @@ impl SecretTarget for VrlTarget {
     }
 }
 
+#[derive(Debug)]
+pub enum ImmutableVrlTarget<'a> {
+    LogEvent(&'a Value, &'a EventMetadata),
+    Metric {
+        metric: &'a Metric,
+        value: Value,
+        multi_value_tags: bool,
+    },
+    Trace(&'a Value, &'a EventMetadata),
+}
+
+impl<'a> ImmutableVrlTarget<'a> {
+    pub fn new(event: &'a Event, info: &ProgramInfo, multi_value_metric_tags: bool) -> Self {
+        match event {
+            Event::Log(event) => {
+                ImmutableVrlTarget::LogEvent(event.value(), event.metadata())
+            }
+            Event::Metric(metric) => {
+                // We pre-generate [`Value`] types for the metric fields accessed in
+                // the event. This allows us to then return references to those
+                // values, even if the field is accessed more than once.
+                let value = precompute_metric_value(&metric, info);
+
+                ImmutableVrlTarget::Metric {
+                    metric,
+                    value,
+                    multi_value_tags: multi_value_metric_tags,
+                }
+            }
+            Event::Trace(event) => {
+                ImmutableVrlTarget::Trace(event.value(), event.metadata())
+            }
+        }
+    }
+    fn metadata(&self) -> &EventMetadata {
+        match self {
+            ImmutableVrlTarget::LogEvent(_, metadata) | ImmutableVrlTarget::Trace(_, metadata) => metadata,
+            ImmutableVrlTarget::Metric { metric, .. } => metric.metadata(),
+        }
+    }
+}
+
+impl Target for ImmutableVrlTarget<'_> {
+    fn target_insert(&mut self, _path: &OwnedTargetPath, _value: Value) -> Result<(), String> {
+        Err("Value is immutable".into())
+    }
+
+    fn target_get(&self, target_path: &OwnedTargetPath) -> Result<Option<&Value>, String> {
+        match target_path.prefix {
+            PathPrefix::Event => match self {
+                ImmutableVrlTarget::LogEvent(log, _) | ImmutableVrlTarget::Trace(log, _) => {
+                    Ok(log.get(&target_path.path))
+                }
+                ImmutableVrlTarget::Metric { value, .. } => target_get_metric(&target_path.path, value),
+            },
+            PathPrefix::Metadata => Ok(self.metadata().value().get(&target_path.path)),
+        }
+    }
+
+    fn target_get_mut(&mut self, _path: &OwnedTargetPath) -> Result<Option<&mut Value>, String> {
+        Err("Value is immutable".into())
+    }
+
+    fn target_remove(&mut self, _path: &OwnedTargetPath, _compact: bool) -> Result<Option<Value>, String> {
+        Err("Value is immutable".into())
+    }
+}
+
+impl SecretTarget for ImmutableVrlTarget<'_> {
+    fn get_secret(&self, key: &str) -> Option<&str> {
+        self.metadata().secrets().get_secret(key)
+    }
+
+    fn insert_secret(&mut self, _key: &str, _value: &str) {
+        warn!("Secrets are immutable");
+    }
+
+    fn remove_secret(&mut self, _key: &str) {
+        warn!("Secrets are immutable");
+    }
+}
+
 /// Retrieves a value from a the provided metric using the path.
 /// Currently the root path and the following paths are supported:
 /// - name

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -5,11 +5,9 @@ use vrl::compiler::{CompilationResult, CompileConfig, Program, TypeState, VrlRun
 use vrl::diagnostic::Formatter;
 use vrl::value::Value;
 
-use crate::config::LogNamespace;
-use crate::event::TargetEvents;
 use crate::{
     conditions::{Condition, Conditional, ConditionalConfig},
-    event::{Event, VrlTarget},
+    event::{Event, ImmutableVrlTarget},
     internal_events::VrlConditionExecutionError,
 };
 
@@ -90,20 +88,13 @@ pub struct Vrl {
 
 impl Vrl {
     fn run(&self, event: Event) -> (Event, RuntimeResult) {
-        let log_namespace = event
-            .maybe_as_log()
-            .map(|log| log.namespace())
-            .unwrap_or(LogNamespace::Legacy);
-        let mut target = VrlTarget::new(event, self.program.info(), false);
+        let mut target = ImmutableVrlTarget::new(&event, self.program.info(), false);
         // TODO: use timezone from remap config
         let timezone = TimeZone::default();
 
         let result = Runtime::default().resolve(&mut target, &self.program, &timezone);
-        let original_event = match target.into_events(log_namespace) {
-            TargetEvents::One(event) => event,
-            _ => panic!("Event was modified in a condition. This is an internal compiler error."),
-        };
-        (original_event, result)
+
+        (event, result)
     }
 }
 


### PR DESCRIPTION
`VrlCondition` is compiled with `.set_read_only()` but, to execute the condition, `VrlTarget` is used, which requires a full copy of the `Event` and the metadata.
It is mitigated by adding `ImmutableVrlTarget`  which doesn't support any mutating operations and doesn't require a full copy of `Event`.
