### PR TITLE
enhancement(aws_s3 sink): add glacier instant retrieval storage class

### DIFF
--- a/changelog.d/s3_sink_add_glacier_ir_storage_class.enhancement.md
+++ b/changelog.d/s3_sink_add_glacier_ir_storage_class.enhancement.md
@@ -1,0 +1,3 @@
+A new `GLACIER_IR` option was added to `storage_class` for `aws_s3` sink.
+
+authors: MikeHsu0618

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -167,6 +167,9 @@ pub enum S3StorageClass {
     /// Glacier Flexible Retrieval.
     Glacier,
 
+    /// Glacier Instant Retrieval.
+    GlacierIr,
+
     /// Glacier Deep Archive.
     DeepArchive,
 }
@@ -181,6 +184,7 @@ impl From<S3StorageClass> for StorageClass {
             S3StorageClass::ExpressOnezone => Self::ExpressOnezone,
             S3StorageClass::OnezoneIa => Self::OnezoneIa,
             S3StorageClass::Glacier => Self::Glacier,
+            S3StorageClass::GlacierIr => Self::GlacierIr,
             S3StorageClass::DeepArchive => Self::DeepArchive,
         }
     }
@@ -393,6 +397,7 @@ mod tests {
         for &(name, storage_class) in &[
             ("DEEP_ARCHIVE", S3StorageClass::DeepArchive),
             ("GLACIER", S3StorageClass::Glacier),
+            ("GLACIER_IR", S3StorageClass::GlacierIr),
             ("INTELLIGENT_TIERING", S3StorageClass::IntelligentTiering),
             ("EXPRESS_ONEZONE", S3StorageClass::ExpressOnezone),
             ("ONEZONE_IA", S3StorageClass::OnezoneIa),

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -1074,6 +1074,7 @@ base: components: sinks: aws_s3: configuration: {
 				DEEP_ARCHIVE:        "Glacier Deep Archive."
 				EXPRESS_ONEZONE:     "High Performance (single Availability zone)."
 				GLACIER:             "Glacier Flexible Retrieval."
+				GLACIER_IR:          "Glacier Instant Retrieval."
 				INTELLIGENT_TIERING: "Intelligent Tiering."
 				ONEZONE_IA:          "Infrequently Accessed (single Availability zone)."
 				REDUCED_REDUNDANCY:  "Reduced Redundancy."


### PR DESCRIPTION
## Summary

This PR addresses the absence of the Glacier Instant Retrieval storage class option, which is available as a configurable option provided by AWS. Following the approach of previous similar PRs, this update introduces support for the Glacier Instant Retrieval storage class.

refer to the [official documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/sc-howtoset.html).

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

```
make test SCOPE="sinks::s3_common"
```



## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

#5245 
#19893 
