### PR TITLE
fix(tests): make the `TELEMETRY` singleton thread local for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10843,6 +10843,7 @@ dependencies = [
  "base64 0.22.1",
  "bitmask-enum",
  "bytes 1.8.0",
+ "cfg-if",
  "chrono",
  "chrono-tz",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ members = [
 ]
 
 [workspace.dependencies]
+cfg-if = { version = "1.0.0", default-features = false }
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "serde"] }
 chrono-tz = { version = "0.10.0", default-features = false, features = ["serde"] }
 clap = { version = "4.5.20", default-features = false, features = ["derive", "error-context", "env", "help", "std", "string", "usage", "wrap_help"] }

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -70,6 +70,7 @@ vector-config = { path = "../vector-config" }
 vector-config-common = { path = "../vector-config-common" }
 vector-config-macros = { path = "../vector-config-macros" }
 vrl.workspace = true
+cfg-if.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2.10.0"

--- a/lib/vector-core/src/config/telemetry.rs
+++ b/lib/vector-core/src/config/telemetry.rs
@@ -17,6 +17,7 @@ cfg_if! {
         /// # Panics
         ///
         /// If deny is set, will panic if telemetry has already been set.
+        /// Also, panics if the lock is poisoned.
         pub fn init_telemetry(telemetry: Telemetry, deny_if_set: bool) {
             TELEMETRY.with(|tl| {
                 let mut tl = tl.lock().expect("telemetry lock poisoned");
@@ -25,6 +26,11 @@ cfg_if! {
             });
         }
 
+        /// Test implementation.
+        ///
+        /// # Panics
+        ///
+        /// If the lock is poisoned.
          pub fn telemetry() -> Telemetry {
             TELEMETRY.with(|tl| {
                let mut tl = tl.lock().expect("telemetry lock poisoned");

--- a/lib/vector-core/src/config/telemetry.rs
+++ b/lib/vector-core/src/config/telemetry.rs
@@ -1,32 +1,71 @@
-use std::sync::{LazyLock, OnceLock};
-
+use cfg_if::cfg_if;
 use vector_common::request_metadata::GroupedCountByteSize;
 use vector_config::configurable_component;
 
-static TELEMETRY: OnceLock<Telemetry> = OnceLock::new();
-static TELEMETRY_DEFAULT: LazyLock<Telemetry> = LazyLock::new(Telemetry::default);
+cfg_if! {
+    // The telemetry code assumes a process wide singleton. When running `cargo test`,
+    // multiple threads might try to read/write this global.
+    if #[cfg(any(test, feature = "test"))] {
+        use std::sync::{Arc, Mutex};
 
-/// Loads the telemetry options from configurations and sets the global options.
-/// Once this is done, configurations can be correctly loaded using configured
-/// log schema defaults.
-///
-/// # Errors
-///
-/// This function will fail if the `builder` fails.
-///
-/// # Panics
-///
-/// If deny is set, will panic if telemetry has already been set.
-pub fn init_telemetry(telemetry: Telemetry, deny_if_set: bool) {
-    assert!(
-        !(TELEMETRY.set(telemetry).is_err() && deny_if_set),
-        "Couldn't set telemetry"
-    );
-}
+        thread_local! {
+            static TELEMETRY: Arc<Mutex<Option<Telemetry>>> = Arc::new(Mutex::new(None));
+        }
 
-/// Returns the telemetry configuration options.
-pub fn telemetry() -> &'static Telemetry {
-    TELEMETRY.get().unwrap_or(&TELEMETRY_DEFAULT)
+        /// Test implementation.
+        ///
+        /// # Panics
+        ///
+        /// If deny is set, will panic if telemetry has already been set.
+        pub fn init_telemetry(telemetry: Telemetry, deny_if_set: bool) {
+            TELEMETRY.with(|tl| {
+                let mut tl = tl.lock().expect("telemetry lock poisoned");
+                assert!(!(tl.is_some() && deny_if_set), "Couldn't set telemetry");
+                *tl = Some(telemetry);
+            });
+        }
+
+         pub fn telemetry() -> Telemetry {
+            TELEMETRY.with(|tl| {
+               let mut tl = tl.lock().expect("telemetry lock poisoned");
+                // For non-test code we return `TELEMETRY_DEFAULT`.
+                // For test code, we will instantiate a default instance per thread.
+                if tl.is_none() {
+                    *tl = Some(Telemetry::default());
+                }
+                tl.clone().unwrap()
+            })
+        }
+    }
+    else {
+        use std::sync::{LazyLock, OnceLock};
+
+        static TELEMETRY: OnceLock<Telemetry> = OnceLock::new();
+        static TELEMETRY_DEFAULT: LazyLock<Telemetry> = LazyLock::new(Telemetry::default);
+
+        /// Loads the telemetry options from configurations and sets the global options.
+        /// Once this is done, configurations can be correctly loaded using configured
+        /// log schema defaults.
+        ///
+        /// # Errors
+        ///
+        /// This function will fail if the `builder` fails.
+        ///
+        /// # Panics
+        ///
+        /// If deny is set, will panic if telemetry has already been set.
+        pub fn init_telemetry(telemetry: Telemetry, deny_if_set: bool) {
+            assert!(
+                !(TELEMETRY.set(telemetry).is_err() && deny_if_set),
+                "Couldn't set telemetry"
+            );
+        }
+
+        /// Returns the telemetry configuration options.
+        pub fn telemetry() -> &'static Telemetry {
+            TELEMETRY.get().unwrap_or(&TELEMETRY_DEFAULT)
+        }
+    }
 }
 
 /// Sets options for the telemetry that Vector emits.


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
Fixes race condition in tests which require access to the global telemetry state.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
* `cargo test`
* `cargo vdev test`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).

## References

<!-- Please list any issues closed by this PR. -->

closes: https://github.com/vectordotdev/vector/issues/21488