### PR TITLE
enhancement(components): Add customizable connection retry options for Pulsar client in Pulsar sink

### DIFF
--- a/changelog.d/21245_pulsar_sink_connection_retry_options.enhancement.md
+++ b/changelog.d/21245_pulsar_sink_connection_retry_options.enhancement.md
@@ -1,0 +1,9 @@
+Expose `connection_retry_options` in the Pulsar sink configuration to allow customizing the connection retry behaviour of the pulsar client. This includes the following options:
+
+- `min_backoff_ms`: Minimum delay between connection retries.
+- `max_backoff_secs`: Maximum delay between reconnection retries.
+- `max_retries`: Maximum number of connection retries.
+- `connection_timeout_secs`: Time limit to establish a connection.
+- `keep_alive_secs`: Keep-alive interval for each broker connection.
+
+authors: FRosner

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -1,4 +1,3 @@
-use std::time::Duration;
 use crate::{
     schema,
     sinks::{
@@ -16,6 +15,7 @@ use pulsar::{
 };
 use pulsar::{error::AuthenticationError, OperationRetryOptions};
 use snafu::ResultExt;
+use std::time::Duration;
 use vector_lib::codecs::{encoding::SerializerConfig, TextSerializerConfig};
 use vector_lib::config::DataType;
 use vector_lib::lookup::lookup_v2::OptionalTargetPath;
@@ -177,7 +177,9 @@ pub enum PulsarCompression {
 }
 
 #[configurable_component]
-#[configurable(description = "Custom connection retry options configuration for the Pulsar client.")]
+#[configurable(
+    description = "Custom connection retry options configuration for the Pulsar client."
+)]
 #[derive(Clone, Debug)]
 pub struct CustomConnectionRetryOptions {
     /// Minimum delay between connection retries.
@@ -253,15 +255,36 @@ impl PulsarSinkConfig {
 
         // Apply configuration for reconnection exponential backoff.
         let default_retry_options = ConnectionRetryOptions::default();
-        let retry_options = self.connection_retry_options.as_ref().map_or(default_retry_options.clone(), |opts| {
-            ConnectionRetryOptions {
-                min_backoff: opts.min_backoff_ms.map_or(default_retry_options.min_backoff, |ms| Duration::from_millis(ms)),
-                max_backoff: opts.max_backoff_secs.map_or(default_retry_options.max_backoff, |secs| Duration::from_secs(secs)),
-                max_retries: opts.max_retries.unwrap_or(default_retry_options.max_retries),
-                connection_timeout: opts.connection_timeout_secs.map_or(default_retry_options.connection_timeout, |secs| Duration::from_secs(secs)),
-                keep_alive: opts.keep_alive_secs.map_or(default_retry_options.keep_alive, |secs| Duration::from_secs(secs)),
-            }
-        });
+        let retry_options =
+            self.connection_retry_options
+                .as_ref()
+                .map_or(default_retry_options.clone(), |opts| {
+                    ConnectionRetryOptions {
+                        min_backoff: opts
+                            .min_backoff_ms
+                            .map_or(default_retry_options.min_backoff, |ms| {
+                                Duration::from_millis(ms)
+                            }),
+                        max_backoff: opts
+                            .max_backoff_secs
+                            .map_or(default_retry_options.max_backoff, |secs| {
+                                Duration::from_secs(secs)
+                            }),
+                        max_retries: opts
+                            .max_retries
+                            .unwrap_or(default_retry_options.max_retries),
+                        connection_timeout: opts
+                            .connection_timeout_secs
+                            .map_or(default_retry_options.connection_timeout, |secs| {
+                                Duration::from_secs(secs)
+                            }),
+                        keep_alive: opts
+                            .keep_alive_secs
+                            .map_or(default_retry_options.keep_alive, |secs| {
+                                Duration::from_secs(secs)
+                            }),
+                    }
+                });
 
         builder = builder.with_connection_retry_options(retry_options);
 

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -121,6 +121,46 @@ base: components: sinks: pulsar: configuration: {
 			}
 		}
 	}
+	connection_retry_options: {
+		description: "Custom connection retry options configuration for the Pulsar client."
+		required:    false
+		type: object: options: {
+			connection_timeout_secs: {
+				description: "Time limit to establish a connection."
+				required:    false
+				type: uint: {
+					examples: [10]
+					unit: "seconds"
+				}
+			}
+			keep_alive_secs: {
+				description: "Keep-alive interval for each broker connection."
+				required:    false
+				type: uint: {
+					examples: [60]
+					unit: "seconds"
+				}
+			}
+			max_backoff_secs: {
+				description: "Maximum delay between reconnection retries."
+				required:    false
+				type: uint: {
+					examples: [30]
+					unit: "seconds"
+				}
+			}
+			max_retries: {
+				description: "Maximum number of connection retries."
+				required:    false
+				type: uint: examples: [12]
+			}
+			min_backoff_ms: {
+				description: "Minimum delay between connection retries."
+				required:    false
+				type: uint: unit: "milliseconds"
+			}
+		}
+	}
 	encoding: {
 		description: "Configures how events are encoded into raw bytes."
 		required:    true


### PR DESCRIPTION
I want to be able to customize the connection retry options for the Pulsar client. This fixes https://github.com/vectordotdev/vector/issues/21242

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
