### PR TITLE
fix(enriching): prevent panic when attaching inputs to sinks with name of a table

### DIFF
--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -698,7 +698,7 @@ impl RunningTopology {
         let added_changed_tables: Vec<&ComponentKey> = diff
             .enrichment_tables
             .changed_and_added()
-            .filter(|k| new_pieces.tasks.contains_key(k))
+            .filter(|k| new_pieces.inputs.contains_key(k))
             .collect();
         for key in added_changed_tables {
             debug!(component = %key, "Connecting inputs for enrichment table sink.");


### PR DESCRIPTION
## Summary

If an enrichment table has the same name as one of components, even when that table is not used as a sink, `topology/running` panics when configuring inputs, because it is not checking the updated `inputs` map, but the `tasks` map when looking up enrichment tables that act as sinks.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Ran vector with the following config:
```yaml
enrichment_tables:
  demo_logs_processor:
    type: file
    file:
      path: /some_file.csv
      encoding:
        type: csv

sources:
  demo_logs_test:
    type: "demo_logs"
    format: "json"

transforms:
  demo_logs_processor:
    type: "remap"
    inputs: ["demo_logs_test"]
    source: |
      . = parse_json!(.message)

sinks:
  console:
    inputs: ["demo_logs_processor"]
    target: "stdout"
    type: "console"
    encoding:
      codec: "json"
```
This config panics on 0.45.0, but it works after this fix.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Closes: #22514
