### PR TITLE
chore(ci): Fix review workflow trigger

### DIFF
--- a/.github/workflows/ci-review-trigger.yml
+++ b/.github/workflows/ci-review-trigger.yml
@@ -52,19 +52,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: |
-      github.event.issue.pull_request && (
-          startsWith(github.event.review.body, '/ci-run-all')
-          || startsWith(github.event.review.body, '/ci-run-cli')
-          || startsWith(github.event.review.body, '/ci-run-misc')
-          || startsWith(github.event.review.body, '/ci-run-deny')
-          || startsWith(github.event.review.body, '/ci-run-component-features')
-          || startsWith(github.event.review.body, '/ci-run-cross')
-          || startsWith(github.event.review.body, '/ci-run-unit-mac')
-          || startsWith(github.event.review.body, '/ci-run-unit-windows')
-          || startsWith(github.event.review.body, '/ci-run-environment')
-          || startsWith(github.event.review.body, '/ci-run-regression')
-          || startsWith(github.event.review.body, '/ci-run-k8s')
-        )
+        startsWith(github.event.review.body, '/ci-run-all')
+        || startsWith(github.event.review.body, '/ci-run-cli')
+        || startsWith(github.event.review.body, '/ci-run-misc')
+        || startsWith(github.event.review.body, '/ci-run-deny')
+        || startsWith(github.event.review.body, '/ci-run-component-features')
+        || startsWith(github.event.review.body, '/ci-run-cross')
+        || startsWith(github.event.review.body, '/ci-run-unit-mac')
+        || startsWith(github.event.review.body, '/ci-run-unit-windows')
+        || startsWith(github.event.review.body, '/ci-run-environment')
+        || startsWith(github.event.review.body, '/ci-run-regression')
+        || startsWith(github.event.review.body, '/ci-run-k8s')
     steps:
       - name: Generate authentication token
         id: generate_token


### PR DESCRIPTION
I believe this check used to exist because comments can be left on PRs or Issues, but since we use reviews now, only PRs should trigger.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
