### PR TITLE
fix(ci): deb-verify cannot use actions/checkout@v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build Vector
         run: make package-x86_64-unknown-linux-musl-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl
           path: target/artifacts/vector*
@@ -90,7 +90,7 @@ jobs:
       - name: Build Vector
         run: make package-x86_64-unknown-linux-gnu-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
           path: target/artifacts/vector*
@@ -118,7 +118,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-aarch64-unknown-linux-musl-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl
           path: target/artifacts/vector*
@@ -146,7 +146,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-aarch64-unknown-linux-gnu-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu
           path: target/artifacts/vector*
@@ -174,7 +174,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-armv7-unknown-linux-gnueabihf-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-gnueabihf
           path: target/artifacts/vector*
@@ -202,7 +202,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-armv7-unknown-linux-musleabihf
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-musleabihf
           path: target/artifacts/vector*
@@ -230,7 +230,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-arm-unknown-linux-gnueabi-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-gnueabi
           path: target/artifacts/vector*
@@ -257,7 +257,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-arm-unknown-linux-musleabi
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
           path: target/artifacts/vector*
@@ -286,7 +286,7 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           make package
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin
           path: target/artifacts/vector*
@@ -333,7 +333,7 @@ jobs:
           export PATH="/c/wix:$PATH"
           ./scripts/package-msi.sh
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-pc-windows-msvc
           path: target/artifacts/vector*
@@ -348,9 +348,13 @@ jobs:
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       DD_PKG_VERSION: "latest"
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     strategy:
       matrix:
         container:
+          - ubuntu:16.04
           - ubuntu:18.04
           - ubuntu:20.04
           - ubuntu:22.04
@@ -374,16 +378,18 @@ jobs:
           curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
+      - name: Checkout Vector
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git_ref }}
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
           path: target/artifacts
       - name: Verify install of DEB package.
         run: |
-          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/${{ inputs.git_ref }}/scripts/verify-install.sh
-          chmod +x ./verify-install.sh
-          ./verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
+          ./scripts/verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
 
   rpm-verify:
     name: Verify RPM Packages
@@ -395,6 +401,9 @@ jobs:
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       DD_PKG_VERSION: "latest"
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     strategy:
       matrix:
         container:
@@ -424,16 +433,18 @@ jobs:
           curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
+      - name: Checkout Vector
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git_ref }}
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
           path: target/artifacts
       - name: Verify install of RPM package.
         run: |
-          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/${{ inputs.git_ref }}/scripts/verify-install.sh
-          chmod +x ./verify-install.sh
-          ./verify-install.sh target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          ./scripts/verify-install.sh target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
 
   macos-verify:
     name: Verify macOS Package
@@ -815,7 +826,7 @@ jobs:
       - name: Generate SHA256 checksums for artifacts
         run: make sha256sum
       - name: Stage checksum for publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: vector-${{ env.VECTOR_VERSION }}-SHA256SUMS
           path: target/artifacts/vector-${{ env.VECTOR_VERSION }}-SHA256SUMS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -374,10 +374,6 @@ jobs:
           curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
-      - name: Checkout Vector
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.git_ref }}
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:
@@ -385,7 +381,9 @@ jobs:
           path: target/artifacts
       - name: Verify install of DEB package.
         run: |
-          ./scripts/verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
+          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/master/scripts/verify-install.sh
+          chmod +x verify-install.sh
+          verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
 
   rpm-verify:
     name: Verify RPM Packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Build Vector
         run: make package-x86_64-unknown-linux-musl-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-musl
           path: target/artifacts/vector*
@@ -90,7 +90,7 @@ jobs:
       - name: Build Vector
         run: make package-x86_64-unknown-linux-gnu-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
           path: target/artifacts/vector*
@@ -118,7 +118,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-aarch64-unknown-linux-musl-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-musl
           path: target/artifacts/vector*
