### PR TITLE
feat(chronicle-sink): add support for compression to Google Chronicle sink

### DIFF
--- a/changelog.d/chronicle_compression_support.enhancement.md
+++ b/changelog.d/chronicle_compression_support.enhancement.md
@@ -1,0 +1,4 @@
+Add compression support to the Chronicle log sink
+Only GZip compression is documented as being supported - https://cloud.google.com/chronicle/docs/reference/ingestion-api#frequently_asked_questions
+
+authors: chocpanda

--- a/changelog.d/chronicle_compression_support.enhancement.md
+++ b/changelog.d/chronicle_compression_support.enhancement.md
@@ -1,4 +1,3 @@
-Add compression support to the Chronicle log sink
-Only GZip compression is documented as being supported - https://cloud.google.com/chronicle/docs/reference/ingestion-api#frequently_asked_questions
+Add Gzip compression support to the`gcp_chronicle_unstructured` sink. See official documentation [here](https://cloud.google.com/chronicle/docs/reference/ingestion-api#frequently_asked_questions).
 
 authors: chocpanda

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -2,13 +2,11 @@
 //! See <https://cloud.google.com/chronicle/docs/reference/ingestion-api#unstructuredlogentries>
 //! for more information.
 use bytes::{Bytes, BytesMut};
-use std::{cell::RefCell, collections::BTreeSet};
 
 use futures_util::{future::BoxFuture, task::Poll};
 use goauth::scopes::Scope;
 use http::{header::HeaderValue, Request, StatusCode, Uri};
 use hyper::Body;
-use indexmap::IndexMap;
 use indoc::indoc;
 use serde::Serialize;
 use serde_json::json;
@@ -17,16 +15,7 @@ use std::collections::HashMap;
 use std::io;
 use tokio_util::codec::Encoder as _;
 use tower::{Service, ServiceBuilder};
-use vector_lib::configurable::attributes::CustomAttribute;
-use vector_lib::configurable::{
-    schema::{
-        apply_base_metadata, generate_const_string_schema, generate_enum_schema,
-        generate_one_of_schema, generate_struct_schema, get_or_generate_schema, SchemaGenerator,
-        SchemaObject,
-    },
-    Configurable, GenerateError, Metadata, ToValue,
-};
-use vector_lib::configurable::{configurable_component, Configurable, GenerateError, Metadata};
+use vector_lib::configurable::{configurable_component};
 use vector_lib::request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata};
 use vector_lib::{
     config::{telemetry, AcknowledgementsConfig, Input},
@@ -36,7 +25,6 @@ use vector_lib::{
 };
 use vrl::value::Kind;
 
-use crate::sinks::util::buffer::compression::CompressionLevel;
 use crate::sinks::util::service::TowerRequestConfigDefaults;
 use crate::{
     codecs::{self, EncodingConfig},
@@ -48,6 +36,7 @@ use crate::{
         gcp_chronicle::{
             partitioner::{ChroniclePartitionKey, ChroniclePartitioner},
             sink::ChronicleSink,
+            compression::ChronicleCompression,
         },
         gcs_common::{
             config::{healthcheck_response, GcsRetryLogic},
@@ -64,106 +53,6 @@ use crate::{
     template::{Template, TemplateParseError},
     tls::{TlsConfig, TlsSettings},
 };
-
-/// Compression configuration.
-#[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
-#[serde(rename_all = "snake_case")]
-#[configurable(metadata(
-    docs::enum_tag_description = "The compression algorithm to use for sending."
-))]
-pub enum ChronicleCompression {
-    /// No compression.
-    #[derivative(Default)]
-    None,
-
-    /// [Gzip][gzip] compression.
-    ///
-    /// [gzip]: https://www.gzip.org/
-    Gzip(CompressionLevel),
-}
-
-impl From<ChronicleCompression> for Compression {
-    fn from(compression: ChronicleCompression) -> Self {
-        match compression {
-            ChronicleCompression::None => Compression::None,
-            ChronicleCompression::Gzip(compression_level) => Compression::Gzip(compression_level),
-        }
-    }
-}
-
-// Schema generation largely copied from `src/sinks/util/buffer/compression`
-impl Configurable for ChronicleCompression {
-    fn metadata() -> Metadata {
-        let mut metadata = Metadata::default();
-        metadata.set_title("Compression configuration.");
-        metadata.set_description("All compression algorithms use the default compression level unless otherwise specified.");
-        metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
-        metadata.add_custom_attribute(CustomAttribute::flag("docs::advanced"));
-        metadata
-    }
-
-    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
-        const ALGORITHM_NAME: &str = "algorithm";
-        const LEVEL_NAME: &str = "level";
-        const LOGICAL_NAME: &str = "logical_name";
-        const ENUM_TAGGING_MODE: &str = "docs::enum_tagging";
-
-        let generate_string_schema = |logical_name: &str,
-                                      title: Option<&'static str>,
-                                      description: &'static str|
-         -> SchemaObject {
-            let mut const_schema = generate_const_string_schema(logical_name.to_lowercase());
-            let mut const_metadata = Metadata::with_description(description);
-            if let Some(title) = title {
-                const_metadata.set_title(title);
-            }
-            const_metadata.add_custom_attribute(CustomAttribute::kv(LOGICAL_NAME, logical_name));
-            apply_base_metadata(&mut const_schema, const_metadata);
-            const_schema
-        };
-
-        // First, we'll create the string-only subschemas for each algorithm, and wrap those up
-        // within a one-of schema.
-        let mut string_metadata = Metadata::with_description("Compression algorithm.");
-        string_metadata.add_custom_attribute(CustomAttribute::kv(ENUM_TAGGING_MODE, "external"));
-
-        let none_string_subschema = generate_string_schema("None", None, "No compression.");
-        let gzip_string_subschema = generate_string_schema(
-            "Gzip",
-            Some("[Gzip][gzip] compression."),
-            "[gzip]: https://www.gzip.org/",
-        );
-
-        let mut all_string_oneof_subschema = generate_one_of_schema(&[none_string_subschema, gzip_string_subschema]);
-        apply_base_metadata(&mut all_string_oneof_subschema, string_metadata);
-
-        let compression_level_schema =
-            get_or_generate_schema(&CompressionLevel::as_configurable_ref(), gen, None)?;
-
-        let mut required = BTreeSet::new();
-        required.insert(ALGORITHM_NAME.to_string());
-
-        let mut properties = IndexMap::new();
-        properties.insert(
-            ALGORITHM_NAME.to_string(),
-            all_string_oneof_subschema.clone(),
-        );
-        properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
-
-        let mut full_subschema = generate_struct_schema(properties, required, None);
-        let mut full_metadata =
-            Metadata::with_description("Compression algorithm and compression level.");
-        full_metadata.add_custom_attribute(CustomAttribute::flag("docs::hidden"));
-        apply_base_metadata(&mut full_subschema, full_metadata);
-
-        Ok(generate_one_of_schema(&[
-            all_string_oneof_subschema,
-            full_subschema,
-        ]))
-    }
-}
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -53,7 +53,6 @@ use crate::{
     tls::{TlsConfig, TlsSettings},
 };
 
