### PR TITLE
feat(new_sink): initial `websocket_listener` sink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -730,6 +730,7 @@ sinks-logs = [
   "sinks-vector",
   "sinks-webhdfs",
   "sinks-websocket",
+  "sinks-websocket-listener",
 ]
 sinks-metrics = [
   "sinks-appsignal",
@@ -798,6 +799,7 @@ sinks-statsd = ["sinks-utils-udp", "tokio-util/net"]
 sinks-utils-udp = []
 sinks-vector = ["sinks-utils-udp", "dep:tonic", "protobuf-build", "dep:prost"]
 sinks-websocket = ["dep:tokio-tungstenite"]
+sinks-websocket-listener = ["dep:tokio-tungstenite"]
 sinks-webhdfs = ["dep:opendal"]
 
 # Identifies that the build is a nightly build

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -20,3 +20,6 @@ pub(crate) mod s3;
 
 #[cfg(any(feature = "transforms-log_to_metric", feature = "sinks-loki"))]
 pub(crate) mod expansion;
+
+#[cfg(feature = "sinks-websocket-listener")]
+pub(crate) mod server_auth;

--- a/src/common/server_auth.rs
+++ b/src/common/server_auth.rs
@@ -1,0 +1,175 @@
+use bytes::Bytes;
+use headers::{authorization::Credentials, Authorization};
+use http::{header::AUTHORIZATION, HeaderMap, HeaderValue};
+use vector_config::configurable_component;
+use vector_lib::{
+    compile_vrl,
+    event::{Event, LogEvent, VrlTarget},
+    sensitive_string::SensitiveString,
+    TimeZone,
+};
+use vrl::{
+    compiler::{runtime::Runtime, CompilationResult, CompileConfig, Program},
+    core::Value,
+    diagnostic::Formatter,
+    prelude::TypeState,
+    value::{KeyString, ObjectMap},
+};
+
+/// Configuration of the authentication strategy for server mode sinks and sources.
+///
+/// HTTP authentication should be used with HTTPS only, as the authentication credentials are passed as an
+/// HTTP header without any additional encryption beyond what is provided by the transport itself.
+#[configurable_component]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
+pub enum Auth {
+    /// Basic authentication.
+    ///
+    /// The username and password are concatenated and encoded via [base64][base64].
+    ///
+    /// [base64]: https://en.wikipedia.org/wiki/Base64
+    Basic {
+        /// The basic authentication username.
+        #[configurable(metadata(docs::examples = "${USERNAME}"))]
+        #[configurable(metadata(docs::examples = "username"))]
+        user: String,
+
+        /// The basic authentication password.
+        #[configurable(metadata(docs::examples = "${PASSWORD}"))]
+        #[configurable(metadata(docs::examples = "password"))]
+        password: SensitiveString,
+    },
+
+    /// Bearer authentication.
+    ///
+    /// The bearer token value (OAuth2, JWT, etc.) is passed as-is.
+    Bearer {
+        /// The bearer authentication token.
+        token: SensitiveString,
+    },
+
+    /// Custom authentication using VRL code.
+    ///
+    /// Takes in request and validates it using VRL code.
+    Custom {
+        /// The VRL boolean expression.
+        source: String,
+    },
+}
+
+impl Auth {
+    pub fn build(
+        &self,
+        enrichment_tables: &vector_lib::enrichment::TableRegistry,
+    ) -> crate::Result<AuthMatcher> {
+        match self {
+            Auth::Basic { user, password } => Ok(AuthMatcher::AuthHeader(
+                Authorization::basic(user, password.inner()).0.encode(),
+            )),
+            Auth::Bearer { token } => Ok(AuthMatcher::AuthHeader(
+                Authorization::bearer(token.inner())
+                    .map_err(|_| "Invalid bearer token")?
+                    .0
+                    .encode(),
+            )),
+            Auth::Custom { source } => {
+                let functions = vrl::stdlib::all()
+                    .into_iter()
+                    .chain(vector_lib::enrichment::vrl_functions())
+                    .chain(vector_vrl_functions::all())
+                    .collect::<Vec<_>>();
+
+                let state = TypeState::default();
+
+                let mut config = CompileConfig::default();
+                config.set_custom(enrichment_tables.clone());
+                config.set_read_only();
+
+                let CompilationResult {
+                    program,
+                    warnings,
+                    config: _,
+                } = compile_vrl(source, &functions, &state, config).map_err(|diagnostics| {
+                    Formatter::new(source, diagnostics).colored().to_string()
+                })?;
+
+                if !program.final_type_info().result.is_boolean() {
+                    return Err("VRL conditions must return a boolean.".into());
+                }
+
+                if !warnings.is_empty() {
+                    let warnings = Formatter::new(source, warnings).colored().to_string();
+                    warn!(message = "VRL compilation warning.", %warnings);
+                }
+
+                Ok(AuthMatcher::Vrl { program })
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AuthMatcher {
+    AuthHeader(HeaderValue),
+    Vrl { program: Program },
+}
+
+impl AuthMatcher {
+    pub fn handle_auth(&self, headers: &HeaderMap<HeaderValue>) -> Result<(), String> {
+        match self {
+            AuthMatcher::AuthHeader(expected) => {
+                if let Some(header) = headers.get(AUTHORIZATION) {
+                    if expected == header {
+                        Ok(())
+                    } else {
+                        Err("Invalid auth header.".to_string())
+                    }
+                } else {
+                    Err("Missing auth header".to_string())
+                }
+            }
+            AuthMatcher::Vrl { program } => {
+                let mut target = VrlTarget::new(
+                    Event::Log(LogEvent::from_map(
+                        ObjectMap::from([(
+                            "headers".into(),
+                            Value::Object(
+                                headers
+                                    .iter()
+                                    .map(|(k, v)| {
+                                        (
+                                            KeyString::from(k.to_string()),
+                                            Value::Bytes(Bytes::copy_from_slice(v.as_bytes())),
+                                        )
+                                    })
+                                    .collect::<ObjectMap>(),
+                            ),
+                        )]),
+                        Default::default(),
+                    )),
+                    program.info(),
+                    false,
+                );
+                // TODO: use timezone from remap config
+                let timezone = TimeZone::default();
+
+                let result = Runtime::default().resolve(&mut target, program, &timezone);
+                match result.map_err(|e| {
+                    warn!("Handling auth failed: {}", e);
+                    "Auth failed".to_string()
+                })? {
+                    vrl::core::Value::Boolean(result) => {
+                        if result {
+                            Ok(())
+                        } else {
+                            Err("Auth failed".to_string())
+                        }
+                    }
+                    _ => Err("Invalid return value".to_string()),
+                }
+            }
+        }
+    }
+}

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -241,6 +241,7 @@ dyn_clone::clone_trait_object!(SinkConfig);
 pub struct SinkContext {
     pub healthcheck: SinkHealthcheckOptions,
     pub globals: GlobalOptions,
+    pub enrichment_tables: vector_lib::enrichment::TableRegistry,
     pub proxy: ProxyConfig,
     pub schema: schema::Options,
     pub app_name: String,
@@ -256,6 +257,7 @@ impl Default for SinkContext {
         Self {
             healthcheck: Default::default(),
             globals: Default::default(),
+            enrichment_tables: Default::default(),
             proxy: Default::default(),
             schema: Default::default(),
             app_name: crate::get_app_name().to_string(),

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -108,6 +108,8 @@ pub mod vector;
 pub mod webhdfs;
 #[cfg(feature = "sinks-websocket")]
 pub mod websocket;
+#[cfg(feature = "sinks-websocket-listener")]
+pub mod websocket_listener;
 
 pub use vector_lib::{config::Input, sink::VectorSink};
 

--- a/src/sinks/websocket_listener/config.rs
+++ b/src/sinks/websocket_listener/config.rs
@@ -1,0 +1,91 @@
+use std::net::SocketAddr;
+
+use vector_lib::codecs::JsonSerializerConfig;
+use vector_lib::configurable::configurable_component;
+
+use crate::{
+    codecs::EncodingConfig,
+    common::server_auth::Auth,
+    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
+    sinks::{Healthcheck, VectorSink},
+    tls::TlsEnableableConfig,
+};
+
+use super::sink::WebSocketListenerSink;
+
+/// Configuration for the `websocket_listener` sink.
+#[configurable_component(sink(
+    "websocket_listener",
+    "Deliver observability event data to websocket clients."
+))]
+#[derive(Clone, Debug)]
+pub struct WebSocketListenerSinkConfig {
+    /// The socket address to listen for connections on.
+    ///
+    /// It _must_ include a port.
+    #[configurable(metadata(docs::examples = "0.0.0.0:80"))]
+    #[configurable(metadata(docs::examples = "localhost:80"))]
+    pub address: SocketAddr,
+
+    #[configurable(derived)]
+    pub tls: Option<TlsEnableableConfig>,
+
+    #[configurable(derived)]
+    pub encoding: EncodingConfig,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::is_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
+
+    #[configurable(derived)]
+    pub auth: Option<Auth>,
+}
+
+impl Default for WebSocketListenerSinkConfig {
+    fn default() -> Self {
+        Self {
+            address: "0.0.0.0:8080".parse().unwrap(),
+            encoding: JsonSerializerConfig::default().into(),
+            tls: None,
+            acknowledgements: Default::default(),
+            auth: None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "websocket_listener")]
+impl SinkConfig for WebSocketListenerSinkConfig {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ws_sink = WebSocketListenerSink::new(self.clone(), &cx)?;
+
+        Ok((
+            VectorSink::from_event_streamsink(ws_sink),
+            Box::pin(async move { Ok(()) }),
+        ))
+    }
+
+    fn input(&self) -> Input {
+        Input::new(self.encoding.config().input_type())
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+}
+
+impl_generate_config_from_default!(WebSocketListenerSinkConfig);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<WebSocketListenerSinkConfig>();
+    }
+}

--- a/src/sinks/websocket_listener/mod.rs
+++ b/src/sinks/websocket_listener/mod.rs
@@ -1,0 +1,4 @@
+mod config;
+mod sink;
+
+pub use config::WebSocketListenerSinkConfig;

--- a/src/sinks/websocket_listener/sink.rs
+++ b/src/sinks/websocket_listener/sink.rs
@@ -1,0 +1,213 @@
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use bytes::BytesMut;
+use futures::{
+    channel::mpsc::{unbounded, UnboundedSender},
+    pin_mut,
+    stream::BoxStream,
+    FutureExt, StreamExt, TryStreamExt,
+};
+use futures_util::future;
+use http::StatusCode;
+use stream_cancel::Tripwire;
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::{
+    handshake::server::{ErrorResponse, Request, Response},
+    Message,
+};
+use tokio_util::codec::Encoder as _;
+use vector_lib::{
+    event::{Event, EventStatus},
+    finalization::Finalizable,
+    internal_event::{
+        ByteSize, BytesSent, CountByteSize, EventsSent, InternalEventHandle, Output, Protocol,
+    },
+    sink::StreamSink,
+    tls::{MaybeTlsIncomingStream, MaybeTlsListener, MaybeTlsSettings},
+    EstimatedJsonEncodedSizeOf,
+};
+
+use crate::{
+    codecs::{Encoder, Transformer},
+    common::server_auth::AuthMatcher,
+    config::SinkContext,
+};
+
+use super::WebSocketListenerSinkConfig;
+
+pub struct WebSocketListenerSink {
+    peers: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Message>>>>,
+    tls: MaybeTlsSettings,
+    transformer: Transformer,
+    encoder: Encoder<()>,
+    address: SocketAddr,
+    auth: Option<AuthMatcher>,
+}
+
+impl WebSocketListenerSink {
+    pub fn new(config: WebSocketListenerSinkConfig, cx: &SinkContext) -> crate::Result<Self> {
+        let tls = MaybeTlsSettings::from_config(config.tls.as_ref(), true)?;
+        let transformer = config.encoding.transformer();
+        let serializer = config.encoding.build()?;
+        let encoder = Encoder::<()>::new(serializer);
+        Ok(Self {
+            peers: Arc::new(Mutex::new(HashMap::new())),
+            tls,
+            address: config.address,
+            transformer,
+            encoder,
+            auth: config
+                .auth
+                .map(|a| a.build(&cx.enrichment_tables))
+                .transpose()?,
+        })
+    }
+
+    const fn should_encode_as_binary(&self) -> bool {
+        use vector_lib::codecs::encoding::Serializer::{
+            Avro, Cef, Csv, Gelf, Json, Logfmt, Native, NativeJson, Protobuf, RawMessage, Text,
+        };
+
+        match self.encoder.serializer() {
+            RawMessage(_) | Avro(_) | Native(_) | Protobuf(_) => true,
+            Cef(_) | Csv(_) | Logfmt(_) | Gelf(_) | Json(_) | Text(_) | NativeJson(_) => false,
+        }
+    }
+
+    async fn handle_connections(
+        auth: Option<AuthMatcher>,
+        peers: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Message>>>>,
+        mut listener: MaybeTlsListener,
+        tripwire: Tripwire,
+    ) {
+        while let Ok(stream) = listener.accept().await {
+            tokio::spawn(Self::handle_connection(
+                auth.clone(),
+                Arc::clone(&peers),
+                stream,
+                tripwire.clone(),
+            ));
+        }
+    }
+
+    async fn handle_connection(
+        auth: Option<AuthMatcher>,
+        peers: Arc<Mutex<HashMap<SocketAddr, UnboundedSender<Message>>>>,
+        stream: MaybeTlsIncomingStream<TcpStream>,
+        tripwire: Tripwire,
+    ) -> Result<(), ()> {
+        let addr = stream.peer_addr();
+        debug!("Incoming TCP connection from: {}", addr);
+
+        let header_callback = |req: &Request, response: Response| match auth
+            .map(|a| a.handle_auth(req.headers()))
+            .unwrap_or(Ok(()))
+        {
+            Ok(_) => Ok(response),
+            Err(message) => {
+                let mut response = ErrorResponse::default();
+                *response.status_mut() = StatusCode::UNAUTHORIZED;
+                *response.body_mut() = Some(message.clone());
+                debug!("Websocket handshake auth validation failed: {}", message);
+                Err(response)
+            }
+        };
+
+        let ws_stream = tokio_tungstenite::accept_hdr_async(stream, header_callback)
+            .await
+            .map_err(|err| {
+                debug!("Error during websocket handshake: {}", err);
+            })?;
+        debug!("WebSocket connection established: {}", addr);
+
+        // Insert the write part of this peer to the peer map.
+        let (tx, rx) = unbounded();
+        peers.lock().unwrap().insert(addr, tx);
+
+        let (outgoing, incoming) = ws_stream.split();
+
+        let broadcast_incoming = incoming.try_for_each(|msg| {
+            debug!(
+                "Received a message from {}: {}",
+                addr,
+                msg.to_text().unwrap()
+            );
+
+            future::ok(())
+        });
+
+        let receive_from_others = rx.map(Ok).forward(outgoing);
+
+        pin_mut!(broadcast_incoming, receive_from_others);
+        future::select(broadcast_incoming, receive_from_others).await;
+        tripwire.then(crate::shutdown::tripwire_handler).await;
+
+        debug!("{} disconnected", &addr);
+        peers.lock().unwrap().remove(&addr);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl StreamSink<Event> for WebSocketListenerSink {
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        let input = input.fuse().peekable();
+        pin_mut!(input);
+
+        let bytes_sent = register!(BytesSent::from(Protocol("websocket".into())));
+        let events_sent = register!(EventsSent::from(Output(None)));
+        let encode_as_binary = self.should_encode_as_binary();
+
+        let listener = self.tls.bind(&self.address).await.map_err(|_| ())?;
+        let (_trigger, tripwire) = Tripwire::new();
+
+        tokio::spawn(Self::handle_connections(
+            self.auth,
+            Arc::clone(&self.peers),
+            listener,
+            tripwire,
+        ));
+
+        while input.as_mut().peek().await.is_some() {
+            let mut event = input.next().await.unwrap();
+            let finalizers = event.take_finalizers();
+
+            self.transformer.transform(&mut event);
+
+            let event_byte_size = event.estimated_json_encoded_size_of();
+
+            let mut bytes = BytesMut::new();
+            match self.encoder.encode(event, &mut bytes) {
+                Ok(()) => {
+                    finalizers.update_status(EventStatus::Delivered);
+
+                    let message = if encode_as_binary {
+                        Message::binary(bytes)
+                    } else {
+                        Message::text(String::from_utf8_lossy(&bytes))
+                    };
+                    let message_len = message.len();
+
+                    let peers = self.peers.lock().unwrap();
+                    let broadcast_recipients = peers.iter().map(|(_, ws_sink)| ws_sink);
+                    for recp in broadcast_recipients {
+                        recp.unbounded_send(message.clone()).unwrap();
+                        events_sent.emit(CountByteSize(1, event_byte_size));
+                        bytes_sent.emit(ByteSize(message_len));
+                    }
+                }
+                Err(_) => {
+                    // Error is handled by `Encoder`.
+                    finalizers.update_status(EventStatus::Errored);
+                }
+            };
+        }
+
+        Ok(())
+    }
+}

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -568,6 +568,7 @@ impl<'a> Builder<'a> {
             let cx = SinkContext {
                 healthcheck,
                 globals: self.config.global.clone(),
+                enrichment_tables: enrichment_tables.clone(),
                 proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
                 schema: self.config.schema,
                 app_name: crate::get_app_name().to_string(),


### PR DESCRIPTION
## Summary

This adds a new sink, similar to `websocket` which acts like a client, while this one acts as a server. It currently broadcasts messages to all currently connected clients. 

It might make sense to add some kind of buffer and allow clients to catch up to missed messages, or something like that, but I wanted to leave such complications for further PRs. 

This also adds customizable authentication using VRL, which would allow us to use custom VRL scripts to check auth, meaning we no longer use hardcoded basic auth and can use enrichment tables to look for credentials.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Started up vector with the following configuration:
```yaml
sources:
  demo_logs_test:
    type: "demo_logs"
    format: "json"

sinks:
  websocket_sink:
    inputs: ["demo_logs_test"]
    type: "websocket_listener"
    address: "0.0.0.0:1234"
    encoding:
      codec: "json"
```

Connected to the server with [websocat](https://github.com/vi/websocat) and observed that events are sent to the client. I have also tested auth in this way, by defining auth header using `websocat`.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).