@@ -146,7 +146,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-aarch64-unknown-linux-gnu-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-aarch64-unknown-linux-gnu
           path: target/artifacts/vector*
@@ -174,7 +174,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-armv7-unknown-linux-gnueabihf-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-gnueabihf
           path: target/artifacts/vector*
@@ -202,7 +202,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-armv7-unknown-linux-musleabihf
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-armv7-unknown-linux-musleabihf
           path: target/artifacts/vector*
@@ -230,7 +230,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-arm-unknown-linux-gnueabi-all
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-gnueabi
           path: target/artifacts/vector*
@@ -257,7 +257,7 @@ jobs:
           DOCKER_PRIVILEGED: "true"
         run: make package-arm-unknown-linux-musleabi
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
           path: target/artifacts/vector*
@@ -286,7 +286,7 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           make package
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-apple-darwin
           path: target/artifacts/vector*
@@ -333,7 +333,7 @@ jobs:
           export PATH="/c/wix:$PATH"
           ./scripts/package-msi.sh
       - name: Stage package artifacts for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-x86_64-pc-windows-msvc
           path: target/artifacts/vector*
@@ -826,7 +826,7 @@ jobs:
       - name: Generate SHA256 checksums for artifacts
         run: make sha256sum
       - name: Stage checksum for publish
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vector-${{ env.VECTOR_VERSION }}-SHA256SUMS
           path: target/artifacts/vector-${{ env.VECTOR_VERSION }}-SHA256SUMS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -381,7 +381,7 @@ jobs:
           path: target/artifacts
       - name: Verify install of DEB package.
         run: |
-          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/master/scripts/verify-install.sh
+          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/${{ inputs.git_ref }}/scripts/verify-install.sh
           chmod +x ./verify-install.sh
           ./verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
 
@@ -431,7 +431,7 @@ jobs:
           path: target/artifacts
       - name: Verify install of RPM package.
         run: |
-          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/master/scripts/verify-install.sh
+          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/${{ inputs.git_ref }}/scripts/verify-install.sh
           chmod +x ./verify-install.sh
           ./verify-install.sh target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -382,8 +382,8 @@ jobs:
       - name: Verify install of DEB package.
         run: |
           curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/master/scripts/verify-install.sh
-          chmod +x verify-install.sh
-          verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
+          chmod +x ./verify-install.sh
+          ./verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
 
   rpm-verify:
     name: Verify RPM Packages
@@ -424,10 +424,6 @@ jobs:
           curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
-      - name: Checkout Vector
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.git_ref }}
       - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
         uses: actions/download-artifact@v3
         with:
@@ -435,7 +431,9 @@ jobs:
           path: target/artifacts
       - name: Verify install of RPM package.
         run: |
-          ./scripts/verify-install.sh target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          curl -o verify-install.sh https://raw.githubusercontent.com/vectordotdev/vector/master/scripts/verify-install.sh
+          chmod +x ./verify-install.sh
+          ./verify-install.sh target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
 
   macos-verify:
     name: Verify macOS Package

--- a/changelog.d/21639_ubuntu-16.breaking.md
+++ b/changelog.d/21639_ubuntu-16.breaking.md
@@ -1,6 +1,0 @@
-With this release, Vector has dropped official support for Ubuntu 16.04 because it forces GitHub Actions to depend on an
-unsecure Node version.
-See details [here](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/).
-However, it is likely that Vector will continue to run on Ubuntu 16.04.
-
-authors: pront


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
The Nightly workflow is broken because Ubuntu 18.04 is on an older glibc version.

```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
``` 

In this PR, I am reverting the changes to `deb-verify` and `rpm-verify`. There are a number of ways we can fix this going forward, but it's not time critical to do these updates.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Manually ran the workflow (TODO add link here).

## Checklist
- [x] Please add a changelog entry if your PR includes user facing changes. Otherwise, apply the "no-changelog" label to this PR. You can find details on [this document](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).

## References

https://github.com/vectordotdev/vector/pull/21639