### PR TITLE
docs(azure_blob sink): Clarify SAS connection_string support 

### DIFF
--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -42,11 +42,25 @@ impl TowerRequestConfigDefaults for AzureBlobTowerRequestConfigDefaults {
 pub struct AzureBlobSinkConfig {
     /// The Azure Blob Storage Account connection string.
     ///
-    /// Authentication with access key is the only supported authentication method.
+    /// Authentication with an access key or shared access signature (SAS)
+    /// are supported authentication methods. If using a non-account SAS,
+    /// healthchecks will fail and will need to be disabled by setting
+    /// `healthcheck.enabled` to `false` for this sink
+    ///
+    /// When generating an account SAS, the following are the minimum required option
+    /// settings for Vector to access blob storage and pass a health check.
+    /// | Option                 | Value              |
+    /// | ---------------------- | ------------------ |
+    /// | Allowed services       | Blob               |
+    /// | Allowed resource types | Container & Object |
+    /// | Allowed permissions    | Read & Create      |
     ///
     /// Either `storage_account`, or this field, must be specified.
     #[configurable(metadata(
         docs::examples = "DefaultEndpointsProtocol=https;AccountName=mylogstorage;AccountKey=storageaccountkeybase64encoded;EndpointSuffix=core.windows.net"
+    ))]
+    #[configurable(metadata(
+        docs::examples = "BlobEndpoint=https://mylogstorage.blob.core.windows.net/;SharedAccessSignature=generatedsastoken"
     ))]
     pub connection_string: Option<SensitiveString>,
 

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -149,12 +149,23 @@ base: components: sinks: azure_blob: configuration: {
 		description: """
 			The Azure Blob Storage Account connection string.
 
-			Authentication with access key is the only supported authentication method.
+			Authentication with an access key or shared access signature (SAS)
+			are supported authentication methods. If using a non-account SAS,
+			healthchecks will fail and will need to be disabled by setting
+			`healthcheck.enabled` to `false` for this sink
+
+			When generating an account SAS, the following are the minimum required option
+			settings for Vector to access blob storage and pass a health check.
+			| Option                 | Value              |
+			| ---------------------- | ------------------ |
+			| Allowed services       | Blob               |
+			| Allowed resource types | Container & Object |
+			| Allowed permissions    | Read & Create      |
 
 			Either `storage_account`, or this field, must be specified.
 			"""
 		required: false
-		type: string: examples: ["DefaultEndpointsProtocol=https;AccountName=mylogstorage;AccountKey=storageaccountkeybase64encoded;EndpointSuffix=core.windows.net"]
+		type: string: examples: ["DefaultEndpointsProtocol=https;AccountName=mylogstorage;AccountKey=storageaccountkeybase64encoded;EndpointSuffix=core.windows.net", "BlobEndpoint=https://mylogstorage.blob.core.windows.net/;SharedAccessSignature=generatedsastoken"]
 	}
 	container_name: {
 		description: "The Azure Blob Storage Account container name."


### PR DESCRIPTION
Update Azure blob storage sink connection_string documentation to show SAS is supported

Closes #15394

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
