### PR TITLE
Add OpenObserve as an officially supported sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -708,6 +708,7 @@ sinks-logs = [
   "sinks-new_relic",
   "sinks-papertrail",
   "sinks-pulsar",
+  "sinks-openobserve",
   "sinks-redis",
   "sinks-sematext",
   "sinks-socket",

--- a/website/cue/reference/components/sinks/base/openobserve.cue
+++ b/website/cue/reference/components/sinks/base/openobserve.cue
@@ -1,0 +1,61 @@
+package metadata
+
+base: components: sinks: openobserve: configuration: {
+    type: "http"
+    inputs: ["source_or_transform_id"]
+    uri: {
+        description: "The OpenObserve endpoint to send data to."
+        required: true
+        type: string: examples: ["http://localhost:5080/api/default/default/_json"]
+    }
+    method: {
+        description: "The HTTP method to use for the request."
+        required: true
+        type: string: default: "post"
+    }
+    auth: {
+        description: "Authentication for OpenObserve."
+        required: true
+        type: object: options: {
+            strategy: {
+                description: "The authentication strategy."
+                required: true
+                type: string: default: "basic"
+            }
+            user: {
+                description: "The username for basic authentication."
+                required: true
+                type: string: examples: ["test@example.com"]
+            }
+            password: {
+                description: "The password for basic authentication."
+                required: true
+                type: string: examples: ["v9Ca7qHaMKELlDtU"]
+            }
+        }
+    }
+    compression: {
+        description: "The compression algorithm to use."
+        required: true
+        type: string: default: "gzip"
+    }
+    encoding: {
+        codec: {
+            description: "The encoding format to use for the request body."
+            required: true
+            type: string: default: "json"
+        }
+        timestamp_format: {
+            description: "The format for encoding timestamps."
+            required: true
+            type: string: default: "rfc3339"
+        }
+    }
+    healthcheck: {
+        enabled: {
+            description: "Enables or disables the health check."
+            required: true
+            type: bool: default: false
+        }
+    }
+}

--- a/website/cue/reference/components/sinks/openobserve.cue
+++ b/website/cue/reference/components/sinks/openobserve.cue
@@ -1,0 +1,60 @@
+package metadata
+
+components: sinks: openobserve: {
+	title: "OpenObserve"
+
+	features: {
+		healthcheck: {
+			enabled: false
+		}
+		send: {
+			compression: {
+				enabled: true
+				default: "gzip"
+			}
+			encoding: {
+				enabled: true
+				codec: {
+					enabled: true
+					default: "json"
+				}
+				timestamp_format: {
+					enabled: true
+					default: "rfc3339"
+				}
+			}
+		}
+	}
+
+	configuration: {
+		type: "http"
+		inputs: ["source_or_transform_id"]
+		uri: {
+			description: "The OpenObserve endpoint to send data to."
+			required: true
+			type: string: default: "http://localhost:5080/api/default/default/_json"
+		}
+		method: {
+			description: "The HTTP method to use."
+			required: true
+			type: string: default: "post"
+		}
+		auth: {
+			strategy: {
+				description: "The authentication strategy."
+				required: true
+				type: string: default: "basic"
+			}
+			user: {
+				description: "The username for basic authentication."
+				required: true
+				type: string: default: "test@example.com"
+			}
+			password: {
+				description: "The password for basic authentication."
+				required: true
+				type: string: default: "your_ingestion_password"
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds OpenObserve as an officially supported sink in Vector's documentation. OpenObserve utilizes an HTTP-based API for data ingestion, and this PR proposes updating the documentation with an example configuration for users to follow.

No new functionality is required, as the current HTTP sink already serves the purpose effectively. The primary goal is to improve user experience by offering clear guidance for setting up Vector with OpenObserve, ensuring confidence in its usage as a supported observability solution.

```[sinks.zinc]
type = "http"
inputs = [ "source_or_transform_id" ]
uri = "http://localhost:5080/api/default/default/_json"
method = "post"
auth.strategy = "basic"
auth.user = "test@example.com"
auth.password = "v9Ca7qHaMKELlDtU"
compression = "gzip"
encoding.codec = "json"
encoding.timestamp_format = "rfc3339"
healthcheck.enabled = false
```

Why This Matters?
By officially documenting OpenObserve as a supported sink, we provide clear setup instructions for users, allowing them to confidently configure Vector for OpenObserve.