### PR TITLE
chore(vrl): use `as_str()` as implemented by `Value` 

### DIFF
--- a/lib/vector-vrl/functions/src/get_secret.rs
+++ b/lib/vector-vrl/functions/src/get_secret.rs
@@ -1,8 +1,7 @@
 use vrl::prelude::*;
 
 fn get_secret(ctx: &mut Context, key: Value) -> std::result::Result<Value, ExpressionError> {
-    let key_bytes = key.as_bytes().expect("argument must be a string");
-    let key_str = String::from_utf8_lossy(key_bytes);
+    let key_str = key.as_str().expect("argument must be a string");
     let value = match ctx.target().get_secret(key_str.as_ref()) {
         Some(secret) => secret.into(),
         None => Value::Null,

--- a/lib/vector-vrl/functions/src/remove_secret.rs
+++ b/lib/vector-vrl/functions/src/remove_secret.rs
@@ -1,8 +1,7 @@
 use vrl::prelude::*;
 
 fn remove_secret(ctx: &mut Context, key: Value) -> std::result::Result<Value, ExpressionError> {
-    let key_bytes = key.as_bytes().expect("argument must be a string");
-    let key_str = String::from_utf8_lossy(key_bytes);
+    let key_str = key.as_str().expect("argument must be a string");
     ctx.target_mut().remove_secret(key_str.as_ref());
     Ok(Value::Null)
 }

--- a/lib/vector-vrl/functions/src/set_secret.rs
+++ b/lib/vector-vrl/functions/src/set_secret.rs
@@ -5,8 +5,8 @@ fn set_secret(
     key: Value,
     secret: Value,
 ) -> std::result::Result<Value, ExpressionError> {
-    let key_str = String::from_utf8_lossy(key.as_bytes().expect("key must be a string"));
-    let secret_str = String::from_utf8_lossy(secret.as_bytes().expect("secret must be a string"));
+    let key_str = key.as_str().expect("key must be a string");
+    let secret_str = secret.as_str().expect("secret must be a string");
 
     ctx.target_mut()
         .insert_secret(key_str.as_ref(), secret_str.as_ref());

--- a/src/sinks/elasticsearch/sink.rs
+++ b/src/sinks/elasticsearch/sink.rs
@@ -119,14 +119,11 @@ pub(super) fn process_log(
         cfg.sync_fields(&mut log);
         cfg.remap_timestamp(&mut log);
     };
-    let id = if let Some(Value::Bytes(key)) =
-        id_key_field.and_then(|key| log.remove((PathPrefix::Event, key)))
-    {
-        Some(String::from_utf8_lossy(&key).into_owned())
-    } else {
-        None
-    };
-    let document_metadata = match (id.clone(), mode.version_type(), mode.version(&log)) {
+
+    let id = id_key_field
+        .and_then(|key| log.remove((PathPrefix::Event, key)))
+        .and_then(|id| id.as_str().map(Into::into));
+    let document_metadata = match (id, mode.version_type(), mode.version(&log)) {
         (None, _, _) => DocumentMetadata::WithoutId,
         (Some(id), None, None) | (Some(id), None, Some(_)) | (Some(id), Some(_), None) => {
             DocumentMetadata::Id(id)

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -772,11 +772,7 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
 
     let timestamp = timestamp_value
         .filter(|&ts| ts.is_bytes())
-        .and_then(|ts| {
-            String::from_utf8_lossy(ts.as_bytes().unwrap())
-                .parse::<u64>()
-                .ok()
-        })
+        .and_then(|ts| ts.as_str().unwrap().parse::<u64>().ok())
         .map(|ts| {
             chrono::Utc
                 .timestamp_opt((ts / 1_000_000) as i64, (ts % 1_000_000) as u32 * 1_000)

--- a/src/sources/kubernetes_logs/parser/docker.rs
+++ b/src/sources/kubernetes_logs/parser/docker.rs
@@ -114,13 +114,10 @@ fn normalize_event(
 
     if let Some(timestamp_key) = timestamp_key {
         let time = log.remove(&timestamp_key).context(TimeFieldMissingSnafu)?;
-
-        let time = match time {
-            Value::Bytes(val) => val,
-            _ => return Err(NormalizationError::TimeValueUnexpectedType),
-        };
-        let time = DateTime::parse_from_rfc3339(String::from_utf8_lossy(time.as_ref()).as_ref())
-            .context(TimeParsingSnafu)?;
+        let time = time
+            .as_str()
+            .ok_or(NormalizationError::TimeValueUnexpectedType)?;
+        let time = DateTime::parse_from_rfc3339(time.as_ref()).context(TimeParsingSnafu)?;
         log_namespace.insert_source_metadata(
             Config::NAME,
             log,


### PR DESCRIPTION
## Summary
Converting to lossy UTF-8 string is already possible by `Value::as_str` method, that now utilizes `simdutf8` that is faster than `String::from_utf8_lossy`.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Standard test case

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).