### PR TITLE
chore(ci): Group together patch updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
     groups:
+      patches:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+
       amq:
         patterns:
         - "amq-*"


### PR DESCRIPTION
Patch updates, per semvar, have a low risk of incompatibility and so I think they can all be grouped together. The changelogs should still be reviewed when merging, but this should reduce CI costs.

I was going to add `minor` here too, but for dependencies pre-1.0, minor updates can be breaking. There is a dependabot issue asking for this behavior to change: https://github.com/dependabot/dependabot-core/issues/9647. Also some discussion about this on: https://github.com/dependabot/dependabot-core/issues/7795

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
