### PR TITLE
docs(vrl): Update documentation for ip_cidr_contains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7641,7 +7641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2 1.0.93",
  "quote 1.0.38",
  "syn 2.0.98",
@@ -11509,7 +11509,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vrl"
 version = "0.21.0"
-source = "git+https://github.com/vectordotdev/vrl?branch=main#acfd9f95b1e99f2c6cfab8567b347d865efde922"
+source = "git+https://github.com/vectordotdev/vrl?branch=main#0f4ed43ccb0fc13a631421a018b7dbdbd336cd6d"
 dependencies = [
  "aes",
  "aes-siv",
@@ -11561,7 +11561,6 @@ dependencies = [
  "mlua",
  "nom",
  "ofb",
- "once_cell",
  "onig",
  "ordered-float 4.6.0",
  "parse-size",

--- a/website/cue/reference/remap/functions/ip_cidr_contains.cue
+++ b/website/cue/reference/remap/functions/ip_cidr_contains.cue
@@ -11,7 +11,7 @@ remap: functions: ip_cidr_contains: {
 			name:        "cidr"
 			description: "The CIDR mask (v4 or v6)."
 			required:    true
-			type: ["string"]
+			type: ["string", "array"]
 		},
 		{
 			name:        "ip"
@@ -31,6 +31,13 @@ remap: functions: ip_cidr_contains: {
 			title: "IPv4 contains CIDR"
 			source: #"""
 				ip_cidr_contains!("192.168.0.0/16", "192.168.10.32")
+				"""#
+			return: true
+		},
+		{
+			title: "IPv4 is private"
+			source: #"""
+				ip_cidr_contains!(["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"], "192.168.10.32")
 				"""#
 			return: true
 		},


### PR DESCRIPTION
## Summary
Update documentation for ip_cidr_contains

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
N/A

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

https://github.com/vectordotdev/vrl/pull/1248
