### PR TITLE
feat(file sink): supports input based on encoding type

### DIFF
--- a/changelog.d/21704_file_sink_supports_encoding_input.feature.md
+++ b/changelog.d/21704_file_sink_supports_encoding_input.feature.md
@@ -1,0 +1,3 @@
+The file sink now supports any input event type that the configured encoding supports. It previously only supported log events.
+
+authors: nionata

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -454,7 +454,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::{log_schema, DataType},
+        config::log_schema,
         test_util::{
             components::{assert_sink_compliance, FILE_SINK_TAGS},
             lines_from_file, lines_from_gzip_file, lines_from_zstd_file, random_events_with_stream,
@@ -768,39 +768,6 @@ mod tests {
 
             let metric_name = input.as_metric().name();
             assert!(output.contains(metric_name));
-        }
-    }
-
-    // The TestSerializer only supports Log and Metric data types. This test asserts the current state of running the vector file sink with an event stream.
-    // A file partition is created and empty lines are written in the file. Running a real vector instance would fail on the configuration because
-    // it would perform an input validation against the output type.
-    #[tokio::test]
-    async fn trace_single_partition_not_supported() {
-        let template = temp_file();
-
-        let config = FileSinkConfig {
-            path: template.clone().try_into().unwrap(),
-            idle_timeout: default_idle_timeout(),
-            encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),
-            compression: Compression::None,
-            acknowledgements: Default::default(),
-            timezone: Default::default(),
-            internal_metrics: FileInternalMetricsConfig {
-                include_file_tag: true,
-            },
-        };
-        assert!((config.input().data_type() & DataType::Trace).is_none());
-
-        let (input, _events) = random_lines_with_stream(100, 64, None);
-
-        run_assert_trace_sink(&config, input.clone()).await;
-
-        let output = lines_from_file(template);
-        assert_eq!(input.len(), output.len());
-
-        for (input, output) in input.into_iter().zip(output) {
-            assert_ne!(input, output);
-            assert_eq!("", output);
         }
     }
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -753,7 +753,7 @@ mod tests {
         let output = (0..metric_count).map(|index| {
             let expected_timestamp = timestamp + (timestamp_offset * index as u32);
             let expected_filename =
-                directory.join(&format!("{}.log", expected_timestamp.format(format)));
+                directory.join(format!("{}.log", expected_timestamp.format(format)));
 
             lines_from_file(expected_filename)
         });
@@ -819,7 +819,7 @@ mod tests {
 
     async fn run_assert_sink(config: &FileSinkConfig, events: impl Iterator<Item = Event> + Send) {
         assert_sink_compliance(&FILE_SINK_TAGS, async move {
-            let sink = FileSink::new(&config, SinkContext::default()).unwrap();
+            let sink = FileSink::new(config, SinkContext::default()).unwrap();
             VectorSink::from_event_streamsink(sink)
                 .run(Box::pin(stream::iter(events.map(Into::into))))
                 .await


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The file sink only supports [log event](https://github.com/vectordotdev/vector/blob/911156972f8d01ed030e5e4acc3eeebbfa396b80/src/sinks/file/mod.rs#L197) input. This PR changes it to support any input that the configured encoding supports.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

### Cargo test

I added single and multi-partition tests to the file sink tests module. I added a `log_` prefix to all the existing tests to disambiguate between the new `metric_` tests. I did not add a compression or reopening test for metrics input as it should be handled by the log tests.

The full test suite passes

```bash
nix develop nixpkgs-unstable#vector
cargo test 
....
test result: ok. 1623 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 23.77s

     Running tests/e2e/mod.rs (target/debug/deps/e2e-eab25220265d1d1d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration/lib.rs (target/debug/deps/integration-1d73c0d5e2cc11c9)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests vector

running 2 tests
test src/expiring_hash_map.rs - expiring_hash_map::ExpiringHashMap<K,V>::next_expired (line 141) ... ignored
test src/expiring_hash_map.rs - expiring_hash_map::ExpiringHashMap<K,V>::next_expired (line 158) ... ok

test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 27.60s

```

### Manual

#### Before

```bash
podman run -p 1337:1337/udp -i -v $(pwd)/vector-influx-socket-file.yaml:/etc/vector/vector.yaml --rm docker.io/timberio/vector:0.42.0-debian
2024-11-04T21:05:14.216066Z  INFO vector::app: Log level is enabled. level="info"
2024-11-04T21:05:14.218669Z  INFO vector::app: Loading configs. paths=["/etc/vector/vector.yaml"]
2024-11-04T21:05:14.220239Z ERROR vector::cli: Configuration error. error=Data type mismatch between in (Metric) and out (Log)
```

#### After

```bash
make environment CONTAINER_TOOL="podman"

mkdir /etc/vector && cat << EOF > /etc/vector/vector.yaml
sources:
  in:
    type: "socket"
    address: "0.0.0.0:1337"
    mode: "udp"
    decoding:
      codec: "influxdb"

sinks:
  out:
    inputs:
      - "in"
    type: "file"
    encoding:
      codec: "native_json"
    path: "/tmp/vector-%Y-%m-%d.log"
EOF

cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/vector`
2024-11-07T19:00:10.170285Z  INFO vector::app: Log level is enabled. level="info"
2024-11-07T19:00:10.172461Z  INFO vector::app: Loading configs. paths=["/etc/vector/vector.yaml"]
2024-11-07T19:00:10.182373Z  INFO vector::topology::running: Running healthchecks.
2024-11-07T19:00:10.182732Z  INFO vector::topology::builder: Healthcheck passed.
2024-11-07T19:00:10.182739Z  INFO vector: Vector has started. debug="true" version="0.43.0" arch="x86_64" revision=""
2024-11-07T19:00:10.182800Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
2024-11-07T19:00:10.183073Z  INFO source{component_kind="source" component_id=in component_type=socket}: vector::sources::socket::udp: Listening. address=0.0.0.0:1337

echo -n "measurement,tag1=value1,tag2=value2 field1=123,field2=1.23 1630424257000000000" | nc -4u -w0 0.0.0.0 1337

cat /tmp/vector-2021-08-31.log 
{"metric":{"name":"measurement_field1","tags":{"tag1":"value1","tag2":"value2"},"timestamp":"2021-08-31T15:37:37Z","kind":"absolute","gauge":{"value":123.0}}}
{"metric":{"name":"measurement_field2","tags":{"tag1":"value1","tag2":"value2"},"timestamp":"2021-08-31T15:37:37Z","kind":"absolute","gauge":{"value":1.23}}}
```

Validation still catches when the encoding type does not support the input type

```bash
cat /etc/vector/vector.yaml 
sources:
  in:
    type: "socket"
    address: "0.0.0.0:1337"
    mode: "udp"
    decoding:
      codec: "influxdb"

sinks:
  out:
    inputs:
      - "in"
    type: "file"
    encoding:
      codec: "avro"
      avro:
        schema: ""
    path: "/tmp/vector.log"
cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/vector`
2024-11-21T20:33:28.560862Z  INFO vector::app: Log level is enabled. level="info"
2024-11-21T20:33:28.563455Z  INFO vector::app: Loading configs. paths=["/etc/vector/vector.yaml"]
2024-11-21T20:33:28.571274Z ERROR vector::cli: Configuration error. error=Data type mismatch between in (["Metric"]) and out (["Log"])

```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

closes #21704 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
