### PR TITLE
feat(internal): Add VECTOR_HOSTNAME env variable

### DIFF
--- a/changelog.d/21789_add_vector_hostname_env_variable.enhancement.md
+++ b/changelog.d/21789_add_vector_hostname_env_variable.enhancement.md
@@ -1,0 +1,4 @@
+Add VECTOR_HOSTNAME env variable to override the hostname used in the Vector events and internal metrics.
+This is useful when Vector is running on system where the hostname is not meaningful, e.g., in a container (Kubernetes).
+
+authors: nabokihms

--- a/changelog.d/21789_add_vector_hostname_env_variable.enhancement.md
+++ b/changelog.d/21789_add_vector_hostname_env_variable.enhancement.md
@@ -1,4 +1,4 @@
 Add VECTOR_HOSTNAME env variable to override the hostname used in the Vector events and internal metrics.
-This is useful when Vector is running on system where the hostname is not meaningful, e.g., in a container (Kubernetes).
+This is useful when Vector is running on a system where the hostname is not meaningful, e.g., in a container (Kubernetes).
 
 authors: nabokihms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,9 +198,9 @@ pub mod built_info {
 
 /// Returns the host name of the current system.
 pub fn get_hostname() -> std::io::Result<String> {
-    let hn = option_env!("VECTOR_HOSTNAME").unwrap_or("");
-    Ok(if !hn.is_empty() {
-        hn.to_string()
+    let hostname = option_env!("VECTOR_HOSTNAME").unwrap_or("");
+    Ok(if !hostname.is_empty() {
+        hostname.to_string()
     } else {
         hostname::get()?.to_string_lossy().into()
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,12 @@ pub mod built_info {
 
 /// Returns the host name of the current system.
 pub fn get_hostname() -> std::io::Result<String> {
-    Ok(hostname::get()?.to_string_lossy().into())
+    let hn = option_env!("VECTOR_HOSTNAME").unwrap_or("");
+    Ok(if !hn.is_empty() {
+        hn.to_string()
+    } else {
+        hostname::get()?.to_string_lossy().into()
+    })
 }
 
 /// Spawn a task with the given name. The name is only used if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,12 +197,12 @@ pub mod built_info {
 }
 
 /// Returns the host name of the current system.
+/// The hostname can be overridden by setting the VECTOR_HOSTNAME environment variable.
 pub fn get_hostname() -> std::io::Result<String> {
-    let hostname = option_env!("VECTOR_HOSTNAME").unwrap_or("");
-    Ok(if !hostname.is_empty() {
+    Ok(if let Ok(hostname) = std::env::var("VECTOR_HOSTNAME") {
         hostname.to_string()
     } else {
-        hostname::get()?.to_string_lossy().into()
+        hostname::get()?.to_string_lossy().into_owned()
     })
 }
 

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -597,19 +597,18 @@ cli: {
 		}
 		VECTOR_HOSTNAME: {
 			description: """
-			  Overrides the hostname used in Vector's logs and metrics.
-			  This is useful when running Vector in a container or on other systems where the hostname is not meaningful.
+				Overrides the hostname used in Vector's logs and metrics.
+				This is useful when running Vector in a container or on other systems where the hostname is not meaningful.
 
-			  The example of how it can be used in Kubernetes pod template:
+				The example of how it can be used in Kubernetes pod template:
 
-			  ```yaml
-			  env:
-			  - name: VECTOR_HOSTNAME
-			    valueFrom:
-			      fieldRef:
-			        fieldPath: spec.nodeName
-			  ```
-			  """
+				```yaml
+				env:
+				- name: VECTOR_HOSTNAME
+					valueFrom:
+						fieldRef:
+							fieldPath: spec.nodeName
+				"""
 			type: string: default: null
 		}
 		VECTOR_LOG: {

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -595,6 +595,23 @@ cli: {
 				"""
 			type: string: default: null
 		}
+		VECTOR_HOSTNAME: {
+			description: """
+			  Overrides the hostname used in Vector's logs and metrics.
+			  This is useful when running Vector in a container or on other systems where the hostname is not meaningful.
+
+			  The example of how it can be used in Kubernetes pod template:
+
+			  ```yaml
+			  env:
+			  - name: VECTOR_HOSTNAME
+			    valueFrom:
+			      fieldRef:
+			        fieldPath: spec.nodeName
+			  ```
+			  """
+			type: string: default: null
+		}
 		VECTOR_LOG: {
 			description: "Vector's log level. Each log level includes messages from higher priority levels."
 			type: string: {


### PR DESCRIPTION

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
By default, Vector uses the hostname returned by the gethostname. However, in cases when Vector is running in containers, it is meaningless because hostname is always the name of the container, e.g., the name of a pod in Kubernetes cluster.

This commit adds the way to override a hostname by using the env variable. In Kubernetes it can be used like this to see the name of a node where the Vector process is running (which is more meaningful).

```
env:
- name: VECTOR_HOSTNAME
  valueFrom:
    fieldRef:
      fieldPath: spec.nodeName
```

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Tested manually in the kubernetes cluster.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Closes https://github.com/vectordotdev/vector/issues/20481
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
