### PR TITLE
chore(deps): Upgrade cargo-deny to latest

### DIFF
--- a/aqua/aqua.yaml
+++ b/aqua/aqua.yaml
@@ -16,7 +16,7 @@ packages:
     registry: local
   - name: crates.io/cargo-nextest@0.9.47
     registry: local
-  - name: crates.io/cargo-deny@0.13.9
+  - name: crates.io/cargo-deny@0.16.1
     registry: local
   - name: crates.io/cargo-msrv@0.15.1
     registry: local

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,4 @@
 [licenses]
-unlicensed = "deny"
-default = "deny"
-copyleft = "deny"
 allow = [
   "0BSD",
   "Apache-2.0",
@@ -53,4 +50,12 @@ ignore = [
     # alert is received during a handshake, `complete_io` does not terminate.
     # Vulnerable version only used in dev-dependencies
     "RUSTSEC-2024-0336",
+
+    # unmaintained dependencies
+    "RUSTSEC-2021-0139", # ansi_term
+    "RUSTSEC-2024-0388", # derivative
+    "RUSTSEC-2024-0384", # instant`
+    "RUSTSEC-2020-0168", # mach
+    "RUSTSEC-2024-0370", # proc-macro-error
+    "RUSTSEC-2024-0320", # yaml-rust
 ]

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -15,7 +15,8 @@ if [[ "$(cargo-nextest --version)" != "cargo-nextest 0.9.72" ]] ; then
   rustup run stable cargo install cargo-nextest --version 0.9.72 --force --locked
 fi
 if ! cargo deny --version >& /dev/null ; then
-  rustup run stable cargo install cargo-deny --force --locked
+if [[ "$(cargo-deny --version)" != "cargo-deny 0.16.1" ]] ; then
+  rustup run stable cargo install cargo-deny --version 0.16.1 --force --locked
 fi
 if ! dd-rust-license-tool --help >& /dev/null ; then
   rustup run stable cargo install dd-rust-license-tool --version 1.0.2 --force --locked

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -14,7 +14,6 @@ fi
 if [[ "$(cargo-nextest --version)" != "cargo-nextest 0.9.72" ]] ; then
   rustup run stable cargo install cargo-nextest --version 0.9.72 --force --locked
 fi
-if ! cargo deny --version >& /dev/null ; then
 if [[ "$(cargo-deny --version)" != "cargo-deny 0.16.1" ]] ; then
   rustup run stable cargo install cargo-deny --version 0.16.1 --force --locked
 fi


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Upgrades cargo-deny to latest version, 0.16.1.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

`cargo vdev check deny`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
