### PR TITLE
chore(releasing): automate the rest of the release prep steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11225,6 +11225,7 @@ dependencies = [
  "hex",
  "indexmap 2.8.0",
  "indicatif",
+ "indoc",
  "itertools 0.14.0",
  "log",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ glob = { version = "0.3.2", default-features = false }
 hickory-proto = { version = "0.24.4", default-features = false, features = ["dnssec"] }
 indexmap = { version = "2.8.0", default-features = false, features = ["serde", "std"] }
 inventory = { version = "0.3" }
+indoc = { version = "2.0.6" }
 metrics = "0.24.1"
 metrics-tracing-context = { version = "0.17.0", default-features = false }
 metrics-util = { version = "0.18.0", default-features = false, features = ["registry"] }
@@ -183,6 +184,7 @@ proptest-derive = { workspace = true, optional = true }
 snafu.workspace = true
 cfg-if.workspace = true
 semver.workspace = true
+indoc.workspace = true
 
 # Internal libs
 dnsmsg-parser = { path = "lib/dnsmsg-parser", optional = true }
@@ -337,7 +339,6 @@ hyper = { version = "0.14.28", default-features = false, features = ["client", "
 hyper-openssl = { version = "0.9.2", default-features = false }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["openssl-tls"] }
 indexmap.workspace = true
-indoc = { version = "2.0.6", default-features = false }
 inventory = { version = "0.3.20", default-features = false }
 ipnet = { version = "2", default-features = false, optional = true, features = ["serde", "std"] }
 itertools = { version = "0.14.0", default-features = false, optional = false, features = ["use_alloc"] }

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -42,7 +42,7 @@ vector-core = { path = "../vector-core", default-features = false, features = ["
 
 [dev-dependencies]
 futures.workspace = true
-indoc = { version = "2", default-features = false }
+indoc.workspace = true
 tokio = { version = "1", features = ["test-util"] }
 similar-asserts = "1.7.0"
 vector-core = { path = "../vector-core", default-features = false, features = ["vrl", "test"] }

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1"
 reqwest = { version = "0.11.26", features = ["json"] }
 serde_json.workspace = true
 tokio = { version = "1.44.1", features = ["full"] }
-indoc = "2.0.6"
+indoc.workspace = true
 env_logger = "0.11"
 tracing = { version = "0.1", features = ["log"] }
 rand.workspace = true

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -35,3 +35,4 @@ sha2 = "0.10.8"
 tempfile.workspace = true
 toml.workspace = true
 semver.workspace = true
+indoc.workspace = true


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Automates more release steps:
* VRL changelog addition to the the release CUE file
* Update version number in `distribution/install.sh`
* Add new version to `website/cue/reference/versions.cue`
* Create new release md file
* Open release prep PR

If only I had a good CUE parser in Rust...

This is not pretty but it automates some error prone steps.  

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
