### PR TITLE
chore(releasing): automate more pre-release steps

### DIFF
--- a/scripts/generate-release-cue.rb
+++ b/scripts/generate-release-cue.rb
@@ -14,6 +14,7 @@
 
 require "json"
 require "time"
+require "optparse"
 require_relative "util/commit"
 require_relative "util/git_log_commit"
 require_relative "util/printer"
@@ -30,6 +31,23 @@ CHANGELOG_DIR = File.join(ROOT, "changelog.d")
 TYPES = ["chore", "docs", "feat", "fix", "enhancement", "perf"]
 TYPES_THAT_REQUIRE_SCOPES = ["feat", "enhancement", "fix"]
 
+# Parse command-line options
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
+
+  opts.on("--new-version VERSION", "Specify the new version (e.g., 1.2.3)") do |v|
+    options[:new_version] = v
+  end
+  opts.on("--[no-]interactive", "Enable/disable interactive prompts (default: true)") do |i|
+    options[:interactive] = i
+  end
+  opts.on_tail("-h", "--help", "Show this help message") do
+    puts opts
+    exit
+  end
+end.parse!
+
 #
 # Functions
 #
@@ -43,66 +61,60 @@ TYPES_THAT_REQUIRE_SCOPES = ["feat", "enhancement", "fix"]
 # This file is created from outstanding commits since the last release.
 # It's meant to be a starting point. The resulting file should be reviewed
 # and edited by a human before being turned into a cue file.
-def create_log_file!(current_commits, new_version)
+def create_log_file!(current_commits, new_version, interactive)
   release_log_path = "#{RELEASE_REFERENCE_DIR}/#{new_version}.log"
 
   # Grab all existing commits
   existing_commits = get_existing_commits!
 
-  # Ensure this release does not include duplicate commits. Notice that we
-  # check the parsed PR numbers. This is necessary to ensure we do not include
-  # cherry-picked commits made available in other releases.
-  #
-  # For example, if we cherry pick a commit from `master` to the `0.8` branch
-  # it will have a different commit sha. Without checking something besides the
-  # sha, this commit would also show up in the next release.
-  new_commits =
-    current_commits.select do |current_commit|
-      !existing_commits.any? do |existing_commit|
-        existing_commit.eql?(current_commit)
-      end
-    end
+  # Filter out duplicate commits
+  new_commits = current_commits.select do |current_commit|
+    !existing_commits.any? { |existing_commit| existing_commit.eql?(current_commit) }
+  end
 
   new_commit_lines = new_commits.collect { |c| c.to_git_log_commit.to_raw }.join("\n")
 
   if new_commits.any?
     if File.exists?(release_log_path)
-      words =
-        <<~EOF
-        I found #{new_commits.length} new commits since you last ran this
-        command. So that I don't erase any other work in that file, please
-        manually add the following commit lines:
+      if interactive
+        words = <<~EOF
+          I found #{new_commits.length} new commits since you last ran this
+          command. So that I don't erase any other work in that file, please
+          manually add the following commit lines:
 
-            #{new_commit_lines.split("\n").collect { |line| "    #{line}" }.join("\n")}
+              #{new_commit_lines.split("\n").collect { |line| "    #{line}" }.join("\n")}
 
-        To:
+          To:
 
-            #{release_log_path}
+              #{release_log_path}
 
-        All done? Ready to proceed?
+          All done? Ready to proceed?
         EOF
 
-      if Util::Printer.get(words, ["y", "n"]) == "n"
-        Util::Printer.error!("Ok, re-run this command when you're ready.")
+        if Util::Printer.get(words, ["y", "n"]) == "n"
+          Util::Printer.error!("Ok, re-run this command when you're ready.")
+        end
       end
     else
       File.open(release_log_path, 'w+') do |file|
         file.write(new_commit_lines)
       end
 
-      words =
-        <<~EOF
-        I've created a release log file here:
+      puts interactive
+      if interactive
+        words = <<~EOF
+          I've created a release log file here:
 
-            #{release_log_path}
+              #{release_log_path}
 
-        Please review the commits and *adjust the commit messages as necessary*.
+          Please review the commits and *adjust the commit messages as necessary*.
 
-        All done? Ready to proceed?
+          All done? Ready to proceed?
         EOF
 
-      if Util::Printer.get(words, ["y", "n"]) == "n"
-        Util::Printer.error!("Ok, re-run this command when you're ready.")
+        if Util::Printer.get(words, ["y", "n"]) == "n"
+          Util::Printer.error!("Ok, re-run this command when you're ready.")
+        end
       end
     end
   end
@@ -391,16 +403,32 @@ end
 #
 # Execute
 #
-
-Dir.chdir "scripts"
+script_dir = File.expand_path(File.dirname(__FILE__))
+Dir.chdir script_dir
 
 Util::Printer.title("Creating release meta file...")
 
 last_tag = `git describe --tags $(git rev-list --tags --max-count=1)`.chomp
 last_version = Util::Version.new(last_tag.gsub(/^v/, ''))
 current_commits = get_commits_since(last_version)
-new_version = get_new_version(last_version, current_commits)
-log_file_path = create_log_file!(current_commits, new_version)
+
+new_version_string = options[:new_version]
+if new_version_string
+  begin
+    new_version = Util::Version.new(new_version_string)
+    if last_version.bump_type(new_version).nil?
+      Util::Printer.error!("The specified version '#{new_version_string}' must be a single patch, minor, or major bump from #{last_version}")
+      exit 1
+    end
+  rescue ArgumentError => e
+    Util::Printer.error!("Invalid version specified: #{e.message}")
+    exit 1
+  end
+else
+  new_version = get_new_version(last_version, current_commits)
+end
+
+log_file_path = create_log_file!(current_commits, new_version, options[":interactive"])
 create_release_file!(new_version)
 File.delete(log_file_path)
 

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -1,11 +1,17 @@
+#![allow(warnings)]
 use crate::git;
 use crate::util::run_command;
 use anyhow::Result;
 use semver::Version;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use toml::map::Map;
 use toml::Value;
