### PR TITLE
docs(exclusive_route transform, route transform): fix links in route/exclusive route

### DIFF
--- a/website/cue/reference/components/transforms/exclusive_route.cue
+++ b/website/cue/reference/components/transforms/exclusive_route.cue
@@ -6,7 +6,7 @@ components: transforms: exclusive_route: {
 	description: """
 		Routes events from one or more streams to unique sub-streams based on a set of user-defined conditions.
 
-		Also, see the [Route](\(urls.vector_route_transform) transform for routing an event to multiple streams.
+		Also, see the [Route](\(urls.vector_route_transform)) transform for routing an event to multiple streams.
 		"""
 
 	classes: {

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -7,7 +7,7 @@ components: transforms: route: {
 		Splits a stream of events into multiple sub-streams based on a set of
 		conditions.
 
-		Also, see the [Exclusive Route](\(urls.vector_exclusive_route_transform) transform for routing an event to
+		Also, see the [Exclusive Route](\(urls.vector_exclusive_route_transform)) transform for routing an event to
 		a single stream.
 		"""
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
Fixes the link to the new Exclusive Route in the Route transform, and vice versa.

e.g
![Screenshot 2024-12-05 at 10 00 49](https://github.com/user-attachments/assets/64d71453-e57f-489f-9305-0e0e5684b37a)


## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
