### PR TITLE
enhancement(aws_s3 source): optionally configure source to defer or delete older notifications

### DIFF
--- a/changelog.d/s3-source-defer-or-delete.enhancement.md
+++ b/changelog.d/s3-source-defer-or-delete.enhancement.md
@@ -1,3 +1,3 @@
-Adds a `max_file_age_secs` and `deferred_queue_url` option to the `aws_s3` source.  If `max_file_age_secs` is specified, then it will require the notification to be created within the defined seconds.  If the `deferred_queue_url` is also specified, instead of just deleting the notification from the `queue_url` it will also enqueue that notification in `deferred_queue_url.`
+Add deferred processing options (`deferred.max_age_secs`, `deferred.queue_url`) to automatically route older event notifications to a separate queue, enabling prioritized processing of recent files
 
 authors: akutta

--- a/changelog.d/s3-source-defer-or-delete.enhancement.md
+++ b/changelog.d/s3-source-defer-or-delete.enhancement.md
@@ -1,0 +1,3 @@
+Adds a `max_file_age_secs` and `deferred_queue_url` option to the `aws_s3` source.  If `max_file_age_secs` is specified, then it will require the notification to be created within the defined seconds.  If the `deferred_queue_url` is also specified, instead of just deleting the notification from the `queue_url` it will also enqueue that notification in `deferred_queue_url.`
+
+authors: akutta

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -7,7 +7,10 @@ use vector_lib::internal_event::{error_stage, error_type};
 
 #[cfg(feature = "sources-aws_s3")]
 mod s3 {
-    use aws_sdk_sqs::types::{BatchResultErrorEntry, DeleteMessageBatchRequestEntry, DeleteMessageBatchResultEntry, SendMessageBatchRequestEntry, SendMessageBatchResultEntry};
+    use aws_sdk_sqs::types::{
+        BatchResultErrorEntry, DeleteMessageBatchRequestEntry, DeleteMessageBatchResultEntry,
+        SendMessageBatchRequestEntry, SendMessageBatchResultEntry,
+    };
 
     use super::*;
     use crate::sources::aws_s3::sqs::ProcessingError;
@@ -153,7 +156,7 @@ mod s3 {
                 "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
                 "stage" => error_stage::PROCESSING,
             )
-                .increment(1);
+            .increment(1);
         }
     }
 
@@ -183,10 +186,9 @@ mod s3 {
                 "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
                 "stage" => error_stage::PROCESSING,
             )
-                .increment(1);
+            .increment(1);
         }
     }
-
 }
 
 #[derive(Debug)]

--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -7,9 +7,7 @@ use vector_lib::internal_event::{error_stage, error_type};
 
 #[cfg(feature = "sources-aws_s3")]
 mod s3 {
-    use aws_sdk_sqs::types::{
-        BatchResultErrorEntry, DeleteMessageBatchRequestEntry, DeleteMessageBatchResultEntry,
-    };
+    use aws_sdk_sqs::types::{BatchResultErrorEntry, DeleteMessageBatchRequestEntry, DeleteMessageBatchResultEntry, SendMessageBatchRequestEntry, SendMessageBatchResultEntry};
 
     use super::*;
     use crate::sources::aws_s3::sqs::ProcessingError;
@@ -114,6 +112,81 @@ mod s3 {
             .increment(1);
         }
     }