-
 /// Compression configuration.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
@@ -530,7 +529,10 @@ impl ChronicleRequestBuilder {
             transformer,
         };
         let compression = Compression::from(config.compression);
-        Ok(Self { encoder, compression })
+        Ok(Self {
+            encoder,
+            compression,
+        })
     }
 }
 

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -24,6 +24,7 @@ use vector_lib::{
 };
 use vrl::value::Kind;
 
+use crate::sinks::util::buffer::compression::CompressionLevel;
 use crate::sinks::util::service::TowerRequestConfigDefaults;
 use crate::{
     codecs::{self, EncodingConfig},
@@ -55,7 +56,7 @@ use crate::{
 
 /// Compression configuration.
 #[configurable_component]
-#[derive(Clone, Debug, Derivative, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
 #[derivative(Default)]
 #[serde(rename_all = "snake_case")]
 #[configurable(metadata(
@@ -69,14 +70,14 @@ pub enum ChronicleCompression {
     /// [Gzip][gzip] compression.
     ///
     /// [gzip]: https://www.gzip.org/
-    Gzip,
+    Gzip(CompressionLevel),
 }
 
 impl From<ChronicleCompression> for Compression {
     fn from(compression: ChronicleCompression) -> Self {
         match compression {
             ChronicleCompression::None => Compression::None,
-            ChronicleCompression::Gzip => Compression::gzip_default(),
+            ChronicleCompression::Gzip(compression_level) => Compression::Gzip(compression_level),
         }
     }
 }
@@ -528,7 +529,7 @@ impl ChronicleRequestBuilder {
             encoder,
             transformer,
         };
-        let compression = Compression::from(config.compression.clone());
+        let compression = Compression::from(config.compression);
         Ok(Self { encoder, compression })
     }
 }

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -110,6 +110,7 @@ pub struct ChronicleUnstructuredTowerRequestConfigDefaults;
 impl TowerRequestConfigDefaults for ChronicleUnstructuredTowerRequestConfigDefaults {
     const RATE_LIMIT_NUM: u64 = 1_000;
 }
