### PR TITLE
docs(vrl): add example syntax for valid expressions.

### DIFF
--- a/website/cue/reference/remap/syntax/expressions.cue
+++ b/website/cue/reference/remap/syntax/expressions.cue
@@ -1,0 +1,20 @@
+package metadata
+
+remap: syntax: expressions: {
+	title: "Expressions"
+	description: """
+		VRL programs are made up of literal and dynamic expressions, described more in detail below.  Expressions can be sparated by newline, or by using a semicolon.
+		"""
+
+	examples: [
+		"""
+		# newline delimited expressions 
+		del(.user_info)
+		.timestamp = now()  
+		""",
+		"""
+		# semicolon delimited expressions
+		del(.user_info); .timestamp = now()
+		"""
+	]
+}

--- a/website/cue/reference/remap/syntax/expressions.cue
+++ b/website/cue/reference/remap/syntax/expressions.cue
@@ -8,15 +8,15 @@ remap: syntax: expressions: {
 
 	examples: [
 		"""
-		# newline delimited expressions
-		del(.user_info)
-		.timestamp = now()
-		.message = "hello world"
-		""",
+			# newline delimited expressions
+			del(.user_info)
+			.timestamp = now()
+			.message = "hello world"
+			""",
 		"""
-		# semicolon delimited expressions
-		del(.user_info); .timestamp = now()
-		.message = "hello world"
-		"""
+			# semicolon delimited expressions
+			del(.user_info); .timestamp = now()
+			.message = "hello world"
+			""",
 	]
 }

--- a/website/cue/reference/remap/syntax/expressions.cue
+++ b/website/cue/reference/remap/syntax/expressions.cue
@@ -3,7 +3,7 @@ package metadata
 remap: syntax: expressions: {
 	title: "Expressions"
 	description: """
-		VRL programs are made up of literal and dynamic expressions, described more in detail below.  Expressions can be sparated by newline, or by using a semicolon.
+		VRL programs are made up of literal and dynamic expressions, described more in detail below.  Expressions can be separated by newline, or by using a semicolon.
 		"""
 
 	examples: [

--- a/website/cue/reference/remap/syntax/expressions.cue
+++ b/website/cue/reference/remap/syntax/expressions.cue
@@ -3,18 +3,20 @@ package metadata
 remap: syntax: expressions: {
 	title: "Expressions"
 	description: """
-		VRL programs are made up of literal and dynamic expressions, described more in detail below.  Expressions can be separated by newline, or by using a semicolon.
+		VRL programs are made up of literal and dynamic expressions, described more in detail below.  Expressions can be separated by newline or semicolon in any combination.
 		"""
 
 	examples: [
 		"""
-		# newline delimited expressions 
+		# newline delimited expressions
 		del(.user_info)
-		.timestamp = now()  
+		.timestamp = now()
+		.message = "hello world"
 		""",
 		"""
 		# semicolon delimited expressions
 		del(.user_info); .timestamp = now()
+		.message = "hello world"
 		"""
 	]
 }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Add documentation for valid VRL syntax using newline and/or semicolons.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Verified the VRL syntax works in the VRL Playground [[share](https://playground.vrl.dev/?state=eyJwcm9ncmFtIjoiIyBSZW1vdmUgc29tZSBmaWVsZHNcbmRlbCguZm9vKTsgLnRpbWVzdGFtcCA9IG5vdygpXG5cbiMgUGFyc2UgSFRUUCBzdGF0dXMgY29kZSBpbnRvIGxvY2FsIHZhcmlhYmxlXG5odHRwX3N0YXR1c19jb2RlID0gcGFyc2VfaW50ISguaHR0cF9zdGF0dXMpO1xuZGVsKC5odHRwX3N0YXR1cylcblxuIyBBZGQgc3RhdHVzXG5pZiBodHRwX3N0YXR1c19jb2RlID49IDIwMCAmJiBodHRwX3N0YXR1c19jb2RlIDw9IDI5OSB7XG4gICAgLnN0YXR1cyA9IFwic3VjY2Vzc1wiXG59IGVsc2Uge1xuICAgIC5zdGF0dXMgPSBcImVycm9yXCJcbn0iLCJldmVudCI6eyJtZXNzYWdlIjoiSGVsbG8gVlJMIiwiZm9vIjoiZGVsZXRlIG1lIiwiaHR0cF9zdGF0dXMiOiIyMDAifSwiaXNfanNvbmwiOmZhbHNlLCJlcnJvciI6bnVsbH0%3D)]

Create and test .cue file documentation:
```
➜  vector git:(bfung/vrl-endofexpresssion-documentation) cd website
➜  website git:(bfung/vrl-endofexpresssion-documentation) make local-preview-build
...
✔✔✔ passed in 642.414083ms
tested 508 documents
➜  website git:(bfung/vrl-endofexpresssion-documentation) make serve
...
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop

```
Then open browser to local site at http://localhost:1313/docs/reference/vrl/expressions/#syntax.
<img width="1275" alt="Screenshot 2024-12-04 at 8 25 23 PM" src="https://github.com/user-attachments/assets/3e5a3c30-c55f-49be-8bf1-458734b1f0f7">

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Discord chat [[link](https://discord.com/channels/742820443487993987/764187584452493323/1313957485408817233)]:
 
