### PR TITLE
docs(releasing): Fix docs for new components in v0.41.0

### DIFF
--- a/website/content/en/docs/reference/configuration/sinks/greptimedb_metrics.md
+++ b/website/content/en/docs/reference/configuration/sinks/greptimedb_metrics.md
@@ -1,9 +1,10 @@
 ---
-title: GreptimeDB
-description: Writes metric data to [GreptimeDB](https://github.com/greptimeteam/greptimedb)
+title: GreptimeDB Metrics
+description: Writes metrics to [GreptimeDB](https://github.com/greptimeteam/greptimedb)
 component_kind: sink
 layout: component
 tags: ["greptimedb", "component", "sink", "storage", "time-series", "metrics"]
+aliases: ["/docs/reference/configuration/sinks/greptimedb"]
 ---
 
 {{/*

--- a/website/content/en/docs/reference/configuration/sources/static_metrics.md
+++ b/website/content/en/docs/reference/configuration/sources/static_metrics.md
@@ -1,0 +1,14 @@
+---
+title: Static metrics
+description: Publish statically configured metrics on an interval
+component_kind: source
+layout: component
+tags: ["vector", "instance", "local", "internal", "component", "source", "metrics"]
+---
+
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -499,6 +499,7 @@ _values: {
 	"string"?: #TypeString & {_args: required: Args.required}
 	"ascii_char"?: #TypeAsciiChar & {_args: required: Args.required}
 	"timestamp"?: #TypeTimestamp & {_args: required: Args.required}
+	"int"?: #TypeInt & {_args: required: Args.required}
 	"uint"?: #TypeUint & {_args: required: Args.required}
 }
 
@@ -616,6 +617,25 @@ _values: {
 	// when examples cannot be derived from the `default` or `enum`
 	// options.
 	examples: [_values.current_timestamp]
+}
+
+#TypeInt: {
+	_args: required: bool
+	let Args = _args
+
+	if !Args.required {
+		// `default` sets the default value.
+		default: int | *null
+	}
+
+	// `examples` clarify values through examples. This should be used
+	// when examples cannot be derived from the `default` or `enum`
+	// options.
+	examples?: [int, ...int]
+
+	// `unit` clarifies the value's unit. While this should be included
+	// as the suffix in the name, this helps to explicitly clarify that.
+	unit?: #Unit | null
 }
 
 #TypeUint: {

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -1199,7 +1199,7 @@ components: {
 						}
 					}
 					type:              "counter"
-					default_namespace: "vector"
+					default_namespace: string | *"vector"
 				}
 
 				_passthrough_distribution: {
@@ -1212,7 +1212,7 @@ components: {
 						}
 					}
 					type:              "distribution"
-					default_namespace: "vector"
+					default_namespace: string | *"vector"
 				}
 
 				_passthrough_gauge: {
@@ -1225,7 +1225,7 @@ components: {
 						}
 					}
 					type:              "gauge"
-					default_namespace: "vector"
+					default_namespace: string | *"vector"
 				}
 
 				_passthrough_histogram: {
@@ -1238,7 +1238,7 @@ components: {
 						}
 					}
 					type:              "gauge"
-					default_namespace: "vector"
+					default_namespace: string | *"vector"
 				}
 
 				_passthrough_set: {
@@ -1251,7 +1251,7 @@ components: {
 						}
 					}
 					type:              "gauge"
-					default_namespace: "vector"
+					default_namespace: string | *"vector"
 				}
 
 				_passthrough_summary: {
@@ -1264,7 +1264,7 @@ components: {
 						}
 					}
 					type:              "gauge"
-					default_namespace: "vector"
+					default_namespace: string | *"vector"
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/greptimedb_logs.cue
@@ -20,7 +20,7 @@ components: sinks: greptimedb_logs: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    10_000_000
+				max_events:   20
 				timeout_secs: 1.0
 			}
 			compression: enabled: false
@@ -45,7 +45,7 @@ components: sinks: greptimedb_logs: {
 				interface: {
 					socket: {
 						api: {
-							title: "GreptimeDB HTTP API"
+							title: "GreptimeDB gRPC API"
 							url:   urls.greptimedb_docs
 						}
 						direction: "outgoing"
@@ -66,9 +66,16 @@ components: sinks: greptimedb_logs: {
 	configuration: base.components.sinks.greptimedb_logs.configuration
 
 	input: {
-		logs:    true
-		metrics: null
-		traces:  false
+		logs: true
+		metrics: {
+			counter:      false
+			distribution: false
+			gauge:        false
+			histogram:    false
+			set:          false
+			summary:      false
+		}
+		traces: false
 	}
 
 	how_it_works: {
@@ -76,7 +83,7 @@ components: sinks: greptimedb_logs: {
 			title: "Setup"
 			body:  """
 				1. Start your own [GreptimeDB](\(urls.greptimedb)) or create an instance on [GreptimeCloud](\(urls.greptimecloud)).
-				2. Configure HTTP endpoint(host:port), optional dbname, authentication information, and pipeline info.
+				2. Configure gRPC endpoint(host:port) and optional dbname and authentication information.
 				"""
 		}
 	}

--- a/website/cue/reference/components/sinks/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/greptimedb_metrics.cue
@@ -1,7 +1,8 @@
 package metadata
 
-components: sinks: greptimedb: {
-	title: "GreptimeDB"
+components: sinks: greptimedb_metrics: {
+	title: "GreptimeDB Metrics"
+	alias: "greptimedb"
 
 	classes: {
 		commonly_used: true
@@ -20,7 +21,7 @@ components: sinks: greptimedb: {
 			batch: {
 				enabled:      true
 				common:       false
-				max_bytes:    10_000_000
+				max_events:   20
 				timeout_secs: 1.0
 			}
 			compression: enabled: false

--- a/website/cue/reference/components/sources/static_metrics.cue
+++ b/website/cue/reference/components/sources/static_metrics.cue
@@ -1,0 +1,84 @@
+package metadata
+
+components: sources: static_metrics: {
+	title: "Static Metrics"
+
+	description: """
+		Publish statically configured metrics on an interval. This can be useful for publishing
+		heartbeats or sending the value of an environment variable as a metric.
+		"""
+
+	classes: {
+		commonly_used: true
+		delivery:      "at_least_once"
+		deployment_roles: ["aggregator", "daemon", "sidecar"]
+		development:   "stable"
+		egress_method: "batch"
+		stateful:      false
+	}
+
+	features: {
+		acknowledgements: false
+		collect: {
+			checkpoint: enabled: false
+			from: service:       services.vector
+		}
+		multiline: enabled: false
+	}
+
+	support: {
+		notices: []
+		requirements: []
+		warnings: []
+	}
+
+	installation: {
+		platform_name: null
+	}
+
+	configuration: base.components.sources.static_metrics.configuration
+
+	output: metrics: {
+		counter: output._passthrough_counter & {
+			default_namespace: "static"
+		}
+		distribution: output._passthrough_distribution & {
+			default_namespace: "static"
+		}
+		gauge: output._passthrough_gauge & {
+			default_namespace: "static"
+		}
+		set: output._passthrough_set & {
+			default_namespace: "static"
+		}
+	}
+
+	examples: [
+		{
+			title: "Emit a heartbeat"
+			configuration: {
+				metrics: [
+					{
+						name: "heartbeat"
+						kind: "absolute"
+						value:
+							gauge: 1
+						tags:
+							env: "${ENV}"
+					},
+				]
+			}
+			input: ""
+			output: metric: {
+				name:      "heartbeat"
+				kind:      "absolute"
+				namespace: "static"
+				timestamp: "2024-09-10T19:04:58Z"
+				gauge:
+					value: 1.0
+				tags:
+					env: "${ENV}"
+			}
+		},
+	]
+}


### PR DESCRIPTION
The new `static_metrics` source and `greptimdb_logs` sink were not correctly documented. Each commit can be reviewed separately.