### PR TITLE
chore(website): bump hugo to latest version

### DIFF
--- a/website/layouts/partials/css.html
+++ b/website/layouts/partials/css.html
@@ -1,34 +1,34 @@
-{{ $serverMode   := site.IsServer }}
+{{ $serverMode := hugo.IsServer }}
 {{ $isHome := .IsHome }}
 {{ $cssInputs := site.Params.css }}
 {{ $includePaths := slice "node_modules" }}
-{{ $devOpts      := dict "includePaths" $includePaths "enableSourceMap" true }}
-{{ $prodOpts     := dict "includePaths" $includePaths "outputStyle" "compressed" }}
-{{ $cssOpts      := cond $serverMode $devOpts $prodOpts }}
-{{ $postCssOpts  := dict "inlineImports" true }}
+{{ $devOpts := dict "includePaths" $includePaths "enableSourceMap" true }}
+{{ $prodOpts := dict "includePaths" $includePaths "outputStyle" "compressed" }}
+{{ $cssOpts := cond $serverMode $devOpts $prodOpts }}
+{{ $postCssOpts := dict "inlineImports" true }}
 {{ $ctx := . }}
 
 {{ range $cssInputs }}
-{{ $opts := merge $cssOpts (dict "targetPath" .output) }}
-
-{{ $postProcess := .post_process }}
-{{ $css := resources.Get .input | resources.ExecuteAsTemplate .input $ctx | toCSS $opts }}
-
-{{ if .postcss }}
-{{ $css = $css | postCSS $postCssOpts }}
-{{ end }}
-
-{{ if not (and (not $isHome) .home_page_only) }}
-{{ if $serverMode }}
-<link rel="stylesheet" href="{{ $css.RelPermalink }}">
-{{ else }}
-{{ $css = $css | fingerprint }}
-
-{{ if $postProcess }}
-{{ $css = $css | resources.PostProcess }}
-{{ end }}
-
-<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
-{{ end }}
-{{ end }}
+  {{ $opts := merge $cssOpts (dict "targetPath" .output) }}
+  
+  {{ $postProcess := .post_process }}
+  {{ $css := resources.Get .input | resources.ExecuteAsTemplate .input $ctx | toCSS $opts }}
+  
+  {{ if .postcss }}
+    {{ $css = $css | postCSS $postCssOpts }}
+  {{ end }}
+  
+  {{ if not (and (not $isHome) .home_page_only) }}
+    {{ if $serverMode }}
+      <link rel="stylesheet" href="{{ $css.RelPermalink }}">
+    {{ else }}
+      {{ $css = $css | fingerprint }}
+      
+      {{ if $postProcess }}
+        {{ $css = $css | resources.PostProcess }}
+      {{ end }}
+      
+      <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
+    {{ end }}
+  {{ end }}
 {{ end }}

--- a/website/layouts/shortcodes/jump.html
+++ b/website/layouts/shortcodes/jump.html
@@ -1,14 +1,22 @@
 {{ $link := .Get 0 }}
 {{ if not $link }}
-{{ errorf "No page title specified" }}
+  {{ errorf "No page title specified" }}
 {{ end }}
 
 {{ $hash := .Get 1 }}
 
-{{ $page := site.GetPage $link }}
-{{ if not $page }}
-{{ errorf "Error in link shortcode at content/%s. No page found at %s." $.Page.File $link }}
+{{/* Try both with and without leading slash for compatibility */}}
+{{ $page := "" }}
+{{ if hasPrefix $link "/" }}
+  {{ $page = site.GetPage (strings.TrimPrefix "/" $link) }}
+{{ else }}
+  {{ $page = site.GetPage $link }}
 {{ end }}
+
+{{ if not $page }}
+  {{ errorf "Error in jump shortcode at %s: No page found at %s. Please ensure the page exists and the path is correct." $.Page.File.Path $link }}
+{{ end }}
+
 <div class="jump">
   <a href="{{ $link }}{{ with $hash }}#{{ . }}{{ end }}">
     <div class="border dark:border-gray-700 rounded-md px-3.5 py-2 hover:border-secondary dark:hover:border-primary">


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

- Updates 2 files so that the site can be built with the latest version of hugo: `vhugo v0.139.4+extended+withdeploy`
- Updates `website/layouts/partials/css.html` to use `hugo.IsSever`
  - `site.IsServer` variable was deprecated in Hugo version 0.112.0
- Updates `website/layouts/shortcodes/jump.html` with the following:
  - Added better path handling that works with both leading slash and no leading slash
  - Improved error message to include the actual file path
  - Added compatibility layer for page lookups

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->
Locally and with a preview site
## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

To test:
1. Pull this branch down
2. run `cd website` from the root directory
3. run `make serve`
4. click around and validate
5. `ctrl + c` in your terminal
6. run `make run-production-site-locally`
7. click around and validate nothing is broken, especially for jump links, a good test is to goto `docs/about/concepts/#sources` anc click `Sources reference`
8. Follow the same click and validate paths on the preview site since this was built on the same version in the CI
