### PR TITLE
docs(external): fix `enrichment_table` and `secret` docs

### DIFF
--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -162,6 +162,7 @@ configuration: {
 									description: "The delimiter used to separate fields in each row of the CSV file."
 									common:      false
 									required:    false
+									relevant_when: "type = \"csv\""
 									type: string: {
 										default: ","
 										examples: [":"]
@@ -177,6 +178,7 @@ configuration: {
 										by their numerical index.
 										"""
 									required: false
+									relevant_when: "type = \"csv\""
 									common:   false
 									type: bool: default: true
 								}

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -573,148 +573,119 @@ configuration: {
 				Configuration options to retrieve secrets from external backend in order to avoid storing secrets in plaintext
 				in Vector config. Multiple backends can be configured. Use `SECRET[<backend_name>.<secret_key>]` to tell Vector to retrieve the secret. This placeholder is replaced by the secret
 				retrieved from the relevant backend.
+
+				When `type` is `exec`, the provided command will be run and provided a list of
+				secrets to fetch, determined from the configuration file, on stdin as JSON in the format:
+
+				```json
+				{"version": "1.0", "secrets": ["secret1", "secret2"]}
+				```
+
+				The executable is expected to respond with the values of these secrets on stdout, also as JSON, in the format:
+
+				```json
+				{
+					"secret1": {"value": "secret_value", "error": null},
+					"secret2": {"value": null, "error": "could not fetch the secret"}
+				}
+				```
+				If an `error` is returned for any secrets, or if the command exits with a non-zero status code,
+				Vector will log the errors and exit.
+
+				Otherwise, the secret must be a JSON text string with key/value pairs. For example:
+				```json
+				{
+					"username": "test",
+					"password": "example-password"
+				}
+				```
+
+				If an error occurred while reading the file or retrieving the secrets, Vector logs the error and exits.
+
+				Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
+				configuration reload process.
+
 				"""
 			required: false
 			type: object: options: {
-				file: {
-					required: true
+				type: {
 					description: """
-						Retrieve secrets from a file path.
-
-						The secret must be a JSON text string with key/value pairs. For example:
-						```json
-						{
-							"username": "test",
-							"password": "example-password"
-						}
-						```
-
-						If an error occurs while reading the file, Vector will log the error and exit.
-
-						Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
-						configuration reload process.
+						The type of secret backend to use.
 						"""
-					type: object: options: {
-						path: {
-							description: "The file path to read."
-							required:    true
-							type: string: {
-								examples: ["/path/to/secret.json"]
-							}
+					required: true
+					type: string: {
+						enum: {
+							"file":                "Retrieve secrets from a file path."
+							"directory":           "Retrieve secrets from file contents in a directory."
+							"exec":                "Run a local command to retrieve secrets."
+							"aws_secrets_manager": "Retrieve secrets from AWS Secrets Manager."
+							"test": 			   "Secret backend for test."
 						}
 					}
 				}
-				directory: {
-					required: true
+				path: {
 					description: """
-						Retrieve secrets from file contents in a directory.
+						When type is `file`, this value is the file path to read.
 
-						The directory must contain files with names corresponding to secret keys.
-
-						If an error occurs while reading the file, Vector will log the error and exit.
-
-						Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
-						configuration reload process.
+						When type is `directory`, this value is the path of the directory with secrets.
 						"""
-					type: object: options: {
-						path: {
-							description: """
-								The path of the directory with secrets.
-								"""
-							required: true
-							type: string: {
-								examples: [
-									"${CREDENTIALS_DIRECTORY}", // https://systemd.io/CREDENTIALS
-									"/path/to/secrets-directory",
-								]
-							}
-						}
-						remove_trailing_whitespace: {
-							description: """
-								Remove trailing whitespace from file contents.
-								"""
-							required: false
-							type: bool: default: false
-						}
+					required:    true
+					relevant_when: "type = \"file\" or type = \"directory\""
+					type: string: {
+						examples: [
+							"/path/to/secret.json",
+							"${CREDENTIALS_DIRECTORY}", // https://systemd.io/CREDENTIALS
+							"/path/to/secrets-directory",
+						]
 					}
 				}
-				exec: {
-					required: true
+				remove_trailing_whitespace: {
 					description: """
-						Run a local command to retrieve secrets.
-
-						The provided command will be run and provided a list of
-						secrets to fetch, determined from the configuration file, on stdin as JSON in the format:
-
-						```json
-						{"version": "1.0", "secrets": ["secret1", "secret2"]}
-						```
-
-						The executable is expected to respond with the values of these secrets on stdout, also as JSON, in the format:
-
-						```json
-						{
-							"secret1": {"value": "secret_value", "error": null},
-							"secret2": {"value": null, "error": "could not fetch the secret"}
-						}
-						```
-
-						If an `error` is returned for any secrets, or if the command exits with a non-zero status code,
-						Vector will log the errors and exit.
-
-						Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
-						configuration reload process.
+						Remove trailing whitespace from file contents.
 						"""
-					type: object: options: {
-						command: {
-							description: """
-								The command to be run, plus any arguments required.
-								"""
-							required: true
-							type: array: {
-								examples: [["/path/to/get-secret", "-s"], ["/path/to/vault-wrapper"]]
-								items: type: string: {}
-							}
-						}
-						timeout: {
-							description: "The amount of time Vector will wait for the command to complete."
-							required:    false
-							common:      false
-							type: uint: {
-								default: 5
-								unit:    "seconds"
-							}
-						}
+					required: false
+					relevant_when: "type = \"directory\""
+					type: bool: default: false
+				}
+				replacement: {
+					description: """
+						Fixed value to replace all secrets with.
+						"""
+					required: false
+					relevant_when: "type = \"test\""
+					type: string: {
+						examples: ["test"]
 					}
 				}
-				aws_secrets_manager: {
-					required: true
+				command: {
 					description: """
-						Retrieve secrets from AWS Secrets Manager.
-
-						The secret must be a JSON text string with key/value pairs. For example:
-						```json
-						{
-							"username": "test",
-							"password": "example-password"
-						}
-						```
-
-						If an error occurred retrieving the secrets, Vector logs the error and exits.
-
-						Secrets are loaded when Vector starts or if Vector receives a `SIGHUP` signal triggering its
-						configuration reload process.
+						The command to be run, plus any arguments required.
 						"""
-					type: object: options: {
-						secret_id: {
-							description: """
-								The ID of the secret to be retrieved.
-								"""
-							required: true
-							type: string: {
-								examples: ["/secret/foo-bar"]
-							}
-						}
+					required: true
+					relevant_when: "type = \"exec\""
+					type: array: {
+						examples: [["/path/to/get-secret", "-s"], ["/path/to/vault-wrapper"]]
+						items: type: string: {}
+					}
+				}
+				timeout: {
+					description: "The amount of time Vector will wait for the command to complete."
+					required:    false
+					relevant_when: "type = \"exec\""
+					common:      false
+					type: uint: {
+						default: 5
+						unit:    "seconds"
+					}
+				}
+				secret_id: {
+					description: """
+						The ID of the secret to be retrieved.
+						"""
+					required: true
+					relevant_when: "type = \"aws_secrets_manager\""
+					type: string: {
+						examples: ["/secret/foo-bar"]
 					}
 				}
 			}

--- a/website/cue/reference/configuration.cue
+++ b/website/cue/reference/configuration.cue
@@ -159,9 +159,9 @@ configuration: {
 								}
 
 								delimiter: {
-									description: "The delimiter used to separate fields in each row of the CSV file."
-									common:      false
-									required:    false
+									description:   "The delimiter used to separate fields in each row of the CSV file."
+									common:        false
+									required:      false
 									relevant_when: "type = \"csv\""
 									type: string: {
 										default: ","
@@ -177,9 +177,9 @@ configuration: {
 										If you set it to `false`, there are no headers and the columns are referred to
 										by their numerical index.
 										"""
-									required: false
+									required:      false
 									relevant_when: "type = \"csv\""
-									common:   false
+									common:        false
 									type: bool: default: true
 								}
 							}
@@ -619,7 +619,7 @@ configuration: {
 							"directory":           "Retrieve secrets from file contents in a directory."
 							"exec":                "Run a local command to retrieve secrets."
 							"aws_secrets_manager": "Retrieve secrets from AWS Secrets Manager."
-							"test": 			   "Secret backend for test."
+							"test":                "Secret backend for test."
 						}
 					}
 				}
@@ -629,7 +629,7 @@ configuration: {
 
 						When type is `directory`, this value is the path of the directory with secrets.
 						"""
-					required:    true
+					required:      true
 					relevant_when: "type = \"file\" or type = \"directory\""
 					type: string: {
 						examples: [
@@ -643,7 +643,7 @@ configuration: {
 					description: """
 						Remove trailing whitespace from file contents.
 						"""
-					required: false
+					required:      false
 					relevant_when: "type = \"directory\""
 					type: bool: default: false
 				}
@@ -651,7 +651,7 @@ configuration: {
 					description: """
 						Fixed value to replace all secrets with.
 						"""
-					required: false
+					required:      false
 					relevant_when: "type = \"test\""
 					type: string: {
 						examples: ["test"]
@@ -661,7 +661,7 @@ configuration: {
 					description: """
 						The command to be run, plus any arguments required.
 						"""
-					required: true
+					required:      true
 					relevant_when: "type = \"exec\""
 					type: array: {
 						examples: [["/path/to/get-secret", "-s"], ["/path/to/vault-wrapper"]]
@@ -669,10 +669,10 @@ configuration: {
 					}
 				}
 				timeout: {
-					description: "The amount of time Vector will wait for the command to complete."
-					required:    false
+					description:   "The amount of time Vector will wait for the command to complete."
+					required:      false
 					relevant_when: "type = \"exec\""
-					common:      false
+					common:        false
 					type: uint: {
 						default: 5
 						unit:    "seconds"
@@ -682,7 +682,7 @@ configuration: {
 					description: """
 						The ID of the secret to be retrieved.
 						"""
-					required: true
+					required:      true
 					relevant_when: "type = \"aws_secrets_manager\""
 					type: string: {
 						examples: ["/secret/foo-bar"]


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

I try to fix the issue mentioned in #22234, and I also find the similar change is needed in `enrichment_table` when I dive deep into the document.

I find the `secret` is not a simple enum, and it's more like a classic Rust enum which may have different optional fields.
Listened the hint by @pront, I find the `kind` field is optional field when `type` is `counter` in `log_to_metrics transform`, which is similar to our case.

The [log_to_metrics docs](https://github.com/vectordotdev/vector/blob/1af287f1f05050e0382d3dac6efb888508dce390/website/cue/reference/components/transforms/base/log_to_metric.cue#L51-L72) insert a optional `relevant_when` field to let the reader knows that this is a optional field in certain case. I try to insert the same notice to both `enrichment_table` and `secret`.

Please note that there are some big change in the PR. At first, I put all of the type descriptions above, and try to merge them into concise one. Secondly, I would merge the optional field description as well when there are conflicted name (`path`) for different `type`.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

```bash
make run-production-site-locally
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

Closes: #22234

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

It looks strange in this PR, but I think a picture worths thousands of world.

Secret description:
![image](https://github.com/user-attachments/assets/6e450d80-1257-40a0-a8d7-06917468a94b)

Secret type:
![image](https://github.com/user-attachments/assets/e676180a-3f9b-4a78-a06f-818123e2a7cd)

Secret optional fields:
![image](https://github.com/user-attachments/assets/67e1e1c2-88fc-490c-99d7-fa6ec9a1ee0a)

