### PR TITLE
fix(reduce transform): surround invalid path segments with quotes

### DIFF
--- a/changelog.d/21201_fields_iter.fix.md
+++ b/changelog.d/21201_fields_iter.fix.md
@@ -1,1 +1,1 @@
-The fields iterator now quotes all invalid path segments. Now the reduce transform can correctly parse path containing special characters.am "c"
+The fields iterator now quotes all invalid path segments and he reduce transform can correctly parse path containing special characters.

--- a/changelog.d/21201_fields_iter.fix.md
+++ b/changelog.d/21201_fields_iter.fix.md
@@ -1,1 +1,1 @@
-The `reduce` transform no longer panics when reducing fields that contain special characters.
+The `reduce` transform can now reduce fields that contain special characters.

--- a/changelog.d/21201_fields_iter.fix.md
+++ b/changelog.d/21201_fields_iter.fix.md
@@ -1,0 +1,1 @@
+The fields iterator now quotes all invalid path segments. Now the reduce transform can correctly parse path containing special characters.am "c"

--- a/changelog.d/21201_fields_iter.fix.md
+++ b/changelog.d/21201_fields_iter.fix.md
@@ -1,1 +1,1 @@
-The fields iterator now quotes all invalid path segments and he reduce transform can correctly parse path containing special characters.
+The `reduce` transform no longer panics when reducing fields that contain special characters.

