### PR TITLE
feat(gcp_stackdriver_logs sink): Support additional top level labels for gcp_stackdriver_logs sink

### DIFF
--- a/changelog.d/add-user-labels-to-gcp-stackdriver-logs-sink.enhancement.md
+++ b/changelog.d/add-user-labels-to-gcp-stackdriver-logs-sink.enhancement.md
@@ -1,0 +1,3 @@
+Allow users to specify top level labels with gcp_stackdriver_logs
+
+authors: stackempty

--- a/changelog.d/add-user-labels-to-gcp-stackdriver-logs-sink.enhancement.md
+++ b/changelog.d/add-user-labels-to-gcp-stackdriver-logs-sink.enhancement.md
@@ -1,4 +1,17 @@
-Add support for labels with gcp_stackdriver_logs config
-Add support for labels from structured logs matching key specified via `labels_key` gcp_stackdriver_logs config
+Add support for static labels in gcp_stackdriver_logs sink.
+
+    This enhancement enables users to define static labels directly in the
+    gcp_stackdriver_logs sink configuration. Static labels are key-value pairs
+    that are consistently applied to all log entries sent to Google Cloud Logging,
+    improving log organization and filtering capabilities.
+
+
+Add support for dynamic labels in gcp_stackdriver_logs sink via `labels_key`.
+
+    This enhancement allows Vector to automatically map fields from structured
+    log entries to Google Cloud LogEntry labels. When a structured log contains
+    fields matching the configured `labels_key`, Vector will populate the
+    corresponding labels in the Google Cloud LogEntry, enabling better log
+    organization and filtering in Google Cloud Logging.
 
 authors: stackempty

--- a/changelog.d/add-user-labels-to-gcp-stackdriver-logs-sink.enhancement.md
+++ b/changelog.d/add-user-labels-to-gcp-stackdriver-logs-sink.enhancement.md
@@ -1,3 +1,4 @@
-Allow users to specify top level labels with gcp_stackdriver_logs
+Add support for labels with gcp_stackdriver_logs config
+Add support for labels from structured logs matching key specified via `labels_key` gcp_stackdriver_logs config
 
 authors: stackempty

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -61,6 +61,13 @@ pub(super) struct StackdriverConfig {
     /// The monitored resource to associate the logs with.
     pub(super) resource: StackdriverResource,
 
+    /// A map of key, value pairs that provides additional information about the log entry.
+    #[configurable(metadata(
+        docs::additional_props_description = "A key, value pair that describes a log entry."
+    ))]
+    #[serde(default)]
+    pub(super) labels: HashMap<String, Template>,
+
     /// The field of the log event from which to take the outgoing log’s `severity` field.
     ///
     /// The named field is removed from the log event if present, and must be either an integer
@@ -208,6 +215,7 @@ impl SinkConfig for StackdriverConfig {
                 self.encoding.clone(),
                 self.log_id.clone(),
                 self.log_name.clone(),
+                self.labels.clone(),
                 self.resource.clone(),
                 self.severity_key.clone(),
             ),

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -168,7 +168,7 @@ pub(super) struct StackdriverLabelConfig {
     /// and extract their values to set as LogEntry labels.
     #[configurable(metadata(docs::examples = "logging.googleapis.com/labels"))]
     #[serde(default = "default_labels_key")]
-    pub(super) labels_key: String,
+    pub(super) labels_key: Option<String>,
 
     /// A map of key, value pairs that provides additional information about the log entry.
     #[configurable(metadata(
@@ -186,8 +186,8 @@ fn labels_examples() -> HashMap<String, String> {
     example
 }
 
-fn default_labels_key() -> String {
-    "logging.googleapis.com/labels".to_string()
+fn default_labels_key() -> Option<String> {
+    Some("logging.googleapis.com/labels".to_string())
 }
 
 /// A monitored resource.

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -61,13 +61,8 @@ pub(super) struct StackdriverConfig {
     /// The monitored resource to associate the logs with.
     pub(super) resource: StackdriverResource,
 
-    /// A map of key, value pairs that provides additional information about the log entry.
-    #[configurable(metadata(
-        docs::additional_props_description = "A key, value pair that describes a log entry."
-    ))]
-    #[configurable(metadata(docs::examples = "labels_examples()"))]
-    #[serde(default)]
-    pub(super) labels: HashMap<String, Template>,
+    #[serde(flatten)]
+    pub(super) label_config: StackdriverLabelConfig,
 
     /// The field of the log event from which to take the outgoing log’s `severity` field.
     ///
