### PR TITLE
fix(kafka sink): retry messages that result in kafka policy violations

### DIFF
--- a/changelog.d/22026-retry-kafka-policy-violations.fix.md
+++ b/changelog.d/22026-retry-kafka-policy-violations.fix.md
@@ -1,0 +1,3 @@
+Retry Kafka messages that error with `RDKafkaErrorCode::PolicyViolation` so messages are not lost.
+
+authors: PriceHiller

--- a/changelog.d/22026-retry-kafka-policy-violations.fix.md
+++ b/changelog.d/22026-retry-kafka-policy-violations.fix.md
@@ -1,3 +1,3 @@
-Retry Kafka messages that error with `RDKafkaErrorCode::PolicyViolation` so messages are not lost.
+Retry Kafka messages that error with a policy violation so messages are not lost.
 
 authors: PriceHiller

--- a/src/sinks/kafka/service.rs
+++ b/src/sinks/kafka/service.rs
@@ -159,9 +159,12 @@ impl Service<KafkaRequest> for KafkaService {
                             })
                             .map_err(|(err, _)| err);
                     }
-                    // Producer queue is full.
+                    // Producer queue is full or a policy has been violated and the request should
+                    // be retried
                     Err((
-                        KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull),
+                        KafkaError::MessageProduction(
+                            RDKafkaErrorCode::QueueFull | RDKafkaErrorCode::PolicyViolation,
+                        ),
                         original_record,
                     )) => {
                         if blocked_state.is_none() {


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Copied from the body of the commit:

> Problem: Some messages were getting dropped by Vector due to Kafka throwing `PolicyViolation` errors. These should be retried as a policy can be as simple as a more aggressive rate limit.
>
> ---
>
> Solution: Retry any messages that had the `RDKafkaErrorCode::PolicyViolation` error.
>
> ---
>
> Note: A dynamic back off may be better, as there may be a rate limit out there that still needs more than 100ms to back off on requests.
>
> ---
>
> See the original issue at https://github.com/vectordotdev/vector/issues/22026
>
> Closes https://github.com/vectordotdev/vector/issues/22026

Ensures Kafka retries messages that error out with `RDKafkaErrorCode::PolicyViolation`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## How did you test this PR?

<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

- `cargo test --no-default-features --features "sinks-console,sinks-kafka,kafka-integration-tests" -- --skip 'sinks::kafka::tests::integration_test' 'sinks::kafka'`
- `make test-integration-kafka`
  - **NOTE**: I am facing a few errors when running the integration tests both with and without this patch. Are they currently broken by any chance?
    Has to do with `sources::kafka::integration_test::drains_acknowledgements_during_rebalance_default_assignments`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist

- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
      run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/vectordotdev/vector/issues/22026

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
