### PR TITLE
docs(vrl stdlib): Fix whitespace for `parse_influxdb` notice

### DIFF
--- a/website/cue/reference/remap/functions/parse_influxdb.cue
+++ b/website/cue/reference/remap/functions/parse_influxdb.cue
@@ -8,9 +8,9 @@ remap: functions: parse_influxdb: {
 		"""
 	notices: [
 		"""
-			    This function will return a log event with the shape of a Vector-compatible metric, but not a metric event itself.
-			    You will likely want to pipe the output of this function through a `log_to_metric` transform with the option `all_metrics`
-				set to `true` to convert the metric-shaped log events to metric events so _real_ metrics are produced.
+			This function will return a log event with the shape of a Vector-compatible metric, but not a metric event itself.
+			You will likely want to pipe the output of this function through a `log_to_metric` transform with the option `all_metrics`
+			set to `true` to convert the metric-shaped log events to metric events so _real_ metrics are produced.
 			""",
 		"""
 			The only metric type that is produced is a `gauge`. Each metric name is prefixed with the `measurement` field, followed


### PR DESCRIPTION
Closes: #21251

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
