### PR TITLE
feat(sample transform): Sample by percent rate

### DIFF
--- a/changelog.d/sample-percentage.feature.md
+++ b/changelog.d/sample-percentage.feature.md
@@ -1,0 +1,3 @@
+The sample transform now accepts a percentage via a new configuration parameter named "percent_rate"
+
+authors: graphcareful

--- a/changelog.d/sample-ratio.feature.md
+++ b/changelog.d/sample-ratio.feature.md
@@ -1,0 +1,3 @@
+The sample transform now accepts a ratio via a new configuration parameter named "ratio"
+
+authors: graphcareful

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -56,7 +56,7 @@ pub struct SampleConfig {
     /// the rest are dropped. This differs from `rate` allowing the configuration of a higher
     /// precion value and also the ability to retain values of greater then 50% of all events. It is
     /// an error to provide a value for both `rate` and `ratio`.
-    #[configurable(metadata(docs::examples = "0.13"))]
+    #[configurable(metadata(docs::examples = 0.13))]
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
     pub ratio: Option<f64>,
 

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -46,7 +46,7 @@ pub struct SampleConfig {
     ///
     /// For example, `rate = 1500` means 1 out of every 1500 events are forwarded and the rest are
     /// dropped. This differs from `ratio` which allows more precise control over the number of events
-    /// retained and values greater then 1/2. It is an error to provide a value for both `rate` and `ratio`.
+    /// retained and values greater than 1/2. It is an error to provide a value for both `rate` and `ratio`.
     #[configurable(metadata(docs::examples = 1500))]
     pub rate: Option<u64>,
 
@@ -54,7 +54,7 @@ pub struct SampleConfig {
     ///
     /// For example, `ratio = .13` means that 13% out of all events on the stream are forwarded and
     /// the rest are dropped. This differs from `rate` allowing the configuration of a higher
-    /// precion value and also the ability to retain values of greater then 50% of all events. It is
+    /// precision value and also the ability to retain values of greater than 50% of all events. It is
     /// an error to provide a value for both `rate` and `ratio`.
     #[configurable(metadata(docs::examples = 0.13))]
     #[configurable(validation(range(min = 0.0, max = 1.0)))]

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -44,10 +44,10 @@ impl SampleMode {
             // field, hashing its contents this component should output events according to the
             // configured ratio.
             //
-            // To do this convert the hash to a number between 0 and 1 and compare to the ratio, to
-            // address issues with precision here the ratio is expanded to meet the width of the type of
-            // the hash.
-            hash_ratio_threshold: (ratio * ((u64::MAX as u128) + 1) as f64) as u64,
+            // To do one option would be to convert the hash to a number between 0 and 1 and compare
+            // to the ratio. However to address issues with precision, here the ratio is scaled to
+            // meet the width of the type of the hash.
+            hash_ratio_threshold: (ratio * (u64::MAX as u128) as f64) as u64,
         }
     }
 
@@ -56,8 +56,7 @@ impl SampleMode {
             Self::Rate { rate, counters } => {
                 let counter_value = counters.entry(group_by_key.clone()).or_default();
                 let old_counter_value = *counter_value;
-                let increment: u64 = *counter_value + 1;
-                *counter_value = increment;
+                *counter_value += 1;
                 old_counter_value % *rate == 0
             }
             Self::Ratio { ratio, values, .. } => {

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -89,7 +89,7 @@ impl Sample {
     // This function is dead code when the feature flag `transforms-impl-sample` is specified but not
     // `transforms-sample`.
     #![allow(dead_code)]
-    pub fn new(
+    pub const fn new(
         name: String,
         rate: SampleMode,
         key_field: Option<String>,

--- a/website/cue/reference/components/transforms/base/sample.cue
+++ b/website/cue/reference/components/transforms/base/sample.cue
@@ -41,11 +41,26 @@ base: components: transforms: sample: configuration: {
 			The rate at which events are forwarded, expressed as `1/N`.
 
 			For example, `rate = 1500` means 1 out of every 1500 events are forwarded and the rest are
-			dropped.
+			dropped. This differs from `ratio` which allows more precise control over the number of events
+			retained and values greater then 1/2. It is an error to provide a value for both `rate` and `ratio`.
 			"""
-		required: true
+		required: false
 		type: uint: examples: [
 			1500,
+		]
+	}
+	ratio: {
+		description: """
+			The rate at which events are forwarded, expressed as a percentage
+
+			For example, `ratio = .13` means that 13% out of all events on the stream are forwarded and
+			the rest are dropped. This differs from `rate` allowing the configuration of a higher
+			precion value and also the ability to retain values of greater then 50% of all events. It is
+			an error to provide a value for both `rate` and `ratio`.
+			"""
+		required: false
+		type: float: examples: [
+			"0.13",
 		]
 	}
 	sample_rate_key: {

--- a/website/cue/reference/components/transforms/base/sample.cue
+++ b/website/cue/reference/components/transforms/base/sample.cue
@@ -42,7 +42,7 @@ base: components: transforms: sample: configuration: {
 
 			For example, `rate = 1500` means 1 out of every 1500 events are forwarded and the rest are
 			dropped. This differs from `ratio` which allows more precise control over the number of events
-			retained and values greater then 1/2. It is an error to provide a value for both `rate` and `ratio`.
+			retained and values greater than 1/2. It is an error to provide a value for both `rate` and `ratio`.
 			"""
 		required: false
 		type: uint: examples: [
@@ -55,7 +55,7 @@ base: components: transforms: sample: configuration: {
 
 			For example, `ratio = .13` means that 13% out of all events on the stream are forwarded and
 			the rest are dropped. This differs from `rate` allowing the configuration of a higher
-			precion value and also the ability to retain values of greater then 50% of all events. It is
+			precision value and also the ability to retain values of greater than 50% of all events. It is
 			an error to provide a value for both `rate` and `ratio`.
 			"""
 		required: false

--- a/website/cue/reference/components/transforms/base/sample.cue
+++ b/website/cue/reference/components/transforms/base/sample.cue
@@ -60,7 +60,7 @@ base: components: transforms: sample: configuration: {
 			"""
 		required: false
 		type: float: examples: [
-			"0.13",
+			0.13,
 		]
 	}
 	sample_rate_key: {


### PR DESCRIPTION
## Summary
This change introduces the ability for the sample processor to reduce the amount of data on a stream in terms of percentages.

This allows for the ability to sample more then 50% of the stream, an ability it did not have before when the rate was expressed by the formula 1/N

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Unit tests. Also added an additional test to explicitly test rates > 50%

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [x] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

