### PR TITLE
fix(new_relic sink): Fix handling of dotted attribute names

### DIFF
--- a/changelog.d/21304-newrelic-log-attribute-dotted-names.fix.md
+++ b/changelog.d/21304-newrelic-log-attribute-dotted-names.fix.md
@@ -1,0 +1,1 @@
+Fixed a bug in the `new_relic` sinks that caused dotted attribute names to be encoded incorrectly with quotes.

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -69,8 +69,7 @@ async fn component_spec_compliance_data_volume() {
 }
 
 #[test]
-fn generate_event_api_model() {
-    // Without message field
+fn generates_event_api_model_without_message_field() {
     let mut map = HashMap::<KeyString, Value>::new();
     map.insert("eventType".into(), Value::from("TestEvent".to_owned()));
     map.insert("user".into(), Value::from("Joe".to_owned()));
@@ -92,8 +91,10 @@ fn generate_event_api_model() {
     );
     assert!(model.0[0].contains_key("user_id"));
     assert_eq!(model.0[0].get("user_id").unwrap(), &Value::Integer(123456));
+}
 
-    // With message field
+#[test]
+fn generates_event_api_model_with_message_field() {
     let mut map = HashMap::<KeyString, Value>::new();
     map.insert("eventType".into(), Value::from("TestEvent".to_owned()));
     map.insert("user".into(), Value::from("Joe".to_owned()));
@@ -124,8 +125,10 @@ fn generate_event_api_model() {
         model.0[0].get("message").unwrap().to_string_lossy(),
         "This is a message".to_owned()
     );
+}
 
-    // With a JSON encoded inside the message field
+#[test]
+fn generates_event_api_model_with_json_inside_message_field() {
     let mut map = HashMap::<KeyString, Value>::new();
     map.insert("eventType".into(), Value::from("TestEvent".to_owned()));
     map.insert("user".into(), Value::from("Joe".to_owned()));
@@ -159,8 +162,7 @@ fn generate_event_api_model() {
 }
 
 #[test]
-fn generate_log_api_model() {
-    // Without message field
+fn generates_log_api_model_without_message_field() {
     let mut map = HashMap::<KeyString, Value>::new();
     map.insert("tag_key".into(), Value::from("tag_value".to_owned()));
     let event = Event::Log(LogEvent::from(map));
@@ -174,8 +176,10 @@ fn generate_log_api_model() {
         "tag_value".to_owned()
     );
     assert!(logs[0].contains_key("message"));
+}
 
-    // With message field
+#[test]
+fn generates_log_api_model_with_message_field() {
     let mut map = HashMap::<KeyString, Value>::new();
     map.insert("tag_key".into(), Value::from("tag_value".to_owned()));
     map.insert(
@@ -200,8 +204,7 @@ fn generate_log_api_model() {
 }
 
 #[test]
-fn generate_metric_api_model() {
-    // Without timestamp
+fn generates_metric_api_model_without_timestamp() {
     let event = Event::Metric(Metric::new(
         "my_metric",
         MetricKind::Absolute,
@@ -222,8 +225,10 @@ fn generate_metric_api_model() {
     assert!(metrics[0].contains_key("value"));
     assert_eq!(metrics[0].get("value").unwrap(), &Value::from(100.0));
     assert!(metrics[0].contains_key("timestamp"));
+}
 
-    // With timestamp
+#[test]
+fn generates_metric_api_model_with_timestamp() {
     let m = Metric::new(
         "my_metric",
         MetricKind::Absolute,
@@ -246,8 +251,10 @@ fn generate_metric_api_model() {
     assert!(metrics[0].contains_key("value"));
     assert_eq!(metrics[0].get("value").unwrap(), &Value::from(100.0));
     assert!(metrics[0].contains_key("timestamp"));
+}
 
-    // Incremental counter
+#[test]
+fn generates_metric_api_model_incremental_counter() {
     let m = Metric::new(
         "my_metric",
         MetricKind::Incremental,

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use futures::{future::ready, stream};
 use serde::Deserialize;
 use vector_lib::config::{init_telemetry, Tags, Telemetry};
+use vrl::value;
 
 use super::*;
 use crate::{
@@ -78,11 +79,11 @@ macro_rules! model_map {
 
 #[test]
 fn generates_event_api_model_without_message_field() {
-    let mut map = HashMap::<KeyString, Value>::new();
-    map.insert("eventType".into(), Value::from("TestEvent".to_owned()));
-    map.insert("user".into(), Value::from("Joe".to_owned()));
-    map.insert("user_id".into(), Value::from(123456));
-    let event = Event::Log(LogEvent::from(map));
+    let event = Event::Log(LogEvent::from(value!({
+        "eventType": "TestEvent",
+        "user": "Joe",
+        "user_id": 123456,
+    })));
     let model =
         EventsApiModel::try_from(vec![event]).expect("Failed mapping events into API model");
 
@@ -98,15 +99,12 @@ fn generates_event_api_model_without_message_field() {
 
 #[test]
 fn generates_event_api_model_with_message_field() {
-    let mut map = HashMap::<KeyString, Value>::new();
-    map.insert("eventType".into(), Value::from("TestEvent".to_owned()));
-    map.insert("user".into(), Value::from("Joe".to_owned()));
-    map.insert("user_id".into(), Value::from(123456));
-    map.insert(
-        "message".into(),
-        Value::from("This is a message".to_owned()),
-    );
-    let event = Event::Log(LogEvent::from(map));
+    let event = Event::Log(LogEvent::from(value!({
+        "eventType": "TestEvent",
+        "user": "Joe",
+        "user_id": 123456,
+        "message": "This is a message",
+    })));
     let model =
         EventsApiModel::try_from(vec![event]).expect("Failed mapping events into API model");
 
@@ -123,15 +121,12 @@ fn generates_event_api_model_with_message_field() {
 
 #[test]
 fn generates_event_api_model_with_json_inside_message_field() {
-    let mut map = HashMap::<KeyString, Value>::new();
-    map.insert("eventType".into(), Value::from("TestEvent".to_owned()));
-    map.insert("user".into(), Value::from("Joe".to_owned()));
-    map.insert("user_id".into(), Value::from(123456));
-    map.insert(
-        "message".into(),
-        Value::from("{\"my_key\" : \"my_value\"}".to_owned()),
-    );
-    let event = Event::Log(LogEvent::from(map));
+    let event = Event::Log(LogEvent::from(value!({
+        "eventType": "TestEvent",
+        "user": "Joe",
+        "user_id": 123456,
+        "message": "{\"my_key\" : \"my_value\"}",
+    })));
     let model =
         EventsApiModel::try_from(vec![event]).expect("Failed mapping events into API model");
 
@@ -148,9 +143,7 @@ fn generates_event_api_model_with_json_inside_message_field() {
 
 #[test]
 fn generates_log_api_model_without_message_field() {
-    let mut map = HashMap::<KeyString, Value>::new();
-    map.insert("tag_key".into(), Value::from("tag_value".to_owned()));
-    let event = Event::Log(LogEvent::from(map));
+    let event = Event::Log(LogEvent::from(value!({"tag_key": "tag_value"})));
     let model = LogsApiModel::try_from(vec![event]).expect("Failed mapping logs into API model");
     let logs = model.0[0].get("logs").expect("Logs data store not present");
 
@@ -165,13 +158,10 @@ fn generates_log_api_model_without_message_field() {
 
 #[test]
 fn generates_log_api_model_with_message_field() {
-    let mut map = HashMap::<KeyString, Value>::new();
-    map.insert("tag_key".into(), Value::from("tag_value".to_owned()));
-    map.insert(
-        "message".into(),
-        Value::from("This is a message".to_owned()),
-    );
-    let event = Event::Log(LogEvent::from(map));
+    let event = Event::Log(LogEvent::from(value!({
+        "tag_key": "tag_value",
+        "message": "This is a message",
+    })));
     let model = LogsApiModel::try_from(vec![event]).expect("Failed mapping logs into API model");
     let logs = model.0[0].get("logs").expect("Logs data store not present");
 

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -1,15 +1,15 @@
-use std::{collections::BTreeMap, convert::TryFrom, num::NonZeroU32, time::SystemTime};
+use std::{convert::TryFrom, num::NonZeroU32, time::SystemTime};
 
 use chrono::{DateTime, Utc};
 use futures::{future::ready, stream};
 use serde::Deserialize;
 use vector_lib::config::{init_telemetry, Tags, Telemetry};
-use vrl::value;
+use vrl::{btreemap, value};
 
 use super::*;
 use crate::{
     config::{GenerateConfig, SinkConfig, SinkContext},
-    event::{Event, KeyString, LogEvent, Metric, MetricKind, MetricValue, Value},
+    event::{Event, LogEvent, Metric, MetricKind, MetricValue},
     test_util::{
         components::{
             run_and_assert_data_volume_sink_compliance, run_and_assert_sink_compliance,
@@ -69,14 +69,6 @@ async fn component_spec_compliance_data_volume() {
     .await;
 }
 
-macro_rules! model_map {
-    ( $( $key:literal :  $value:expr , )* ) => {
-        [ $( ( KeyString::from($key), Value::from($value) ), )* ]
-            .into_iter()
-            .collect::<BTreeMap<_, _>>()
-    }
-}
-
 #[test]
 fn generates_event_api_model_without_message_field() {
     let event = Event::Log(LogEvent::from(value!({
@@ -89,10 +81,10 @@ fn generates_event_api_model_without_message_field() {
 
     assert_eq!(
         &model.0[..],
-        &[model_map! {
-            "eventType": "TestEvent",
-            "user": "Joe",
-            "user_id": 123456,
+        &[btreemap! {
+            "eventType" => "TestEvent",
+            "user" => "Joe",
+            "user_id" => 123456,
         }]
     );
 }
@@ -110,11 +102,11 @@ fn generates_event_api_model_with_message_field() {
 
     assert_eq!(
         &model.0[..],
-        &[model_map! {
-            "eventType": "TestEvent",
-            "user": "Joe",
-            "user_id": 123456,
-            "message": "This is a message",
+        &[btreemap! {
+            "eventType" =>"TestEvent",
+            "user" =>"Joe",
+            "user_id" =>123456,
+            "message" =>"This is a message",
         }]
     );
 }
@@ -132,11 +124,11 @@ fn generates_event_api_model_with_json_inside_message_field() {
 
     assert_eq!(
         &model.0[..],
-        &[model_map! {
-            "eventType": "TestEvent",
-            "user": "Joe",
-            "user_id": 123456,
-            "my_key": "my_value",
+        &[btreemap! {
+            "eventType" =>"TestEvent",
+            "user" =>"Joe",
+            "user_id" =>123456,
+            "my_key" =>"my_value",
         }]
     );
 }
@@ -149,9 +141,9 @@ fn generates_log_api_model_without_message_field() {
 
     assert_eq!(
         &logs[..],
-        &[model_map! {
-            "tag_key": "tag_value",
-            "message": "log from vector",
+        &[btreemap! {
+            "tag_key" =>"tag_value",
+            "message" =>"log from vector",
         }]
     );
 }
@@ -167,9 +159,9 @@ fn generates_log_api_model_with_message_field() {
 
     assert_eq!(
         &logs[..],
-        &[model_map! {
-            "tag_key": "tag_value",
-            "message": "This is a message",
+        &[btreemap! {
+            "tag_key" =>"tag_value",
+            "message" =>"This is a message",
         }]
     );
 }
@@ -186,10 +178,10 @@ fn generates_log_api_model_with_dotted_fields() {
 
     assert_eq!(
         &logs[..],
-        &[model_map! {
-            "one.two": 1,
-            "three": model_map! {"four": 2,},
-            "message": "log from vector",
+        &[btreemap! {
+            "one.two" =>1,
+            "three" =>btreemap! {"four" =>2,},
+            "message" =>"log from vector",
         }]
     );
 }
@@ -209,11 +201,11 @@ fn generates_metric_api_model_without_timestamp() {
 
     assert_eq!(
         &metrics[..],
-        &[model_map! {
-            "name": "my_metric",
-            "value": 100.0,
-            "timestamp": metrics[0].get("timestamp").unwrap().clone(),
-            "type": "gauge",
+        &[btreemap! {
+            "name" =>"my_metric",
+            "value" =>100.0,
+            "timestamp" =>metrics[0].get("timestamp").unwrap().clone(),
+            "type" =>"gauge",
         }]
     );
 }
@@ -236,11 +228,11 @@ fn generates_metric_api_model_with_timestamp() {
 
     assert_eq!(
         &metrics[..],
-        &[model_map! {
-            "name": "my_metric",
-            "value": 100.0,
-            "timestamp": stamp.timestamp(),
-            "type": "gauge",
+        &[btreemap! {
+            "name" =>"my_metric",
+            "value" =>100.0,
+            "timestamp" =>stamp.timestamp(),
+            "type" =>"gauge",
         }]
     );
 }
@@ -264,12 +256,12 @@ fn generates_metric_api_model_incremental_counter() {
 
     assert_eq!(
         &metrics[..],
-        &[model_map! {
-            "name": "my_metric",
-            "value": 100.0,
-            "interval.ms": 1000,
-            "timestamp": stamp.timestamp(),
-            "type": "count",
+        &[btreemap! {
+            "name" =>"my_metric",
+            "value" =>100.0,
+            "interval.ms" =>1000,
+            "timestamp" =>stamp.timestamp(),
+            "type" =>"count",
         }]
     );
 }


### PR DESCRIPTION
This converts log event into a logs API model simply by transmuting the type
wrapper and dropping all arrays, which are not supported by the API. We could
flatten out the keys, as this is what New Relic does internally, and we used to
do that, but the flattening iterator accessed through
`LogEvent::convert_to_fields` adds quotes to dotted fields names, which produces
broken attributes in New Relic, and nesting objects is actually a (slightly)
more efficient representation of the key names.