### PR TITLE
chore(ci): revert recent changes to the regression workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     labels:
       - "domain: deps"
       - "no-changelog"
-      - "ci-condition: skip-regression"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
@@ -72,7 +71,6 @@ updates:
     labels:
       - "domain: releasing"
       - "no-changelog"
-      - "ci-condition: skip-regression"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
@@ -83,7 +81,6 @@ updates:
     labels:
       - "domain: ci"
       - "no-changelog"
-      - "ci-condition: skip-regression"
     commit-message:
       prefix: "chore(ci)"
     groups:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,9 +32,7 @@ on:
   # Don't want to run this on each PR commit, but because GH doesn't allow specifying different required checks
   # for pull request and merge queue, we need to "run" it in pull request, but in the jobs we will just auto pass.
   pull_request:
-  # Also, this workflow runs every Monday at 5:00 AM UTC.
-  schedule:
-    - cron: "0 5 * * 1"
+
 concurrency:
   # In flight runs will be canceled only by re-trigger through the merge queue or if additional PR commits are pushed.
   # The comment.html_url should always be unique.
@@ -47,96 +45,77 @@ env:
 
 jobs:
 
-  # Determine if the suite should run
-  check-should-run:
-    runs-on: ubuntu-latest
-    outputs:
-      should-run: ${{ steps.set-should-run.outputs.SHOULD_RUN }}
-    steps:
-      - name: Determine if should run
-        id: set-should-run
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" != "pull_request_review" &&
-                  "${{ !contains(github.event.pull_request.labels.*.name, 'ci-condition: skip-regression') }}" == "true" ]]; then
-            # The small caveat here is that we still want to run the suite via a review comment.
-            echo "SHOULD_RUN=false" >> $GITHUB_OUTPUT
-          else
-            echo "SHOULD_RUN=true" >> $GITHUB_OUTPUT
-          fi
-
   # Only run this workflow if files changed in areas that could possibly introduce a regression
-  check-source-changed:
+  should-run:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: check-should-run
-    if: ${{ needs.check-should-run.outputs.should-run == 'true' }}
+    if: github.event_name != 'pull_request'
     outputs:
       source_changed: ${{ steps.filter.outputs.SOURCE_CHANGED }}
+      comment_valid: ${{ steps.comment.outputs.isTeamMember }}
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Collect file changes
-      id: changes
-      if: github.event_name == 'merge_group'
-      uses: dorny/paths-filter@v3
-      with:
-        base: ${{ github.event.merge_group.base_ref }}
-        ref: ${{ github.event.merge_group.head_ref }}
-        list-files: shell
-        filters: |
-          all_changed:
-            - added|deleted|modified: "**"
-          ignore:
-            - "./.github/!(regression.yml)"
-            - "./.gitignore"
-            - "distribution/**"
-            - "rust-doc/**"
-            - "docs/**"
-            - "rfcs/**"
-            - "testing/**"
-            - "tilt/**"
-            - "website/**"
-            - "*.md"
-            - "Tiltfile"
-            - "netlify.toml"
-            - "NOTICE"
-            - "LICENSE-3rdparty.csv"
-            - "LICENSE"
-            - "lib/codecs/tests/data/**"
+      - name: Collect file changes
+        id: changes
+        if: github.event_name == 'merge_group'
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ github.event.merge_group.base_ref }}
+          ref: ${{ github.event.merge_group.head_ref }}
+          list-files: shell
+          filters: |
+            all_changed:
+              - added|deleted|modified: "**"
+            ignore:
+              - "./.github/!(regression.yml)"
+              - "./.gitignore"
+              - "distribution/**"
+              - "rust-doc/**"
+              - "docs/**"
+              - "rfcs/**"
+              - "testing/**"
+              - "tilt/**"
+              - "website/**"
+              - "*.md"
+              - "Tiltfile"
+              - "netlify.toml"
+              - "NOTICE"
+              - "LICENSE-3rdparty.csv"
+              - "LICENSE"
+              - "lib/codecs/tests/data/**"
 
