### PR TITLE
fix(file source)!: use uncompressed content for fingerprinting files (lines and ignored_header_bytes)

### DIFF
--- a/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
+++ b/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
@@ -3,4 +3,4 @@ as a source of truth when fingerprinting lines and checking
 ignored_header_bytes. Previously this was using the compressed bytes. Only gzip
 supported for now.
 
-authors: roykim98 
+authors: roykim98

--- a/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
+++ b/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
@@ -1,4 +1,4 @@
-Changes the fingerprinter for file sources to use uncompressed file content
+Changes the fingerprint for file sources to use uncompressed file content
 as a source of truth when fingerprinting lines and checking
 ignored_header_bytes. Previously this was using the compressed bytes. Only gzip
 supported for now.

--- a/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
+++ b/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
@@ -1,0 +1,6 @@
+Changes the fingerprinter for file sources to use uncompressed file content
+as a source of truth when fingerprinting lines and checking
+ignored_header_bytes. Previously this was using the compressed bytes. Only gzip
+supported for now.
+
+authors: roykim98 

--- a/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
+++ b/changelog.d/22050-fingerprint-uncompressed-file-content.fix.md
@@ -1,6 +1,5 @@
 Changes the fingerprint for file sources to use uncompressed file content
 as a source of truth when fingerprinting lines and checking
