### PR TITLE
chore(ci): regression detection v2 followups

### DIFF
--- a/.github/workflows/regression_v2.yml
+++ b/.github/workflows/regression_v2.yml
@@ -116,7 +116,7 @@ jobs:
     outputs:
       source_changed: ${{ steps.filter.outputs.SOURCE_CHANGED }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Collect file changes
         id: changes
@@ -192,9 +192,9 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-inputs.outputs.baseline-sha }}
           path: baseline-vector
@@ -231,9 +231,9 @@ jobs:
     steps:
       - uses: colpal/actions-clean@v1
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-inputs.outputs.comparison-sha }}
           path: comparison-vector
@@ -386,7 +386,7 @@ jobs:
             -f context='Regression Detection Suite / submission' \
             -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-inputs.outputs.comparison-sha }}
 
@@ -501,7 +501,7 @@ jobs:
       - should-run-gate
       - resolve-inputs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
@@ -592,7 +592,7 @@ jobs:
             -f context='Regression Detection Suite / analyze-experiment' \
             -f target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-inputs.outputs.comparison-sha }}
 

--- a/.github/workflows/regression_v2.yml
+++ b/.github/workflows/regression_v2.yml
@@ -175,6 +175,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-source-changed
     if: ${{ needs.check-source-changed.outputs.source_changed }}
+    steps:
+      - name: Gate check passed
+        run: echo "Source code changes detected, proceeding with regression tests"
 
   ##
   ## BUILD

--- a/.github/workflows/regression_v2.yml
+++ b/.github/workflows/regression_v2.yml
@@ -152,7 +152,6 @@ jobs:
       # wouldn't likely introduce regressions.
       - name: Determine if should not run due to irrelevant file changes
         id: filter
-        if: github.event_name == 'merge_group'
         env:
           ALL: ${{ steps.changes.outputs.all_changed_files }}
           IGNORE: ${{ steps.changes.outputs.ignore_files }}

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -1,7 +1,7 @@
 #
 # VECTOR BUILDER
 #
-FROM ghcr.io/vectordotdev/vector/soak-builder@sha256:c51a7091de2caebaa690e17f37dbfed4d4059dcdf5114a5596e8ca9b5ef494f3 as builder
+FROM ghcr.io/vectordotdev/vector/soak-builder@sha256:c51a7091de2caebaa690e17f37dbfed4d4059dcdf5114a5596e8ca9b5ef494f3 AS builder
 WORKDIR /vector
 COPY . .
 RUN bash scripts/environment/install-protoc.sh


### PR DESCRIPTION
* There is one real fix here, the `should-run-gate` job requires a step. 
* Tested here and the workflow runs properly: https://github.com/vectordotdev/vector/actions/runs/11482190851
  * the failure is due to a known issue
* Also fixed all deprecation warnings for this new workflow.