### PR TITLE
fix(gcp service): Prevent overflow for gcp token expiry calculation

### DIFF
--- a/changelog.d/20231-gcs-token-refresh.fix.md
+++ b/changelog.d/20231-gcs-token-refresh.fix.md
@@ -1,0 +1,3 @@
+Fix for overflow when calculating next refresh interval for gcs tokens.
+
+authors: graphcareful


### PR DESCRIPTION
## Summary
The simple calculation for the next deadline to sleep the gcp refresh token thread performs a subtraction which is unchecked.

The value of `expires_in` may be less then the constant `METADATA_TOKEN_EXPIRY_MARGIN_SECS`, causing the deadline to overflow and making the thread sleep for a long duration. Upon the next time the sink pushes to GCS the token would have already expired since the refresh thread hadn't awaken on time.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
No tests as of yet have been added.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

closes: https://github.com/vectordotdev/vector/issues/20231
