### PR TITLE
feat(lz4 encoder/decoder): add documentation for Lz4 encode and decode features in vrl

### DIFF
--- a/website/cue/reference/remap/functions/decode_lz4.cue
+++ b/website/cue/reference/remap/functions/decode_lz4.cue
@@ -1,0 +1,32 @@
+package metadata
+
+remap: functions: decode_lz4: {
+	category: "Codec"
+	description: """
+		Decodes the `value` (an lz4 string) into its original string.
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The lz4 block data to decode."
+			required:    true
+			type: ["string"]
+		},
+	]
+	internal_failure_reasons: [
+		"`value` unable to decode value with lz4 decoder.",
+	]
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Decode Lz4 data"
+			source: #"""
+				encoded_text = decode_base64!("LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=")
+				decode_lz4!(encoded_text)
+				"""#
+			return: "The quick brown fox jumps over 13 lazy dogs."
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/encode_lz4.cue
+++ b/website/cue/reference/remap/functions/encode_lz4.cue
@@ -1,0 +1,30 @@
+package metadata
+
+remap: functions: encode_lz4: {
+	category:    "Codec"
+	description: """
+		Encodes the `value` to [Lz4](\(urls.lz4)).
+		"""
+
+	arguments: [
+		{
+			name:        "value"
+			description: "The string to encode."
+			required:    true
+			type: ["string"]
+		}
+	]
+	internal_failure_reasons: []
+	return: types: ["string"]
+
+	examples: [
+		{
+			title: "Encode to Lz4"
+			source: #"""
+				encoded_text = encode_lz4!("The quick brown fox jumps over 13 lazy dogs.")
+				encode_base64(encoded_text)
+				"""#
+			return: "LAAAAPAdVGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4="
+		},
+	]
+}

--- a/website/cue/reference/remap/functions/encode_lz4.cue
+++ b/website/cue/reference/remap/functions/encode_lz4.cue
@@ -12,7 +12,7 @@ remap: functions: encode_lz4: {
 			description: "The string to encode."
 			required:    true
 			type: ["string"]
-		}
+		},
 	]
 	internal_failure_reasons: []
 	return: types: ["string"]


### PR DESCRIPTION
## Summary

This is a linked PR for adding lz4 encode and decode support to vrl. The parent PR can be found here: https://github.com/vectordotdev/vrl/pull/1339

It is unclear how documentation changes linked to new features in VRL should be handled. The page here https://github.com/vectordotdev/vrl/pull/1339 states that no changelog is required, yet in the checklist it does require it. Happy to make changes based on your feedback.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

This PR has had the various cue checks as outlined in the docs/DOCUMENTING.md page

## Does this PR include user-facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

