### PR TITLE
chore(core): Wrap event metadata in `Arc` for performance

### DIFF
--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -618,7 +618,7 @@ impl From<OutputId> for crate::config::OutputId {
 
 impl From<EventMetadata> for Metadata {
     fn from(value: EventMetadata) -> Self {
-        let EventMetadata {
+        let super::metadata::Inner {
             value,
             secrets,
             source_id,
@@ -627,13 +627,9 @@ impl From<EventMetadata> for Metadata {
             datadog_origin_metadata,
             source_event_id,
             ..
-        } = value;
+        } = value.into_owned();
 
-        let secrets = if secrets.is_empty() {
-            None
-        } else {
-            Some(secrets.into())
-        };
+        let secrets = (!secrets.is_empty()).then(|| secrets.into());
 
         Self {
             value: Some(encode_value(value)),


### PR DESCRIPTION
The `EventMetadata` structure contains a number of sub-structures that can cause extensive deep copies when an event is cloned, most notably `value: vrl::value::Value`. To improve this, wrap the actual inner event metadata in an `Arc`, and use the standard tools from that type to only clone it when needed to provide a mutable or owned copy.