### PR TITLE
enhancement(throttle transform): Refactor throttle/rate limiter logic into reusable wrapper

### DIFF
--- a/src/transforms/throttle/config.rs
+++ b/src/transforms/throttle/config.rs
@@ -1,0 +1,100 @@
+use governor::clock;
+use serde_with::serde_as;
+use std::time::Duration;
+use vector_lib::config::{clone_input_definitions, LogNamespace};
+use vector_lib::configurable::configurable_component;
+
+use super::transform::Throttle;
+use crate::{
+    conditions::AnyCondition,
+    config::{DataType, Input, OutputId, TransformConfig, TransformContext, TransformOutput},
+    schema,
+    template::Template,
+    transforms::Transform,
+};
+
+/// Configuration of internal metrics for the Throttle transform.
+#[configurable_component]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ThrottleInternalMetricsConfig {
+    /// Whether or not to emit the `events_discarded_total` internal metric with the `key` tag.
+    ///
+    /// If true, the counter will be incremented for each discarded event, including the key value
+    /// associated with the discarded event. If false, the counter will not be emitted. Instead, the
+    /// number of discarded events can be seen through the `component_discarded_events_total` internal
+    /// metric.
+    ///
+    /// Note that this defaults to false because the `key` tag has potentially unbounded cardinality.
+    /// Only set this to true if you know that the number of unique keys is bounded.
+    #[serde(default)]
+    pub emit_events_discarded_per_key: bool,
+}
+
+/// Configuration for the `throttle` transform.
+#[serde_as]
+#[configurable_component(transform("throttle", "Rate limit logs passing through a topology."))]
+#[derive(Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ThrottleConfig {
+    /// The number of events allowed for a given bucket per configured `window_secs`.
+    ///
+    /// Each unique key has its own `threshold`.
+    pub threshold: u32,
+
+    /// The time window in which the configured `threshold` is applied, in seconds.
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
+    #[configurable(metadata(docs::human_name = "Time Window"))]
+    pub window_secs: Duration,
+
+    /// The value to group events into separate buckets to be rate limited independently.
+    ///
+    /// If left unspecified, or if the event doesn't have `key_field`, then the event is not rate
+    /// limited separately.
+    #[configurable(metadata(docs::examples = "{{ message }}", docs::examples = "{{ hostname }}",))]
+    pub key_field: Option<Template>,
+
+    /// A logical condition used to exclude events from sampling.
+    pub exclude: Option<AnyCondition>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub internal_metrics: ThrottleInternalMetricsConfig,
+}
+
+impl_generate_config_from_default!(ThrottleConfig);
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "throttle")]
+impl TransformConfig for ThrottleConfig {
+    async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
+        Throttle::new(self, context, clock::MonotonicClock).map(Transform::event_task)
+    }
+
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn outputs(
+        &self,
+        _: vector_lib::enrichment::TableRegistry,
+        input_definitions: &[(OutputId, schema::Definition)],
+        _: LogNamespace,
+    ) -> Vec<TransformOutput> {
+        // The event is not modified, so the definition is passed through as-is
+        vec![TransformOutput::new(
+            DataType::Log,
+            clone_input_definitions(input_definitions),
+        )]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ThrottleConfig;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<ThrottleConfig>();
+    }
+}

--- a/src/transforms/throttle/mod.rs
+++ b/src/transforms/throttle/mod.rs
@@ -1,0 +1,3 @@
+pub mod config;
+pub mod rate_limiter;
+pub mod transform;