+
 /// Configuration for the `gcp_chronicle_unstructured` sink.
 #[configurable_component(sink(
     "gcp_chronicle_unstructured",
@@ -158,6 +159,7 @@ pub struct ChronicleUnstructuredConfig {
     pub encoding: EncodingConfig,
 
     #[serde(default)]
+    #[configurable(derived)]
     pub compression: ChronicleCompression,
 
     #[configurable(derived)]

--- a/src/sinks/gcp_chronicle/compression.rs
+++ b/src/sinks/gcp_chronicle/compression.rs
@@ -47,7 +47,7 @@ impl TryFrom<Compression> for ChronicleCompression {
             Compression::None => Ok(ChronicleCompression::None),
             Compression::Gzip(compression_level) => {
                 Ok(ChronicleCompression::Gzip(compression_level))
-            },
+            }
             _ => Err("Compression type is not supported by Chronicle".to_string()),
         }
     }
@@ -139,9 +139,7 @@ impl<'de> de::Deserialize<'de> for ChronicleCompression {
         D: de::Deserializer<'de>,
     {
         Compression::deserialize(deserializer)
-            .and_then(|x| ChronicleCompression::try_from(x)
-                .map_err(|err| de::Error::custom(err))
-            )
+            .and_then(|x| ChronicleCompression::try_from(x).map_err(|err| de::Error::custom(err)))
     }
 }
 

--- a/src/sinks/gcp_chronicle/compression.rs
+++ b/src/sinks/gcp_chronicle/compression.rs
@@ -1,0 +1,155 @@
+use serde::{de, ser};
+use serde_json::Value;
+use std::{cell::RefCell, collections::BTreeSet};
+use vector_lib::configurable::ToValue;
+
+use indexmap::IndexMap;
+use vector_lib::configurable::attributes::CustomAttribute;
+use vector_lib::configurable::{
+    schema::{
+        apply_base_metadata, generate_const_string_schema, generate_one_of_schema,
+        generate_struct_schema, get_or_generate_schema, SchemaGenerator, SchemaObject,
+    },
+    Configurable, GenerateError, Metadata,
+};
+
+use crate::sinks::util::buffer::compression::CompressionLevel;
+use crate::sinks::util::Compression;
+
+/// Compression configuration.
+#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
+#[derivative(Default)]
+pub enum ChronicleCompression {
+    /// No compression.
+    #[derivative(Default)]
+    None,
+
+    /// [Gzip][gzip] compression.
+    ///
+    /// [gzip]: https://www.gzip.org/
+    Gzip(CompressionLevel),
+}
+
+impl From<ChronicleCompression> for Compression {
+    fn from(compression: ChronicleCompression) -> Self {
+        match compression {
+            ChronicleCompression::None => Compression::None,
+            ChronicleCompression::Gzip(compression_level) => Compression::Gzip(compression_level),
+        }
+    }
+}
+
+impl TryFrom<Compression> for ChronicleCompression {
+    type Error = String;
+
+    fn try_from(compression: Compression) -> Result<Self, Self::Error> {
+        match compression {
+            Compression::None => Ok(ChronicleCompression::None),
+            Compression::Gzip(compression_level) => {
+                Ok(ChronicleCompression::Gzip(compression_level))
+            },
+            _ => Err("Compression type is not supported by Chronicle".to_string()),
+        }
+    }
+}
+
+// Schema generation largely copied from `src/sinks/util/buffer/compression`
+impl Configurable for ChronicleCompression {
+    fn metadata() -> Metadata {
+        let mut metadata = Metadata::default();
+        metadata.set_title("Compression configuration.");
+        metadata.set_description("All compression algorithms use the default compression level unless otherwise specified.");
+        metadata.add_custom_attribute(CustomAttribute::kv("docs::enum_tagging", "external"));
+        metadata.add_custom_attribute(CustomAttribute::flag("docs::advanced"));
+        metadata
+    }
+
+    fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        const ALGORITHM_NAME: &str = "algorithm";
+        const LEVEL_NAME: &str = "level";
+        const LOGICAL_NAME: &str = "logical_name";
+        const ENUM_TAGGING_MODE: &str = "docs::enum_tagging";
+
+        let generate_string_schema = |logical_name: &str,
+                                      title: Option<&'static str>,
+                                      description: &'static str|
+         -> SchemaObject {
+            let mut const_schema = generate_const_string_schema(logical_name.to_lowercase());
+            let mut const_metadata = Metadata::with_description(description);
+            if let Some(title) = title {
+                const_metadata.set_title(title);
+            }
+            const_metadata.add_custom_attribute(CustomAttribute::kv(LOGICAL_NAME, logical_name));
+            apply_base_metadata(&mut const_schema, const_metadata);
+            const_schema
+        };
+
+        // First, we'll create the string-only subschemas for each algorithm, and wrap those up
+        // within a one-of schema.
+        let mut string_metadata = Metadata::with_description("Compression algorithm.");
+        string_metadata.add_custom_attribute(CustomAttribute::kv(ENUM_TAGGING_MODE, "external"));
+
+        let none_string_subschema = generate_string_schema("None", None, "No compression.");
+        let gzip_string_subschema = generate_string_schema(
+            "Gzip",
+            Some("[Gzip][gzip] compression."),
+            "[gzip]: https://www.gzip.org/",
+        );
+
+        let mut all_string_oneof_subschema =
+            generate_one_of_schema(&[none_string_subschema, gzip_string_subschema]);
+        apply_base_metadata(&mut all_string_oneof_subschema, string_metadata);
+
+        let compression_level_schema =
+            get_or_generate_schema(&CompressionLevel::as_configurable_ref(), gen, None)?;
+
+        let mut required = BTreeSet::new();
+        required.insert(ALGORITHM_NAME.to_string());
+
+        let mut properties = IndexMap::new();
+        properties.insert(
+            ALGORITHM_NAME.to_string(),
+            all_string_oneof_subschema.clone(),
+        );
+        properties.insert(LEVEL_NAME.to_string(), compression_level_schema);
+
+        let mut full_subschema = generate_struct_schema(properties, required, None);
+        let mut full_metadata =
+            Metadata::with_description("Compression algorithm and compression level.");
+        full_metadata.add_custom_attribute(CustomAttribute::flag("docs::hidden"));
+        apply_base_metadata(&mut full_subschema, full_metadata);
+
+        Ok(generate_one_of_schema(&[
+            all_string_oneof_subschema,
+            full_subschema,
+        ]))
+    }
+}
+
+impl ToValue for ChronicleCompression {
+    fn to_value(&self) -> Value {
+        serde_json::to_value(Compression::from(*self))
+            .expect("Could not convert compression settings to JSON")
+    }
+}
+
+impl<'de> de::Deserialize<'de> for ChronicleCompression {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Compression::deserialize(deserializer)
+            .and_then(|x| ChronicleCompression::try_from(x)
+                .map_err(|err| de::Error::custom(err))
+            )
+    }
+}
+
+impl ser::Serialize for ChronicleCompression {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        Compression::serialize(&Compression::from(*self), serializer)
+    }
+}

