### PR TITLE
fix(ARC): Fix possible deadlock in adaptive concurrency decrease

### DIFF
--- a/changelog.d/adaptive-concurrency-deadlock.fix.md
+++ b/changelog.d/adaptive-concurrency-deadlock.fix.md
@@ -1,0 +1,3 @@
+Setting `adaptive_concurrency.decrease_ratio` in a sink to a value less than 0.5
+could lead to a deadlock where no transmission slots are available. This has
+been adjusted to ensure at least one slot is always available.

--- a/src/sinks/util/adaptive_concurrency/controller.rs
+++ b/src/sinks/util/adaptive_concurrency/controller.rs
@@ -242,11 +242,14 @@ impl<L> Controller<L> {
         else if inner.current_limit > 1
             && (inner.had_back_pressure || current_rtt.unwrap_or(0.0) >= past_rtt.mean + threshold)
         {
-            // Decrease (multiplicative) the current concurrency limit
-            let to_forget = inner.current_limit
-                - (inner.current_limit as f64 * self.settings.decrease_ratio) as usize;
-            self.semaphore.forget_permits(to_forget);
-            inner.current_limit -= to_forget;
+            // Decrease (multiplicative) the current concurrency limit. The floor rounding in the
+            // `usize` conversion guarantees the new limit is smaller than the current limit, and
+            // the `.max` ensures the new limit is above zero.
+            let new_limit =
+                ((inner.current_limit as f64 * self.settings.decrease_ratio) as usize).max(1);
+            self.semaphore
+                .forget_permits(inner.current_limit - new_limit);
+            inner.current_limit = new_limit;
         }
         self.limit.emit(AdaptiveConcurrencyLimitData {
             concurrency: inner.current_limit as u64,


### PR DESCRIPTION
When the decrease ratio is set to a value less than 0.5, then the number of concurrency slots to forget in the case of back pressure can be set to the current concurrency limit. This causes the concurrency limit to be dropped down to zero, leading to a deadlock.

Fixes #21340