### PR TITLE
fix(proto): Remove error log when source_event_id is not present

### DIFF
--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -93,7 +93,7 @@ message Metadata {
   optional string source_type = 4;
   OutputId upstream_id = 5;
   Secrets secrets = 6;
-  optional bytes source_event_id = 8;
+  bytes source_event_id = 7;
 }
 
 message Metric {

--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -93,7 +93,7 @@ message Metadata {
   optional string source_type = 4;
   OutputId upstream_id = 5;
   Secrets secrets = 6;
-  bytes source_event_id = 7;
+  optional bytes source_event_id = 7;
 }
 
 message Metric {

--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -93,7 +93,7 @@ message Metadata {
   optional string source_type = 4;
   OutputId upstream_id = 5;
   Secrets secrets = 6;
-  optional bytes source_event_id = 7;
+  optional bytes source_event_id = 8;
 }
 
 message Metric {

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -1186,7 +1186,10 @@ mod test {
         // Check if event id is UUID v7
         let log1 = LogEvent::default();
         assert_eq!(
-            log1.metadata().source_event_id().get_version(),
+            log1.metadata()
+                .source_event_id()
+                .expect("source_event_id should be auto-generated for new events")
+                .get_version(),
             Some(Version::SortRand)
         );
 

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -72,7 +72,7 @@ pub struct EventMetadata {
 
     /// An internal vector id that can be used to identify this event across all components.
     #[derivative(PartialEq = "ignore")]
-    pub(crate) source_event_id: Uuid,
+    pub(crate) source_event_id: Option<Uuid>,
 }
 
 /// Metric Origin metadata for submission to Datadog.
@@ -223,7 +223,7 @@ impl EventMetadata {
     }
 
     /// Returns a reference to the event id.
-    pub fn source_event_id(&self) -> Uuid {
+    pub fn source_event_id(&self) -> Option<Uuid> {
         self.source_event_id
     }
 }
@@ -240,7 +240,7 @@ impl Default for EventMetadata {
             upstream_id: None,
             dropped_fields: ObjectMap::new(),
             datadog_origin_metadata: None,
-            source_event_id: Uuid::now_v7(),
+            source_event_id: Some(Uuid::now_v7()),
         }
     }
 }
@@ -314,7 +314,7 @@ impl EventMetadata {
 
     /// Replaces the existing `source_event_id` with the given one.
     #[must_use]
-    pub fn with_source_event_id(mut self, source_event_id: Uuid) -> Self {
+    pub fn with_source_event_id(mut self, source_event_id: Option<Uuid>) -> Self {
         self.source_event_id = source_event_id;
         self
     }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -642,7 +642,7 @@ impl From<EventMetadata> for Metadata {
             source_type: source_type.map(|s| s.to_string()),
             upstream_id: upstream_id.map(|id| id.as_ref().clone()).map(Into::into),
             secrets,
-            source_event_id: source_event_id.map_or(vec![], std::convert::Into::into)
+            source_event_id: source_event_id.map_or(vec![], std::convert::Into::into),
         }
     }
 }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -677,8 +677,6 @@ impl From<Metadata> for EventMetadata {
 
         if let Ok(uuid) = Uuid::from_slice(&value.source_event_id) {
             metadata = metadata.with_source_event_id(uuid);
-        } else {
-            error!("Invalid source_event_id in metadata");
         }
 
         metadata

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -642,7 +642,7 @@ impl From<EventMetadata> for Metadata {
             source_type: source_type.map(|s| s.to_string()),
             upstream_id: upstream_id.map(|id| id.as_ref().clone()).map(Into::into),
             secrets,
-            source_event_id: Some(source_event_id.into()),
+            source_event_id: source_event_id.map_or(vec![], std::convert::Into::into)
         }
     }
 }
@@ -675,16 +675,7 @@ impl From<Metadata> for EventMetadata {
             metadata = metadata.with_origin_metadata(origin_metadata.into());
         }
 
-        if let Some(source_event_id) = value.source_event_id {
-            match Uuid::from_slice(&source_event_id) {
-                Ok(uuid) => metadata = metadata.with_source_event_id(uuid),
-                Err(error) => error!(
-                    message = "Invalid source_event_id in metadata",
-                    error = %error,
-                    internal_rate_limit = true
-                ),
-            };
-        }
+        metadata = metadata.with_source_event_id(Uuid::from_slice(&value.source_event_id).ok());
 
         metadata
     }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -642,7 +642,7 @@ impl From<EventMetadata> for Metadata {
             source_type: source_type.map(|s| s.to_string()),
             upstream_id: upstream_id.map(|id| id.as_ref().clone()).map(Into::into),
             secrets,
-            source_event_id: source_event_id.into(),
+            source_event_id: Some(source_event_id.into()),
         }
     }
 }
@@ -675,8 +675,15 @@ impl From<Metadata> for EventMetadata {
             metadata = metadata.with_origin_metadata(origin_metadata.into());
         }
 
-        if let Ok(uuid) = Uuid::from_slice(&value.source_event_id) {
-            metadata = metadata.with_source_event_id(uuid);
+        if let Some(source_event_id) = value.source_event_id {
+            match Uuid::from_slice(&source_event_id) {
+                Ok(uuid) => metadata = metadata.with_source_event_id(uuid),
+                Err(error) => error!(
+                    message = "Invalid source_event_id in metadata",
+                    error = %error,
+                    internal_rate_limit = true
+                ),
+            };
         }
 
         metadata

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -675,7 +675,22 @@ impl From<Metadata> for EventMetadata {
             metadata = metadata.with_origin_metadata(origin_metadata.into());
         }
 
-        metadata = metadata.with_source_event_id(Uuid::from_slice(&value.source_event_id).ok());
+        let maybe_source_event_id = if value.source_event_id.is_empty() {
+            None
+        } else {
+            match Uuid::from_slice(&value.source_event_id) {
+                Ok(id) => Some(id),
+                Err(error) => {
+                    error!(
+                        message = "Failed to parse source_event_id: {}",
+                        %error,
+                        internal_log_rate_limit = true
+                    );
+                    None
+                }
+            }
+        };
+        metadata = metadata.with_source_event_id(maybe_source_event_id);
 
         metadata
     }


### PR DESCRIPTION
https://github.com/vectordotdev/vector/pull/21074 added a new field `source_event_id` which uniquely identifies an event as it passes through different components. 

Initially made the assumption that `source_event_id` will always be present in proto, and if it is not present we should log an error. However, did not account for the cases such as when the source is a previous version of vector [#21252](https://github.com/vectordotdev/vector/issues/21252), resulting in a noisy error logs. Removing this log as well as making `source_event_id` Optional in `EventMetadata`

