### PR TITLE
fix(http sink): Adds an extra clone before shipping off http body

### DIFF
--- a/src/sinks/http/encoder.rs
+++ b/src/sinks/http/encoder.rs
@@ -90,7 +90,7 @@ impl SinkEncoder<Vec<Event>> for HttpEncoder {
             _ => {}
         }
 
-        let body = body.freeze();
+        let body = body.clone().freeze();
 
         write_all(writer, n_events, body.as_ref()).map(|()| (body.len(), byte_size))
     }


### PR DESCRIPTION
## Summary
This introduces a slight performance regression. You probably shouldn't merge it.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?


## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

