### PR TITLE
feat(cli): Add support for rendering to mermaid with `vector graph` command

### DIFF
--- a/changelog.d/14082_add_mermaid_support.feature.md
+++ b/changelog.d/14082_add_mermaid_support.feature.md
@@ -1,0 +1,3 @@
+Add support for rendering to Mermaid format in `vector graph`
+
+authors: Firehed

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -200,31 +200,31 @@ fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
     // https://mermaid.js.org/syntax/flowchart.html#styling-and-classes
     writeln!(mermaid, "\n  %% Sources").unwrap();
     for (id, _) in config.sources() {
-        writeln!(mermaid, "  {}[/{}/]", id, id).unwrap();
+        writeln!(mermaid, "  {id}[/{id}/]").unwrap();
     }
 
     writeln!(mermaid, "\n  %% Transforms").unwrap();
     for (id, transform) in config.transforms() {
-        writeln!(mermaid, "  {}{{{}}}", id, id).unwrap();
+        writeln!(mermaid, "  {id}{{{id}}}").unwrap();
 
         for input in transform.inputs.iter() {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id).unwrap();
+                writeln!(mermaid, "  {0} -->|{port}| {id}", input.component).unwrap();
             } else {
-                writeln!(mermaid, "  {} --> {}", input.component, id).unwrap();
+                writeln!(mermaid, "  {0} --> {id}", input.component).unwrap();
             }
         }
     }
 
     writeln!(mermaid, "\n  %% Sinks").unwrap();
     for (id, sink) in config.sinks() {
-        writeln!(mermaid, "  {}[\\{}\\]", id, id).unwrap();
+        writeln!(mermaid, "  {id}[\\{id}\\]").unwrap();
 
         for input in &sink.inputs {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id).unwrap();
+                writeln!(mermaid, "  {0} -->|{port}| {id}", input.component).unwrap();
             } else {
-                writeln!(mermaid, "  {} --> {}", input.component, id).unwrap();
+                writeln!(mermaid, "  {0} --> {id}", input.component).unwrap();
             }
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -49,6 +49,9 @@ pub struct Opts {
     pub config_dirs: Vec<PathBuf>,
 
     /// Set the output format
+    ///
+    /// See https://mermaid.js.org/syntax/flowchart.html#styling-and-classes for
+    /// information on the `mermaid` format.
     #[arg(id = "format", long, default_value = "dot")]
     pub format: OutputFormat,
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -47,6 +47,16 @@ pub struct Opts {
         value_delimiter(',')
     )]
     pub config_dirs: Vec<PathBuf>,
+
+    /// Set the output format
+    #[arg(id = "format", long, default_value = "dot")]
+    pub format: OutputFormat,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Dot,
+    Mermaid,
 }
 
 impl Opts {
@@ -96,6 +106,19 @@ pub(crate) fn cmd(opts: &Opts) -> exitcode::ExitCode {
         }
     };
 
+    let format = opts.format;
+    match format {
+        OutputFormat::Dot => render_dot(config),
+        OutputFormat::Mermaid => render_mermaid(config),
+    }
+}
+
+fn render_mermaid(_: config::Config) -> exitcode::ExitCode {
+    eprintln!("mermaid path");
+    exitcode::CONFIG
+}
+
+fn render_dot(config: config::Config) -> exitcode::ExitCode {
     let mut dot = String::from("digraph {\n");
 
     for (id, source) in config.sources() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -116,6 +116,17 @@ pub(crate) fn cmd(opts: &Opts) -> exitcode::ExitCode {
 fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
     let mut mermaid = String::from("flowchart TD;\n");
 
+    // Note: The `.graph.node_attributes` config is ignored for Mermaid rendering
+    // since it's explicitly set to be in DOT format. It should be possible to
+    // adapt but it's likely to lead to conflicts between the two formats.
+    //
+    // It could look like:
+    // node_id@{shape: shapename}
+    // style node_id key:value,key2:value2
+    //
+    // (shapename would replace the shorthand in the current version)
+    //
+    // https://mermaid.js.org/syntax/flowchart.html#styling-and-classes
     writeln!(mermaid, "\n  %% Sources").expect("write to String never fails");
     for (id, _) in config.sources() {
         writeln!(mermaid, "  {}[/{}/]", id, id)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -198,40 +198,33 @@ fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
     // (shapename would replace the shorthand in the current version)
     //
     // https://mermaid.js.org/syntax/flowchart.html#styling-and-classes
-    writeln!(mermaid, "\n  %% Sources").expect("write to String never fails");
+    writeln!(mermaid, "\n  %% Sources").unwrap();
     for (id, _) in config.sources() {
-        writeln!(mermaid, "  {}[/{}/]", id, id)
-            .expect("write to String never fails");
+        writeln!(mermaid, "  {}[/{}/]", id, id).unwrap();
     }
 
-    writeln!(mermaid, "\n  %% Transforms").expect("write to String never fails");
+    writeln!(mermaid, "\n  %% Transforms").unwrap();
     for (id, transform) in config.transforms() {
-        writeln!(mermaid, "  {}{{{}}}", id, id)
-            .expect("write to String never fails");
+        writeln!(mermaid, "  {}{{{}}}", id, id).unwrap();
 
         for input in transform.inputs.iter() {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id)
-                    .expect("write to String never fails");
+                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id).unwrap();
             } else {
-                writeln!(mermaid, "  {} --> {}", input.component, id)
-                    .expect("write to String never fails");
+                writeln!(mermaid, "  {} --> {}", input.component, id).unwrap();
             }
         }
     }
 
