### PR TITLE
docs(external): update vector tap help

### DIFF
--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -13,7 +13,7 @@ use crate::config::api::default_graphql_url;
 #[derive(Parser, Debug, Clone)]
 #[command(rename_all = "kebab-case")]
 pub struct Opts {
-    /// Interval to sample logs at, in milliseconds
+    /// Interval to sample events at, in milliseconds
     #[arg(default_value = "500", short = 'i', long)]
     interval: u32,
 


### PR DESCRIPTION
`vector tap -h` interval option states `Interval to sample _logs_ at, in milliseconds`, but website documentation states `Interval to sample _events_ at, in milliseconds`. Small change to sync them

(previous vector tap)
```console
> vector tap -h
Observe output log events from source or transform components. Logs are sampled at a specified
interval

Usage: vector tap [OPTIONS] [COMPONENT_ID_PATTERNS]...

Arguments:
  [COMPONENT_ID_PATTERNS]...  Components IDs to observe (comma-separated; accepts glob
                              patterns)

Options:
  -i, --interval <INTERVAL>        Interval to sample logs at, in milliseconds [default: 500]
  -u, --url <URL>                  GraphQL API server endpoint
  -l, --limit <LIMIT>              Maximum number of events to sample each interval [default:
                                   100]
  -f, --format <FORMAT>            Encoding format for events printed to screen [default: json]
                                   [possible values: json, yaml, logfmt]
      --outputs-of <OUTPUTS_OF>    Components (sources, transforms) IDs whose outputs to
                                   observe (comma-separated; accepts glob patterns)
      --inputs-of <INPUTS_OF>      Components (transforms, sinks) IDs whose inputs to observe
                                   (comma-separated; accepts glob patterns)
  -q, --quiet                      Quiet output includes only events
  -m, --meta                       Include metadata such as the event's associated component ID
  -n, --no-reconnect               Whether to reconnect if the underlying API connection drops.
                                   By default, tap will attempt to reconnect if the connection
                                   drops
  -d, --duration-ms <DURATION_MS>  Specifies a duration (in milliseconds) to sample logs (e.g.
                                   specifying 10000 will sample logs for 10 seconds then exit)
  -h, --help                       Print help
```

(now)
```console
> vector tap -h
Observe output log events from source or transform components. Logs are sampled at a specified
interval

Usage: vector tap [OPTIONS] [COMPONENT_ID_PATTERNS]...

Arguments:
  [COMPONENT_ID_PATTERNS]...  Components IDs to observe (comma-separated; accepts glob
                              patterns)

Options:
  -i, --interval <INTERVAL>        Interval to sample logs at, in milliseconds [default: 500]
  -u, --url <URL>                  GraphQL API server endpoint
  -l, --limit <LIMIT>              Maximum number of events to sample each interval [default:
                                   100]
  -f, --format <FORMAT>            Encoding format for events printed to screen [default: json]
                                   [possible values: json, yaml, logfmt]
      --outputs-of <OUTPUTS_OF>    Components (sources, transforms) IDs whose outputs to
                                   observe (comma-separated; accepts glob patterns)
      --inputs-of <INPUTS_OF>      Components (transforms, sinks) IDs whose inputs to observe
                                   (comma-separated; accepts glob patterns)
  -q, --quiet                      Quiet output includes only events
  -m, --meta                       Include metadata such as the event's associated component ID
  -n, --no-reconnect               Whether to reconnect if the underlying API connection drops.
                                   By default, tap will attempt to reconnect if the connection
                                   drops
  -d, --duration-ms <DURATION_MS>  Specifies a duration (in milliseconds) to sample logs (e.g.
                                   specifying 10000 will sample logs for 10 seconds then exit)
  -h, --help                       Print help
```