@@ -110,13 +105,6 @@ pub(super) struct StackdriverConfig {
         skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
-}
-
-fn labels_examples() -> HashMap<String, String> {
-    let mut example = HashMap::new();
-    example.insert("user_label_1".to_string(), "value_1".to_string());
-    example.insert("user_label_2".to_string(), "{{ template_value_2 }}".to_string());
-    example
 }
 
 pub(super) fn default_endpoint() -> String {
@@ -171,6 +159,37 @@ pub(super) enum StackdriverLogName {
     Project(String),
 }
 
+/// Label Configuration.
+#[configurable_component]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default)]
+pub(super) struct StackdriverLabelConfig {
+    /// The value of this field is used to retrieve the associated labels from the `jsonPayload`
+    /// and extract their values to set as LogEntry labels.
+    #[configurable(metadata(docs::examples = "logging.googleapis.com/labels"))]
+    #[serde(default = "default_labels_key")]
+    pub(super) labels_key: String,
+
+    /// A map of key, value pairs that provides additional information about the log entry.
+    #[configurable(metadata(
+        docs::additional_props_description = "A key, value pair that describes a log entry."
+    ))]
+    #[configurable(metadata(docs::examples = "labels_examples()"))]
+    #[serde(default)]
+    pub(super) labels: HashMap<String, Template>,
+}
+
+fn labels_examples() -> HashMap<String, String> {
+    let mut example = HashMap::new();
+    example.insert("label_1".to_string(), "value_1".to_string());
+    example.insert("label_2".to_string(), "{{ template_value_2 }}".to_string());
+    example
+}
+
+fn default_labels_key() -> String {
+    "logging.googleapis.com/labels".to_string()
+}
+
 /// A monitored resource.
 ///
 /// Monitored resources in GCP allow associating logs and metrics specifically with native resources
@@ -223,7 +242,7 @@ impl SinkConfig for StackdriverConfig {
                 self.encoding.clone(),
                 self.log_id.clone(),
                 self.log_name.clone(),
-                self.labels.clone(),
+                self.label_config.clone(),
                 self.resource.clone(),
                 self.severity_key.clone(),
             ),

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -186,7 +186,7 @@ fn labels_examples() -> HashMap<String, String> {
     example
 }
 
-fn default_labels_key() -> Option<String> {
+pub(super) fn default_labels_key() -> Option<String> {
     Some("logging.googleapis.com/labels".to_string())
 }
 

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -65,6 +65,7 @@ pub(super) struct StackdriverConfig {
     #[configurable(metadata(
         docs::additional_props_description = "A key, value pair that describes a log entry."
     ))]
+    #[configurable(metadata(docs::examples = "labels_examples()"))]
     #[serde(default)]
     pub(super) labels: HashMap<String, Template>,
 