+
+    #[derive(Debug)]
+    pub struct SqsMessageSentSucceeded {
+        pub message_ids: Vec<SendMessageBatchResultEntry>,
+    }
+
+    impl InternalEvent for SqsMessageSentSucceeded {
+        fn emit(self) {
+            trace!(message = "Deferred SQS message(s).",
+            message_ids = %self.message_ids.iter()
+                .map(|x| x.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", "));
+            counter!("sqs_message_defer_succeeded_total").increment(self.message_ids.len() as u64);
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct SqsMessageSentPartialError {
+        pub entries: Vec<BatchResultErrorEntry>,
+    }
+
+    impl InternalEvent for SqsMessageSentPartialError {
+        fn emit(self) {
+            error!(
+                message = "Sending of deferred SQS message(s) failed.",
+                message_ids = %self.entries.iter()
+                    .map(|x| format!("{}/{}", x.id, x.code))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                error_code = "failed_deferring_some_sqs_messages",
+                error_type = error_type::ACKNOWLEDGMENT_FAILED,
+                stage = error_stage::PROCESSING,
+                internal_log_rate_limit = true,
+            );
+            counter!(
+                "component_errors_total",
+                "error_code" => "failed_deferring_some_sqs_messages",
+                "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
+                "stage" => error_stage::PROCESSING,
+            )
+                .increment(1);
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct SqsMessageSendBatchError<E> {
+        pub entries: Vec<SendMessageBatchRequestEntry>,
+        pub error: E,
+    }
+
+    impl<E: std::fmt::Display> InternalEvent for SqsMessageSendBatchError<E> {
+        fn emit(self) {
+            error!(
+                message = "Sending of deferred SQS message(s) failed.",
+                message_ids = %self.entries.iter()
+                    .map(|x| x.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                error = %self.error,
+                error_code = "failed_deferring_all_sqs_messages",
+                error_type = error_type::ACKNOWLEDGMENT_FAILED,
+                stage = error_stage::PROCESSING,
+                internal_log_rate_limit = true,
+            );
+            counter!(
+                "component_errors_total",
+                "error_code" => "failed_deferring_all_sqs_messages",
+                "error_type" => error_type::ACKNOWLEDGMENT_FAILED,
+                "stage" => error_stage::PROCESSING,
+            )
+                .increment(1);
+        }
+    }
+
 }
 
 #[derive(Debug)]

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -152,18 +152,20 @@ pub(super) struct Config {
     #[serde(flatten)]
     pub(super) timeout: Option<AwsTimeout>,
 
-    /// The URL of the SQS queue to send notifications if file is too old
-    /// If not set and delete_message = true then the message is deleted without pulling the file
+    /// Used in conjunction with `max_file_age` to forward events to a different queue for later processing.
+    /// If the event is older than `max_file_age` seconds, it is forwarded to this queue.
+    /// If this is not set, the event is deleted.
     #[configurable(metadata(
         docs::examples = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
     ))]
     #[configurable(validation(format = "uri"))]
     pub(super) deferred_queue_url: Option<String>,
 
-    /// The maximum age of a file before it is forwarded to the retry queue
-    /// If not set, files are never forwarded to the retry queue
+    /// Event must have been emitted within the last `max_file_age` seconds to be processed.
+    /// If the event is older, it can be forwarded to the `deferred_queue_url` for later processing
+    /// otherwise it is deleted.
     ///
-    /// This is useful for processing fresher data and allowing a secondary process to handle older data
+    /// This is useful for preferring to process more recent files.
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::examples = 3600))]
     pub(super) max_file_age: Option<u64>,

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -63,16 +63,16 @@ static SUPPORTED_S3_EVENT_VERSION: LazyLock<semver::VersionReq> =
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub(super) struct DeferredConfig {
-    /// The URL of the queue to forward events to when they are older than max_age_secs.
+    /// The URL of the queue to forward events to when they are older than `max_age_secs`.
     #[configurable(metadata(
         docs::examples = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
     ))]
     #[configurable(validation(format = "uri"))]
     pub(super) queue_url: String,
 
-    /// Event must have been emitted within the last max_age_secs seconds to be processed.
-    /// If the event is older, it is forwarded to the queue_url for later processing.
-    /// This is useful for preferring to process more recent files.
+    /// Event must have been emitted within the last `max_age_secs` seconds to be processed.
+    ///
+    /// If the event is older, it is forwarded to the `queue_url` for later processing.
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::examples = 3600))]
     pub(super) max_age_secs: u64,

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -621,9 +621,9 @@ impl IngestorProcess {
             });
         }
 
