### PR TITLE
feat(http source): Digest access authentication

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -57,13 +57,15 @@ pub enum HttpError {
     #[snafu(display("Failed to build HTTP request: {}", source))]
     BuildRequest { source: http::Error },
     #[snafu(display("Expected 401 with Digest Auth"))]
-    DigestAuthExpectation
+    DigestAuthExpectation,
 }
 
 impl HttpError {
     pub const fn is_retriable(&self) -> bool {
         match self {
-            HttpError::BuildRequest { .. } | HttpError::MakeProxyConnector { .. } | HttpError::DigestAuthExpectation => false,
+            HttpError::BuildRequest { .. }
+            | HttpError::MakeProxyConnector { .. }
+            | HttpError::DigestAuthExpectation => false,
             HttpError::CallRequest { .. }
             | HttpError::BuildTlsConnector { .. }
             | HttpError::MakeHttpsConnector { .. } => true,
@@ -298,7 +300,7 @@ pub enum Auth {
         token: SensitiveString,
     },
     /// Digest authentication.
-    /// 
+    ///
     /// requires a round trip to the server to get the challenge and then send the response
     Digest {
         /// The digest authentication username.
@@ -352,7 +354,7 @@ impl Auth {
             Auth::Digest { user, password } => {
                 let auth = Authorization::basic(user.as_str(), password.inner());
                 map.typed_insert(auth);
-            },
+            }
         }
     }
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -130,6 +130,9 @@ impl SinkConfig for DatabendConfig {
             Some(Auth::Bearer { .. }) => {
                 return Err("Bearer authentication is not supported currently".into());
             }
+            Some(Auth::Digest { .. }) => {
+                return Err("Digest authentication is not supported currently".into());
+            },
             None => {}
         }
         if let Some(database) = &self.database {

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -132,7 +132,7 @@ impl SinkConfig for DatabendConfig {
             }
             Some(Auth::Digest { .. }) => {
                 return Err("Digest authentication is not supported currently".into());
-            },
+            }
             None => {}
         }
         if let Some(database) = &self.database {

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -322,7 +322,7 @@ fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
                 ),
                 Auth::Bearer { token } => {
                     HeaderValue::from_str(format!("Bearer {}", token.inner()).as_str())
-                },
+                }
                 Auth::Digest { .. } => {
                     error!("Digest authentication is not supported.");
                     return false;

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -322,6 +322,10 @@ fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
                 ),
                 Auth::Bearer { token } => {
                     HeaderValue::from_str(format!("Bearer {}", token.inner()).as_str())
+                },
+                Auth::Digest { .. } => {
+                    error!("Digest authentication is not supported.");
+                    return false;
                 }
             };
 

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -586,6 +586,7 @@ mod tests {
                                                 user: _user,
                                                 password: _password,
                                             } => { /* Not needed for tests at the moment */ }
+                                            Auth::Digest { .. } => { /* Not needed for tests at the moment */ }
                                         }
                                     }
                                     Ok(res)

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -13,11 +13,11 @@ use futures_util::{stream, FutureExt, StreamExt, TryFutureExt};
 use http::{response::Parts, Uri};
 use hyper::{Body, Request};
 use md5::Digest;
-use vector_lib::sensitive_string::SensitiveString;
 use std::time::Duration;
 use std::{collections::HashMap, future::ready};
 use tokio_stream::wrappers::IntervalStream;
 use vector_lib::json_size::JsonSize;
+use vector_lib::sensitive_string::SensitiveString;
 
 use crate::{
     http::{Auth, HttpClient},
@@ -178,7 +178,6 @@ pub(crate) async fn call<
 
             // building an empty request should be infallible
             let mut request = builder.body(Body::empty()).expect("error creating request");
-            
             let mut is_digest = false;
             let mut username = "".to_string();
             let mut user_password = SensitiveString::default();
@@ -193,7 +192,7 @@ pub(crate) async fn call<
                     _ => false
                 };
             }
-            
+
             tokio::time::timeout(inputs.timeout, client.send(request))
             .then({
                 let headers_value = headers.clone();

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -236,7 +236,6 @@ pub(crate) async fn call<
                             if part.contains("nonce") {
                                 nonce = part.split("=").collect::<Vec<&str>>()[1].trim_matches('"');
                             }
-                            println!("{}", part);
                         }
                         let ha1 = format!("{:x}", md5::Md5::digest(format!("{}:{}:{}", username_inner, realm, user_password_inner.inner())));
                         let ha2 = format!("{:x}", md5::Md5::digest(format!("GET:{}", uri.path())));

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -219,11 +219,13 @@ pub(crate) async fn call<
                         if status != 401 {
                             return Ok(Err(crate::http::HttpError::DigestAuthExpectation))
                         }
-                        let parts = response_headers
-                            .get("www-authenticate")
-                            .unwrap()
-                            .to_str()
-                            .unwrap();
+                        let parts = match response_headers.get("www-authenticate") {
+                            Some(header_value) => match header_value.to_str() {
+                                Ok(value) => value,
+                                Err(_) => return Ok(Err(crate::http::HttpError::DigestAuthExpectation)),
+                            },
+                            None => return Ok(Err(crate::http::HttpError::DigestAuthExpectation)),
+                        };
                         let parts: Vec<&str> = parts.split(",").collect();
                         let mut realm = "";
                         let mut nonce = "";


### PR DESCRIPTION
## Summary
Adding [rfc2617](https://datatracker.ietf.org/doc/html/rfc2617) to http source

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
The datacenter/compute infrastructure I manage uses this authentication method for its endpoint. I successfully ran vector against one of these devices and received expected results back.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References
None.
