### PR TITLE
enhancement(internal): Implement Display trait for Discriminant type

### DIFF
--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -166,7 +166,7 @@ impl Display for Discriminant {
             if i != 0 {
                 write!(fmt, "-")?;
             }
-            write!(fmt, "{}", value.as_ref().map_or("none".to_string(), std::string::ToString::to_string))?
+            write!(fmt, "{}", value.as_ref().map_or("none".to_string(), ToString::to_string))?
         }
         Ok(())
     }

--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 use super::{LogEvent, ObjectMap, Value};
@@ -160,13 +159,17 @@ fn hash_null<H: Hasher>(hasher: &mut H) {
     hasher.write_u8(0);
 }
 
-impl Display for Discriminant {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+impl fmt::Display for Discriminant {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         for (i, value) in self.values.iter().enumerate() {
             if i != 0 {
                 write!(fmt, "-")?;
             }
-            write!(fmt, "{}", value.as_ref().map_or("none".to_string(), ToString::to_string))?
+            if let Some(value) = value {
+                value.fmt(fmt)?;
+            } else {
+                fmt.write_str("none")?;
+            }
         }
         Ok(())
     }

--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -162,17 +162,13 @@ fn hash_null<H: Hasher>(hasher: &mut H) {
 
 impl Display for Discriminant {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        fmt.write_str(
-            &self
-                .values
-                .iter()
-                .map(|x| {
-                    x.as_ref()
-                        .map_or("none".to_string(), std::string::ToString::to_string)
-                })
-                .collect::<Vec<String>>()
-                .join("-"),
-        )
+        for (i, value) in self.values.iter().enumerate() {
+            if i != 0 {
+                write!(fmt, "-")?;
+            }
+            write!(fmt, "{}", value.as_ref().map_or("none".to_string(), std::string::ToString::to_string))?
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Implements the `Display` trait for the `Discriminant` type, which will be used elsewhere to format a `Discriminant` type for metrics. For now not trimming quotes on Bytes type Values to simplify things (something like `trim_matches` will trim quotes that are technically a part of the string, for example if the String is `"""`, then `trim_matches` will trim this to an empty string)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ ] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

Added unit test

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [ ] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
