### PR TITLE
fix(config): Correct `filter` transform generation via `vector generate` to use a comparison

### DIFF
--- a/changelog.d/22079_correct_filter_condition_via_vector_generate.fix.md
+++ b/changelog.d/22079_correct_filter_condition_via_vector_generate.fix.md
@@ -1,0 +1,4 @@
+What: Fixed a typo in the condition of the filter component created via `vector generate`.
+How: Replaced the assignment (`=`) with the equality (`==`) operator.
+
+authors: abcdam

--- a/changelog.d/22079_correct_filter_condition_via_vector_generate.fix.md
+++ b/changelog.d/22079_correct_filter_condition_via_vector_generate.fix.md
@@ -1,4 +1,3 @@
-What: Fixed a typo in the condition of the filter component created via `vector generate`.
-How: Replaced the assignment (`=`) with the equality (`==`) operator.
+The `filter` transform now generates a more accurate config when generated via `vector generate` by using a comparison rather than an assignment.
 
 authors: abcdam

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -34,7 +34,7 @@ impl From<AnyCondition> for FilterConfig {
 
 impl GenerateConfig for FilterConfig {
     fn generate_config() -> toml::Value {
-        toml::from_str(r#"condition = ".message = \"value\"""#).unwrap()
+        toml::from_str(r#"condition = ".message == \"value\"""#).unwrap()
     }
 }
 


### PR DESCRIPTION
Fixed typo in filter component produced by `vector generate`

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->
Untested. I stumbled upon it while playing around with `vector generate` in the cli.
Can be reproduced with e.g. `# vector generate /filter`. If this PR doesn't follow the guidelines, feel free to delete it and push the fix.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
