### PR TITLE
enhancement(transforms): redundant clone in `log_to_metric` transform

### DIFF
--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -745,7 +745,7 @@ fn to_metrics(event: &Event) -> Result<Metric, TransformError> {
         }
     };
 
-    let tags = &mut MetricTags::default();
+    let mut tags = MetricTags::default();
 
     if let Some(els) = log.get(event_path!("tags")) {
         if let Some(el) = els.as_object() {
@@ -754,7 +754,7 @@ fn to_metrics(event: &Event) -> Result<Metric, TransformError> {
             }
         }
     }
-    let tags_result = Some(tags.clone());
+    let tags_result = Some(tags);
 
     let kind_str = match try_get_string_from_log(log, "kind")? {
         Some(n) => n,


### PR DESCRIPTION
Found this unused clone while working on #21429. Didn't add this in that PR because it seemed unrelated to me. If you want me to include this small change in #21429 I'll do it without problem.

I think a changelog entry is not necessary for this internal fix.