### PR TITLE
fix(aws provider): Enable rt-tokio on all applicable AWS crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "base64-simd",
  "bytes 1.7.1",
  "bytes-utils",
+ "futures-core",
  "http 0.2.9",
  "http 1.1.0",
  "http-body 0.4.5",
@@ -1276,6 +1277,8 @@ dependencies = [
  "ryu",
  "serde",
  "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,25 +190,25 @@ metrics.workspace = true
 metrics-tracing-context = { version = "0.15.0", default-features = false }
 
 # AWS - Official SDK
-aws-sdk-s3 = { version = "1.4.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-sqs = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-sns = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-cloudwatch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-cloudwatchlogs = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-secretsmanager = { version = "1.3.0", default-features = false, features = ["behavior-version-latest"], optional = true }
+aws-sdk-s3 = { version = "1.4.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-sqs = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-sns = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-cloudwatch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-cloudwatchlogs = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-secretsmanager = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 # The sts crate is needed despite not being referred to anywhere in the code because we need to set the
 # `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication
 # is configured.
-aws-sdk-sts = { version = "1.3.1", default-features = false, features = ["behavior-version-latest"], optional = true }
+aws-sdk-sts = { version = "1.3.1", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-types = { version = "1.3.3", default-features = false, optional = true }
 aws-sigv4 = { version = "1.2.4", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "1.0.1", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso"], optional = true }
+aws-config = { version = "1.0.1", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso", "rt-tokio"], optional = true }
 aws-credential-types = { version = "1.2.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-smithy-http = { version = "0.60", default-features = false, features = ["event-stream"], optional = true }
-aws-smithy-types = { version = "1.2.2", default-features = false, optional = true }
+aws-smithy-http = { version = "0.60", default-features = false, features = ["event-stream", "rt-tokio"], optional = true }
+aws-smithy-types = { version = "1.2.2", default-features = false, features = ["rt-tokio"], optional = true }
 aws-smithy-runtime-api = { version = "1.7.2", default-features = false, optional = true }
 aws-smithy-runtime = { version = "1.7.1", default-features = false, features = ["client", "connector-hyper-0-14-x", "rt-tokio"], optional = true }
 aws-smithy-async = { version = "1.2.1", default-features = false, features = ["rt-tokio"], optional = true }

--- a/changelog.d/aws-rt-tokio.fix.md
+++ b/changelog.d/aws-rt-tokio.fix.md
@@ -1,0 +1,1 @@
+AWS components no longer panic when the EcsContainer auth provider is used.


### PR DESCRIPTION
We missed it for the aws-config crate which leads to a panic when the `EcsContainer` credentials provider is used. Some of the other additions are redundant since they just enable the feature on subpackages that we already enabled the feature on (like `aws-smithy-runtime`), but adding for completeness.

Ref: https://github.com/vectordotdev/vector/issues/20662#issuecomment-2368363337

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
