### PR TITLE
enhancement(greptimedb): add optional new_naming strategy for greptimedb sink

### DIFF
--- a/changelog.d/21331-new-greptimedb-metric-option.enhancement.md
+++ b/changelog.d/21331-new-greptimedb-metric-option.enhancement.md
@@ -1,0 +1,1 @@
+Add an option `new_naming` to use `greptime_value` and `greptime_timestamp` for value and timestamp fields, in order to keep consistency with greptime's convention.

--- a/changelog.d/21331-new-greptimedb-metric-option.enhancement.md
+++ b/changelog.d/21331-new-greptimedb-metric-option.enhancement.md
@@ -1,1 +1,3 @@
 Add an option `new_naming` to use `greptime_value` and `greptime_timestamp` for value and timestamp fields, in order to keep consistency with greptime's convention.
+
+authors: sunng87

--- a/scripts/integration/greptimedb/test.yaml
+++ b/scripts/integration/greptimedb/test.yaml
@@ -12,7 +12,7 @@ runner:
 matrix:
   # Temporarily pegging to the latest known stable release
   # since using `latest` is failing consistently.
-  version: [v0.9.0]
+  version: [v0.9.3]
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -111,10 +111,22 @@ pub struct GreptimeDBMetricsConfig {
     #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    /// Use greptime prefixed naming for time index and value columns
+    /// Use Greptime's prefixed naming for time index and value columns.
     ///
-    /// This is to keep consistency with greptimedb's naming pattern
-    /// Default to `false` for compatibility
+    /// This is to keep consistency with GreptimeDB's naming pattern. By
+    /// default, this sink will use `val` for value column name, and `ts` for
+    /// time index name. When turned on, `greptime_value` and
+    /// `greptime_timestamp` will be used for these names.
+    ///
+    /// If you are using this Vector sink together with other data ingestion
+    /// sources of GreptimeDB, like Prometheus Remote Write and Influxdb Line
+    /// Protocol, it is highly recommended to turn on this.
+    ///
+    /// Also if there is a tag name conflict from your data source, for
+    /// example, you have a tag named as `val` or `ts`, you need to turn on
+    /// this option to avoid the conflict.
+    ///
+    /// Default to `false` for compatibility.
     #[configurable(metadata(docs::examples = false))]
     pub new_naming: Option<bool>,
 }

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -127,7 +127,7 @@ pub struct GreptimeDBMetricsConfig {
     /// this option to avoid the conflict.
     ///
     /// Default to `false` for compatibility.
-    #[configurable(metadata(docs::examples = false))]
+    #[configurable]
     pub new_naming: Option<bool>,
 }
 

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -3,6 +3,7 @@ use crate::sinks::{
         default_dbname,
         metrics::{
             request::GreptimeDBGrpcRetryLogic,
+            request_builder::RequestBuilderOptions,
             service::{healthcheck, GreptimeDBGrpcService},
             sink,
         },
@@ -109,6 +110,13 @@ pub struct GreptimeDBMetricsConfig {
 
     #[configurable(derived)]
     pub tls: Option<TlsConfig>,
+
+    /// Use greptime prefixed naming for time index and value columns
+    ///
+    /// This is to keep consistency with greptimedb's naming pattern
+    /// Default to `false` for compatibility
+    #[configurable(metadata(docs::examples = false))]
+    pub new_naming: Option<bool>,
 }
 
 impl_generate_config_from_default!(GreptimeDBMetricsConfig);
@@ -124,6 +132,9 @@ impl SinkConfig for GreptimeDBMetricsConfig {
         let sink = sink::GreptimeDBGrpcSink {
             service,
             batch_settings: self.batch.into_batcher_settings()?,
+            request_builder_options: RequestBuilderOptions {
+                use_new_naming: self.new_naming.unwrap_or(false),
+            },
         };
 
         let healthcheck = healthcheck(self)?;

--- a/src/sinks/greptimedb/metrics/integration_tests.rs
+++ b/src/sinks/greptimedb/metrics/integration_tests.rs
@@ -39,7 +39,9 @@ async fn test_greptimedb_sink() {
         .unwrap();
 
     let base_time = Utc::now();
-    let events: Vec<_> = (0..10).map(|idx| create_event(idx, base_time)).collect();
+    let events: Vec<_> = (0..10)
+        .map(|idx| create_event("my_counter", idx, base_time))
+        .collect();
     run_and_assert_sink_compliance(sink, stream::iter(events), &SINK_TAGS).await;
 
     let query_response = query_client
@@ -66,14 +68,73 @@ async fn test_greptimedb_sink() {
     )
 }
 
+#[tokio::test]
+async fn test_greptimedb_sink_new_naming() {
+    trace_init();
+    let cfg = format!(
+        r#"endpoint= "{}"
+new_naming = true
+"#,
+        std::env::var("GREPTIMEDB_ENDPOINT").unwrap_or_else(|_| "localhost:4001".to_owned())
+    );
+
+    let (config, _) = load_sink::<GreptimeDBMetricsConfig>(&cfg).unwrap();
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+
+    let query_client = query_client();
+
+    // Drop the table and data inside
+    let _ = query_client
+        .get(&format!(
+            "{}/v1/sql",
+            std::env::var("GREPTIMEDB_HTTP").unwrap_or_else(|_| "http://localhost:4000".to_owned())
+        ))
+        .query(&[("sql", "DROP TABLE ns_my_counter")])
+        .send()
+        .await
+        .unwrap();
+
+    let base_time = Utc::now();
+    let events: Vec<_> = (0..10)
+        .map(|idx| create_event("my_counter_new", idx, base_time))
+        .collect();
+    run_and_assert_sink_compliance(sink, stream::iter(events), &SINK_TAGS).await;
+
+    let query_response = query_client
+        .get(&format!(
+            "{}/v1/sql",
+            std::env::var("GREPTIMEDB_HTTP").unwrap_or_else(|_| "http://localhost:4000".to_owned())
+        ))
+        .query(&[(
+            "sql",
+            "SELECT region, greptime_value, greptime_timestamp FROM ns_my_counter_new",
+        )])
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .expect("Fetch json from greptimedb failed");
+    let result: serde_json::Value =
+        serde_json::from_str(&query_response).expect("Invalid json returned from greptimedb query");
+    assert_eq!(
+        result
+            .pointer("/output/0/records/rows")
+            .and_then(|v| v.as_array())
+            .expect("Error getting greptimedb response array")
+            .len(),
+        10
+    )
+}
+
 fn query_client() -> reqwest::Client {
     reqwest::Client::builder().build().unwrap()
 }
 
-fn create_event(i: i32, base_time: DateTime<Utc>) -> Event {
+fn create_event(name: &str, i: i32, base_time: DateTime<Utc>) -> Event {
     Event::Metric(
         Metric::new(
-            "my_counter".to_owned(),
+            name.to_owned(),
             MetricKind::Incremental,
             MetricValue::Counter { value: i as f64 },
         )

--- a/src/sinks/greptimedb/metrics/request.rs
+++ b/src/sinks/greptimedb/metrics/request.rs
@@ -1,5 +1,8 @@
 use crate::sinks::{
-    greptimedb::metrics::{batch::GreptimeDBBatchSizer, request_builder::metric_to_insert_request},
+    greptimedb::metrics::{
+        batch::GreptimeDBBatchSizer,
+        request_builder::{metric_to_insert_request, RequestBuilderOptions},
+    },
     prelude::*,
 };
 use greptimedb_ingester::{api::v1::*, Error as GreptimeError};
@@ -18,7 +21,7 @@ pub(super) struct GreptimeDBGrpcRequest {
 
 impl GreptimeDBGrpcRequest {
     // convert metrics event to GreptimeDBGrpcRequest
-    pub(super) fn from_metrics(metrics: Vec<Metric>) -> Self {
+    pub(super) fn from_metrics(metrics: Vec<Metric>, options: &RequestBuilderOptions) -> Self {
         let mut items = Vec::with_capacity(metrics.len());
         let mut finalizers = EventFinalizers::default();
         let mut request_metadata_builder = RequestMetadataBuilder::default();
@@ -31,7 +34,7 @@ impl GreptimeDBGrpcRequest {
 
             request_metadata_builder.track_event(metric.clone());
 
-            items.push(metric_to_insert_request(metric));
+            items.push(metric_to_insert_request(metric, options));
         }
 
         let request_size =

--- a/src/sinks/greptimedb/metrics/sink.rs
+++ b/src/sinks/greptimedb/metrics/sink.rs
@@ -1,7 +1,8 @@
 use crate::sinks::{
     greptimedb::metrics::{
         batch::GreptimeDBBatchSizer, request::GreptimeDBGrpcRequest,
-        request::GreptimeDBGrpcRetryLogic, service::GreptimeDBGrpcService,
+        request::GreptimeDBGrpcRetryLogic, request_builder::RequestBuilderOptions,
+        service::GreptimeDBGrpcService,
     },
     prelude::*,
     util::buffer::metrics::{MetricNormalize, MetricSet},
@@ -30,6 +31,7 @@ impl MetricNormalize for GreptimeDBMetricNormalize {
 pub struct GreptimeDBGrpcSink {
     pub(super) service: Svc<GreptimeDBGrpcService, GreptimeDBGrpcRetryLogic>,
     pub(super) batch_settings: BatcherSettings,
+    pub(super) request_builder_options: RequestBuilderOptions,
 }
 
 impl GreptimeDBGrpcSink {
@@ -41,7 +43,7 @@ impl GreptimeDBGrpcSink {
                 self.batch_settings
                     .as_item_size_config(GreptimeDBBatchSizer),
             )
-            .map(GreptimeDBGrpcRequest::from_metrics)
+            .map(|m| GreptimeDBGrpcRequest::from_metrics(m, &self.request_builder_options))
             .into_driver(self.service)
             .protocol("grpc")
             .run()

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -101,10 +101,10 @@ base: components: sinks: greptimedb: configuration: {
 	}
 	new_naming: {
 		description: """
-			Use greptime prefixed naming for time index and value columns
+			Use Greptime's prefixed naming for time index and value columns.
 
-			This is to keep consistency with greptimedb's naming pattern
-			Default to `false` for compatibility
+			This is to keep consistency with GreptimeDB's naming pattern.
+			Default to `false` for compatibility.
 			"""
 		required: false
 		type: bool: examples: [

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -119,9 +119,7 @@ base: components: sinks: greptimedb: configuration: {
 			Default to `false` for compatibility.
 			"""
 		required: false
-		type: bool: examples: [
-			false,
-		]
+		type: bool: {}
 	}
 	password: {
 		description: """

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -99,6 +99,18 @@ base: components: sinks: greptimedb: configuration: {
 		required: false
 		type: string: examples: ["grpc_compression"]
 	}
+	new_naming: {
+		description: """
+			Use greptime prefixed naming for time index and value columns
+
+			This is to keep consistency with greptimedb's naming pattern
+			Default to `false` for compatibility
+			"""
+		required: false
+		type: bool: examples: [
+			false,
+		]
+	}
 	password: {
 		description: """
 			The password for your GreptimeDB instance.

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -103,7 +103,19 @@ base: components: sinks: greptimedb: configuration: {
 		description: """
 			Use Greptime's prefixed naming for time index and value columns.
 
-			This is to keep consistency with GreptimeDB's naming pattern.
+			This is to keep consistency with GreptimeDB's naming pattern. By
+			default, this sink will use `val` for value column name, and `ts` for
+			time index name. When turned on, `greptime_value` and
+			`greptime_timestamp` will be used for these names.
+
+			If you are using this Vector sink together with other data ingestion
+			sources of GreptimeDB, like Prometheus Remote Write and Influxdb Line
+			Protocol, it is highly recommended to turn on this.
+
+			Also if there is a tag name conflict from your data source, for
+			example, you have a tag named as `val` or `ts`, you need to turn on
+			this option to avoid the conflict.
+
 			Default to `false` for compatibility.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
@@ -101,10 +101,10 @@ base: components: sinks: greptimedb_metrics: configuration: {
 	}
 	new_naming: {
 		description: """
-			Use greptime prefixed naming for time index and value columns
+			Use Greptime's prefixed naming for time index and value columns.
 
-			This is to keep consistency with greptimedb's naming pattern
-			Default to `false` for compatibility
+			This is to keep consistency with GreptimeDB's naming pattern.
+			Default to `false` for compatibility.
 			"""
 		required: false
 		type: bool: examples: [

--- a/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
@@ -99,6 +99,18 @@ base: components: sinks: greptimedb_metrics: configuration: {
 		required: false
 		type: string: examples: ["grpc_compression"]
 	}
+	new_naming: {
+		description: """
+			Use greptime prefixed naming for time index and value columns
+
+			This is to keep consistency with greptimedb's naming pattern
+			Default to `false` for compatibility
+			"""
+		required: false
+		type: bool: examples: [
+			false,
+		]
+	}
 	password: {
 		description: """
 			The password for your GreptimeDB instance.

--- a/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
@@ -119,9 +119,7 @@ base: components: sinks: greptimedb_metrics: configuration: {
 			Default to `false` for compatibility.
 			"""
 		required: false
-		type: bool: examples: [
-			false,
-		]
+		type: bool: {}
 	}
 	password: {
 		description: """

--- a/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
@@ -103,7 +103,19 @@ base: components: sinks: greptimedb_metrics: configuration: {
 		description: """
 			Use Greptime's prefixed naming for time index and value columns.
 
-			This is to keep consistency with GreptimeDB's naming pattern.
+			This is to keep consistency with GreptimeDB's naming pattern. By
+			default, this sink will use `val` for value column name, and `ts` for
+			time index name. When turned on, `greptime_value` and
+			`greptime_timestamp` will be used for these names.
+
+			If you are using this Vector sink together with other data ingestion
+			sources of GreptimeDB, like Prometheus Remote Write and Influxdb Line
+			Protocol, it is highly recommended to turn on this.
+
+			Also if there is a tag name conflict from your data source, for
+			example, you have a tag named as `val` or `ts`, you need to turn on
+			this option to avoid the conflict.
+
 			Default to `false` for compatibility.
 			"""
 		required: false


### PR DESCRIPTION
This patch adds an option `new_naming` to use `greptime_value` and `greptime_timestamp` for value and timestamp fields, in order to keep consistency with greptime's convention. 

To maintain backward-compatibility, the new option is `false` by default. It will not affect any previous user. 