--- a/src/transforms/throttle/rate_limiter.rs
+++ b/src/transforms/throttle/rate_limiter.rs
@@ -1,0 +1,57 @@
+use governor::clock;
+use governor::middleware::NoOpMiddleware;
+use governor::state::keyed::DashMapStateStore;
+use governor::{Quota, RateLimiter};
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio;
+
+/// Re-usable wrapper around the structs/type from the governor crate.
+/// Spawns a background task that periodically flushes keys that haven't been accessed recently.
+pub struct RateLimiterRunner<K, C>
+where
+    K: Hash + Eq + Clone,
+    C: clock::Clock,
+{
+    pub rate_limiter: Arc<RateLimiter<K, DashMapStateStore<K>, C, NoOpMiddleware<C::Instant>>>,
+    flush_handle: tokio::task::JoinHandle<()>,
+}
+
+impl<K, C> RateLimiterRunner<K, C>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    C: clock::Clock + Clone + Send + Sync + 'static,
+{
+    pub fn start(quota: Quota, clock: C, flush_keys_interval: Duration) -> Self {
+        let rate_limiter = Arc::new(RateLimiter::dashmap_with_clock(quota, clock));
+
+        let rate_limiter_clone = Arc::clone(&rate_limiter);
+        let flush_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(flush_keys_interval);
+            loop {
+                interval.tick().await;
+                rate_limiter_clone.retain_recent();
+            }
+        });
+
+        Self {
+            rate_limiter,
+            flush_handle,
+        }
+    }
+
+    pub fn check_key(&self, key: &K) -> bool {
+        self.rate_limiter.check_key(key).is_ok()
+    }
+}
+
+impl<K, C> Drop for RateLimiterRunner<K, C>
+where
+    K: Hash + Eq + Clone,
+    C: clock::Clock,
+{
+    fn drop(&mut self) {
+        self.flush_handle.abort();
+    }
+}

--- a/src/transforms/throttle/transform.rs
+++ b/src/transforms/throttle/transform.rs
@@ -1,112 +1,36 @@
-use std::{num::NonZeroU32, pin::Pin, time::Duration};
-
 use async_stream::stream;
 use futures::{Stream, StreamExt};
-use governor::{clock, Quota, RateLimiter};
-use serde_with::serde_as;
+use governor::{clock, Quota};
 use snafu::Snafu;
-use vector_lib::config::{clone_input_definitions, LogNamespace};
-use vector_lib::configurable::configurable_component;
+use std::hash::Hash;
+use std::{num::NonZeroU32, pin::Pin, time::Duration};
 
+use super::{
+    config::{ThrottleConfig, ThrottleInternalMetricsConfig},
+    rate_limiter::RateLimiterRunner,
+};
 use crate::{
-    conditions::{AnyCondition, Condition},
-    config::{DataType, Input, OutputId, TransformConfig, TransformContext, TransformOutput},
+    conditions::Condition,
+    config::TransformContext,
     event::Event,
     internal_events::{TemplateRenderingError, ThrottleEventDiscarded},
-    schema,
     template::Template,
-    transforms::{TaskTransform, Transform},
+    transforms::TaskTransform,
 };
