### PR TITLE
chore(ci): Revert "dependabot allow all dep types"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
       time: "04:00" # UTC
-    allow:
-      - dependency-type: "all"
     labels:
       - "domain: deps"
       - "no-changelog"


### PR DESCRIPTION
We stopped receiving PRs since vectordotdev/vector#21958. Although that configuration is valid based on the public docs. Reverting to test if this is the root cause. If it is, it is worth following up with GitHub support.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow