### PR TITLE
fix(clickhouse sink)!: make `skip_unknown_fields` optional

### DIFF
--- a/changelog.d/22013-optional-clickhouse-skip_unknown_fields.breaking.md
+++ b/changelog.d/22013-optional-clickhouse-skip_unknown_fields.breaking.md
@@ -1,0 +1,3 @@
+Allow the `skip_unknown_fields` setting to be optional, thereby allowing use of the defaults provided by the ClickHouse server. Setting it to `true` will permit skipping unknown fields and `false` will make ClickHouse strict on what fields it accepts.
+
+authors: PriceHiller

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -72,8 +72,10 @@ pub struct ClickhouseConfig {
     pub format: Format,
 
     /// Sets `input_format_skip_unknown_fields`, allowing ClickHouse to discard fields not present in the table schema.
+    ///
+    /// If left unspecified, use the default provided by the `ClickHouse` server.
     #[serde(default)]
-    pub skip_unknown_fields: bool,
+    pub skip_unknown_fields: Option<bool>,
 
     /// Sets `date_time_input_format` to `best_effort`, allowing ClickHouse to properly parse RFC3339/ISO 8601.
     #[serde(default)]

--- a/src/sinks/clickhouse/integration_tests.rs
+++ b/src/sinks/clickhouse/integration_tests.rs
@@ -96,7 +96,7 @@ async fn skip_unknown_fields() {
     let config = ClickhouseConfig {
         endpoint: host.parse().unwrap(),
         table: table.clone().try_into().unwrap(),
-        skip_unknown_fields: true,
+        skip_unknown_fields: Some(true),
         compression: Compression::None,
         batch,
         request: TowerRequestConfig {

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -394,9 +394,13 @@ base: components: sinks: clickhouse: configuration: {
 		}
 	}
 	skip_unknown_fields: {
-		description: "Sets `input_format_skip_unknown_fields`, allowing ClickHouse to discard fields not present in the table schema."
-		required:    false
-		type: bool: default: false
+		description: """
+			Sets `input_format_skip_unknown_fields`, allowing ClickHouse to discard fields not present in the table schema.
+
+			If left unspecified, use the default provided by the `ClickHouse` server.
+			"""
+		required: false
+		type: bool: {}
 	}
 	table: {
 		description: "The table that data is inserted into."


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Copied from the body of the commit:

> Problem: The Clickhouse sink's `skip_unknown_fields` doesn't follow the Clickhouse server default. It always sends a value for `skip_unknown_fields`; furthermore, there is also no way to _disable_ `skip_unknown_fields` setting a "strict" mode for Clickhouse. We really want to permit either a default value from the Clickhouse server, meaning we shouldn't specify `skip_unknown_fields` by default. Otherwise, if a user _wants_ to specify the strict mode for unknown fields, they should then pass either `true` or `false` for click house.
>
> Solution: Change the `skip_unknown_fields` value to be of an `Option<bool>` instead of just a `bool`. This permits using the defaults provided by the Clickhouse server and doesn't send the `skip_unknown_fields` value to the server if left unspecified.
>
> See https://github.com/vectordotdev/vector/issues/22013 for the original issue report.
>
> Closes https://github.com/vectordotdev/vector/issues/22013


Allow the `skip_unknown_fields` setting to be optional, thereby allowing use of the defaults provided by the ClickHouse server. Setting it to `true` will permit skipping unknown fields and `false` will make ClickHouse strict on what fields it accepts.

**NOTE:** I am unfamiliar with ClickHouse and Vector's code as a whole, so it is _very_ possible I have missed something.

Also, does this qualify as a `Bug fix` or a `New feature`? Technically this does add functionality that didn't exist previously, but does so by encoding a fix.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

By running:

1. `cargo test --lib --no-default-features --features "sinks-console,sinks-clickhouse,clickhouse-integration-tests" 'sinks::clickhouse::service'`
2. `cargo test --lib --no-default-features --features "sinks-console,sinks-clickhouse,clickhouse-integration-tests" 'sinks::clickhouse::config'`
3. `make test-integration-clickhouse`

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
      run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/vectordotdev/vector/issues/22013

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
