### PR TITLE
refactor(SharedTopologyController): Add blocking lock helper to SharedTopologyController

### DIFF
--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -19,6 +19,10 @@ impl SharedTopologyController {
         Self(Arc::new(Mutex::new(inner)))
     }
 
+    pub fn blocking_lock(&self) -> MutexGuard<TopologyController> {
+        self.0.blocking_lock()
+    }
+
     pub async fn lock(&self) -> MutexGuard<TopologyController> {
         self.0.lock().await
     }


### PR DESCRIPTION
### Overview

Have a use case which requires acquiring a lock on this resource from a non-async function, adding this helper method to simplify this flow.