-ignored_header_bytes. Previously this was using the compressed bytes. Only gzip
-supported for now.
+`ignored_header_bytes`. Previously this was using the compressed bytes. For now, only gzip compression is supported.
 
 authors: roykim98

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -100,15 +100,12 @@ impl UncompressedReader for UncompressedReaderImpl {
             // magic headers for algorithms can be of different lengths, and using a buffer too long could exceed the length of the file
             // so instantiate and check the various sizes in monotonically increasing order
             let magic_header_bytes = compression_algorithm.magic_header_bytes();
-            let mut magic = vec![0u8; magic_header_bytes.len()];
 
-            let result = fp.read_exact(&mut magic);
-            let reset = fp.seek(SeekFrom::Start(0));
-            if reset.is_err() {
-                return Err(reset.unwrap_err());
-            } else if result.is_err() {
-                return Err(result.unwrap_err());
-            } else if magic == magic_header_bytes {
+            let mut magic = vec![0u8; magic_header_bytes.len()];
+            fp.seek(SeekFrom::Start(0))?;
+            fp.read_exact(&mut magic)?;
+
+            if magic == magic_header_bytes {
                 return Ok(Some(compression_algorithm));
             } else {
                 continue;

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -72,18 +72,18 @@ impl From<u64> for FileFingerprint {
 
 #[derive(Debug, Copy, Clone)]
 enum SupportedCompressionAlgorithms {
-    GZIP,
+    Gzip,
 }
 
 impl SupportedCompressionAlgorithms {
     fn values() -> Vec<SupportedCompressionAlgorithms> {
         // Enumerate these from smallest magic_header_bytes to largest
-        vec![SupportedCompressionAlgorithms::GZIP]
+        vec![SupportedCompressionAlgorithms::Gzip]
     }
 
     fn magic_header_bytes(&self) -> &'static [u8] {
         match self {
-            SupportedCompressionAlgorithms::GZIP => &[0x1f, 0x8b],
+            SupportedCompressionAlgorithms::Gzip => &[0x1f, 0x8b],
         }
     }
 }
@@ -112,12 +112,12 @@ impl UncompressedReader for UncompressedReaderImpl {
             }
         }
         fp.seek(SeekFrom::Start(0))?;
-        return Ok(algorithm);
+        Ok(algorithm)
     }
     fn reader<'a>(fp: &'a mut File) -> Result<Box<dyn BufRead + 'a>, std::io::Error> {
         // To support new compression algorithms, add them below
         match Self::check(fp)? {
-            Some(SupportedCompressionAlgorithms::GZIP) => {
+            Some(SupportedCompressionAlgorithms::Gzip) => {
                 Ok(Box::new(BufReader::new(GzDecoder::new(BufReader::new(fp)))))
             }
             // No compression, or read the raw bytes
@@ -132,7 +132,7 @@ fn skip_first_n_bytes<R: BufRead>(reader: &mut R, n: usize) -> io::Result<()> {
     let mut skipped_bytes = 0;
     while skipped_bytes < n {
         let chunk = reader.fill_buf()?;
-        let bytes_to_skip = std::cmp::min(chunk.len(), (n - skipped_bytes) as usize);
+        let bytes_to_skip = std::cmp::min(chunk.len(), n - skipped_bytes);
         reader.consume(bytes_to_skip);
         skipped_bytes += bytes_to_skip;
     }

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -8,6 +8,7 @@ use std::{
 use crc::Crc;
 use flate2::bufread::GzDecoder;
 use serde::{Deserialize, Serialize};
+use vector_common::constants::GZIP_MAGIC;
 
 use crate::{metadata_ext::PortableFileExt, FileSourceInternalEvents};
 
@@ -83,7 +84,7 @@ impl SupportedCompressionAlgorithms {
 
     fn magic_header_bytes(&self) -> &'static [u8] {
         match self {
-            SupportedCompressionAlgorithms::Gzip => &[0x1f, 0x8b],
+            SupportedCompressionAlgorithms::Gzip => GZIP_MAGIC,
         }
     }
 }

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -134,6 +134,7 @@ impl UncompressedReader for UncompressedReaderImpl {
         fp.seek(SeekFrom::Start(0))?;
         Ok(algorithm)
     }
+
     fn reader<'a>(fp: &'a mut File) -> Result<Box<dyn BufRead + 'a>, std::io::Error> {
         // To support new compression algorithms, add them below
         match Self::check(fp)? {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -298,7 +298,8 @@ pub enum FingerprintConfig {
         bytes: Option<usize>,
 
         /// The number of bytes to skip ahead (or ignore) when reading the data used for generating the checksum.
-        /// If the file is compressed, the number of bytes refer to the header in the uncompressed content.
+        /// If the file is compressed, the number of bytes refer to the header in the uncompressed content. Only
+        /// gzip is supported at this time.
         ///
         /// This can be helpful if all files share a common header that should be skipped.
         #[serde(default = "default_ignored_header_bytes")]
@@ -307,7 +308,8 @@ pub enum FingerprintConfig {
 
         /// The number of lines to read for generating the checksum.
         ///
-        /// The number of lines are determined from the uncompressed content if the file is compressed.
+        /// The number of lines are determined from the uncompressed content if the file is compressed. Only
+        /// gzip is supported at this time.
         ///
         /// If the file has less than this amount of lines, it won’t be read at all.
         #[serde(default = "default_lines")]

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -298,6 +298,7 @@ pub enum FingerprintConfig {
         bytes: Option<usize>,
 
         /// The number of bytes to skip ahead (or ignore) when reading the data used for generating the checksum.
+        /// If the file is compressed, the number of bytes refer to the header in the uncompressed content.
         ///
         /// This can be helpful if all files share a common header that should be skipped.
         #[serde(default = "default_ignored_header_bytes")]
@@ -306,7 +307,7 @@ pub enum FingerprintConfig {
 
         /// The number of lines to read for generating the checksum.
         ///
-        /// If your files share a common header that is not always a fixed size,
+        /// The number of lines are determined from the uncompressed content if the file is compressed.
         ///
         /// If the file has less than this amount of lines, it won’t be read at all.
         #[serde(default = "default_lines")]

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -98,7 +98,8 @@ base: components: sources: file: configuration: {
 			ignored_header_bytes: {
 				description: """
 					The number of bytes to skip ahead (or ignore) when reading the data used for generating the checksum.
-					If the file is compressed, the number of bytes refer to the header in the uncompressed content.
+					If the file is compressed, the number of bytes refer to the header in the uncompressed content. Only
+					gzip is supported at this time.
 
 					This can be helpful if all files share a common header that should be skipped.
 					"""
@@ -113,7 +114,8 @@ base: components: sources: file: configuration: {
 				description: """
 					The number of lines to read for generating the checksum.
 
-					The number of lines are determined from the uncompressed content if the file is compressed.
+					The number of lines are determined from the uncompressed content if the file is compressed. Only
+					gzip is supported at this time
 
 					If the file has less than this amount of lines, it won’t be read at all.
 					"""

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -115,7 +115,7 @@ base: components: sources: file: configuration: {
 					The number of lines to read for generating the checksum.
 
 					The number of lines are determined from the uncompressed content if the file is compressed. Only
-					gzip is supported at this time
+					gzip is supported at this time.
 
 					If the file has less than this amount of lines, it won’t be read at all.
 					"""

--- a/website/cue/reference/components/sources/base/file.cue
+++ b/website/cue/reference/components/sources/base/file.cue
@@ -98,6 +98,7 @@ base: components: sources: file: configuration: {
 			ignored_header_bytes: {
 				description: """
 					The number of bytes to skip ahead (or ignore) when reading the data used for generating the checksum.
+					If the file is compressed, the number of bytes refer to the header in the uncompressed content.
 
 					This can be helpful if all files share a common header that should be skipped.
 					"""
@@ -112,7 +113,7 @@ base: components: sources: file: configuration: {
 				description: """
 					The number of lines to read for generating the checksum.
 
-					If your files share a common header that is not always a fixed size,
+					The number of lines are determined from the uncompressed content if the file is compressed.
 
 					If the file has less than this amount of lines, it won’t be read at all.
 					"""

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -219,7 +219,7 @@ components: sources: file: {
 				check](\(urls.crc)) (CRC) on the first N lines of the file. This serves as a
 				*fingerprint* that uniquely identifies the file. The number of lines, N, that are
 				read can be set using the [`fingerprint.lines`](#fingerprint.lines) and
-				[`fingerprint.ignored_header_bytes`](#fingerprint.ignored_header_bytes) options. Note 
+				[`fingerprint.ignored_header_bytes`](#fingerprint.ignored_header_bytes) options. Note
 				that for compressed files, these lines and header bytes refer to the uncompressed content.
 
 				This strategy avoids the common pitfalls associated with using device and inode

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -219,7 +219,8 @@ components: sources: file: {
 				check](\(urls.crc)) (CRC) on the first N lines of the file. This serves as a
 				*fingerprint* that uniquely identifies the file. The number of lines, N, that are
 				read can be set using the [`fingerprint.lines`](#fingerprint.lines) and
-				[`fingerprint.ignored_header_bytes`](#fingerprint.ignored_header_bytes) options.
+				[`fingerprint.ignored_header_bytes`](#fingerprint.ignored_header_bytes) options. Note 
+				that for compressed files, these lines and header bytes refer to the uncompressed content.
 
 				This strategy avoids the common pitfalls associated with using device and inode
 				names since inode names can be reused across files. This enables Vector to properly


### PR DESCRIPTION
## Summary
This PR addresses https://github.com/vectordotdev/vector/issues/13193.

This PR will handle the case where attempting to fingerprint compressed content. It will also handle a use case with log rotation, where an uncompressed active file might be monitored and then rotated into a compressed file with a new inode by a log rotation service. By comparing the uncompressed lines as a source of truth, it prevents messages from processing the files 2X.

I chose to explicitly check the magic bytes header by enumerating the signatures to make checking the different headers consistent. I checked a couple compression libraries, and I figured it would be complicated to try to move the ownership of a reader into multiple decoders with inconsistent functions that did not all permit easy checking of the magic header. Of course, if only gzip is expected to be supported for the foreseeable future, this is a moot point and we can just fall back to instantiating the gzip library to check

BREAKING CHANGE: When sourcing from compressed files, `ignored_header_bytes` will no longer look at the compressed file's bytes, which would include the magic bytes for the compression header. Instead, it will ignore the bytes from the uncompressed content. Similarly, `lines` will no longer look for new line delimiters in the compressed content, but the uncompressed content. Arguably, both of these current mechanisms as a bug, as compressed content would not have any explicit lines or intentional header aside from the magic bytes.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

## How did you test this PR?
Unit tests

```
cargo test --package file-source --lib -- fingerprinter::test --show-output
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).

## References

- Closes: https://github.com/vectordotdev/vector/issues/13193
