### PR TITLE
#11185: Allow specifying a KMS key and tags for newly created AWS CloudWatch log groups.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-kms"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374513bec90ddc64288c1f1e5cb4b95e6df6e42a47d9e332a713f97f66cf9043"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.9.0",
+ "http 0.2.9",
+ "regex",
+ "tracing 0.1.41",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10964,6 +10986,7 @@ dependencies = [
  "aws-sdk-elasticsearch",
  "aws-sdk-firehose",
  "aws-sdk-kinesis",
+ "aws-sdk-kms",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
  "aws-sdk-sns",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ aws-sdk-sqs = { version = "1.3.0", default-features = false, features = ["behavi
 aws-sdk-sns = { version = "1.6.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-cloudwatch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-cloudwatchlogs = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-kms = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
@@ -757,7 +758,7 @@ sinks-metrics = [
 
 sinks-amqp = ["lapin"]
 sinks-appsignal = []
-sinks-aws_cloudwatch_logs = ["aws-core", "dep:aws-sdk-cloudwatchlogs"]
+sinks-aws_cloudwatch_logs = ["aws-core", "dep:aws-sdk-cloudwatchlogs", "dep:aws-sdk-kms"]
 sinks-aws_cloudwatch_metrics = ["aws-core", "dep:aws-sdk-cloudwatch"]
 sinks-aws_kinesis_firehose = ["aws-core", "dep:aws-sdk-firehose"]
 sinks-aws_kinesis_streams = ["aws-core", "dep:aws-sdk-kinesis"]

--- a/scripts/integration/aws/compose.yaml
+++ b/scripts/integration/aws/compose.yaml
@@ -6,7 +6,7 @@ services:
   mock-localstack:
     image: docker.io/localstack/localstack:3
     environment:
-    - SERVICES=kinesis,s3,cloudwatch,es,firehose,sqs,sns,logs
+    - SERVICES=kinesis,s3,cloudwatch,es,firehose,kms,sqs,sns,logs
   mock-ecs:
     image: docker.io/amazon/amazon-ecs-local-container-endpoints:latest
     volumes:

--- a/scripts/integration/aws/test.yaml
+++ b/scripts/integration/aws/test.yaml
@@ -11,6 +11,7 @@ env:
   ECS_ADDRESS: http://mock-ecs
   ELASTICSEARCH_ADDRESS: http://mock-localstack:4566
   KINESIS_ADDRESS: http://mock-localstack:4566
+  KMS_ADDRESS: http://mock-localstack:4566
   S3_ADDRESS: http://mock-localstack:4566
   SQS_ADDRESS: http://mock-localstack:4566
   SNS_ADDRESS: http://mock-localstack:4566

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use futures::FutureExt;
 use serde::{de, Deserialize, Deserializer};
@@ -164,6 +165,14 @@ pub struct CloudwatchLogsSinkConfig {
         skip_serializing_if = "crate::serde::is_default"
     )]
     pub acknowledgements: AcknowledgementsConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub kms_key: Option<String>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub tags: Option<HashMap<String, String>>,
 }
 
 impl CloudwatchLogsSinkConfig {
@@ -248,6 +257,8 @@ fn default_config(encoding: EncodingConfig) -> CloudwatchLogsSinkConfig {
         assume_role: Default::default(),
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: Default::default(),
+        tags: Default::default(),
     }
 }
 

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use aws_config::Region;
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
+use aws_sdk_kms::Client as KMSClient;
 use chrono::Duration;
 use futures::{stream, StreamExt};
 use similar_asserts::assert_eq;
@@ -9,7 +11,7 @@ use vector_lib::codecs::TextSerializerConfig;
 use vector_lib::lookup;
 
 use super::*;
-use crate::aws::create_client;
+use crate::aws::{create_client, ClientBuilder};
 use crate::aws::{AwsAuthentication, RegionOrEndpoint};
 use crate::sinks::aws_cloudwatch_logs::config::CloudwatchLogsClientBuilder;
 use crate::{
@@ -27,6 +29,20 @@ const GROUP_NAME: &str = "vector-cw";
 
 fn cloudwatch_address() -> String {
     std::env::var("CLOUDWATCH_ADDRESS").unwrap_or_else(|_| "http://localhost:4566".into())
+}
+
+fn kms_address() -> String {
+    std::env::var("KMS_ADDRESS").unwrap_or_else(|_| "http://localhost:4566".into())
+}
+
+struct KMSClientBuilder;
+
+impl ClientBuilder for KMSClientBuilder {
+    type Client = aws_sdk_kms::client::Client;
+
+    fn build(&self, config: &aws_types::SdkConfig) -> Self::Client {
+        aws_sdk_kms::client::Client::new(config)
+    }
 }
 
 #[tokio::test]
@@ -51,6 +67,8 @@ async fn cloudwatch_insert_log_event() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let (sink, _) = config.build(SinkContext::default()).await.unwrap();
@@ -102,6 +120,8 @@ async fn cloudwatch_insert_log_events_sorted() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let (sink, _) = config.build(SinkContext::default()).await.unwrap();
@@ -178,6 +198,8 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let (sink, _) = config.build(SinkContext::default()).await.unwrap();
@@ -255,6 +277,8 @@ async fn cloudwatch_dynamic_group_and_stream_creation() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let (sink, _) = config.build(SinkContext::default()).await.unwrap();
@@ -285,6 +309,88 @@ async fn cloudwatch_dynamic_group_and_stream_creation() {
 }
 
 #[tokio::test]
+async fn cloudwatch_dynamic_group_and_stream_creation_with_kms_key_and_tags() {
+    trace_init();
+
+    let stream_name = gen_name();
+    let group_name = gen_name();
+
+    let config = CloudwatchLogsSinkConfig {
+        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        group_name: Template::try_from(group_name.as_str()).unwrap(),
+        region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
+        encoding: TextSerializerConfig::default().into(),
+        create_missing_group: true,
+        create_missing_stream: true,
+        retention: Default::default(),
+        compression: Default::default(),
+        batch: Default::default(),
+        request: Default::default(),
+        tls: Default::default(),
+        assume_role: None,
+        auth: Default::default(),
+        acknowledgements: Default::default(),
+        kms_key: Some(create_kms_client_test().await.create_key().send().await.unwrap().key_metadata().unwrap().key_id().parse().unwrap()),
+        tags: Some(HashMap::from_iter(vec![("key".to_string(), "value".to_string())])),
+    };
+
+    let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+
+    let timestamp = chrono::Utc::now();
+
+    let (mut input_lines, events) = random_lines_with_stream(100, 11, None);
+    run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
+
+    let response = create_client_test()
+        .await
+        .get_log_events()
+        .log_stream_name(stream_name)
+        .log_group_name(group_name.clone())
+        .start_time(timestamp.timestamp_millis())
+        .send()
+        .await
+        .unwrap();
+
+    let events = response.events.unwrap();
+
+    let mut output_lines = events
+        .into_iter()
+        .map(|e| e.message.unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(output_lines.sort(), input_lines.sort());
+
+    let log_group = create_client_test()
+        .await
+        .describe_log_groups()
+        .log_group_name_pattern(group_name.clone())
+        .limit(1)
+        .send()
+        .await
+        .unwrap()
+        .log_groups()
+        .first()
+        .unwrap()
+        .clone();
+
+    let kms_key = log_group.kms_key_id().unwrap();
+    assert_eq!(kms_key, config.kms_key.unwrap());
+
+    // TODO: tags are not returned properly - investigate
+    /*let tags = create_client_test()
+        .await
+        .list_tags_for_resource()
+        .resource_arn(log_group.arn().unwrap())
+        .send()
+        .await
+        .unwrap()
+        .tags()
+        .unwrap()
+        .clone();
+    assert_eq!(tags, config.tags.unwrap());*/
+}
+
+#[tokio::test]
 async fn cloudwatch_insert_log_event_batched() {
     trace_init();
 
@@ -311,6 +417,8 @@ async fn cloudwatch_insert_log_event_batched() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let (sink, _) = config.build(SinkContext::default()).await.unwrap();
@@ -362,6 +470,8 @@ async fn cloudwatch_insert_log_event_partitioned() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let (sink, _) = config.build(SinkContext::default()).await.unwrap();
@@ -455,6 +565,8 @@ async fn cloudwatch_healthcheck() {
         assume_role: None,
         auth: Default::default(),
         acknowledgements: Default::default(),
+        kms_key: None,
+        tags: None,
     };
 
     let client = config.create_client(&ProxyConfig::default()).await.unwrap();
@@ -478,6 +590,25 @@ async fn create_client_test() -> CloudwatchLogsClient {
     )
     .await
     .unwrap()
+}
+
+async fn create_kms_client_test() -> KMSClient {
+    let auth = AwsAuthentication::test_auth();
+    let region = Some(Region::new("us-east-1"));
+    let endpoint = Some(kms_address());
+    let proxy = ProxyConfig::default();
+
+    create_client::<KMSClientBuilder>(
+        &KMSClientBuilder {},
+        &auth,
+        region,
+        endpoint,
+        &proxy,
+        None,
+        None,
+    )
+        .await
+        .unwrap()
 }
 
 async fn ensure_group() {

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
     task::{ready, Context, Poll},
 };
-
+use std::collections::HashMap;
 use aws_sdk_cloudwatchlogs::{
     operation::{
         create_log_group::CreateLogGroupError,
@@ -40,6 +40,8 @@ struct Client {
     group_name: String,
     headers: IndexMap<HeaderName, HeaderValue>,
     retention_days: u32,
+    kms_key: Option<String>,
+    tags: Option<HashMap<String, String>>,
 }
 
 type ClientResult<T, E> = BoxFuture<'static, Result<T, SdkError<E, HttpResponse>>>;
@@ -63,6 +65,8 @@ impl CloudwatchFuture {
         create_missing_group: bool,
         create_missing_stream: bool,
         retention: Retention,
+        kms_key: Option<String>,
+        tags: Option<HashMap<String, String>>,
         mut events: Vec<Vec<InputLogEvent>>,
         token: Option<String>,
         token_tx: oneshot::Sender<Option<String>>,
@@ -74,6 +78,8 @@ impl CloudwatchFuture {
             group_name,
             headers,
             retention_days,
+            kms_key,
+            tags
         };
 
         let state = if let Some(token) = token {
@@ -288,10 +294,14 @@ impl Client {
     pub fn create_log_group(&self) -> ClientResult<(), CreateLogGroupError> {
         let client = self.client.clone();
         let group_name = self.group_name.clone();
+        let kms_key = self.kms_key.clone();
+        let tags = self.tags.clone();
         Box::pin(async move {
             client
                 .create_log_group()
                 .log_group_name(group_name)
+                .set_kms_key_id(kms_key)
+                .set_tags(tags)
                 .send()
                 .await?;
             Ok(())

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -240,6 +240,9 @@ impl CloudwatchLogsSvc {
 
         let retention = config.retention.clone();
 
+        let kms_key = config.kms_key.clone();
+        let tags = config.tags.clone();
+
         CloudwatchLogsSvc {
             headers,
             client,
@@ -248,6 +251,8 @@ impl CloudwatchLogsSvc {
             create_missing_group,
             create_missing_stream,
             retention,
+            kms_key,
+            tags,
             token: None,
             token_rx: None,
         }
@@ -322,6 +327,8 @@ impl Service<Vec<InputLogEvent>> for CloudwatchLogsSvc {
                 self.create_missing_group,
                 self.create_missing_stream,
                 self.retention.clone(),
+                self.kms_key.clone(),
+                self.tags.clone(),
                 event_batches,
                 self.token.take(),
                 tx,
@@ -340,6 +347,8 @@ pub struct CloudwatchLogsSvc {
     create_missing_group: bool,
     create_missing_stream: bool,
     retention: Retention,
+    kms_key: Option<String>,
+    tags: Option<HashMap<String, String>>,
     token: Option<String>,
     token_rx: Option<oneshot::Receiver<Option<String>>>,
 }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Implements the feature request #11185 by allowing users to specify a KMS key and tags for AWS CloudWatch log group sinks that are being used when creating new groups.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?

* New integration test is provided in the PR.
* Manually
  * Get yourself an AWS environment
  * Create a new KMS key and make sure that key can be used to encrypt CloudWatch log groups (for an example Key policy snippet see below)
  * Create a Vector config file as seen below, replace `$KMS_KEY` with the ARN of the key created in the previous step.
  * Run Vector: vector --config ./vector.yaml, see 3 new log groups being created: One without both custom KMS key and tags, one with only tags and one with both custom KMS key and tags.

Key policy that allows the usage in log groups in `us-east-1`:

```
{
  "Sid": "Allow use of the key for CloudWatch",
  "Effect": "Allow",
  "Principal": {
    "Service": "logs.us-east-1.amazonaws.com"
  },
  "Action": [
    "kms:Encrypt",
    "kms:Decrypt",
    "kms:ReEncrypt*",
    "kms:GenerateDataKey*",
    "kms:DescribeKey"
  ],
  "Resource": "*"
}
```

`vector.yaml`

```
sources:
  demo_logs:
    type: demo_logs
    format: json
sinks:
  cloudwatch_logs_without:
    type: aws_cloudwatch_logs
    inputs: [demo_logs]
    group_name: /without
    stream_name: demo-stream
    encoding:
      codec: json
  cloudwatch_logs_standard:
    type: aws_cloudwatch_logs
    inputs: [demo_logs]
    group_name: /standard
    stream_name: demo-stream
    encoding:
      codec: json
    tags:
      type: standard
  cloudwatch_logs_custom_kms_key:
    type: aws_cloudwatch_logs
    inputs: [demo_logs]
    group_name: /with-kms
    stream_name: demo-stream
    encoding:
      codec: json
    kms_key: $KMS_KEY
    tags:
      type: kms-key
```

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: #11185