### PR TITLE
docs(vrl): Fix syntax for function arguments

### DIFF
--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -722,8 +722,8 @@
             {{- .name -}}
           </span>:
           <span class="text-gray-200">
-            <{{ delimit .type `><span class="text-grey-500"> |
-          </span>` }}></span>{{ if not $isLast }}, {{ end -}}
+            &lt;{{ delimit .type `<span class="text-grey-500"> | </span>` | safeHTML}}&gt;
+          </span>{{ if not $isLast }}, {{ end -}}
           {{ end -}}
           {{- if gt (len $optionalArgs) 0 -}},
           [{{- $lastArg := sub (len $optionalArgs) 1 -}}
@@ -733,13 +733,13 @@
             {{- .name -}}
           </span>:
           <span class="text-gray-200">
-            <{{ delimit .type `><span class="text-grey-500"> |
-          </span>` }}></span>{{ if not $isLast }}, {{ end -}}
+            &lt;{{ delimit .type `<span class="text-grey-500"> | </span>`  | safeHTML}}&gt;
+          </span>{{ if not $isLast }}, {{ end -}}
           {{ end -}}]{{ end }})
           {{- with $return -}}
           <div class="ml-3">
             <span class="font-extrabold">::</span> <span class="text-gray-200">
-              <{{ delimit .types " | " }}>
+              &lt;{{ delimit .types " | " }}&gt;
             </span>{{ if not $infallible }}, &lt;error>{{ end }}
           </div>
           {{- end -}}

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -740,7 +740,7 @@
           <div class="ml-3">
             <span class="font-extrabold">::</span> <span class="text-gray-200">
               &lt;{{ delimit .types " | " }}&gt;
-            </span>{{ if not $infallible }}, &lt;error>{{ end }}
+            </span>{{ if not $infallible }}, &lt;error&gt;{{ end }}
           </div>
           {{- end -}}
         </div>

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -722,7 +722,7 @@
             {{- .name -}}
           </span>:
           <span class="text-gray-200">
-            <{{ delimit .type `<span class="text-grey-500"> |
+            <{{ delimit .type `><span class="text-grey-500"> |
           </span>` }}></span>{{ if not $isLast }}, {{ end -}}
           {{ end -}}
           {{- if gt (len $optionalArgs) 0 -}},
@@ -733,7 +733,7 @@
             {{- .name -}}
           </span>:
           <span class="text-gray-200">
-            <{{ delimit .type `<span class="text-grey-500"> |
+            <{{ delimit .type `><span class="text-grey-500"> |
           </span>` }}></span>{{ if not $isLast }}, {{ end -}}
           {{ end -}}]{{ end }})
           {{- with $return -}}


### PR DESCRIPTION
Make sure HTML characters are escaped or marked as escaped.

Before:
https://vector.dev/docs/reference/vrl/functions/#remove

After:

https://jszwedko-website-fix-vrl-arguments-syntax.d1a7j77663uxsc.amplifyapp.com/docs/reference/vrl/functions/#remove