### PR TITLE
docs(external): add missing Quad9 credits in changelog entries

### DIFF
--- a/changelog.d/22479_websocket_server_sink_buffering.feature.md
+++ b/changelog.d/22479_websocket_server_sink_buffering.feature.md
@@ -1,4 +1,4 @@
 Add message buffering feature to `websocket_server` sink, that enables replaying missed messages to
 newly connected clients.
 
-authors: esensar
+authors: esensar Quad9DNS

--- a/changelog.d/22528_enrichment_panic.fix.md
+++ b/changelog.d/22528_enrichment_panic.fix.md
@@ -1,3 +1,3 @@
 Prevent panic when an enrichment table has the same name as one of components.
 
-authors: esensar
+authors: esensar Quad9DNS


### PR DESCRIPTION
## Summary

This adds missing Quad9 credits in my recently merged PRs, because that work was sponsored by Quad9.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

---
>Sponsored by [Quad9](https://quad9.net/)