### PR TITLE
feat(source): adding metric ingestion to opentelemetry source

### DIFF
--- a/changelog.d/opentelemetry_metrics.feature.md
+++ b/changelog.d/opentelemetry_metrics.feature.md
@@ -1,0 +1,3 @@
+Support ingesting metrics through opentelemetry source(experimental)
+
+authors: cmcmacs

--- a/lib/opentelemetry-proto/build.rs
+++ b/lib/opentelemetry-proto/build.rs
@@ -9,9 +9,11 @@ fn main() -> Result<(), Error> {
                 "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
                 "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
                 "src/proto/opentelemetry-proto/opentelemetry/proto/logs/v1/logs.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto",
                 "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto",
                 "src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
                 "src/proto/opentelemetry-proto/opentelemetry/proto/collector/logs/v1/logs_service.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
             ],
             &["src/proto/opentelemetry-proto"],
         )?;

--- a/lib/opentelemetry-proto/src/proto.rs
+++ b/lib/opentelemetry-proto/src/proto.rs
@@ -10,6 +10,11 @@ pub mod collector {
             tonic::include_proto!("opentelemetry.proto.collector.logs.v1");
         }
     }
+    pub mod metrics {
+        pub mod v1 {
+            tonic::include_proto!("opentelemetry.proto.collector.metrics.v1");
+        }
+    }
 }
 
 /// Common types used across all event types.
@@ -23,6 +28,13 @@ pub mod common {
 pub mod logs {
     pub mod v1 {
         tonic::include_proto!("opentelemetry.proto.logs.v1");
+    }
+}
+
+/// Generated types used for metrics.
+pub mod metrics {
+    pub mod v1 {
+        tonic::include_proto!("opentelemetry.proto.metrics.v1");
     }
 }
 

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -15,6 +15,7 @@ use vector_lib::internal_event::{
 };
 use vector_lib::opentelemetry::proto::collector::{
     logs::v1::{ExportLogsServiceRequest, ExportLogsServiceResponse},
+    metrics::v1::{ExportMetricsServiceRequest, ExportMetricsServiceResponse},
     trace::v1::{ExportTraceServiceRequest, ExportTraceServiceResponse},
 };
 use vector_lib::tls::MaybeTlsIncomingStream;
@@ -100,7 +101,13 @@ pub(crate) fn build_warp_filter(
         out.clone(),
         bytes_received.clone(),
         events_received.clone(),
-        headers,
+        headers.clone(),
+    );
+    let metrics_filters = build_warp_metrics_filter(
+        acknowledgements,
+        out.clone(),
+        bytes_received.clone(),
+        events_received.clone(),
     );
     let trace_filters = build_warp_trace_filter(
         acknowledgements,
@@ -108,7 +115,12 @@ pub(crate) fn build_warp_filter(
         bytes_received,
         events_received,
     );
-    log_filters.or(trace_filters).unify().boxed()
+    log_filters
+        .or(trace_filters)
+        .unify()
+        .or(metrics_filters)
+        .unify()
+        .boxed()
 }
 
 fn enrich_events(
@@ -164,6 +176,37 @@ fn build_warp_log_filter(
                 )
             },
         )
+        .boxed()
+}
+
+fn build_warp_metrics_filter(
+    acknowledgements: bool,
+    out: SourceSender,
+    bytes_received: Registered<BytesReceived>,
+    events_received: Registered<EventsReceived>,
+) -> BoxedFilter<(Response,)> {
+    warp::post()
+        .and(warp::path!("v1" / "metrics"))
+        .and(warp::header::exact_ignore_case(
+            "content-type",
+            "application/x-protobuf",
+        ))
+        .and(warp::header::optional::<String>("content-encoding"))
+        .and(warp::body::bytes())
+        .and_then(move |encoding_header: Option<String>, body: Bytes| {
+            let events = decode(encoding_header.as_deref(), body).and_then(|body| {
+                bytes_received.emit(ByteSize(body.len()));
+                decode_metrics_body(body, &events_received)
+            });
+
+            handle_request(
+                events,
+                acknowledgements,
+                out.clone(),
+                super::METRICS,
+                ExportMetricsServiceResponse::default(),
+            )
+        })
         .boxed()
 }
 
