### PR TITLE
docs(vrl stdlib): Document regex replacement group escaping

### DIFF
--- a/website/cue/reference/remap/functions/replace.cue
+++ b/website/cue/reference/remap/functions/replace.cue
@@ -5,7 +5,14 @@ remap: functions: replace: {
 	description: """
 		Replaces all matching instances of `pattern` in `value`.
 
-		The `pattern` argument accepts regular expression capture groups. **Note**: Use `$$foo` instead of `$foo`, which is interpreted in a configuration file.
+		The `pattern` argument accepts regular expression capture groups.
+
+		**Note when using capture groups**:
+		- You will need to escape the `$` by using `$$` to avoid Vector interpreting it as an
+		  [environment variable when loading configuration](/docs/reference/configuration/#escaping)
+		- If you want a literal `$` in the replacement pattern, you will also need to escape this
+		  with `$$`. When combined with environment variable interpolation in config files this
+		  means you will need to use `$$$$` to have a literal `$` in the replacement pattern.
 		"""
 
 	arguments: [


### PR DESCRIPTION
Closes: https://github.com/vectordotdev/vector/issues/21462