### PR TITLE
docs(kafka source, kafka sink): include kafka source in `librdkafka` section

### DIFF
--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -79,7 +79,7 @@ components: _kafka: {
 		librdkafka: {
 			title: "librdkafka"
 			body:  """
-				The `kafka` sink uses [`librdkafka`](\(urls.librdkafka)) under the hood. This
+				The `kafka` source and sink use [`librdkafka`](\(urls.librdkafka)) under the hood. This
 				is a battle-tested, high performance, and reliable library that facilitates
 				communication with Kafka. As Vector produces static MUSL builds,
 				this dependency is packaged with Vector, meaning you do not need to install it.


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
In the docs for the kafka source, the section about  `librdkafka` [here](https://vector.dev/docs/reference/configuration/sources/kafka/#librdkafka) currently only mentions the sink. This includes the source in the description since we also use it there -- see `rdkafka` import in the source [here](https://github.com/vectordotdev/vector/blob/master/src/sources/kafka.rs#L1550-L1559).
 
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->
- ran `./website/scripts/cue.sh fmt` 
- `CI=true make check-docs` validated succesfully

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [n/a] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
