### PR TITLE
chore(dev): replace plork images

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -510,3 +510,4 @@ UMTS
 WCDMA
 XMODEM
 cbor
+requestline

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -442,7 +442,6 @@ PIDs
 PII
 plainify
 ple
-plork
 podspec
 Ponge
 POSINT

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -88,6 +88,8 @@ jobs:
         with:
           submodules: "recursive"
 
+      - run: docker image prune -af ; docker container prune -f
+
       - name: Download JSON artifact from changes.yml
         uses: actions/download-artifact@v4
         with:

--- a/docs/tutorials/sinks/2_http_sink.md
+++ b/docs/tutorials/sinks/2_http_sink.md
@@ -503,6 +503,7 @@ with socketserver.TCPServer(("", PORT), Handler) as httpd:
 ```
 
 Run the server:
+
 ```sh
 python3 simple_http_server.py
 ```

--- a/docs/tutorials/sinks/2_http_sink.md
+++ b/docs/tutorials/sinks/2_http_sink.md
@@ -457,10 +457,54 @@ incoming events and the `BasicService` we created above.
 
 We can now run our new sink.
 
-Let's run a test HTTP server to accept the responses our sink sends:
+Here is a potential `simple_http_server.py` server to accept the responses our sink sends:
 
+```python
+import http.server
+import socketserver
+
+
+class RequestHandler(http.server.BaseHTTPRequestHandler):
+   def do_GET(self):
+      # Print the request line and headers
+      print(f"Request Line: {self.requestline}")
+      print("Headers:")
+      for header, value in self.headers.items():
+         print(f"{header}: {value}")
+
+      # Send a response
+      self.send_response(200)
+      self.send_header('Content-type', 'text/html')
+      self.end_headers()
+      self.wfile.write(b'GET request received')
+
+   def do_POST(self):
+      print(f"Request Line: {self.requestline}")
+      print("Headers:")
+      for header, value in self.headers.items():
+         print(f"{header}: {value}")
+
+      content_length = int(self.headers['Content-Length'])
+      post_data = self.rfile.read(content_length)
+      print(f"Body: {post_data.decode('utf-8')}")
+
+      self.send_response(200)
+      self.send_header('Content-type', 'text/html')
+      self.end_headers()
+      self.wfile.write(b'POST request received')
+
+
+PORT = 3000
+Handler = RequestHandler
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+   print(f"Serving HTTP on port {PORT}...")
+   httpd.serve_forever()
+```
+
+Run the server:
 ```sh
-python3 -m http.server 3000
+python3 simple_http_server.py
 ```
 
 Our sink has a new configuration field for the endpoint. Update it to look like:

--- a/docs/tutorials/sinks/2_http_sink.md
+++ b/docs/tutorials/sinks/2_http_sink.md
@@ -460,7 +460,7 @@ We can now run our new sink.
 Let's run a test HTTP server to accept the responses our sink sends:
 
 ```sh
-docker run -p 3000:3000 plork/httpdump
+python3 -m http.server 3000
 ```
 
 Our sink has a new configuration field for the endpoint. Update it to look like:

--- a/scripts/integration/gcp/compose.yaml
+++ b/scripts/integration/gcp/compose.yaml
@@ -7,7 +7,7 @@ services:
     - PUBSUB_PROJECT1=testproject,topic1:subscription1
     - PUBSUB_PROJECT2=sourceproject,topic2:subscription2
   chronicle-emulator:
-    image: docker.io/plork/chronicle-emulator:${CONFIG_VERSION}
+    image: docker.io/timberio/chronicle-emulator:${CONFIG_VERSION}
     ports:
     - 3000:3000
     volumes:


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Use images owned by the Vector org.

I published a new image today: https://hub.docker.com/repository/docker/timberio/chronicle-emulator/general


## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
