### PR TITLE
chore(ci): Update lading to 0.25.4

### DIFF
--- a/regression/config.yaml
+++ b/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.3
+  version: 0.25.4
 
 target:
 


### PR DESCRIPTION
This release of lading contains a fix for splunk-hec tests that do not transmit an ackId.
