### PR TITLE
docs(external): fix OpenTelemetry Sink Quickstart to match expected log data model

### DIFF
--- a/website/cue/reference/components/sinks/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/opentelemetry.cue
@@ -42,9 +42,9 @@ components: sinks: opentelemetry: {
 			title: "Quickstart"
 			body: """
 				This sink is a wrapper over the HTTP sink. The following is an example of how you can push OTEL logs to an OTEL collector.
-				
+
 				1. The Vector config:
-				
+
 				```yaml
 				sources:
 					generate_syslog:
@@ -52,24 +52,15 @@ components: sinks: opentelemetry: {
 						format: "syslog"
 						count: 100000
 						interval: 1
-				
+
 				transforms:
 					remap_syslog:
 						inputs: ["generate_syslog"]
 						type: "remap"
 						source: |
 							syslog = parse_syslog!(.message)
-				
-							.timestamp_nanos = to_unix_timestamp!(syslog.timestamp, unit: "nanoseconds")
-							.body = syslog
-							.service_name = syslog.appname
-							.resource_attributes.source_type = .source_type
-							.resource_attributes.host.hostname = syslog.hostname
-							.resource_attributes.service.name = syslog.appname
-							.attributes.syslog.procid = syslog.procid
-							.attributes.syslog.facility = syslog.facility
-							.attributes.syslog.version = syslog.version
-							.severity_text = if includes(["emerg", "err", "crit", "alert"], syslog.severity) {
+
+							severity_text = if includes(["emerg", "err", "crit", "alert"], syslog.severity) {
 								"ERROR"
 							} else if syslog.severity == "warning" {
 								"WARN"
@@ -78,15 +69,39 @@ components: sinks: opentelemetry: {
 							} else if includes(["info", "notice"], syslog.severity) {
 								"INFO"
 							} else {
-							 syslog.severity
+								syslog.severity
 							}
-							.scope_name = syslog.msgid
-				
+
+							.resourceLogs = [{
+								"resource": {
+									"attributes": [
+										{ "key": "source_type", "value": { "stringValue": .source_type } },
+										{ "key": "service.name", "value": { "stringValue": syslog.appname } },
+										{ "key": "host.hostname", "value": { "stringValue": syslog.hostname } }
+									]
+								},
+								"scopeLogs": [{
+									"scope": {
+										"name": syslog.msgid
+									},
+									"logRecords": [{
+										"timeUnixNano": to_unix_timestamp!(syslog.timestamp, unit: "nanoseconds"),
+										"body": { "stringValue": syslog.message },
+										"severityText": severity_text,
+										"attributes": [
+											{ "key": "syslog.procid", "value": { "stringValue": to_string(syslog.procid) } },
+											{ "key": "syslog.facility", "value": { "stringValue": syslog.facility } },
+											{ "key": "syslog.version", "value": { "stringValue": to_string(syslog.version) } }
+										]
+									}]
+								}]
+							}]
+
 							del(.message)
 							del(.timestamp)
 							del(.service)
 							del(.source_type)
-				
+
 				sinks:
 					emit_syslog:
 						inputs: ["remap_syslog"]
@@ -102,26 +117,27 @@ components: sinks: opentelemetry: {
 							headers:
 								content-type: application/json
 				```
-				
+
 				2. Sample OTEL collector config:
-				
+
 				```yaml
 				receivers:
 					otlp:
 						protocols:
 							http:
 								endpoint: "0.0.0.0:5318"
-				
+
 				exporters:
 					debug:
+						verbosity: detailed
 					otlp:
 						endpoint: localhost:4317
 						tls:
 							insecure: true
-				
+
 				processors:
 					batch: {}
-				
+
 				service:
 					pipelines:
 						logs:
@@ -129,19 +145,19 @@ components: sinks: opentelemetry: {
 							processors: [batch]
 							exporters: [debug]
 				```
-				
+
 				3. Run the OTEL instance:
-				
+
 				```sh
 				./otelcol --config ./otel/config.yaml
 				```
-				
+
 				4. Run Vector:
-				
+
 				```sh
 				VECTOR_LOG=debug cargo run -- --config /path/to/vector/config.yaml
 				```
-				
+
 				"""
 		}
 	}

--- a/website/cue/reference/components/sinks/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/opentelemetry.cue
@@ -158,6 +158,77 @@ components: sinks: opentelemetry: {
 				VECTOR_LOG=debug cargo run -- --config /path/to/vector/config.yaml
 				```
 
+				In the console for the OTEL Collector you will be able to see the logs and their contents as they come in.
+
+				Here's an example of a JSON payload Vector will ship:
+
+				```json
+				{
+				  "host": "localhost",
+				  "resourceLogs": [
+					{
+					  "resource": {
+						"attributes": [
+						  {
+							"key": "source_type",
+							"value": {
+							  "stringValue": "demo_logs"
+							}
+						  },
+						  {
+							"key": "service.name",
+							"value": {
+							  "stringValue": "shaneIxD"
+							}
+						  },
+						  {
+							"key": "host.hostname",
+							"value": {
+							  "stringValue": "random.org"
+							}
+						  }
+						]
+					  },
+					  "scopeLogs": [
+						{
+						  "logRecords": [
+							{
+							  "attributes": [
+								{
+								  "key": "syslog.procid",
+								  "value": {
+									"stringValue": "7906"
+								  }
+								},
+								{
+								  "key": "syslog.facility",
+								  "value": {
+									"stringValue": "local0"
+								  }
+								},
+								{
+								  "key": "syslog.version",
+								  "value": {
+									"stringValue": "1"
+								  }
+								}
+							  ],
+							  "body": {
+								"stringValue": "Maybe we just shouldn't use computers"
+							  },
+							  "severityText": "WARN",
+							  "timeUnixNano": 1737045415051000000
+							}
+						  ],
+						  "scope": {
+							"name": "ID856"
+						  }
+						}
+					  ]
+					}
+				  ]
+				}
+				```
 				"""
 		}
 	}


### PR DESCRIPTION


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
This PR fixes the issue outlined [here](https://github.com/vectordotdev/vector/issues/22216). Currently the OpenTelemetry Sink's quickstart in the docs does not match the expected payload, causing the Collector to return 200 Success but not actually ingest the log. 

This PR updates the format so that it matches examples [provided by OpenTelemetry](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/#examples).

Additionally, it sets the debug exporter to verbose so that new users experimenting with this logging can get console output of what they are sending. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [X] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [X] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: https://github.com/vectordotdev/vector/issues/22216
