### PR TITLE
chore(deps): Ignore RUSTSEC-2024-0421 temporarily

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -51,6 +51,10 @@ ignore = [
     # Vulnerable version only used in dev-dependencies
     "RUSTSEC-2024-0336",
 
+    # idna accepts Punycode labels that do not produce any non-ASCII when decoded
+    # Need to update some direct dependencies before we can upgrade idna to fix
+    "RUSTSEC-2024-0421",
+
     # unmaintained dependencies
     "RUSTSEC-2021-0139", # ansi_term
     "RUSTSEC-2024-0388", # derivative


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Ignore RUSTSEC-2024-0421 until we can upgrade direct dependencies to upgrade idna:

- mongodb (https://github.com/mongodb/mongo-rust-driver/blob/main/migration-3.0.md)
- hickory-proto (https://github.com/vectordotdev/vector/pull/21759/files)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

`cargo deny -L error check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

https://github.com/vectordotdev/vector/pull/21996
