### PR TITLE
docs(websocket_server sink): add `how_it_works` section for `websocket_server`

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -236,6 +236,7 @@ jobs:
             statsd sink
             vector sink
             websocket sink
+            websocket_server sink
             blog website
             css website
             guides website

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -83,4 +83,38 @@ components: sinks: websocket_server: {
 		connection_established_total: components.sources.internal_metrics.output.metrics.connection_established_total
 		connection_shutdown_total:    components.sources.internal_metrics.output.metrics.connection_shutdown_total
 	}
+
+	how_it_works: {
+		simple_configuration: {
+			title: "Example configuration"
+			body: """
+			The `websocket_server` sink component can be useful when data needs to be broadcasted to
+			a number of clients. Here is an example of a very simple websocket server sink
+			configuration:
+
+			```yaml
+			sources:
+				demo_logs_test:
+					type: "demo_logs"
+					format: "json"
+
+			sinks:
+				websocket_sink:
+					inputs: ["demo_logs_test"]
+					type: "websocket_listener"
+					address: "0.0.0.0:1234"
+					auth:
+						username: "test"
+						password: "test"
+					encoding:
+						codec: "json"
+			```
+
+			With this configuration, a websocket server will listen for connections on 1234 port.
+			For clients to connect, they need to provide credentials in the Authorization header,
+			because `auth` configuration is defined (by default, no auth is required). In this case,
+			it requires Basic auth with defined username and password.
+			"""
+		}
+	}
 }

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -88,33 +88,33 @@ components: sinks: websocket_server: {
 		simple_configuration: {
 			title: "Example configuration"
 			body: """
-			The `websocket_server` sink component can be useful when data needs to be broadcasted to
-			a number of clients. Here is an example of a very simple websocket server sink
-			configuration:
+				The `websocket_server` sink component can be useful when data needs to be broadcasted to
+				a number of clients. Here is an example of a very simple websocket server sink
+				configuration:
 
-			```yaml
-			sources:
-				demo_logs_test:
-					type: "demo_logs"
-					format: "json"
+				```yaml
+				sources:
+					demo_logs_test:
+						type: "demo_logs"
+						format: "json"
 
-			sinks:
-				websocket_sink:
-					inputs: ["demo_logs_test"]
-					type: "websocket_listener"
-					address: "0.0.0.0:1234"
-					auth:
-						username: "test"
-						password: "test"
-					encoding:
-						codec: "json"
-			```
+				sinks:
+					websocket_sink:
+						inputs: ["demo_logs_test"]
+						type: "websocket_listener"
+						address: "0.0.0.0:1234"
+						auth:
+							username: "test"
+							password: "test"
+						encoding:
+							codec: "json"
+				```
 
-			With this configuration, a websocket server will listen for connections on 1234 port.
-			For clients to connect, they need to provide credentials in the Authorization header,
-			because `auth` configuration is defined (by default, no auth is required). In this case,
-			it requires Basic auth with defined username and password.
-			"""
+				With this configuration, a websocket server will listen for connections on 1234 port.
+				For clients to connect, they need to provide credentials in the Authorization header,
+				because `auth` configuration is defined (by default, no auth is required). In this case,
+				it requires Basic auth with defined username and password.
+				"""
 		}
 	}
 }


### PR DESCRIPTION
## Summary

I have added a very simple usage example for `websocket_server`, per request in https://github.com/vectordotdev/vector/pull/22213#issuecomment-2669380311.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Related: #22213