### PR TITLE
chore(config): log component graph when there's an error 

### DIFF
--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -40,7 +40,9 @@ pub enum DataType {
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list()
-            .entries(Self::flags().filter_map(|&(name, value)| self.contains(value).then(|| name)))
+            .entries(
+                Self::flags().filter_map(|&(name, value)| self.contains(value).then_some(name)),
+            )
             .finish()
     }
 }
@@ -199,7 +201,7 @@ fn fmt_helper(
         Some(port) => write!(f, "port: \"{port}\",",),
         None => write!(f, "port: None,"),
     }?;
-    write!(f, " types: {}", data_type)
+    write!(f, " types: {data_type}")
 }
 
 impl fmt::Display for SourceOutput {

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -40,9 +40,7 @@ pub enum DataType {
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list()
-            .entries(Self::flags().filter_map(|&(name, value)| {
-                self.contains(value).then(|| name)
-            }))
+            .entries(Self::flags().filter_map(|&(name, value)| self.contains(value).then(|| name)))
             .finish()
     }
 }
@@ -192,9 +190,13 @@ impl SourceOutput {
     }
 }
 
-fn fmt_helper(f: &mut fmt::Formatter<'_>, maybe_port: Option<&String>, data_type: DataType) -> fmt::Result {
+fn fmt_helper(
+    f: &mut fmt::Formatter<'_>,
+    maybe_port: Option<&String>,
+    data_type: DataType,
+) -> fmt::Result {
     match maybe_port {
-        Some(port) => write!(f, "port: \"{port}\",", ),
+        Some(port) => write!(f, "port: \"{port}\",",),
         None => write!(f, "port: None,"),
     }?;
     write!(f, " types: {}", data_type)

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -30,6 +30,7 @@ pub const MEMORY_BUFFER_DEFAULT_MAX_EVENTS: NonZeroUsize =
 // This enum should be kept alphabetically sorted as the bitmask value is used when
 // sorting sources by data type in the GraphQL API.
 #[bitmask(u8)]
+#[bitmask_config(flags_iter)]
 pub enum DataType {
     Log,
     Metric,
@@ -38,11 +39,11 @@ pub enum DataType {
 
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut t = Vec::new();
-        self.contains(DataType::Log).then(|| t.push("Log"));
-        self.contains(DataType::Metric).then(|| t.push("Metric"));
-        self.contains(DataType::Trace).then(|| t.push("Trace"));
-        f.write_str(&t.join(","))
+        f.debug_list()
+            .entries(Self::flags().filter_map(|&(name, value)| {
+                self.contains(value).then(|| name)
+            }))
+            .finish()
     }
 }
 
@@ -191,6 +192,20 @@ impl SourceOutput {
     }
 }
 
+fn fmt_helper(f: &mut fmt::Formatter<'_>, maybe_port: Option<&String>, data_type: DataType) -> fmt::Result {
+    match maybe_port {
+        Some(port) => write!(f, "port: \"{port}\",", ),
+        None => write!(f, "port: None,"),
+    }?;
+    write!(f, " types: {}", data_type)
+}
+
+impl fmt::Display for SourceOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_helper(f, self.port.as_ref(), self.ty)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TransformOutput {
     pub port: Option<String>,
@@ -201,6 +216,12 @@ pub struct TransformOutput {
     /// has multiple connected sources, it is possible to have multiple output
     /// definitions - one for each input.
     pub log_schema_definitions: HashMap<OutputId, schema::Definition>,
+}
+
+impl fmt::Display for TransformOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_helper(f, self.port.as_ref(), self.ty)
+    }
 }
 
 impl TransformOutput {

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -1,10 +1,10 @@
-use indexmap::{set::IndexSet, IndexMap};
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt;
 use super::{
     schema, ComponentKey, DataType, OutputId, SinkOuter, SourceOuter, SourceOutput, TransformOuter,
     TransformOutput,
 };
+use indexmap::{set::IndexSet, IndexMap};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum Node {
@@ -31,7 +31,10 @@ impl fmt::Display for Node {
                 Ok(())
             }
             Node::Transform { in_ty, outputs } => {
-                write!(f, "component_kind: source\n  input_types: {in_ty}\n  outputs:")?;
+                write!(
+                    f,
+                    "component_kind: source\n  input_types: {in_ty}\n  outputs:"
+                )?;
                 for output in outputs {
                     write!(f, "\n    {}", output)?;
                 }
@@ -163,14 +166,16 @@ impl Graph {
                 Some(Node::Sink { .. }) => "sink",
                 _ => panic!("only transforms and sinks have inputs"),
             };
-            info!("Available components:\n{}",  self.nodes
+            info!(
+                "Available components:\n{}",
+                self.nodes
                     .iter()
                     .map(|(key, node)| format!("\"{}\":\n  {}", key, node))
                     .collect::<Vec<_>>()
-                    .join("\n"));
+                    .join("\n")
+            );
             Err(format!(
                 "Input \"{from}\" for {output_type} \"{to}\" doesn't match any components.",
-
             ))
         }
     }

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -544,7 +544,7 @@ mod test {
 
         assert_eq!(
             Err(vec![
-                "Data type mismatch between in (Log) and out (Metric)".into()
+                "Data type mismatch between in ([\"Log\"]) and out ([\"Metric\"])".into()
             ]),
             graph.typecheck()
         );


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
When I was doing some local experiments, I realized the error message doesn't have much information attached. I think this extra log will be helpful for other folks when developing.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

Wrong config:
```
data_dir: /some/path
sources:
  source0:
    count: 10
    format: json
    interval: 1.0
    type: demo_logs
    decoding:
      codec: bytes
    framing:
      method: bytes
transforms:
  transform0:
    inputs:
      - source0
    reroute_unmatched: true
    type: route
    route:
      a:
        source: '!exists(.foo)'
        type: vrl
      b:
        source: exists(.foo)
        type: vrl
sinks:
  sink0:
    inputs:
      - transform0.a
    target: stdout
    type: console
    encoding:
      codec: json
      json:
        pretty: true
    buffer:
      type: memory
      max_events: 500
      when_full: block

  sink1:
    inputs:
      - transform0
    target: stdout
    type: console
    encoding:
      codec: json
      json:
        pretty: true
    buffer:
      type: memory
      max_events: 500
      when_full: block

  sink2:
    inputs:
      - transform0._unmatched
    target: stdout
    type: console
    encoding:
      codec: json
      json:
        pretty: true
    buffer:
      type: memory
      max_events: 500
      when_full: block
```

Output:
```
2024-10-31T18:34:51.976834Z  INFO vector::config::graph: Available components:
"sink0":
  component_kind: sink
  types: ["Log", "Metric", "Trace"]
"sink2":
  component_kind: sink
  types: ["Log", "Metric", "Trace"]
"transform0":
  component_kind: source
  input_types: ["Log", "Metric", "Trace"]
  outputs:
    port: "a", types: ["Log", "Metric", "Trace"]
    port: "b", types: ["Log", "Metric", "Trace"]
    port: "_unmatched", types: ["Log", "Metric", "Trace"]
"source0":
  component_kind: source
  outputs:
    port: None, types: ["Log"]
"sink1":
  component_kind: sink
  types: ["Log", "Metric", "Trace"]
2024-10-31T18:34:51.977193Z ERROR vector::cli: Configuration error. error=Input "transform0" for sink "sink1" doesn't match any components.
```
## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