-
-/// Configuration of internal metrics for the Throttle transform.
-#[configurable_component]
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-#[serde(deny_unknown_fields)]
-pub struct ThrottleInternalMetricsConfig {
-    /// Whether or not to emit the `events_discarded_total` internal metric with the `key` tag.
-    ///
-    /// If true, the counter will be incremented for each discarded event, including the key value
-    /// associated with the discarded event. If false, the counter will not be emitted. Instead, the
-    /// number of discarded events can be seen through the `component_discarded_events_total` internal
-    /// metric.
-    ///
-    /// Note that this defaults to false because the `key` tag has potentially unbounded cardinality.
-    /// Only set this to true if you know that the number of unique keys is bounded.
-    #[serde(default)]
-    pub emit_events_discarded_per_key: bool,
-}
-
-/// Configuration for the `throttle` transform.
-#[serde_as]
-#[configurable_component(transform("throttle", "Rate limit logs passing through a topology."))]
-#[derive(Clone, Debug, Default)]
-#[serde(deny_unknown_fields)]
-pub struct ThrottleConfig {
-    /// The number of events allowed for a given bucket per configured `window_secs`.
-    ///
-    /// Each unique key has its own `threshold`.
-    threshold: u32,
-
-    /// The time window in which the configured `threshold` is applied, in seconds.
-    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
-    #[configurable(metadata(docs::human_name = "Time Window"))]
-    window_secs: Duration,
-
-    /// The value to group events into separate buckets to be rate limited independently.
-    ///
-    /// If left unspecified, or if the event doesn't have `key_field`, then the event is not rate
-    /// limited separately.
-    #[configurable(metadata(docs::examples = "{{ message }}", docs::examples = "{{ hostname }}",))]
-    key_field: Option<Template>,
-
-    /// A logical condition used to exclude events from sampling.
-    exclude: Option<AnyCondition>,
-
-    #[configurable(derived)]
-    #[serde(default)]
-    internal_metrics: ThrottleInternalMetricsConfig,
-}
-
-impl_generate_config_from_default!(ThrottleConfig);
-
-#[async_trait::async_trait]
-#[typetag::serde(name = "throttle")]
-impl TransformConfig for ThrottleConfig {
-    async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        Throttle::new(self, context, clock::MonotonicClock).map(Transform::event_task)
-    }
-
-    fn input(&self) -> Input {
-        Input::log()
-    }
-
-    fn outputs(
-        &self,
-        _: vector_lib::enrichment::TableRegistry,
-        input_definitions: &[(OutputId, schema::Definition)],
-        _: LogNamespace,
-    ) -> Vec<TransformOutput> {
-        // The event is not modified, so the definition is passed through as-is
-        vec![TransformOutput::new(
-            DataType::Log,
-            clone_input_definitions(input_definitions),
-        )]
-    }
-}
 
 #[derive(Clone)]
 pub struct Throttle<C: clock::Clock<Instant = I>, I: clock::Reference> {
-    quota: Quota,
-    flush_keys_interval: Duration,
+    pub quota: Quota,
+    pub flush_keys_interval: Duration,
     key_field: Option<Template>,
     exclude: Option<Condition>,
-    clock: C,
+    pub clock: C,
     internal_metrics: ThrottleInternalMetricsConfig,
 }
 
 impl<C, I> Throttle<C, I>
 where
-    C: clock::Clock<Instant = I>,
+    C: clock::Clock<Instant = I> + Send + Sync + 'static + Clone,
     I: clock::Reference,
 {
     pub fn new(
@@ -142,11 +66,26 @@ where
             internal_metrics: config.internal_metrics.clone(),
         })
     }
+
+    #[must_use]
+    pub fn start_rate_limiter<K>(&self) -> RateLimiterRunner<K, C>
+    where
+        K: Hash + Eq + Clone + Send + Sync + 'static,
+    {
+        RateLimiterRunner::start(self.quota, self.clock.clone(), self.flush_keys_interval)
+    }
+
+    pub fn emit_event_discarded(&self, key: String) {
+        emit!(ThrottleEventDiscarded {
+            key,
+            emit_events_discarded_per_key: self.internal_metrics.emit_events_discarded_per_key
+        });
+    }
 }
 
 impl<C, I> TaskTransform<Event> for Throttle<C, I>
 where