-        if self.state.max_file_age_secs.is_some() {
+        if let Some(max_age_secs) = self.state.max_file_age_secs {
             let delta = Utc::now() - s3_event.event_time;
-            if delta.num_seconds() > self.state.max_file_age_secs.unwrap() as i64 {
+            if delta.num_seconds() > max_age_secs as i64 {
                 return Err(ProcessingError::FileTooOld {
                     bucket: s3_event.s3.bucket.name.clone(),
                     key: s3_event.s3.object.key.clone(),

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -513,11 +513,17 @@ impl IngestorProcess {
         // Should consider removing failed deferrals from the delete_entries
         if !deferred_entries.is_empty() {
             let Some(deferred) = &self.state.deferred else {
-                warn!(message = "Deferred queue not configured, but received deferred entries.");
+                warn!(
+                    message = "Deferred queue not configured, but received deferred entries.",
+                    internal_log_rate_limit = true
+                );
                 return;
             };
             let cloned_entries = deferred_entries.clone();
-            match self.send_messages(deferred_entries, deferred.queue_url.clone()).await {
+            match self
+                .send_messages(deferred_entries, deferred.queue_url.clone())
+                .await
+            {
                 Ok(result) => {
                     if !result.successful.is_empty() {
                         emit!(SqsMessageSentSucceeded {

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -714,9 +714,9 @@ base: components: sources: aws_s3: configuration: {
 				type: object: options: {
 					max_age_secs: {
 						description: """
-																Event must have been emitted within the last max_age_secs seconds to be processed.
-																If the event is older, it is forwarded to the queue_url for later processing.
-																This is useful for preferring to process more recent files.
+																Event must have been emitted within the last `max_age_secs` seconds to be processed.
+
+																If the event is older, it is forwarded to the `queue_url` for later processing.
 																"""
 						required: true
 						type: uint: {
@@ -725,7 +725,7 @@ base: components: sources: aws_s3: configuration: {
 						}
 					}
 					queue_url: {
-						description: "The URL of the queue to forward events to when they are older than max_age_secs."
+						description: "The URL of the queue to forward events to when they are older than `max_age_secs`."
 						required:    true
 						type: string: examples: ["https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"]
 					}

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -710,8 +710,8 @@ base: components: sources: aws_s3: configuration: {
 			}
 			deferred_queue_url: {
 				description: """
-					Used in conjunction with `max_file_age` to forward events to a different queue for later processing.
-					If the event is older than `max_file_age` seconds, it is forwarded to this queue.
+					Used in conjunction with `max_file_age_secs` to forward events to a different queue for later processing.
+					If the event is older than `max_file_age_secs` seconds, it is forwarded to this queue.
 					If this is not set, the event is deleted.
 					"""
 				required: false
@@ -735,9 +735,9 @@ base: components: sources: aws_s3: configuration: {
 				required: false
 				type: bool: default: true
 			}
-			max_file_age: {
+			max_file_age_secs: {
 				description: """
-					Event must have been emitted within the last `max_file_age` seconds to be processed.
+					Event must have been emitted within the last `max_file_age_secs` seconds to be processed.
 					If the event is older, it can be forwarded to the `deferred_queue_url` for later processing
 					otherwise it is deleted.
 

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -708,6 +708,15 @@ base: components: sources: aws_s3: configuration: {
 					unit: "seconds"
 				}
 			}
+			deferred_queue_url: {
+				description: """
+					Used in conjunction with `max_file_age` to forward events to a different queue for later processing.
+					If the event is older than `max_file_age` seconds, it is forwarded to this queue.
+					If this is not set, the event is deleted.
+					"""
+				required: false
+				type: string: examples: ["https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"]
+			}
 			delete_failed_message: {
 				description: """
 					Whether to delete non-retryable messages.
@@ -725,6 +734,20 @@ base: components: sources: aws_s3: configuration: {
 					"""
 				required: false
 				type: bool: default: true
+			}
+			max_file_age: {
+				description: """
+					Event must have been emitted within the last `max_file_age` seconds to be processed.
+					If the event is older, it can be forwarded to the `deferred_queue_url` for later processing
+					otherwise it is deleted.
+
+					This is useful for preferring to process more recent files.
+					"""
+				required: false
+				type: uint: {
+					examples: [3600]
+					unit: "seconds"
+				}
 			}
 			max_number_of_messages: {
 				description: """

--- a/website/cue/reference/components/sources/base/aws_s3.cue
+++ b/website/cue/reference/components/sources/base/aws_s3.cue
@@ -708,14 +708,28 @@ base: components: sources: aws_s3: configuration: {
 					unit: "seconds"
 				}
 			}
-			deferred_queue_url: {
-				description: """
-					Used in conjunction with `max_file_age_secs` to forward events to a different queue for later processing.
-					If the event is older than `max_file_age_secs` seconds, it is forwarded to this queue.
-					If this is not set, the event is deleted.
-					"""
-				required: false
-				type: string: examples: ["https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"]
+			deferred: {
+				description: "Configuration for deferring events to another queue based on their age."
+				required:    false
+				type: object: options: {
+					max_age_secs: {
+						description: """
+																Event must have been emitted within the last max_age_secs seconds to be processed.
+																If the event is older, it is forwarded to the queue_url for later processing.
+																This is useful for preferring to process more recent files.
+																"""
+						required: true
+						type: uint: {
+							examples: [3600]
+							unit: "seconds"
+						}
+					}
+					queue_url: {
+						description: "The URL of the queue to forward events to when they are older than max_age_secs."
+						required:    true
+						type: string: examples: ["https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"]
+					}
+				}
 			}
 			delete_failed_message: {
 				description: """
@@ -734,20 +748,6 @@ base: components: sources: aws_s3: configuration: {
 					"""
 				required: false
 				type: bool: default: true
-			}
-			max_file_age_secs: {
-				description: """
-					Event must have been emitted within the last `max_file_age_secs` seconds to be processed.
-					If the event is older, it can be forwarded to the `deferred_queue_url` for later processing
-					otherwise it is deleted.
-
-					This is useful for preferring to process more recent files.
-					"""
-				required: false
-				type: uint: {
-					examples: [3600]
-					unit: "seconds"
-				}
 			}
 			max_number_of_messages: {
 				description: """


### PR DESCRIPTION
## Summary

Introduces new optionally configurable options `max_file_age_secs` and `deferred_queue_url` to the `aws_s3` source.  This enables users to decide if they want to requeue S3 notification messages to a different SQS Queue for deferred processing or delete them after a certain age.

This is useful under a couple scenarios:
- the data is idempotent and we do not care to process all messages (no `deferred_queue_url` defined)
- the more recent data is more important and providing visibility to this data is more important than the older data
  - using the `deferred_queue_url` this prevents us from losing the data, but let's us set a lower priority to it.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

I ran a build locally with the below configuration to confirm that we were were not downloading the s3 files if configured to ignore them and that a different `aws_s3` source could consume and still process the deferred messages.

```
sources:
  vector_internal_metrics:
    type: "internal_metrics"
    scrape_interval_secs: 30
    tags:
      host_key: "host"

  primary_logs:
    type: "aws_s3"
    region: "us-west-2"
    compression: "gzip"
    decoding:
      codec: "json"
    sqs:
      queue_url: "https://sqs.us-west-2.amazonaws.com/<account-id>/tmp-dkutta"
      client_concurrency: 10
      visibility_timeout_secs: 600
      deferred_queue_url: "https://sqs.us-west-2.amazonaws.com/<account-id>/tmp-deferred-dkutta"
      max_file_age_secs: 60
      max_number_of_messages: 10

  deferred_logs:
    type: "aws_s3"
    region: "us-west-2"
    compression: "gzip"
    decoding:
      codec: "json"
    sqs:
      queue_url: "https://sqs.us-west-2.amazonaws.com/<account-id>/tmp-deferred-dkutta"
      client_concurrency: 1
      visibility_timeout_secs: 600
      max_number_of_messages: 10

sinks:
  primary_blackhole:
    type: blackhole
    inputs:
      - primary_logs
    print_interval_secs: 20

  deferred_blackhole:
    type: blackhole
    inputs:
      - deferred_logs
    print_interval_secs: 20
```



Scenario:
- Allow queue_url to buffer a decent number of messages (~1800) with an oldest message age of >30 minutes.
- Configure Vector to only process notifications from within the last minute
- Configure Vector to add new `aws_s3` source of the deferred queue
- send both to different blackholes and monitor

On initial startup, the only log lines being processed were from the deferred queue, which had originally started empty.
![Scre
![Screenshot 2025-03-19 at 10 58 46 AM](https://github.com/user-attachments/assets/8dd6f013-f85d-4d87-b024-1d815497b7e6)
enshot 2025-03-19 at 10 58 46 AM](https://github.com/user-attachments/assets/b2ae4bef-9a0d-4863-9f2f-b3b68eebefcd)

Once the primary `aws_s3` source begun processing notifications that were < 60 seconds old, it begun sending log events to the primary blackhole.
![Screenshot 2025-03-19 at 11 04 38 AM](https://github.com/user-attachments/assets/5c7c9ce8-442b-43ab-bcf1-ef378ac5630a)

When we finished the deferred queue, no new messages were sent to it and we kept processing the primary queue per normal operation.
![Screenshot 2025-03-19 at 11 33 06 AM](https://github.com/user-attachments/assets/99f8c387-be02-4886-b6fb-0e906e7f092e)

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.



## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References
