### PR TITLE
fix(utilization_metric): run a separate task for utilization to ensure it is regularly published

### DIFF
--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -1,21 +1,24 @@
 use std::{
+    collections::HashMap,
     pin::Pin,
     task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use futures::{Stream, StreamExt};
-use metrics::gauge;
+use metrics::Gauge;
 use pin_project::pin_project;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
+use vector_lib::{id::ComponentKey, shutdown::ShutdownSignal};
 
 use crate::stats;
 
 #[pin_project]
 pub(crate) struct Utilization<S> {
-    timer: Timer,
-    intervals: IntervalStream,
+    timer_tx: UnboundedSender<UtilizationTimerMessage>,
+    component_key: ComponentKey,
     inner: S,
 }
 
@@ -42,23 +45,169 @@ where
         // ready, with the side-effect of reporting every so often about how
         // long the wait gap is.
         //
-        // To achieve this we poll the `intervals` stream and if a new interval
-        // is ready we hit `Timer::report` and loop back around again to poll
-        // for a new `Event`. Calls to `Timer::start_wait` will only have an
-        // effect if `stop_wait` has been called, so the structure of this loop
-        // avoids double-measures.
+        // This will just measure the time, while UtilizationEmitter collects
+        // all the timers and emits utilization value periodically
         let this = self.project();
+        if this
+            .timer_tx
+            .send(UtilizationTimerMessage::StartWait(
+                this.component_key.clone(),
+                Instant::now(),
+            ))
+            .is_err()
+        {
+            debug!(component_id = ?this.component_key, "Couldn't send utilization start wait message from wrapped stream.");
+        }
+        let result = ready!(this.inner.poll_next_unpin(cx));
+        if this
+            .timer_tx
+            .send(UtilizationTimerMessage::StopWait(
+                this.component_key.clone(),
+                Instant::now(),
+            ))
+            .is_err()
+        {
+            debug!(component_id = ?this.component_key, "Couldn't send utilization stop wait message from wrapped stream.");
+        }
+        Poll::Ready(result)
+    }
+}
+
+pub(crate) struct Timer {
+    overall_start: Instant,
+    span_start: Instant,
+    waiting: bool,
+    total_wait: Duration,
+    ewma: stats::Ewma,
+    gauge: Gauge,
+}
+
+/// A simple, specialized timer for tracking spans of waiting vs not-waiting
+/// time and reporting a smoothed estimate of utilization.
+///
+/// This implementation uses the idea of spans and reporting periods. Spans are
+/// a period of time spent entirely in one state, aligning with state
+/// transitions but potentially more granular.  Reporting periods are expected
+/// to be of uniform length and used to aggregate span data into time-weighted
+/// averages.
+impl Timer {
+    pub(crate) fn new(gauge: Gauge) -> Self {
+        Self {
+            overall_start: Instant::now(),
+            span_start: Instant::now(),
+            waiting: false,
+            total_wait: Duration::new(0, 0),
+            ewma: stats::Ewma::new(0.9),
+            gauge,
+        }
+    }
+
+    /// Begin a new span representing time spent waiting
+    pub(crate) fn start_wait(&mut self, at: Instant) {
+        if !self.waiting {
+            self.end_span(at);
+            self.waiting = true;
+        }
+    }
+
+    /// Complete the current waiting span and begin a non-waiting span
+    pub(crate) fn stop_wait(&mut self, at: Instant) -> Instant {
+        if self.waiting {
+            let now = self.end_span(at);
+            self.waiting = false;
+            now
+        } else {
+            at
+        }
+    }
+
+    /// Meant to be called on a regular interval, this method calculates wait
+    /// ratio since the last time it was called and reports the resulting
+    /// utilization average.
+    pub(crate) fn report(&mut self) {
+        // End the current span so it can be accounted for, but do not change
+        // whether or not we're in the waiting state. This way the next span
+        // inherits the correct status.
+        let now = self.end_span(Instant::now());
+
+        let total_duration = now.duration_since(self.overall_start);
+        let wait_ratio = self.total_wait.as_secs_f64() / total_duration.as_secs_f64();
+        let utilization = 1.0 - wait_ratio;
+
+        self.ewma.update(utilization);
+        let avg = self.ewma.average().unwrap_or(f64::NAN);
+        debug!(utilization = %avg);
+        self.gauge.set(avg);
+
+        // Reset overall statistics for the next reporting period.
+        self.overall_start = self.span_start;
+        self.total_wait = Duration::new(0, 0);
+    }
+
+    fn end_span(&mut self, at: Instant) -> Instant {
+        if self.waiting {
+            self.total_wait += at - self.span_start;
+        }
+        self.span_start = at;
+        self.span_start
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum UtilizationTimerMessage {
+    StartWait(ComponentKey, Instant),
+    StopWait(ComponentKey, Instant),
+}
+
+pub(crate) struct UtilizationEmitter {
+    timers: HashMap<ComponentKey, Timer>,
+    timer_rx: UnboundedReceiver<UtilizationTimerMessage>,
+    timer_tx: UnboundedSender<UtilizationTimerMessage>,
+    intervals: IntervalStream,
+}
+
+impl UtilizationEmitter {
+    pub(crate) fn new() -> Self {
+        let (timer_tx, timer_rx) = unbounded_channel();
+        Self {
+            timers: HashMap::default(),
+            intervals: IntervalStream::new(interval(Duration::from_secs(5))),
+            timer_tx,
+            timer_rx,
+        }
+    }
+
+    pub(crate) fn add_component(&mut self, key: ComponentKey, gauge: Gauge) {
+        self.timers.insert(key, Timer::new(gauge));
+    }
+
+    pub(crate) fn get_sender(&self) -> UnboundedSender<UtilizationTimerMessage> {
+        self.timer_tx.clone()
+    }
+
+    pub(crate) async fn run_utilization(&mut self, mut shutdown: ShutdownSignal) {
         loop {
-            this.timer.start_wait();
-            match this.intervals.poll_next_unpin(cx) {
-                Poll::Ready(_) => {
-                    this.timer.report();
-                    continue;
-                }
-                Poll::Pending => {
-                    let result = ready!(this.inner.poll_next_unpin(cx));
-                    this.timer.stop_wait();
-                    return Poll::Ready(result);
+            tokio::select! {
+                message = self.timer_rx.recv() => {
+                    match message {
+                        Some(UtilizationTimerMessage::StartWait(key, start_time)) => {
+                            self.timers.get_mut(&key).unwrap().start_wait(start_time);
+                        }
+                        Some(UtilizationTimerMessage::StopWait(key, stop_time)) => {
+                            self.timers.get_mut(&key).unwrap().stop_wait(stop_time);
+                        }
+                        None => break,
+                    }
+                },
+
+                Some(_) = self.intervals.next() => {
+                    for timer in self.timers.values_mut() {
+                        timer.report();
+                    }
+                },
+
+                _ = &mut shutdown => {
+                    break
                 }
             }
         }
@@ -72,88 +221,15 @@ where
 /// and the rest of the time it is doing useful work. This is more true for
 /// sinks than transforms, which can be blocked by downstream components, but
 /// with knowledge of the config the data is still useful.
-pub(crate) fn wrap<S>(inner: S) -> Utilization<S> {
+#[allow(clippy::missing_const_for_fn)]
+pub(crate) fn wrap<S>(
+    timer_tx: UnboundedSender<UtilizationTimerMessage>,
+    component_key: ComponentKey,
+    inner: S,
+) -> Utilization<S> {
     Utilization {
-        timer: Timer::new(),
-        intervals: IntervalStream::new(interval(Duration::from_secs(5))),
+        timer_tx,
+        component_key,
         inner,
-    }
-}
-
-pub(super) struct Timer {
-    overall_start: Instant,
-    span_start: Instant,
-    waiting: bool,
-    total_wait: Duration,
-    ewma: stats::Ewma,
-}
-
-/// A simple, specialized timer for tracking spans of waiting vs not-waiting
-/// time and reporting a smoothed estimate of utilization.
-///
-/// This implementation uses the idea of spans and reporting periods. Spans are
-/// a period of time spent entirely in one state, aligning with state
-/// transitions but potentially more granular.  Reporting periods are expected
-/// to be of uniform length and used to aggregate span data into time-weighted
-/// averages.
-impl Timer {
-    pub(crate) fn new() -> Self {
-        Self {
-            overall_start: Instant::now(),
-            span_start: Instant::now(),
-            waiting: false,
-            total_wait: Duration::new(0, 0),
-            ewma: stats::Ewma::new(0.9),
-        }
-    }
-
-    /// Begin a new span representing time spent waiting
-    pub(crate) fn start_wait(&mut self) {
-        if !self.waiting {
-            self.end_span();
-            self.waiting = true;
-        }
-    }
-
-    /// Complete the current waiting span and begin a non-waiting span
-    pub(crate) fn stop_wait(&mut self) -> Instant {
-        if self.waiting {
-            let now = self.end_span();
-            self.waiting = false;
-            now
-        } else {
-            Instant::now()
-        }
-    }
-
-    /// Meant to be called on a regular interval, this method calculates wait
-    /// ratio since the last time it was called and reports the resulting
-    /// utilization average.
-    pub(crate) fn report(&mut self) {
-        // End the current span so it can be accounted for, but do not change
-        // whether or not we're in the waiting state. This way the next span
-        // inherits the correct status.
-        let now = self.end_span();
-
-        let total_duration = now.duration_since(self.overall_start);
-        let wait_ratio = self.total_wait.as_secs_f64() / total_duration.as_secs_f64();
-        let utilization = 1.0 - wait_ratio;
-
-        self.ewma.update(utilization);
-        let avg = self.ewma.average().unwrap_or(f64::NAN);
-        debug!(utilization = %avg);
-        gauge!("utilization").set(avg);
-
-        // Reset overall statistics for the next reporting period.
-        self.overall_start = self.span_start;
-        self.total_wait = Duration::new(0, 0);
-    }
-
-    fn end_span(&mut self) -> Instant {
-        if self.waiting {
-            self.total_wait += self.span_start.elapsed();
-        }
-        self.span_start = Instant::now();
-        self.span_start
     }
 }


### PR DESCRIPTION
## Summary
This adds a separate task that runs periodically to emit utilization metrics and collect messages from components that need their utilization metrics calculated. This ensures that utilization metric is published even when no events are running through a component.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Ran vector with internal metrics and observer that utilization was updated every ~5 secs, instead of only when events are running.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: #20216