### PR TITLE
enhancement(unit tests): Allow objects and arrays in log_fields test input

### DIFF
--- a/changelog.d/log-fields-additional-types.enhancement.md
+++ b/changelog.d/log-fields-additional-types.enhancement.md
@@ -1,0 +1,4 @@
+Allow additional types to be used in `tests.inputs.log_fields` values, including
+nested objects and arrays.
+
+authors: tmccombs

--- a/lib/vector-config/src/external/vrl.rs
+++ b/lib/vector-config/src/external/vrl.rs
@@ -53,9 +53,16 @@ impl Configurable for VrlValue {
 }
 
 impl ToValue for VrlValue {
+    /// Converts a `VrlValue` into a `serde_json::Value`.
+    ///
+    /// This conversion should always succeed, though it may result in a loss
+    /// of type information for some value types.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if serialization fails, which is not expected
+    /// under normal circumstances.
     fn to_value(&self) -> Value {
-        // As far as I can tell, this should always succeed, although
-        // it will lose type information for some value types
         serde_json::to_value(self).expect("Unable to serialize VRL value")
     }
 }

--- a/lib/vector-config/src/external/vrl.rs
+++ b/lib/vector-config/src/external/vrl.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 use serde_json::Value;
-use vrl::{compiler::VrlRuntime, datadog_search_syntax::QueryNode};
+use vrl::{compiler::VrlRuntime, datadog_search_syntax::QueryNode, value::Value as VrlValue};
 
 use crate::{
     schema::{generate_string_schema, SchemaGenerator, SchemaObject},
@@ -34,5 +34,28 @@ impl Configurable for QueryNode {
         Self: Sized,
     {
         Ok(generate_string_schema())
+    }
+}
+
+impl Configurable for VrlValue {
+    fn is_optional() -> bool {
+        true
+    }
+
+    fn metadata() -> Metadata {
+        Metadata::with_transparent(true)
+    }
+
+    fn generate_schema(_: &RefCell<SchemaGenerator>) -> Result<SchemaObject, GenerateError> {
+        // We don't have any constraints on the inputs
+        Ok(SchemaObject::default())
+    }
+}
+
+impl ToValue for VrlValue {
+    fn to_value(&self) -> Value {
+        // As far as I can tell, this should always succeed, although
+        // it will lose type information for some value types
+        serde_json::to_value(self).expect("Unable to serialize VRL value")
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,13 @@ use std::{
     time::Duration,
 };
 
-use crate::{conditions, event::Metric, secrets::SecretBackends, serde::OneOrMany};
+use crate::{
+    conditions,
+    event::{Metric, Value},
+    secrets::SecretBackends,
+    serde::OneOrMany,
+};
+
 use indexmap::IndexMap;
 use serde::Serialize;
 
@@ -473,24 +479,6 @@ impl TestDefinition<OutputId> {
     }
 }
 
-/// Value for a log field.
-#[configurable_component]
-#[derive(Clone, Debug)]
-#[serde(untagged)]
-pub enum TestInputValue {
-    /// A string.
-    String(String),
-
-    /// An integer.
-    Integer(i64),
-
-    /// A floating-point number.
-    Float(f64),
-
-    /// A boolean.
-    Boolean(bool),
-}
-
 /// A unit test input.
 ///
 /// An input describes not only the type of event to insert, but also which transform within the
@@ -522,7 +510,7 @@ pub struct TestInput {
     /// The set of log fields to use when creating a log input event.
     ///
     /// Only relevant when `type` is `log`.
-    pub log_fields: Option<IndexMap<String, TestInputValue>>,
+    pub log_fields: Option<IndexMap<String, Value>>,
 
     /// The metric to use as an input event.
     ///

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -18,7 +18,6 @@ use std::{
 
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use indexmap::IndexMap;
-use ordered_float::NotNan;
 use tokio::sync::{
     oneshot::{self, Receiver},
     Mutex,
@@ -39,9 +38,9 @@ use crate::{
     conditions::Condition,
     config::{
         self, loading, ComponentKey, Config, ConfigBuilder, ConfigPath, SinkOuter, SourceOuter,
-        TestDefinition, TestInput, TestInputValue, TestOutput,
+        TestDefinition, TestInput, TestOutput,
     },
-    event::{Event, EventMetadata, LogEvent, Value},
+    event::{Event, EventMetadata, LogEvent},
     signal,
     topology::{builder::TopologyPieces, RunningTopology},
 };
@@ -622,16 +621,8 @@ fn build_input_event(input: &TestInput) -> Result<Event, String> {
             if let Some(log_fields) = &input.log_fields {
                 let mut event = LogEvent::from_str_legacy("");
                 for (path, value) in log_fields {
-                    let value: Value = match value {
-                        TestInputValue::String(s) => Value::from(s.to_owned()),
-                        TestInputValue::Boolean(b) => Value::from(*b),
-                        TestInputValue::Integer(i) => Value::from(*i),
-                        TestInputValue::Float(f) => Value::from(
-                            NotNan::new(*f).map_err(|_| "NaN value not supported".to_string())?,
-                        ),
-                    };
                     event
-                        .parse_path_and_insert(path, value)
+                        .parse_path_and_insert(path, value.clone())
                         .map_err(|e| e.to_string())?;
                 }
                 Ok(event.into())

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -805,6 +805,9 @@ async fn test_log_input() {
                 message = "this is the message"
                 int_val = 5
                 bool_val = true
+                arr_val = [1, 2, "hi", false]
+                obj_val = { a =  true, b = "b", c = 5 }
+
 
             [[tests.outputs]]
               extract_from = "foo"
@@ -816,6 +819,10 @@ async fn test_log_input() {
                     assert_eq!(.message, "this is the message")
                     assert!(.bool_val)
                     assert_eq!(.int_val, 5)
+                    assert_eq!(.arr_val, [1, 2, "hi", false])
+                    assert!(.obj_val.a)
+                    assert_eq!(.obj_val.b, "b")
+                    assert_eq!(.obj_val.c, 5)
                 """
       "#})
     .unwrap();


### PR DESCRIPTION
By making vrl Value a configurable type



<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No


## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

Closes: #9386
