### PR TITLE
fix(file source): Remove known small files based on remove_after_secs

### DIFF
--- a/changelog.d/22786_remove_empty_file_after_secs.fix.md
+++ b/changelog.d/22786_remove_empty_file_after_secs.fix.md
@@ -1,0 +1,3 @@
+Remove known small files based on remove_after_secs.
+
+authors: linw1995

--- a/changelog.d/22786_remove_empty_file_after_secs.fix.md
+++ b/changelog.d/22786_remove_empty_file_after_secs.fix.md
@@ -1,3 +1,3 @@
-Remove known small files based on remove_after_secs.
+Fixed `file` source bug where known small files were not deleted after the specified `remove_after_secs`.
 
 authors: linw1995


### PR DESCRIPTION
Remove known small files based on remove_after_secs.

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

This test checks whether Vector properly removes empty log files after the configured `remove_after_secs` timeout.

#### Configuration

```yaml
data_dir: ./data

sources:
  in:
    type: "file"
    include:
      - ./log/**/*.log
    remove_after_secs: 60

sinks:
  out:
    inputs: ["in"]
    type: "console"
    encoding:
      codec: "text"
```

Use the above config to start a Vector instance.

#### Steps

```sh
# Create an empty log file
touch ./log/emptyfile.log

# Create another file that will receive data later
touch ./log/file.log

# Wait 10 seconds
sleep 10s

# Append a single log line to file.log
echo "single line" >> ./log/file.log

# Wait 30 more seconds
sleep 30s

# Append another line
echo "single line" >> ./log/file.log
```

#### Expected Behavior

- `emptyfile.log` should be deleted after 60 seconds since it remains empty.
- `file.log` should **not** be deleted immediately, because it receives data during the interval and becomes fingerprintable.

#### Observed Vector Logs

```text
2025-04-18T16:17:47.016459Z  WARN source{component_kind="source" component_id=in component_type=file}:file_server: vector::internal_events::file::source: Currently ignoring file too small to fingerprint. file=log/emptyfile.log
2025-04-18T16:17:47.016606Z  WARN source{component_kind="source" component_id=in component_type=file}:file_server: vector::internal_events::file::source: Currently ignoring file too small to fingerprint. file=log/file.log
2025-04-18T16:17:57.269562Z  INFO source{component_kind="source" component_id=in component_type=file}:file_server: vector::internal_events::file::source: Found new file to watch. file=log/file.log
single line
single line
2025-04-18T16:18:48.601732Z  INFO source{component_kind="source" component_id=in component_type=file}:file_server: vector::internal_events::file::source: File deleted. file=log/emptyfile.log
2025-04-18T16:19:46.045848Z  INFO source{component_kind="source" component_id=in component_type=file}:file_server: vector::internal_events::file::source: File deleted. file=log/file.log
2025-04-18T16:19:46.045917Z  INFO source{component_kind="source" component_id=in component_type=file}:file_server: vector::internal_events::file::source: Stopped watching file. file=log/file.log reached_eof="true"
```

#### Conclusion

Vector removes empty files as expected. However, files that start empty and receive data *later* are still deleted if they are not updated frequently enough to maintain activity within the `remove_after_secs` window. This behavior may vary depending on how quickly the file becomes fingerprintable.

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them. To minimize round-trips see the following local checks:
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: #22762

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
