### PR TITLE
fix(dev): use explicit cast because deranged crate may break compile

### DIFF
--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -456,8 +456,7 @@ impl AgentDDSketch {
         // something horribly broken.
         assert!(
             keys.len()
-                <= u32::MAX
-                    .try_into()
+                <= TryInto::<usize>::try_into(u32::MAX)
                     .expect("we don't support 16-bit systems")
         );
 

--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -456,8 +456,7 @@ impl AgentDDSketch {
         // something horribly broken.
         assert!(
             keys.len()
-                <= TryInto::<usize>::try_into(u32::MAX)
-                    .expect("we don't support 16-bit systems")
+                <= TryInto::<usize>::try_into(u32::MAX).expect("we don't support 16-bit systems")
         );
 
         keys.sort_unstable();


### PR DESCRIPTION
This patch adds an explicit type conversion to avoid the ambiguity:
```
assert!(
    keys.len()
        <= usize::try_from(u32::MAX)
            .expect("we don't support 16-bit systems")
);

```
When you self compile Vector with `time` or `domain` crate, you will meet this error:
```
error[E0283]: type annotations needed
   --> /home/suika/.cargo/git/checkouts/vector-7010c25277c07669/063cabb/lib/vector-core/src/metrics/ddsketch.rs:460:22
    |
459 |                 <= u32::MAX
    |                 -- type must be known at this point
460 |                     .try_into()
    |                      ^^^^^^^^
    |
    = note: multiple `impl`s satisfying `usize: PartialOrd<_>` found in the following crates: `core`, `deranged`:
            - impl PartialOrd for usize;
            - impl<MIN, MAX> PartialOrd<deranged::RangedUsize<MIN, MAX>> for usize
              where the constant `MIN` has type `usize`, the constant `MAX` has type `usize`;
help: try using a fully qualified path to specify the expected types
    |
459 |                 <= <u32 as TryInto<T>>::try_into(u32::MAX)
    |                    ++++++++++++++++++++++++++++++       
```
We can use  turbofish syntax (.try_into::<usize>()) to explicit specify which type we need.