### PR TITLE
feat(opentelemetry source): add instrumentation scope to logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,8 +3394,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.4",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]

--- a/changelog.d/21404-opentelemetry-logs-instrumentation-scope.feature.md
+++ b/changelog.d/21404-opentelemetry-logs-instrumentation-scope.feature.md
@@ -1,0 +1,3 @@
+Adds `scope` information to logs received via the `opentelemetry` source
+
+authors: srstrickland

--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -14,7 +14,7 @@ use vrl::{
 };
 
 use super::proto::{
-    common::v1::{any_value::Value as PBValue, KeyValue, InstrumentationScope},
+    common::v1::{any_value::Value as PBValue, InstrumentationScope, KeyValue},
     logs::v1::{LogRecord, ResourceLogs, SeverityNumber},
     resource::v1::Resource,
     trace::v1::{
@@ -42,20 +42,18 @@ impl ResourceLogs {
     pub fn into_event_iter(self, log_namespace: LogNamespace) -> impl Iterator<Item = Event> {
         let now = Utc::now();
 
-        self.scope_logs
-            .into_iter()
-            .flat_map(move |scope_log| {
-                let scope = scope_log.scope;
-                let resource = self.resource.clone();
-                scope_log.log_records.into_iter().map(move |log_record| {
-                    ResourceLog {
-                        resource: resource.clone(),
-                        scope: scope.clone(),
-                        log_record,
-                    }
-                    .into_event(log_namespace, now)
-                })
+        self.scope_logs.into_iter().flat_map(move |scope_log| {
+            let scope = scope_log.scope;
+            let resource = self.resource.clone();
+            scope_log.log_records.into_iter().map(move |log_record| {
+                ResourceLog {
+                    resource: resource.clone(),
+                    scope: scope.clone(),
+                    log_record,
+                }
+                .into_event(log_namespace, now)
             })
+        })
     }
 }
 
@@ -252,7 +250,10 @@ impl ResourceLog {
                 log_namespace.insert_source_metadata(
                     SOURCE_NAME,
                     &mut log,
-                    Some(LegacyKey::Overwrite(path!(SCOPE_KEY, DROPPED_ATTRIBUTES_COUNT_KEY))),
+                    Some(LegacyKey::Overwrite(path!(
+                        SCOPE_KEY,
+                        DROPPED_ATTRIBUTES_COUNT_KEY
+                    ))),
                     path!(SCOPE_KEY, DROPPED_ATTRIBUTES_COUNT_KEY),
                     scope.dropped_attributes_count,
                 );

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -9,7 +9,7 @@ use vector_lib::config::LogNamespace;
 use vector_lib::lookup::path;
 use vector_lib::opentelemetry::proto::{
     collector::logs::v1::{logs_service_client::LogsServiceClient, ExportLogsServiceRequest},
-    common::v1::{any_value, AnyValue, KeyValue, InstrumentationScope},
+    common::v1::{any_value, AnyValue, InstrumentationScope, KeyValue},
     logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
     resource::v1::Resource as OtelResource,
 };
@@ -148,15 +148,18 @@ async fn receive_grpc_logs_vector_namespace() {
             &value!("some.scope.name")
         );
         assert_eq!(
-            meta.get(path!("opentelemetry", "scope", "version")).unwrap(),
+            meta.get(path!("opentelemetry", "scope", "version"))
+                .unwrap(),
             &value!("1.2.3")
         );
         assert_eq!(
-            meta.get(path!("opentelemetry", "scope", "attributes")).unwrap(),
+            meta.get(path!("opentelemetry", "scope", "attributes"))
+                .unwrap(),
             &value!({scope_attr: "scope_val"})
         );
         assert_eq!(
-            meta.get(path!("opentelemetry", "scope", "dropped_attributes_count")).unwrap(),
+            meta.get(path!("opentelemetry", "scope", "dropped_attributes_count"))
+                .unwrap(),
             &value!(7)
         );
         assert_eq!(

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -112,6 +112,47 @@ components: sources: opentelemetry: {
 						]
 					}
 				}
+				"scope.name": {
+					description: "Instrumentation scope name (often logger name)."
+					required:   false
+					common:     true
+					type: string: {
+						default: null
+						examples: ["some.module.name"]
+					}
+				}
+				"scope.version": {
+					description: "Instrumentation scope version."
+					required:	false
+					common:     false
+					type: string: {
+						default: null
+						examples: ["1.2.3"]
+					}
+				}
+				"scope.attributes": {
+					description: "Set of attributes that belong to the instrumentation scope."
+					required:	false
+					common:     false
+					type: object: {
+						default: null
+						examples: [
+							{
+								"attr1":	"value1"
+								"attr2":	"value2"
+								"attr3":	"value3"
+							},
+						]
+					}
+				}
+				"scope.dropped_attributes_count": {
+					description: "Number of attributes dropped from the instrumentation scope (if not zero)."
+					required:	false
+					common:     false
+					type: uint: {
+						unit: null
+					}
+				}
 				message: {
 					description: "Contains the body of the log record."
 					required:    false

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -135,7 +135,6 @@ components: sources: opentelemetry: {
 					required:	false
 					common:     false
 					type: object: {
-						default: null
 						examples: [
 							{
 								"attr1":	"value1"

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -114,8 +114,8 @@ components: sources: opentelemetry: {
 				}
 				"scope.name": {
 					description: "Instrumentation scope name (often logger name)."
-					required:   false
-					common:     true
+					required:    false
+					common:      true
 					type: string: {
 						default: null
 						examples: ["some.module.name"]
@@ -123,8 +123,8 @@ components: sources: opentelemetry: {
 				}
 				"scope.version": {
 					description: "Instrumentation scope version."
-					required:	false
-					common:     false
+					required:    false
+					common:      false
 					type: string: {
 						default: null
 						examples: ["1.2.3"]
@@ -132,22 +132,22 @@ components: sources: opentelemetry: {
 				}
 				"scope.attributes": {
 					description: "Set of attributes that belong to the instrumentation scope."
-					required:	false
-					common:     false
+					required:    false
+					common:      false
 					type: object: {
 						examples: [
 							{
-								"attr1":	"value1"
-								"attr2":	"value2"
-								"attr3":	"value3"
+								"attr1": "value1"
+								"attr2": "value2"
+								"attr3": "value3"
 							},
 						]
 					}
 				}
 				"scope.dropped_attributes_count": {
 					description: "Number of attributes dropped from the instrumentation scope (if not zero)."
-					required:	false
-					common:     false
+					required:    false
+					common:      false
 					type: uint: {
 						unit: null
 					}


### PR DESCRIPTION
This introduces an optional `scope` object to logs, representing the InstrumentationScope object from the OTel protocol. This object may include:

* `name` (if nonempty)
* `version` (if nonempty)
* `attributes` (if nonempty)
* `dropped_attributes_count` (if nonzero)

This is particularly important for transmitting the logger name.

This PR only addresses instrumentation scope for logs.

resolves #21404

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
