### PR TITLE
fix(aws_s3 sink): Respect endpoint_url field in AWS_CONFIG_FILE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11265,6 +11265,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-runtime",
  "aws-sdk-cloudwatch",
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-elasticsearch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,30 +1032,34 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.4.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcafc2fe52cc30b2d56685e2fa6a879ba50d79704594852112337a472ddbd24"
+checksum = "3038614b6cf7dd68d9a7b5b39563d04337eb3678d1d4173e356e927b0356158a"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json 0.60.7",
+ "aws-smithy-http 0.61.1",
+ "aws-smithy-json 0.61.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes 1.10.1",
+ "fastrand 2.3.0",
+ "hex",
+ "hmac",
  "http 0.2.9",
  "http-body 0.4.5",
+ "lru 0.12.5",
  "once_cell",
  "percent-encoding",
- "regex",
+ "regex-lite",
+ "sha2",
  "tracing 0.1.41",
  "url",
 ]
@@ -1232,15 +1236,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a373ec01aede3dd066ec018c1bc4e8f5dd11b2c11c59c8eef1a5c68101f397"
+checksum = "db2dc8d842d872529355c72632de49ef8c5a2949a4472f10e802f28cf925770c"
 dependencies = [
  "aws-smithy-http 0.60.12",
  "aws-smithy-types",
  "bytes 1.10.1",
  "crc32c",
  "crc32fast",
+ "crc64fast-nvme",
  "hex",
  "http 0.2.9",
  "http-body 0.4.5",
@@ -1268,7 +1273,6 @@ version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes 1.10.1",
@@ -2580,9 +2584,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
-version = "0.6.4"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version 0.4.1",
 ]
@@ -2594,6 +2598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crc64fast-nvme"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
+dependencies = [
+ "crc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,11 +814,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.5.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+checksum = "80c950a809d39bc9480207cb1cfc879ace88ea7e3a4392a8e9999e45d6e5692e"
 dependencies = [
  "aws-credential-types",
+ "aws-http",
  "aws-runtime",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
@@ -834,11 +835,11 @@ dependencies = [
  "fastrand 2.3.0",
  "hex",
  "http 0.2.9",
+ "hyper 0.14.28",
  "ring",
  "time",
  "tokio",
  "tracing 0.1.41",
- "url",
  "zeroize",
 ]
 
@@ -872,40 +873,22 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-<<<<<<< HEAD
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce0953f7fc1c4428511345e28ea3e98c8b59c9e91eafae30bf76d71d70642693"
-=======
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
->>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
+ "aws-http",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
-<<<<<<< HEAD
  "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "fastrand 2.3.0",
-=======
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes 1.9.0",
- "fastrand 2.1.1",
->>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
  "http 0.2.9",
- "http-body 0.4.5",
- "once_cell",
  "percent-encoding",
- "pin-project-lite",
  "tracing 0.1.41",
  "uuid",
 ]
@@ -1144,17 +1127,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86575c7604dcdb583aba3390200e5333d8e4fe597bad54f57b190aaf4fac9771"
-=======
-version = "1.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
->>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
+ "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
@@ -1165,24 +1143,18 @@ dependencies = [
  "aws-types",
  "bytes 1.10.1",
  "http 0.2.9",
- "once_cell",
- "regex-lite",
+ "regex",
  "tracing 0.1.41",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef0d7c1d0730adb5e85407174483a579e39576e0f4350ecd0fac69ec1217b1b"
-=======
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
->>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
+ "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
@@ -1193,24 +1165,18 @@ dependencies = [
  "aws-types",
  "bytes 1.10.1",
  "http 0.2.9",
- "once_cell",
- "regex-lite",
+ "regex",
  "tracing 0.1.41",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f45778089751d5aa8645a02dd60865fa0eea39f00be5db2c7779bc50b83db19a"
-=======
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
->>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
+ "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
@@ -1222,8 +1188,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "http 0.2.9",
- "once_cell",
- "regex-lite",
+ "regex",
  "tracing 0.1.41",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,19 +814,18 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.0.1"
+version = "1.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c950a809d39bc9480207cb1cfc879ace88ea7e3a4392a8e9999e45d6e5692e"
+checksum = "90aff65e86db5fe300752551c1b015ef72b708ac54bded8ef43d0d53cb7cb0b1"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-http 0.61.1",
+ "aws-smithy-json 0.61.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -835,11 +834,11 @@ dependencies = [
  "fastrand 2.3.0",
  "hex",
  "http 0.2.9",
- "hyper 0.14.28",
  "ring",
  "time",
  "tokio",
  "tracing 0.1.41",
+ "url",
  "zeroize",
 ]
 
@@ -873,22 +872,26 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.0.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0953f7fc1c4428511345e28ea3e98c8b59c9e91eafae30bf76d71d70642693"
+checksum = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.60.12",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "bytes 1.10.1",
  "fastrand 2.3.0",
  "http 0.2.9",
+ "http-body 0.4.5",
+ "once_cell",
  "percent-encoding",
+ "pin-project-lite",
  "tracing 0.1.41",
  "uuid",
 ]
@@ -904,7 +907,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -927,7 +930,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -950,7 +953,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -972,7 +975,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -994,7 +997,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1016,7 +1019,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1041,7 +1044,7 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1068,7 +1071,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1091,7 +1094,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1114,7 +1117,7 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1127,60 +1130,59 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.6.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86575c7604dcdb583aba3390200e5333d8e4fe597bad54f57b190aaf4fac9771"
+checksum = "e65ff295979977039a25f5a0bf067a64bc5e6aa38f3cef4037cf42516265553c"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-http 0.61.1",
+ "aws-smithy-json 0.61.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes 1.10.1",
  "http 0.2.9",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing 0.1.41",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.6.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef0d7c1d0730adb5e85407174483a579e39576e0f4350ecd0fac69ec1217b1b"
+checksum = "91430a60f754f235688387b75ee798ef00cfd09709a582be2b7525ebb5306d4f"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-http 0.61.1",
+ "aws-smithy-json 0.61.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes 1.10.1",
  "http 0.2.9",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing 0.1.41",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.6.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45778089751d5aa8645a02dd60865fa0eea39f00be5db2c7779bc50b83db19a"
+checksum = "9276e139d39fff5a0b0c984fc2d30f970f9a202da67234f948fda02e5bea1dbe"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.60.12",
- "aws-smithy-json",
+ "aws-smithy-http 0.61.1",
+ "aws-smithy-json 0.61.2",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1188,7 +1190,8 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "http 0.2.9",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing 0.1.41",
 ]
 
