### PR TITLE
 enhancement(vector source): add `headers` option

### DIFF
--- a/changelog.d/add_headers_vector_source.enhancement.md
+++ b/changelog.d/add_headers_vector_source.enhancement.md
@@ -1,0 +1,3 @@
+Add option to add https headers to vector source's event logs
+
+authors: anil-db

--- a/changelog.d/add_headers_vector_source.enhancement.md
+++ b/changelog.d/add_headers_vector_source.enhancement.md
@@ -1,3 +1,3 @@
-Add option to add https headers to vector source's event logs
+Add `headers` option to the `vector` source config. Use this setting to provide custom headers.
 
 authors: anil-db

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -338,7 +338,7 @@ fn socket_addr_to_ip_string(addr: &SocketAddr) -> String {
     addr.ip().to_string()
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum HttpConfigParamKind {
     Glob(glob::Pattern),
     Exact(String),

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -13,6 +13,8 @@ use vector_lib::{
     EstimatedJsonEncodedSizeOf,
 };
 
+use crate::sources::http_server::{build_param_matcher, remove_duplicates, HttpConfigParamKind};
+use crate::sources::util::add_headers;
 use crate::{
     config::{
         DataType, GenerateConfig, Resource, SourceAcknowledgementsConfig, SourceConfig,
@@ -40,6 +42,7 @@ struct Service {
     pipeline: SourceSender,
     acknowledgements: bool,
     log_namespace: LogNamespace,
+    headers: Vec<HttpConfigParamKind>,
 }
 
 #[tonic::async_trait]
@@ -48,6 +51,7 @@ impl proto::Service for Service {
         &self,
         request: Request<proto::PushEventsRequest>,
     ) -> Result<Response<proto::PushEventsResponse>, Status> {
+        let request_metadata = request.metadata().clone();
         let mut events: Vec<Event> = request
             .into_inner()
             .events
@@ -65,6 +69,13 @@ impl proto::Service for Service {
                 );
             }
         }
+        add_headers(
+            &mut events,
+            &self.headers,
+            &request_metadata.into_headers(),
+            self.log_namespace,
+            VectorConfig::NAME,
+        );
 
         let count = events.len();
         let byte_size = events.estimated_json_encoded_size_of();
@@ -138,6 +149,20 @@ pub struct VectorConfig {
     #[serde(default)]
     #[configurable(metadata(docs::hidden))]
     pub log_namespace: Option<bool>,
+
+    /// A list of HTTP headers to include in the log event.
+    ///
+    /// Accepts the wildcard (`*`) character for headers matching a specified pattern.
+    ///
+    /// Specifying "*" results in all headers included in the log event.
+    ///
+    /// These headers are not included in the JSON payload if a field with a conflicting name exists.
+    #[serde(default)]
+    #[configurable(metadata(docs::examples = "User-Agent"))]
+    #[configurable(metadata(docs::examples = "X-My-Custom-Header"))]
+    #[configurable(metadata(docs::examples = "X-*"))]
+    #[configurable(metadata(docs::examples = "*"))]
+    headers: Vec<String>,
 }
 
 impl VectorConfig {
@@ -158,6 +183,7 @@ impl Default for VectorConfig {
             tls: None,
             acknowledgements: Default::default(),
             log_namespace: None,
+            headers: Default::default(),
         }
     }
 }
@@ -180,6 +206,7 @@ impl SourceConfig for VectorConfig {
             pipeline: cx.out,
             acknowledgements,
             log_namespace,
+            headers: build_param_matcher(&remove_duplicates(self.headers.clone(), "headers"))?,
         })
         .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
         // Tonic added a default of 4MB in 0.9. This replaces the old behavior.

--- a/website/cue/reference/components/sources/base/vector.cue
+++ b/website/cue/reference/components/sources/base/vector.cue
@@ -31,6 +31,22 @@ base: components: sources: vector: configuration: {
 		required: true
 		type: string: {}
 	}
+	headers: {
+		description: """
+			A list of HTTP headers to include in the log event.
+
+			Accepts the wildcard (`*`) character for headers matching a specified pattern.
+
+			Specifying "*" results in all headers included in the log event.
+
+			These headers are not included in the JSON payload if a field with a conflicting name exists.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: examples: ["User-Agent", "X-My-Custom-Header", "X-*", "*"]
+		}
+	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."
 		required:    false


### PR DESCRIPTION
## Summary
This PR adds option to include http headers in vector source log events similar to http source.
most of function and structs are reused from http source.

Use case: we have a use case where between vector sink in edge node and vector source in aggregator, there is a proxy. 
this proxy is responsible for validation and adding a header for `Provenance` purpose for log source.
we need to attach this Provenance header value to log event in aggregator which later will go to ETL pipeline.

GRPC protocol provide these headers as metadata and it seems tonic's Request struct exposes them as metadata but vector source just drops/ignores that field.

This pr is trying to use that metadata to add the header in log event is configure.
by default header config is empty string hence no data is added.
 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
tested manually
with below config 
```
{
    "acknowledgements": {
        "enabled": true
    },  
    "api": {
        "address": "0.0.0.0:8686",
        "enabled": true
    },  
    "data_dir": "/vector-data-dir",
    "schema": {
        "log_namespace": false
    },  
    "sinks": {
        "print": {
            "encoding": {
                "codec": "json"
            },  
            "inputs": [
                "agentTier2"
            ],  
            "type": "console"
        }   
    },  
    "sources": {
        "agentTier2": {
            "address": "0.0.0.0:6001",
            "tls": {
                "alpn_protocols": [
                    "h2"
                ],  
                "ca_file": "${VECTOR_TLS_CA_FILE}",
                "crt_file": "${VECTOR_TLS_CRT_FILE}",
                "enabled": true,
                "key_file": "${VECTOR_TLS_KEY_FILE}",
                "verify_certificate": false
            },  
            "headers": ["*"],
            "type": "vector"
        }   
    }   
}
```

a sample log message with envoy header added as event property.
```
{"application_timestamp":"2025-03-20T18:28:24.061466172Z","content-type":"application/grpc","grpc-encoding":"gzip","message":{"crc32":null,"instance_id":"logging-agent-4dljt","is_delivered_by_logging_agent":true,"length":2738,"message":"a pproto messafe","metadata":{"container_name":null,"org_id":null,"pod_id":"logging-agent-4dljt","public_host_name":null, "stream_offset":17770549,"upload_time":1742495304062,"workspace_id":null},"message_tag":"MESSAGE_TAG_ARCHIVED_MESSAGE","parse_success":true,"source_type":"vector","te":"trailers","timestamp":"2025-03-20T18:28:24.914968113Z","x-envoy-expected-rq-timeout-ms":"60000","x-forwarded-proto":"https","x-request-id":"e9f83ed8-9eef-4154-ba09-a2e95c4544cb"}
```


## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
