### PR TITLE
enhancement(dnstap source): add EDE code 30 to known EDE codes

### DIFF
--- a/changelog.d/21743_add_ede_code_30.enhancement.md
+++ b/changelog.d/21743_add_ede_code_30.enhancement.md
@@ -1,0 +1,3 @@
+EDE code 30 (Invalid Query Type) (added in https://datatracker.ietf.org/doc/draft-ietf-dnsop-compact-denial-of-existence/04/) has been added to recognized EDE codes and has correct `purpose` attached to it.
+
+authors: esensar

--- a/lib/dnsmsg-parser/src/ede.rs
+++ b/lib/dnsmsg-parser/src/ede.rs
@@ -52,6 +52,7 @@ impl EDE {
             27 => Some("Unsupported NSEC3 Iterations Value"),
             28 => Some("Unable to conform to policy"),
             29 => Some("Synthesized"),
+            30 => Some("Invalid Query Type"),
             _ => None,
         }
     }


### PR DESCRIPTION
This adds EDE code 30 (Invalid Query Type), added in https://datatracker.ietf.org/doc/draft-ietf-dnsop-compact-denial-of-existence/04/ (which can also be seen in the EDE list -
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes) to the list of known ede codes, which generates the purpose string.