### PR TITLE
docs(vrl): document punycode as an IDN function

### DIFF
--- a/website/cue/reference/remap/functions/decode_punycode.cue
+++ b/website/cue/reference/remap/functions/decode_punycode.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: decode_punycode: {
 	category:    "Codec"
 	description: """
-		Decodes a [punycode](\(urls.punycode)) encoded `value`, like an internationalized domain name ([IDN](\(urls.idn))).
+		Decodes a [punycode](\(urls.punycode)) encoded `value`, like an internationalized domain name ([IDN](\(urls.idn))). This function assumes that the value passed is meant to be used in IDN context and that it is either a domain name or a part of it.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/decode_punycode.cue
+++ b/website/cue/reference/remap/functions/decode_punycode.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: decode_punycode: {
 	category:    "Codec"
 	description: """
-		Decodes a [punycode](\(urls.punycode)) encoded `value`, like an internationalized domain name ([IDN](\(urls.idn))). This function assumes that the value passed is meant to be used in IDN context and that it is either a domain name or a part of it.
+		Decodes a [punycode](\(urls.punycode)) encoded `value`, such as an internationalized domain name ([IDN](\(urls.idn))). This function assumes that the value passed is meant to be used in IDN context and that it is either a domain name or a part of it.
 		"""
 
 	arguments: [

--- a/website/cue/reference/remap/functions/encode_punycode.cue
+++ b/website/cue/reference/remap/functions/encode_punycode.cue
@@ -3,7 +3,7 @@ package metadata
 remap: functions: encode_punycode: {
 	category:    "Codec"
 	description: """
-		Encodes a `value` to [punycode](\(urls.punycode)). Useful for internationalized domain names ([IDN](\(urls.idn))).
+		Encodes a `value` to [punycode](\(urls.punycode)). Useful for internationalized domain names ([IDN](\(urls.idn))). This function assumes that the value passed is meant to be used in IDN context and that it is either a domain name or a part of it.
 		"""
 
 	arguments: [


### PR DESCRIPTION
This adds a note to `encode_punycode` and `decode_punycode` to inform users that it is meant to be used in IDN context and that passed values are handled like domain names. This is important because punycode by default doesn't use `xn--` prefix, but it is added in IDN context.

Related: https://github.com/vectordotdev/vrl/pull/1104