### PR TITLE
feat(internal): Make fields in HumioLogsConfig public

### DIFF
--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -35,7 +35,7 @@ pub struct HumioLogsConfig {
         docs::examples = "${HUMIO_TOKEN}",
         docs::examples = "A94A8FE5CCB19BA61C4C08"
     ))]
-    pub(super) token: SensitiveString,
+    pub token: SensitiveString,
 
     /// The base URL of the Humio instance.
     ///
@@ -49,15 +49,15 @@ pub struct HumioLogsConfig {
         docs::examples = "http://127.0.0.1",
         docs::examples = "https://example.com",
     ))]
-    pub(super) endpoint: String,
+    pub endpoint: String,
 
     /// The source of events sent to this sink.
     ///
     /// Typically the filename the logs originated from. Maps to `@source` in Humio.
-    pub(super) source: Option<Template>,
+    pub source: Option<Template>,
 
     #[configurable(derived)]
-    pub(super) encoding: EncodingConfig,
+    pub encoding: EncodingConfig,
 
     /// The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
     ///
@@ -67,7 +67,7 @@ pub struct HumioLogsConfig {
         docs::examples = "none",
         docs::examples = "{{ event_type }}"
     ))]
-    pub(super) event_type: Option<Template>,
+    pub event_type: Option<Template>,
 
     /// Overrides the name of the log field used to retrieve the hostname to send to Humio.
     ///
@@ -76,7 +76,7 @@ pub struct HumioLogsConfig {
     ///
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     #[serde(default = "config_host_key_target_path")]
-    pub(super) host_key: OptionalTargetPath,
+    pub host_key: OptionalTargetPath,
 
     /// Event fields to be added to Humio’s extra fields.
     ///
@@ -86,7 +86,7 @@ pub struct HumioLogsConfig {
     ///
     /// [humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
     #[serde(default)]
-    pub(super) indexed_fields: Vec<ConfigValuePath>,
+    pub indexed_fields: Vec<ConfigValuePath>,
 
     /// Optional name of the repository to ingest into.
     ///
@@ -99,26 +99,26 @@ pub struct HumioLogsConfig {
     /// [humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
     #[serde(default)]
     #[configurable(metadata(docs::examples = "{{ host }}", docs::examples = "custom_index"))]
-    pub(super) index: Option<Template>,
+    pub index: Option<Template>,
 
     #[configurable(derived)]
     #[serde(default)]
-    pub(super) compression: Compression,
+    pub compression: Compression,
 
     #[configurable(derived)]
     #[serde(default)]
-    pub(super) request: TowerRequestConfig,
+    pub request: TowerRequestConfig,
 
     #[configurable(derived)]
     #[serde(default)]
-    pub(super) batch: BatchConfig<SplunkHecDefaultBatchSettings>,
+    pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
 
     #[configurable(derived)]
-    pub(super) tls: Option<TlsConfig>,
+    pub tls: Option<TlsConfig>,
 
     /// Overrides the name of the log field used to retrieve the nanosecond-enabled timestamp to send to Humio.
     #[serde(default = "timestamp_nanos_key")]
-    pub(super) timestamp_nanos_key: Option<String>,
+    pub timestamp_nanos_key: Option<String>,
 
     #[configurable(derived)]
     #[serde(
@@ -136,7 +136,7 @@ pub struct HumioLogsConfig {
     ///
     /// [global_timestamp_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.timestamp_key
     #[serde(default = "config_timestamp_key_target_path")]
-    pub(super) timestamp_key: OptionalTargetPath,
+    pub timestamp_key: OptionalTargetPath,
 }
 
 fn default_endpoint() -> String {


### PR DESCRIPTION
### Summary

Want to re-use the `humio_logs` integration elsewhere, which includes using the `HumioLogsConfig` struct. However, the fields in this struct are currently marked `pub(super)`, need to switch this to `pub`. 

### How did you test this PR?

`cargo build`

