### PR TITLE
chore(ci): add codec test data dir to regression workflow ignore filter

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -83,6 +83,7 @@ jobs:
             - "NOTICE"
             - "LICENSE-3rdparty.csv"
             - "LICENSE"
+            - "lib/codecs/tests/data/**"
 
     # This step allows us to conservatively run the tests if we added a new
     # file or directory for source code, but forgot to add it to this workflow.


### PR DESCRIPTION
We recently discovered in https://github.com/vectordotdev/vector/pull/21074 , that PRs which regenerate the fixture files for codec tests (which results in a 💩  ton of file changes) , breaks a check in this workflow due to

```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/vector/vector'. Argument list too long
```

hit on the `filter` job.

We should ignore that test data dir anyway and hopefully it addresses that issue.