--- a/src/sinks/gcp_chronicle/compression.rs
+++ b/src/sinks/gcp_chronicle/compression.rs
@@ -7,13 +7,15 @@ use indexmap::IndexMap;
 use vector_lib::configurable::attributes::CustomAttribute;
 use vector_lib::configurable::{
     schema::{
-        apply_base_metadata, generate_one_of_schema,
-        generate_struct_schema, get_or_generate_schema, SchemaGenerator, SchemaObject,
+        apply_base_metadata, generate_one_of_schema, generate_struct_schema,
+        get_or_generate_schema, SchemaGenerator, SchemaObject,
     },
     Configurable, GenerateError, Metadata,
 };
 
-use crate::sinks::util::buffer::compression::{generate_string_schema, CompressionLevel, ALGORITHM_NAME, ENUM_TAGGING_MODE, LEVEL_NAME};
+use crate::sinks::util::buffer::compression::{
+    generate_string_schema, CompressionLevel, ALGORITHM_NAME, ENUM_TAGGING_MODE, LEVEL_NAME,
+};
 use crate::sinks::util::Compression;
 
 /// Compression configuration.

--- a/src/sinks/gcp_chronicle/mod.rs
+++ b/src/sinks/gcp_chronicle/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "sinks-gcp-chronicle")]
 pub mod chronicle_unstructured;
+pub mod compression;
 pub mod partitioner;
 pub mod sink;

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -272,6 +272,22 @@ impl ser::Serialize for Compression {
     }
 }
 