@@ -109,6 +110,13 @@ pub(super) struct StackdriverConfig {
         skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
+}
+
+fn labels_examples() -> HashMap<String, String> {
+    let mut example = HashMap::new();
+    example.insert("user_label_1".to_string(), "value_1".to_string());
+    example.insert("user_label_2".to_string(), "{{ template_value_2 }}".to_string());
+    example
 }
 
 pub(super) fn default_endpoint() -> String {

--- a/src/sinks/gcp/stackdriver/logs/encoder.rs
+++ b/src/sinks/gcp/stackdriver/logs/encoder.rs
@@ -96,9 +96,8 @@ impl StackdriverLogsEncoder {
         let labels_key = self
             .label_config
             .labels_key
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or_else(|| "logging.googleapis.com/labels".into());
+            .as_deref()
+            .unwrap_or("logging.googleapis.com/labels");
 
         // merge log_labels in the specified labels_key into the labels map.
         if let Some(Value::Object(log_labels)) = log.remove(event_path!(labels_key)) {

--- a/src/sinks/gcp/stackdriver/logs/encoder.rs
+++ b/src/sinks/gcp/stackdriver/logs/encoder.rs
@@ -13,7 +13,9 @@ use crate::{
     template::TemplateRenderingError,
 };
 
-use super::config::{StackdriverLabelConfig, StackdriverLogName, StackdriverResource};
+use super::config::{
+    default_labels_key, StackdriverLabelConfig, StackdriverLogName, StackdriverResource,
+};
 
 #[derive(Clone, Debug)]
 pub(super) struct StackdriverLogsEncoder {
@@ -93,11 +95,13 @@ impl StackdriverLogsEncoder {
             .map(remap_severity)
             .unwrap_or_else(|| 0.into());
 
+        let default_labels_key = default_labels_key();
         let labels_key = self
             .label_config
             .labels_key
             .as_deref()
-            .unwrap_or("logging.googleapis.com/labels");
+            .or_else(|| default_labels_key.as_deref())
+            .unwrap();
 
         // merge log_labels in the specified labels_key into the labels map.
         if let Some(Value::Object(log_labels)) = log.remove(event_path!(labels_key)) {

--- a/src/sinks/gcp/stackdriver/logs/encoder.rs
+++ b/src/sinks/gcp/stackdriver/logs/encoder.rs
@@ -100,7 +100,7 @@ impl StackdriverLogsEncoder {
             .label_config
             .labels_key
             .as_deref()
-            .or_else(|| default_labels_key.as_deref())
+            .or(default_labels_key.as_deref())
             .unwrap();
 
         // merge log_labels in the specified labels_key into the labels map.

--- a/src/sinks/gcp/stackdriver/logs/encoder.rs
+++ b/src/sinks/gcp/stackdriver/logs/encoder.rs
@@ -93,15 +93,20 @@ impl StackdriverLogsEncoder {
             .map(remap_severity)
             .unwrap_or_else(|| 0.into());
 
+        let labels_key = self
+            .label_config
+            .labels_key
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or_else(|| "logging.googleapis.com/labels".into());
+
         // merge log_labels in the specified labels_key into the labels map.
-        if let Some(log_labels) = log.remove(event_path!(self.label_config.labels_key.as_str())) {
-            if let Value::Object(log_labels) = log_labels {
-                labels.extend(
-                    log_labels
-                        .into_iter()
-                        .map(|(k, v)| (k.to_string(), v.to_string_lossy().into_owned())),
-                );
-            }
+        if let Some(Value::Object(log_labels)) = log.remove(event_path!(labels_key)) {
+            labels.extend(
+                log_labels
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string_lossy().into_owned())),
+            );
         }
 
         let mut event = Event::Log(log);

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -79,7 +79,7 @@ fn encode_valid() {
         Template::try_from("{{ log_id }}").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
         StackdriverLabelConfig {
-            labels_key: Some("logging.googleapis.com/labels".to_owned()),
+            labels_key: None,
             labels: HashMap::from([(
                 "config_user_label_1".to_owned(),
                 Template::try_from("config_user_value_1").unwrap(),
@@ -143,7 +143,7 @@ fn encode_inserts_timestamp() {
         Template::try_from("testlogs").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
         StackdriverLabelConfig {
-            labels_key: Some("user_label_key".to_owned()),
+            labels_key: None,
             labels: HashMap::from([(
                 "config_user_label_1".to_owned(),
                 Template::try_from("value_1").unwrap(),
@@ -225,7 +225,7 @@ async fn correct_request() {
         Template::try_from("testlogs").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
         StackdriverLabelConfig {
-            labels_key: Some("user_label_key".to_owned()),
+            labels_key: None,
             labels: HashMap::from([(
                 "config_user_label_1".to_owned(),
                 Template::try_from("value_1").unwrap(),

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -76,6 +76,10 @@ fn encode_valid() {
         transformer,
         Template::try_from("{{ log_id }}").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
+        HashMap::from([(
+            "user_label_1".to_owned(),
+            Template::try_from("value_1").unwrap(),
+        )]),
         StackdriverResource {
             type_: "generic_node".to_owned(),
             labels: HashMap::from([
@@ -108,6 +112,7 @@ fn encode_valid() {
             "logName":"projects/project/logs/testlogs",
             "jsonPayload":{"message":"hello world"},
             "severity":100,
+            "labels":{"user_label_1":"value_1"},
             "resource":{
                 "type":"generic_node",
                 "labels":{"namespace":"office","node_id":"10.10.10.1"}
@@ -124,6 +129,10 @@ fn encode_inserts_timestamp() {
         transformer,
         Template::try_from("testlogs").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
+        HashMap::from([(
+            "user_label_1".to_owned(),
+            Template::try_from("value_1").unwrap(),
+        )]),
         StackdriverResource {
             type_: "generic_node".to_owned(),
             labels: HashMap::from([(
@@ -153,6 +162,7 @@ fn encode_inserts_timestamp() {
             "logName":"projects/project/logs/testlogs",
             "jsonPayload":{"message":"hello world","timestamp":"2020-01-01T12:30:00Z"},
             "severity":100,
+            "labels":{"user_label_1":"value_1"},
             "resource":{
                 "type":"generic_node",
                 "labels":{"namespace":"office"}},
@@ -198,6 +208,10 @@ async fn correct_request() {
         transformer,
         Template::try_from("testlogs").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
+        HashMap::from([(
+            "user_label_1".to_owned(),
+            Template::try_from("value_1").unwrap(),
+        )]),
         StackdriverResource {
             type_: "generic_node".to_owned(),
             labels: HashMap::from([(
@@ -251,6 +265,9 @@ async fn correct_request() {
                     "jsonPayload": {
                         "message": "hello"
                     },
+                    "labels": {
+                        "user_label_1": "value_1"
+                    },
                     "resource": {
                         "type": "generic_node",
                         "labels": {
@@ -263,6 +280,9 @@ async fn correct_request() {
                     "severity": 0,
                     "jsonPayload": {
                         "message": "world"
+                    },
+                    "labels": {
+                        "user_label_1": "value_1"
                     },
                     "resource": {
                         "type": "generic_node",

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -79,7 +79,7 @@ fn encode_valid() {
         Template::try_from("{{ log_id }}").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
         StackdriverLabelConfig {
-            labels_key: "logging.googleapis.com/labels".to_owned(),
+            labels_key: Some("logging.googleapis.com/labels".to_owned()),
             labels: HashMap::from([(
                 "config_user_label_1".to_owned(),
                 Template::try_from("config_user_value_1").unwrap(),
@@ -143,7 +143,7 @@ fn encode_inserts_timestamp() {
         Template::try_from("testlogs").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
         StackdriverLabelConfig {
-            labels_key: "user_label_key".to_owned(),
+            labels_key: Some("user_label_key".to_owned()),
             labels: HashMap::from([(
                 "config_user_label_1".to_owned(),
                 Template::try_from("value_1").unwrap(),
@@ -225,7 +225,7 @@ async fn correct_request() {
         Template::try_from("testlogs").unwrap(),
         StackdriverLogName::Project("project".to_owned()),
         StackdriverLabelConfig {
-            labels_key: "user_label_key".to_owned(),
+            labels_key: Some("user_label_key".to_owned()),
             labels: HashMap::from([(
                 "config_user_label_1".to_owned(),
                 Template::try_from("value_1").unwrap(),

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -144,10 +144,16 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 	labels: {
 		description: "A map of key, value pairs that provides additional information about the log entry."
 		required:    false
-		type: object: options: "*": {
-			description: "A key, value pair that describes a log entry."
-			required:    true
-			type: string: syntax: "template"
+		type: object: {
+			examples: [{
+				user_label_1: "value_1"
+				user_label_2: "{{ template_value_2 }}"
+			}]
+			options: "*": {
+				description: "A key, value pair that describes a log entry."
+				required:    true
+				type: string: syntax: "template"
+			}
 		}
 	}
 	log_id: {

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -141,6 +141,15 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 		required: true
 		type: string: {}
 	}
+	labels: {
+		description: "A map of key, value pairs that provides additional information about the log entry."
+		required:    false
+		type: object: options: "*": {
+			description: "A key, value pair that describes a log entry."
+			required:    true
+			type: string: syntax: "template"
+		}
+	}
 	log_id: {
 		description: """
 			The log ID to which to publish logs.

--- a/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/base/gcp_stackdriver_logs.cue
@@ -146,14 +146,25 @@ base: components: sinks: gcp_stackdriver_logs: configuration: {
 		required:    false
 		type: object: {
 			examples: [{
-				user_label_1: "value_1"
-				user_label_2: "{{ template_value_2 }}"
+				label_1: "value_1"
+				label_2: "{{ template_value_2 }}"
 			}]
 			options: "*": {
 				description: "A key, value pair that describes a log entry."
 				required:    true
 				type: string: syntax: "template"
 			}
+		}
+	}
+	labels_key: {
+		description: """
+			The value of this field is used to retrieve the associated labels from the `jsonPayload`
+			and extract their values to set as LogEntry labels.
+			"""
+		required: false
+		type: string: {
+			default: "logging.googleapis.com/labels"
+			examples: ["logging.googleapis.com/labels"]
 		}
 	}
 	log_id: {


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This adds top level label field according to LogEntry docs https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.labels! 
This will allow users add additional labels to the label field in log entries not just the ones in resource object!

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

- Ran the unit tests
  ```bash
  cargo test --package vector --lib -- sinks::gcp::stackdriver::logs::tests --show-output```
- cargo test --all
- Tested against an existing google account and viewed the logs in GCL.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->
Closes: https://github.com/vectordotdev/vector/issues/8516

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
