### PR TITLE
chore(ci): skip regression checks for PRs with the `ci-condition: skip-regression` label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     labels:
       - "domain: deps"
       - "no-changelog"
+      - "ci-condition: skip-regression"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
@@ -71,6 +72,7 @@ updates:
     labels:
       - "domain: releasing"
       - "no-changelog"
+      - "ci-condition: skip-regression"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
@@ -81,6 +83,7 @@ updates:
     labels:
       - "domain: ci"
       - "no-changelog"
+      - "ci-condition: skip-regression"
     commit-message:
       prefix: "chore(ci)"
     groups:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -47,11 +47,30 @@ env:
 
 jobs:
 
+  # Determine if the suite should run
+  check-should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.set-should-run.outputs.SHOULD_RUN }}
+    steps:
+      - name: Determine if should run
+        id: set-should-run
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" != "pull_request_review" &&
+                  "${{ !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
+            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
+          else
+            echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
+          fi
+
   # Only run this workflow if files changed in areas that could possibly introduce a regression
-  should-run:
+  check-source-changed:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name != 'pull_request'
+    needs: check-should-run
+    if: ${{ needs.check-should-run.outputs.should-run == 'true' }}
     outputs:
       source_changed: ${{ steps.filter.outputs.SOURCE_CHANGED }}
       comment_valid: ${{ steps.comment.outputs.isTeamMember }}
@@ -116,8 +135,8 @@ jobs:
     name: Compute metadata
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: should-run
-    if: github.event_name != 'merge_group' || needs.should-run.outputs.source_changed == 'true'
+    needs: check-source-changed
+    if: github.event_name != 'merge_group' || needs.check-source-changed.outputs.source_changed == 'true'
     outputs:
       pr-number: ${{ steps.pr-metadata-merge-queue.outputs.PR_NUMBER || steps.pr-metadata-comment.outputs.PR_NUMBER }}
       baseline-sha: ${{ steps.pr-metadata-merge-queue.outputs.BASELINE_SHA || steps.pr-metadata-comment.outputs.BASELINE_SHA }}
@@ -755,11 +774,9 @@ jobs:
       - analyze-experiment
     env:
       FAILED: ${{ contains(needs.*.result, 'failure') }}
-      SKIP_REGRESSION: "${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}"
-
     steps:
       - name: (PR review) Submit PR result as failed
-        if: github.event_name == 'pull_request_review' && env.FAILED == 'true' && env.SKIP_REGRESSION == 'true'
+        if: github.event_name == 'pull_request_review' && env.FAILED == 'true'
         uses: myrotvorets/set-commit-status-action@v2.0.1
         with:
           sha: ${{ github.event.review.commit_id }}
@@ -768,7 +785,7 @@ jobs:
           status: 'failure'
 
       - name: (PR review) Submit PR result as success
-        if: github.event_name == 'pull_request_review' && env.FAILED != 'true' && env.SKIP_REGRESSION == 'true'
+        if: github.event_name == 'pull_request_review' && env.FAILED != 'true'
         uses: myrotvorets/set-commit-status-action@v2.0.1
         with:
           sha: ${{ github.event.review.commit_id }}
@@ -777,11 +794,11 @@ jobs:
           status: 'success'
 
       - name: (PR) Indicate why skipped
-        if: github.event_name == 'pull_request' || env.SKIP_REGRESSION == 'true'
+        if: github.event_name == 'pull_request'
         run: |
           echo "### Workflow skipped" >> $GITHUB_STEP_SUMMARY
           echo "This workflow doesn't run on PRs automatically." >> $GITHUB_STEP_SUMMARY
-          echo "This workflow doesn't run on PRs created by Dependabot." >> $GITHUB_STEP_SUMMARY
+          echo "This workflow doesn't run on PRs with the 'ci-condition: skip-regression' label." >> $GITHUB_STEP_SUMMARY
           echo "To trigger a run, leave a review comment with \`/ci-run-regression\`" >> $GITHUB_STEP_SUMMARY
 
       - name: exit

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -755,8 +755,8 @@ jobs:
       - analyze-experiment
     env:
       FAILED: ${{ contains(needs.*.result, 'failure') }}
