### PR TITLE
fix(ci): Prevent workflow from triggering unless previous workflow succeeds

### DIFF
--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -39,3 +39,4 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
+      

--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -7,6 +7,15 @@ on:
       - completed
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo workflow run conclusion
+        run: |
+          echo "Workflow run conclusion: ${{ github.event.workflow_run.conclusion }}"
+          echo "Workflow run head branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "Workflow run head sha: ${{ github.event.workflow_run.head_sha }}"
+
   deploy_vector_preview_site:
     if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
     uses: ./.github/workflows/create_preview_sites.yml

--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -39,4 +39,3 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
-      

--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy_vector_preview_site:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/create_preview_sites.yml
     with:
       APP_ID: "d1a7j77663uxsc"
@@ -18,6 +19,7 @@ jobs:
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
 
   deploy_rust_doc_preview_site:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/create_preview_sites.yml
     with:
       APP_ID: "d1hoyoksbulg25"
@@ -28,6 +30,7 @@ jobs:
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
 
   deploy_vrl_playground_preview_site:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/create_preview_sites.yml
     with:
       APP_ID: "d2lr4eds605rpz"
@@ -36,4 +39,3 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
-

--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -7,15 +7,6 @@ on:
       - completed
 
 jobs:
-  debug:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo workflow run conclusion
-        run: |
-          echo "Workflow run conclusion: ${{ github.event.workflow_run.conclusion }}"
-          echo "Workflow run head branch: ${{ github.event.workflow_run.head_branch }}"
-          echo "Workflow run head sha: ${{ github.event.workflow_run.head_sha }}"
-
   deploy_vector_preview_site:
     if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
     uses: ./.github/workflows/create_preview_sites.yml

--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy_vector_preview_site:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
     uses: ./.github/workflows/create_preview_sites.yml
     with:
       APP_ID: "d1a7j77663uxsc"
@@ -19,7 +19,7 @@ jobs:
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
 
   deploy_rust_doc_preview_site:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
     uses: ./.github/workflows/create_preview_sites.yml
     with:
       APP_ID: "d1hoyoksbulg25"
@@ -30,7 +30,7 @@ jobs:
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
 
   deploy_vrl_playground_preview_site:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
     uses: ./.github/workflows/create_preview_sites.yml
     with:
       APP_ID: "d2lr4eds605rpz"

--- a/.github/workflows/preview_site_trigger.yml
+++ b/.github/workflows/preview_site_trigger.yml
@@ -2,7 +2,7 @@ name: Call Build Preview
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   approval_check:


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
- Adds conditional to the deploy jobs to only run if the trigger workflow has a status of `success`

Context:
https://github.com/orgs/community/discussions/26238
https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run