-    # This step allows us to conservatively run the tests if we added a new
-    # file or directory for source code, but forgot to add it to this workflow.
-    # Instead, we may unnecessarily run the test on new file or dir additions that
-    # wouldn't likely introduce regressions.
-    - name: Determine if should not run due to irrelevant file changes
-      id: filter
-      if: github.event_name == 'merge_group'
-      env:
-        ALL: ${{ steps.changes.outputs.all_changed_files }}
-        IGNORE: ${{ steps.changes.outputs.ignore_files }}
-      run: |
-        echo "ALL='${{ env.ALL }}'"
-        echo "IGNORE='${{ env.IGNORE }}'"
-        export SOURCE_CHANGED=$(comm -2 -3 <(printf "%s\n" "${{ env.ALL }}") <(printf "%s\n" "${{ env.IGNORE }}"))
-        echo "SOURCE_CHANGED='${SOURCE_CHANGED}'"
-
-        if [ "${SOURCE_CHANGED}" == "" ]; then
-          export SOURCE_CHANGED="false"
-        else
-          export SOURCE_CHANGED="true"
-        fi
-
-        echo "SOURCE_CHANGED='${SOURCE_CHANGED}'"
-        echo "SOURCE_CHANGED=${SOURCE_CHANGED}" >> $GITHUB_OUTPUT
+      # This step allows us to conservatively run the tests if we added a new
+      # file or directory for source code, but forgot to add it to this workflow.
+      # Instead, we may unnecessarily run the test on new file or dir additions that
+      # wouldn't likely introduce regressions.
+      - name: Determine if should not run due to irrelevant file changes
+        id: filter
+        if: github.event_name == 'merge_group'
+        env:
+          ALL: ${{ steps.changes.outputs.all_changed_files }}
+          IGNORE: ${{ steps.changes.outputs.ignore_files }}
+        run: |
+          echo "ALL='${{ env.ALL }}'"
+          echo "IGNORE='${{ env.IGNORE }}'"
+          export SOURCE_CHANGED=$(comm -2 -3 <(printf "%s\n" "${{ env.ALL }}") <(printf "%s\n" "${{ env.IGNORE }}"))
+          echo "SOURCE_CHANGED='${SOURCE_CHANGED}'"
+          
+          if [ "${SOURCE_CHANGED}" == "" ]; then
+            export SOURCE_CHANGED="false"
+          else
+            export SOURCE_CHANGED="true"
+          fi
+          
+          echo "SOURCE_CHANGED='${SOURCE_CHANGED}'"
+          echo "SOURCE_CHANGED=${SOURCE_CHANGED}" >> $GITHUB_OUTPUT
 
   compute-metadata:
     name: Compute metadata
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: check-source-changed
-    if: github.event_name != 'merge_group' || needs.check-source-changed.outputs.source_changed == 'true'
+    needs: should-run
+    if: github.event_name != 'merge_group' || needs.should-run.outputs.source_changed == 'true'
     outputs:
       pr-number: ${{ steps.pr-metadata-merge-queue.outputs.PR_NUMBER || steps.pr-metadata-comment.outputs.PR_NUMBER }}
       baseline-sha: ${{ steps.pr-metadata-merge-queue.outputs.BASELINE_SHA || steps.pr-metadata-comment.outputs.BASELINE_SHA }}
@@ -797,9 +776,8 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "### Workflow skipped" >> $GITHUB_STEP_SUMMARY
-          echo "This workflow doesn't run on PRs automatically." >> $GITHUB_STEP_SUMMARY
-          echo "This workflow doesn't run on PRs with the 'ci-condition: skip-regression' label." >> $GITHUB_STEP_SUMMARY
-          echo "To trigger a run, leave a review comment with \`/ci-run-regression\`" >> $GITHUB_STEP_SUMMARY
+          echo "This workflow doesn't run on PR's automatically." >> $GITHUB_STEP_SUMMARY
+          echo "To trigger a run, leave a comment with \`/ci-run-regression\`" >> $GITHUB_STEP_SUMMARY
 
       - name: exit
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -100,13 +100,13 @@ jobs:
           echo "IGNORE='${{ env.IGNORE }}'"
           export SOURCE_CHANGED=$(comm -2 -3 <(printf "%s\n" "${{ env.ALL }}") <(printf "%s\n" "${{ env.IGNORE }}"))
           echo "SOURCE_CHANGED='${SOURCE_CHANGED}'"
-          
+
           if [ "${SOURCE_CHANGED}" == "" ]; then
             export SOURCE_CHANGED="false"
           else
             export SOURCE_CHANGED="true"
           fi
-          
+
           echo "SOURCE_CHANGED='${SOURCE_CHANGED}'"
           echo "SOURCE_CHANGED=${SOURCE_CHANGED}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The previous idea to use a PR label is not feasible, see [comment](https://github.com/vectordotdev/vector/pull/21540#issuecomment-2420299282). 