--- a/lib/vector-core/src/event/test/mod.rs
+++ b/lib/vector-core/src/event/test/mod.rs
@@ -21,10 +21,13 @@ fn event_iteration() {
     assert_eq!(
         all,
         vec![
-            ("Ke$ha".into(), "It's going down, I'm yelling timber".into()),
             (
                 "Pitbull".into(),
                 "The bigger they are, the harder they fall".into()
+            ),
+            (
+                "\"Ke$ha\"".into(),
+                "It's going down, I'm yelling timber".into()
             ),
         ]
         .into_iter()

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -334,53 +334,6 @@ impl TaskTransform<Event> for Reduce {
     }
 }
 
-// TODO delete after issue 21077 is resolved.
-// fn quote_invalid_paths(path: &str) -> String {
-//     let components: Vec<&str> = path.split('.').collect();
-//
-//     let index: Vec<bool> = components
-//         .iter()
-//         .map(|component| component.ends_with('\\'))
-//         .collect();
-//
-//     let mut escaping = false;
-//     let mut result = String::new();
-//     index.iter().enumerate().for_each(|(i, _)| {
-//         let current = components[i].trim_end_matches('\\');
-//         if i == 0 {
-//             if index[0] {
-//                 escaping = true;
-//                 result.push('"');
-//             }
-//             result.push_str(current);
-//         } else if i == index.len() - 1 {
-//             result.push_str(current);
-//             if escaping {
-//                 escaping = false;
-//                 result.push('"');
-//             };
-//         } else if !index[i - 1] && index[i] {
-//             escaping = true;
-//             result.push('"');
-//             result.push_str(current);
-//         } else if index[i - 1] && index[i] {
-//             escaping = true;
-//             result.push_str(current);
-//         } else if index[i - 1] && !index[i] {
-//             result.push_str(current);
-//             escaping = false;
-//             result.push('"');
-//         } else {
-//             result.push_str(current);
-//         }
-//
-//         if i < components.len() - 1 {
-//             result.push('.');
-//         }
-//     });
-//     result
-// }
-
 #[cfg(test)]
 mod test {
     use indoc::indoc;

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -78,16 +78,8 @@ impl ReduceState {
 
         if let Some(fields_iter) = e.all_event_fields_skip_array_elements() {
             for (path, value) in fields_iter {
-                // TODO: This can be removed once issue 21077 is resolved.
-                //       Technically we need to quote any special characters (like `-` or `*` or ` `).
-                let parsable_path = if path.contains("\\.") {
-                    quote_invalid_paths(&path).into()
-                } else {
-                    path.clone()
-                };
-
                 // This should not return an error, unless there is a bug in the event fields iterator.
-                let parsed_path = match parse_target_path(&parsable_path) {
+                let parsed_path = match parse_target_path(&path) {
                     Ok(path) => path,
                     Err(error) => {
                         emit!(ReduceAddEventError { error, path });
@@ -343,51 +335,51 @@ impl TaskTransform<Event> for Reduce {
 }
 
 // TODO delete after issue 21077 is resolved.
-fn quote_invalid_paths(path: &str) -> String {
-    let components: Vec<&str> = path.split('.').collect();
-
-    let index: Vec<bool> = components
-        .iter()
-        .map(|component| component.ends_with('\\'))
-        .collect();
-
-    let mut escaping = false;
-    let mut result = String::new();
-    index.iter().enumerate().for_each(|(i, _)| {
-        let current = components[i].trim_end_matches('\\');
-        if i == 0 {
-            if index[0] {
-                escaping = true;
-                result.push('"');
-            }
-            result.push_str(current);
-        } else if i == index.len() - 1 {
-            result.push_str(current);
-            if escaping {
-                escaping = false;
-                result.push('"');
-            };
-        } else if !index[i - 1] && index[i] {
-            escaping = true;
-            result.push('"');
-            result.push_str(current);
-        } else if index[i - 1] && index[i] {
-            escaping = true;
-            result.push_str(current);
-        } else if index[i - 1] && !index[i] {
-            result.push_str(current);
-            escaping = false;
-            result.push('"');
-        } else {
-            result.push_str(current);
-        }
-
-        if i < components.len() - 1 {
-            result.push('.');
-        }
-    });
-    result
-}
+// fn quote_invalid_paths(path: &str) -> String {
+//     let components: Vec<&str> = path.split('.').collect();
+//
+//     let index: Vec<bool> = components
+//         .iter()
+//         .map(|component| component.ends_with('\\'))
+//         .collect();
+//
+//     let mut escaping = false;
+//     let mut result = String::new();
+//     index.iter().enumerate().for_each(|(i, _)| {
+//         let current = components[i].trim_end_matches('\\');
+//         if i == 0 {
+//             if index[0] {
+//                 escaping = true;
+//                 result.push('"');
+//             }
+//             result.push_str(current);
+//         } else if i == index.len() - 1 {
+//             result.push_str(current);
+//             if escaping {
+//                 escaping = false;
+//                 result.push('"');
+//             };
+//         } else if !index[i - 1] && index[i] {
+//             escaping = true;
+//             result.push('"');
+//             result.push_str(current);
+//         } else if index[i - 1] && index[i] {
+//             escaping = true;
+//             result.push_str(current);
+//         } else if index[i - 1] && !index[i] {
+//             result.push_str(current);
+//             escaping = false;
+//             result.push('"');
+//         } else {
+//             result.push_str(current);
+//         }
+//
+//         if i < components.len() - 1 {
+//             result.push('.');
+//         }
+//     });
+//     result
+// }
 
 #[cfg(test)]
 mod test {
@@ -993,6 +985,7 @@ merge_strategies.bar = "concat"
             r#"
             group_by = [ "id" ]
             merge_strategies.events = "array"
+            merge_strategies."\"a-b\"" = "retain"
             merge_strategies.another = "discard"
 
             [ends_when]
@@ -1017,6 +1010,7 @@ merge_strategies.bar = "concat"
                 btreemap! {"id" => 777, "another" => btreemap!{ "a" => 1}},
             ));
             e_1.insert("events", v_1.clone());
+            e_1.insert("\"a-b\"", 2);
             tx.send(e_1.into()).await.unwrap();
 
             let v_2 = Value::from(btreemap! {
@@ -1029,6 +1023,7 @@ merge_strategies.bar = "concat"
                 btreemap! {"id" => 777, "test_end" => "done", "another" => btreemap!{ "b" => 2}},
             ));
             e_2.insert("events", v_2.clone());
+            e_2.insert("\"a-b\"", 2);
             tx.send(e_2.into()).await.unwrap();
 
             let output = out.recv().await.unwrap().into_log();
@@ -1036,6 +1031,7 @@ merge_strategies.bar = "concat"
                 "id" => 1554,
                 "events" => vec![v_1, v_2],
                 "another" => btreemap!{ "a" => 1},
+                "a-b" => 2,
                 "test_end" => "done"
             });
             assert_eq!(*output.value(), expected_value);
@@ -1045,48 +1041,5 @@ merge_strategies.bar = "concat"
             assert_eq!(out.recv().await, None);
         })
         .await
-    }
-
-    #[test]
-    fn quote_paths_tests() {
-        let input = "one";
-        let expected = "one";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = ".one";
-        let expected = ".one";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = "one.two.three.four";
-        let expected = "one.two.three.four";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = r"one.two.three\.four";
-        let expected = "one.two.\"three.four\"";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = r"one.two.three\.four\.five";
-        let expected = "one.two.\"three.four.five\"";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = r"one.two.three\.four\.five.six";
-        let expected = "one.two.\"three.four.five\".six";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = r"one.two\.three.four\.five.six.seven\.eight";
-        let expected = "one.\"two.three\".\"four.five\".six.\"seven.eight\"";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
-
-        let input = r"one.two\.three\.four\.five.six\.seven.eight";
-        let expected = "one.\"two.three.four.five\".\"six.seven\".eight";
-        let result = quote_invalid_paths(input);
-        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
Closes: #21165

Related PR: https://github.com/vectordotdev/vector/pull/21067.

### Summary 
* [Path segments](https://vector.dev/docs/reference/vrl/expressions/#path) which contain special characters need to be quoted. 
* The fields iterator used to only escape the `.` character. Now it detects if a path segment needs to be quoted.
* This is a more generic fix compared to the ad-hoc `quote_invalid_paths` function. A side benefit, it that this PR paves the way for https://github.com/vectordotdev/vector/issues/21077.

### Testing 
Added/enhanced unit tests.

#### Vector Unit Test

```
transforms:
  reduce_scalyr:
    type: reduce
    inputs:
    - my_input
    group_by:
    - session
    expire_after_ms: 2000
    max_events: 500
    merge_strategies:
      events: array
tests:
- name: map_reduce_scalyr.no_sev
  inputs:
  - type: vrl
    insert_at: reduce_scalyr
    source: |
      . = {
        "events": {
          "attrs": {
            "msg": "foo"
          },
          "sev": 3,
          "ts": "1602349656452332000"
        },
        "session": "session",
        "sessionInfo": {
          "kubernetes.cluster": "cluster",
          "kubernetes.container-name": "container",
          "kubernetes.namespace.name": "namespace",
          "kubernetes.pod.name": "pod",
          "logfile": "p",
          "serverHost": "n"
        },
        "token": "token"
      }
  - type: vrl
    insert_at: reduce_scalyr
    source: |
      . = {
        "events": {
          "attrs": {
            "msg": "bar"
          },
          "sev": 3,
          "ts": "1602349656460000000"
        },
        "session": "session",
        "sessionInfo": {
          "kubernetes.cluster": "cluster",
          "kubernetes.container-name": "container",
          "kubernetes.namespace.name": "namespace",
          "kubernetes.pod.name": "pod",
          "logfile": "p",
          "serverHost": "n"
        },
        "token": "token"
      }
  outputs:
  - extract_from: reduce_scalyr
    conditions:
    - type: vrl
      source: |
        assert_eq!(., {
          "events": [
            {
              "ts": "1602349656452332000",
              "sev": 3,
              "attrs": {
                "msg": "foo",
              },
            },
            {
              "ts": "1602349656460000000",
              "sev": 3,
              "attrs": {
                "msg": "bar",
              },
            },
          ],
          "session": "session",
          "sessionInfo": {
            "kubernetes.cluster": "cluster",
            "kubernetes.container-name": "container",
            "kubernetes.namespace.name": "namespace",
            "kubernetes.pod.name": "pod",
            "logfile": "p",
            "serverHost": "n"
          },
          "token": "token",
        })
```