### PR TITLE
docs(external): add missing Quad9 credits in previous releases

### DIFF
--- a/website/cue/reference/releases/0.36.0.cue
+++ b/website/cue/reference/releases/0.36.0.cue
@@ -138,7 +138,7 @@ releases: "0.36.0": {
 			description: """
 				Added support for parsing HTTPS (type 65) and SVCB (type 64) resource records from DNS messages
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "fix"

--- a/website/cue/reference/releases/0.37.0.cue
+++ b/website/cue/reference/releases/0.37.0.cue
@@ -76,21 +76,21 @@ releases: "0.37.0": {
 			description: """
 				Added support for TCP mode for DNSTAP source. As the `dnstap` source now supports multiple socket types, you will need to update your configuration to specify which type - either `mode: unix` for the existing unix sockets mode or `mode: tcp` for the new tcp mode.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"
 			description: """
 				Added support for more DNS record types (HINFO, CSYNC, OPT, DNSSEC CDS, DNSSEC CDNSKEY, DNSSEC KEY)
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "feat"
 			description: """
 				Added support for parsing EDNS EDE (Extended DNS errors) options
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"
@@ -112,14 +112,14 @@ releases: "0.37.0": {
 				Added `lowercase_hostnames` option to `dnstap` source, to filter hostnames in DNS records and
 				lowercase them for consistency.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "feat"
 			description: """
 				Added support for `permit_origin` config option for all sources with TCP mode (`fluent`, `logstash`, `statsd`, `syslog`).
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "feat"
@@ -128,7 +128,7 @@ releases: "0.37.0": {
 				City type for unknown types and will instead return an error. New MMDB enrichment table should be
 				used for such types.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "chore"

--- a/website/cue/reference/releases/0.37.1.cue
+++ b/website/cue/reference/releases/0.37.1.cue
@@ -20,7 +20,7 @@ releases: "0.37.1": {
 			description: """
 				Fixed an issue where `GeoLite2-City` MMDB database type was not supported.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 	]
 

--- a/website/cue/reference/releases/0.38.0.cue
+++ b/website/cue/reference/releases/0.38.0.cue
@@ -46,7 +46,7 @@ releases: "0.38.0": {
 			description: """
 				Support was added for additional config options for `length_delimited` framing.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"

--- a/website/cue/reference/releases/0.41.0.cue
+++ b/website/cue/reference/releases/0.41.0.cue
@@ -94,7 +94,7 @@ releases: "0.41.0": {
 			description: """
 				A new `static_metrics` source was added. This source periodically emits preconfigured values.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "fix"

--- a/website/cue/reference/releases/0.42.0.cue
+++ b/website/cue/reference/releases/0.42.0.cue
@@ -42,7 +42,7 @@ releases: "0.42.0": {
 			description: """
 				Adds more aggregations to `aggregate` transform: count, diff, max, min, mean, sum, latest and stdev. The current aggregation is named `auto` and is made the default (acts like a combination of `sum` and `latest`).
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"
@@ -63,7 +63,7 @@ releases: "0.42.0": {
 			description: """
 				Adds support for additional `graph` configuration on each component so that users can add arbitrary graphviz node attributes when generating a graph through `vector graph`.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"

--- a/website/cue/reference/releases/0.43.0.cue
+++ b/website/cue/reference/releases/0.43.0.cue
@@ -174,7 +174,7 @@ releases: "0.43.0": {
 			description: """
 				The `dnstap` source now supports decoding of EDE code 30 (Invalid Query Type) (added in [Compact Denial of Existence in DNSSEC](https://datatracker.ietf.org/doc/draft-ietf-dnsop-compact-denial-of-existence/04/)) and has the correct `purpose` attached to it.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"

--- a/website/cue/reference/releases/0.44.0.cue
+++ b/website/cue/reference/releases/0.44.0.cue
@@ -97,7 +97,7 @@ releases: "0.44.0": {
 			description: """
 				Add VRL function `parse_dnstap` that can parse dnstap data and produce output in the same format as `dnstap` source.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "enhancement"

--- a/website/cue/reference/releases/0.45.0.cue
+++ b/website/cue/reference/releases/0.45.0.cue
@@ -81,7 +81,7 @@ releases: "0.45.0": {
 				Add a new type of `enrichment_table` - `memory`, which can also act as a sink, ingesting all the
 				data and storing it per key, enabling it to be read from all other enrichment tables.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type:        "feat"
@@ -120,14 +120,14 @@ releases: "0.45.0": {
 			description: """
 				The `tag_cardinality_limit` transform now supports customizing limits for specific metrics, matched by metric name and optionally, its namespace.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "feat"
 			description: """
 				Add `websocket_server` sink that acts as a websocket server and broadcasts events to all clients.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "feat"
@@ -137,7 +137,7 @@ releases: "0.45.0": {
 
 				You can read more in this [how it works](/docs/reference/configuration/sources/http_server/#authorization-configuration) section.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "fix"
@@ -151,7 +151,7 @@ releases: "0.45.0": {
 			description: """
 				The `dnstap` source now uses [v20250201](https://github.com/dnstap/dnstap.pb/releases/tag/v20250201) dnstap protobuf schema.
 				"""
-			contributors: ["esensar"]
+			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "fix"


### PR DESCRIPTION
## Summary

This adds missing Quad9 credits in my PRs from previous releases, because that work was sponsored by Quad9.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

---
>Sponsored by [Quad9](https://quad9.net/)