### PR TITLE
refactor(tap): Refactor internal logic for vector tap into lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10841,9 +10841,12 @@ dependencies = [
 name = "vector-tap"
 version = "0.1.0"
 dependencies = [
+ "async-graphql",
  "chrono",
  "colored",
+ "futures 0.3.30",
  "futures-util",
+ "glob",
  "portpicker",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
@@ -10853,7 +10856,11 @@ dependencies = [
  "tokio-tungstenite 0.20.1",
  "tracing 0.1.40",
  "url",
+ "uuid",
  "vector-api-client",
+ "vector-buffers",
+ "vector-common",
+ "vector-core",
 ]
 
 [[package]]

--- a/lib/vector-common/src/id.rs
+++ b/lib/vector-common/src/id.rs
@@ -1,7 +1,8 @@
 use std::ops::Deref;
 
-pub use vector_lib::config::ComponentKey;
-use vector_lib::configurable::configurable_component;
+use vector_config::configurable_component;
+
+pub use crate::config::ComponentKey;
 
 /// A list of upstream [source][sources] or [transform][transforms] IDs.
 ///

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -53,6 +53,7 @@ pub mod shutdown;
 #[cfg(feature = "sensitive_string")]
 pub mod sensitive_string;
 
+pub mod id;
 pub mod trigger;
 
 #[macro_use]

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -44,6 +44,8 @@ pub mod finalization;
 pub mod finalizer;
 pub use finalizer::EmptyStream;
 
+pub mod id;
+
 pub mod internal_event;
 
 pub mod request_metadata;
@@ -53,7 +55,6 @@ pub mod shutdown;
 #[cfg(feature = "sensitive_string")]
 pub mod sensitive_string;
 
-pub mod id;
 pub mod trigger;
 
 #[macro_use]

--- a/lib/vector-lib/Cargo.toml
+++ b/lib/vector-lib/Cargo.toml
@@ -21,7 +21,7 @@ vector-stream = { path = "../vector-stream" }
 vector-tap = { path = "../vector-tap" }
 
 [features]
-api = ["vector-core/api"]
+api = ["vector-core/api", "vector-tap/api"]
 api-client = ["dep:vector-api-client"]
 lua = ["vector-core/lua"]
 file-source = ["dep:file-source"]

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -9,7 +9,7 @@ pub use vector_buffers as buffers;
 pub use vector_common::event_test_util;
 pub use vector_common::{
     assert_event_data_eq, btreemap, byte_size_of, byte_size_of::ByteSizeOf, conversion,
-    encode_logfmt, finalization, finalizer, impl_event_data_eq, internal_event, json_size,
+    encode_logfmt, finalization, finalizer, id, impl_event_data_eq, internal_event, json_size,
     registered_event, request_metadata, sensitive_string, shutdown, trigger, Error, Result,
     TimeZone,
 };

--- a/lib/vector-tap/Cargo.toml
+++ b/lib/vector-tap/Cargo.toml
@@ -7,7 +7,10 @@ publish = false
 license = "MPL-2.0"
 
 [dependencies]
+async-graphql = { version = "7.0.7", default-features = false, features = ["playground"], optional = true}
 colored = { version = "2.1.0", default-features = false }
+futures = { version = "0.3.30", default-features = false, features = ["std"] }
+glob = { version = "0.3.1", default-features = false }
 serde_yaml = { version = "0.9.34", default-features = false }
 snafu = { version = "0.7.5", default-features = false }
 tokio = { version = "1.39.3", default-features = false, features = ["time"] }
@@ -15,7 +18,11 @@ tokio-stream = { version = "0.1.15", default-features = false, features = ["sync
 tokio-tungstenite = { version = "0.20.1", default-features = false }
 tracing = { version = "0.1.34", default-features = false }
 url = { version = "2.5.2", default-features = false }
+uuid.workspace = true
 vector-api-client = { path = "../vector-api-client" }
+vector-common = { path = "../vector-common" }
+vector-core = { path = "../vector-core" }
+vector-buffers = { path = "../vector-buffers" }
 futures-util = "0.3.30"
 
 [dev-dependencies]
@@ -23,6 +30,9 @@ chrono = { workspace = true }
 portpicker = { path = "../portpicker" }
 serde_json = { workspace = true }
 tokio = { version = "1.39.3", default-features = false, features = ["test-util"] }
+
+[features]
+api = ["dep:async-graphql"]
 
 
 

--- a/lib/vector-tap/src/lib.rs
+++ b/lib/vector-tap/src/lib.rs
@@ -3,6 +3,10 @@
 #[macro_use]
 extern crate tracing;
 
+pub mod notification;
+pub mod tap;
+pub mod topology;
+
 use std::{borrow::Cow, collections::BTreeMap};
 
 use colored::{ColoredString, Colorize};

--- a/lib/vector-tap/src/notification.rs
+++ b/lib/vector-tap/src/notification.rs
@@ -1,9 +1,11 @@
-use async_graphql::{Object, SimpleObject, Union};
+#[cfg(feature = "api")]
+use async_graphql::{SimpleObject, Union};
 
-#[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "api", derive(SimpleObject))]
 /// A component was found that matched the provided pattern
 pub struct Matched {
-    #[graphql(skip)]
+    #[cfg_attr(feature = "api", graphql(skip))]
     message: String,
     /// Pattern that raised the notification
     pub pattern: String,
@@ -18,10 +20,11 @@ impl Matched {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "api", derive(SimpleObject))]
 /// There isn't currently a component that matches this pattern
 pub struct NotMatched {
-    #[graphql(skip)]
+    #[cfg_attr(feature = "api", graphql(skip))]
     message: String,
     /// Pattern that raised the notification
     pub pattern: String,
@@ -39,11 +42,12 @@ impl NotMatched {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "api", derive(SimpleObject))]
 /// The pattern matched source(s) which cannot be tapped for inputs or sink(s)
 /// which cannot be tapped for outputs
 pub struct InvalidMatch {
-    #[graphql(skip)]
+    #[cfg_attr(feature = "api", graphql(skip))]
     message: String,
     /// Pattern that raised the notification
     pattern: String,
@@ -61,7 +65,8 @@ impl InvalidMatch {
     }
 }
 
-#[derive(Union, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "api", derive(Union))]
 /// A specific kind of notification with additional details
 pub enum Notification {
     Matched(Matched),
@@ -70,37 +75,11 @@ pub enum Notification {
 }
 
 impl Notification {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             Notification::Matched(n) => n.message.as_ref(),
             Notification::NotMatched(n) => n.message.as_ref(),
             Notification::InvalidMatch(n) => n.message.as_ref(),
         }
-    }
-}
-
-/// This wrapper struct hoists `message` up from [`Notification`] for a more
-/// natural querying experience. While ideally [`Notification`] would be a
-/// GraphQL interface with a common `message` field, an interface cannot be
-/// directly nested into the union of [`super::OutputEventsPayload`].
-///
-/// The GraphQL specification forbids such a nesting:
-/// <http://spec.graphql.org/October2021/#sel-HAHdfFDABABkG3_I>
-#[derive(Debug, Clone)]
-pub struct EventNotification {
-    pub notification: Notification,
-}
-
-#[Object]
-/// A notification regarding events observation
-impl EventNotification {
-    /// Notification details
-    async fn notification(&self) -> &Notification {
-        &self.notification
-    }
-
-    /// The human-readable message associated with the notification
-    async fn message(&self) -> &str {
-        self.notification.as_str()
     }
 }

--- a/lib/vector-tap/src/tap.rs
+++ b/lib/vector-tap/src/tap.rs
@@ -11,23 +11,21 @@ use tokio::sync::{
 };
 use tracing::{Instrument, Span};
 use uuid::Uuid;
-use vector_lib::buffers::{topology::builder::TopologyBuilder, WhenFull};
+use vector_buffers::{topology::builder::TopologyBuilder, WhenFull};
+use vector_common::config::ComponentKey;
+use vector_core::event::{EventArray, LogArray, MetricArray, TraceArray};
 
-use super::{
-    schema::events::{
-        notification::{InvalidMatch, Matched, NotMatched, Notification},
-        TapPatterns,
-    },
-    ShutdownRx, ShutdownTx,
-};
-use crate::{
-    config::ComponentKey,
-    event::{EventArray, LogArray, MetricArray, TraceArray},
-    topology::{fanout, fanout::ControlChannel, TapOutput, TapResource, WatchRx},
-};
+use vector_core::fanout;
+
+use crate::notification::{InvalidMatch, Matched, NotMatched, Notification};
+use crate::topology::{TapOutput, TapResource, WatchRx};
 
 /// A tap sender is the control channel used to surface tap payloads to a client.
 type TapSender = tokio_mpsc::Sender<TapPayload>;
+
+// Shutdown channel types
+type ShutdownTx = oneshot::Sender<()>;
+type ShutdownRx = oneshot::Receiver<()>;
 
 const TAP_BUFFER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(100) };
 
@@ -70,6 +68,32 @@ impl GlobMatcher<&str> for Pattern {
                 patterns.iter().any(|pattern| pattern.matches(rhs))
             }
         }
+    }
+}
+
+/// Patterns (glob) used by tap to match against components and access events
+/// flowing into (for_inputs) or out of (for_outputs) specified components
+#[derive(Debug)]
+pub struct TapPatterns {
+    pub for_outputs: HashSet<String>,
+    pub for_inputs: HashSet<String>,
+}
+
+impl TapPatterns {
+    pub const fn new(for_outputs: HashSet<String>, for_inputs: HashSet<String>) -> Self {
+        Self {
+            for_outputs,
+            for_inputs,
+        }
+    }
+
+    /// Get all user-specified patterns
+    pub fn all_patterns(&self) -> HashSet<String> {
+        self.for_outputs
+            .iter()
+            .cloned()
+            .chain(self.for_inputs.iter().cloned())
+            .collect()
     }
 }
 
