### PR TITLE
fix(file source): Execute checkpoint migration for every new file for kubernetes_log source.

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -221,8 +221,9 @@ where
                                 }
                             }
                         } else {
-                            // try maybe_upgrade since kubernetes_log doesn't have path available
-                            // when initialization.
+                            // maybe_upgrade is not executed during file_server's initialization with `kubernetes_log`
+                            // because `kubernetes_logs` source returns the files after it fetches k8s metadata.
+                            // so execute maybe_upgrade everytime new file is added to file_server.
                             checkpointer.maybe_upgrade(
                                 &path,
                                 file_id,

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -221,6 +221,15 @@ where
                                 }
                             }
                         } else {
+                            // try maybe_upgrade since kubernetes_log doesn't have path available
+                            // when initialization.
+                            checkpointer.maybe_upgrade(
+                                &path,
+                                file_id,
+                                &self.fingerprinter,
+                                &mut fingerprint_buffer,
+                            );
+
                             // untracked file fingerprint
                             self.watch_new_file(path, file_id, &mut fp_map, &checkpoints, false);
                             self.emitter.emit_files_open(fp_map.len());


### PR DESCRIPTION
fix https://github.com/vectordotdev/vector/issues/20798

Checkpoint migration was only executed when file_server is being initialized.
However kubernetes_log's PathProvider doesn't load paths at the start-up (because it have to fetch k8s metadata). So for kubernetes_log, migration will not be executed.

This PR suggests executing checkpoint migration whenever a new file appears. Migration process is quite simple, so I don't think it's too computationally intensive.