### PR TITLE
enhancement(kubernetes_logs source): support scraping metadata from Kubernetes log files on Windows

### DIFF
--- a/changelog.d/18521-kubernetes-windows-metadata.enhancement.md
+++ b/changelog.d/18521-kubernetes-windows-metadata.enhancement.md
@@ -1,0 +1,3 @@
+Changed the kubernetes log enricher to use `std::path::MAIN_SEPARATOR` to faciliate extracting the pod info on Windows as well as Linux.
+
+authors: damoxc

--- a/changelog.d/18521-kubernetes-windows-metadata.enhancement.md
+++ b/changelog.d/18521-kubernetes-windows-metadata.enhancement.md
@@ -1,3 +1,3 @@
-Changed the kubernetes log enricher to use `std::path::MAIN_SEPARATOR` to faciliate extracting the pod info on Windows as well as Linux.
+Changed the kubernetes log enricher to use `std::path::MAIN_SEPARATOR` to facilitate extracting the pod info on Windows as well as Linux.
 
 authors: damoxc

--- a/changelog.d/18521-kubernetes-windows-metadata.enhancement.md
+++ b/changelog.d/18521-kubernetes-windows-metadata.enhancement.md
@@ -1,3 +1,3 @@
-Changed the kubernetes log enricher to use `std::path::MAIN_SEPARATOR` to facilitate extracting the pod info on Windows as well as Linux.
+The Kubernetes Logs source can now enrich logs with pod information on Windows.
 
 authors: damoxc

