### PR TITLE
fix(gcp_pubsub source): Remove Tonic default 4MB decode size limit

### DIFF
--- a/changelog.d/22090_remove_gcp_pubsub_msg_size_limit.fix.md
+++ b/changelog.d/22090_remove_gcp_pubsub_msg_size_limit.fix.md
@@ -1,0 +1,1 @@
+Remove default 4MB message size limit in gcp_pubsub source imposed by Tonic 0.9

--- a/changelog.d/22090_remove_gcp_pubsub_msg_size_limit.fix.md
+++ b/changelog.d/22090_remove_gcp_pubsub_msg_size_limit.fix.md
@@ -1,1 +1,3 @@
-Remove default 4MB message size limit in gcp_pubsub source imposed by Tonic 0.9
+The `gcp_pubsub` source no longer has a 4MB message size limit.
+
+authors: sbalmos

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -479,7 +479,9 @@ impl PubsubSource {
                 }
                 Ok(req)
             },
-        );
+        )
+        // Tonic added a default of 4MB in 0.9. This replaces the old behavior.
+        .max_decoding_message_size(usize::MAX);
 
         let (ack_ids_sender, ack_ids_receiver) = mpsc::channel(ACK_QUEUE_SIZE);
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Removes the default 4MB message size decoding limit created by Tonic 0.9, preventing the gcp_pubsub source from receiving messages larger than this size.

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

Created a test PubSub topic in a personal GCP account, published a >4MB size message to the topic, and read from the subscription successfully.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [X] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [-] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: #22090

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
