### PR TITLE
chore(ci): fix 'check-should-run' script

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -59,7 +59,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
-            # This will run in the conext of a CI review trigger.
+            # This will run in the context of a CI review trigger.
             echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
           elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -59,12 +59,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
+            # This will run in the conext of a CI review trigger.
             echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
           elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
-            # The small caveat here is that we still want to run the suite via a review comment.
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
           else
-           echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
+            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
           fi
 
   # Only run this workflow if files changed in areas that could possibly introduce a regression

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -58,12 +58,13 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" != "pull_request_review" &&
-                  "${{ !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
+          elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
+            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
             # The small caveat here is that we still want to run the suite via a review comment.
             echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
           else
-            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
+           echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
           fi
 
   # Only run this workflow if files changed in areas that could possibly introduce a regression


### PR DESCRIPTION
This PR is a follow-up to https://github.com/vectordotdev/vector/pull/21507#discussion_r1803756641. 

Regarding `pull_request_review` vs `workflow_call`, last time I checked [here](https://github.com/vectordotdev/vector/pull/21507#pullrequestreview-2373537622) the event name was `pull_request_review`. So I am preserving that in this PR.