+
+const ALPINE_PREFIX: &str = "FROM docker.io/alpine:";
+const ALPINE_DOCKERFILE: &str = "distribution/docker/alpine/Dockerfile";
+const DEBIAN_PREFIX: &str = "FROM docker.io/debian:";
+const DEBIAN_DOCKERFILE: &str = "distribution/docker/debian/Dockerfile";
 
 /// Release preparations CLI options.
 #[derive(clap::Args, Debug)]
@@ -17,17 +23,41 @@ pub struct Cli {
     /// The new VRL version.
     #[arg(long)]
     vrl_version: Version,
+    /// Optional: The Alpine version to use in `distribution/docker/alpine/Dockerfile`.
+    /// You can find the latest version here: https://alpinelinux.org/releases/.
+    #[arg(long)]
+    alpine_version: Option<String>,
+    /// Optional: The Debian version to use in `distribution/docker/debian/Dockerfile`.
+    /// You can find the latest version here: https://www.debian.org/releases/.
+    #[arg(long)]
+    debian_version: Option<String>,
 }
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        create_release_branches(&self.version)?;
-        pin_vrl_version(&self.vrl_version)?;
+        // create_release_branches(&self.version)?;
+        // pin_vrl_version(&self.vrl_version)?;
+
+        update_dockerfile_base_version(
+            &get_repo_root().join(ALPINE_DOCKERFILE),
+            self.alpine_version.as_deref(),
+            ALPINE_PREFIX,
+        )?;
+
+        update_dockerfile_base_version(
+            &get_repo_root().join(DEBIAN_DOCKERFILE),
+            self.debian_version.as_deref(),
+            DEBIAN_PREFIX,
+        )?;
 
         // TODO automate more steps such as 'cargo vdev build release-cue'
         println!("Continue the release preparation process manually.");
         Ok(())
     }
+}
+
+fn get_repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().to_path_buf()
 }
 
 /// Steps 1 & 2
@@ -49,7 +79,7 @@ fn create_release_branches(new_version: &Version) -> Result<()> {
 
 /// Step 3
 fn pin_vrl_version(new_version: &Version) -> Result<()> {
-    let cargo_toml_path = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().join("Cargo.toml");
+    let cargo_toml_path = get_repo_root().join("Cargo.toml");
     let contents = fs::read_to_string(&cargo_toml_path).expect("Failed to read Cargo.toml");
 
     // Needs this hybrid approach to preserve ordering.
@@ -74,5 +104,48 @@ fn pin_vrl_version(new_version: &Version) -> Result<()> {
     fs::write(&cargo_toml_path, lines.join("\n")).expect("Failed to write Cargo.toml");
     run_command("cargo update -p vrl");
     git::commit(&format!("chore(releasing): Pinned VRL version to {new_version}"))?;
+    Ok(())
+}
+
+/// Step 4 & 5
+fn update_dockerfile_base_version(
+    dockerfile_path: &Path,
+    new_version: Option<&str>,
+    prefix: &str,
+) -> Result<()> {
+    if let Some(version) = new_version {
+        let contents = fs::read_to_string(dockerfile_path)?;
+
+        if !contents.starts_with(prefix) {
+            return Err(anyhow::anyhow!(
+                "Dockerfile at {} does not start with {prefix}",
+                dockerfile_path.display()
+            ));
+        }
+
+        let mut lines = contents.lines();
+        let first_line = lines.next().expect("File should have at least one line");
+        let rest = lines.collect::<Vec<&str>>().join("\n");
+
+        // Split into prefix, version, and suffix
+        // E.g. "FROM docker.io/alpine:", "3.21", " AS builder"
+        let after_prefix = first_line
+            .strip_prefix(prefix)
+            .ok_or_else(|| anyhow::anyhow!("Failed to strip prefix in {}", dockerfile_path.display()))?;
+        let parts: Vec<&str> = after_prefix.splitn(2, ' ').collect();
+        let suffix = parts.get(1).unwrap_or(&"");
+
+        // Rebuild with new version
+        let updated_version_line = format!("{prefix}{version} {suffix}");
+        let new_contents = format!("{updated_version_line}\n{rest}");
+
+        fs::write(dockerfile_path, &new_contents)?;
+        git::commit(&format!(
+            "chore(releasing): Bump {} version to {version}", dockerfile_path.strip_prefix(get_repo_root()).unwrap().display(),
+        ))?;
+    } else {
+        println!(
+            "No version specified for {dockerfile_path:?}; skipping update");
+    }
     Ok(())
 }

--- a/vdev/src/util.rs
+++ b/vdev/src/util.rs
@@ -86,7 +86,7 @@ impl<T: AsRef<OsStr>> ChainArgs for [T] {
     }
 }
 
-pub fn run_command(cmd: &str) {
+pub fn run_command(cmd: &str) -> String {
     let output = Command::new("sh")
         .arg("-c")
         .arg(cmd)
@@ -100,4 +100,6 @@ pub fn run_command(cmd: &str) {
         );
         process::exit(1);
     }
+
+    String::from_utf8_lossy(&output.stdout).to_string()
 }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR automates three additional release step:
* dockerfile version bumps
* generate release cue file
  * Required enhancements to the `generate-release-cue.rb` script
* kubectl.cue version bump

The next PR will automate the last four steps.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ ] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
