### PR TITLE
fix(socket sink): gracefully shutdown on reload when stream is terminated

### DIFF
--- a/changelog.d/21455-socket-sink-graceful-reload.fix.md
+++ b/changelog.d/21455-socket-sink-graceful-reload.fix.md
@@ -1,0 +1,3 @@
+All TCP based socket sinks now gracefully handle config reloads under load. Previously, when a configuration reload occurred and data was flowing through the topology, the vector process crashed due to the TCP sink attempting to access the stream when it had been terminated.
+
+authors: neuronull

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub mod serde;
 #[cfg(windows)]
 pub mod service;
 pub mod signal;
-#[cfg(all(any(feature = "sinks-socket", feature = "sinks-statsd"), unix))]
+#[cfg(unix)]
 pub(crate) mod sink_ext;
 #[allow(unreachable_pub)]
 pub mod sinks;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ pub mod serde;
 #[cfg(windows)]
 pub mod service;
 pub mod signal;
-#[cfg(unix)]
 pub(crate) mod sink_ext;
 #[allow(unreachable_pub)]
 pub mod sinks;

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -9,7 +9,6 @@ use std::{
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::{stream::BoxStream, task::noop_waker_ref, SinkExt, StreamExt};
-use futures_util::{future::ready, stream};
 use snafu::{ResultExt, Snafu};
 use tokio::{
     io::{AsyncRead, ReadBuf},
@@ -29,6 +28,7 @@ use crate::{
         ConnectionOpen, OpenGauge, SocketMode, SocketSendError, TcpSocketConnectionEstablished,
         TcpSocketConnectionShutdown, TcpSocketOutgoingConnectionError,
     },
+    sink_ext::VecSinkExt,
     sinks::{
         util::{
             retries::ExponentialBackoff,
@@ -281,34 +281,34 @@ where
         // We need [Peekable](https://docs.rs/futures/0.3.6/futures/stream/struct.Peekable.html) for initiating
         // connection only when we have something to send.
         let mut encoder = self.encoder.clone();
-        let mut input = input.map(|mut event| {
-            let byte_size = event.size_of();
-            let json_byte_size = event.estimated_json_encoded_size_of();
-            let finalizers = event.metadata_mut().take_finalizers();
-            self.transformer.transform(&mut event);
-            let mut bytes = BytesMut::new();
+        let mut input = input
+            .map(|mut event| {
+                let byte_size = event.size_of();
+                let json_byte_size = event.estimated_json_encoded_size_of();
+                let finalizers = event.metadata_mut().take_finalizers();
+                self.transformer.transform(&mut event);
+                let mut bytes = BytesMut::new();
 
-            // Errors are handled by `Encoder`.
-            if encoder.encode(event, &mut bytes).is_ok() {
-                let item = bytes.freeze();
-                EncodedEvent {
-                    item,
-                    finalizers,
-                    byte_size,
-                    json_byte_size,
+                // Errors are handled by `Encoder`.
+                if encoder.encode(event, &mut bytes).is_ok() {
+                    let item = bytes.freeze();
+                    EncodedEvent {
+                        item,
+                        finalizers,
+                        byte_size,
+                        json_byte_size,
+                    }
+                } else {
+                    EncodedEvent::new(Bytes::new(), 0, JsonSize::zero())
                 }
-            } else {
-                EncodedEvent::new(Bytes::new(), 0, JsonSize::zero())
-            }
-        });
+            })
+            .peekable();
 
-        while let Some(item) = input.next().await {
+        while Pin::new(&mut input).peek().await.is_some() {
             let mut sink = self.connect().await;
             let _open_token = OpenGauge::new().open(|count| emit!(ConnectionOpen { count }));
 
-            let mut mapped_input = stream::once(ready(item)).chain(&mut input).map(Ok);
-
-            let result = match sink.send_all(&mut mapped_input).await {
+            let result = match sink.send_all_peekable(&mut (&mut input).peekable()).await {
                 Ok(()) => sink.close().await,
                 Err(error) => Err(error),
             };


### PR DESCRIPTION
fixes: #15952
fixes: #14515 

It looks like a [PR](https://github.com/vectordotdev/vector/pull/12755) introduced a regression while making changes to the tcp socket sink to emit internal telemetry in accordance with the component specification.

This introduced a bug where the `TcpSink` crashes Vector during config reloads, while events are flowing through the topology.

The fix is to restore the behavior of peeking onto the stream before attempting to access the next event.

To test this, just use the `socket` sink in `tcp` mode, and watch the vector config. Send events continuously. Change the name of the input to the sink. In the before case, it crashes. After the fix, it does not.

### reproducing it (before fix)

```
RUST_BACKTRACE=1 VECTOR_LOG=info ./target/debug/vector --config ../vector_configs/http_server_socket.yaml --watch-config
2024-10-08T19:17:41.160536Z  INFO vector::app: Log level is enabled. level="info"
2024-10-08T19:17:41.163068Z  INFO vector::config::watcher: Creating configuration file watcher.
2024-10-08T19:17:41.164893Z  INFO vector::config::watcher: Watching configuration files.
2024-10-08T19:17:41.165237Z  INFO vector::app: Loading configs. paths=["../vector_configs/http_server_socket.yaml"]
2024-10-08T19:17:41.177815Z  INFO vector::topology::running: Running healthchecks.
2024-10-08T19:17:41.178421Z  INFO vector: Vector has started. debug="true" version="0.42.0" arch="aarch64" revision=""
2024-10-08T19:17:41.178566Z  INFO source{component_kind="source" component_id=http2 component_type=http}: vector::sources::util::http::prelude: Building HTTP server. address=0.0.0.0:4242
2024-10-08T19:17:41.179324Z  INFO vector::topology::builder: Healthcheck passed.
2024-10-08T19:17:58.679911Z  INFO vector::config::watcher: Configuration file changed.
2024-10-08T19:17:58.683478Z  INFO vector::topology::running: Reloading running topology with new configuration.
thread 'vector-worker' panicked at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stream-cancel-0.8.2/src/combinator.rs:165:40:
`async fn` resumed after completion
stack backtrace:
   0: rust_begin_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_const::panic_const_async_fn_resumed
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:180:21
   3: <stream_cancel::combinator::Tripwire as core::future::future::Future>::poll::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stream-cancel-0.8.2/src/combinator.rs:165:40
   4: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123:9
   5: <stream_cancel::combinator::Tripwire as core::future::future::Future>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stream-cancel-0.8.2/src/combinator.rs:180:9
   6: <stream_cancel::combinator::TakeUntilIf<S,F> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stream-cancel-0.8.2/src/combinator.rs:93:45
   7: <core::pin::Pin<P> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.30/src/stream.rs:120:9
   8: <futures_util::stream::stream::map::Map<St,F> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/stream/stream/map.rs:58:26
   9: <futures_util::stream::stream::flatten::Flatten<St,<St as futures_core::stream::Stream>::Item> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/stream/stream/flatten.rs:55:44
  10: <futures_util::stream::stream::FlatMap<St,U,F> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/lib.rs:102:13
  11: <core::pin::Pin<P> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.30/src/stream.rs:120:9
  12: <futures_util::stream::stream::map::Map<St,F> as futures_core::stream::Stream>::poll_next
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/stream/stream/map.rs:58:26
  13: futures_util::stream::stream::StreamExt::poll_next_unpin
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/stream/stream/mod.rs:1638:9
  14: <futures_util::stream::stream::next::Next<St> as core::future::future::Future>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/stream/stream/next.rs:32:9
  15: <vector::sinks::util::tcp::TcpSink<E> as vector_core::sink::StreamSink<vector_core::event::Event>>::run::{{closure}}
             at ./src/sinks/util/tcp.rs:305:45
  16: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123:9
  17: <vector_core::sink::EventStream<T> as vector_core::sink::StreamSink<vector_core::event::array::EventArray>>::run::{{closure}}
             at ./lib/vector-core/src/sink.rs:178:30
  18: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123:9
  19: vector_core::sink::VectorSink::run::{{closure}}
             at ./lib/vector-core/src/sink.rs:21:55
  20: vector::topology::builder::Builder::build_sinks::{{closure}}::{{closure}}
             at ./src/topology/builder.rs:619:18
  21: <vector::topology::task::Task as core::future::future::Future>::poll
             at ./src/topology/task.rs:92:9
  22: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::future::future::Future>::poll
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panic/unwind_safe.rs:297:9
  23: <futures_util::future::future::catch_unwind::CatchUnwind<Fut> as core::future::future::Future>::poll::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/future/future/catch_unwind.rs:36:42
  24: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panic/unwind_safe.rs:272:9
  25: std::panicking::try::do_call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
  26: ___rust_try
  27: std::panicking::try
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
  28: std::panic::catch_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
  29: <futures_util::future::future::catch_unwind::CatchUnwind<Fut> as core::future::future::Future>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/future/future/catch_unwind.rs:36:9
  30: vector::topology::handle_errors::{{closure}}
             at ./src/topology/mod.rs:66:10
  31: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-0.1.40/src/instrument.rs:321:9
  32: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:331:17
  33: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/loom/std/unsafe_cell.rs:16:9
  34: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:320:13
  35: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:500:19
  36: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panic/unwind_safe.rs:272:9
  37: std::panicking::try::do_call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
  38: ___rust_try
  39: std::panicking::try
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
  40: std::panic::catch_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
  41: tokio::runtime::task::harness::poll_future
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:488:18
  42: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:209:27
  43: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:154:15
  44: tokio::runtime::task::raw::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:271:5
  45: tokio::runtime::task::raw::RawTask::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:201:18
  46: tokio::runtime::task::LocalNotified<S>::run
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/mod.rs:436:9
  47: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:598:13
  48: tokio::runtime::coop::with_budget
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:107:5
  49: tokio::runtime::coop::budget
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:73:5
  50: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:597:9
  51: tokio::runtime::scheduler::multi_thread::worker::Context::run
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:548:24
  52: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:513:21
  53: tokio::runtime::context::scoped::Scoped<T>::set
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/scoped.rs:40:9
  54: tokio::runtime::context::set_scheduler::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context.rs:180:26
  55: std::thread::local::LocalKey<T>::try_with
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/thread/local.rs:286:12
  56: std::thread::local::LocalKey<T>::with
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/thread/local.rs:262:9
  57: tokio::runtime::context::set_scheduler
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context.rs:180:9
  58: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:508:9
  59: tokio::runtime::context::runtime::enter_runtime
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/runtime.rs:65:16
  60: tokio::runtime::scheduler::multi_thread::worker::run
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:500:5
  61: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:466:45
  62: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/task.rs:42:21
  63: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:331:17
  64: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/loom/std/unsafe_cell.rs:16:9
  65: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:320:13
  66: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:500:19
  67: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panic/unwind_safe.rs:272:9
  68: std::panicking::try::do_call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40
  69: ___rust_try
  70: std::panicking::try
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19
  71: std::panic::catch_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14
  72: tokio::runtime::task::harness::poll_future
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:488:18
  73: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:209:27
  74: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:154:15
  75: tokio::runtime::task::raw::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:271:5
  76: tokio::runtime::task::raw::RawTask::poll
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:201:18
  77: tokio::runtime::task::UnownedTask<S>::run
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/mod.rs:473:9
  78: tokio::runtime::blocking::pool::Task::run
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/pool.rs:160:9
  79: tokio::runtime::blocking::pool::Inner::run
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/pool.rs:518:17
  80: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/pool.rs:476:13
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2024-10-08T19:17:58.818471Z ERROR sink{component_kind="sink" component_id=socket2 component_type=socket}: vector::topology: An error occurred that Vector couldn't handle: the task panicked and was aborted.
thread 'main' panicked at src/topology/running.rs:520:54:
called `Result::unwrap()` on an `Err` value: Panicked
stack backtrace:
   0: rust_begin_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14
   2: core::result::unwrap_failed
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/result.rs:1654:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/result.rs:1077:23
   4: vector::topology::running::RunningTopology::shutdown_diff::{{closure}}
             at ./src/topology/running.rs:520:30
   5: vector::topology::running::RunningTopology::reload_config_and_respawn::{{closure}}
             at ./src/topology/running.rs:244:62
   6: vector::topology::controller::TopologyController::reload::{{closure}}
             at ./src/topology/controller.rs:107:14
   7: vector::app::reload_config_from_result::{{closure}}
             at ./src/app.rs:357:72
   8: vector::app::handle_signal::{{closure}}
             at ./src/app.rs:341:72
   9: vector::app::StartedApplication::main::{{closure}}
             at ./src/app.rs:291:19
  10: vector::app::StartedApplication::run::{{closure}}
             at ./src/app.rs:264:21
  11: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123:9
  12: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/park.rs:281:63
  13: tokio::runtime::coop::with_budget
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:107:5
  14: tokio::runtime::coop::budget
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:73:5
  15: tokio::runtime::park::CachedParkThread::block_on
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/park.rs:281:31
  16: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/blocking.rs:66:9
  17: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/mod.rs:87:13
  18: tokio::runtime::context::runtime::enter_runtime
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/runtime.rs:65:16
  19: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/mod.rs:86:9
  20: tokio::runtime::runtime::Runtime::block_on_inner
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/runtime.rs:363:45
  21: tokio::runtime::runtime::Runtime::block_on
             at /Users/neuronull/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/runtime.rs:333:13
  22: vector::app::Application::run
             at ./src/app.rs:154:9
  23: vector::main
             at ./src/main.rs:40:21
  24: core::ops::function::FnOnce::call_once
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


```


after the fix:
```
VECTOR_LOG=info ./target/debug/vector --config ../vector_configs/http_server_socket.yaml --watch-config
2024-10-08T19:16:09.774602Z  INFO vector::app: Log level is enabled. level="info"
2024-10-08T19:16:09.777461Z  INFO vector::config::watcher: Creating configuration file watcher.
2024-10-08T19:16:09.779871Z  INFO vector::config::watcher: Watching configuration files.
2024-10-08T19:16:09.780024Z  INFO vector::app: Loading configs. paths=["../vector_configs/http_server_socket.yaml"]
2024-10-08T19:16:09.792364Z  INFO vector::topology::running: Running healthchecks.
2024-10-08T19:16:09.792828Z  INFO vector: Vector has started. debug="true" version="0.42.0" arch="aarch64" revision=""
2024-10-08T19:16:09.793156Z  INFO source{component_kind="source" component_id=http3 component_type=http}: vector::sources::util::http::prelude: Building HTTP server. address=0.0.0.0:4242
2024-10-08T19:16:09.793841Z  INFO vector::topology::builder: Healthcheck passed.
2024-10-08T19:16:27.711462Z  INFO vector::config::watcher: Configuration file changed.
2024-10-08T19:16:27.716493Z  INFO vector::topology::running: Reloading running topology with new configuration.
2024-10-08T19:16:27.722131Z  INFO vector::topology::running: Running healthchecks.
2024-10-08T19:16:27.722741Z  INFO vector::topology::running: New configuration loaded successfully.
2024-10-08T19:16:27.722882Z  INFO source{component_kind="source" component_id=http2 component_type=http}: vector::sources::util::http::prelude: Building HTTP server. address=0.0.0.0:4242
2024-10-08T19:16:27.722941Z  INFO vector: Vector has reloaded. path=[File("../vector_configs/http_server_socket.yaml", None)]
2024-10-08T19:16:27.725322Z  INFO vector::topology::builder: Healthcheck passed.
```