### PR TITLE
feat(websocket_server sink): add message buffering for `websocket_server`

### DIFF
--- a/changelog.d/22479_websocket_server_sink_buffering.feature.md
+++ b/changelog.d/22479_websocket_server_sink_buffering.feature.md
@@ -1,0 +1,4 @@
+Add message buffering feature to `websocket_server` sink, that enables replaying missed messages to
+newly connected clients.
+
+authors: esensar

--- a/src/sinks/websocket_server/buffering.rs
+++ b/src/sinks/websocket_server/buffering.rs
@@ -16,7 +16,8 @@ use vector_lib::{
 pub struct MessageBufferingConfig {
     /// Max events to hold in buffer.
     ///
-    /// When the buffer is full, oldest messages are overwritten.
+    /// The buffer is backed by a ring buffer, so the oldest messages will be lost when the size
+    /// limit is reached.
     #[serde(default = "default_max_events")]
     pub max_events: NonZeroUsize,
 

--- a/src/sinks/websocket_server/buffering.rs
+++ b/src/sinks/websocket_server/buffering.rs
@@ -1,0 +1,146 @@
+use std::{collections::VecDeque, num::NonZeroUsize};
+
+use bytes::Bytes;
+use tokio_tungstenite::tungstenite::{handshake::server::Request, Message};
+use url::Url;
+use uuid::Uuid;
+use vector_config::configurable_component;
+use vector_lib::{
+    event::{Event, MaybeAsLogMut},
+    lookup::lookup_v2::ConfigValuePath,
+};
+
+/// Configuration for message buffering which enables message replay for clients that connect later.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub struct MessageBufferingConfig {
+    /// Max events to hold in buffer.
+    ///
+    /// When the buffer is full, oldest messages are overwritten.
+    #[serde(default = "default_max_events")]
+    pub max_events: NonZeroUsize,
+
+    /// Message ID path.
+    ///
+    /// This has to be defined to expose message ID to clients in the messages. Using that ID,
+    /// clients can request replay starting from the message ID of their choosing.
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub message_id_path: Option<ConfigValuePath>,
+}
+
+const fn default_max_events() -> NonZeroUsize {
+    unsafe { NonZeroUsize::new_unchecked(1000) }
+}
+
+const LAST_RECEIVED_QUERY_PARAM_NAME: &str = "last_received";
+
+pub struct BufferReplayRequest {
+    should_replay: bool,
+    replay_from: Option<Uuid>,
+}
+
+impl BufferReplayRequest {
+    pub const NO_REPLAY: Self = Self {
+        should_replay: false,
+        replay_from: None,
+    };
+    pub const REPLAY_ALL: Self = Self {
+        should_replay: true,
+        replay_from: None,
+    };
+
+    const fn with_replay_from(replay_from: Uuid) -> Self {
+        Self {
+            should_replay: true,
+            replay_from: Some(replay_from),
+        }
+    }
+
+    pub fn replay_messages(
+        &self,
+        buffer: &VecDeque<(Uuid, Message)>,
+        replay: impl FnMut(&(Uuid, Message)),
+    ) {
+        if self.should_replay {
+            buffer
+                .iter()
+                .filter(|(id, _)| Some(*id) > self.replay_from)
+                .for_each(replay);
+        }
+    }
+}
+
+pub trait WsMessageBufferConfig {
+    /// Returns true if this configuration enables buffering.
+    fn should_buffer(&self) -> bool;
+    /// Returns configured size of the buffer.
+    fn buffer_capacity(&self) -> usize;
+    /// Extracts buffer replay request from the given connection request, based on configuration.
+    fn extract_message_replay_request(&self, request: &Request) -> BufferReplayRequest;
+    /// Adds a message ID that can be used for requesting replay into the event.
+    /// Created ID is returned to be stored in the buffer.
+    fn add_replay_message_id_to_event(&self, event: &mut Event) -> Uuid;
+}
+
+impl WsMessageBufferConfig for Option<MessageBufferingConfig> {
+    fn should_buffer(&self) -> bool {
+        self.is_some()
+    }
+
+    fn buffer_capacity(&self) -> usize {
+        self.as_ref().map_or(0, |mb| mb.max_events.get())
+    }
+
+    fn extract_message_replay_request(&self, request: &Request) -> BufferReplayRequest {
+        // Early return if buffering is disabled
+        if self.is_none() {
+            return BufferReplayRequest::NO_REPLAY;
+        }
+
+        // Early return if query params are missing
+        let Some(query_params) = request.uri().query() else {
+            return BufferReplayRequest::NO_REPLAY;
+        };
+
+        // Early return if there is no query param for replay
+        if !query_params.contains(LAST_RECEIVED_QUERY_PARAM_NAME) {
+            return BufferReplayRequest::NO_REPLAY;
+        }
+
+        let base_url = Url::parse("ws://localhost").ok();
+        if let Ok(url) = Url::options()
+            .base_url(base_url.as_ref())
+            .parse(request.uri().to_string().as_str())
+        {
+            if let Some((_, last_received_param_value)) = url
+                .query_pairs()
+                .find(|(k, _)| k == LAST_RECEIVED_QUERY_PARAM_NAME)
+            {
+                if let Ok(last_received_val) = Uuid::parse_str(&last_received_param_value) {
+                    return BufferReplayRequest::with_replay_from(last_received_val);
+                }
+            }
+        }
+
+        // Even if we can't find the provided message ID, we should dump whatever we have
+        // buffered so far, because the provided message ID might have expired by now
+        BufferReplayRequest::REPLAY_ALL
+    }
+
+    fn add_replay_message_id_to_event(&self, event: &mut Event) -> Uuid {
+        let message_id = Uuid::now_v7();
+        if let Some(MessageBufferingConfig {
+            message_id_path: Some(ref message_id_path),
+            ..
+        }) = self
+        {
+            if let Some(log) = event.maybe_as_log_mut() {
+                let mut buffer = [0; 36];
+                let uuid = message_id.hyphenated().encode_lower(&mut buffer);
+                log.value_mut()
+                    .insert(message_id_path, Bytes::copy_from_slice(uuid.as_bytes()));
+            }
+        }
+        message_id
+    }
+}

--- a/src/sinks/websocket_server/config.rs
+++ b/src/sinks/websocket_server/config.rs
@@ -61,15 +61,20 @@ impl Default for WebSocketListenerSinkConfig {
     }
 }
 