+pub const ALGORITHM_NAME: &str = "algorithm";
+pub const LEVEL_NAME: &str = "level";
+pub const LOGICAL_NAME: &str = "logical_name";
+pub const ENUM_TAGGING_MODE: &str = "docs::enum_tagging";
+
+pub fn generate_string_schema(logical_name: &str, title: Option<&'static str>, description: &'static str) -> SchemaObject {
+    let mut const_schema = generate_const_string_schema(logical_name.to_lowercase());
+    let mut const_metadata = Metadata::with_description(description);
+    if let Some(title) = title {
+        const_metadata.set_title(title);
+    }
+    const_metadata.add_custom_attribute(CustomAttribute::kv(LOGICAL_NAME, logical_name));
+    apply_base_metadata(&mut const_schema, const_metadata);
+    const_schema
+}
+
 // TODO: Consider an approach for generating schema of "string or object" structure used by this type.
 impl Configurable for Compression {
     fn referenceable_name() -> Option<&'static str> {
@@ -288,25 +304,6 @@ impl Configurable for Compression {
     }
 
     fn generate_schema(gen: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
-        const ALGORITHM_NAME: &str = "algorithm";
-        const LEVEL_NAME: &str = "level";
-        const LOGICAL_NAME: &str = "logical_name";
-        const ENUM_TAGGING_MODE: &str = "docs::enum_tagging";
-
-        let generate_string_schema = |logical_name: &str,
-                                      title: Option<&'static str>,
-                                      description: &'static str|
-         -> SchemaObject {
-            let mut const_schema = generate_const_string_schema(logical_name.to_lowercase());
-            let mut const_metadata = Metadata::with_description(description);
-            if let Some(title) = title {
-                const_metadata.set_title(title);
-            }
-            const_metadata.add_custom_attribute(CustomAttribute::kv(LOGICAL_NAME, logical_name));
-            apply_base_metadata(&mut const_schema, const_metadata);
-            const_schema
-        };
-
         // First, we'll create the string-only subschemas for each algorithm, and wrap those up
         // within a one-of schema.
         let mut string_metadata = Metadata::with_description("Compression algorithm.");

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -277,7 +277,11 @@ pub const LEVEL_NAME: &str = "level";
 pub const LOGICAL_NAME: &str = "logical_name";
 pub const ENUM_TAGGING_MODE: &str = "docs::enum_tagging";
 
-pub fn generate_string_schema(logical_name: &str, title: Option<&'static str>, description: &'static str) -> SchemaObject {
+pub fn generate_string_schema(
+    logical_name: &str,
+    title: Option<&'static str>,
+    description: &'static str,
+) -> SchemaObject {
     let mut const_schema = generate_const_string_schema(logical_name.to_lowercase());
     let mut const_metadata = Metadata::with_description(description);
     if let Some(title) = title {

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -76,20 +76,21 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 		}
 	}
 	compression: {
-		description: "Compression configuration."
-		required:    false
-		type: {
-			object: options: gzip: {
-				description: "Compression level."
-				required:    true
-				type: {
-					string: enum: ["none", "fast", "best", "default"]
-					uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
-				}
-			}
-			string: {
-				default: "none"
-				enum: none: "No compression."
+		description: """
+			Compression configuration.
+
+			All compression algorithms use the default compression level unless otherwise specified.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://www.gzip.org/
+					"""
+				none: "No compression."
 			}
 		}
 	}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -78,15 +78,18 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 	compression: {
 		description: "Compression configuration."
 		required:    false
-		type: string: {
-			default: "none"
-			enum: {
-				gzip: """
-					[Gzip][gzip] compression.
-
-					[gzip]: https://www.gzip.org/
-					"""
-				none: "No compression."
+		type: {
+			object: options: gzip: {
+				description: "Compression level."
+				required:    true
+				type: {
+					string: enum: ["none", "fast", "best", "default"]
+					uint: enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+				}
+			}
+			string: {
+				default: "none"
+				enum: none: "No compression."
 			}
 		}
 	}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -75,6 +75,21 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 			}
 		}
 	}
+	compression: {
+		description: "Compression configuration."
+		required:    false
+		type: string: {
+			default: "none"
+			enum: {
+				gzip: """
+					[Gzip][gzip] compression.
+
+					[gzip]: https://www.gzip.org/
+					"""
+				none: "No compression."
+			}
+		}
+	}
 	credentials_path: {
 		description: """
 			Path to a [service account][gcp_service_account_credentials] credentials JSON file.


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Google Chronicle's ingestion API supports use of GZip compression - https://cloud.google.com/chronicle/docs/reference/ingestion-api#frequently_asked_questions