-    writeln!(mermaid, "\n  %% Sinks").expect("write to String never fails");
+    writeln!(mermaid, "\n  %% Sinks").unwrap();
     for (id, sink) in config.sinks() {
-        writeln!(mermaid, "  {}[\\{}\\]", id, id)
-            .expect("write to String never fails");
+        writeln!(mermaid, "  {}[\\{}\\]", id, id).unwrap();
 
         for input in &sink.inputs {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id)
-                    .expect("write to String never fails");
+                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id).unwrap();
             } else {
-                writeln!(mermaid, "  {} --> {}", input.component, id)
-                    .expect("write to String never fails");
+                writeln!(mermaid, "  {} --> {}", input.component, id).unwrap();
             }
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -113,66 +113,6 @@ pub(crate) fn cmd(opts: &Opts) -> exitcode::ExitCode {
     }
 }
 
-fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
-    let mut mermaid = String::from("flowchart TD;\n");
-
-    // Note: The `.graph.node_attributes` config is ignored for Mermaid rendering
-    // since it's explicitly set to be in DOT format. It should be possible to
-    // adapt but it's likely to lead to conflicts between the two formats.
-    //
-    // It could look like:
-    // node_id@{shape: shapename}
-    // style node_id key:value,key2:value2
-    //
-    // (shapename would replace the shorthand in the current version)
-    //
-    // https://mermaid.js.org/syntax/flowchart.html#styling-and-classes
-    writeln!(mermaid, "\n  %% Sources").expect("write to String never fails");
-    for (id, _) in config.sources() {
-        writeln!(mermaid, "  {}[/{}/]", id, id)
-            .expect("write to String never fails");
-    }
-
-    writeln!(mermaid, "\n  %% Transforms").expect("write to String never fails");
-    for (id, transform) in config.transforms() {
-        writeln!(mermaid, "  {}{{{}}}", id, id)
-            .expect("write to String never fails");
-
-        for input in transform.inputs.iter() {
-            if let Some(port) = &input.port {
-                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id)
-                    .expect("write to String never fails");
-            } else {
-                writeln!(mermaid, "  {} --> {}", input.component, id)
-                    .expect("write to String never fails");
-            }
-        }
-    }
-
-    writeln!(mermaid, "\n  %% Sinks").expect("write to String never fails");
-    for (id, sink) in config.sinks() {
-        writeln!(mermaid, "  {}[\\{}\\]", id, id)
-            .expect("write to String never fails");
-
-        for input in &sink.inputs {
-            if let Some(port) = &input.port {
-                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id)
-                    .expect("write to String never fails");
-            } else {
-                writeln!(mermaid, "  {} --> {}", input.component, id)
-                    .expect("write to String never fails");
-            }
-        }
-    }
-
-    #[allow(clippy::print_stdout)]
-    {
-        println!("{}", mermaid);
-    }
-
-    exitcode::OK
-}
-
 fn render_dot(config: config::Config) -> exitcode::ExitCode {
     let mut dot = String::from("digraph {\n");
 
@@ -239,6 +179,66 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
     #[allow(clippy::print_stdout)]
     {
         println!("{}", dot);
+    }
+
+    exitcode::OK
+}
+
+fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
+    let mut mermaid = String::from("flowchart TD;\n");
+
+    // Note: The `.graph.node_attributes` config is ignored for Mermaid rendering
+    // since it's explicitly set to be in DOT format. It should be possible to
+    // adapt but it's likely to lead to conflicts between the two formats.
+    //
+    // It could look like:
+    // node_id@{shape: shapename}
+    // style node_id key:value,key2:value2
+    //
+    // (shapename would replace the shorthand in the current version)
+    //
+    // https://mermaid.js.org/syntax/flowchart.html#styling-and-classes
+    writeln!(mermaid, "\n  %% Sources").expect("write to String never fails");
+    for (id, _) in config.sources() {
+        writeln!(mermaid, "  {}[/{}/]", id, id)
+            .expect("write to String never fails");
+    }
+
+    writeln!(mermaid, "\n  %% Transforms").expect("write to String never fails");
+    for (id, transform) in config.transforms() {
+        writeln!(mermaid, "  {}{{{}}}", id, id)
+            .expect("write to String never fails");
+
+        for input in transform.inputs.iter() {
+            if let Some(port) = &input.port {
+                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id)
+                    .expect("write to String never fails");
+            } else {
+                writeln!(mermaid, "  {} --> {}", input.component, id)
+                    .expect("write to String never fails");
+            }
+        }
+    }
+
+    writeln!(mermaid, "\n  %% Sinks").expect("write to String never fails");
+    for (id, sink) in config.sinks() {
+        writeln!(mermaid, "  {}[\\{}\\]", id, id)
+            .expect("write to String never fails");
+
+        for input in &sink.inputs {
+            if let Some(port) = &input.port {
+                writeln!(mermaid, "  {} -->|{}| {}", input.component, port, id)
+                    .expect("write to String never fails");
+            } else {
+                writeln!(mermaid, "  {} --> {}", input.component, id)
+                    .expect("write to String never fails");
+            }
+        }
+    }
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("{}", mermaid);
     }
 
     exitcode::OK

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -114,7 +114,7 @@ pub(crate) fn cmd(opts: &Opts) -> exitcode::ExitCode {
 }
 
 fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
