### PR TITLE
fix(sample transform): use configured sample_rate_key value

### DIFF
--- a/changelog.d/pass-sample-rate-key-config.fix.md
+++ b/changelog.d/pass-sample-rate-key-config.fix.md
@@ -1,4 +1,3 @@
 The `sample` transform now correctly uses the configured `sample_rate_key` instead of always using `"sample_rate"`.
 
 authors: dekelpilli
-

--- a/changelog.d/pass-sample-rate-key-config.fix.md
+++ b/changelog.d/pass-sample-rate-key-config.fix.md
@@ -1,0 +1,4 @@
+The `sample` transform now correctly uses the configured `sample_rate_key` instead of always using `"sample_rate"`.
+
+authors: dekelpilli
+

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -90,7 +90,7 @@ impl TransformConfig for SampleConfig {
                 .as_ref()
                 .map(|condition| condition.build(&context.enrichment_tables))
                 .transpose()?,
-            default_sample_rate_key(),
+            self.sample_rate_key.clone(),
         )))
     }
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Currently, the new `sample_rate_key` option in the `sample` transform is being ignored and the default value (`"sample_rate"`) is always used.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

I built vector locally and ran it against the following config:

```json
{
  "sources": {
    "s": {
      "type": "http_server",
      "acknowledgements": false,
      "address": "0.0.0.0:${PORT:-1234}",
      "decoding": {
        "codec": "native_json"
      },
      "path_key": ""
    }
  },
  "transforms": {
    "x": {
      "type": "sample",
      "sample_rate_key": "",
      "rate": 2,
      "inputs": [
        "s"
      ]
    }
  },
  "sinks": {
    "serr": {
      "encoding": {
        "codec": "json"
      },
      "target": "stderr",
      "type": "console",
      "inputs": [
        "x"
      ]
    }
  }
}
```

I tested with the following values of `sample_rate_key`:
- `""`
- `"x_sample_rate"`
- `"sample_rate"`
- `sample_rate_key` not included

And saw that the right key was added for each (including no key for the first one)

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
