### PR TITLE
docs: Remove "What is" from about pages

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -161,14 +161,14 @@ identifier = "about"
 weight = 1
 
 [[languages.en.menus.footer]]
-name = "What is Vector?"
+name = "Vector"
 url = "/docs/about"
 parent = "about"
 weight = 1
 
 [[languages.en.menus.footer]]
-name = "What is Observability Pipelines?"
-url = "/docs/about/what-is-observability-pipelines"
+name = "Observability Pipelines"
+url = "/docs/about/observability-pipelines"
 parent = "about"
 weight = 2
 

--- a/website/content/en/docs/about/observability-pipelines.md
+++ b/website/content/en/docs/about/observability-pipelines.md
@@ -2,6 +2,8 @@
 title: Observability Pipelines
 weight: 2
 tags: ["concepts"]
+aliases:
+- ./what-is-abservability-pipelines
 ---
 
 Datadog's Observability Pipelines are commercial observability data pipelines for collecting, processing, and routing observability data from any source to any destination in the infrastructure that you own or manage.

--- a/website/content/en/docs/about/observability-pipelines.md
+++ b/website/content/en/docs/about/observability-pipelines.md
@@ -1,5 +1,5 @@
 ---
-title: What are Observability Pipelines?
+title: Observability Pipelines
 weight: 2
 tags: ["concepts"]
 ---

--- a/website/content/en/docs/about/observability-pipelines.md
+++ b/website/content/en/docs/about/observability-pipelines.md
@@ -3,7 +3,7 @@ title: Observability Pipelines
 weight: 2
 tags: ["concepts"]
 aliases:
-- ./what-is-abservability-pipelines
+- ./what-is-observability-pipelines
 ---
 
 Datadog's Observability Pipelines are commercial observability data pipelines for collecting, processing, and routing observability data from any source to any destination in the infrastructure that you own or manage.

--- a/website/content/en/docs/about/vector.md
+++ b/website/content/en/docs/about/vector.md
@@ -2,6 +2,8 @@
 title: Vector
 weight: 1
 tags: ["concepts"]
+aliases:
+- ./what-is-vector
 ---
 
 Vector is a high-performance observability data pipeline that puts organizations in control of their observability data. [Collect], [transform], and [route] all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors. Open source and up to 10x faster than every alternative.

--- a/website/content/en/docs/about/vector.md
+++ b/website/content/en/docs/about/vector.md
@@ -1,5 +1,5 @@
 ---
-title: What is Vector?
+title: Vector
 weight: 1
 tags: ["concepts"]
 ---


### PR DESCRIPTION
This isn't adding much and is/are is confusing for Observability Pipelines.

Supersedes: #21444

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
