### PR TITLE
docs(gcs sink): add 401 and 408 under retry policy

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -635,12 +635,12 @@ components: sinks: [Name=string]: {
 
 				retry_policy: {
 					title: "Retry policy"
-					body: """
+					body: *"""
 						Vector will retry failed requests (status == 429, >= 500, and != 501).
 						Other responses will not be retried. You can control the number of
 						retry attempts and backoff rate with the `request.retry_attempts` and
 						`request.retry_backoff_secs` options.
-						"""
+						""" | string
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -141,6 +141,16 @@ components: sinks: gcp_cloud_storage: {
 				"""
 		}
 
+		retry_policy: {
+			title: "Retry policy"
+			body: """
+				Vector will retry failed requests (status == 401, == 408, == 429, >= 500, and != 501).
+				Other responses will not be retried. You can control the number of
+				retry attempts and backoff rate with the `request.retry_attempts` and
+				`request.retry_backoff_secs` options.
+				"""
+		}
+
 		storage_class: {
 			title: "Storage Class"
 			body:  """


### PR DESCRIPTION
This PR updates the retry policy for the GCS sink documentation to include retries for the HTTP error 401 and 408 error codes, which are currently undocumented.
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
