### PR TITLE
chore(lua transform): Fix example of setting nested field

### DIFF
--- a/website/cue/reference/components/transforms/lua.cue
+++ b/website/cue/reference/components/transforms/lua.cue
@@ -63,6 +63,7 @@ components: transforms: lua: {
 						-- Add root level field
 						event.log.field = "new value"
 						-- Add nested field
+						event.log.nested = {}
 						event.log.nested.field = "nested value"
 						-- Rename field
 						event.log.renamed_field = event.log.field_to_rename


### PR DESCRIPTION
The parent has to be initialized first.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
