### PR TITLE
chore(tests): Fix event `size_of` test

### DIFF
--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -72,16 +72,16 @@ fn size_greater_than_allocated_size() {
 #[derive(Debug, Clone)]
 pub(crate) enum Action {
     Contains {
-        key: String,
+        key: KeyString,
     },
     SizeOf,
     /// Insert a key/value pair into the [`LogEvent`]
     InsertFlat {
-        key: String,
+        key: KeyString,
         value: Value,
     },
     Remove {
-        key: String,
+        key: KeyString,
     },
 }
 
@@ -89,15 +89,15 @@ impl Arbitrary for Action {
     fn arbitrary(g: &mut Gen) -> Self {
         match u8::arbitrary(g) % 3 {
             0 => Action::InsertFlat {
-                key: String::from(Name::arbitrary(g)),
+                key: String::from(Name::arbitrary(g)).into(),
                 value: Value::arbitrary(g),
             },
             1 => Action::SizeOf,
             2 => Action::Contains {
-                key: String::from(Name::arbitrary(g)),
+                key: String::from(Name::arbitrary(g)).into(),
             },
             3 => Action::Remove {
-                key: String::from(Name::arbitrary(g)),
+                key: String::from(Name::arbitrary(g)).into(),
             },
             _ => unreachable!(),
         }


### PR DESCRIPTION
The strings used in this test are actually object map keys, which must have the type `KeyString`. This works now when `KeyString` is a simple wrapping of `String` but breaks if the types are different.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
