### PR TITLE
chore(external docs): render array of object type in component docs

### DIFF
--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -136,7 +136,7 @@
         </span>
 
         {{ if eq $k "object" }}
-        <div class="py-2">
+        <div class="mt-2">
             {{ template "config-object" (dict "name" $name "config" $v "level" 4) }}
         </div>
         {{ end }}
@@ -1636,7 +1636,7 @@
 
 {{ define "config-array-examples" }}
 {{ $json := .examples | jsonify (dict "indent" "  ") }}
-<div x-data="{ open: false }" class="mt-2.5 border rounded py-2 px-3 dark:border-gray-700">
+<div x-data="{ open: false }" class="mt-2 border rounded py-2 px-3 dark:border-gray-700">
   <span class="flex justify-between items-center">
     <span class="text-sm">
       Examples

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -131,6 +131,9 @@
 
           <span class="flex items-center space-x-1">
             {{ partial "badge.html" (dict "word" $k "color" "gray") }}
+            {{ if $v.syntax }} 
+            {{ partial "badge.html" (dict "word" $v.syntax "color" "gray") }}
+            {{ end }}
           </span>
         </span>
 

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -136,7 +136,9 @@
         </span>
 
         {{ if eq $k "object" }}
+        <div class="py-2">
             {{ template "config-object" (dict "name" $name "config" $v "level" 4) }}
+        </div>
         {{ end }}
         
         {{ with $v.examples }}

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -131,7 +131,6 @@
 
           <span class="flex items-center space-x-1">
             {{ partial "badge.html" (dict "word" $k "color" "gray") }}
-            {{ partial "badge.html" (dict "word" $v.syntax "color" "gray") }}
           </span>
         </span>
 

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -135,6 +135,10 @@
           </span>
         </span>
 
+        {{ if eq $k "object" }}
+            {{ template "config-object" (dict "name" $name "config" $v "level" 4) }}
+        {{ end }}
+        
         {{ with $v.examples }}
         {{ template "config-array-examples" (dict "examples" .) }}
         {{ end }}


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Try to resolve #22136.

`log_to_metric` transforms

![image](https://github.com/user-attachments/assets/78ab91fe-280b-4cec-b578-77fcc014807c)

`static metric`

![image](https://github.com/user-attachments/assets/c0c37263-c542-486b-b7eb-e6298670c07f)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

```
make quick-build
make serve
```

Navigate to [log to metric transforms](http://localhost:1313/docs/reference/configuration/transforms/log_to_metric/) and [static metric](http://localhost:1313/docs/reference/configuration/sources/static_metrics/)

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

Close #22136 
