### PR TITLE
docs(config): Update wrapped_json.yaml example

### DIFF
--- a/config/examples/wrapped_json.yaml
+++ b/config/examples/wrapped_json.yaml
@@ -24,13 +24,13 @@ transforms:
     drop_on_error: false
     source: |
       message = del(.message)
-      . |= parse_json!(string!(message))
+      . |= object!(parse_json!(string!(message)))
 
       parent = del(.parent)
-      . |= parse_json!(string!(parent))
+      . |= object!(parse_json!(string!(parent)))
 
       child = del(.child)
-      . |= parse_json!(string!(child))
+      . |= object!(parse_json!(string!(child)))
 
 # Print the data to STDOUT for inspection
 # Docs: https://vector.dev/docs/reference/sinks/console


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Fix the wrapped json example to work with the latest Vector version (v0.42.0). I was going to add tests here, but `vector validate --no-environment` doesn't execute VRL and so wouldn't have failed. See https://github.com/vectordotdev/vector/issues/15037

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Ran `vector validate` locally.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes https://github.com/vectordotdev/vector/issues/21741

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
