### PR TITLE
chore(config): Configure `datadog_search` condition directly

### DIFF
--- a/lib/vector-config/src/external/vrl.rs
+++ b/lib/vector-config/src/external/vrl.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 use serde_json::Value;
-use vrl::compiler::VrlRuntime;
+use vrl::{compiler::VrlRuntime, datadog_search_syntax::QueryNode};
 
 use crate::{
     schema::{generate_string_schema, SchemaGenerator, SchemaObject},
@@ -25,5 +25,14 @@ impl ToValue for VrlRuntime {
         Value::String(match self {
             VrlRuntime::Ast => "ast".to_owned(),
         })
+    }
+}
+
+impl Configurable for QueryNode {
+    fn generate_schema(_gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError>
+    where
+        Self: Sized,
+    {
+        Ok(generate_string_schema())
     }
 }

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -28,7 +28,7 @@ impl Default for DatadogSearchConfig {
 impl_generate_config_from_default!(DatadogSearchConfig);
 
 /// Runner that contains the boxed `Matcher` function to check whether an `Event` matches
-/// a [Datadog Search Syntax query] (https://docs.datadoghq.com/logs/explorer/search_syntax/).
+/// a [Datadog Search Syntax query](https://docs.datadoghq.com/logs/explorer/search_syntax/).
 #[derive(Debug, Clone)]
 pub struct DatadogSearchRunner {
     matcher: Box<dyn Matcher<Event>>,


### PR DESCRIPTION
The `datadog_search` condition previously was configured with a generic string, which would accept any text. When that condition was built, it would then parse that search string into a query data structure. Since that query data structure now supports deserialization directly, we can use that as the configuration type and skip the extra parse step.

This should not change any user facing behavior except for the exact wording of the error message for invalid query strings.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
