### PR TITLE
chore(deps): Handle recent GitHub Actions deprecations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -264,7 +264,7 @@ jobs:
 
   build-x86_64-apple-darwin-packages:
     name: Build Vector for x86_64-apple-darwin (.tar.gz)
-    runs-on: macos-latest-xl
+    runs-on: macos-latest-xlarge
     timeout-minutes: 90
     needs: generate-publish-metadata
     env:
@@ -448,13 +448,16 @@ jobs:
 
   macos-verify:
     name: Verify macOS Package
-    runs-on: macos-12
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     needs:
       - generate-publish-metadata
       - build-x86_64-apple-darwin-packages
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
+    strategy:
+      matrix:
+        runner: [macos-13, macos-14, macos-15]
     steps:
       - name: Checkout Vector
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -457,7 +457,7 @@ jobs:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
     strategy:
       matrix:
-        runner: [macos-13, macos-14, macos-15]
+        runner: [macos-14, macos-15]
     steps:
       - name: Checkout Vector
         uses: actions/checkout@v3


### PR DESCRIPTION
Ref: https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

As part of this, I changed the MacOS package verification to test on all available runner versions.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