-      SKIP_REGRESSION:
-        ${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}
+      SKIP_REGRESSION: "${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}"
+
     steps:
       - name: (PR review) Submit PR result as failed
         if: github.event_name == 'pull_request_review' && env.FAILED == 'true' && env.SKIP_REGRESSION == 'true'

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -787,7 +787,7 @@ jobs:
       - name: exit
         run: |
           echo "failed=${{ env.FAILED }}"
-          if [[ "${{ env.FAILED }}" == "true" ]] ; then
+          if [[ "$FAILED" == "true" ]] ; then
             exit 1
           else
             exit 0

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,7 +32,9 @@ on:
   # Don't want to run this on each PR commit, but because GH doesn't allow specifying different required checks
   # for pull request and merge queue, we need to "run" it in pull request, but in the jobs we will just auto pass.
   pull_request:
-
+  # Also, this workflow runs every Monday at 5:00 AM UTC.
+  schedule:
+    - cron: "0 5 * * 1"
 concurrency:
   # In flight runs will be canceled only by re-trigger through the merge queue or if additional PR commits are pushed.
   # The comment.html_url should always be unique.
@@ -753,9 +755,11 @@ jobs:
       - analyze-experiment
     env:
       FAILED: ${{ contains(needs.*.result, 'failure') }}
+      SKIP_REGRESSION:
+        ${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}
     steps:
       - name: (PR review) Submit PR result as failed
-        if: github.event_name == 'pull_request_review' && env.FAILED == 'true'
+        if: github.event_name == 'pull_request_review' && env.FAILED == 'true' && env.SKIP_REGRESSION == 'true'
         uses: myrotvorets/set-commit-status-action@v2.0.1
         with:
           sha: ${{ github.event.review.commit_id }}
@@ -764,7 +768,7 @@ jobs:
           status: 'failure'
 
       - name: (PR review) Submit PR result as success
-        if: github.event_name == 'pull_request_review' && env.FAILED != 'true'
+        if: github.event_name == 'pull_request_review' && env.FAILED != 'true' && env.SKIP_REGRESSION == 'true'
         uses: myrotvorets/set-commit-status-action@v2.0.1
         with:
           sha: ${{ github.event.review.commit_id }}
@@ -773,16 +777,17 @@ jobs:
           status: 'success'
 
       - name: (PR) Indicate why skipped
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || env.SKIP_REGRESSION == 'true'
         run: |
-           echo "### Workflow skipped" >> $GITHUB_STEP_SUMMARY
-           echo "This workflow doesn't run on PR's automatically." >> $GITHUB_STEP_SUMMARY
-           echo "To trigger a run, leave a comment with \`/ci-run-regression\`" >> $GITHUB_STEP_SUMMARY
+          echo "### Workflow skipped" >> $GITHUB_STEP_SUMMARY
+          echo "This workflow doesn't run on PRs automatically." >> $GITHUB_STEP_SUMMARY
+          echo "This workflow doesn't run on PRs created by Dependabot." >> $GITHUB_STEP_SUMMARY
+          echo "To trigger a run, leave a review comment with \`/ci-run-regression\`" >> $GITHUB_STEP_SUMMARY
 
       - name: exit
         run: |
           echo "failed=${{ env.FAILED }}"
-          if [[ "$FAILED" == "true" ]] ; then
+          if [[ "${{ env.FAILED }}" == "true" ]] ; then
             exit 1
           else
             exit 0

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -60,9 +60,10 @@ jobs:
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" != "pull_request_review" &&
                   "${{ !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
-            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
-          else
+            # The small caveat here is that we still want to run the suite via a review comment.
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
+          else
+            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
           fi
 
   # Only run this workflow if files changed in areas that could possibly introduce a regression


### PR DESCRIPTION
### Summary
* PR with the `"ci-condition: skip-regression"` label will skip the regression detector suite 
* PRs created by [dependabot[bot]](https://github.com/vectordotdev/vector/commits?author=dependabot%5Bbot%5D) will always have this label.
* What about regressions introduced by crate bumps? 
  * To mitigate this risk, we will now run the suite weekly. This will allows us to investigate any regressions before we release a new Vector versions.
  * Also, we can keep on eye for changelogs describing performance changes and trigger the regression suite on those PRs with review comments. 

In the future, we can also consider making this only run on schedule (e.g. nightly). But let's see how this smaller change works out.
  
## Testing

Check what happens when:
- A new commit is pushed
- A `/ci-run-regression` review comment is posted