### PR TITLE
feat!(gcp_stackdriver_logs sink): Support more fields

### DIFF
--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -106,7 +106,7 @@ fn encode_valid() {
         json,
         serde_json::json!({
             "logName":"projects/project/logs/testlogs",
-            "jsonPayload":{"message":"hello world"},
+            "textPayload":{"message":"hello world"},
             "severity":100,
             "resource":{
                 "type":"generic_node",
@@ -151,7 +151,7 @@ fn encode_inserts_timestamp() {
         json,
         serde_json::json!({
             "logName":"projects/project/logs/testlogs",
-            "jsonPayload":{"message":"hello world","timestamp":"2020-01-01T12:30:00Z"},
+            "textPayload":{"message":"hello world"},
             "severity":100,
             "resource":{
                 "type":"generic_node",
@@ -248,7 +248,7 @@ async fn correct_request() {
                 {
                     "logName": "projects/project/logs/testlogs",
                     "severity": 0,
-                    "jsonPayload": {
+                    "textPayload": {
                         "message": "hello"
                     },
                     "resource": {
@@ -261,7 +261,7 @@ async fn correct_request() {
                 {
                     "logName": "projects/project/logs/testlogs",
                     "severity": 0,
-                    "jsonPayload": {
+                    "textPayload": {
                         "message": "world"
                     },
                     "resource": {


### PR DESCRIPTION
draft: I'm not sure this is the right approach, as its a breaking change and doesn't follow the pattern of other fields, like `severity key`. However, using a remap to get events in the right format seems flexible than having a bunch of 'xx key' config options, for which you still need a remap to provide a default/fallback.

If the approach is ok I'll add more fields, fix up the tests and the changelog.

## Summary

The LogEntry[1] type supports a lot more fields than are currently supported by the sink. This change adds support for labels, but more fields can be added the same way.

Additionally this removes the timestamp from the message, if set, instead of having it in both the 'timestamp' field, as well as part of the message payload.

It also changes the payload type from json to text if the message is only a string. This makes the GCP search queries simpler, e.g. `textPayload: "some message" instead of `jsonPayload.msg: "some message".

[1]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

## How did you test this PR?

Sending logs to GCP

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- #22374