### PR TITLE
fix(transforms): optional metric namespace in `log_to_metric` transform

### DIFF
--- a/changelog.d/21423-optional-namespace-log-to-metric.fix.md
+++ b/changelog.d/21423-optional-namespace-log-to-metric.fix.md
@@ -1,0 +1,2 @@
+When using the `all_metrics: true` flag in `log_to_metric` transform, the `namespace` field is now optional and no longer required. If the `namespace` field is not provided,
+the produced metric will not have a namespace at all.

--- a/changelog.d/21423-optional-namespace-log-to-metric.fix.md
+++ b/changelog.d/21423-optional-namespace-log-to-metric.fix.md
@@ -1,2 +1,4 @@
 When using the `all_metrics: true` flag in `log_to_metric` transform, the `namespace` field is now optional and no longer required. If the `namespace` field is not provided,
 the produced metric will not have a namespace at all.
+
+authors: jorgehermo9

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -795,12 +795,15 @@ fn to_metrics(event: &Event) -> Result<Metric, TransformError> {
 
     let value = value.ok_or(TransformError::MetricDetailsNotFound)?;
 
-    Ok(
-        Metric::new_with_metadata(name, kind, value, log.metadata().clone())
-            .with_namespace(try_get_string_from_log(log, "namespace")?)
-            .with_tags(tags_result)
-            .with_timestamp(timestamp),
-    )
+    let mut metric = Metric::new_with_metadata(name, kind, value, log.metadata().clone())
+        .with_tags(tags_result)
+        .with_timestamp(timestamp);
+
+    if let Ok(namespace) = try_get_string_from_log(log, "namespace") {
+        metric = metric.with_namespace(namespace);
+    }
+
+    Ok(metric)
 }
 
 impl FunctionTransform for LogToMetric {
@@ -1608,11 +1611,19 @@ mod tests {
     }
 
     //  Metric Metadata Tests
+    //
     fn create_log_event(json_str: &str) -> Event {
+        create_log_event_with_namespace(json_str, Some("test_namespace"))
+    }
+
+    fn create_log_event_with_namespace(json_str: &str, namespace: Option<&str>) -> Event {
         let mut log_value: Value =
             serde_json::from_str(json_str).expect("JSON was not well-formatted");
         log_value.insert("timestamp", ts());
-        log_value.insert("namespace", "test_namespace");
+
+        if let Some(namespace) = namespace {
+            log_value.insert("namespace", namespace);
+        }
 
         let mut metadata = EventMetadata::default();
         metadata.set_source_id(Arc::new(ComponentKey::from("in")));
@@ -1996,6 +2007,44 @@ mod tests {
                 metric.metadata().clone(),
             )
             .with_namespace(Some("test_namespace"))
+            .with_tags(Some(metric_tags!(
+                "env" => "test_env",
+                "host" => "localhost",
+            )))
+            .with_timestamp(Some(ts()))
+        );
+    }
+
+    #[tokio::test]
+    async fn transform_all_metrics_optional_namespace() {
+        let config = parse_yaml_config(
+            r#"
+            metrics: []
+            all_metrics: true
+            "#,
+        );
+
+        let json_str = r#"{
+          "counter": {
+            "value": 10.0
+          },
+          "kind": "incremental",
+          "name": "test.transform.counter",
+          "tags": {
+            "env": "test_env",
+            "host": "localhost"
+          }
+        }"#;
+        let log = create_log_event_with_namespace(json_str, None);
+        let metric = do_transform(config, log.clone()).await.unwrap();
+        assert_eq!(
+            *metric.as_metric(),
+            Metric::new_with_metadata(
+                "test.transform.counter",
+                MetricKind::Incremental,
+                MetricValue::Counter { value: 10.0 },
+                metric.metadata().clone(),
+            )
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",


### PR DESCRIPTION
Closes #21423

Now this config

```toml
[sources.sample]
type = "demo_logs"
lines = ["weather,location=us-midwest temperature=82 1465839830100400200"]
format = "shuffle"

[transforms.influx]
type = "remap"
inputs = ["sample"]
source = """
. = parse_influxdb!(.message)
"""

[transforms.log_to_metric]
type = "log_to_metric"
inputs = ["influx"]
all_metrics = true
metrics = []

[sinks.console]
type = "console"
inputs = ["log_to_metric"]
encoding.codec = "native_json"
```

Produces the following output:

```console
2024-10-05T09:19:29.994825Z  INFO vector::app: Log level is enabled. level="info"
2024-10-05T09:19:29.996361Z  INFO vector::app: Loading configs. paths=["config.toml"]
2024-10-05T09:19:30.009987Z  INFO vector::topology::running: Running healthchecks.
2024-10-05T09:19:30.010365Z  INFO vector::topology::builder: Healthcheck passed.
2024-10-05T09:19:30.010418Z  INFO vector: Vector has started. debug="true" version="0.42.0" arch="x86_64" revision=""
2024-10-05T09:19:30.010485Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
{"metric":{"name":"weather_temperature","tags":{"location":"us-midwest"},"timestamp":"2016-06-13T17:43:50.100400200Z","kind":"absolute","gauge":{"value":82.0}}}
{"metric":{"name":"weather_temperature","tags":{"location":"us-midwest"},"timestamp":"2016-06-13T17:43:50.100400200Z","kind":"absolute","gauge":{"value":82.0}}}
{"metric":{"name":"weather_temperature","tags":{"location":"us-midwest"},"timestamp":"2016-06-13T17:43:50.100400200Z","kind":"absolute","gauge":{"value":82.0}}}
```