-    C: clock::Clock<Instant = I> + Send + 'static + Clone,
+    C: clock::Clock<Instant = I> + Send + Sync + 'static + Clone,
     I: clock::Reference + Send + 'static,
 {
     fn transform(
@@ -156,68 +95,43 @@ where
     where
         Self: 'static,
     {
-        let mut flush_keys = tokio::time::interval(self.flush_keys_interval * 2);
-
-        let limiter = RateLimiter::dashmap_with_clock(self.quota, self.clock.clone());
+        let limiter = self.start_rate_limiter();
 
         Box::pin(stream! {
-          loop {
-            let done = tokio::select! {
-                biased;
+            while let Some(event) = input_rx.next().await {
+                let (throttle, event) = match self.exclude.as_ref() {
+                    Some(condition) => {
+                        let (result, event) = condition.check(event);
+                        (!result, event)
+                    },
+                    _ => (true, event)
+                };
+                let output = if throttle {
+                    let key = self.key_field.as_ref().and_then(|t| {
+                        t.render_string(&event)
+                            .map_err(|error| {
+                                emit!(TemplateRenderingError {
+                                    error,
+                                    field: Some("key_field"),
+                                    drop_event: false,
+                                })
+                            })
+                            .ok()
+                    });
 
-                maybe_event = input_rx.next() => {
-                    match maybe_event {
-                        None => true,
-                        Some(event) => {
-                            let (throttle, event) = match self.exclude.as_ref() {
-                                Some(condition) => {
-                                    let (result, event) = condition.check(event);
-                                    (!result, event)
-                                },
-                                _ => (true, event)
-                            };
-                            let output = if throttle {
-                                let key = self.key_field.as_ref().and_then(|t| {
-                                    t.render_string(&event)
-                                        .map_err(|error| {
-                                            emit!(TemplateRenderingError {
-                                                error,
-                                                field: Some("key_field"),
-                                                drop_event: false,
-                                            })
-                                        })
-                                        .ok()
-                                });
-
-                                match limiter.check_key(&key) {
-                                    Ok(()) => {
-                                        Some(event)
-                                    }
-                                    _ => {
-                                        emit!(ThrottleEventDiscarded{
-                                            key: key.unwrap_or_else(|| "None".to_string()),
-                                            emit_events_discarded_per_key: self.internal_metrics.emit_events_discarded_per_key
-                                        });
-                                        None
-                                    }
-                                }
-                            } else {
-                                Some(event)
-                            };
-                            if let Some(event) = output {
-                                yield event;
-                            }
-                            false
-                        }
+                    if limiter.check_key(&key) {
+                        Some(event)
+                    } else {
+                        self.emit_event_discarded(key.unwrap_or_else(|| "None".to_string()));
+                        None
                     }
+                } else {
+                    Some(event)
+                };
+                if let Some(event) = output {
+                    yield event;
                 }
-                _ = flush_keys.tick() => {
-                    limiter.retain_recent();
-                    false
-                }
-            };
-            if done { break }
-          }
+            }
         })
     }
 }
@@ -235,17 +149,13 @@ mod tests {
     use futures::SinkExt;
 
     use super::*;
+    use crate::transforms::Transform;
     use crate::{
         event::LogEvent, test_util::components::assert_transform_compliance,
         transforms::test::create_topology,
     };
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
-
-    #[test]
-    fn generate_config() {
-        crate::test_util::test_generate_config::<ThrottleConfig>();
-    }
 
     #[tokio::test]
     async fn throttle_events() {

--- a/src/transforms/throttle/transform.rs
+++ b/src/transforms/throttle/transform.rs
@@ -30,7 +30,7 @@ pub struct Throttle<C: clock::Clock<Instant = I>, I: clock::Reference> {
 
 impl<C, I> Throttle<C, I>
 where
-    C: clock::Clock<Instant = I> + Send + Sync + 'static + Clone,
+    C: clock::Clock<Instant = I> + Clone + Send + Sync + 'static,
     I: clock::Reference,
 {
     pub fn new(
@@ -85,7 +85,7 @@ where
 
 impl<C, I> TaskTransform<Event> for Throttle<C, I>
 where
-    C: clock::Clock<Instant = I> + Send + Sync + 'static + Clone,
+    C: clock::Clock<Instant = I> + Clone + Send + Sync + 'static,
     I: clock::Reference + Send + 'static,
 {
     fn transform(


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

We want to re-use pieces of the `throttle` processor implementation, in particular the rate-limiter logic. Refactors out constructing / running the rate limiter (mainly by running I mean periodically flushing old keys) into a separate struct that can be re-used elsewhere. Also refactors out some metrics related code, and moves the `throttle` implementation inside it's own folder in `transforms` (further split `throttle.rs` into 2 files, `config.rs` and `transform.rs` to mimic the file structure seen in other transform implementations such as `sample`, `dedupe`, etc.)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Tested with vector config/pipeline containing throttle processor

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
