### PR TITLE
fix(nats source): use correct default value for subscriber_capacity

### DIFF
--- a/changelog.d/21383-nats-subscriber-capacity.fix.md
+++ b/changelog.d/21383-nats-subscriber-capacity.fix.md
@@ -1,0 +1,3 @@
+Updates the `subscriber_capacity` default for the NATS source to the correct value of 65536, which is the same value that the upstream `async_nats` library uses.
+
+authors: benjamin-awd

--- a/src/sources/nats.rs
+++ b/src/sources/nats.rs
@@ -116,7 +116,7 @@ fn default_subject_key_field() -> OptionalValuePath {
 }
 
 const fn default_subscription_capacity() -> usize {
-    4096
+    65536
 }
 
 impl GenerateConfig for NatsSourceConfig {

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -487,7 +487,7 @@ base: components: sources: nats: configuration: {
 			[async_nats_subscription_capacity]: https://docs.rs/async-nats/latest/async_nats/struct.ConnectOptions.html#method.subscription_capacity
 			"""
 		required: false
-		type: uint: default: 4096
+		type: uint: default: 65536
 	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."


### PR DESCRIPTION
This PR updates the NATS source to use the same `subscriber_capacity` as the upstream async_nats library.

Closes https://github.com/vectordotdev/vector/issues/21383