@@ -1306,6 +1309,15 @@ name = "aws-smithy-json"
 version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
 dependencies = [
  "aws-smithy-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,12 +814,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.0.1"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c950a809d39bc9480207cb1cfc879ace88ea7e3a4392a8e9999e45d6e5692e"
+checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
@@ -835,11 +834,11 @@ dependencies = [
  "fastrand 2.3.0",
  "hex",
  "http 0.2.9",
- "hyper 0.14.28",
  "ring",
  "time",
  "tokio",
  "tracing 0.1.41",
+ "url",
  "zeroize",
 ]
 
@@ -873,22 +872,40 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
+<<<<<<< HEAD
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce0953f7fc1c4428511345e28ea3e98c8b59c9e91eafae30bf76d71d70642693"
+=======
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+>>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
+<<<<<<< HEAD
  "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "fastrand 2.3.0",
+=======
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.9.0",
+ "fastrand 2.1.1",
+>>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
  "http 0.2.9",
+ "http-body 0.4.5",
+ "once_cell",
  "percent-encoding",
+ "pin-project-lite",
  "tracing 0.1.41",
  "uuid",
 ]
@@ -1127,12 +1144,17 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
+<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86575c7604dcdb583aba3390200e5333d8e4fe597bad54f57b190aaf4fac9771"
+=======
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+>>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
@@ -1143,18 +1165,24 @@ dependencies = [
  "aws-types",
  "bytes 1.10.1",
  "http 0.2.9",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing 0.1.41",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
+<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef0d7c1d0730adb5e85407174483a579e39576e0f4350ecd0fac69ec1217b1b"
+=======
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+>>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
@@ -1165,18 +1193,24 @@ dependencies = [
  "aws-types",
  "bytes 1.10.1",
  "http 0.2.9",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing 0.1.41",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
+<<<<<<< HEAD
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f45778089751d5aa8645a02dd60865fa0eea39f00be5db2c7779bc50b83db19a"
+=======
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
+>>>>>>> 0d322fb49 (Add some debug logging and try clearing region if we're manually setting endpoint url from config)
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.60.12",
@@ -1188,7 +1222,8 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "http 0.2.9",
- "regex",
+ "once_cell",
+ "regex-lite",
  "tracing 0.1.41",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ metrics.workspace = true
 metrics-tracing-context.workspace = true
 
 # AWS - Official SDK
-aws-sdk-s3 = { version = "1.4.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-s3 = { version = "1.15.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-sqs = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-sns = { version = "1.6.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-cloudwatch = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,7 +234,7 @@ aws-sdk-secretsmanager = { version = "1.6.0", default-features = false, features
 # `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication
 # is configured.
 aws-sdk-sts = { version = "1.3.1", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
-aws-types = { version = "1.3.3", default-features = false, optional = true }
+aws-types = { version = "1.3.5", default-features = false, optional = true }
 aws-sigv4 = { version = "1.2.9", default-features = false, features = ["sign-http"], optional = true }
 aws-config = { version = "1.1.9", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso", "rt-tokio"], optional = true }
 aws-credential-types = { version = "1.2.1", default-features = false, features = ["hardcoded-credentials"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,12 +230,11 @@ aws-sdk-elasticsearch = { version = "1.3.0", default-features = false, features 
 aws-sdk-firehose = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-kinesis = { version = "1.3.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sdk-secretsmanager = { version = "1.6.0", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
-# The sts crate is needed despite not being referred to anywhere in the code because we need to set the
-# `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication
-# is configured.
 aws-config = { version = "1.1.9", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso", "rt-tokio"], optional = true }
 aws-credential-types = { version = "1.2.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
 aws-runtime = { version = "1.4.3", optional = true }
+# The `aws-sdk-sts` crate is needed despite not being referred to anywhere in the code because we need to set the
+# `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication is configured.
 aws-sdk-sts = { version = "1.3.1", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
 aws-sigv4 = { version = "1.2.9", default-features = false, features = ["sign-http"], optional = true }
 aws-smithy-async = { version = "1.2.5", default-features = false, features = ["rt-tokio"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ aws-types = { version = "1.3.5", default-features = false, optional = true }
 aws-sigv4 = { version = "1.2.9", default-features = false, features = ["sign-http"], optional = true }
 aws-config = { version = "1.1.9", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso", "rt-tokio"], optional = true }
 aws-credential-types = { version = "1.2.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
+aws-runtime = { version = "1.4.3", optional = true }
 aws-smithy-http = { version = "0.61", default-features = false, features = ["event-stream", "rt-tokio"], optional = true }
 aws-smithy-types = { version = "1.2.11", default-features = false, features = ["rt-tokio"], optional = true }
 aws-smithy-runtime-api = { version = "1.7.3", default-features = false, optional = true }
@@ -518,6 +519,7 @@ api-client = [
 aws-core = [
   "aws-config",
   "dep:aws-credential-types",
+  "aws-runtime",
   "dep:aws-sigv4",
   "dep:aws-types",
   "dep:aws-smithy-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,9 +234,9 @@ aws-sdk-secretsmanager = { version = "1.6.0", default-features = false, features
 # `behavior-version-latest` feature. Without this we get a runtime panic when `auth.assume_role` authentication
 # is configured.
 aws-sdk-sts = { version = "1.3.1", default-features = false, features = ["behavior-version-latest", "rt-tokio"], optional = true }
-aws-types = { version = "1.3.5", default-features = false, optional = true }
+aws-types = { version = "1.3.3", default-features = false, optional = true }
 aws-sigv4 = { version = "1.2.9", default-features = false, features = ["sign-http"], optional = true }
-aws-config = { version = "~1.0.1", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso", "rt-tokio"], optional = true }
+aws-config = { version = "1.1.9", default-features = false, features = ["behavior-version-latest", "credentials-process", "sso", "rt-tokio"], optional = true }
 aws-credential-types = { version = "1.2.1", default-features = false, features = ["hardcoded-credentials"], optional = true }
 aws-smithy-http = { version = "0.61", default-features = false, features = ["event-stream", "rt-tokio"], optional = true }
 aws-smithy-types = { version = "1.2.11", default-features = false, features = ["rt-tokio"], optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -155,6 +155,7 @@ crc,https://github.com/mrhooray/crc-rs,MIT OR Apache-2.0,"Rui Hu <code@mrhooray.
 crc-catalog,https://github.com/akhilles/crc-catalog,MIT OR Apache-2.0,Akhil Velagapudi <akhilvelagapudi@gmail.com>
 crc32c,https://github.com/zowens/crc32c,Apache-2.0 OR MIT,Zack Owens
 crc32fast,https://github.com/srijs/rust-crc32fast,MIT OR Apache-2.0,"Sam Rijs <srijs@airpost.net>, Alex Crichton <alex@alexcrichton.com>"
+crc64fast-nvme,https://github.com/awesomized/crc64fast-nvme,MIT OR Apache-2.0,"The TiKV Project Developers, Don MacAskill"
 crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
 crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
 crossbeam-epoch,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-epoch Authors

--- a/changelog.d/22686_s3_sink_endpoint_url_from_aws_config_file.fix.md
+++ b/changelog.d/22686_s3_sink_endpoint_url_from_aws_config_file.fix.md
@@ -1,0 +1,3 @@
+Fixed a bug in the `aws_s3` sink, where the `endpoint_url` field in AWS_CONFIG_FILE was not respected by Vector.
+
+authors: ganelo

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -1,19 +1,16 @@
 //! Authentication settings for AWS components.
 use std::time::Duration;
 
-#[allow(deprecated)]
 use aws_config::{
     default_provider::credentials::DefaultCredentialsChain,
     identity::IdentityCache,
     imds,
-    profile::{
-        profile_file::{ProfileFileKind, ProfileFiles},
-        ProfileFileCredentialsProvider,
-    },
+    profile::ProfileFileCredentialsProvider,
     provider_config::ProviderConfig,
     sts::AssumeRoleProviderBuilder,
 };
 use aws_credential_types::{provider::SharedCredentialsProvider, Credentials};
+use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
 use aws_smithy_async::time::SystemTimeSource;
 use aws_smithy_runtime_api::client::identity::SharedIdentityCache;
 use aws_types::{region::Region, SdkConfig};
@@ -303,9 +300,8 @@ impl AwsAuthentication {
 
                 // The SDK uses the default profile out of the box, but doesn't provide an optional
                 // type in the builder. We can just hardcode it so that everything works.
-                #[allow(deprecated)]
-                let profile_files = ProfileFiles::builder()
-                    .with_file(ProfileFileKind::Credentials, credentials_file)
+                let profile_files = EnvConfigFiles::builder()
+                    .with_file(EnvConfigFileKind::Credentials, credentials_file)
                     .build();
 
                 let provider_config = ProviderConfig::empty().with_http_client(connector);

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -2,11 +2,8 @@
 use std::time::Duration;
 
 use aws_config::{
-    default_provider::credentials::DefaultCredentialsChain,
-    identity::IdentityCache,
-    imds,
-    profile::ProfileFileCredentialsProvider,
-    provider_config::ProviderConfig,
+    default_provider::credentials::DefaultCredentialsChain, identity::IdentityCache, imds,
+    profile::ProfileFileCredentialsProvider, provider_config::ProviderConfig,
     sts::AssumeRoleProviderBuilder,
 };
 use aws_credential_types::{provider::SharedCredentialsProvider, Credentials};

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -1,6 +1,7 @@
 //! Authentication settings for AWS components.
 use std::time::Duration;
 
+#[allow(deprecated)]
 use aws_config::{
     default_provider::credentials::DefaultCredentialsChain,
     identity::IdentityCache,
@@ -302,6 +303,7 @@ impl AwsAuthentication {
 
                 // The SDK uses the default profile out of the box, but doesn't provide an optional
                 // type in the builder. We can just hardcode it so that everything works.
+                #[allow(deprecated)]
                 let profile_files = ProfileFiles::builder()
                     .with_file(ProfileFileKind::Credentials, credentials_file)
                     .build();

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -55,7 +55,10 @@ static RETRIABLE_CODES: OnceLock<RegexSet> = OnceLock::new();
 /// Checks if the request can be retried after the given error was returned.
 pub fn is_retriable_error<T>(error: &SdkError<T, HttpResponse>) -> bool {
     match error {
-        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => true,
+        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => {
+            info!(message = "Got timeout or dispatch error", error = format!("{error:?}"));
+            true
+        },
         SdkError::ConstructionFailure(_) => false,
         SdkError::ResponseError(err) => check_response(err.raw()),
         SdkError::ServiceError(err) => check_response(err.raw()),

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -196,6 +196,7 @@ where
     // The default credentials chains will look for a region if not given but we'd like to
     // error up front if later SDK calls will fail due to lack of region configuration
     let region = resolve_region(proxy, tls_options, region).await?;
+    debug!("Got region", ?region);
 
     let provider_config =
         aws_config::provider_config::ProviderConfig::empty().with_region(Some(region.clone()));
@@ -225,7 +226,10 @@ where
     } else if let Some(endpoint_from_config) =
       aws_config::default_provider::endpoint_url::endpoint_url_provider(&provider_config).await
     {
-      config_builder = config_builder.endpoint_url(endpoint_from_config);
+        debug!("Got endpoint from config", ?endpoint_from_config);
+      config_builder = config_builder.endpoint_url(endpoint_from_config).region(None);
+    } else {
+        debug!("Did not get endpoint from config", ?provider_config);
     }
 
     if let Some(use_fips) =

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -196,7 +196,7 @@ where
     // The default credentials chains will look for a region if not given but we'd like to
     // error up front if later SDK calls will fail due to lack of region configuration
     let region = resolve_region(proxy, tls_options, region).await?;
-    debug!("Got region", ?region);
+    debug!(message= "Got region", region = format!("{region:?}"));
 
     let provider_config =
         aws_config::provider_config::ProviderConfig::empty().with_region(Some(region.clone()));
@@ -226,10 +226,10 @@ where
     } else if let Some(endpoint_from_config) =
       aws_config::default_provider::endpoint_url::endpoint_url_provider(&provider_config).await
     {
-        debug!("Got endpoint from config", ?endpoint_from_config);
+        debug!(message = "Got endpoint from config", endpoint_from_config);
       config_builder = config_builder.endpoint_url(endpoint_from_config).region(None);
     } else {
-        debug!("Did not get endpoint from config", ?provider_config);
+        debug!(message = "Did not get endpoint from config", provider_config = format!("{provider_config:?}"));
     }
 
     if let Some(use_fips) =

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -196,7 +196,7 @@ where
     // The default credentials chains will look for a region if not given but we'd like to
     // error up front if later SDK calls will fail due to lack of region configuration
     let region = resolve_region(proxy, tls_options, region).await?;
-    debug!(message= "Got region", region = format!("{region:?}"));
+    debug!(message = "Got region", region = format!("{region:?}"));
 
     let provider_config =
         aws_config::provider_config::ProviderConfig::empty().with_region(Some(region.clone()));
@@ -224,12 +224,17 @@ where
     if let Some(endpoint_override) = endpoint {
         config_builder = config_builder.endpoint_url(endpoint_override);
     } else if let Some(endpoint_from_config) =
-      aws_config::default_provider::endpoint_url::endpoint_url_provider(&provider_config).await
+        aws_config::default_provider::endpoint_url::endpoint_url_provider(&provider_config).await
     {
         debug!(message = "Got endpoint from config", endpoint_from_config);
-      config_builder = config_builder.endpoint_url(endpoint_from_config).region(None);
+        config_builder = config_builder
+            .endpoint_url(endpoint_from_config)
+            .region(None);
     } else {
-        debug!(message = "Did not get endpoint from config", provider_config = format!("{provider_config:?}"));
+        debug!(
+            message = "Did not get endpoint from config",
+            provider_config = format!("{provider_config:?}")
+        );
     }
 
     if let Some(use_fips) =

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -55,8 +55,9 @@ static RETRIABLE_CODES: OnceLock<RegexSet> = OnceLock::new();
 /// Checks if the request can be retried after the given error was returned.
 pub fn is_retriable_error<T>(error: &SdkError<T, HttpResponse>) -> bool {
     match error {
-        SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => {
-            info!(message = "Got timeout or dispatch error", error = format!("{error:?}"));
+        SdkError::TimeoutError(_) => true,
+        SdkError::DispatchFailure(err) => {
+            info!(message = "Got timeout or dispatch error", error = format!("{err:?}"));
             true
         },
         SdkError::ConstructionFailure(_) => false,

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -196,7 +196,7 @@ where
     // The default credentials chains will look for a region if not given but we'd like to
     // error up front if later SDK calls will fail due to lack of region configuration
     let region = resolve_region(proxy, tls_options, region).await?;
-    debug!(message = "Got region", region = format!("{region:?}"));
+    info!(message = "Got region", region = format!("{region:?}"));
 
     let provider_config =
         aws_config::provider_config::ProviderConfig::empty().with_region(Some(region.clone()));
@@ -226,12 +226,12 @@ where
     } else if let Some(endpoint_from_config) =
         aws_config::default_provider::endpoint_url::endpoint_url_provider(&provider_config).await
     {
-        debug!(message = "Got endpoint from config", endpoint_from_config);
+        info!(message = "Got endpoint from config", endpoint_from_config);
         config_builder = config_builder
             .endpoint_url(endpoint_from_config)
             .region(None);
     } else {
-        debug!(
+        info!(
             message = "Did not get endpoint from config",
             provider_config = format!("{provider_config:?}")
         );

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -222,6 +222,10 @@ where
 
     if let Some(endpoint_override) = endpoint {
         config_builder = config_builder.endpoint_url(endpoint_override);
+    } else if let Some(endpoint_from_config) =
+      aws_config::default_provider::endpoint_url::endpoint_url_provider(&provider_config).await
+    {
+      config_builder = config_builder.endpoint_url(endpoint_from_config);
     }
 
     if let Some(use_fips) =

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -228,8 +228,7 @@ where
     {
         info!(message = "Got endpoint from config", endpoint_from_config);
         config_builder = config_builder
-            .endpoint_url(endpoint_from_config)
-            .region(None);
+            .endpoint_url(endpoint_from_config);
     } else {
         info!(
             message = "Did not get endpoint from config",

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -258,7 +258,7 @@ impl S3SinkConfig {
     }
 
     pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
-        debug!("Creating service for S3 sink", ?self.region);
+        debug!(message = "Creating service for S3 sink", region = format!("region: {0:?}, endpoint: {1:?}", self.region.region(), self.region.endpoint()));
         s3_common::config::create_service(
             &self.region,
             &self.auth,

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -258,7 +258,14 @@ impl S3SinkConfig {
     }
 
     pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
-        debug!(message = "Creating service for S3 sink", region = format!("region: {0:?}, endpoint: {1:?}", self.region.region(), self.region.endpoint()));
+        debug!(
+            message = "Creating service for S3 sink",
+            region = format!(
+                "region: {0:?}, endpoint: {1:?}",
+                self.region.region(),
+                self.region.endpoint()
+            )
+        );
         s3_common::config::create_service(
             &self.region,
             &self.auth,

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -258,7 +258,7 @@ impl S3SinkConfig {
     }
 
     pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
-        debug!(
+        info!(
             message = "Creating service for S3 sink",
             region = format!(
                 "region: {0:?}, endpoint: {1:?}",

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -258,14 +258,6 @@ impl S3SinkConfig {
     }
 
     pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
-        info!(
-            message = "Creating service for S3 sink",
-            region = format!(
-                "region: {0:?}, endpoint: {1:?}",
-                self.region.region(),
-                self.region.endpoint()
-            )
-        );
         s3_common::config::create_service(
             &self.region,
             &self.auth,

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -258,6 +258,7 @@ impl S3SinkConfig {
     }
 
     pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
+        debug!("Creating service for S3 sink", ?self.region);
         s3_common::config::create_service(
             &self.region,
             &self.auth,


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Prior to this PR, when endpoint_url was set in AWS_CONFIG_FILE, Vector would ignore it. After this PR, Vector will continue prioritizing manually-configured endpoint_url on an aws_s3 sink, but it will also use the value from AWS_CONFIG_FILE otherwise (assuming one is provided there).

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->
Confirmed in a dev environment running Vector built from source off of this branch in a helm chart, writing to Ceph's S3 endpoint as configured in AWS_CONFIG_FILE but not configured in aws_s3 sink.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: https://github.com/vectordotdev/vector/issues/22686
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
