### PR TITLE
chore(ci): enable retries for choco installations

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,15 +23,15 @@ jobs:
     env:
       PR_HAS_LABEL: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') }}
     steps:
-        # checkout full depth because in the check_changelog_fragments script, we need to specify a
-        # merge base. If we only shallow clone the repo, git may not have enough history to determine
-        # the base.
+      # Checkout full depth because in the check_changelog_fragments script, we need to specify a
+      # merge base. If we only shallow clone the repo, git may not have enough history to determine
+      # the base.
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Generate authentication token
-        # don't run this step if the PR is from a fork or dependabot since the secrets won't exist
+        # Don't run this step if the PR is from a fork or dependabot since the secrets won't exist
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         id: generate_token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
@@ -39,37 +39,16 @@ jobs:
           app_id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
           private_key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
 
-      - name: Get PR comment author
-        # don't run this step if the PR is from a fork or dependabot since the secrets won't exist
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        id: author
-        uses: tspascoal/get-user-teams-membership@v3
-        with:
-          username: ${{ github.actor }}
-          team: 'Vector'
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - env:
-          # if the prior step did not run, this var will be ''
-          AUTHOR_IS_TEAM_MEMBER: ${{ steps.author.outputs.isTeamMember }}
-        run: |
+      - run: |
           if [[ $PR_HAS_LABEL == 'true' ]] ; then
             echo "'no-changelog' label detected."
             exit 0
           fi
 
-          # helper script needs to reference the master branch to compare against
+          # Helper script needs to reference the master branch to compare against
           git fetch origin master:refs/remotes/origin/master
 
-          # If the PR author is an external contributor, validate that the
-          # changelog fragments added contain the author line for website rendering.
-          args=""
-          if [[ $AUTHOR_IS_TEAM_MEMBER != 'true' ]] ; then
-            echo "PR author detected to be an external contributor."
-            args="--authors"
-          fi
-
-          ./scripts/check_changelog_fragments.sh ${args}
+          ./scripts/check_changelog_fragments.sh --authors
 
   check-changelog:
     name: Changelog

--- a/scripts/check_changelog_fragments.sh
+++ b/scripts/check_changelog_fragments.sh
@@ -56,22 +56,18 @@ while IFS= read -r fname; do
     exit 1
   fi
 
-  # if specified, this option validates that the contents of the news fragment
-  # contains a properly formatted authors line at the end of the file, generally
-  # used for external contributor PRs.
-  if [[ $1 == "--authors" ]]; then
-    last=$( tail -n 1 "${CHANGELOG_DIR}/${fname}" )
-    if [[ "${last}" == "authors: "*@* ]]; then
-      echo "invalid fragment contents: author should not be prefixed with @"
-      exit 1
-    elif [[ "${last}" == "authors: "*,* ]]; then
-      echo "invalid fragment contents: authors should be space delimited, not comma delimited."
-      exit 1
-    elif ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
-      echo "invalid fragment contents: author option was specified but fragment ${fname} contains no authors."
-      exit 1
-    fi
-
+  # Validate that the contents of the news fragment contain a properly formatted authors line
+  # at the end of the file.
+  last=$( tail -n 1 "${CHANGELOG_DIR}/${fname}" )
+  if [[ "${last}" == "authors: "*@* ]]; then
+    echo "invalid fragment contents: author should not be prefixed with @"
+    exit 1
+  elif [[ "${last}" == "authors: "*,* ]]; then
+    echo "invalid fragment contents: authors should be space delimited, not comma delimited."
+    exit 1
+  elif ! [[ "${last}" =~ ^(authors: .*)$ ]]; then
+    echo "invalid fragment contents: author option was specified but fragment ${fname} contains no authors."
+    exit 1
   fi
 
 done <<< "$FRAGMENTS"

--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -12,6 +12,9 @@ if ($env:RELEASE_BUILDER -ne "true") {
     rustup run stable cargo install cargo-nextest --version 0.9.72 --locked
 }
 
+# Enable retries to avoid transient network issues.
+export NUGET_ENABLE_ENHANCED_HTTP_RETRY=true
+
 # Install some required dependencies / tools.
 choco install make
 choco install protoc

--- a/scripts/util/retry.sh
+++ b/scripts/util/retry.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Usage: ./retry.sh -r <max_retries> -d <delay_in_seconds> -c "<command>"
+# Example: ./retry.sh -r 5 -d 30 -c "choco install protoc"
+
+max_retries=3
+delay=10
+command=""
+
+# Parse options
+while getopts "r:d:c:" opt; do
+  case $opt in
+    r)
+      max_retries=$OPTARG
+      ;;
+    d)
+      delay=$OPTARG
+      ;;
+    c)
+      command=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Check if command is provided
+if [[ -z "$command" ]]; then
+  echo "Usage: $0 -r <max_retries> -d <delay_in_seconds> -c \"<command>\""
+  exit 1
+fi
+
+attempt=1
+
+while [[ $attempt -le $max_retries ]]; do
+  echo "Attempt $attempt to run: $command"
+
+  if eval "$command"; then
+    echo "Command succeeded on attempt $attempt."
+    exit 0
+  else
+    echo "Attempt $attempt failed. Retrying in $delay seconds..."
+    ((attempt++))
+    sleep $delay
+    delay=$((delay * 2))  # Exponential backoff (increase delay each time)
+  fi
+
+  if [[ $attempt -gt $max_retries ]]; then
+    echo "Command failed after $max_retries attempts."
+    exit 1
+  fi
+done


### PR DESCRIPTION
This is an attempt to reduce flakes such as https://github.com/vectordotdev/vector/actions/runs/11247975194/job/31272362725#step:3:67. An alternative that I considered was a generic retry script but this change is easier.