### PR TITLE
fix(reduce transform): enable quoting for invalid fields

### DIFF
--- a/changelog.d/21989-reduce-quote-invalid-path.fix.md
+++ b/changelog.d/21989-reduce-quote-invalid-path.fix.md
@@ -1,3 +1,3 @@
-Fix reduce to quote invalid paths by default.
+Fix `reduce` transform to quote invalid paths by default. Quoting make those paths valid.
 
 authors: pront

--- a/changelog.d/21989-reduce-quote-invalid-path.fix.md
+++ b/changelog.d/21989-reduce-quote-invalid-path.fix.md
@@ -1,0 +1,3 @@
+Fix reduce to quote invalid paths by default.
+
+authors: pront

--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -64,7 +64,7 @@ pub struct FieldsIter<'a> {
     path: Vec<PathComponent<'a>>,
     /// Treat array as a single value and don't traverse each element.
     skip_array_elements: bool,
-    /// Surround invalid field with quotes to make them parsable.
+    /// Surround invalid fields with quotes to make them parsable.
     quote_invalid_fields: bool,
 }
 

--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -64,22 +64,22 @@ pub struct FieldsIter<'a> {
     path: Vec<PathComponent<'a>>,
     /// Treat array as a single value and don't traverse each element.
     skip_array_elements: bool,
-    /// Add quoting to field names containing periods.
-    quote_meta: bool,
+    /// Surround invalid field with quotes to make them parsable.
+    quote_invalid_fields: bool,
 }
 
 impl<'a> FieldsIter<'a> {
     fn new(
         path_prefix: Option<PathPrefix>,
         fields: &'a ObjectMap,
-        quote_meta: bool,
+        quote_invalid_fields: bool,
     ) -> FieldsIter<'a> {
         FieldsIter {
             path_prefix,
             stack: vec![LeafIter::Map(fields.iter())],
             path: vec![],
             skip_array_elements: false,
-            quote_meta,
+            quote_invalid_fields,
         }
     }
 
@@ -91,7 +91,7 @@ impl<'a> FieldsIter<'a> {
             stack: vec![LeafIter::Root((value, false))],
             path: vec![],
             skip_array_elements: false,
-            quote_meta: false,
+            quote_invalid_fields: true,
         }
     }
 
@@ -101,7 +101,7 @@ impl<'a> FieldsIter<'a> {
             stack: vec![LeafIter::Map(fields.iter())],
             path: vec![],
             skip_array_elements: true,
-            quote_meta: false,
+            quote_invalid_fields: true,
         }
     }
 
@@ -143,7 +143,7 @@ impl<'a> FieldsIter<'a> {
             match path_iter.next() {
                 None => break res.into(),
                 Some(PathComponent::Key(key)) => {
-                    if self.quote_meta && !IS_VALID_PATH_SEGMENT.is_match(key) {
+                    if self.quote_invalid_fields && !IS_VALID_PATH_SEGMENT.is_match(key) {
                         res.push_str(&format!("\"{key}\""));
                     } else {
                         res.push_str(key);

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -1005,21 +1005,17 @@ merge_strategies.bar = "concat"
               source = "exists(.test_end)"
             "#,
         ))
-            .unwrap();
+        .unwrap();
 
         assert_transform_compliance(async move {
             let (tx, rx) = mpsc::channel(1);
 
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), config).await;
 
-            let e_1 = LogEvent::from(Value::from(
-                btreemap! {"a b" => 1}
-            ));
+            let e_1 = LogEvent::from(Value::from(btreemap! {"a b" => 1}));
             tx.send(e_1.into()).await.unwrap();
 
-            let e_2 = LogEvent::from(Value::from(
-                btreemap! {"a b" => 2, "test_end" => "done"}
-            ));
+            let e_2 = LogEvent::from(Value::from(btreemap! {"a b" => 2, "test_end" => "done"}));
             tx.send(e_2.into()).await.unwrap();
 
             let output = out.recv().await.unwrap().into_log();
@@ -1033,6 +1029,6 @@ merge_strategies.bar = "concat"
             topology.stop().await;
             assert_eq!(out.recv().await, None);
         })
-            .await
+        .await
     }
 }

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -995,4 +995,44 @@ merge_strategies.bar = "concat"
         })
         .await
     }
+
+    #[tokio::test]
+    async fn merged_quoted_path() {
+        let config = toml::from_str::<ReduceConfig>(indoc!(
+            r#"
+            [ends_when]
+              type = "vrl"
+              source = "exists(.test_end)"
+            "#,
+        ))
+            .unwrap();
+
+        assert_transform_compliance(async move {
+            let (tx, rx) = mpsc::channel(1);
+
+            let (topology, mut out) = create_topology(ReceiverStream::new(rx), config).await;
+
+            let e_1 = LogEvent::from(Value::from(
+                btreemap! {"a b" => 1}
+            ));
+            tx.send(e_1.into()).await.unwrap();
+
+            let e_2 = LogEvent::from(Value::from(
+                btreemap! {"a b" => 2}
+            ));
+            tx.send(e_2.into()).await.unwrap();
+
+            let output = out.recv().await.unwrap().into_log();
+            let expected_value = Value::from(btreemap! {
+                "a b" => 3,
+                "test_end" => "done"
+            });
+            assert_eq!(*output.value(), expected_value);
+
+            drop(tx);
+            topology.stop().await;
+            assert_eq!(out.recv().await, None);
+        })
+            .await
+    }
 }

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -1018,7 +1018,7 @@ merge_strategies.bar = "concat"
             tx.send(e_1.into()).await.unwrap();
 
             let e_2 = LogEvent::from(Value::from(
-                btreemap! {"a b" => 2}
+                btreemap! {"a b" => 2, "test_end" => "done"}
             ));
             tx.send(e_2.into()).await.unwrap();
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
https://github.com/vectordotdev/vector/pull/21323 added unquoted iterators but it also made the other iterators return unquoted fields.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

```
transforms:
  transform0:
    type: reduce
    inputs:
      - my_input
    group_by:
      - id
    expire_after_ms: 2000
    max_events: 500
    merge_strategies:
      foo: array
tests:
  - name: map_transform0.space
    inputs:
      - type: vrl
        insert_at: transform0
        source: |
          . = {
            "a b": 1
          }
      - type: vrl
        insert_at: transform0
        source: |
          . = {
            "a b": 1
          }
    outputs:
      - extract_from: transform0
        conditions:
          - type: vrl
            source: |
              assert_eq!(., {"a b": 2})
```

Also added a unit test to cover this.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

- Closes: https://github.com/vectordotdev/vector/issues/21983

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
