### PR TITLE
docs(external): add `how_it_works` section for auth config

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -1290,7 +1290,7 @@ components: {
 					\(kind)s:
 					  \(Name)_\(kind):
 						type: "\(Name)"
-						...
+						# ...
 						auth:
 						  strategy: "custom"
 						  source: |-
@@ -1311,7 +1311,7 @@ components: {
 							  # No errors, so we can return true
 							  true
 							}
-						...
+						# ...
 					```
 					"""
 				}

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -179,6 +179,7 @@ components: {
 		let Args = _args
 
 		auto_generated: bool | *false
+		has_auth:       bool | *false
 
 		if Args.kind == "source" {
 			acknowledgements: bool
@@ -1273,6 +1274,48 @@ components: {
 		}
 
 		how_it_works: {
+			if features.has_auth == true {
+				authorization: {
+					title: "Authorization configuration"
+					body:  """
+					This component has a server component that supports authorization. Authorization
+					supports multiple strategies. [Basic access authentication](\(urls.basic_auth)) is the default, which
+					supports defining a username and password to be used when connecting to the server.
+
+					Custom authorization provides a greater flexibility. It supports writing custom
+					authorization code using VRL. Here is an example that looks up the token in an
+					enrichment table backed by a CSV file.
+
+					```yaml
+					\(kind)s:
+					  \(Name)_\(kind):
+						type: "\(Name)"
+						...
+						auth:
+						  strategy: "custom"
+						  source: |-
+							# We can access request headers here
+							# Let's say that we expect a custom authorization header
+							# In format "Vector {uuid}"
+							parts = split!(.headers.authorization, " ", 2)
+							# We expect Authorization header in format "Vector {uuid}"
+							if parts[0] != "Vector" {
+							  # The header didn't start with Vector, reject
+							  # Returning false means that authentication should fail
+							  false
+							} else {
+							  # Look for uuid in enrichment table (let's say that it has a token column)
+							  # Any errors also reject requests
+							  # We could then do some additional checks on the result from the table
+							  result = get_enrichment_table_record!("auth_data", { "token": parts[1] })
+							  # No errors, so we can return true
+							  true
+							}
+						...
+					```
+					"""
+				}
+			}
 			state: {
 				title: "State"
 

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -16,6 +16,7 @@ components: sinks: websocket_server: {
 	features: {
 		acknowledgements: true
 		auto_generated:   true
+		has_auth:         true
 		healthcheck: enabled: true
 		send: {
 			compression: enabled: false

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -22,6 +22,7 @@ components: sources: heroku_logs: {
 
 	features: {
 		auto_generated:   true
+		has_auth:         true
 		acknowledgements: true
 		multiline: enabled: false
 		codecs: {

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -17,6 +17,7 @@ components: sources: http_server: {
 
 	features: {
 		acknowledgements: true
+		has_auth:         true
 		multiline: enabled: false
 		codecs: {
 			enabled:         true

--- a/website/cue/reference/components/sources/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/prometheus_pushgateway.cue
@@ -14,6 +14,7 @@ components: sources: prometheus_pushgateway: {
 
 	features: {
 		auto_generated:   true
+		has_auth:         true
 		acknowledgements: true
 		multiline: enabled: false
 		receive: {

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -14,6 +14,7 @@ components: sources: prometheus_remote_write: {
 
 	features: {
 		auto_generated:   true
+		has_auth:         true
 		acknowledgements: true
 		multiline: enabled: false
 		receive: {


### PR DESCRIPTION
## Summary

This adds an `Authorization configuration` `How it works` section to every component that uses shared server auth configuration, added in (#22236). It is rendered for every component that has the new feature flag set to true (`features.has_auth`).

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Related: #22236