### PR TITLE
fix(new_relic sink): Put log API attributes in separate structure

### DIFF
--- a/changelog.d/21313-new-relic-logs-attributes.fix.md
+++ b/changelog.d/21313-new-relic-logs-attributes.fix.md
@@ -1,0 +1,4 @@
+Previously, when the `new_relic` sink sent non-standard event fields to the logs
+API, it would include those fields beside the standard event fields (i.e.
+`message` and `timestamp`). Now, any such fields are sent in an `attributes`
+object, as specified by the New Relic logs API documentation.

--- a/src/sinks/new_relic/mod.rs
+++ b/src/sinks/new_relic/mod.rs
@@ -5,13 +5,13 @@ mod model;
 mod service;
 mod sink;
 
-pub use config::*;
-pub use encoding::*;
-pub use model::*;
-pub use service::*;
-pub use sink::*;
+use config::*;
+use encoding::*;
+use model::*;
+use service::*;
+use sink::*;
 
-pub use super::{Healthcheck, VectorSink};
+use super::{Healthcheck, VectorSink};
 
 #[cfg(test)]
-pub mod tests;
+mod tests;


### PR DESCRIPTION
The New Relic log API specifies that all attributes other than `message` and `timestamp` should go into an `attributes` field, which may contain any JSON object data except for arrays. This change reworks the logs API model to move all attributes from the log event into this attributes field as well as using structures to encode fields with fixed names instead of using dynamic maps.

The tests have also been updated to compare the overall structure of the output data model so as to ensure that the resulting encoding generated by `serde` matches what we is specified in the New Relic API documentation.