### PR TITLE
docs(vrl): fix vrl code example

### DIFF
--- a/website/content/en/docs/reference/vrl/_index.md
+++ b/website/content/en/docs/reference/vrl/_index.md
@@ -45,7 +45,9 @@ Let's have a look at a more complex example. Imagine that you're working with
 HTTP log events that look like this:
 
 ```text
-"{\"status\":200,\"timestamp\":\"2021-03-01T19:19:24.646170Z\",\"message\":\"SUCCESS\",\"username\":\"ub40fan4life\"}"
+{
+  "message": "{\"status\":200,\"timestamp\":\"2021-03-01T19:19:24.646170Z\",\"message\":\"SUCCESS\",\"username\":\"ub40fan4life\"}"
+}
 ```
 
 You want to apply these changes to each event:

--- a/website/content/en/docs/reference/vrl/_index.md
+++ b/website/content/en/docs/reference/vrl/_index.md
@@ -53,7 +53,7 @@ HTTP log events that look like this:
 You want to apply these changes to each event:
 
 - Parse the raw string into JSON
-- Attempts to convert the timestamp and checks if the conversion was successful
+- Attempt to convert the timestamp and checks if the conversion was successful
 - If the conversion is successful, convert the time to a UNIX timestamp; otherwise, use the current time
 - Remove the `username` field
 - Remove the temporary timestamp (`parsed_timestamp`) field


### PR DESCRIPTION
This update addresses the incorrect usage of the `to_timestamp` function in the provided VRL code example. To ensure proper parsing of the timestamp format, I have included the `parse_timestamp` function, based on a more accurate example that effectively handles timestamp conversion. The original code attempted to convert a timestamp using a non-existent function, which could lead to confusion for users.

Playground Link: https://playground.vrl.dev/?state=eyJwcm9ncmFtIjoiLiA9IHBhcnNlX2pzb24hKHN0cmluZyEoLm1lc3NhZ2UpKVxuXG4ucGFyc2VkX3RpbWVzdGFtcCA9IHBhcnNlX3RpbWVzdGFtcCEoLnRpbWVzdGFtcCwgZm9ybWF0OiBcIiVZLSVtLSVkVCVIOiVNOiVTLiVmWlwiKVxuXG5pZiBpc190aW1lc3RhbXAoLnBhcnNlZF90aW1lc3RhbXApIHtcbiAgLnRpbWVzdGFtcCA9IHRvX3VuaXhfdGltZXN0YW1wKC5wYXJzZWRfdGltZXN0YW1wKVxufSBlbHNlIHtcbiAgLnRpbWVzdGFtcCA9IHRvX3VuaXhfdGltZXN0YW1wKG5vdygpKSAgXG59XG5cbmRlbCgudXNlcm5hbWUpXG5kZWwoLnBhcnNlZF90aW1lc3RhbXApXG4ubWVzc2FnZSA9IGRvd25jYXNlKHN0cmluZyEoLm1lc3NhZ2UpKSIsImV2ZW50Ijp7Im1lc3NhZ2UiOiJ7XCJzdGF0dXNcIjoyMDAsXCJ0aW1lc3RhbXBcIjpcIjIwMjEtMDMtMDFUMTk6MTk6MjQuNjQ2MTcwWlwiLFwibWVzc2FnZVwiOlwiU1VDQ0VTU1wiLFwidXNlcm5hbWVcIjpcInViNDBmYW40bGlmZVwifSJ9LCJpc19qc29ubCI6ZmFsc2UsImVycm9yIjpudWxsfQ%3D%3D

![image](https://github.com/user-attachments/assets/e83c5eee-83e4-454b-a11e-2fdd582e6097)


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