@@ -239,6 +282,31 @@ fn decode_log_body(
         .resource_logs
         .into_iter()
         .flat_map(|v| v.into_event_iter(log_namespace))
+        .collect();
+
+    events_received.emit(CountByteSize(
+        events.len(),
+        events.estimated_json_encoded_size_of(),
+    ));
+
+    Ok(events)
+}
+
+fn decode_metrics_body(
+    body: Bytes,
+    events_received: &Registered<EventsReceived>,
+) -> Result<Vec<Event>, ErrorMessage> {
+    let request = ExportMetricsServiceRequest::decode(body).map_err(|error| {
+        ErrorMessage::new(
+            StatusCode::BAD_REQUEST,
+            format!("Could not decode request: {}", error),
+        )
+    })?;
+
+    let events: Vec<Event> = request
+        .resource_metrics
+        .into_iter()
+        .flat_map(|v| v.into_event_iter())
         .collect();
 
     events_received.emit(CountByteSize(

--- a/src/sources/opentelemetry/integration_tests.rs
+++ b/src/sources/opentelemetry/integration_tests.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use itertools::Itertools;
 use serde_json::json;
 
-use super::{LOGS, TRACES};
+use super::{LOGS, METRICS, TRACES};
 use crate::{
     config::{log_schema, SourceConfig, SourceContext},
     event::EventStatus,
@@ -15,12 +15,17 @@ use crate::{
 };
 use prost::Message;
 
+use super::{tests::new_source, GrpcConfig, HttpConfig, OpentelemetryConfig};
 use vector_lib::opentelemetry::proto::{
-    collector::trace::v1::ExportTraceServiceRequest,
+    collector::{metrics::v1::ExportMetricsServiceRequest, trace::v1::ExportTraceServiceRequest},
+    common::v1::{any_value::Value::StringValue, AnyValue, InstrumentationScope, KeyValue},
+    metrics::v1::{
+        metric::Data, number_data_point::Value, Gauge, Metric, NumberDataPoint, ResourceMetrics,
+        ScopeMetrics,
+    },
+    resource::v1::Resource,
     trace::v1::{ResourceSpans, ScopeSpans, Span},
 };
-
-use super::{tests::new_source, GrpcConfig, HttpConfig, OpentelemetryConfig};
 
 fn otel_health_url() -> String {
     std::env::var("OTEL_HEALTH_URL").unwrap_or_else(|_| "http://0.0.0.0:13133".to_owned())
@@ -177,6 +182,108 @@ async fn receive_trace() {
         // The Opentelemetry Collector is configured to send to both the gRPC and HTTP endpoints
         // so we should expect to collect two events from the single log sent.
         let events = collect_n(trace_output, 2).await;
+        assert_eq!(events.len(), 2);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn receive_metric() {
+    // generate a metrics gauge request
+    let req = ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(StringValue("vector-collector".to_string())),
+                    }),
+                }],
+                dropped_attributes_count: 0,
+            }),
+            schema_url: "".to_string(),
+            scope_metrics: vec![ScopeMetrics {
+                scope: Some(InstrumentationScope {
+                    name: "vector-collector-instrumentation".to_string(),
+                    version: "0.111.0".to_string(),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                }),
+                schema_url: "".to_string(),
+                metrics: vec![Metric {
+                    name: "some.random.metric".to_string(),
+                    description: "Some random metric we use for test".to_string(),
+                    unit: "1".to_string(),
+                    data: Some(Data::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            attributes: vec![
+                                KeyValue {
+                                    key: "host".to_string(),
+                                    value: Some(AnyValue {
+                                        value: Some(StringValue("localhost".to_string())),
+                                    }),
+                                },
+                                KeyValue {
+                                    key: "service".to_string(),
+                                    value: Some(AnyValue {
+                                        value: Some(StringValue("vector-collector".to_string())),
+                                    }),
+                                },
+                            ],
+                            start_time_unix_nano: 0,
+                            time_unix_nano: SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap()
+                                .as_nanos() as u64,
+                            value: Some(Value::AsDouble(42.0)),
+                            exemplars: vec![],
+                            flags: 0,
+                        }],
+                    })),
+                }],
+            }],
+        }],
+    };
+
+    let body = req.encode_to_vec();
+
+    assert_source_compliance(&SOURCE_TAGS, async {
+        wait_ready(otel_health_url()).await;
+
+        let config = OpentelemetryConfig {
+            grpc: GrpcConfig {
+                address: source_grpc_address().parse().unwrap(),
+                tls: Default::default(),
+            },
+            http: HttpConfig {
+                address: source_http_address().parse().unwrap(),
+                tls: Default::default(),
+                keepalive: Default::default(),
+                headers: vec![],
+            },
+            acknowledgements: Default::default(),
+            log_namespace: Default::default(),
+        };
+
+        let (sender, metrics_output, _) = new_source(EventStatus::Delivered, METRICS.to_string());
+        let server = config
+            .build(SourceContext::new_test(sender, None))
+            .await
+            .unwrap();
+        tokio::spawn(server);
+        wait_for_tcp(source_grpc_address()).await;
+        wait_for_tcp(source_http_address()).await;
+
+        let client = reqwest::Client::new();
+        let _res = client
+            .post(format!("{}/v1/metrics", otel_otlp_url()))
+            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+            .body(body)
+            .send()
+            .await
+            .expect("Failed to send metrics to Opentelemetry Collector.");
+
+        let events = collect_n(metrics_output, 2).await;
         assert_eq!(events.len(), 2);
     })
     .await;

