### PR TITLE
chore(website): Update `typesense-sync` depedency, search config

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -56,7 +56,7 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
     "typesense": "^1.8.2",
-    "typesense-sync": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.5.tgz"
+    "typesense-sync": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.1.0.tgz"
   },
   "browserslist": [
     "since 2017-06"

--- a/website/scripts/typesense-sync.ts
+++ b/website/scripts/typesense-sync.ts
@@ -1,9 +1,9 @@
 import { typesenseSync } from 'typesense-sync';
-import { saveSettings } from 'typesense-sync/settings';
-import tsConfig from "../typesense.config.json" assert { type: "json" };
+import { saveSettings } from 'typesense-sync';
+import tsConfig from "../typesense.config.json";
 
 const syncCollection = async () => {
-  const promises = []
+  const promises: Promise<any>[] = []
 
   for (const collection of tsConfig.collections) {
     console.log(`Updating collection ${collection.name}`)

--- a/website/scripts/typesense-sync.ts
+++ b/website/scripts/typesense-sync.ts
@@ -14,6 +14,6 @@ const syncCollection = async () => {
 }
 
 saveSettings()
-  // .then(() => syncCollection())
+  .then(() => syncCollection())
   .then(() => console.log('Typesense sync completed'))
   .catch(error => console.log('An error occurred', error))

--- a/website/scripts/typesense-sync.ts
+++ b/website/scripts/typesense-sync.ts
@@ -1,6 +1,6 @@
-import { typesenseSync } from 'typesense-sync';
-import { saveSettings } from 'typesense-sync';
-import tsConfig from "../typesense.config.json";
+const { typesenseSync } = require('typesense-sync');
+const { saveSettings } = require('typesense-sync/settings');
+const tsConfig = require('../typesense.config.json');
 
 const syncCollection = async () => {
   const promises: Promise<any>[] = []
@@ -14,6 +14,6 @@ const syncCollection = async () => {
 }
 
 saveSettings()
-  .then(() => syncCollection())
+  // .then(() => syncCollection())
   .then(() => console.log('Typesense sync completed'))
   .catch(error => console.log('An error occurred', error))

--- a/website/scripts/typesense-sync.ts
+++ b/website/scripts/typesense-sync.ts
@@ -1,21 +1,19 @@
 import { typesenseSync } from 'typesense-sync';
-import * as dotenv from 'dotenv';
-const documentsFile = './public/search.json';
+import { saveSettings } from 'typesense-sync/settings';
+import tsConfig from "../typesense.config.json" assert { type: "json" };
 
-dotenv.config();
-/*
- * @param {string} documentsFile - Path to the documents file. (required)
- * @param {Object} gitDiff - Object containing updated and deleted files (optional).
- * @param {string} aliasCollectionName - Name of the alias collection (optional).
- */
+const syncCollection = async () => {
+  const promises = []
 
-const collectionName = 'vector_docs'
+  for (const collection of tsConfig.collections) {
+    console.log(`Updating collection ${collection.name}`)
+    promises.push(typesenseSync(collection.name, collection.file_path))
+  }
 
+  return await Promise.all(promises)
+}
 
-typesenseSync(collectionName, documentsFile)
-  .then(() => {
-    console.log('Typesense update completed.');
-  })
-  .catch((error) => {
-    console.error('An error occurred:', error);
-  });
+saveSettings()
+  .then(() => syncCollection())
+  .then(() => console.log('Typesense sync completed'))
+  .catch(error => console.log('An error occurred', error))

--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -2,7 +2,133 @@
   "collections": [
     {
       "name": "vector_docs_v1",
+      "file_path": "./public/search.json",
       "synonyms": [],
+      "schema": {
+        "fields": [
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": ".*",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "auto"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "content",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "itemUrl",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "level",
+            "optional": true,
+            "sort": true,
+            "stem": false,
+            "type": "int64"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "pageTitle",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "pageUrl",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "ranking",
+            "optional": true,
+            "sort": true,
+            "stem": false,
+            "type": "int64"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "section",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "tags",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string[]"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "title",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string"
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "hierarchy",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string[]"
+          }
+        ]
+      },
       "presets": [
         {
           "name": "vector_docs_search",

--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -11,17 +11,6 @@
             "index": true,
             "infix": false,
             "locale": "",
-            "name": ".*",
-            "optional": true,
-            "sort": false,
-            "stem": false,
-            "type": "auto"
-          },
-          {
-            "facet": false,
-            "index": true,
-            "infix": false,
-            "locale": "",
             "name": "content",
             "optional": true,
             "sort": false,

--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -120,7 +120,7 @@
       },
       "presets": [
         {
-          "name": "vector_docs_search_test",
+          "name": "vector_docs_search",
           "search_parameters": {
             "sort_by": "level:desc,ranking:desc,_text_match:desc",
             "query_by": "content,hierarchy,title,tags"

--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -120,7 +120,7 @@
       },
       "presets": [
         {
-          "name": "vector_docs_search",
+          "name": "vector_docs_search_test",
           "search_parameters": {
             "sort_by": "level:desc,ranking:desc,_text_match:desc",
             "query_by": "content,hierarchy,title,tags"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1809,6 +1809,15 @@ axios@^1.6.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.7.2:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-plugin-macros@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
@@ -3762,19 +3771,24 @@ tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 typescript@^4.1.3:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
-"typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.5.tgz":
-  version "1.0.5"
-  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.5.tgz#ac91efdac310926ad580da227355656643540bce"
+"typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.1.0.tgz":
+  version "1.1.0"
+  resolved "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.1.0.tgz#9e142972e2d6b255b3f90b3a8545c39e2e4b8cb7"
   dependencies:
     "@babel/runtime" "^7.25.0"
     crypto "^1.0.1"
     dotenv "^16.4.5"
-    typesense "^1.8.2"
+    typesense "^2.0.3"
     winston "^3.14.2"
     yargs "^17.7.2"
 
@@ -3785,6 +3799,15 @@ typesense@^1.8.2:
   dependencies:
     axios "^1.6.0"
     loglevel "^1.8.1"
+
+typesense@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/typesense/-/typesense-2.0.3.tgz#cbce737544186fb338cf90bd2a76b33cb1e3a281"
+  integrity sha512-fRJjFdDNZn6qF9XzIk+bB8n8cm0fiAx1SGcpLDfNcsGtp8znITfG+SO+l/qk63GCRXZwJGq7wrMDLFUvblJSHA==
+  dependencies:
+    axios "^1.7.2"
+    loglevel "^1.8.1"
+    tslib "^2.6.2"
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
- Bump `typesense-sync` to `v1.1.0`
- Updates `typesense.config.json` in accordance with package updates, including schema definition for easier updates in the future

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

## How did you test this PR?
- Latest build was successful here including typesense job: https://us-east-1.console.aws.amazon.com/amplify/apps/d1a7j77663uxsc/branches/brian.deutsch%2Ftypesense-update/deployments
- No changes to UI

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
