### PR TITLE
chore(deps): bump no-proxy from 0.3.4 to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,19 +2026,6 @@ checksum = "8d18b093eba54c9aaa1e3784d4361eb2ba944cf7d0a932a830132238f483e8d8"
 
 [[package]]
 name = "cidr-utils"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2315f7119b7146d6a883de6acd63ddf96071b5f79d9d98d2adaa84d749f6abf1"
-dependencies = [
- "debug-helper",
- "num-bigint",
- "num-traits",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "cidr-utils"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25c0a9fb70c2c2cc2a520aa259b1d1345650046a07df1b6da1d3cefcd327f43e"
@@ -2816,12 +2803,6 @@ name = "deadpool-runtime"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
-
-[[package]]
-name = "debug-helper"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "der"
@@ -5855,11 +5836,11 @@ dependencies = [
 
 [[package]]
 name = "no-proxy"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b41e7479dc3678ea792431e04bafd62a31879035f4a5fa707602df062f58c77"
+checksum = "6d688d11967f7f52e273fb8f8f07ecb094254fed630e22a0cab60cc98047a5db"
 dependencies = [
- "cidr-utils 0.5.11",
+ "cidr-utils",
  "serde",
 ]
 
@@ -10400,7 +10381,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "chrono-tz",
- "cidr-utils 0.6.1",
+ "cidr-utils",
  "clap",
  "colored",
  "console-subscriber",
@@ -10944,7 +10925,7 @@ dependencies = [
  "charset",
  "chrono",
  "chrono-tz",
- "cidr-utils 0.6.1",
+ "cidr-utils",
  "clap",
  "codespan-reporting",
  "community-id",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -170,7 +170,6 @@ dashmap,https://github.com/xacrimon/dashmap,MIT,Acrimon <joel.wejdenstal@gmail.c
 data-encoding,https://github.com/ia0/data-encoding,MIT,Julien Cretin <git@ia0.eu>
 data-url,https://github.com/servo/rust-url,MIT OR Apache-2.0,Simon Sapin <simon.sapin@exyr.org>
 databend-client,https://github.com/datafuselabs/bendsql,Apache-2.0,Databend Authors <opensource@datafuselabs.com>
-debug-helper,https://github.com/magiclen/debug-helper,MIT,Magic Len <len@magiclen.org>
 der,https://github.com/RustCrypto/formats/tree/master/der,Apache-2.0 OR MIT,RustCrypto Developers
 deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 derivative,https://github.com/mcarton/rust-derivative,MIT OR Apache-2.0,mcarton <cartonmartin+git@gmail.com>

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -16,7 +16,7 @@ chrono-tz.workspace = true
 encoding_rs = { version = "0.8", default-features = false, features = ["alloc", "serde"] }
 indexmap.workspace = true
 inventory = { version = "0.3" }
-no-proxy = { version = "0.3.4", default-features = false, features = ["serialize"] }
+no-proxy = { version = "0.3.5", default-features = false, features = ["serialize"] }
 num-traits = { version = "0.2.19", default-features = false }
 serde.workspace = true
 serde_json.workspace = true

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -31,7 +31,7 @@ metrics.workspace = true
 metrics-tracing-context.workspace = true
 metrics-util.workspace = true
 mlua = { version = "0.9.9", default-features = false, features = ["lua54", "send", "vendored"], optional = true }
-no-proxy = { version  = "0.3.4", default-features = false, features = ["serialize"] }
+no-proxy = { version  = "0.3.5", default-features = false, features = ["serialize"] }
 once_cell = { version = "1.19", default-features = false }
 ordered-float = { version = "4.3.0", default-features = false }
 openssl = { version = "0.10.66", default-features = false, features = ["vendored"] }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
There has been some updates on `cidr-utils` used by `no-proxy` and a security fix on `async-graphql` (not used by vector, the feature is disabled).