-    let mut mermaid = String::from("graph TD;\n");
+    let mut mermaid = String::from("flowchart TD;\n");
 
     writeln!(mermaid, "\n  %% Sources").expect("write to String never fails");
     for (id, _) in config.sources() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -187,17 +187,6 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
 fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
     let mut mermaid = String::from("flowchart TD;\n");
 
-    // Note: The `.graph.node_attributes` config is ignored for Mermaid rendering
-    // since it's explicitly set to be in DOT format. It should be possible to
-    // adapt but it's likely to lead to conflicts between the two formats.
-    //
-    // It could look like:
-    // node_id@{shape: shapename}
-    // style node_id key:value,key2:value2
-    //
-    // (shapename would replace the shorthand in the current version)
-    //
-    // https://mermaid.js.org/syntax/flowchart.html#styling-and-classes
     writeln!(mermaid, "\n  %% Sources").unwrap();
     for (id, _) in config.sources() {
         writeln!(mermaid, "  {id}[/{id}/]").unwrap();


### PR DESCRIPTION
## Summary

Adds support for rendering to `mermaid` format by running `vector graph --format mermaid`, as discussed and described in #14082.

Note: The `.graph.node_attributes` config is ignored for Mermaid rendering since it's explicitly set to be in DOT format. It should be possible to adapt but it's likely to lead to conflicts between the two formats.

In terms of implementing, could look like:
```
node_id@{shape: shapename}
style node_id key:value,key2:value2
```
(shapename would replace the shorthand in the current version; i.e. `/id/`)

https://mermaid.js.org/syntax/flowchart.html#styling-and-classes

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Ran `vector graph` against an existing config with:
- no new flags
- `--format dot`
- `--format mermaid`

I observed no behavioral changes for the first two paths, and output rendered in mermaid format for the latter. I tested the output at https://mermaid.live to verify it rendered as expected.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them. To minimize round-trips see the following local checks:
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: https://github.com/vectordotdev/vector/issues/14082