-/// Message buffering
+/// Configuration for message buffering which enables message replay for clients that connect later.
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct MessageBuffering {
-    /// Max events
+    /// Max events to hold in buffer.
+    ///
+    /// When the buffer is full, oldest messages are overwritten.
     #[serde(default = "default_max_events")]
     pub max_events: NonZeroUsize,
 
-    /// Message id path
+    /// Message ID path.
+    ///
+    /// This has to be defined to expose message ID to clients in the messages. Using that ID,
+    /// clients can request replay starting from the message ID of their choosing.
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub message_id_path: Option<ConfigValuePath>,
 }

--- a/src/sinks/websocket_server/mod.rs
+++ b/src/sinks/websocket_server/mod.rs
@@ -1,3 +1,4 @@
+mod buffering;
 mod config;
 mod sink;
 

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -226,14 +226,11 @@ impl StreamSink<Event> for WebSocketListenerSink {
 
         let listener = self.tls.bind(&self.address).await.map_err(|_| ())?;
 
-        let message_buffer = Arc::new(Mutex::new(VecDeque::with_capacity(
-            if let Some(MessageBuffering { ref max_events, .. }) = self.message_buffering {
-                max_events.get()
-            } else {
-                0
-            },
-        )));
-
+let message_buffer = Arc::new(Mutex::new(VecDeque::with_capacity(
+    self.message_buffering
+        .as_ref()
+        .map_or(0, |mb| mb.max_events.get()),
+)));
         tokio::spawn(
             Self::handle_connections(
                 self.auth,

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -117,8 +117,7 @@ impl WebSocketListenerSink {
         open_gauge: OpenGauge,
     ) -> Result<(), ()> {
         // Base url for parsing request URLs that may be relative
-        // It should never panic, since valid URL is hard-coded
-        let base_url = Url::parse("ws://localhost").unwrap();
+        let base_url = Url::parse("ws://localhost").ok();
         let addr = stream.peer_addr();
         debug!("Incoming TCP connection from: {}", addr);
 
@@ -131,7 +130,7 @@ impl WebSocketListenerSink {
                 // buffered so far, because the provided message ID might have expired by now
                 should_replay = true;
                 if let Ok(url) = Url::options()
-                    .base_url(Some(&base_url))
+                    .base_url(base_url.as_ref())
                     .parse(req.uri().to_string().as_str())
                 {
                     if let Some((_, last_received_param_value)) =

--- a/website/cue/reference/components/sinks/base/websocket_server.cue
+++ b/website/cue/reference/components/sinks/base/websocket_server.cue
@@ -427,6 +427,22 @@ base: components: sinks: websocket_server: configuration: {
 			}
 		}
 	}
+	message_buffering: {
+		description: "Message buffering"
+		required:    false
+		type: object: options: {
+			max_events: {
+				description: "Max events"
+				required:    false
+				type: uint: default: 1000
+			}
+			message_id_path: {
+				description: "Message id path"
+				required:    false
+				type: string: {}
+			}
+		}
+	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."
 		required:    false

--- a/website/cue/reference/components/sinks/base/websocket_server.cue
+++ b/website/cue/reference/components/sinks/base/websocket_server.cue
@@ -435,7 +435,8 @@ base: components: sinks: websocket_server: configuration: {
 				description: """
 					Max events to hold in buffer.
 
-					When the buffer is full, oldest messages are overwritten.
+					The buffer is backed by a ring buffer, so the oldest messages will be lost when the size
+					limit is reached.
 					"""
 				required: false
 				type: uint: default: 1000

--- a/website/cue/reference/components/sinks/base/websocket_server.cue
+++ b/website/cue/reference/components/sinks/base/websocket_server.cue
@@ -428,17 +428,26 @@ base: components: sinks: websocket_server: configuration: {
 		}
 	}
 	message_buffering: {
-		description: "Message buffering"
+		description: "Configuration for message buffering which enables message replay for clients that connect later."
 		required:    false
 		type: object: options: {
 			max_events: {
-				description: "Max events"
-				required:    false
+				description: """
+					Max events to hold in buffer.
+
+					When the buffer is full, oldest messages are overwritten.
+					"""
+				required: false
 				type: uint: default: 1000
 			}
 			message_id_path: {
-				description: "Message id path"
-				required:    false
+				description: """
+					Message ID path.
+
+					This has to be defined to expose message ID to clients in the messages. Using that ID,
+					clients can request replay starting from the message ID of their choosing.
+					"""
+				required: false
 				type: string: {}
 			}
 		}

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -83,4 +83,37 @@ components: sinks: websocket_server: {
 		connection_established_total: components.sources.internal_metrics.output.metrics.connection_established_total
 		connection_shutdown_total:    components.sources.internal_metrics.output.metrics.connection_shutdown_total
 	}
+
+	how_it_works: {
+		message_buffering: {
+			title: "Message buffering"
+			body: """
+			The `message_buffering` configuration option can be used to enable this feature. It can
+			be used to define a number of events to be buffered, to enable replay for clients that
+			may want to continue from last message after disconnection. To provide clients with the
+			message ID, `message_buffering.message_id_path` needs to be defined, which will be used
+			to encode the ID inside outgoing messages. The buffer is backed by a ring buffer, so
+			oldest messages will be lost when the size limit is reached.
+
+			Once clients have the ID, on future connections that ID can be sent in the
+			`last_received` query parameter and all buffered messages since that message will be
+			sent to the client immediatelly on connection. If the message can't be found, entire
+			buffer will be replayed.
+
+			Example config:
+			```yaml
+			sinks:
+				websocket_export:
+					type: websocket_server
+					inputs: ["demo_logs_test"]
+					address: "0.0.0.0:1234"
+						message_buffering:
+							max_events: 1000
+							message_id_path: "message_id"
+					encoding:
+						codec: "json"
+			```
+			"""
+		}
+	}
 }

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -123,16 +123,16 @@ components: sinks: websocket_server: {
 			title: "Message buffering"
 			body: """
 				The `message_buffering` configuration option can be used to enable this feature. It can
-				be used to define a number of events to be buffered, to enable replay for clients that
+				be used to define a number of events to be buffered, which would enable replay for clients that
 				may want to continue from the last message after disconnection. To provide clients with the
 				message ID, `message_buffering.message_id_path` needs to be defined, which is used
 				to encode the ID inside outgoing messages. The buffer is backed by a ring buffer, so
-				oldest messages will be lost when the size limit is reached.
+				the oldest messages will be lost when the size limit is reached.
 
-				Once clients have the ID, on future connections that ID can be sent in the
+				Once clients have the ID, on future connections that the ID can be sent in the
 				`last_received` query parameter and all buffered messages since that message are
 				sent to the client immediately on connection. If the message can't be found, the entire
-				buffer will be replayed.
+				buffer is replayed.
 
 				Example config:
 				```yaml

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -122,11 +122,10 @@ components: sinks: websocket_server: {
 		message_buffering: {
 			title: "Message buffering"
 			body: """
-				The `message_buffering` configuration option can be used to enable this feature. It can
-				be used to define a number of events to be buffered, which would enable replay for clients that
-				may want to continue from the last message after disconnection. To provide clients with the
-				message ID, `message_buffering.message_id_path` needs to be defined, which is used
-				to encode the outgoing messages ID. The buffer is backed by a ring buffer, so
+				The `message_buffering` configuration option enables event buffering. It defines the number
+				of events to buffer, allowing clients to replay messages after a disconnection.
+				To provide clients with the message ID, define `message_buffering.message_id_path`.
+				This encodes the outgoing messages ID. The buffer is backed by a ring buffer, so
 				the oldest messages are discarded when the size limit is reached.
 
 				After clients have the ID, they can send it in the `last_received` query parameter on future connections.

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -88,32 +88,32 @@ components: sinks: websocket_server: {
 		message_buffering: {
 			title: "Message buffering"
 			body: """
-			The `message_buffering` configuration option can be used to enable this feature. It can
-			be used to define a number of events to be buffered, to enable replay for clients that
-			may want to continue from last message after disconnection. To provide clients with the
-			message ID, `message_buffering.message_id_path` needs to be defined, which will be used
-			to encode the ID inside outgoing messages. The buffer is backed by a ring buffer, so
-			oldest messages will be lost when the size limit is reached.
+				The `message_buffering` configuration option can be used to enable this feature. It can
+				be used to define a number of events to be buffered, to enable replay for clients that
+				may want to continue from last message after disconnection. To provide clients with the
+				message ID, `message_buffering.message_id_path` needs to be defined, which will be used
+				to encode the ID inside outgoing messages. The buffer is backed by a ring buffer, so
+				oldest messages will be lost when the size limit is reached.
 
-			Once clients have the ID, on future connections that ID can be sent in the
-			`last_received` query parameter and all buffered messages since that message will be
-			sent to the client immediately on connection. If the message can't be found, entire
-			buffer will be replayed.
+				Once clients have the ID, on future connections that ID can be sent in the
+				`last_received` query parameter and all buffered messages since that message will be
+				sent to the client immediately on connection. If the message can't be found, entire
+				buffer will be replayed.
 
-			Example config:
-			```yaml
-			sinks:
-				websocket_export:
-					type: websocket_server
-					inputs: ["demo_logs_test"]
-					address: "0.0.0.0:1234"
-						message_buffering:
-							max_events: 1000
-							message_id_path: "message_id"
-					encoding:
-						codec: "json"
-			```
-			"""
+				Example config:
+				```yaml
+				sinks:
+					websocket_export:
+						type: websocket_server
+						inputs: ["demo_logs_test"]
+						address: "0.0.0.0:1234"
+							message_buffering:
+								max_events: 1000
+								message_id_path: "message_id"
+						encoding:
+							codec: "json"
+				```
+				"""
 		}
 	}
 }

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -127,12 +127,11 @@ components: sinks: websocket_server: {
 				may want to continue from the last message after disconnection. To provide clients with the
 				message ID, `message_buffering.message_id_path` needs to be defined, which is used
 				to encode the outgoing messages ID. The buffer is backed by a ring buffer, so
-				the oldest messages will be lost when the size limit is reached.
+				the oldest messages are discarded when the size limit is reached.
 
-				Once clients have the ID, on future connections that the ID can be sent in the
-				`last_received` query parameter and all buffered messages since that message are
-				sent to the client immediately on connection. If the message can't be found, the entire
-				buffer is replayed.
+				After clients have the ID, they can send it in the `last_received` query parameter on future connections.
+				All buffered messages since that ID are then sent to the client immediately upon connection.
+				If the message can't be found, the entire buffer is replayed.
 
 				Example config:
 				```yaml

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -90,14 +90,14 @@ components: sinks: websocket_server: {
 			body: """
 				The `message_buffering` configuration option can be used to enable this feature. It can
 				be used to define a number of events to be buffered, to enable replay for clients that
-				may want to continue from last message after disconnection. To provide clients with the
-				message ID, `message_buffering.message_id_path` needs to be defined, which will be used
+				may want to continue from the last message after disconnection. To provide clients with the
+				message ID, `message_buffering.message_id_path` needs to be defined, which is used
 				to encode the ID inside outgoing messages. The buffer is backed by a ring buffer, so
 				oldest messages will be lost when the size limit is reached.
 
 				Once clients have the ID, on future connections that ID can be sent in the
-				`last_received` query parameter and all buffered messages since that message will be
-				sent to the client immediately on connection. If the message can't be found, entire
+				`last_received` query parameter and all buffered messages since that message are
+				sent to the client immediately on connection. If the message can't be found, the entire
 				buffer will be replayed.
 
 				Example config:

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -126,7 +126,7 @@ components: sinks: websocket_server: {
 				be used to define a number of events to be buffered, which would enable replay for clients that
 				may want to continue from the last message after disconnection. To provide clients with the
 				message ID, `message_buffering.message_id_path` needs to be defined, which is used
-				to encode the ID inside outgoing messages. The buffer is backed by a ring buffer, so
+				to encode the outgoing messages ID. The buffer is backed by a ring buffer, so
 				the oldest messages will be lost when the size limit is reached.
 
 				Once clients have the ID, on future connections that the ID can be sent in the

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -97,7 +97,7 @@ components: sinks: websocket_server: {
 
 			Once clients have the ID, on future connections that ID can be sent in the
 			`last_received` query parameter and all buffered messages since that message will be
-			sent to the client immediatelly on connection. If the message can't be found, entire
+			sent to the client immediately on connection. If the message can't be found, entire
 			buffer will be replayed.
 
 			Example config:


### PR DESCRIPTION
## Summary

This adds a message buffer to `websocket_server`, backed by a ring buffer, which hold a set maximum number of messages to replay to clients that connect late, or re-connect after losing connection. Messages are replayed based on `last_received` query parameter.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Besides the added unit tests, this was tested with the following configuration:
```yaml
sources:
  demo_logs_test:
    type: "demo_logs"
    format: "json"

sinks:
  websocket_sink:
    inputs: ["demo_logs_test"]
    type: "websocket_server"
    address: "0.0.0.0:1234"
    message_buffering:
      message_id_path: "message_id"
    acknowledgements:
      enabled: false
    encoding:
      codec: "json"
```

When connecting to the websocket using the url "ws://localhost:1234", messages were received as previously, but when sent with "ws://localhost:1234?last_received={some-message-id}", all data since that message was sent before all the new incoming events (if available). Also, if connected with "ws://localhost:1234?last_received=" (empty, or invalid message id), all data from the buffer was sent before new events.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Related: #22213
