### PR TITLE
fix(releasing): Fix install.sh handling of new directory structure on MacOS

### DIFF
--- a/distribution/install.sh
+++ b/distribution/install.sh
@@ -205,7 +205,9 @@ install_from_archive() {
         ensure tar -xzf "$_file" --directory="$_unpack_dir" --strip-components=2
         # copy all files (including hidden), ref: https://askubuntu.com/a/86891
         ensure cp -r "$_unpack_dir/bin/." "$prefix/bin"
-        ensure cp -r "$_unpack_dir/etc/." "$prefix/etc"
+        if [ -d "$_unpack_dir/etc/." ]; then
+          ensure cp -r "$_unpack_dir/etc/." "$prefix/etc"
+        fi
         ensure mkdir -p "$prefix/share/vector/config"
         ensure cp -r "$_unpack_dir/config/." "$prefix/share/vector/config"
         ensure cp "$_unpack_dir"/README.md "$prefix/share/vector/"


### PR DESCRIPTION
`etc/` doesn't exist in the MacOS packages. In the Linux packages it houses the SystemD files.

Closes: https://github.com/vectordotdev/vector/issues/21400

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
