### PR TITLE
chore(deps): Bump VRL to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10915,8 +10915,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vrl"
-version = "0.17.0"
-source = "git+https://github.com/vectordotdev/vrl?rev=bab1cd50658f8a50008902e96e9fa4e5c5a9547c#bab1cd50658f8a50008902e96e9fa4e5c5a9547c"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78418b391bfef6a37127f5d7283a46b2a23e19b676640841fcf334e40740d919"
 dependencies = [
  "aes",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ toml = { version = "0.8.19", default-features = false, features = ["display", "p
 tonic = { version = "0.11", default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
 tonic-build = { version = "0.11", default-features = false, features = ["transport", "prost"] }
 uuid = { version = "1.10.0", features = ["v4", "v7", "serde"] }
-vrl = { git = "https://github.com/vectordotdev/vrl", rev = "bab1cd50658f8a50008902e96e9fa4e5c5a9547c", features = ["arbitrary", "cli", "test", "test_framework"] }
+vrl = { version = "0.18.0", features = ["arbitrary", "cli", "test", "test_framework"] }
 
 [dependencies]
 pin-project.workspace = true


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
