### PR TITLE
chore(ci): enable http retries for choco installations

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -435,6 +435,7 @@ rpms
 rstest
 rsyslog
 rsyslogd
+scriptblock
 security-tab
 servlet
 Sinjo

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -119,3 +119,4 @@
 ^lib/codecs/tests/data/native_encoding/
 ^\Qwebsite/config.toml\E$
 ignore$
+^\Qscripts/environment/bootstrap-windows-2019.ps1\E$

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -236,9 +236,3 @@ uuid_from_friendly_id!\(".*"\)
 
 # changelog.d fragment authors line
 ^authors: .*$
-
-# Pattern for matching CLI flags
-\s--?(\w+)\s
-
-# Workaround for spellchecker bug.
-Retry-Command

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -237,5 +237,5 @@ uuid_from_friendly_id!\(".*"\)
 # changelog.d fragment authors line
 ^authors: .*$
 
-# Pattern for PowerShell script
-(?i)\b\w+-Command\b
+# Pattern for matching CLI flags
+\s--?(\w+)\s

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -236,3 +236,6 @@ uuid_from_friendly_id!\(".*"\)
 
 # changelog.d fragment authors line
 ^authors: .*$
+
+# Pattern for PowerShell script
+(?i)\b\w+-Command\b

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -239,3 +239,6 @@ uuid_from_friendly_id!\(".*"\)
 
 # Pattern for matching CLI flags
 \s--?(\w+)\s
+
+# Workaround for spellchecker bug.
+Retry-Command

--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -13,7 +13,7 @@ if ($env:RELEASE_BUILDER -ne "true") {
 }
 
 # Enable retries to avoid transient network issues.
-export NUGET_ENABLE_ENHANCED_HTTP_RETRY=true
+$env:NUGET_ENABLE_ENHANCED_HTTP_RETRY = "true"
 
 # Install some required dependencies / tools.
 choco install make

--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -47,12 +47,12 @@ function Retry-Command {
 $command_1 = {
   choco install make
 }
-Retry-Command -Command $command_1 -Retries 3 -DelaySeconds 2
+Retry-Command -Command $command_1 -Retries 5 -DelaySeconds 2
 
 $command_2 = {
   choco install protoc
 }
-Retry-Command -Command $command_2 -Retries 3 -DelaySeconds 2
+Retry-Command -Command $command_2 -Retries 5 -DelaySeconds 2
 
 # Set a specific override path for libclang.
 echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/scripts/environment/bootstrap-windows-2019.ps1
+++ b/scripts/environment/bootstrap-windows-2019.ps1
@@ -12,6 +12,9 @@ if ($env:RELEASE_BUILDER -ne "true") {
     rustup run stable cargo install cargo-nextest --version 0.9.72 --locked
 }
 
+# Enable retries to avoid transient network issues.
+export NUGET_ENABLE_ENHANCED_HTTP_RETRY=true
+
 # Install some required dependencies / tools.
 choco install make
 choco install protoc


### PR DESCRIPTION
This is an attempt to reduce flakes such as [this one](https://github.com/vectordotdev/vector/actions/runs/11247975194/job/31272362725#step:3:67). An alternative that I considered was a generic retry script but this change is easier.