### PR TITLE
chore(deps): Update to Rust 1.82.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,7 @@ load('ext://helm_resource', 'helm_resource', 'helm_repo')
 docker_build(
     ref='timberio/vector',
     context='.',
-    build_args={'RUST_VERSION': '1.81.0'},
+    build_args={'RUST_VERSION': '1.82.0'},
     dockerfile='tilt/Dockerfile'
     )
 

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -28,9 +28,11 @@ use crate::tcp::{self, TcpKeepaliveConfig};
 
 impl TlsSettings {
     pub fn acceptor(&self) -> crate::tls::Result<SslAcceptor> {
-        if self.identity.is_none() { Err(TlsError::MissingRequiredIdentity) } else {
-            let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls())
-                .context(CreateAcceptorSnafu)?;
+        if self.identity.is_none() {
+            Err(TlsError::MissingRequiredIdentity)
+        } else {
+            let mut acceptor =
+                SslAcceptor::mozilla_intermediate(SslMethod::tls()).context(CreateAcceptorSnafu)?;
             self.apply_context_base(&mut acceptor, true)?;
             Ok(acceptor.build())
         }

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -28,14 +28,11 @@ use crate::tcp::{self, TcpKeepaliveConfig};
 
 impl TlsSettings {
     pub fn acceptor(&self) -> crate::tls::Result<SslAcceptor> {
-        match self.identity {
-            None => Err(TlsError::MissingRequiredIdentity),
-            Some(_) => {
-                let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls())
-                    .context(CreateAcceptorSnafu)?;
-                self.apply_context_base(&mut acceptor, true)?;
-                Ok(acceptor.build())
-            }
+        if self.identity.is_none() { Err(TlsError::MissingRequiredIdentity) } else {
+            let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls())
+                .context(CreateAcceptorSnafu)?;
+            self.apply_context_base(&mut acceptor, true)?;
+            Ok(acceptor.build())
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81"
+channel = "1.82"
 profile = "default"


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Update Rust toolchain to 1.82.0. Surprisingly few clippy changes this time.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Ran `cargo clippy` locally, but will rely on CI for other tests.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
