### PR TITLE
docs(external): fix wording in common sinks components docs

### DIFF
--- a/lib/codecs/src/encoding/format/cef.rs
+++ b/lib/codecs/src/encoding/format/cef.rs
@@ -195,7 +195,7 @@ impl std::fmt::Display for Version {
 #[derive(Debug, Clone)]
 pub struct CefSerializerOptions {
     /// CEF Version. Can be either 0 or 1.
-    /// Equals to "0" by default.
+    /// Set to "0" by default.
     pub version: Version,
 
     /// Identifies the vendor of the product.
@@ -208,7 +208,7 @@ pub struct CefSerializerOptions {
     /// The value length must be less than or equal to 63.
     pub device_product: String,
 
-    /// Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+    /// Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
     /// The value length must be less than or equal to 31.
     pub device_version: String,
 
@@ -220,8 +220,8 @@ pub struct CefSerializerOptions {
     /// Reflects importance of the event.
     ///
     /// It must point to a number from 0 to 10.
-    /// 0 = Lowest, 10 = Highest.
-    /// Equals to "cef.severity" by default.
+    /// 0 = lowest_importance, 10 = highest_importance.
+    /// Set to "cef.severity" by default.
     pub severity: ConfigTargetPath,
 
     /// This is a path that points to the human-readable description of a log event.

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -27,8 +27,8 @@ pub enum QuoteStyle {
     Necessary,
 
     /// Puts quotes around all fields that are non-numeric.
-    /// Namely, when writing a field that does not parse as a valid float or integer,
-    /// then quotes are used even if they aren't strictly necessary.
+    /// This means that when writing a field that does not parse as a valid float or integer,
+    /// quotes are used even if they aren't strictly necessary.
     NonNumeric,
 
     /// Never writes quotes, even if it produces invalid CSV data.
@@ -84,9 +84,9 @@ pub struct CsvSerializerOptions {
     )]
     pub delimiter: u8,
 
-    /// Enable double quote escapes.
+    /// Enables double quote escapes.
     ///
-    /// This is enabled by default, but it may be disabled. When disabled, quotes in
+    /// This is enabled by default, but you can disable it. When disabled, quotes in
     /// field data are escaped instead of doubled.
     #[serde(
         default = "default_double_quote",
@@ -99,7 +99,7 @@ pub struct CsvSerializerOptions {
     /// In some variants of CSV, quotes are escaped using a special escape character
     /// like \ (instead of escaping quotes by doubling them).
     ///
-    /// To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+    /// To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
     #[configurable(metadata(docs::type_override = "ascii_char"))]
     #[serde(
         default = "default_escape",
@@ -121,18 +121,18 @@ pub struct CsvSerializerOptions {
     #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub quote_style: QuoteStyle,
 
-    /// Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-    /// This defaults to a reasonable setting.
+    /// Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+    /// This defaults to 8KB.
     #[serde(default = "default_capacity")]
     pub capacity: usize,
 
-    /// Configures the fields that will be encoded, as well as the order in which they
+    /// Configures the fields that are encoded, as well as the order in which they
     /// appear in the output.
     ///
-    /// If a field is not present in the event, the output will be an empty string.
+    /// If a field is not present in the event, the output for that field is an empty string.
     ///
-    /// Values of type `Array`, `Object`, and `Regex` are not supported and the
-    /// output will be an empty string.
+    /// Values of type `Array`, `Object`, and `Regex` are not supported, and the
+    /// output for any of these types is an empty string.
     pub fields: Vec<ConfigTargetPath>,
 }
 

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -206,11 +206,11 @@ pub enum SerializerConfig {
     /// Vector's encoder currently adheres more strictly to the GELF spec, with
     /// the exception that some characters such as `@`  are allowed in field names.
     ///
-    /// Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-    /// by Graylog, and is much more relaxed than the GELF spec.
+    /// Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+    /// by Graylog and is much more relaxed than the GELF spec.
     ///
     /// Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-    /// the codec may continue to relax the enforcement of specification.
+    /// the codec might continue to relax the enforcement of the specification.
     ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
     /// [implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -357,9 +357,9 @@ impl From<SourceAcknowledgementsConfig> for AcknowledgementsConfig {
 pub struct AcknowledgementsConfig {
     /// Whether or not end-to-end acknowledgements are enabled.
     ///
-    /// When enabled for a sink, any source connected to that sink where the source supports
-    /// end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-    /// connected** sinks before acknowledging them at the source.
+    /// When enabled for a sink, any source that supports end-to-end
+    /// acknowledgements that is connected to that sink waits for events
+    /// to be acknowledged by **all connected sinks** before acknowledging them at the source.
     ///
     /// Enabling or disabling acknowledgements at the sink level takes precedence over any global
     /// [`acknowledgements`][global_acks] configuration.

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -92,7 +92,7 @@ pub struct TlsConfig {
     /// If enabled, certificates must not be expired and must be issued by a trusted
     /// issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
     /// certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-    /// so on until the verification process reaches a root certificate.
+    /// so on, until the verification process reaches a root certificate.
     ///
     /// Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
     pub verify_certificate: Option<bool>,
@@ -109,7 +109,7 @@ pub struct TlsConfig {
 
     /// Sets the list of supported ALPN protocols.
     ///
-    /// Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+    /// Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
     /// that they are defined.
     #[configurable(metadata(docs::examples = "h2"))]
     pub alpn_protocols: Option<Vec<String>>,
@@ -127,7 +127,7 @@ pub struct TlsConfig {
     /// The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
     /// an inline string in PEM format.
     ///
-    /// If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+    /// If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
     #[serde(alias = "crt_path")]
     #[configurable(metadata(docs::examples = "/path/to/host_certificate.crt"))]
     #[configurable(metadata(docs::human_name = "Certificate File Path"))]

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -54,7 +54,7 @@ pub struct MetricToLogConfig {
 
     /// Controls how metric tag values are encoded.
     ///
-    /// When set to `single`, only the last non-bare value of tags are displayed with the
+    /// When set to `single`, only the last non-bare value of tags is displayed with the
     /// metric.  When set to `full`, all metric tags are exposed as separate assignments as
     /// described by [the `native_json` codec][vector_native_json].
     ///

--- a/website/cue/reference/components/sinks/base/amqp.cue
+++ b/website/cue/reference/components/sinks/base/amqp.cue
@@ -14,9 +14,9 @@ base: components: sinks: amqp: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -90,7 +90,7 @@ base: components: sinks: amqp: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -123,8 +123,8 @@ base: components: sinks: amqp: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -132,7 +132,7 @@ base: components: sinks: amqp: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -166,11 +166,11 @@ base: components: sinks: amqp: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -234,8 +234,8 @@ base: components: sinks: amqp: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -247,9 +247,9 @@ base: components: sinks: amqp: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -262,20 +262,20 @@ base: components: sinks: amqp: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -301,8 +301,8 @@ base: components: sinks: amqp: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -430,7 +430,7 @@ base: components: sinks: amqp: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -452,7 +452,7 @@ base: components: sinks: amqp: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -493,7 +493,7 @@ base: components: sinks: amqp: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/appsignal.cue
+++ b/website/cue/reference/components/sinks/base/appsignal.cue
@@ -14,9 +14,9 @@ base: components: sinks: appsignal: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -331,7 +331,7 @@ base: components: sinks: appsignal: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -353,7 +353,7 @@ base: components: sinks: appsignal: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -404,7 +404,7 @@ base: components: sinks: appsignal: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -278,7 +278,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -311,8 +311,8 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -320,7 +320,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -354,11 +354,11 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -422,8 +422,8 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -435,9 +435,9 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -450,20 +450,20 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -489,8 +489,8 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -859,7 +859,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -881,7 +881,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -922,7 +922,7 @@ base: components: sinks: aws_cloudwatch_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/base/aws_cloudwatch_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -427,7 +427,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -449,7 +449,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -490,7 +490,7 @@ base: components: sinks: aws_cloudwatch_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_firehose.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -257,7 +257,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -290,8 +290,8 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -299,7 +299,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -333,11 +333,11 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -401,8 +401,8 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -414,9 +414,9 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -429,20 +429,20 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -468,8 +468,8 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -785,7 +785,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -807,7 +807,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -848,7 +848,7 @@ base: components: sinks: aws_kinesis_firehose: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/base/aws_kinesis_streams.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -257,7 +257,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -290,8 +290,8 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -299,7 +299,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -333,11 +333,11 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -401,8 +401,8 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -414,9 +414,9 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -429,20 +429,20 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -468,8 +468,8 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -785,7 +785,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -807,7 +807,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -848,7 +848,7 @@ base: components: sinks: aws_kinesis_streams: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_s3.cue
+++ b/website/cue/reference/components/sinks/base/aws_s3.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_s3: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -366,7 +366,7 @@ base: components: sinks: aws_s3: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -399,8 +399,8 @@ base: components: sinks: aws_s3: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -408,7 +408,7 @@ base: components: sinks: aws_s3: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -442,11 +442,11 @@ base: components: sinks: aws_s3: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -510,8 +510,8 @@ base: components: sinks: aws_s3: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -523,9 +523,9 @@ base: components: sinks: aws_s3: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -538,20 +538,20 @@ base: components: sinks: aws_s3: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -577,8 +577,8 @@ base: components: sinks: aws_s3: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -1132,7 +1132,7 @@ base: components: sinks: aws_s3: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -1154,7 +1154,7 @@ base: components: sinks: aws_s3: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -1195,7 +1195,7 @@ base: components: sinks: aws_s3: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_sns.cue
+++ b/website/cue/reference/components/sinks/base/aws_sns.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_sns: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -188,7 +188,7 @@ base: components: sinks: aws_sns: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -221,8 +221,8 @@ base: components: sinks: aws_sns: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -230,7 +230,7 @@ base: components: sinks: aws_sns: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -264,11 +264,11 @@ base: components: sinks: aws_sns: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -332,8 +332,8 @@ base: components: sinks: aws_sns: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -345,9 +345,9 @@ base: components: sinks: aws_sns: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -360,20 +360,20 @@ base: components: sinks: aws_sns: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -399,8 +399,8 @@ base: components: sinks: aws_sns: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -714,7 +714,7 @@ base: components: sinks: aws_sns: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -736,7 +736,7 @@ base: components: sinks: aws_sns: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -777,7 +777,7 @@ base: components: sinks: aws_sns: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/base/aws_sqs.cue
@@ -14,9 +14,9 @@ base: components: sinks: aws_sqs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -188,7 +188,7 @@ base: components: sinks: aws_sqs: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -221,8 +221,8 @@ base: components: sinks: aws_sqs: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -230,7 +230,7 @@ base: components: sinks: aws_sqs: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -264,11 +264,11 @@ base: components: sinks: aws_sqs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -332,8 +332,8 @@ base: components: sinks: aws_sqs: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -345,9 +345,9 @@ base: components: sinks: aws_sqs: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -360,20 +360,20 @@ base: components: sinks: aws_sqs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -399,8 +399,8 @@ base: components: sinks: aws_sqs: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -719,7 +719,7 @@ base: components: sinks: aws_sqs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -741,7 +741,7 @@ base: components: sinks: aws_sqs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -782,7 +782,7 @@ base: components: sinks: aws_sqs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/axiom.cue
+++ b/website/cue/reference/components/sinks/base/axiom.cue
@@ -8,9 +8,9 @@ base: components: sinks: axiom: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -304,7 +304,7 @@ base: components: sinks: axiom: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -326,7 +326,7 @@ base: components: sinks: axiom: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -367,7 +367,7 @@ base: components: sinks: axiom: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/azure_blob.cue
+++ b/website/cue/reference/components/sinks/base/azure_blob.cue
@@ -14,9 +14,9 @@ base: components: sinks: azure_blob: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -222,7 +222,7 @@ base: components: sinks: azure_blob: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -255,8 +255,8 @@ base: components: sinks: azure_blob: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -264,7 +264,7 @@ base: components: sinks: azure_blob: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -298,11 +298,11 @@ base: components: sinks: azure_blob: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -366,8 +366,8 @@ base: components: sinks: azure_blob: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -379,9 +379,9 @@ base: components: sinks: azure_blob: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -394,20 +394,20 @@ base: components: sinks: azure_blob: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -433,8 +433,8 @@ base: components: sinks: azure_blob: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/base/azure_monitor_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: azure_monitor_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -345,7 +345,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -367,7 +367,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -408,7 +408,7 @@ base: components: sinks: azure_monitor_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/blackhole.cue
+++ b/website/cue/reference/components/sinks/base/blackhole.cue
@@ -14,9 +14,9 @@ base: components: sinks: blackhole: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/clickhouse.cue
+++ b/website/cue/reference/components/sinks/base/clickhouse.cue
@@ -14,9 +14,9 @@ base: components: sinks: clickhouse: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -418,7 +418,7 @@ base: components: sinks: clickhouse: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -440,7 +440,7 @@ base: components: sinks: clickhouse: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -481,7 +481,7 @@ base: components: sinks: clickhouse: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/console.cue
+++ b/website/cue/reference/components/sinks/base/console.cue
@@ -14,9 +14,9 @@ base: components: sinks: console: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -74,7 +74,7 @@ base: components: sinks: console: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -107,8 +107,8 @@ base: components: sinks: console: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -116,7 +116,7 @@ base: components: sinks: console: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -150,11 +150,11 @@ base: components: sinks: console: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -218,8 +218,8 @@ base: components: sinks: console: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -231,9 +231,9 @@ base: components: sinks: console: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -246,20 +246,20 @@ base: components: sinks: console: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -285,8 +285,8 @@ base: components: sinks: console: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/databend.cue
+++ b/website/cue/reference/components/sinks/base/databend.cue
@@ -14,9 +14,9 @@ base: components: sinks: databend: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -151,8 +151,8 @@ base: components: sinks: databend: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -164,9 +164,9 @@ base: components: sinks: databend: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -179,20 +179,20 @@ base: components: sinks: databend: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -218,8 +218,8 @@ base: components: sinks: databend: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -503,7 +503,7 @@ base: components: sinks: databend: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -525,7 +525,7 @@ base: components: sinks: databend: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -566,7 +566,7 @@ base: components: sinks: databend: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/datadog_events.cue
+++ b/website/cue/reference/components/sinks/base/datadog_events.cue
@@ -14,9 +14,9 @@ base: components: sinks: datadog_events: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -265,7 +265,7 @@ base: components: sinks: datadog_events: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -287,7 +287,7 @@ base: components: sinks: datadog_events: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -338,7 +338,7 @@ base: components: sinks: datadog_events: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/base/datadog_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: datadog_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -368,7 +368,7 @@ base: components: sinks: datadog_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -390,7 +390,7 @@ base: components: sinks: datadog_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -441,7 +441,7 @@ base: components: sinks: datadog_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/base/datadog_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: datadog_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -307,7 +307,7 @@ base: components: sinks: datadog_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -329,7 +329,7 @@ base: components: sinks: datadog_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -380,7 +380,7 @@ base: components: sinks: datadog_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/base/datadog_traces.cue
@@ -14,9 +14,9 @@ base: components: sinks: datadog_traces: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -331,7 +331,7 @@ base: components: sinks: datadog_traces: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -353,7 +353,7 @@ base: components: sinks: datadog_traces: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -404,7 +404,7 @@ base: components: sinks: datadog_traces: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/base/elasticsearch.cue
@@ -14,9 +14,9 @@ base: components: sinks: elasticsearch: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -526,7 +526,7 @@ base: components: sinks: elasticsearch: configuration: {
 				description: """
 					Controls how metric tag values are encoded.
 
-					When set to `single`, only the last non-bare value of tags are displayed with the
+					When set to `single`, only the last non-bare value of tags is displayed with the
 					metric.  When set to `full`, all metric tags are exposed as separate assignments as
 					described by [the `native_json` codec][vector_native_json].
 
@@ -834,7 +834,7 @@ base: components: sinks: elasticsearch: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -856,7 +856,7 @@ base: components: sinks: elasticsearch: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -897,7 +897,7 @@ base: components: sinks: elasticsearch: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/file.cue
+++ b/website/cue/reference/components/sinks/base/file.cue
@@ -14,9 +14,9 @@ base: components: sinks: file: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -94,7 +94,7 @@ base: components: sinks: file: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -127,8 +127,8 @@ base: components: sinks: file: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -136,7 +136,7 @@ base: components: sinks: file: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -170,11 +170,11 @@ base: components: sinks: file: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -238,8 +238,8 @@ base: components: sinks: file: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -251,9 +251,9 @@ base: components: sinks: file: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -266,20 +266,20 @@ base: components: sinks: file: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -305,8 +305,8 @@ base: components: sinks: file: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/base/gcp_chronicle_unstructured.cue
@@ -14,9 +14,9 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -162,7 +162,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -195,8 +195,8 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -204,7 +204,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -238,11 +238,11 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -306,8 +306,8 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -319,9 +319,9 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -334,20 +334,20 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -373,8 +373,8 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -719,7 +719,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -741,7 +741,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -782,7 +782,7 @@ base: components: sinks: gcp_chronicle_unstructured: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/base/gcp_cloud_storage.cue
@@ -14,9 +14,9 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -235,7 +235,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -268,8 +268,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -277,7 +277,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -311,11 +311,11 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -379,8 +379,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -392,9 +392,9 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -407,20 +407,20 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -446,8 +446,8 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -896,7 +896,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -918,7 +918,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -959,7 +959,7 @@ base: components: sinks: gcp_cloud_storage: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/base/gcp_pubsub.cue
@@ -14,9 +14,9 @@ base: components: sinks: gcp_pubsub: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -141,7 +141,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -174,8 +174,8 @@ base: components: sinks: gcp_pubsub: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -183,7 +183,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -217,11 +217,11 @@ base: components: sinks: gcp_pubsub: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -285,8 +285,8 @@ base: components: sinks: gcp_pubsub: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -298,9 +298,9 @@ base: components: sinks: gcp_pubsub: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -313,20 +313,20 @@ base: components: sinks: gcp_pubsub: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -352,8 +352,8 @@ base: components: sinks: gcp_pubsub: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -654,7 +654,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -676,7 +676,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -717,7 +717,7 @@ base: components: sinks: gcp_pubsub: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -421,7 +421,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -443,7 +443,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -484,7 +484,7 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -342,7 +342,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -364,7 +364,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -405,7 +405,7 @@ base: components: sinks: gcp_stackdriver_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/greptimedb.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb.cue
@@ -14,9 +14,9 @@ base: components: sinks: greptimedb: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -326,7 +326,7 @@ base: components: sinks: greptimedb: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -348,7 +348,7 @@ base: components: sinks: greptimedb: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -389,7 +389,7 @@ base: components: sinks: greptimedb: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: greptimedb_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -392,7 +392,7 @@ base: components: sinks: greptimedb_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -414,7 +414,7 @@ base: components: sinks: greptimedb_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -455,7 +455,7 @@ base: components: sinks: greptimedb_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/greptimedb_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: greptimedb_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -326,7 +326,7 @@ base: components: sinks: greptimedb_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -348,7 +348,7 @@ base: components: sinks: greptimedb_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -389,7 +389,7 @@ base: components: sinks: greptimedb_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/honeycomb.cue
+++ b/website/cue/reference/components/sinks/base/honeycomb.cue
@@ -14,9 +14,9 @@ base: components: sinks: honeycomb: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/http.cue
+++ b/website/cue/reference/components/sinks/base/http.cue
@@ -14,9 +14,9 @@ base: components: sinks: http: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -187,7 +187,7 @@ base: components: sinks: http: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -220,8 +220,8 @@ base: components: sinks: http: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -229,7 +229,7 @@ base: components: sinks: http: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -263,11 +263,11 @@ base: components: sinks: http: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -331,8 +331,8 @@ base: components: sinks: http: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -344,9 +344,9 @@ base: components: sinks: http: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -359,20 +359,20 @@ base: components: sinks: http: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -398,8 +398,8 @@ base: components: sinks: http: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -806,7 +806,7 @@ base: components: sinks: http: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -828,7 +828,7 @@ base: components: sinks: http: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -869,7 +869,7 @@ base: components: sinks: http: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/humio_logs.cue
+++ b/website/cue/reference/components/sinks/base/humio_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: humio_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -140,7 +140,7 @@ base: components: sinks: humio_logs: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -173,8 +173,8 @@ base: components: sinks: humio_logs: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -182,7 +182,7 @@ base: components: sinks: humio_logs: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -216,11 +216,11 @@ base: components: sinks: humio_logs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -284,8 +284,8 @@ base: components: sinks: humio_logs: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -297,9 +297,9 @@ base: components: sinks: humio_logs: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -312,20 +312,20 @@ base: components: sinks: humio_logs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -351,8 +351,8 @@ base: components: sinks: humio_logs: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -731,7 +731,7 @@ base: components: sinks: humio_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -753,7 +753,7 @@ base: components: sinks: humio_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -794,7 +794,7 @@ base: components: sinks: humio_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/base/humio_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: humio_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -182,7 +182,7 @@ base: components: sinks: humio_metrics: configuration: {
 		description: """
 			Controls how metric tag values are encoded.
 
-			When set to `single`, only the last non-bare value of tags are displayed with the
+			When set to `single`, only the last non-bare value of tags is displayed with the
 			metric.  When set to `full`, all metric tags are exposed as separate assignments as
 			described by [the `native_json` codec][vector_native_json].
 
@@ -418,7 +418,7 @@ base: components: sinks: humio_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -440,7 +440,7 @@ base: components: sinks: humio_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -481,7 +481,7 @@ base: components: sinks: humio_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: influxdb_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -404,7 +404,7 @@ base: components: sinks: influxdb_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -426,7 +426,7 @@ base: components: sinks: influxdb_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -467,7 +467,7 @@ base: components: sinks: influxdb_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/base/influxdb_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: influxdb_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -348,7 +348,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -370,7 +370,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -411,7 +411,7 @@ base: components: sinks: influxdb_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/kafka.cue
+++ b/website/cue/reference/components/sinks/base/kafka.cue
@@ -14,9 +14,9 @@ base: components: sinks: kafka: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -129,7 +129,7 @@ base: components: sinks: kafka: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -162,8 +162,8 @@ base: components: sinks: kafka: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -171,7 +171,7 @@ base: components: sinks: kafka: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -205,11 +205,11 @@ base: components: sinks: kafka: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -273,8 +273,8 @@ base: components: sinks: kafka: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -286,9 +286,9 @@ base: components: sinks: kafka: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -301,20 +301,20 @@ base: components: sinks: kafka: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -340,8 +340,8 @@ base: components: sinks: kafka: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -544,7 +544,7 @@ base: components: sinks: kafka: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -566,7 +566,7 @@ base: components: sinks: kafka: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -617,7 +617,7 @@ base: components: sinks: kafka: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/keep.cue
+++ b/website/cue/reference/components/sinks/base/keep.cue
@@ -14,9 +14,9 @@ base: components: sinks: keep: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/logdna.cue
+++ b/website/cue/reference/components/sinks/base/logdna.cue
@@ -14,9 +14,9 @@ base: components: sinks: logdna: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/loki.cue
+++ b/website/cue/reference/components/sinks/base/loki.cue
@@ -14,9 +14,9 @@ base: components: sinks: loki: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -189,7 +189,7 @@ base: components: sinks: loki: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -222,8 +222,8 @@ base: components: sinks: loki: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -231,7 +231,7 @@ base: components: sinks: loki: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -265,11 +265,11 @@ base: components: sinks: loki: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -333,8 +333,8 @@ base: components: sinks: loki: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -346,9 +346,9 @@ base: components: sinks: loki: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -361,20 +361,20 @@ base: components: sinks: loki: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -400,8 +400,8 @@ base: components: sinks: loki: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -812,7 +812,7 @@ base: components: sinks: loki: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -834,7 +834,7 @@ base: components: sinks: loki: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -875,7 +875,7 @@ base: components: sinks: loki: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/mezmo.cue
+++ b/website/cue/reference/components/sinks/base/mezmo.cue
@@ -14,9 +14,9 @@ base: components: sinks: mezmo: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/mqtt.cue
+++ b/website/cue/reference/components/sinks/base/mqtt.cue
@@ -14,9 +14,9 @@ base: components: sinks: mqtt: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -84,7 +84,7 @@ base: components: sinks: mqtt: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -117,8 +117,8 @@ base: components: sinks: mqtt: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -126,7 +126,7 @@ base: components: sinks: mqtt: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -160,11 +160,11 @@ base: components: sinks: mqtt: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -228,8 +228,8 @@ base: components: sinks: mqtt: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -241,9 +241,9 @@ base: components: sinks: mqtt: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -256,20 +256,20 @@ base: components: sinks: mqtt: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -295,8 +295,8 @@ base: components: sinks: mqtt: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -426,7 +426,7 @@ base: components: sinks: mqtt: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -448,7 +448,7 @@ base: components: sinks: mqtt: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -499,7 +499,7 @@ base: components: sinks: mqtt: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/nats.cue
+++ b/website/cue/reference/components/sinks/base/nats.cue
@@ -14,9 +14,9 @@ base: components: sinks: nats: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -174,7 +174,7 @@ base: components: sinks: nats: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -207,8 +207,8 @@ base: components: sinks: nats: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -216,7 +216,7 @@ base: components: sinks: nats: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -250,11 +250,11 @@ base: components: sinks: nats: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -318,8 +318,8 @@ base: components: sinks: nats: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -331,9 +331,9 @@ base: components: sinks: nats: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -346,20 +346,20 @@ base: components: sinks: nats: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -385,8 +385,8 @@ base: components: sinks: nats: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -688,7 +688,7 @@ base: components: sinks: nats: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -710,7 +710,7 @@ base: components: sinks: nats: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -761,7 +761,7 @@ base: components: sinks: nats: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/new_relic.cue
+++ b/website/cue/reference/components/sinks/base/new_relic.cue
@@ -19,9 +19,9 @@ base: components: sinks: new_relic: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/base/opentelemetry.cue
@@ -17,9 +17,9 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 				description: """
 					Whether or not end-to-end acknowledgements are enabled.
 
-					When enabled for a sink, any source connected to that sink where the source supports
-					end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-					connected** sinks before acknowledging them at the source.
+					When enabled for a sink, any source that supports end-to-end
+					acknowledgements that is connected to that sink waits for events
+					to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 					Enabling or disabling acknowledgements at the sink level takes precedence over any global
 					[`acknowledgements`][global_acks] configuration.
@@ -190,7 +190,7 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 						}
 						device_version: {
 							description: """
-																				Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																				Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																				The value length must be less than or equal to 31.
 																				"""
 							required: true
@@ -223,8 +223,8 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 																				Reflects importance of the event.
 
 																				It must point to a number from 0 to 10.
-																				0 = Lowest, 10 = Highest.
-																				Equals to "cef.severity" by default.
+																				0 = lowest_importance, 10 = highest_importance.
+																				Set to "cef.severity" by default.
 																				"""
 							required: true
 							type: string: {}
@@ -232,7 +232,7 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 						version: {
 							description: """
 																				CEF Version. Can be either 0 or 1.
-																				Equals to "0" by default.
+																				Set to "0" by default.
 																				"""
 							required: true
 							type: string: enum: {
@@ -266,11 +266,11 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 																			Vector's encoder currently adheres more strictly to the GELF spec, with
 																			the exception that some characters such as `@`  are allowed in field names.
 
-																			Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-																			by Graylog, and is much more relaxed than the GELF spec.
+																			Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+																			by Graylog and is much more relaxed than the GELF spec.
 
 																			Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-																			the codec may continue to relax the enforcement of specification.
+																			the codec might continue to relax the enforcement of the specification.
 
 																			[gelf]: https://docs.graylog.org/docs/gelf
 																			[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -334,8 +334,8 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 					type: object: options: {
 						capacity: {
 							description: """
-																				Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																				This defaults to a reasonable setting.
+																				Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																				This defaults to 8KB.
 																				"""
 							required: false
 							type: uint: default: 8192
@@ -347,9 +347,9 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 						}
 						double_quote: {
 							description: """
-																				Enable double quote escapes.
+																				Enables double quote escapes.
 
-																				This is enabled by default, but it may be disabled. When disabled, quotes in
+																				This is enabled by default, but you can disable it. When disabled, quotes in
 																				field data are escaped instead of doubled.
 																				"""
 							required: false
@@ -362,20 +362,20 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 																				In some variants of CSV, quotes are escaped using a special escape character
 																				like \\ (instead of escaping quotes by doubling them).
 
-																				To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																				To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																				"""
 							required: false
 							type: ascii_char: default: "\""
 						}
 						fields: {
 							description: """
-																				Configures the fields that will be encoded, as well as the order in which they
+																				Configures the fields that are encoded, as well as the order in which they
 																				appear in the output.
 
-																				If a field is not present in the event, the output will be an empty string.
+																				If a field is not present in the event, the output for that field is an empty string.
 
-																				Values of type `Array`, `Object`, and `Regex` are not supported and the
-																				output will be an empty string.
+																				Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																				output for any of these types is an empty string.
 																				"""
 							required: true
 							type: array: items: type: string: {}
@@ -401,8 +401,8 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 									never: "Never writes quotes, even if it produces invalid CSV data."
 									non_numeric: """
 																							Puts quotes around all fields that are non-numeric.
-																							Namely, when writing a field that does not parse as a valid float or integer,
-																							then quotes are used even if they aren't strictly necessary.
+																							This means that when writing a field that does not parse as a valid float or integer,
+																							quotes are used even if they aren't strictly necessary.
 																							"""
 								}
 							}
@@ -807,7 +807,7 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 					description: """
 						Sets the list of supported ALPN protocols.
 
-						Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+						Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 						that they are defined.
 						"""
 					required: false
@@ -829,7 +829,7 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 						The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 						an inline string in PEM format.
 
-						If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+						If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 						"""
 					required: false
 					type: string: examples: ["/path/to/host_certificate.crt"]
@@ -870,7 +870,7 @@ base: components: sinks: opentelemetry: configuration: protocol: {
 						If enabled, certificates must not be expired and must be issued by a trusted
 						issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 						certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-						so on until the verification process reaches a root certificate.
+						so on, until the verification process reaches a root certificate.
 
 						Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 						"""

--- a/website/cue/reference/components/sinks/base/papertrail.cue
+++ b/website/cue/reference/components/sinks/base/papertrail.cue
@@ -14,9 +14,9 @@ base: components: sinks: papertrail: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -74,7 +74,7 @@ base: components: sinks: papertrail: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -107,8 +107,8 @@ base: components: sinks: papertrail: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -116,7 +116,7 @@ base: components: sinks: papertrail: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -150,11 +150,11 @@ base: components: sinks: papertrail: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -218,8 +218,8 @@ base: components: sinks: papertrail: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -231,9 +231,9 @@ base: components: sinks: papertrail: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -246,20 +246,20 @@ base: components: sinks: papertrail: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -285,8 +285,8 @@ base: components: sinks: papertrail: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -407,7 +407,7 @@ base: components: sinks: papertrail: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -429,7 +429,7 @@ base: components: sinks: papertrail: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -480,7 +480,7 @@ base: components: sinks: papertrail: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_exporter.cue
@@ -14,9 +14,9 @@ base: components: sinks: prometheus_exporter: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -173,7 +173,7 @@ base: components: sinks: prometheus_exporter: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -195,7 +195,7 @@ base: components: sinks: prometheus_exporter: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -246,7 +246,7 @@ base: components: sinks: prometheus_exporter: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/base/prometheus_remote_write.cue
@@ -14,9 +14,9 @@ base: components: sinks: prometheus_remote_write: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -528,7 +528,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -550,7 +550,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -591,7 +591,7 @@ base: components: sinks: prometheus_remote_write: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/pulsar.cue
+++ b/website/cue/reference/components/sinks/base/pulsar.cue
@@ -14,9 +14,9 @@ base: components: sinks: pulsar: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -208,7 +208,7 @@ base: components: sinks: pulsar: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -241,8 +241,8 @@ base: components: sinks: pulsar: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -250,7 +250,7 @@ base: components: sinks: pulsar: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -284,11 +284,11 @@ base: components: sinks: pulsar: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -352,8 +352,8 @@ base: components: sinks: pulsar: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -365,9 +365,9 @@ base: components: sinks: pulsar: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -380,20 +380,20 @@ base: components: sinks: pulsar: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -419,8 +419,8 @@ base: components: sinks: pulsar: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/redis.cue
+++ b/website/cue/reference/components/sinks/base/redis.cue
@@ -14,9 +14,9 @@ base: components: sinks: redis: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -127,7 +127,7 @@ base: components: sinks: redis: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -160,8 +160,8 @@ base: components: sinks: redis: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -169,7 +169,7 @@ base: components: sinks: redis: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -203,11 +203,11 @@ base: components: sinks: redis: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -271,8 +271,8 @@ base: components: sinks: redis: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -284,9 +284,9 @@ base: components: sinks: redis: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -299,20 +299,20 @@ base: components: sinks: redis: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -338,8 +338,8 @@ base: components: sinks: redis: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/base/sematext_logs.cue
@@ -14,9 +14,9 @@ base: components: sinks: sematext_logs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/base/sematext_metrics.cue
@@ -14,9 +14,9 @@ base: components: sinks: sematext_metrics: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.

--- a/website/cue/reference/components/sinks/base/socket.cue
+++ b/website/cue/reference/components/sinks/base/socket.cue
@@ -14,9 +14,9 @@ base: components: sinks: socket: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -86,7 +86,7 @@ base: components: sinks: socket: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -119,8 +119,8 @@ base: components: sinks: socket: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -128,7 +128,7 @@ base: components: sinks: socket: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -162,11 +162,11 @@ base: components: sinks: socket: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -230,8 +230,8 @@ base: components: sinks: socket: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -243,9 +243,9 @@ base: components: sinks: socket: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -258,20 +258,20 @@ base: components: sinks: socket: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -297,8 +297,8 @@ base: components: sinks: socket: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -499,7 +499,7 @@ base: components: sinks: socket: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -521,7 +521,7 @@ base: components: sinks: socket: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -572,7 +572,7 @@ base: components: sinks: socket: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -9,9 +9,9 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				description: """
 					Whether or not end-to-end acknowledgements are enabled.
 
-					When enabled for a sink, any source connected to that sink where the source supports
-					end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-					connected** sinks before acknowledging them at the source.
+					When enabled for a sink, any source that supports end-to-end
+					acknowledgements that is connected to that sink waits for events
+					to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 					Enabling or disabling acknowledgements at the sink level takes precedence over any global
 					[`acknowledgements`][global_acks] configuration.
@@ -190,7 +190,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -223,8 +223,8 @@ base: components: sinks: splunk_hec_logs: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -232,7 +232,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -266,11 +266,11 @@ base: components: sinks: splunk_hec_logs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -334,8 +334,8 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -347,9 +347,9 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -362,20 +362,20 @@ base: components: sinks: splunk_hec_logs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -401,8 +401,8 @@ base: components: sinks: splunk_hec_logs: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -795,7 +795,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -817,7 +817,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -858,7 +858,7 @@ base: components: sinks: splunk_hec_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -9,9 +9,9 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 				description: """
 					Whether or not end-to-end acknowledgements are enabled.
 
-					When enabled for a sink, any source connected to that sink where the source supports
-					end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-					connected** sinks before acknowledging them at the source.
+					When enabled for a sink, any source that supports end-to-end
+					acknowledgements that is connected to that sink waits for events
+					to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 					Enabling or disabling acknowledgements at the sink level takes precedence over any global
 					[`acknowledgements`][global_acks] configuration.
@@ -394,7 +394,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -416,7 +416,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -457,7 +457,7 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/statsd.cue
+++ b/website/cue/reference/components/sinks/base/statsd.cue
@@ -14,9 +14,9 @@ base: components: sinks: statsd: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -136,7 +136,7 @@ base: components: sinks: statsd: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -158,7 +158,7 @@ base: components: sinks: statsd: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -209,7 +209,7 @@ base: components: sinks: statsd: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/vector.cue
+++ b/website/cue/reference/components/sinks/base/vector.cue
@@ -14,9 +14,9 @@ base: components: sinks: vector: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -275,7 +275,7 @@ base: components: sinks: vector: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -297,7 +297,7 @@ base: components: sinks: vector: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -348,7 +348,7 @@ base: components: sinks: vector: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sinks/base/webhdfs.cue
+++ b/website/cue/reference/components/sinks/base/webhdfs.cue
@@ -14,9 +14,9 @@ base: components: sinks: webhdfs: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -140,7 +140,7 @@ base: components: sinks: webhdfs: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -173,8 +173,8 @@ base: components: sinks: webhdfs: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -182,7 +182,7 @@ base: components: sinks: webhdfs: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -216,11 +216,11 @@ base: components: sinks: webhdfs: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -284,8 +284,8 @@ base: components: sinks: webhdfs: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -297,9 +297,9 @@ base: components: sinks: webhdfs: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -312,20 +312,20 @@ base: components: sinks: webhdfs: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -351,8 +351,8 @@ base: components: sinks: webhdfs: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}

--- a/website/cue/reference/components/sinks/base/websocket.cue
+++ b/website/cue/reference/components/sinks/base/websocket.cue
@@ -14,9 +14,9 @@ base: components: sinks: websocket: configuration: {
 			description: """
 				Whether or not end-to-end acknowledgements are enabled.
 
-				When enabled for a sink, any source connected to that sink where the source supports
-				end-to-end acknowledgements as well, waits for events to be acknowledged by **all
-				connected** sinks before acknowledging them at the source.
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
 
 				Enabling or disabling acknowledgements at the sink level takes precedence over any global
 				[`acknowledgements`][global_acks] configuration.
@@ -121,7 +121,7 @@ base: components: sinks: websocket: configuration: {
 					}
 					device_version: {
 						description: """
-																Identifies the version of the problem. In combination with device product and vendor, it composes the unique id of the device that sends messages.
+																Identifies the version of the problem. The combination of the device product, vendor and this value make up the unique id of the device that sends messages.
 																The value length must be less than or equal to 31.
 																"""
 						required: true
@@ -154,8 +154,8 @@ base: components: sinks: websocket: configuration: {
 																Reflects importance of the event.
 
 																It must point to a number from 0 to 10.
-																0 = Lowest, 10 = Highest.
-																Equals to "cef.severity" by default.
+																0 = lowest_importance, 10 = highest_importance.
+																Set to "cef.severity" by default.
 																"""
 						required: true
 						type: string: {}
@@ -163,7 +163,7 @@ base: components: sinks: websocket: configuration: {
 					version: {
 						description: """
 																CEF Version. Can be either 0 or 1.
-																Equals to "0" by default.
+																Set to "0" by default.
 																"""
 						required: true
 						type: string: enum: {
@@ -197,11 +197,11 @@ base: components: sinks: websocket: configuration: {
 						Vector's encoder currently adheres more strictly to the GELF spec, with
 						the exception that some characters such as `@`  are allowed in field names.
 
-						Other GELF codecs such as Loki's, use a [Go SDK][implementation] that is maintained
-						by Graylog, and is much more relaxed than the GELF spec.
+						Other GELF codecs, such as Loki's, use a [Go SDK][implementation] that is maintained
+						by Graylog and is much more relaxed than the GELF spec.
 
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
-						the codec may continue to relax the enforcement of specification.
+						the codec might continue to relax the enforcement of the specification.
 
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
@@ -265,8 +265,8 @@ base: components: sinks: websocket: configuration: {
 				type: object: options: {
 					capacity: {
 						description: """
-																Set the capacity (in bytes) of the internal buffer used in the CSV writer.
-																This defaults to a reasonable setting.
+																Sets the capacity (in bytes) of the internal buffer used in the CSV writer.
+																This defaults to 8KB.
 																"""
 						required: false
 						type: uint: default: 8192
@@ -278,9 +278,9 @@ base: components: sinks: websocket: configuration: {
 					}
 					double_quote: {
 						description: """
-																Enable double quote escapes.
+																Enables double quote escapes.
 
-																This is enabled by default, but it may be disabled. When disabled, quotes in
+																This is enabled by default, but you can disable it. When disabled, quotes in
 																field data are escaped instead of doubled.
 																"""
 						required: false
@@ -293,20 +293,20 @@ base: components: sinks: websocket: configuration: {
 																In some variants of CSV, quotes are escaped using a special escape character
 																like \\ (instead of escaping quotes by doubling them).
 
-																To use this, `double_quotes` needs to be disabled as well otherwise it is ignored.
+																To use this, `double_quotes` needs to be disabled as well; otherwise, this setting is ignored.
 																"""
 						required: false
 						type: ascii_char: default: "\""
 					}
 					fields: {
 						description: """
-																Configures the fields that will be encoded, as well as the order in which they
+																Configures the fields that are encoded, as well as the order in which they
 																appear in the output.
 
-																If a field is not present in the event, the output will be an empty string.
+																If a field is not present in the event, the output for that field is an empty string.
 
-																Values of type `Array`, `Object`, and `Regex` are not supported and the
-																output will be an empty string.
+																Values of type `Array`, `Object`, and `Regex` are not supported, and the
+																output for any of these types is an empty string.
 																"""
 						required: true
 						type: array: items: type: string: {}
@@ -332,8 +332,8 @@ base: components: sinks: websocket: configuration: {
 								never: "Never writes quotes, even if it produces invalid CSV data."
 								non_numeric: """
 																			Puts quotes around all fields that are non-numeric.
-																			Namely, when writing a field that does not parse as a valid float or integer,
-																			then quotes are used even if they aren't strictly necessary.
+																			This means that when writing a field that does not parse as a valid float or integer,
+																			quotes are used even if they aren't strictly necessary.
 																			"""
 							}
 						}
@@ -451,7 +451,7 @@ base: components: sinks: websocket: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -473,7 +473,7 @@ base: components: sinks: websocket: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -524,7 +524,7 @@ base: components: sinks: websocket: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/amqp.cue
+++ b/website/cue/reference/components/sources/base/amqp.cue
@@ -499,7 +499,7 @@ base: components: sources: amqp: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -521,7 +521,7 @@ base: components: sources: amqp: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -562,7 +562,7 @@ base: components: sources: amqp: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/base/aws_kinesis_firehose.cue
@@ -561,7 +561,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -583,7 +583,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -634,7 +634,7 @@ base: components: sources: aws_kinesis_firehose: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -787,7 +787,7 @@ base: components: sources: aws_s3: configuration: {
 						description: """
 																Sets the list of supported ALPN protocols.
 
-																Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+																Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 																that they are defined.
 																"""
 						required: false
@@ -809,7 +809,7 @@ base: components: sources: aws_s3: configuration: {
 																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 																an inline string in PEM format.
 
-																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 																"""
 						required: false
 						type: string: examples: ["/path/to/host_certificate.crt"]
@@ -850,7 +850,7 @@ base: components: sources: aws_s3: configuration: {
 																If enabled, certificates must not be expired and must be issued by a trusted
 																issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 																certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-																so on until the verification process reaches a root certificate.
+																so on, until the verification process reaches a root certificate.
 
 																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 																"""
@@ -898,7 +898,7 @@ base: components: sources: aws_s3: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -920,7 +920,7 @@ base: components: sources: aws_s3: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -961,7 +961,7 @@ base: components: sources: aws_s3: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/aws_sqs.cue
+++ b/website/cue/reference/components/sources/base/aws_sqs.cue
@@ -625,7 +625,7 @@ base: components: sources: aws_sqs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -647,7 +647,7 @@ base: components: sources: aws_sqs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -688,7 +688,7 @@ base: components: sources: aws_sqs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/datadog_agent.cue
+++ b/website/cue/reference/components/sources/base/datadog_agent.cue
@@ -540,7 +540,7 @@ base: components: sources: datadog_agent: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -562,7 +562,7 @@ base: components: sources: datadog_agent: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -613,7 +613,7 @@ base: components: sources: datadog_agent: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/dnstap.cue
+++ b/website/cue/reference/components/sources/base/dnstap.cue
@@ -182,7 +182,7 @@ base: components: sources: dnstap: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -209,7 +209,7 @@ base: components: sources: dnstap: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -260,7 +260,7 @@ base: components: sources: dnstap: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/fluent.cue
+++ b/website/cue/reference/components/sources/base/fluent.cue
@@ -73,7 +73,7 @@ base: components: sources: fluent: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -100,7 +100,7 @@ base: components: sources: fluent: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -151,7 +151,7 @@ base: components: sources: fluent: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/base/gcp_pubsub.cue
@@ -583,7 +583,7 @@ base: components: sources: gcp_pubsub: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -605,7 +605,7 @@ base: components: sources: gcp_pubsub: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -646,7 +646,7 @@ base: components: sources: gcp_pubsub: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/heroku_logs.cue
+++ b/website/cue/reference/components/sources/base/heroku_logs.cue
@@ -526,7 +526,7 @@ base: components: sources: heroku_logs: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -548,7 +548,7 @@ base: components: sources: heroku_logs: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -599,7 +599,7 @@ base: components: sources: heroku_logs: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/http.cue
+++ b/website/cue/reference/components/sources/base/http.cue
@@ -617,7 +617,7 @@ base: components: sources: http: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -639,7 +639,7 @@ base: components: sources: http: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -690,7 +690,7 @@ base: components: sources: http: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/http_client.cue
+++ b/website/cue/reference/components/sources/base/http_client.cue
@@ -556,7 +556,7 @@ base: components: sources: http_client: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -578,7 +578,7 @@ base: components: sources: http_client: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -619,7 +619,7 @@ base: components: sources: http_client: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/http_server.cue
+++ b/website/cue/reference/components/sources/base/http_server.cue
@@ -617,7 +617,7 @@ base: components: sources: http_server: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -639,7 +639,7 @@ base: components: sources: http_server: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -690,7 +690,7 @@ base: components: sources: http_server: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/kafka.cue
+++ b/website/cue/reference/components/sources/base/kafka.cue
@@ -660,7 +660,7 @@ base: components: sources: kafka: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -682,7 +682,7 @@ base: components: sources: kafka: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -733,7 +733,7 @@ base: components: sources: kafka: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/logstash.cue
+++ b/website/cue/reference/components/sources/base/logstash.cue
@@ -69,7 +69,7 @@ base: components: sources: logstash: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -96,7 +96,7 @@ base: components: sources: logstash: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -147,7 +147,7 @@ base: components: sources: logstash: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/nats.cue
+++ b/website/cue/reference/components/sources/base/nats.cue
@@ -564,7 +564,7 @@ base: components: sources: nats: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -586,7 +586,7 @@ base: components: sources: nats: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -637,7 +637,7 @@ base: components: sources: nats: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/base/nginx_metrics.cue
@@ -85,7 +85,7 @@ base: components: sources: nginx_metrics: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -107,7 +107,7 @@ base: components: sources: nginx_metrics: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -148,7 +148,7 @@ base: components: sources: nginx_metrics: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/opentelemetry.cue
+++ b/website/cue/reference/components/sources/base/opentelemetry.cue
@@ -47,7 +47,7 @@ base: components: sources: opentelemetry: configuration: {
 							description: """
 																Sets the list of supported ALPN protocols.
 
-																Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+																Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 																that they are defined.
 																"""
 							required: false
@@ -69,7 +69,7 @@ base: components: sources: opentelemetry: configuration: {
 																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 																an inline string in PEM format.
 
-																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 																"""
 							required: false
 							type: string: examples: ["/path/to/host_certificate.crt"]
@@ -120,7 +120,7 @@ base: components: sources: opentelemetry: configuration: {
 																If enabled, certificates must not be expired and must be issued by a trusted
 																issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 																certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-																so on until the verification process reaches a root certificate.
+																so on, until the verification process reaches a root certificate.
 
 																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 																"""
@@ -226,7 +226,7 @@ base: components: sources: opentelemetry: configuration: {
 							description: """
 																Sets the list of supported ALPN protocols.
 
-																Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+																Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 																that they are defined.
 																"""
 							required: false
@@ -248,7 +248,7 @@ base: components: sources: opentelemetry: configuration: {
 																The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 																an inline string in PEM format.
 
-																If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+																If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 																"""
 							required: false
 							type: string: examples: ["/path/to/host_certificate.crt"]
@@ -299,7 +299,7 @@ base: components: sources: opentelemetry: configuration: {
 																If enabled, certificates must not be expired and must be issued by a trusted
 																issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 																certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-																so on until the verification process reaches a root certificate.
+																so on, until the verification process reaches a root certificate.
 
 																Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 																"""

--- a/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/base/prometheus_pushgateway.cue
@@ -99,7 +99,7 @@ base: components: sources: prometheus_pushgateway: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -121,7 +121,7 @@ base: components: sources: prometheus_pushgateway: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -172,7 +172,7 @@ base: components: sources: prometheus_pushgateway: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/base/prometheus_remote_write.cue
@@ -89,7 +89,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -111,7 +111,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -162,7 +162,7 @@ base: components: sources: prometheus_remote_write: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/base/prometheus_scrape.cue
@@ -131,7 +131,7 @@ base: components: sources: prometheus_scrape: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -153,7 +153,7 @@ base: components: sources: prometheus_scrape: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -194,7 +194,7 @@ base: components: sources: prometheus_scrape: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/socket.cue
+++ b/website/cue/reference/components/sources/base/socket.cue
@@ -563,7 +563,7 @@ base: components: sources: socket: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -590,7 +590,7 @@ base: components: sources: socket: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -641,7 +641,7 @@ base: components: sources: socket: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/splunk_hec.cue
+++ b/website/cue/reference/components/sources/base/splunk_hec.cue
@@ -124,7 +124,7 @@ base: components: sources: splunk_hec: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -146,7 +146,7 @@ base: components: sources: splunk_hec: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -197,7 +197,7 @@ base: components: sources: splunk_hec: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/statsd.cue
+++ b/website/cue/reference/components/sources/base/statsd.cue
@@ -87,7 +87,7 @@ base: components: sources: statsd: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -114,7 +114,7 @@ base: components: sources: statsd: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -165,7 +165,7 @@ base: components: sources: statsd: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/syslog.cue
+++ b/website/cue/reference/components/sources/base/syslog.cue
@@ -113,7 +113,7 @@ base: components: sources: syslog: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -140,7 +140,7 @@ base: components: sources: syslog: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -191,7 +191,7 @@ base: components: sources: syslog: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/sources/base/vector.cue
+++ b/website/cue/reference/components/sources/base/vector.cue
@@ -39,7 +39,7 @@ base: components: sources: vector: configuration: {
 				description: """
 					Sets the list of supported ALPN protocols.
 
-					Declare the supported ALPN protocols, which are used during negotiation with peer. They are prioritized in the order
+					Declare the supported ALPN protocols, which are used during negotiation with a peer. They are prioritized in the order
 					that they are defined.
 					"""
 				required: false
@@ -61,7 +61,7 @@ base: components: sources: vector: configuration: {
 					The certificate must be in DER, PEM (X.509), or PKCS#12 format. Additionally, the certificate can be provided as
 					an inline string in PEM format.
 
-					If this is set, and is not a PKCS#12 archive, `key_file` must also be set.
+					If this is set _and_ is not a PKCS#12 archive, `key_file` must also be set.
 					"""
 				required: false
 				type: string: examples: ["/path/to/host_certificate.crt"]
@@ -112,7 +112,7 @@ base: components: sources: vector: configuration: {
 					If enabled, certificates must not be expired and must be issued by a trusted
 					issuer. This verification operates in a hierarchical manner, checking that the leaf certificate (the
 					certificate presented by the client/server) is not only valid, but that the issuer of that certificate is also valid, and
-					so on until the verification process reaches a root certificate.
+					so on, until the verification process reaches a root certificate.
 
 					Do NOT set this to `false` unless you understand the risks of not verifying the validity of certificates.
 					"""

--- a/website/cue/reference/components/transforms/base/metric_to_log.cue
+++ b/website/cue/reference/components/transforms/base/metric_to_log.cue
@@ -17,7 +17,7 @@ base: components: transforms: metric_to_log: configuration: {
 		description: """
 			Controls how metric tag values are encoded.
 
-			When set to `single`, only the last non-bare value of tags are displayed with the
+			When set to `single`, only the last non-bare value of tags is displayed with the
 			metric.  When set to `full`, all metric tags are exposed as separate assignments as
 			described by [the `native_json` codec][vector_native_json].
 


### PR DESCRIPTION
## Summary

Updates wording in common sinks component docs (as suggested by @neko-dd)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Related: https://github.com/vectordotdev/vector/pull/22213#issuecomment-2619497057

---
>Sponsored by [Quad9](https://quad9.net/)
