### PR TITLE
fix(config): correctly propagate http config provider Result to caller

### DIFF
--- a/changelog.d/21873-correctly-propagate-http-config-provider.fix.md
+++ b/changelog.d/21873-correctly-propagate-http-config-provider.fix.md
@@ -1,0 +1,3 @@
+Fix the HTTP config provider to correctly parse TOML provided by the given HTTP endpoint.
+
+authors: PriceHiller

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -131,7 +131,7 @@ async fn http_request_to_config_builder(
         .await
         .map_err(|e| vec![e.to_owned()])?;
 
-    config::load(config_str.chunk(), crate::config::format::Format::Toml)?
+    config::load(config_str.chunk(), crate::config::format::Format::Toml)
 }
 
 /// Polls the HTTP endpoint after/every `poll_interval_secs`, returning a stream of `ConfigBuilder`.


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Copied from the body of the commit:

> Problem: The HTTP config provider has been failing to parse the provided TOML from its endpoint when polled. My best guess is that including the `?` on the end of the http provider load results in the TOML parser subtly exploding due to the aliased return type (`BuildResult`).
>
> It appears that this was broken in `8ed9ec24c1eba0b2191d7c1f24ec2a7540b5bebf`.
>
> See https://github.com/vectordotdev/vector/issues/21873 for the initial issue report.
>
> Solution: Correctly propagate the `ConfigBuilder` by not using the `?` operator. This appears to allow the TOML parser to correctly pick up on the return type.
> ...

I'm not entirely certain _why_ the TOML parser is choking when we use the sugar `?`. Best I can tell, is the generated match arms aren't wrapping the `Ok` case and instead return the inner full value. What's surprising to me, is the complete lack of the compiler having a meltdown about this.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

In two ways:

1. Building `vector` with my fix in place and testing the provided files from https://github.com/vectordotdev/vector/issues/21873:

  ```toml
  [provider]
  type = "http"
  url = "http://localhost/vector.toml"
  ```

  ```toml
# http://localhost/vector.toml
  [sources.demo]
  type = "demo_logs"
  format = "syslog"
  interval = 1

  [sinks.print]
  type = "console"
  encoding = { codec = "json", json = {pretty = true }}
  inputs = ["demo"]
  ```

2. Running relevant unit tests via: `cargo test --no-default-features --features "sinks-console,sources-demo_logs" `

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
      run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

- Closes: https://github.com/vectordotdev/vector/issues/21873

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