--- a/tests/data/opentelemetry/config.yaml
+++ b/tests/data/opentelemetry/config.yaml
@@ -29,3 +29,6 @@ service:
     traces:
       receivers: [otlp]
       exporters: [otlp,otlphttp]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp,otlphttp]

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -41,7 +41,7 @@ components: sources: opentelemetry: {
 		requirements: []
 		warnings: [
 			"""
-				The `opentelemetry` source only supports log and trace events at this time.
+				The `opentelemetry` source only supports log, trace and metric events at this time.
 				""",
 		]
 		notices: []
@@ -64,6 +64,12 @@ components: sources: opentelemetry: {
 			name: "traces"
 			description: """
 				Received trace events will go to this output stream. Use `<component_id>.traces` as an input to downstream transforms and sinks.
+				"""
+		},
+		{
+			name: "metrics"
+			description: """
+				Received metric events will go to this output stream. Use `<component_id>.metrics` as an input to downstream transforms and sinks.
 				"""
 		},
 	]
@@ -254,6 +260,12 @@ components: sources: opentelemetry: {
 			title: "Ingest OTLP traces"
 			body: """
 				Trace support is experimental and subject to change as Vector has no strongly-typed structure for traces internally. Instead traces are stored as a key/value map similar to logs. This may change in the future to be a structured format.
+				"""
+		}
+		metrics: {
+			title: "Ingest metrics"
+			body: """
+				Metrics support is experimental and subject to change due to the differences in metrics structure between internal Vector metric DataModel and OpenTelemetry, difference to note: Exponential Histogram is transformed into regular Aggregated Histogram, buckets are being calculated based on the base and scale.
 				"""
 		}
 	}


### PR DESCRIPTION
## Summary
This PR adds ability to accept metrics via Opentelemetry Source.
Due to challenges in mapping OpentelMetrics to Internal Vector DataModel, there are different mechanics to create the mapping, but overall the short view:
OpenTelemetry Gauge => Vector Gauge(MetricKind::Absolute)
OpenTelemetry Sum => Vector Counter(if is_monotonic, then MetricKind::Incremental else MetricKind::Absolute)
OpenTelemetry Histogram => Vector AggregatedHistogram
OpenTelemetry Exponential Histogram => Vector AggregatedHistogram <- this is pretty strange, but I don't know how to do it better, we basically restore bucket ranges from scale
OpenTelemetry Summary(deprecated) => Vector Aggregated Summary

Doc for reference: https://opentelemetry.io/docs/specs/otel/metrics/data-model/

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [x] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- [ ] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: [https://github.com/vectordotdev/vector/issues/17309](https://github.com/vectordotdev/vector/issues/17309)
