### PR TITLE
fix(sources): fix unexpected timestamp field

### DIFF
--- a/changelog.d/20404-log-redundant-timestamp.fix.md
+++ b/changelog.d/20404-log-redundant-timestamp.fix.md
@@ -1,0 +1,4 @@
+`exec` and `http_server` sources no longer attach a redundant `timestamp` field
+when log namespacing is enabled.
+
+authors: rwakulszowa

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -260,8 +260,7 @@ impl SourceConfig for ExecConfig {
             .framing
             .clone()
             .unwrap_or_else(|| self.decoding.default_stream_framing());
-        let decoder =
-            DecodingConfig::new(framing, self.decoding.clone(), LogNamespace::Legacy).build()?;
+        let decoder = DecodingConfig::new(framing, self.decoding.clone(), log_namespace).build()?;
 
         match &self.mode {
             Mode::Scheduled => {

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -356,8 +356,11 @@ pub fn build_param_matcher(list: &[String]) -> crate::Result<Vec<HttpConfigParam
 #[typetag::serde(name = "http_server")]
 impl SourceConfig for SimpleHttpConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
-        let decoder = self.get_decoding_config()?.build()?;
         let log_namespace = cx.log_namespace(self.log_namespace);
+        let decoder = self
+            .get_decoding_config()?
+            .build()?
+            .with_log_namespace(log_namespace);
 
         let source = SimpleHttpSource {
             headers: build_param_matcher(&remove_duplicates(self.headers.clone(), "headers"))?,


### PR DESCRIPTION
When log namespacing is enabled, `exec` and `http_server` sources include a redundant `timestamp` field when decoding is enabled. When decoding is not enabled, they put the content under a _"message"_ key, instead of directly in the root object.

In the case of `exec`, the issue was caused by passing a hardcoded `LogNamespace` value to the decoder. Fixed by passing the parsed value.

In the case of `http_server`, the decoder ignored the global `LogNamespace`. Fixed by passing the correctly parsed value to the decoder.

Fixes #20404.

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
