### PR TITLE
* doc fix, fixing a ref path which goes to 404

### DIFF
--- a/website/content/en/docs/setup/installation/platforms/kubernetes.md
+++ b/website/content/en/docs/setup/installation/platforms/kubernetes.md
@@ -53,7 +53,7 @@ namespace: vector
 
 bases:
   # Include Vector recommended base (from git).
-  - github.com/vectordotdev/vector/distribution/kubernetes/vector-agent?ref=master
+  - github.com/vectordotdev/vector/tree/master/distribution/kubernetes/vector-agent
 
 images:
   # Override the Vector image to pin the version used.


### PR DESCRIPTION
github.com/vectordotdev/vector/distribution/kubernetes/vector-agent?ref=master does not exist, updated to github.com/vectordotdev/vector/tree/master/distribution/kubernetes/vector-agent
