### PR TITLE
feat(datadog service): Add datadog_log_metadata to events

### DIFF
--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -86,6 +86,10 @@ message OutputId {
   optional string port = 2;
 }
 
+message DatadogLogMetadata {
+  repeated bytes split_array_child_event_id = 1;
+}
+
 message Metadata {
   Value value = 1;
   DatadogOriginMetadata datadog_origin_metadata = 2;
@@ -94,6 +98,7 @@ message Metadata {
   OutputId upstream_id = 5;
   Secrets secrets = 6;
   bytes source_event_id = 7;
+  DatadogLogMetadata datadog_log_metadata = 8;
 }
 
 message Metric {

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -78,6 +78,10 @@ pub(super) struct Inner {
     /// An internal vector id that can be used to identify this event across all components.
     #[derivative(PartialEq = "ignore")]
     pub(crate) source_event_id: Option<Uuid>,
+
+    /// Metadata for every field that might be added by Datadog-specific components.
+    #[serde(default)]
+    pub(crate) datadog_log_metadata: Option<DatadogLogMetadata>,
 }
 
 /// Metric Origin metadata for submission to Datadog.
@@ -119,6 +123,29 @@ impl DatadogMetricOriginMetadata {
     /// Returns a reference to the `OriginService`.
     pub fn service(&self) -> Option<u32> {
         self.origin_service
+    }
+}
+/// Metric Origin metadata for submission to Datadog.
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DatadogLogMetadata {
+    /// Identifier for every child event in the split array processor
+    /// This is a list in case of multiple split array processors
+    split_array_child_event_id: Option<Vec<Uuid>>,
+}
+
+impl DatadogLogMetadata {
+    /// Creates a new `DatadogLogMetadata`.
+    /// Only used for logs
+    #[must_use]
+    pub fn new(split_array_child_event_id: Option<Vec<Uuid>>) -> Self {
+        Self {
+            split_array_child_event_id,
+        }
+    }
+
+    /// Returns a reference to the `OriginProduct`.
+    pub fn split_array_child_event_id(&self) -> Option<Vec<Uuid>> {
+        self.split_array_child_event_id.clone()
     }
 }
 
@@ -239,6 +266,11 @@ impl EventMetadata {
     pub fn source_event_id(&self) -> Option<Uuid> {
         self.0.source_event_id
     }
+
+    /// Returns a reference to the `DatadogLogMetadata`.
+    pub fn datadog_log_metadata(&self) -> Option<&DatadogLogMetadata> {
+        self.0.datadog_log_metadata.as_ref()
+    }
 }
 
 impl Default for Inner {
@@ -254,6 +286,7 @@ impl Default for Inner {
             dropped_fields: ObjectMap::new(),
             datadog_origin_metadata: None,
             source_event_id: Some(Uuid::now_v7()),
+            datadog_log_metadata: None,
         }
     }
 }
@@ -335,6 +368,13 @@ impl EventMetadata {
     #[must_use]
     pub fn with_source_event_id(mut self, source_event_id: Option<Uuid>) -> Self {
         self.get_mut().source_event_id = source_event_id;
+        self
+    }
+
+    /// Replaces the existing `DatadogLogMetadata` with the given one.
+    #[must_use]
+    pub fn with_datadog_log_metadata(mut self, datadog_log_metadata: DatadogLogMetadata) -> Self {
+        self.get_mut().datadog_log_metadata = Some(datadog_log_metadata);
         self
     }
 

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -7,7 +7,7 @@ pub use finalization::{
     Finalizable,
 };
 pub use log_event::LogEvent;
-pub use metadata::{DatadogMetricOriginMetadata, EventMetadata, WithMetadata};
+pub use metadata::{DatadogLogMetadata, DatadogMetricOriginMetadata, EventMetadata, WithMetadata};
 pub use metric::{Metric, MetricKind, MetricTags, MetricValue, StatisticKind};
 pub use r#ref::{EventMutRef, EventRef};
 use serde::{Deserialize, Serialize};

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -600,6 +600,28 @@ impl From<DatadogOriginMetadata> for super::DatadogMetricOriginMetadata {
         )
     }
 }
+impl From<super::DatadogLogMetadata> for DatadogLogMetadata {
+    fn from(value: super::DatadogLogMetadata) -> Self {
+        Self {
+            split_array_child_event_id: value
+                .split_array_child_event_id()
+                .map(|ids| ids.into_iter().map(|id| id.as_bytes().to_vec()).collect())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<DatadogLogMetadata> for super::DatadogLogMetadata {
+    fn from(value: DatadogLogMetadata) -> Self {
+        Self::new(Some(
+            value
+                .split_array_child_event_id
+                .into_iter()
+                .filter_map(|id| Uuid::from_slice(&id).ok())
+                .collect(),
+        ))
+    }
+}
 
 impl From<crate::config::OutputId> for OutputId {
     fn from(value: crate::config::OutputId) -> Self {
@@ -626,6 +648,7 @@ impl From<EventMetadata> for Metadata {
             upstream_id,
             datadog_origin_metadata,
             source_event_id,
+            datadog_log_metadata,
             ..
         } = value.into_owned();
 
@@ -634,6 +657,7 @@ impl From<EventMetadata> for Metadata {
         Self {
             value: Some(encode_value(value)),
             datadog_origin_metadata: datadog_origin_metadata.map(Into::into),
+            datadog_log_metadata: datadog_log_metadata.map(Into::into),
             source_id: source_id.map(|s| s.to_string()),
             source_type: source_type.map(|s| s.to_string()),
             upstream_id: upstream_id.map(|id| id.as_ref().clone()).map(Into::into),
@@ -669,6 +693,10 @@ impl From<Metadata> for EventMetadata {
 
         if let Some(origin_metadata) = value.datadog_origin_metadata {
             metadata = metadata.with_origin_metadata(origin_metadata.into());
+        }
+
+        if let Some(datadog_log_metadata) = value.datadog_log_metadata {
+            metadata = metadata.with_datadog_log_metadata(datadog_log_metadata.into());
         }
 
         let maybe_source_event_id = if value.source_event_id.is_empty() {


### PR DESCRIPTION
## Summary
Adds a new `datadog_log_metadata` field in the event's metadata, so we can put any Datadog-specific field into it.

The first (and for now, only) field inside it is `split_array_child_event_id`, which will be used to keep track of each field

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ ] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
