### PR TITLE
feat: multicast udp socket support

### DIFF
--- a/lib/vector-config/src/stdlib.rs
+++ b/lib/vector-config/src/stdlib.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     hash::Hash,
-    net::SocketAddr,
+    net::{Ipv4Addr, SocketAddr},
     num::{
         NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU16, NonZeroU32, NonZeroU64,
         NonZeroU8, NonZeroUsize,
@@ -397,6 +397,31 @@ impl Configurable for SocketAddr {
 }
 
 impl ToValue for SocketAddr {
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}
+
+impl Configurable for Ipv4Addr {
+    fn referenceable_name() -> Option<&'static str> {
+        Some("stdlib::Ipv4Addr")
+    }
+
+    fn metadata() -> Metadata {
+        let mut metadata = Metadata::default();
+        metadata.set_description("An IPv4 address.");
+        metadata
+    }
+
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        // TODO: We don't need anything other than a string schema to (de)serialize a `Ipv4Addr`,
+        // but we eventually should have validation since the format for the possible permutations
+        // is well-known and can be easily codified.
+        Ok(generate_string_schema())
+    }
+}
+
+impl ToValue for Ipv4Addr {
     fn to_value(&self) -> Value {
         Value::String(self.to_string())
     }


### PR DESCRIPTION
Closes #5732

This PR is still in draft. I have a few pending `TODOs` and also missing tests to propertly check this. Although, this happy path is working.

In order to test this, use this vector config:

```toml
[sources.multicast_udp]
type = "socket"
mode = "udp"
address = "0.0.0.0:4242"
multicast_groups = ["224.0.0.2"]


[sinks.console]
type = "console"
inputs = ["multicast_udp"]
encoding.codec = "json"
```

and with this command
```sh
echo "hello" | nc 224.0.0.2 4242 -u
```

you can see logs in vector.
<img width="494" alt="image" src="https://github.com/user-attachments/assets/764c3224-be79-45a6-a184-64668262755a" />


I would like to receive some feedback about how the configuration of this settings should look like.

Also, note that IPv6 is not supported. We can work on that, but maybe it is not worth it if no one request that.

@nomalord take a look into this please, It would be great if you can build the binary from this branch and test if it works in your systems.

@dalesample as you were the first requester of this I also ping you, just in case (although this issue was created 4 years ago)