### PR TITLE
fix(kubernetes_logs source): UID to identify meta cache 

### DIFF
--- a/src/kubernetes/meta_cache.rs
+++ b/src/kubernetes/meta_cache.rs
@@ -31,14 +31,20 @@ impl MetaCache {
 pub struct MetaDescribe {
     name: String,
     namespace: String,
+    uid: String,
 }
 
 impl MetaDescribe {
     pub fn from_meta(meta: &ObjectMeta) -> Self {
         let name = meta.name.clone().unwrap_or_default();
         let namespace = meta.namespace.clone().unwrap_or_default();
+        let uid = meta.uid.clone().unwrap_or_default();
 
-        Self { name, namespace }
+        Self {
+            name,
+            namespace,
+            uid,
+        }
     }
 }
 


### PR DESCRIPTION
This fixes #13467

This intends to have vectors custom metadata cache for `kubernetes_logs` be more precise. At the moment. Pods are identified by there name and namespace. As stated in the [pull request](https://github.com/vectordotdev/vector/pull/14462#pullrequestreview-1139359009) implementing the custom cache this may be insufficient to correctly identify a Pod. It so happens that the same metadata object provided by `kube-rs`does offer a [uid](https://github.com/Arnavion/k8s-openapi/blob/789dfef4c4022d13a09a4d4c97067be7472db160/src/v1_26/apimachinery/pkg/apis/meta/v1/object_meta.rs#L60-L63) which may be used.

At the moment we are testing to simply add the uid to the `MetaDescribe` struct. But since the store is only used to determine if an object exists and its data is not needed it may be possible to use the uid only.