### PR TITLE
docs(vrl): Update docs for new AES-SIV encryption/decryption types available in latest VRL.

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -985,6 +985,7 @@ sigterm
 singlethreaded
 sinkbuilder
 sinknetworkbytessent
+SIV
 sizecache
 Sizefor
 skinparam

--- a/website/cue/reference/remap/functions/decrypt.cue
+++ b/website/cue/reference/remap/functions/decrypt.cue
@@ -13,6 +13,8 @@ remap: functions: decrypt: {
 		* AES-256-OFB (key = 32 bytes, iv = 16 bytes)
 		* AES-192-OFB  (key = 24 bytes, iv = 16 bytes)
 		* AES-128-OFB (key = 16 bytes, iv = 16 bytes)
+		* AES-128-SIV (key = 32 bytes, iv = 16 bytes)
+		* AES-256-SIV (key = 64 bytes, iv = 16 bytes)
 		* Deprecated - AES-256-CTR (key = 32 bytes, iv = 16 bytes)
 		* Deprecated - AES-192-CTR (key = 24 bytes, iv = 16 bytes)
 		* Deprecated - AES-128-CTR (key = 16 bytes, iv = 16 bytes)

--- a/website/cue/reference/remap/functions/encrypt.cue
+++ b/website/cue/reference/remap/functions/encrypt.cue
@@ -13,6 +13,8 @@ remap: functions: encrypt: {
 		* AES-256-OFB (key = 32 bytes, iv = 16 bytes)
 		* AES-192-OFB  (key = 24 bytes, iv = 16 bytes)
 		* AES-128-OFB (key = 16 bytes, iv = 16 bytes)
+		* AES-128-SIV (key = 32 bytes, iv = 16 bytes)
+		* AES-256-SIV (key = 64 bytes, iv = 16 bytes)
 		* Deprecated - AES-256-CTR (key = 32 bytes, iv = 16 bytes)
 		* Deprecated - AES-192-CTR (key = 24 bytes, iv = 16 bytes)
 		* Deprecated - AES-128-CTR (key = 16 bytes, iv = 16 bytes)


### PR DESCRIPTION
## Summary
Update docs for new AES-SIV encryption/decryption types available in latest VRL.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Not tested.

## Checklist
- [ ] Please add a changelog entry if your PR includes user facing changes. Otherwise, apply the "no-changelog" label to this PR. You can find details on [this document](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).

## References
https://github.com/vectordotdev/vrl/pull/1101
