### PR TITLE
chore(ci): Update install.sh workflow to not publish to AWS

### DIFF
--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -9,6 +9,30 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
+        - name: (PR comment) Get PR branch
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: (PR comment) Set latest commit status as pending
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          context: Update install.sh Suite
+          status: pending
+
+      - name: (PR comment) Checkout PR branch
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+      - name: Checkout branch
+        if: ${{ github.event_name != 'issue_comment' }}
+        uses: actions/checkout@v3
+
       - run: sudo apt-get install --yes curl bc
       - run: bash distribution/install.sh -- -y
       - run: ~/.vector/bin/vector --version

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
-        - name: (PR comment) Get PR branch
+      - name: (PR comment) Get PR branch
         if: ${{ github.event_name == 'issue_comment' }}
         uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -33,14 +33,9 @@ jobs:
         if: ${{ github.event_name != 'issue_comment' }}
         uses: actions/checkout@v3
 
-      - run: sudo apt-get install --yes curl bc
+      - run: sudo apt-get install --yes bc
       - run: bash distribution/install.sh -- -y
       - run: ~/.vector/bin/vector --version
-
-      - name: (PR comment) Get PR branch
-        if: github.event_name == 'issue_comment'
-        uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
 
       - name: (PR comment) Set latest commit status as ${{ job.status }}
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -5,57 +5,12 @@ on:
   workflow_dispatch:
 
 jobs:
-
-  sync-install:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-      - name: (PR comment) Get PR branch
-        if: ${{ github.event_name == 'issue_comment' }}
-        uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-
-      - name: (PR comment) Set latest commit status as pending
-        if: ${{ github.event_name == 'issue_comment' }}
-        uses: myrotvorets/set-commit-status-action@v2.0.1
-        with:
-          sha: ${{ steps.comment-branch.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          context: Update install.sh Suite
-          status: pending
-
-      - name: (PR comment) Checkout PR branch
-        if: ${{ github.event_name == 'issue_comment' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
-
-      - name: Checkout branch
-        if: ${{ github.event_name != 'issue_comment' }}
-        uses: actions/checkout@v3
-
-      - run: pip3 install awscli --upgrade --user
-      - env:
-          AWS_ACCESS_KEY_ID: "${{ secrets.CI_AWS_ACCESS_KEY_ID }}"
-          AWS_SECRET_ACCESS_KEY: "${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}"
-        run: make sync-install
-
-      - name: (PR comment) Set latest commit status as failed
-        uses: myrotvorets/set-commit-status-action@v2.0.1
-        if: failure() && github.event_name == 'issue_comment'
-        with:
-          sha: ${{ steps.comment-branch.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          context: Update install.sh Suite
-          status: 'failure'
-
   test-install:
-    needs: sync-install
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
       - run: sudo apt-get install --yes curl bc
-      - run:  curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y
+      - run: bash distribution/install.sh -- -y
       - run: ~/.vector/bin/vector --version
 
       - name: (PR comment) Get PR branch

--- a/Makefile
+++ b/Makefile
@@ -645,10 +645,6 @@ release-push: ## Push new Vector version
 release-s3: ## Release artifacts to S3
 	@cargo vdev release s3
 
-.PHONY: sync-install
-sync-install: ## Sync the install.sh script for access via sh.vector.dev
-	@aws s3 cp distribution/install.sh s3://sh.vector.dev --sse --acl public-read
-
 .PHONY: sha256sum
 sha256sum: ## Generate SHA256 checksums of CI artifacts
 	scripts/checksum.sh


### PR DESCRIPTION
We no longer host install.sh in AWS S3 but instead reference it from GitHub. This change happened a while ago, but we apparently never updated the CI wrokflow; we just never noticed since we haven't changed the script since then.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