--- a/src/sources/kubernetes_logs/path_helpers.rs
+++ b/src/sources/kubernetes_logs/path_helpers.rs
@@ -34,7 +34,7 @@ pub(super) fn build_pod_logs_directory(
 ///
 /// Inspired by <https://github.com/kubernetes/kubernetes/blob/31305966789525fca49ec26c289e565467d1f1c4/pkg/kubelet/kuberuntime/helpers.go#L186>
 pub(super) fn parse_log_file_path(path: &str) -> Option<LogFileInfo<'_>> {
-    let mut components = path.rsplit('/');
+    let mut components = path.rsplit(std::path::MAIN_SEPARATOR);
 
     let _log_file_name = components.next()?;
     let container_name = components.next()?;

--- a/src/sources/kubernetes_logs/path_helpers.rs
+++ b/src/sources/kubernetes_logs/path_helpers.rs
@@ -69,11 +69,27 @@ mod tests {
 
     #[test]
     fn test_build_pod_logs_directory() {
+        let path = format!(
+            "{}{}",
+            std::path::MAIN_SEPARATOR,
+            [
+                "var",
+                "log",
+                "pods",
+                "sandbox0-ns_sandbox0-name_sandbox0-uid",
+            ]
+            .iter()
+            .collect::<PathBuf>()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+        );
+        let s_path = path.as_str();
         let cases = vec![
             // Valid inputs.
             (
                 ("sandbox0-ns", "sandbox0-name", "sandbox0-uid"),
-                "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid",
+                s_path,
             ),
             // Invalid inputs.
             (("", "", ""), "/var/log/pods/__"),
@@ -89,10 +105,28 @@ mod tests {
 
     #[test]
     fn test_parse_log_file_path() {
+        let path = format!(
+            "{}{}",
+            std::path::MAIN_SEPARATOR,
+            [
+                "var",
+                "log",
+                "pods",
+                "sandbox0-ns_sandbox0-name_sandbox0-uid",
+                "sandbox0-container0-name",
+                "1.log",
+            ]
+            .iter()
+            .collect::<PathBuf>()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+        );
+        let s_path = path.as_str();
         let cases = vec![
             // Valid inputs.
             (
-                "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/sandbox0-container0-name/1.log",
+                s_path,
                 Some(LogFileInfo {
                     pod_namespace: "sandbox0-ns",
                     pod_name: "sandbox0-name",

--- a/src/sources/kubernetes_logs/path_helpers.rs
+++ b/src/sources/kubernetes_logs/path_helpers.rs
@@ -87,10 +87,7 @@ mod tests {
         let s_path = path.as_str();
         let cases = vec![
             // Valid inputs.
-            (
-                ("sandbox0-ns", "sandbox0-name", "sandbox0-uid"),
-                s_path,
-            ),
+            (("sandbox0-ns", "sandbox0-name", "sandbox0-uid"), s_path),
             // Invalid inputs.
             (("", "", ""), "/var/log/pods/__"),
         ];

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -752,9 +752,10 @@ mod tests {
 
     #[test]
     fn test_annotate_from_file_info() {
+        let path = ["var", "log", "pods", "sandbox0-ns_sandbox0-name_sandbox0-uid", "sandbox0-container0-name", "1.log"].iter().collect::<PathBuf>();
         let cases = vec![(
             FieldsSpec::default(),
-            "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/sandbox0-container0-name/1.log",
+            path,
             {
                 let mut log = LogEvent::default();
                 log.insert(event_path!("kubernetes", "container_name"), "sandbox0-container0-name");
@@ -766,7 +767,7 @@ mod tests {
                 container_name: OwnedTargetPath::event(owned_value_path!("container_name")).into(),
                 ..Default::default()
             },
-            "/var/log/pods/sandbox0-ns_sandbox0-name_sandbox0-uid/sandbox0-container0-name/1.log",
+            path,
             {
                 let mut log = LogEvent::default();
                 log.insert(event_path!("container_name"), "sandbox0-container0-name");

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -480,6 +480,7 @@ fn annotate_from_container(
 mod tests {
     use k8s_openapi::api::core::v1::PodIP;
     use similar_asserts::assert_eq;
+    use std::path::PathBuf;
     use vector_lib::lookup::{event_path, metadata_path};
 
     use super::*;

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -752,29 +752,45 @@ mod tests {
 
     #[test]
     fn test_annotate_from_file_info() {
-        let path = ["var", "log", "pods", "sandbox0-ns_sandbox0-name_sandbox0-uid", "sandbox0-container0-name", "1.log"].iter().collect::<PathBuf>();
-        let cases = vec![(
-            FieldsSpec::default(),
-            path,
-            {
-                let mut log = LogEvent::default();
-                log.insert(event_path!("kubernetes", "container_name"), "sandbox0-container0-name");
-                log
-            },
-            LogNamespace::Legacy,
-        ),(
-            FieldsSpec{
-                container_name: OwnedTargetPath::event(owned_value_path!("container_name")).into(),
-                ..Default::default()
-            },
-            path,
-            {
-                let mut log = LogEvent::default();
-                log.insert(event_path!("container_name"), "sandbox0-container0-name");
-                log
-            },
-            LogNamespace::Legacy,
-        )];
+        let path = [
+            "var",
+            "log",
+            "pods",
+            "sandbox0-ns_sandbox0-name_sandbox0-uid",
+            "sandbox0-container0-name",
+            "1.log",
+        ]
+        .iter()
+        .collect::<PathBuf>();
+        let cases = vec![
+            (
+                FieldsSpec::default(),
+                path,
+                {
+                    let mut log = LogEvent::default();
+                    log.insert(
+                        event_path!("kubernetes", "container_name"),
+                        "sandbox0-container0-name",
+                    );
+                    log
+                },
+                LogNamespace::Legacy,
+            ),
+            (
+                FieldsSpec {
+                    container_name: OwnedTargetPath::event(owned_value_path!("container_name"))
+                        .into(),
+                    ..Default::default()
+                },
+                path,
+                {
+                    let mut log = LogEvent::default();
+                    log.insert(event_path!("container_name"), "sandbox0-container0-name");
+                    log
+                },
+                LogNamespace::Legacy,
+            ),
+        ];
 
         for (fields_spec, file, expected, log_namespace) in cases.into_iter() {
             let mut log = LogEvent::default();

--- a/src/sources/kubernetes_logs/pod_metadata_annotator.rs
+++ b/src/sources/kubernetes_logs/pod_metadata_annotator.rs
@@ -753,20 +753,28 @@ mod tests {
 
     #[test]
     fn test_annotate_from_file_info() {
-        let path = [
-            "var",
-            "log",
-            "pods",
-            "sandbox0-ns_sandbox0-name_sandbox0-uid",
-            "sandbox0-container0-name",
-            "1.log",
-        ]
-        .iter()
-        .collect::<PathBuf>();
+        let path = &format!(
+            "{}{}",
+            std::path::MAIN_SEPARATOR,
+            [
+                "var",
+                "log",
+                "pods",
+                "sandbox0-ns_sandbox0-name_sandbox0-uid",
+                "sandbox0-container0-name",
+                "1.log",
+            ]
+            .iter()
+            .collect::<PathBuf>()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+        );
+        let s_path = path.as_str();
         let cases = vec![
             (
                 FieldsSpec::default(),
-                path,
+                s_path,
                 {
                     let mut log = LogEvent::default();
                     log.insert(
@@ -783,7 +791,7 @@ mod tests {
                         .into(),
                     ..Default::default()
                 },
-                path,
+                s_path,
                 {
                     let mut log = LogEvent::default();
                     log.insert(event_path!("container_name"), "sandbox0-container0-name");


### PR DESCRIPTION
This implements the changes from #19799, including the suggested fix for the failing test. I've been running the change with the path separator successfully for 5 months on Windows.

This resolves #18521.