### PR TITLE
fix(transforms): Fix matching boolean values for Datadog search s…

### DIFF
--- a/changelog.d/fix_matching_boolean_fields_in_datadog_search.fix.md
+++ b/changelog.d/fix_matching_boolean_fields_in_datadog_search.fix.md
@@ -1,0 +1,1 @@
+Fix bug in implementation of Datadog search syntax which causes queries based on attributes with boolean values to be ignored.

--- a/changelog.d/fix_matching_boolean_fields_in_datadog_search.fix.md
+++ b/changelog.d/fix_matching_boolean_fields_in_datadog_search.fix.md
@@ -1,1 +1,3 @@
 Fix bug in implementation of Datadog search syntax which causes queries based on attributes with boolean values to be ignored.
+
+authors: ArunPiduguDD

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -623,11 +623,7 @@ mod test {
                 log_event!["tags" => vec!["a:bla"]],
             ),
             // Boolean attribute match.
-            (
-                "@a:true",
-                log_event!["a" => true],
-                log_event!["a" => false],
-            ),
+            ("@a:true", log_event!["a" => true], log_event!["a" => false]),
             // Boolean attribute match (negate).
             (
                 "NOT @a:false",
@@ -1185,7 +1181,7 @@ mod test {
                 log_event!["field" => "value1"],
                 log_event!["field" => "value"],
             ),
-            // negate AND bool and string
+            // negate AND of bool and string
             (
                 "NOT (@field:true AND @field2:value2)",
                 log_event!["field" => false, "field2" => "value2"],

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -141,7 +141,7 @@ impl Filter<LogEvent> for EventFilter {
             Field::Attribute(field) => {
                 let to_match = to_match.to_owned();
 
-                bool_string_or_numeric_match(field, move |value| value == to_match)
+                simple_scalar_match(field, move |value| value == to_match)
             }
         })
     }
@@ -303,9 +303,9 @@ impl Filter<LogEvent> for EventFilter {
     }
 }
 
-/// Returns a `Matcher` that returns true if the log event resolves to a string or
-/// numeric which matches the provided `func`.
-fn bool_string_or_numeric_match<S, F>(field: S, func: F) -> Box<dyn Matcher<LogEvent>>
+/// Returns a `Matcher` that returns true if the field resolves to a string,
+/// numeric, or boolean which matches the provided `func`.
+fn simple_scalar_match<S, F>(field: S, func: F) -> Box<dyn Matcher<LogEvent>>
 where
     S: Into<String>,
     F: Fn(Cow<str>) -> bool + Send + Sync + Clone + 'static,
@@ -323,7 +323,7 @@ where
     })
 }
 
-/// Returns a `Matcher` that returns true if the log event resolves to a string which
+/// Returns a `Matcher` that returns true if the field resolves to a string which
 /// matches the provided `func`.
 fn string_match<S, F>(field: S, func: F) -> Box<dyn Matcher<LogEvent>>
 where


### PR DESCRIPTION
### Overview

There is a bug in the current implementation of Datadog search syntax which causes queries based on attributes with boolean values to be ignored. This is b/c we are only checking if the type of the attribute is a string or numeric (currently ignoring the boolean case).

Fixes this bug by checking if the attribute value is type boolean