### PR TITLE
fix(loki): serialize the structured metadata to JSON

### DIFF
--- a/changelog.d/21443-serialize-loki-structured-metadata-to-json.fix.md
+++ b/changelog.d/21443-serialize-loki-structured-metadata-to-json.fix.md
@@ -1,0 +1,3 @@
+Serializes structured metadata to JSON for the Grafana Loki sink
+
+authors: maxboone

--- a/src/sinks/loki/event.rs
+++ b/src/sinks/loki/event.rs
@@ -137,9 +137,11 @@ pub struct LokiEvent {
 
 impl ByteSizeOf for LokiEvent {
     fn allocated_bytes(&self) -> usize {
-        self.timestamp.allocated_bytes() + self.event.allocated_bytes() + self.structured_metadata.iter().fold(0, |res, item| {
-            res + item.0.allocated_bytes() + item.1.allocated_bytes()
-        })
+        self.timestamp.allocated_bytes()
+            + self.event.allocated_bytes()
+            + self.structured_metadata.iter().fold(0, |res, item| {
+                res + item.0.allocated_bytes() + item.1.allocated_bytes()
+            })
     }
 }
 
@@ -153,7 +155,13 @@ impl Serialize for LokiEvent {
         let event = String::from_utf8_lossy(&self.event);
         seq.serialize_element(&event)?;
         // Convert structured_metadata into a map structure
-        seq.serialize_element(&self.structured_metadata.iter().cloned().collect::<HashMap<String, String>>())?;
+        seq.serialize_element(
+            &self
+                .structured_metadata
+                .iter()
+                .cloned()
+                .collect::<HashMap<String, String>>(),
+        )?;
         seq.end()
     }
 }

--- a/src/sinks/loki/event.rs
+++ b/src/sinks/loki/event.rs
@@ -137,7 +137,10 @@ pub struct LokiEvent {
 
 impl ByteSizeOf for LokiEvent {
     fn allocated_bytes(&self) -> usize {
-        self.timestamp.allocated_bytes() + self.event.allocated_bytes()
+        let metadata_size: usize = self.structured_metadata.iter()
+            .map(|(key, value)| key.allocated_bytes() + value.allocated_bytes())
+            .sum();
+        self.timestamp.allocated_bytes() + self.event.allocated_bytes() + metadata_size
     }
 }
 
@@ -150,6 +153,11 @@ impl Serialize for LokiEvent {
         seq.serialize_element(&self.timestamp.to_string())?;
         let event = String::from_utf8_lossy(&self.event);
         seq.serialize_element(&event)?;
+        let metadata: Vec<(String, String)> = self.structured_metadata
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        seq.serialize_element(&metadata)?;
         seq.end()
     }
 }

--- a/src/sinks/loki/event.rs
+++ b/src/sinks/loki/event.rs
@@ -148,11 +148,12 @@ impl Serialize for LokiEvent {
     where
         S: serde::Serializer,
     {
-        let mut seq = serializer.serialize_seq(Some(2))?;
+        let mut seq = serializer.serialize_seq(Some(3))?;
         seq.serialize_element(&self.timestamp.to_string())?;
         let event = String::from_utf8_lossy(&self.event);
         seq.serialize_element(&event)?;
-        seq.serialize_element(&self.structured_metadata)?;
+        // Convert structured_metadata into a map structure
+        seq.serialize_element(&self.structured_metadata.iter().cloned().collect::<HashMap<String, String>>())?;
         seq.end()
     }
 }


### PR DESCRIPTION
fixes: #21443

Structured metadata wasn't added to the serializer implementation, which likely caused it not to be sent to Loki. I added the serialization.

Considering the `Encoder<Vec<LokiRecord>> for LokiBatchEncoder` is not unit tested anywhere, thus I tested it by trying to (JSON) serialize the event and see if the structured metadata is (correctly) in there.