### PR TITLE
chore(ci): simplify chanelog validation to always check for authors

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -48,7 +48,7 @@ jobs:
           # Helper script needs to reference the master branch to compare against
           git fetch origin master:refs/remotes/origin/master
 
-          ./scripts/check_changelog_fragments.sh --authors
+          ./scripts/check_changelog_fragments.sh
 
   check-changelog:
     name: Changelog

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,15 +23,15 @@ jobs:
     env:
       PR_HAS_LABEL: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') }}
     steps:
-        # checkout full depth because in the check_changelog_fragments script, we need to specify a
-        # merge base. If we only shallow clone the repo, git may not have enough history to determine
-        # the base.
+      # Checkout full depth because in the check_changelog_fragments script, we need to specify a
+      # merge base. If we only shallow clone the repo, git may not have enough history to determine
+      # the base.
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Generate authentication token
-        # don't run this step if the PR is from a fork or dependabot since the secrets won't exist
+        # Don't run this step if the PR is from a fork or dependabot since the secrets won't exist
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         id: generate_token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
@@ -39,37 +39,16 @@ jobs:
           app_id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
           private_key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
 
-      - name: Get PR comment author
-        # don't run this step if the PR is from a fork or dependabot since the secrets won't exist
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        id: author
-        uses: tspascoal/get-user-teams-membership@v3
-        with:
-          username: ${{ github.actor }}
-          team: 'Vector'
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - env:
-          # if the prior step did not run, this var will be ''
-          AUTHOR_IS_TEAM_MEMBER: ${{ steps.author.outputs.isTeamMember }}
-        run: |
+      - run: |
           if [[ $PR_HAS_LABEL == 'true' ]] ; then
             echo "'no-changelog' label detected."
             exit 0
           fi
 
-          # helper script needs to reference the master branch to compare against
+          # Helper script needs to reference the master branch to compare against
           git fetch origin master:refs/remotes/origin/master
 
-          # If the PR author is an external contributor, validate that the
-          # changelog fragments added contain the author line for website rendering.
-          args=""
-          if [[ $AUTHOR_IS_TEAM_MEMBER != 'true' ]] ; then
-            echo "PR author detected to be an external contributor."
-            args="--authors"
-          fi
-
-          ./scripts/check_changelog_fragments.sh ${args}
+          ./scripts/check_changelog_fragments.sh --authors
 
   check-changelog:
     name: Changelog

--- a/scripts/check_changelog_fragments.sh
+++ b/scripts/check_changelog_fragments.sh
@@ -56,22 +56,17 @@ while IFS= read -r fname; do
     exit 1
   fi
 
-  # if specified, this option validates that the contents of the news fragment
-  # contains a properly formatted authors line at the end of the file, generally
-  # used for external contributor PRs.
-  if [[ $1 == "--authors" ]]; then
-    last=$( tail -n 1 "${CHANGELOG_DIR}/${fname}" )
-    if [[ "${last}" == "authors: "*@* ]]; then
-      echo "invalid fragment contents: author should not be prefixed with @"
-      exit 1
-    elif [[ "${last}" == "authors: "*,* ]]; then
-      echo "invalid fragment contents: authors should be space delimited, not comma delimited."
-      exit 1
-    elif ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
-      echo "invalid fragment contents: author option was specified but fragment ${fname} contains no authors."
-      exit 1
-    fi
-
+  # Each fragment should have a properly formatted authors line at the end of the file.
+  last=$( tail -n 1 "${CHANGELOG_DIR}/${fname}" )
+  if [[ "${last}" == "authors: "*@* ]]; then
+    echo "invalid fragment contents: author should not be prefixed with @"
+    exit 1
+  elif [[ "${last}" == "authors: "*,* ]]; then
+    echo "invalid fragment contents: authors should be space delimited, not comma delimited."
+    exit 1
+  elif ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
+    echo "invalid fragment contents: author option was specified but fragment ${fname} contains no authors."
+    exit 1
   fi
 
 done <<< "$FRAGMENTS"


### PR DESCRIPTION
Now an author line is always required. Removed the Vector team check to simplify validation. 