### PR TITLE
fix(new_relic sink): Do not quote paths containing periods for the event API

### DIFF
--- a/changelog.d/new-relic-event-path-quoting.fix.md
+++ b/changelog.d/new-relic-event-path-quoting.fix.md
@@ -1,0 +1,3 @@
+The `new_relic` sink, when sending to the `event` API, would quote field names
+containing periods or other meta-characters. This would produce broken field
+names in the New Relic interface, and so that quoting has been removed.

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -434,7 +434,7 @@ impl LogEvent {
     pub fn all_event_fields(
         &self,
     ) -> Option<impl Iterator<Item = (KeyString, &Value)> + Serialize> {
-        self.as_map().map(|map| all_fields(map, true))
+        self.as_map().map(all_fields)
     }
 
     /// Similar to [`LogEvent::all_event_fields`], but doesn't traverse individual array elements.
@@ -460,7 +460,7 @@ impl LogEvent {
     /// (i.e. containing periods, square brackets, etc) are quoted.
     pub fn convert_to_fields(&self) -> impl Iterator<Item = (KeyString, &Value)> + Serialize {
         if let Some(map) = self.as_map() {
-            util::log::all_fields(map, true)
+            util::log::all_fields(map)
         } else {
             util::log::all_fields_non_object_root(self.value())
         }
@@ -472,7 +472,7 @@ impl LogEvent {
         &self,
     ) -> impl Iterator<Item = (KeyString, &Value)> + Serialize {
         if let Some(map) = self.as_map() {
-            util::log::all_fields(map, false)
+            util::log::all_fields_unquoted(map)
         } else {
             util::log::all_fields_non_object_root(self.value())
         }

--- a/lib/vector-core/src/event/util/log/keys.rs
+++ b/lib/vector-core/src/event/util/log/keys.rs
@@ -5,7 +5,7 @@ use crate::event::{KeyString, ObjectMap};
 /// It is implemented as a wrapper around `all_fields` to reduce code
 /// duplication.
 pub fn keys(fields: &ObjectMap) -> impl Iterator<Item = KeyString> + '_ {
-    all_fields(fields).map(|(k, _)| k)
+    all_fields(fields, true).map(|(k, _)| k)
 }
 
 #[cfg(test)]

--- a/lib/vector-core/src/event/util/log/keys.rs
+++ b/lib/vector-core/src/event/util/log/keys.rs
@@ -5,7 +5,7 @@ use crate::event::{KeyString, ObjectMap};
 /// It is implemented as a wrapper around `all_fields` to reduce code
 /// duplication.
 pub fn keys(fields: &ObjectMap) -> impl Iterator<Item = KeyString> + '_ {
-    all_fields(fields, true).map(|(k, _)| k)
+    all_fields(fields).map(|(k, _)| k)
 }
 
 #[cfg(test)]

--- a/lib/vector-core/src/event/util/log/mod.rs
+++ b/lib/vector-core/src/event/util/log/mod.rs
@@ -2,7 +2,8 @@ mod all_fields;
 mod keys;
 
 pub use all_fields::{
-    all_fields, all_fields_non_object_root, all_fields_skip_array_elements, all_metadata_fields,
+    all_fields, all_fields_non_object_root, all_fields_skip_array_elements, all_fields_unquoted,
+    all_metadata_fields,
 };
 pub use keys::keys;
 

--- a/src/sinks/new_relic/model.rs
+++ b/src/sinks/new_relic/model.rs
@@ -169,7 +169,7 @@ impl TryFrom<Vec<Event>> for EventsApiModel {
                 };
 
                 let mut event_model = ObjectMap::new();
-                for (k, v) in log.convert_to_fields() {
+                for (k, v) in log.convert_to_fields_unquoted() {
                     event_model.insert(k, v.clone());
                 }
 

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -135,6 +135,27 @@ fn generates_event_api_model_with_json_inside_message_field() {
 }
 
 #[test]
+fn generates_event_api_model_with_dotted_fields() {
+    let sub = value!({"two":"three"});
+    let event = Event::Log(LogEvent::from(value!({
+        "one.two": "Joe",
+        "eventType": "TestEvent",
+        "four": sub,
+    })));
+    let model =
+        EventsApiModel::try_from(vec![event]).expect("Failed mapping events into API model");
+
+    assert_eq!(
+        to_value(&model).unwrap(),
+        json!([{
+            "eventType": "TestEvent",
+            "one.two": "Joe",
+            "four.two": "three",
+        }])
+    );
+}
+
+#[test]
 fn generates_log_api_model_without_message_field() {
     let event = Event::Log(LogEvent::from(value!({"tag_key": "tag_value"})));
     let model = LogsApiModel::try_from(vec![event]).expect("Failed mapping logs into API model");


### PR DESCRIPTION
This could not be accomplished the same way as #21305 since the event API cannot handle nested JSON data. Instead, a new `LogEvent::convert_to_fields_unquoted` method was added to produce the flattened data without quoting.