@@ -183,7 +207,7 @@ impl TapController {
 }
 
 /// Provides a `ShutdownTx` that disconnects a component sink when it drops out of scope.
-fn shutdown_trigger(control_tx: ControlChannel, sink_id: ComponentKey) -> ShutdownTx {
+fn shutdown_trigger(control_tx: fanout::ControlChannel, sink_id: ComponentKey) -> ShutdownTx {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
     tokio::spawn(async move {
@@ -396,7 +420,6 @@ async fn tap_handler(
                 }
 
                 // Warnings on invalid matches.
-
                 for pattern in patterns.for_inputs.iter() {
                     if let Ok(glob) = glob::Pattern::new(pattern) {
                         let invalid_matches = source_keys.iter().filter(|key| glob.matches(key)).cloned().collect::<Vec<_>>();

--- a/lib/vector-tap/src/tap.rs
+++ b/lib/vector-tap/src/tap.rs
@@ -14,7 +14,6 @@ use uuid::Uuid;
 use vector_buffers::{topology::builder::TopologyBuilder, WhenFull};
 use vector_common::config::ComponentKey;
 use vector_core::event::{EventArray, LogArray, MetricArray, TraceArray};
-
 use vector_core::fanout;
 
 use crate::notification::{InvalidMatch, Matched, NotMatched, Notification};

--- a/lib/vector-tap/src/topology.rs
+++ b/lib/vector-tap/src/topology.rs
@@ -1,0 +1,34 @@
+use std::collections::{HashMap, HashSet};
+use tokio::sync::watch;
+use vector_common::config::ComponentKey;
+use vector_common::id::Inputs;
+use vector_core::config::OutputId;
+use vector_core::fanout;
+
+/// A tappable output consisting of an output ID and associated metadata
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct TapOutput {
+    pub output_id: OutputId,
+    pub component_kind: &'static str,
+    pub component_type: String,
+}
+
+/// Resources used by the `tap` API to monitor component inputs and outputs,
+/// updated alongside the topology
+#[derive(Debug, Default, Clone)]
+pub struct TapResource {
+    // Outputs and their corresponding Fanout control
+    pub outputs: HashMap<TapOutput, fanout::ControlChannel>,
+    // Components (transforms, sinks) and their corresponding inputs
+    pub inputs: HashMap<ComponentKey, Inputs<OutputId>>,
+    // Source component keys used to warn against invalid pattern matches
+    pub source_keys: Vec<String>,
+    // Sink component keys used to warn against invalid pattern matches
+    pub sink_keys: Vec<String>,
+    // Components removed on a reload (used to drop TapSinks)
+    pub removals: HashSet<ComponentKey>,
+}
+
+// Watcher types for topology changes.
+pub type WatchTx = watch::Sender<TapResource>;
+pub type WatchRx = watch::Receiver<TapResource>;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,14 +2,8 @@
 mod handler;
 mod schema;
 mod server;
-pub mod tap;
 #[cfg(all(test, feature = "vector-api-tests"))]
 mod tests;
 
 pub use schema::build_schema;
 pub use server::Server;
-use tokio::sync::oneshot;
-
-// Shutdown channel types used by the server and tap.
-type ShutdownTx = oneshot::Sender<()>;
-type ShutdownRx = oneshot::Receiver<()>;

--- a/src/api/schema/events/encoding.rs
+++ b/src/api/schema/events/encoding.rs
@@ -2,7 +2,7 @@ use async_graphql::Enum;
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
 /// Encoding format for the event
-pub(crate) enum EventEncodingType {
+pub enum EventEncodingType {
     Json,
     Yaml,
     Logfmt,

--- a/src/api/schema/events/log.rs
+++ b/src/api/schema/events/log.rs
@@ -3,10 +3,11 @@ use std::borrow::Cow;
 use async_graphql::Object;
 use chrono::{DateTime, Utc};
 use vector_lib::encode_logfmt;
+use vector_lib::event;
+use vector_lib::tap::topology::TapOutput;
 use vrl::event_path;
 
 use super::EventEncodingType;
-use crate::{event, topology::TapOutput};
 
 #[derive(Debug, Clone)]
 pub struct Log {

--- a/src/api/schema/events/metric.rs
+++ b/src/api/schema/events/metric.rs
@@ -2,12 +2,10 @@ use async_graphql::{Enum, Object};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use vector_lib::encode_logfmt;
+use vector_lib::event;
+use vector_lib::tap::topology::TapOutput;
 
 use super::EventEncodingType;
-use crate::{
-    event::{self, KeyString},
-    topology::TapOutput,
-};
 
 #[derive(Debug, Clone)]
 pub struct Metric {
@@ -128,7 +126,7 @@ impl Metric {
                     .expect("logfmt serialization of metric event failed: conversion to serde Value failed. Please report.");
                 match json {
                     Value::Object(map) => encode_logfmt::encode_map(
-                        &map.into_iter().map(|(k,v)| (KeyString::from(k), v)).collect(),
+                        &map.into_iter().map(|(k,v)| (event::KeyString::from(k), v)).collect(),
                     )
                     .expect("logfmt serialization of metric event failed. Please report."),
                     _ => panic!("logfmt serialization of metric event failed: metric converted to unexpected serde Value. Please report."),

--- a/src/api/schema/events/mod.rs
+++ b/src/api/schema/events/mod.rs
@@ -1,47 +1,20 @@
-mod encoding;
+pub mod encoding;
 pub mod log;
 pub mod metric;
-pub mod notification;
 pub mod output;
 pub mod trace;
-
-use std::collections::HashSet;
 
 use async_graphql::{Context, Subscription};
 use encoding::EventEncodingType;
 use futures::{stream, Stream, StreamExt};
-use output::OutputEventsPayload;
+use output::{from_tap_payload_to_output_events, OutputEventsPayload};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use tokio::{select, sync::mpsc, time};
 use tokio_stream::wrappers::ReceiverStream;
-
-use crate::{api::tap::TapController, topology::WatchRx};
-
-/// Patterns (glob) used by tap to match against components and access events
-/// flowing into (for_inputs) or out of (for_outputs) specified components
-#[derive(Debug)]
-pub struct TapPatterns {
-    pub for_outputs: HashSet<String>,
-    pub for_inputs: HashSet<String>,
-}
-
-impl TapPatterns {
-    pub const fn new(for_outputs: HashSet<String>, for_inputs: HashSet<String>) -> Self {
-        Self {
-            for_outputs,
-            for_inputs,
-        }
-    }
-
-    /// Get all user-specified patterns
-    pub fn all_patterns(&self) -> HashSet<String> {
-        self.for_outputs
-            .iter()
-            .cloned()
-            .chain(self.for_inputs.iter().cloned())
-            .collect()
-    }
-}
+use vector_lib::tap::{
+    tap::{TapController, TapPatterns},
+    topology::WatchRx,
+};
 
 #[derive(Debug, Default)]
 pub struct EventsSubscription;
@@ -81,7 +54,7 @@ pub(crate) fn create_events_stream(
     // interval, this is capped to the same value.
     let (tap_tx, tap_rx) = mpsc::channel(limit);
     let mut tap_rx = ReceiverStream::new(tap_rx)
-        .flat_map(|payload| stream::iter(<Vec<OutputEventsPayload>>::from(payload)));
+        .flat_map(|payload| stream::iter(from_tap_payload_to_output_events(payload)));
 
     // The resulting vector of `Event` sent to the client. Only one result set will be streamed
     // back to the client at a time. This value is set higher than `1` to prevent blocking the event

--- a/src/api/schema/events/output.rs
+++ b/src/api/schema/events/output.rs
@@ -1,7 +1,36 @@
-use async_graphql::Union;
+use async_graphql::{Object, Union};
 
-use super::{log::Log, metric::Metric, notification::EventNotification, trace::Trace};
-use crate::api::tap::TapPayload;
+use crate::api::schema::events::log::Log;
+use crate::api::schema::events::metric::Metric;
+use crate::api::schema::events::trace::Trace;
+use vector_lib::tap::notification::Notification;
+use vector_lib::tap::tap::TapPayload;
+
+/// This wrapper struct hoists `message` up from [`Notification`] for a more
+/// natural querying experience. While ideally [`Notification`] would be a
+/// GraphQL interface with a common `message` field, an interface cannot be
+/// directly nested into the union of [`super::OutputEventsPayload`].
+///
+/// The GraphQL specification forbids such a nesting:
+/// <http://spec.graphql.org/October2021/#sel-HAHdfFDABABkG3_I>
+#[derive(Debug, Clone)]
+pub struct EventNotification {
+    pub notification: Notification,
+}
+
+#[Object]
+/// A notification regarding events observation
+impl EventNotification {
+    /// Notification details
+    async fn notification(&self) -> &Notification {
+        &self.notification
+    }
+
+    /// The human-readable message associated with the notification
+    async fn message(&self) -> &str {
+        self.notification.as_str()
+    }
+}
 
 #[derive(Union, Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -21,26 +50,24 @@ pub enum OutputEventsPayload {
 }
 
 /// Convert an `api::TapPayload` to the equivalent GraphQL type.
-impl From<TapPayload> for Vec<OutputEventsPayload> {
-    fn from(t: TapPayload) -> Self {
-        match t {
-            TapPayload::Log(output, log_array) => log_array
-                .into_iter()
-                .map(|log| OutputEventsPayload::Log(Log::new(output.clone(), log)))
-                .collect(),
-            TapPayload::Metric(output, metric_array) => metric_array
-                .into_iter()
-                .map(|metric| OutputEventsPayload::Metric(Metric::new(output.clone(), metric)))
-                .collect(),
-            TapPayload::Notification(notification) => {
-                vec![OutputEventsPayload::Notification(EventNotification {
-                    notification,
-                })]
-            }
-            TapPayload::Trace(output, trace_array) => trace_array
-                .into_iter()
-                .map(|trace| OutputEventsPayload::Trace(Trace::new(output.clone(), trace)))
-                .collect(),
+pub(crate) fn from_tap_payload_to_output_events(t: TapPayload) -> Vec<OutputEventsPayload> {
+    match t {
+        TapPayload::Log(output, log_array) => log_array
+            .into_iter()
+            .map(|log| OutputEventsPayload::Log(Log::new(output.clone(), log)))
+            .collect(),
+        TapPayload::Metric(output, metric_array) => metric_array
+            .into_iter()
+            .map(|metric| OutputEventsPayload::Metric(Metric::new(output.clone(), metric)))
+            .collect(),
+        TapPayload::Notification(notification) => {
+            vec![OutputEventsPayload::Notification(EventNotification {
+                notification,
+            })]
         }
+        TapPayload::Trace(output, trace_array) => trace_array
+            .into_iter()
+            .map(|trace| OutputEventsPayload::Trace(Trace::new(output.clone(), trace)))
+            .collect(),
     }
 }

--- a/src/api/schema/events/trace.rs
+++ b/src/api/schema/events/trace.rs
@@ -1,9 +1,10 @@
 use async_graphql::Object;
 use vector_lib::encode_logfmt;
+use vector_lib::event;
+use vector_lib::tap::topology::TapOutput;
 use vrl::event_path;
 
 use super::EventEncodingType;
-use crate::{event, topology::TapOutput};
 
 #[derive(Debug, Clone)]
 pub struct Trace {

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -14,18 +14,18 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tower::ServiceBuilder;
 use tracing::Span;
+use vector_lib::tap::topology;
 use warp::{filters::BoxedFilter, http::Response, ws::Ws, Filter, Reply};
 
-use super::{handler, schema, ShutdownTx};
+use super::{handler, schema};
 use crate::{
     config::{self, api},
     http::build_http_trace_layer,
     internal_events::{SocketBindError, SocketMode},
-    topology,
 };
 
 pub struct Server {
-    _shutdown: ShutdownTx,
+    _shutdown: oneshot::Sender<()>,
     addr: SocketAddr,
 }
 

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -1,9 +1,10 @@
 use super::{
-    builder::ConfigBuilder, graph::Graph, id::Inputs, transform::get_transform_output_ids,
-    validation, Config, OutputId,
+    builder::ConfigBuilder, graph::Graph, transform::get_transform_output_ids, validation, Config,
+    OutputId,
 };
 
 use indexmap::IndexSet;
+use vector_lib::id::Inputs;
 
 pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<String>> {
     let mut errors = Vec::new();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,7 +29,6 @@ mod diff;
 mod enrichment_table;
 pub mod format;
 mod graph;
-mod id;
 mod loading;
 pub mod provider;
 pub mod schema;
@@ -47,7 +46,6 @@ pub use cmd::{cmd, Opts};
 pub use diff::ConfigDiff;
 pub use enrichment_table::{EnrichmentTableConfig, EnrichmentTableOuter};
 pub use format::{Format, FormatHint};
-pub use id::{ComponentKey, Inputs};
 pub use loading::{
     load, load_builder_from_paths, load_from_paths, load_from_paths_with_provider_and_secrets,
     load_from_str, load_source_from_paths, merge_path_lists, process_paths, COLLECTOR,
@@ -63,8 +61,12 @@ pub use transform::{
 pub use unit_test::{build_unit_tests, build_unit_tests_main, UnitTestResult};
 pub use validation::warnings;
 pub use vars::{interpolate, ENVIRONMENT_VARIABLE_INTERPOLATION_REGEX};
-pub use vector_lib::config::{
-    init_log_schema, init_telemetry, log_schema, proxy::ProxyConfig, telemetry, LogSchema, OutputId,
+pub use vector_lib::{
+    config::{
+        init_log_schema, init_telemetry, log_schema, proxy::ProxyConfig, telemetry, ComponentKey,
+        LogSchema, OutputId,
+    },
+    id::Inputs,
 };
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -11,10 +11,11 @@ use vector_lib::configurable::{
 };
 use vector_lib::{
     config::{AcknowledgementsConfig, GlobalOptions, Input},
+    id::Inputs,
     sink::VectorSink,
 };
 
-use super::{id::Inputs, schema, ComponentKey, ProxyConfig, Resource};
+use super::{schema, ComponentKey, ProxyConfig, Resource};
 use crate::extra_context::ExtraContext;
 use crate::sinks::{util::UriSerde, Healthcheck};
 

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -12,13 +12,14 @@ use vector_lib::configurable::{
 };
 use vector_lib::{
     config::{GlobalOptions, Input, LogNamespace, TransformOutput},
+    id::Inputs,
     schema,
     transform::Transform,
 };
 
 use super::schema::Options as SchemaOptions;
+use super::ComponentKey;
 use super::OutputId;
-use super::{id::Inputs, ComponentKey};
 use crate::extra_context::ExtraContext;
 
 pub type BoxedTransform = Box<dyn TransformConfig>;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -20,13 +20,12 @@ mod task;
 mod test;
 
 use std::{
-    collections::{HashMap, HashSet},
     panic::AssertUnwindSafe,
     sync::{Arc, Mutex},
 };
 
 use futures::{Future, FutureExt};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
 use vector_lib::buffers::topology::channel::{BufferReceiverStream, BufferSender};
 
 pub use self::builder::TopologyPieces;
@@ -35,7 +34,7 @@ pub use self::running::{RunningTopology, ShutdownErrorReceiver};
 
 use self::task::{Task, TaskError, TaskResult};
 use crate::{
-    config::{ComponentKey, Config, ConfigDiff, Inputs, OutputId},
+    config::{ComponentKey, Config, ConfigDiff},
     event::EventArray,
     signal::ShutdownError,
 };
@@ -46,34 +45,6 @@ type BuiltBuffer = (
     BufferSender<EventArray>,
     Arc<Mutex<Option<BufferReceiverStream<EventArray>>>>,
 );
-
-/// A tappable output consisting of an output ID and associated metadata
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct TapOutput {
-    pub output_id: OutputId,
-    pub component_kind: &'static str,
-    pub component_type: String,
-}
-
-/// Resources used by the `tap` API to monitor component inputs and outputs,
-/// updated alongside the topology
-#[derive(Debug, Default, Clone)]
-pub struct TapResource {
-    // Outputs and their corresponding Fanout control
-    pub outputs: HashMap<TapOutput, fanout::ControlChannel>,
-    // Components (transforms, sinks) and their corresponding inputs
-    pub inputs: HashMap<ComponentKey, Inputs<OutputId>>,
-    // Source component keys used to warn against invalid pattern matches
-    pub source_keys: Vec<String>,
-    // Sink component keys used to warn against invalid pattern matches
-    pub sink_keys: Vec<String>,
-    // Components removed on a reload (used to drop TapSinks)
-    pub removals: HashSet<ComponentKey>,
-}
-
-// Watcher types for topology changes.
-type WatchTx = watch::Sender<TapResource>;
-pub type WatchRx = watch::Receiver<TapResource>;
 
 pub(super) fn take_healthchecks(
     diff: &ConfigDiff,

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -6,22 +6,13 @@ use std::{
     },
 };
 
-use futures::{future, Future, FutureExt};
-use tokio::{
-    sync::{mpsc, watch},
-    time::{interval, sleep_until, Duration, Instant},
-};
-use tracing::Instrument;
-use vector_lib::buffers::topology::channel::BufferSender;
-use vector_lib::trigger::DisabledTrigger;
-
 use super::{
     builder,
     builder::TopologyPieces,
     fanout::{ControlChannel, ControlMessage},
     handle_errors, retain, take_healthchecks,
     task::TaskOutput,
-    BuiltBuffer, TapOutput, TapResource, TaskHandle, WatchRx, WatchTx,
+    BuiltBuffer, TaskHandle,
 };
 use crate::{
     config::{ComponentKey, Config, ConfigDiff, HealthcheckOptions, Inputs, OutputId, Resource},
@@ -31,6 +22,15 @@ use crate::{
     signal::ShutdownError,
     spawn_named,
 };
+use futures::{future, Future, FutureExt};
+use tokio::{
+    sync::{mpsc, watch},
+    time::{interval, sleep_until, Duration, Instant},
+};
+use tracing::Instrument;
+use vector_lib::buffers::topology::channel::BufferSender;
+use vector_lib::tap::topology::{TapOutput, TapResource, WatchRx, WatchTx};
+use vector_lib::trigger::DisabledTrigger;
 
 pub type ShutdownErrorReceiver = mpsc::UnboundedReceiver<ShutdownError>;
 


### PR DESCRIPTION
### Overview

There was a previous PR which refactored the logic used by the `vector tap` command into a general library for a new use case (retrieving a live view of events flowing into Vector): https://github.com/vectordotdev/vector/pull/20850

It was originally thought that the same logic used to implement the command could be re-used, however the new use case requires an overhaul in the logic used to sample events using `tap`. Additionally, re-using the logic used by the `vector tap` command involves calling Vector's GraphQL API, which adds an intermediate step / further complicates the flow.

Instead, we can move the underlying logic used to implement `tap` / the GraphQL API in the into a general library, and use this new internal library directly to read events (as well as have a custom event sampling strategy depending on the use case). 

Planning to undo the changes in https://github.com/vectordotdev/vector/pull/20850 as well in a separate, follow-up PR

