### PR TITLE
feat!(opentelemetry sink): Add support for encoders

### DIFF
--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -17,7 +17,7 @@ use super::proto::{
         any_value::Value as PBValue, AnyValue, ArrayValue, InstrumentationScope, KeyValue,
         KeyValueList,
     },
-    logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber},
+    logs::v1::{LogRecord, ResourceLogs, SeverityNumber},
     resource::v1::Resource,
     trace::v1::{
         span::{Event as SpanEvent, Link},

--- a/lib/opentelemetry-proto/src/convert.rs
+++ b/lib/opentelemetry-proto/src/convert.rs
@@ -7,15 +7,17 @@ use vector_core::{
     config::{log_schema, LegacyKey, LogNamespace},
     event::{Event, LogEvent, TraceEvent},
 };
-use vrl::value::KeyString;
 use vrl::{
     event_path,
-    value::{ObjectMap, Value},
+    value::{KeyString, ObjectMap, Value},
 };
 
 use super::proto::{
-    common::v1::{any_value::Value as PBValue, InstrumentationScope, KeyValue},
-    logs::v1::{LogRecord, ResourceLogs, SeverityNumber},
+    common::v1::{
+        any_value::Value as PBValue, AnyValue, ArrayValue, InstrumentationScope, KeyValue,
+        KeyValueList,
+    },
+    logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber},
     resource::v1::Resource,
     trace::v1::{
         span::{Event as SpanEvent, Link},
@@ -75,6 +77,32 @@ impl ResourceSpans {
     }
 }
 
+impl From<Value> for AnyValue {
+    fn from(value: Value) -> Self {
+        let v = match value {
+            Value::Null => return AnyValue { value: None },
+            Value::Boolean(b) => PBValue::BoolValue(b),
+            Value::Integer(i) => PBValue::IntValue(i),
+            Value::Float(f) => PBValue::DoubleValue(f.into()),
+            Value::Regex(r) => PBValue::StringValue(r.as_str().to_string()),
+            Value::Timestamp(t) => PBValue::StringValue(t.to_string()),
+            Value::Bytes(bytes) => PBValue::BytesValue(bytes.into()),
+            Value::Object(obj) => PBValue::KvlistValue(obj.into()),
+            Value::Array(arr) => PBValue::ArrayValue(arr.into()),
+        };
+
+        AnyValue { value: Some(v) }
+    }
+}
+
+impl From<Vec<Value>> for ArrayValue {
+    fn from(values: Vec<Value>) -> Self {
+        ArrayValue {
+            values: values.into_iter().map(|v| v.into()).collect(),
+        }
+    }
+}
+
 impl From<PBValue> for Value {
     fn from(av: PBValue) -> Self {
         match av {
@@ -118,6 +146,35 @@ fn kv_list_into_value(arr: Vec<KeyValue>) -> Value {
             })
             .collect::<ObjectMap>(),
     )
+}
+
+impl From<KeyValueList> for Vec<KeyValue> {
+    fn from(value: KeyValueList) -> Self {
+        value.values
+    }
+}
+
+impl From<ObjectMap> for KeyValueList {
+    fn from(value: ObjectMap) -> Self {
+        let v = value
+            .into_iter()
+            .map(|(k, v)| KeyValue {
+                key: k.to_string(),
+                value: Some(v.into()),
+            })
+            .collect();
+        KeyValueList { values: v }
+    }
+}
+
+impl TryFrom<Value> for KeyValueList {
+    type Error = &'static str;
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Object(map) => Ok(map.into()),
+            _ => Err("Invalid Value type for KeyValueList"),
+        }
+    }
 }
 
 fn to_hex(d: &[u8]) -> String {

--- a/src/sinks/opentelemetry/config.rs
+++ b/src/sinks/opentelemetry/config.rs
@@ -1,0 +1,314 @@
+//! Configuration for the `gcp_stackdriver_logs` sink.
+
+use crate::{
+    gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
+    http::HttpClient,
+    schema,
+    sinks::{
+        gcs_common::config::healthcheck_response,
+        prelude::*,
+        util::{
+            http::{http_response_retry_logic, HttpService},
+            service::TowerRequestConfigDefaults,
+            BoxedRawValue, RealtimeSizeBasedDefaultBatchSettings,
+        },
+    },
+};
+use http::{Request, Uri};
+use hyper::Body;
+use snafu::Snafu;
+use std::collections::HashMap;
+use vector_lib::lookup::lookup_v2::ConfigValuePath;
+use vrl::value::Kind;
+
+use super::{
+    encoder::StackdriverLogsEncoder, request_builder::StackdriverLogsRequestBuilder,
+    service::StackdriverLogsServiceRequestBuilder, sink::StackdriverLogsSink,
+};
+
+#[derive(Debug, Snafu)]
+enum HealthcheckError {
+    #[snafu(display("Resource not found"))]
+    NotFound,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct StackdriverTowerRequestConfigDefaults;
+
+impl TowerRequestConfigDefaults for StackdriverTowerRequestConfigDefaults {
+    const RATE_LIMIT_NUM: u64 = 1_000;
+}
+
+/// Configuration for the `gcp_stackdriver_logs` sink.
+#[configurable_component(sink(
+    "gcp_stackdriver_logs",
+    "Deliver logs to GCP's Cloud Operations suite."
+))]
+#[derive(Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub(super) struct StackdriverConfig {
+    #[serde(skip, default = "default_endpoint")]
+    pub(super) endpoint: String,
+
+    #[serde(flatten)]
+    pub(super) log_name: StackdriverLogName,
+
+    /// The log ID to which to publish logs.
+    ///
+    /// This is a name you create to identify this log stream.
+    pub(super) log_id: Template,
+
+    /// The monitored resource to associate the logs with.
+    pub(super) resource: StackdriverResource,
+
+    #[serde(flatten)]
+    pub(super) label_config: StackdriverLabelConfig,
+
+    /// The field of the log event from which to take the outgoing log’s `severity` field.
+    ///
+    /// The named field is removed from the log event if present, and must be either an integer
+    /// between 0 and 800 or a string containing one of the [severity level names][sev_names] (case
+    /// is ignored) or a common prefix such as `err`.
+    ///
+    /// If no severity key is specified, the severity of outgoing records is set to 0 (`DEFAULT`).
+    ///
+    /// See the [GCP Stackdriver Logging LogSeverity description][logsev_docs] for more details on
+    /// the value of the `severity` field.
+    ///
+    /// [sev_names]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+    /// [logsev_docs]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+    #[configurable(metadata(docs::examples = "severity"))]
+    pub(super) severity_key: Option<ConfigValuePath>,
+
+    #[serde(flatten)]
+    pub(super) auth: GcpAuthConfig,
+
+    #[configurable(derived)]
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub(super) encoding: Transformer,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub(super) batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub(super) request: TowerRequestConfig<StackdriverTowerRequestConfigDefaults>,
+
+    #[configurable(derived)]
+    pub(super) tls: Option<TlsConfig>,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::is_default"
+    )]
+    acknowledgements: AcknowledgementsConfig,
+}
+
+pub(super) fn default_endpoint() -> String {
+    "https://logging.googleapis.com/v2/entries:write".to_string()
+}
+
+// 10MB limit for entries.write: https://cloud.google.com/logging/quotas#api-limits
+const MAX_BATCH_PAYLOAD_SIZE: usize = 10_000_000;
+
+/// Logging locations.
+#[configurable_component]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default)]
+pub(super) enum StackdriverLogName {
+    /// The billing account ID to which to publish logs.
+    ///
+    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
+    #[serde(rename = "billing_account_id")]
+    #[configurable(metadata(docs::examples = "012345-6789AB-CDEF01"))]
+    BillingAccount(String),
+
+    /// The folder ID to which to publish logs.
+    ///
+    /// See the [Google Cloud Platform folder documentation][folder_docs] for more details.
+    ///
+    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
+    ///
+    /// [folder_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-folders
+    #[serde(rename = "folder_id")]
+    #[configurable(metadata(docs::examples = "My Folder"))]
+    Folder(String),
+
+    /// The organization ID to which to publish logs.
+    ///
+    /// This would be the identifier assigned to your organization on Google Cloud Platform.
+    ///
+    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
+    #[serde(rename = "organization_id")]
+    #[configurable(metadata(docs::examples = "622418129737"))]
+    Organization(String),
+
+    /// The project ID to which to publish logs.
+    ///
+    /// See the [Google Cloud Platform project management documentation][project_docs] for more details.
+    ///
+    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
+    ///
+    /// [project_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+    #[derivative(Default)]
+    #[serde(rename = "project_id")]
+    #[configurable(metadata(docs::examples = "vector-123456"))]
+    Project(String),
+}
+
+/// Label Configuration.
+#[configurable_component]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default)]
+pub(super) struct StackdriverLabelConfig {
+    /// The value of this field is used to retrieve the associated labels from the `jsonPayload`
+    /// and extract their values to set as LogEntry labels.
+    #[configurable(metadata(docs::examples = "logging.googleapis.com/labels"))]
+    #[serde(default = "default_labels_key")]
+    pub(super) labels_key: Option<String>,
+
+    /// A map of key, value pairs that provides additional information about the log entry.
+    #[configurable(metadata(
+        docs::additional_props_description = "A key, value pair that describes a log entry."
+    ))]
+    #[configurable(metadata(docs::examples = "labels_examples()"))]
+    #[serde(default)]
+    pub(super) labels: HashMap<String, Template>,
+}
+
+fn labels_examples() -> HashMap<String, String> {
+    let mut example = HashMap::new();
+    example.insert("label_1".to_string(), "value_1".to_string());
+    example.insert("label_2".to_string(), "{{ template_value_2 }}".to_string());
+    example
+}
+
+pub(super) fn default_labels_key() -> Option<String> {
+    Some("logging.googleapis.com/labels".to_string())
+}
+
+/// A monitored resource.
+///
+/// Monitored resources in GCP allow associating logs and metrics specifically with native resources
+/// within Google Cloud Platform. This takes the form of a "type" field which identifies the
+/// resource, and a set of type-specific labels to uniquely identify a resource of that type.
+///
+/// See [Monitored resource types][mon_docs] for more information.
+///
+/// [mon_docs]: https://cloud.google.com/monitoring/api/resources
+// TODO: this type is specific to the stackdrivers log sink because it allows for template-able
+// label values, but we should consider replacing `sinks::gcp::GcpTypedResource` with this so both
+// the stackdriver metrics _and_ logs sink can have template-able label values, and less duplication
+#[configurable_component]
+#[derive(Clone, Debug, Default)]
+pub(super) struct StackdriverResource {
+    /// The monitored resource type.
+    ///
+    /// For example, the type of a Compute Engine VM instance is `gce_instance`.
+    /// See the [Google Cloud Platform monitored resource documentation][gcp_resources] for
+    /// more details.
+    ///
+    /// [gcp_resources]: https://cloud.google.com/monitoring/api/resources
+    #[serde(rename = "type")]
+    pub(super) type_: String,
+
+    /// Type-specific labels.
+    #[serde(flatten)]
+    #[configurable(metadata(docs::additional_props_description = "A type-specific label."))]
+    #[configurable(metadata(docs::examples = "label_examples()"))]
+    pub(super) labels: HashMap<String, Template>,
+}
+
+fn label_examples() -> HashMap<String, String> {
+    let mut example = HashMap::new();
+    example.insert("instanceId".to_string(), "Twilight".to_string());
+    example.insert("zone".to_string(), "{{ zone }}".to_string());
+    example
+}
+
+impl_generate_config_from_default!(StackdriverConfig);
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "gcp_stackdriver_logs")]
+impl SinkConfig for StackdriverConfig {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let auth = self.auth.build(Scope::LoggingWrite).await?;
+
+        let request_builder = StackdriverLogsRequestBuilder {
+            encoder: StackdriverLogsEncoder::new(
+                self.encoding.clone(),
+                self.log_id.clone(),
+                self.log_name.clone(),
+                self.label_config.clone(),
+                self.resource.clone(),
+                self.severity_key.clone(),
+            ),
+        };
+
+        let batch_settings = self
+            .batch
+            .validate()?
+            .limit_max_bytes(MAX_BATCH_PAYLOAD_SIZE)?
+            .into_batcher_settings()?;
+
+        let request_limits = self.request.into_settings();
+
+        let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
+        let client = HttpClient::new(tls_settings, cx.proxy())?;
+
+        let uri: Uri = self.endpoint.parse()?;
+
+        let stackdriver_logs_service_request_builder = StackdriverLogsServiceRequestBuilder {
+            uri: uri.clone(),
+            auth: auth.clone(),
+        };
+
+        let service = HttpService::new(client.clone(), stackdriver_logs_service_request_builder);
+
+        let service = ServiceBuilder::new()
+            .settings(request_limits, http_response_retry_logic())
+            .service(service);
+
+        let sink = StackdriverLogsSink::new(service, batch_settings, request_builder);
+
+        let healthcheck = healthcheck(client, auth.clone(), uri).boxed();
+
+        auth.spawn_regenerate_token();
+
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn input(&self) -> Input {
+        let requirement =
+            schema::Requirement::empty().required_meaning("timestamp", Kind::timestamp());
+
+        Input::log().with_schema_requirement(requirement)
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+}
+
+async fn healthcheck(client: HttpClient, auth: GcpAuthenticator, uri: Uri) -> crate::Result<()> {
+    let entries: Vec<BoxedRawValue> = Vec::new();
+    let events = serde_json::json!({ "entries": entries });
+
+    let body = crate::serde::json::to_bytes(&events).unwrap().freeze();
+
+    let mut request = Request::post(uri)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .unwrap();
+
+    auth.apply(&mut request);
+
+    let request = request.map(Body::from);
+
+    let response = client.send(request).await?;
+
+    healthcheck_response(response, HealthcheckError::NotFound.into())
+}

--- a/src/sinks/opentelemetry/config.rs
+++ b/src/sinks/opentelemetry/config.rs
@@ -1,87 +1,35 @@
-//! Configuration for the `gcp_stackdriver_logs` sink.
+//! Configuration for the `opentelemetry` sink.
 
 use crate::{
-    gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
-    http::HttpClient,
+    http::{Auth, HttpClient, MaybeAuth},
     schema,
     sinks::{
-        gcs_common::config::healthcheck_response,
         prelude::*,
         util::{
-            http::{http_response_retry_logic, HttpService},
-            service::TowerRequestConfigDefaults,
-            BoxedRawValue, RealtimeSizeBasedDefaultBatchSettings,
+            http::{http_response_retry_logic, HttpService, RequestConfig},
+            RealtimeSizeBasedDefaultBatchSettings, UriSerde,
         },
     },
 };
-use http::{Request, Uri};
+use http::{Request, StatusCode};
 use hyper::Body;
-use snafu::Snafu;
-use std::collections::HashMap;
-use vector_lib::lookup::lookup_v2::ConfigValuePath;
 use vrl::value::Kind;
 
 use super::{
-    encoder::StackdriverLogsEncoder, request_builder::StackdriverLogsRequestBuilder,
-    service::StackdriverLogsServiceRequestBuilder, sink::StackdriverLogsSink,
+    encoder::OpentelemetryEncoder, request_builder::OpentelemetryRequestBuilder,
+    service::OpentelemetryServiceRequestBuilder, sink::OpentelemetrySink,
 };
 
-#[derive(Debug, Snafu)]
-enum HealthcheckError {
-    #[snafu(display("Resource not found"))]
-    NotFound,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct StackdriverTowerRequestConfigDefaults;
-
-impl TowerRequestConfigDefaults for StackdriverTowerRequestConfigDefaults {
-    const RATE_LIMIT_NUM: u64 = 1_000;
-}
-
-/// Configuration for the `gcp_stackdriver_logs` sink.
-#[configurable_component(sink(
-    "gcp_stackdriver_logs",
-    "Deliver logs to GCP's Cloud Operations suite."
-))]
+/// Configuration for the `opentelemetry` sink.
+#[configurable_component(sink("opentelemetry", "Deliver logs to OpenTelemetry"))]
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
-pub(super) struct StackdriverConfig {
-    #[serde(skip, default = "default_endpoint")]
-    pub(super) endpoint: String,
-
-    #[serde(flatten)]
-    pub(super) log_name: StackdriverLogName,
-
-    /// The log ID to which to publish logs.
+pub(super) struct OpenTelemetryConfig {
+    /// The full URI to make HTTP requests to.
     ///
-    /// This is a name you create to identify this log stream.
-    pub(super) log_id: Template,
-
-    /// The monitored resource to associate the logs with.
-    pub(super) resource: StackdriverResource,
-
-    #[serde(flatten)]
-    pub(super) label_config: StackdriverLabelConfig,
-
-    /// The field of the log event from which to take the outgoing log’s `severity` field.
-    ///
-    /// The named field is removed from the log event if present, and must be either an integer
-    /// between 0 and 800 or a string containing one of the [severity level names][sev_names] (case
-    /// is ignored) or a common prefix such as `err`.
-    ///
-    /// If no severity key is specified, the severity of outgoing records is set to 0 (`DEFAULT`).
-    ///
-    /// See the [GCP Stackdriver Logging LogSeverity description][logsev_docs] for more details on
-    /// the value of the `severity` field.
-    ///
-    /// [sev_names]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
-    /// [logsev_docs]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
-    #[configurable(metadata(docs::examples = "severity"))]
-    pub(super) severity_key: Option<ConfigValuePath>,
-
-    #[serde(flatten)]
-    pub(super) auth: GcpAuthConfig,
+    /// This should include the protocol and host, but can also include the port, path, and any other valid part of a URI.
+    #[configurable(metadata(docs::examples = "https://10.22.212.22:9000/v1"))]
+    pub(super) uri: UriSerde,
 
     #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
@@ -93,7 +41,7 @@ pub(super) struct StackdriverConfig {
 
     #[configurable(derived)]
     #[serde(default)]
-    pub(super) request: TowerRequestConfig<StackdriverTowerRequestConfigDefaults>,
+    pub(super) request: RequestConfig,
 
     #[configurable(derived)]
     pub(super) tls: Option<TlsConfig>,
@@ -105,178 +53,47 @@ pub(super) struct StackdriverConfig {
         skip_serializing_if = "crate::serde::is_default"
     )]
     acknowledgements: AcknowledgementsConfig,
+
+    #[configurable(derived)]
+    pub auth: Option<Auth>,
 }
 
-pub(super) fn default_endpoint() -> String {
-    "https://logging.googleapis.com/v2/entries:write".to_string()
-}
-
-// 10MB limit for entries.write: https://cloud.google.com/logging/quotas#api-limits
-const MAX_BATCH_PAYLOAD_SIZE: usize = 10_000_000;
-
-/// Logging locations.
-#[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
-pub(super) enum StackdriverLogName {
-    /// The billing account ID to which to publish logs.
-    ///
-    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
-    #[serde(rename = "billing_account_id")]
-    #[configurable(metadata(docs::examples = "012345-6789AB-CDEF01"))]
-    BillingAccount(String),
-
-    /// The folder ID to which to publish logs.
-    ///
-    /// See the [Google Cloud Platform folder documentation][folder_docs] for more details.
-    ///
-    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
-    ///
-    /// [folder_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-folders
-    #[serde(rename = "folder_id")]
-    #[configurable(metadata(docs::examples = "My Folder"))]
-    Folder(String),
-
-    /// The organization ID to which to publish logs.
-    ///
-    /// This would be the identifier assigned to your organization on Google Cloud Platform.
-    ///
-    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
-    #[serde(rename = "organization_id")]
-    #[configurable(metadata(docs::examples = "622418129737"))]
-    Organization(String),
-
-    /// The project ID to which to publish logs.
-    ///
-    /// See the [Google Cloud Platform project management documentation][project_docs] for more details.
-    ///
-    ///	Exactly one of `billing_account_id`, `folder_id`, `organization_id`, or `project_id` must be set.
-    ///
-    /// [project_docs]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
-    #[derivative(Default)]
-    #[serde(rename = "project_id")]
-    #[configurable(metadata(docs::examples = "vector-123456"))]
-    Project(String),
-}
-
-/// Label Configuration.
-#[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
-pub(super) struct StackdriverLabelConfig {
-    /// The value of this field is used to retrieve the associated labels from the `jsonPayload`
-    /// and extract their values to set as LogEntry labels.
-    #[configurable(metadata(docs::examples = "logging.googleapis.com/labels"))]
-    #[serde(default = "default_labels_key")]
-    pub(super) labels_key: Option<String>,
-
-    /// A map of key, value pairs that provides additional information about the log entry.
-    #[configurable(metadata(
-        docs::additional_props_description = "A key, value pair that describes a log entry."
-    ))]
-    #[configurable(metadata(docs::examples = "labels_examples()"))]
-    #[serde(default)]
-    pub(super) labels: HashMap<String, Template>,
-}
-
-fn labels_examples() -> HashMap<String, String> {
-    let mut example = HashMap::new();
-    example.insert("label_1".to_string(), "value_1".to_string());
-    example.insert("label_2".to_string(), "{{ template_value_2 }}".to_string());
-    example
-}
-
-pub(super) fn default_labels_key() -> Option<String> {
-    Some("logging.googleapis.com/labels".to_string())
-}
-
-/// A monitored resource.
-///
-/// Monitored resources in GCP allow associating logs and metrics specifically with native resources
-/// within Google Cloud Platform. This takes the form of a "type" field which identifies the
-/// resource, and a set of type-specific labels to uniquely identify a resource of that type.
-///
-/// See [Monitored resource types][mon_docs] for more information.
-///
-/// [mon_docs]: https://cloud.google.com/monitoring/api/resources
-// TODO: this type is specific to the stackdrivers log sink because it allows for template-able
-// label values, but we should consider replacing `sinks::gcp::GcpTypedResource` with this so both
-// the stackdriver metrics _and_ logs sink can have template-able label values, and less duplication
-#[configurable_component]
-#[derive(Clone, Debug, Default)]
-pub(super) struct StackdriverResource {
-    /// The monitored resource type.
-    ///
-    /// For example, the type of a Compute Engine VM instance is `gce_instance`.
-    /// See the [Google Cloud Platform monitored resource documentation][gcp_resources] for
-    /// more details.
-    ///
-    /// [gcp_resources]: https://cloud.google.com/monitoring/api/resources
-    #[serde(rename = "type")]
-    pub(super) type_: String,
-
-    /// Type-specific labels.
-    #[serde(flatten)]
-    #[configurable(metadata(docs::additional_props_description = "A type-specific label."))]
-    #[configurable(metadata(docs::examples = "label_examples()"))]
-    pub(super) labels: HashMap<String, Template>,
-}
-
-fn label_examples() -> HashMap<String, String> {
-    let mut example = HashMap::new();
-    example.insert("instanceId".to_string(), "Twilight".to_string());
-    example.insert("zone".to_string(), "{{ zone }}".to_string());
-    example
-}
-
-impl_generate_config_from_default!(StackdriverConfig);
+impl_generate_config_from_default!(OpenTelemetryConfig);
 
 #[async_trait::async_trait]
-#[typetag::serde(name = "gcp_stackdriver_logs")]
-impl SinkConfig for StackdriverConfig {
+#[typetag::serde(name = "opentelemetry")]
+impl SinkConfig for OpenTelemetryConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let auth = self.auth.build(Scope::LoggingWrite).await?;
-
-        let request_builder = StackdriverLogsRequestBuilder {
-            encoder: StackdriverLogsEncoder::new(
-                self.encoding.clone(),
-                self.log_id.clone(),
-                self.log_name.clone(),
-                self.label_config.clone(),
-                self.resource.clone(),
-                self.severity_key.clone(),
-            ),
+        let request_builder = OpentelemetryRequestBuilder {
+            encoder: OpentelemetryEncoder::new(self.encoding.clone()),
         };
 
-        let batch_settings = self
-            .batch
-            .validate()?
-            .limit_max_bytes(MAX_BATCH_PAYLOAD_SIZE)?
-            .into_batcher_settings()?;
-
-        let request_limits = self.request.into_settings();
+        let batch_settings = self.batch.validate()?.into_batcher_settings()?;
 
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
 
-        let uri: Uri = self.endpoint.parse()?;
-
-        let stackdriver_logs_service_request_builder = StackdriverLogsServiceRequestBuilder {
-            uri: uri.clone(),
-            auth: auth.clone(),
+        let service_request_builder = OpentelemetryServiceRequestBuilder {
+            uri: self.uri.uri.clone(),
+            auth: self.auth.choose_one(&self.uri.auth)?,
         };
 
-        let service = HttpService::new(client.clone(), stackdriver_logs_service_request_builder);
+        let service = HttpService::new(client.clone(), service_request_builder);
+
+        let request_limits = self.request.tower.into_settings();
 
         let service = ServiceBuilder::new()
             .settings(request_limits, http_response_retry_logic())
             .service(service);
 
-        let sink = StackdriverLogsSink::new(service, batch_settings, request_builder);
+        let sink = OpentelemetrySink::new(service, batch_settings, request_builder);
 
-        let healthcheck = healthcheck(client, auth.clone(), uri).boxed();
-
-        auth.spawn_regenerate_token();
+        let healthcheck = match cx.healthcheck.uri {
+            Some(healthcheck_uri) => {
+                healthcheck(healthcheck_uri, self.auth.clone(), client.clone()).boxed()
+            }
+            None => future::ok(()).boxed(),
+        };
 
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
     }
@@ -293,22 +110,19 @@ impl SinkConfig for StackdriverConfig {
     }
 }
 
-async fn healthcheck(client: HttpClient, auth: GcpAuthenticator, uri: Uri) -> crate::Result<()> {
-    let entries: Vec<BoxedRawValue> = Vec::new();
-    let events = serde_json::json!({ "entries": entries });
+async fn healthcheck(uri: UriSerde, auth: Option<Auth>, client: HttpClient) -> crate::Result<()> {
+    let auth = auth.choose_one(&uri.auth)?;
+    let uri = uri.with_default_parts();
+    let mut request = Request::head(&uri.uri).body(Body::empty()).unwrap();
 
-    let body = crate::serde::json::to_bytes(&events).unwrap().freeze();
-
-    let mut request = Request::post(uri)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .unwrap();
-
-    auth.apply(&mut request);
-
-    let request = request.map(Body::from);
+    if let Some(auth) = auth {
+        auth.apply(&mut request);
+    }
 
     let response = client.send(request).await?;
 
-    healthcheck_response(response, HealthcheckError::NotFound.into())
+    match response.status() {
+        StatusCode::OK => Ok(()),
+        status => Err(HealthcheckError::UnexpectedStatus { status }.into()),
+    }
 }

--- a/src/sinks/opentelemetry/encoder.rs
+++ b/src/sinks/opentelemetry/encoder.rs
@@ -1,5 +1,5 @@
-//! Encoding for the `gcp_stackdriver_logs` sink.
-
+#![allow(unused_imports)]
+#![allow(warnings)]
 use std::{collections::HashMap, io};
 
 use bytes::BytesMut;
@@ -13,186 +13,23 @@ use crate::{
     template::TemplateRenderingError,
 };
 
-use super::config::{
-    default_labels_key, StackdriverLabelConfig, StackdriverLogName, StackdriverResource,
-};
-
 #[derive(Clone, Debug)]
-pub(super) struct StackdriverLogsEncoder {
+pub(super) struct OpentelemetryEncoder {
     transformer: Transformer,
-    log_id: Template,
-    log_name: StackdriverLogName,
-    label_config: StackdriverLabelConfig,
-    resource: StackdriverResource,
-    severity_key: Option<ConfigValuePath>,
 }
 
-impl StackdriverLogsEncoder {
-    /// Creates a new `StackdriverLogsEncoder`.
-    pub(super) const fn new(
-        transformer: Transformer,
-        log_id: Template,
-        log_name: StackdriverLogName,
-        label_config: StackdriverLabelConfig,
-        resource: StackdriverResource,
-        severity_key: Option<ConfigValuePath>,
-    ) -> Self {
-        Self {
-            transformer,
-            log_id,
-            log_name,
-            label_config,
-            resource,
-            severity_key,
-        }
+impl OpentelemetryEncoder {
+    /// Creates a new `OpentelemetryEncoder`.
+    pub(super) const fn new(transformer: Transformer) -> Self {
+        Self { transformer }
     }
 
     pub(super) fn encode_event(&self, event: Event) -> Option<serde_json::Value> {
-        let mut labels = HashMap::with_capacity(self.label_config.labels.len());
-        for (key, template) in &self.label_config.labels {
-            let value = template
-                .render_string(&event)
-                .map_err(|error| {
-                    emit!(crate::internal_events::TemplateRenderingError {
-                        error,
-                        field: Some("labels"),
-                        drop_event: true,
-                    });
-                })
-                .ok()?;
-            labels.insert(key.clone(), value);
-        }
-        let mut resource_labels = HashMap::with_capacity(self.resource.labels.len());
-        for (key, template) in &self.resource.labels {
-            let value = template
-                .render_string(&event)
-                .map_err(|error| {
-                    emit!(crate::internal_events::TemplateRenderingError {
-                        error,
-                        field: Some("resource.labels"),
-                        drop_event: true,
-                    });
-                })
-                .ok()?;
-            resource_labels.insert(key.clone(), value);
-        }
-        let log_name = self
-            .log_name(&event)
-            .map_err(|error| {
-                emit!(crate::internal_events::TemplateRenderingError {
-                    error,
-                    field: Some("log_id"),
-                    drop_event: true,
-                });
-            })
-            .ok()?;
-
-        let mut log = event.into_log();
-        let severity = self
-            .severity_key
-            .as_ref()
-            .and_then(|key| log.remove((PathPrefix::Event, &key.0)))
-            .map(remap_severity)
-            .unwrap_or_else(|| 0.into());
-
-        let default_labels_key = default_labels_key();
-        let labels_key = self
-            .label_config
-            .labels_key
-            .as_deref()
-            .or(default_labels_key.as_deref())
-            .unwrap();
-
-        // merge log_labels in the specified labels_key into the labels map.
-        if let Some(Value::Object(log_labels)) = log.remove(event_path!(labels_key)) {
-            labels.extend(
-                log_labels
-                    .into_iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string_lossy().into_owned())),
-            );
-        }
-
-        let mut event = Event::Log(log);
-        self.transformer.transform(&mut event);
-
-        let log = event.into_log();
-
-        let mut entry = Map::with_capacity(5);
-        entry.insert("logName".into(), json!(log_name));
-        entry.insert("jsonPayload".into(), json!(log));
-        entry.insert("severity".into(), json!(severity));
-        entry.insert("labels".into(), json!(labels));
-        entry.insert(
-            "resource".into(),
-            json!({
-                "type": self.resource.type_,
-                "labels": resource_labels,
-            }),
-        );
-
-        // If the event contains a timestamp, send it in the main message so gcp can pick it up.
-        if let Some(timestamp) = log.get_timestamp() {
-            entry.insert("timestamp".into(), json!(timestamp));
-        }
-
-        Some(json!(entry))
-    }
-
-    fn log_name(&self, event: &Event) -> Result<String, TemplateRenderingError> {
-        use StackdriverLogName::*;
-
-        let log_id = self.log_id.render_string(event)?;
-
-        Ok(match &self.log_name {
-            BillingAccount(acct) => format!("billingAccounts/{}/logs/{}", acct, log_id),
-            Folder(folder) => format!("folders/{}/logs/{}", folder, log_id),
-            Organization(org) => format!("organizations/{}/logs/{}", org, log_id),
-            Project(project) => format!("projects/{}/logs/{}", project, log_id),
-        })
+        Some(json!({"a": "b"}))
     }
 }
 
-pub(super) fn remap_severity(severity: Value) -> Value {
-    let n = match severity {
-        Value::Integer(n) => n - n % 100,
-        Value::Bytes(s) => {
-            let s = String::from_utf8_lossy(&s);
-            match s.parse::<usize>() {
-                Ok(n) => (n - n % 100) as i64,
-                Err(_) => match s.to_uppercase() {
-                    s if s.starts_with("EMERG") || s.starts_with("FATAL") => 800,
-                    s if s.starts_with("ALERT") => 700,
-                    s if s.starts_with("CRIT") => 600,
-                    s if s.starts_with("ERR") || s == "ER" => 500,
-                    s if s.starts_with("WARN") => 400,
-                    s if s.starts_with("NOTICE") => 300,
-                    s if s.starts_with("INFO") => 200,
-                    s if s.starts_with("DEBUG") || s.starts_with("TRACE") => 100,
-                    s if s.starts_with("DEFAULT") => 0,
-                    _ => {
-                        warn!(
-                            message = "Unknown severity value string, using DEFAULT.",
-                            value = %s,
-                            internal_log_rate_limit = true
-                        );
-                        0
-                    }
-                },
-            }
-        }
-        value => {
-            warn!(
-                message = "Unknown severity value type, using DEFAULT.",
-                ?value,
-                internal_log_rate_limit = true
-            );
-            0
-        }
-    };
-    Value::Integer(n)
-}
-
-impl SinkEncoder<Vec<Event>> for StackdriverLogsEncoder {
+impl SinkEncoder<Vec<Event>> for OpentelemetryEncoder {
     fn encode_input(
         &self,
         events: Vec<Event>,

--- a/src/sinks/opentelemetry/encoder.rs
+++ b/src/sinks/opentelemetry/encoder.rs
@@ -1,0 +1,226 @@
+//! Encoding for the `gcp_stackdriver_logs` sink.
+
+use std::{collections::HashMap, io};
+
+use bytes::BytesMut;
+use serde_json::{json, to_vec, Map};
+use vector_lib::lookup::lookup_v2::ConfigValuePath;
+use vrl::event_path;
+use vrl::path::PathPrefix;
+
+use crate::{
+    sinks::{prelude::*, util::encoding::Encoder as SinkEncoder},
+    template::TemplateRenderingError,
+};
+
+use super::config::{
+    default_labels_key, StackdriverLabelConfig, StackdriverLogName, StackdriverResource,
+};
+
+#[derive(Clone, Debug)]
+pub(super) struct StackdriverLogsEncoder {
+    transformer: Transformer,
+    log_id: Template,
+    log_name: StackdriverLogName,
+    label_config: StackdriverLabelConfig,
+    resource: StackdriverResource,
+    severity_key: Option<ConfigValuePath>,
+}
+
+impl StackdriverLogsEncoder {
+    /// Creates a new `StackdriverLogsEncoder`.
+    pub(super) const fn new(
+        transformer: Transformer,
+        log_id: Template,
+        log_name: StackdriverLogName,
+        label_config: StackdriverLabelConfig,
+        resource: StackdriverResource,
+        severity_key: Option<ConfigValuePath>,
+    ) -> Self {
+        Self {
+            transformer,
+            log_id,
+            log_name,
+            label_config,
+            resource,
+            severity_key,
+        }
+    }
+
+    pub(super) fn encode_event(&self, event: Event) -> Option<serde_json::Value> {
+        let mut labels = HashMap::with_capacity(self.label_config.labels.len());
+        for (key, template) in &self.label_config.labels {
+            let value = template
+                .render_string(&event)
+                .map_err(|error| {
+                    emit!(crate::internal_events::TemplateRenderingError {
+                        error,
+                        field: Some("labels"),
+                        drop_event: true,
+                    });
+                })
+                .ok()?;
+            labels.insert(key.clone(), value);
+        }
+        let mut resource_labels = HashMap::with_capacity(self.resource.labels.len());
+        for (key, template) in &self.resource.labels {
+            let value = template
+                .render_string(&event)
+                .map_err(|error| {
+                    emit!(crate::internal_events::TemplateRenderingError {
+                        error,
+                        field: Some("resource.labels"),
+                        drop_event: true,
+                    });
+                })
+                .ok()?;
+            resource_labels.insert(key.clone(), value);
+        }
+        let log_name = self
+            .log_name(&event)
+            .map_err(|error| {
+                emit!(crate::internal_events::TemplateRenderingError {
+                    error,
+                    field: Some("log_id"),
+                    drop_event: true,
+                });
+            })
+            .ok()?;
+
+        let mut log = event.into_log();
+        let severity = self
+            .severity_key
+            .as_ref()
+            .and_then(|key| log.remove((PathPrefix::Event, &key.0)))
+            .map(remap_severity)
+            .unwrap_or_else(|| 0.into());
+
+        let default_labels_key = default_labels_key();
+        let labels_key = self
+            .label_config
+            .labels_key
+            .as_deref()
+            .or(default_labels_key.as_deref())
+            .unwrap();
+
+        // merge log_labels in the specified labels_key into the labels map.
+        if let Some(Value::Object(log_labels)) = log.remove(event_path!(labels_key)) {
+            labels.extend(
+                log_labels
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string_lossy().into_owned())),
+            );
+        }
+
+        let mut event = Event::Log(log);
+        self.transformer.transform(&mut event);
+
+        let log = event.into_log();
+
+        let mut entry = Map::with_capacity(5);
+        entry.insert("logName".into(), json!(log_name));
+        entry.insert("jsonPayload".into(), json!(log));
+        entry.insert("severity".into(), json!(severity));
+        entry.insert("labels".into(), json!(labels));
+        entry.insert(
+            "resource".into(),
+            json!({
+                "type": self.resource.type_,
+                "labels": resource_labels,
+            }),
+        );
+
+        // If the event contains a timestamp, send it in the main message so gcp can pick it up.
+        if let Some(timestamp) = log.get_timestamp() {
+            entry.insert("timestamp".into(), json!(timestamp));
+        }
+
+        Some(json!(entry))
+    }
+
+    fn log_name(&self, event: &Event) -> Result<String, TemplateRenderingError> {
+        use StackdriverLogName::*;
+
+        let log_id = self.log_id.render_string(event)?;
+
+        Ok(match &self.log_name {
+            BillingAccount(acct) => format!("billingAccounts/{}/logs/{}", acct, log_id),
+            Folder(folder) => format!("folders/{}/logs/{}", folder, log_id),
+            Organization(org) => format!("organizations/{}/logs/{}", org, log_id),
+            Project(project) => format!("projects/{}/logs/{}", project, log_id),
+        })
+    }
+}
+
+pub(super) fn remap_severity(severity: Value) -> Value {
+    let n = match severity {
+        Value::Integer(n) => n - n % 100,
+        Value::Bytes(s) => {
+            let s = String::from_utf8_lossy(&s);
+            match s.parse::<usize>() {
+                Ok(n) => (n - n % 100) as i64,
+                Err(_) => match s.to_uppercase() {
+                    s if s.starts_with("EMERG") || s.starts_with("FATAL") => 800,
+                    s if s.starts_with("ALERT") => 700,
+                    s if s.starts_with("CRIT") => 600,
+                    s if s.starts_with("ERR") || s == "ER" => 500,
+                    s if s.starts_with("WARN") => 400,
+                    s if s.starts_with("NOTICE") => 300,
+                    s if s.starts_with("INFO") => 200,
+                    s if s.starts_with("DEBUG") || s.starts_with("TRACE") => 100,
+                    s if s.starts_with("DEFAULT") => 0,
+                    _ => {
+                        warn!(
+                            message = "Unknown severity value string, using DEFAULT.",
+                            value = %s,
+                            internal_log_rate_limit = true
+                        );
+                        0
+                    }
+                },
+            }
+        }
+        value => {
+            warn!(
+                message = "Unknown severity value type, using DEFAULT.",
+                ?value,
+                internal_log_rate_limit = true
+            );
+            0
+        }
+    };
+    Value::Integer(n)
+}
+
+impl SinkEncoder<Vec<Event>> for StackdriverLogsEncoder {
+    fn encode_input(
+        &self,
+        events: Vec<Event>,
+        writer: &mut dyn io::Write,
+    ) -> io::Result<(usize, GroupedCountByteSize)> {
+        let mut byte_size = telemetry().create_request_count_byte_size();
+        let mut n_events = events.len();
+        let mut body = BytesMut::new();
+
+        let mut entries = Vec::with_capacity(n_events);
+        for event in &events {
+            let size = event.estimated_json_encoded_size_of();
+            if let Some(data) = self.encode_event(event.clone()) {
+                byte_size.add_event(event, size);
+                entries.push(data)
+            } else {
+                // encode_event() emits the `TemplateRenderingError` internal event,
+                // which emits an `EventsDropped`, so no need to here.
+                n_events -= 1;
+            }
+        }
+
+        let events = json!({ "entries": entries });
+
+        body.extend(&to_vec(&events)?);
+
+        let body = body.freeze();
+
+        write_all(writer, n_events, body.as_ref()).map(|()| (body.len(), byte_size))
+    }
+}

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -1,8 +1,5 @@
-//! The GCP Stackdriver Logs [`vector_lib::sink::VectorSink`].
+//! OpenTelemetry sink[`vector_lib::sink::VectorSink`].
 //!
-//! This module contains the [`vector_lib::sink::VectorSink`] instance that is responsible for
-//! taking a stream of [`vector_lib::event::Event`]s and forwarding them to the GCP
-//! Stackdriver service.
 
 mod config;
 mod encoder;

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -1,95 +1,14 @@
-use crate::codecs::{EncodingConfigWithFraming, Transformer};
-use crate::config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext};
-use crate::sinks::http::config::{HttpMethod, HttpSinkConfig};
-use crate::sinks::{Healthcheck, VectorSink};
-use indoc::indoc;
-use vector_config::component::GenerateConfig;
-use vector_lib::codecs::encoding::{FramingConfig, SerializerConfig};
-use vector_lib::codecs::JsonSerializerConfig;
-use vector_lib::configurable::configurable_component;
+//! The GCP Stackdriver Logs [`vector_lib::sink::VectorSink`].
+//!
+//! This module contains the [`vector_lib::sink::VectorSink`] instance that is responsible for
+//! taking a stream of [`vector_lib::event::Event`]s and forwarding them to the GCP
+//! Stackdriver service.
 
-/// Configuration for the `OpenTelemetry` sink.
-#[configurable_component(sink("opentelemetry", "Deliver OTLP data over HTTP."))]
-#[derive(Clone, Debug, Default)]
-pub struct OpenTelemetryConfig {
-    /// Protocol configuration
-    #[configurable(derived)]
-    protocol: Protocol,
-}
-
-/// The protocol used to send data to OpenTelemetry.
-/// Currently only HTTP is supported, but we plan to support gRPC.
-/// The proto definitions are defined [here](https://github.com/vectordotdev/vector/blob/master/lib/opentelemetry-proto/src/proto/opentelemetry-proto/opentelemetry/proto/README.md).
-#[configurable_component]
-#[derive(Clone, Debug)]
-#[serde(rename_all = "snake_case", tag = "type")]
-#[configurable(metadata(docs::enum_tag_description = "The communication protocol."))]
-pub enum Protocol {
-    /// Send data over HTTP.
-    Http(HttpSinkConfig),
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Protocol::Http(HttpSinkConfig {
-            encoding: EncodingConfigWithFraming::new(
-                Some(FramingConfig::NewlineDelimited),
-                SerializerConfig::Json(JsonSerializerConfig::default()),
-                Transformer::default(),
-            ),
-            uri: Default::default(),
-            method: HttpMethod::Post,
-            auth: Default::default(),
-            headers: Default::default(),
-            compression: Default::default(),
-            payload_prefix: Default::default(),
-            payload_suffix: Default::default(),
-            batch: Default::default(),
-            request: Default::default(),
-            tls: Default::default(),
-            acknowledgements: Default::default(),
-        })
-    }
-}
-
-impl GenerateConfig for OpenTelemetryConfig {
-    fn generate_config() -> toml::Value {
-        toml::from_str(indoc! {r#"
-            [protocol]
-            type = "http"
-            uri = "http://localhost:5318/v1/logs"
-            encoding.codec = "json"
-        "#})
-        .unwrap()
-    }
-}
-
-#[async_trait::async_trait]
-#[typetag::serde(name = "opentelemetry")]
-impl SinkConfig for OpenTelemetryConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        match &self.protocol {
-            Protocol::Http(config) => config.build(cx).await,
-        }
-    }
-
-    fn input(&self) -> Input {
-        match &self.protocol {
-            Protocol::Http(config) => config.input(),
-        }
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        match self.protocol {
-            Protocol::Http(ref config) => config.acknowledgements(),
-        }
-    }
-}
+mod config;
+mod encoder;
+mod request_builder;
+mod service;
+mod sink;
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn generate_config() {
-        crate::test_util::test_generate_config::<super::OpenTelemetryConfig>();
-    }
-}
+mod tests;

--- a/src/sinks/opentelemetry/request_builder.rs
+++ b/src/sinks/opentelemetry/request_builder.rs
@@ -1,0 +1,47 @@
+//! `RequestBuilder` implementation for the `gcp_stackdriver_logs` sink.
+
+use bytes::Bytes;
+use std::io;
+
+use crate::sinks::{prelude::*, util::http::HttpRequest};
+
+use super::encoder::StackdriverLogsEncoder;
+
+pub(super) struct StackdriverLogsRequestBuilder {
+    pub(super) encoder: StackdriverLogsEncoder,
+}
+
+impl RequestBuilder<Vec<Event>> for StackdriverLogsRequestBuilder {
+    type Metadata = EventFinalizers;
+    type Events = Vec<Event>;
+    type Encoder = StackdriverLogsEncoder;
+    type Payload = Bytes;
+    type Request = HttpRequest<()>;
+    type Error = io::Error;
+
+    fn compression(&self) -> Compression {
+        Compression::None
+    }
+
+    fn encoder(&self) -> &Self::Encoder {
+        &self.encoder
+    }
+
+    fn split_input(
+        &self,
+        mut events: Vec<Event>,
+    ) -> (Self::Metadata, RequestMetadataBuilder, Self::Events) {
+        let finalizers = events.take_finalizers();
+        let builder = RequestMetadataBuilder::from_events(&events);
+        (finalizers, builder, events)
+    }
+
+    fn build_request(
+        &self,
+        metadata: Self::Metadata,
+        request_metadata: RequestMetadata,
+        payload: EncodeResult<Self::Payload>,
+    ) -> Self::Request {
+        HttpRequest::new(payload.into_payload(), metadata, request_metadata, ())
+    }
+}

--- a/src/sinks/opentelemetry/request_builder.rs
+++ b/src/sinks/opentelemetry/request_builder.rs
@@ -1,20 +1,20 @@
-//! `RequestBuilder` implementation for the `gcp_stackdriver_logs` sink.
+//! `RequestBuilder` implementation for the `opentelemetry` sink.
 
 use bytes::Bytes;
 use std::io;
 
 use crate::sinks::{prelude::*, util::http::HttpRequest};
 
-use super::encoder::StackdriverLogsEncoder;
+use super::encoder::OpentelemetryEncoder;
 
-pub(super) struct StackdriverLogsRequestBuilder {
-    pub(super) encoder: StackdriverLogsEncoder,
+pub(super) struct OpentelemetryRequestBuilder {
+    pub(super) encoder: OpentelemetryEncoder,
 }
 
-impl RequestBuilder<Vec<Event>> for StackdriverLogsRequestBuilder {
+impl RequestBuilder<Vec<Event>> for OpentelemetryRequestBuilder {
     type Metadata = EventFinalizers;
     type Events = Vec<Event>;
-    type Encoder = StackdriverLogsEncoder;
+    type Encoder = OpentelemetryEncoder;
     type Payload = Bytes;
     type Request = HttpRequest<()>;
     type Error = io::Error;

--- a/src/sinks/opentelemetry/service.rs
+++ b/src/sinks/opentelemetry/service.rs
@@ -1,0 +1,34 @@
+//! Service implementation for the `gcp_stackdriver_logs` sink.
+
+use bytes::Bytes;
+use http::{header::CONTENT_TYPE, Request, Uri};
+
+use crate::{
+    gcp::GcpAuthenticator,
+    sinks::{
+        util::http::{HttpRequest, HttpServiceRequestBuilder},
+        HTTPRequestBuilderSnafu,
+    },
+};
+use snafu::ResultExt;
+
+#[derive(Debug, Clone)]
+pub(super) struct StackdriverLogsServiceRequestBuilder {
+    pub(super) uri: Uri,
+    pub(super) auth: GcpAuthenticator,
+}
+
+impl HttpServiceRequestBuilder<()> for StackdriverLogsServiceRequestBuilder {
+    fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
+        let builder = Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/json");
+
+        let mut request = builder
+            .body(request.take_payload())
+            .context(HTTPRequestBuilderSnafu)
+            .map_err(Into::<crate::Error>::into)?;
+
+        self.auth.apply(&mut request);
+
+        Ok(request)
+    }
+}

--- a/src/sinks/opentelemetry/service.rs
+++ b/src/sinks/opentelemetry/service.rs
@@ -20,7 +20,8 @@ pub(super) struct OpentelemetryServiceRequestBuilder {
 
 impl HttpServiceRequestBuilder<()> for OpentelemetryServiceRequestBuilder {
     fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
-        let builder = Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/json");
+        let builder =
+            Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/x-protobuf");
 
         let mut request = builder
             .body(request.take_payload())

--- a/src/sinks/opentelemetry/sink.rs
+++ b/src/sinks/opentelemetry/sink.rs
@@ -1,0 +1,77 @@
+//! Implementation of the `gcp_stackdriver_logs` sink.
+
+use crate::sinks::{
+    prelude::*,
+    util::http::{HttpJsonBatchSizer, HttpRequest},
+};
+
+use super::request_builder::StackdriverLogsRequestBuilder;
+
+pub(super) struct StackdriverLogsSink<S> {
+    service: S,
+    batch_settings: BatcherSettings,
+    request_builder: StackdriverLogsRequestBuilder,
+}
+
+impl<S> StackdriverLogsSink<S>
+where
+    S: Service<HttpRequest<()>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: std::fmt::Debug + Into<crate::Error> + Send,
+{
+    /// Creates a new `StackdriverLogsSink`.
+    pub(super) const fn new(
+        service: S,
+        batch_settings: BatcherSettings,
+        request_builder: StackdriverLogsRequestBuilder,
+    ) -> Self {
+        Self {
+            service,
+            batch_settings,
+            request_builder,
+        }
+    }
+
+    async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        input
+            // Batch the input stream with size calculation based on the estimated encoded json size
+            .batched(self.batch_settings.as_item_size_config(HttpJsonBatchSizer))
+            // Build requests with no concurrency limit.
+            .request_builder(
+                default_request_builder_concurrency_limit(),
+                self.request_builder,
+            )
+            // Filter out any errors that occurred in the request building.
+            .filter_map(|request| async move {
+                match request {
+                    Err(error) => {
+                        emit!(SinkRequestBuildError { error });
+                        None
+                    }
+                    Ok(req) => Some(req),
+                }
+            })
+            // Generate the driver that will send requests and handle retries,
+            // event finalization, and logging/internal metric reporting.
+            .into_driver(self.service)
+            .run()
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> StreamSink<Event> for StackdriverLogsSink<S>
+where
+    S: Service<HttpRequest<()>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Response: DriverResponse + Send + 'static,
+    S::Error: std::fmt::Debug + Into<crate::Error> + Send,
+{
+    async fn run(
+        self: Box<Self>,
+        input: futures_util::stream::BoxStream<'_, Event>,
+    ) -> Result<(), ()> {
+        self.run_inner(input).await
+    }
+}

--- a/src/sinks/opentelemetry/sink.rs
+++ b/src/sinks/opentelemetry/sink.rs
@@ -1,9 +1,6 @@
 //! Implementation of the `opentelemetry` sink.
 
-use crate::sinks::{
-    prelude::*,
-    util::http::{HttpJsonBatchSizer, HttpRequest},
-};
+use crate::sinks::{prelude::*, util::http::HttpRequest};
 
 use super::request_builder::OpentelemetryRequestBuilder;
 
@@ -11,11 +8,15 @@ pub(super) struct OpentelemetrySink<S> {
     service: S,
     batch_settings: BatcherSettings,
     request_builder: OpentelemetryRequestBuilder,
+
+    log_endpoint: String,
+    trace_endpoint: String,
+    metric_endpoint: String,
 }
 
 impl<S> OpentelemetrySink<S>
 where
-    S: Service<HttpRequest<()>> + Send + 'static,
+    S: Service<HttpRequest<PartitionKey>> + Send + 'static,
     S::Future: Send + 'static,
     S::Response: DriverResponse + Send + 'static,
     S::Error: std::fmt::Debug + Into<crate::Error> + Send,
@@ -25,18 +26,27 @@ where
         service: S,
         batch_settings: BatcherSettings,
         request_builder: OpentelemetryRequestBuilder,
+        log_endpoint: String,
+        trace_endpoint: String,
+        metric_endpoint: String,
     ) -> Self {
         Self {
             service,
             batch_settings,
             request_builder,
+
+            log_endpoint,
+            trace_endpoint,
+            metric_endpoint,
         }
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         input
-            // Batch the input stream with size calculation based on the estimated encoded json size
-            .batched(self.batch_settings.as_item_size_config(HttpJsonBatchSizer))
+            .batched_partitioned(
+                KeyPartitioner::new(self.log_endpoint, self.trace_endpoint, self.metric_endpoint),
+                || self.batch_settings.as_byte_size_config(),
+            )
             // Build requests with no concurrency limit.
             .request_builder(
                 default_request_builder_concurrency_limit(),
@@ -63,7 +73,7 @@ where
 #[async_trait::async_trait]
 impl<S> StreamSink<Event> for OpentelemetrySink<S>
 where
-    S: Service<HttpRequest<()>> + Send + 'static,
+    S: Service<HttpRequest<PartitionKey>> + Send + 'static,
     S::Future: Send + 'static,
     S::Response: DriverResponse + Send + 'static,
     S::Error: std::fmt::Debug + Into<crate::Error> + Send,
@@ -73,5 +83,45 @@ where
         input: futures_util::stream::BoxStream<'_, Event>,
     ) -> Result<(), ()> {
         self.run_inner(input).await
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub(super) struct PartitionKey {
+    pub endpoint: String,
+}
+
+struct KeyPartitioner {
+    log_endpoint: String,
+    trace_endpoint: String,
+    metric_endpoint: String,
+}
+
+impl KeyPartitioner {
+    pub fn new(log_endpoint: String, trace_endpoint: String, metric_endpoint: String) -> Self {
+        Self {
+            log_endpoint,
+            trace_endpoint,
+            metric_endpoint,
+        }
+    }
+}
+
+impl Partitioner for KeyPartitioner {
+    type Item = Event;
+    type Key = PartitionKey;
+
+    fn partition(&self, event: &Self::Item) -> Self::Key {
+        match event {
+            Event::Log(_) => PartitionKey {
+                endpoint: self.log_endpoint.clone(),
+            },
+            Event::Trace(_) => PartitionKey {
+                endpoint: self.trace_endpoint.clone(),
+            },
+            Event::Metric(_) => PartitionKey {
+                endpoint: self.metric_endpoint.clone(),
+            },
+        }
     }
 }

--- a/src/sinks/opentelemetry/sink.rs
+++ b/src/sinks/opentelemetry/sink.rs
@@ -1,30 +1,30 @@
-//! Implementation of the `gcp_stackdriver_logs` sink.
+//! Implementation of the `opentelemetry` sink.
 
 use crate::sinks::{
     prelude::*,
     util::http::{HttpJsonBatchSizer, HttpRequest},
 };
 
-use super::request_builder::StackdriverLogsRequestBuilder;
+use super::request_builder::OpentelemetryRequestBuilder;
 
-pub(super) struct StackdriverLogsSink<S> {
+pub(super) struct OpentelemetrySink<S> {
     service: S,
     batch_settings: BatcherSettings,
-    request_builder: StackdriverLogsRequestBuilder,
+    request_builder: OpentelemetryRequestBuilder,
 }
 
-impl<S> StackdriverLogsSink<S>
+impl<S> OpentelemetrySink<S>
 where
     S: Service<HttpRequest<()>> + Send + 'static,
     S::Future: Send + 'static,
     S::Response: DriverResponse + Send + 'static,
     S::Error: std::fmt::Debug + Into<crate::Error> + Send,
 {
-    /// Creates a new `StackdriverLogsSink`.
+    /// Creates a new `OpentelemetrySink`.
     pub(super) const fn new(
         service: S,
         batch_settings: BatcherSettings,
-        request_builder: StackdriverLogsRequestBuilder,
+        request_builder: OpentelemetryRequestBuilder,
     ) -> Self {
         Self {
             service,
@@ -61,7 +61,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<S> StreamSink<Event> for StackdriverLogsSink<S>
+impl<S> StreamSink<Event> for OpentelemetrySink<S>
 where
     S: Service<HttpRequest<()>> + Send + 'static,
     S::Future: Send + 'static,

--- a/src/sinks/opentelemetry/tests.rs
+++ b/src/sinks/opentelemetry/tests.rs
@@ -1,0 +1,349 @@
+//! Unit tests for the `gcp_stackdriver_logs` sink.
+
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use futures::{future::ready, stream};
+use http::Uri;
+use indoc::indoc;
+use serde::Deserialize;
+use std::collections::HashMap;
+use vector_lib::lookup::lookup_v2::ConfigValuePath;
+use vrl::{event_path, value};
+
+use crate::{
+    config::{GenerateConfig, SinkConfig, SinkContext},
+    event::{LogEvent, Value},
+    gcp::GcpAuthenticator,
+    sinks::{
+        gcp::stackdriver::logs::{
+            config::{StackdriverLabelConfig, StackdriverLogName},
+            encoder::remap_severity,
+            service::StackdriverLogsServiceRequestBuilder,
+        },
+        prelude::*,
+        util::{
+            encoding::Encoder as _,
+            http::{HttpRequest, HttpServiceRequestBuilder},
+        },
+    },
+    test_util::{
+        components::{run_and_assert_sink_compliance, HTTP_SINK_TAGS},
+        http::{always_200_response, spawn_blackhole_http_server},
+    },
+};
+
+use super::{
+    config::{default_endpoint, StackdriverConfig, StackdriverResource},
+    encoder::StackdriverLogsEncoder,
+};
+
+#[test]
+fn generate_config() {
+    crate::test_util::test_generate_config::<StackdriverConfig>();
+}
+
+#[tokio::test]
+async fn component_spec_compliance() {
+    let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
+
+    let config = StackdriverConfig::generate_config().to_string();
+    let mut config = StackdriverConfig::deserialize(toml::de::ValueDeserializer::new(&config))
+        .expect("config should be valid");
+
+    // If we don't override the credentials path/API key, it tries to directly call out to the Google Instance
+    // Metadata API, which we clearly don't have in unit tests. :)
+    config.auth.credentials_path = None;
+    config.auth.api_key = Some("fake".to_string().into());
+    config.endpoint = mock_endpoint.to_string();
+
+    let context = SinkContext::default();
+    let (sink, _healthcheck) = config.build(context).await.unwrap();
+
+    let event = Event::Log(LogEvent::from("simple message"));
+    run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
+}
+
+#[test]
+fn encode_valid() {
+    let mut transformer = Transformer::default();
+    transformer
+        .set_except_fields(Some(vec![
+            "anumber".into(),
+            "node_id".into(),
+            "log_id".into(),
+        ]))
+        .unwrap();
+
+    let encoder = StackdriverLogsEncoder::new(
+        transformer,
+        Template::try_from("{{ log_id }}").unwrap(),
+        StackdriverLogName::Project("project".to_owned()),
+        StackdriverLabelConfig {
+            labels_key: None,
+            labels: HashMap::from([(
+                "config_user_label_1".to_owned(),
+                Template::try_from("config_user_value_1").unwrap(),
+            )]),
+        },
+        StackdriverResource {
+            type_: "generic_node".to_owned(),
+            labels: HashMap::from([
+                (
+                    "namespace".to_owned(),
+                    Template::try_from("office").unwrap(),
+                ),
+                (
+                    "node_id".to_owned(),
+                    Template::try_from("{{ node_id }}").unwrap(),
+                ),
+            ]),
+        },
+        Some(ConfigValuePath::try_from("anumber".to_owned()).unwrap()),
+    );
+
+    let mut log = [
+        ("message", "hello world"),
+        ("anumber", "100"),
+        ("node_id", "10.10.10.1"),
+        ("log_id", "testlogs"),
+    ]
+    .iter()
+    .copied()
+    .collect::<LogEvent>();
+    log.insert(
+        event_path!("logging.googleapis.com/labels"),
+        value!({user_label_1: "user_value_1"}),
+    );
+
+    let json = encoder.encode_event(Event::from(log)).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "logName":"projects/project/logs/testlogs",
+            "jsonPayload":{"message":"hello world"},
+            "severity":100,
+            "labels":{
+                "config_user_label_1":"config_user_value_1",
+                "user_label_1":"user_value_1"
+            },
+            "resource":{
+                "type":"generic_node",
+                "labels":{"namespace":"office","node_id":"10.10.10.1"}
+            }
+        })
+    );
+}
+
+#[test]
+fn encode_inserts_timestamp() {
+    let transformer = Transformer::default();
+
+    let encoder = StackdriverLogsEncoder::new(
+        transformer,
+        Template::try_from("testlogs").unwrap(),
+        StackdriverLogName::Project("project".to_owned()),
+        StackdriverLabelConfig {
+            labels_key: None,
+            labels: HashMap::from([(
+                "config_user_label_1".to_owned(),
+                Template::try_from("value_1").unwrap(),
+            )]),
+        },
+        StackdriverResource {
+            type_: "generic_node".to_owned(),
+            labels: HashMap::from([(
+                "namespace".to_owned(),
+                Template::try_from("office").unwrap(),
+            )]),
+        },
+        Some(ConfigValuePath::try_from("anumber".to_owned()).unwrap()),
+    );
+
+    let mut log = LogEvent::default();
+    log.insert("message", Value::Bytes("hello world".into()));
+    log.insert("anumber", Value::Bytes("100".into()));
+    log.insert(
+        "timestamp",
+        Value::Timestamp(
+            Utc.with_ymd_and_hms(2020, 1, 1, 12, 30, 0)
+                .single()
+                .expect("invalid timestamp"),
+        ),
+    );
+
+    let json = encoder.encode_event(Event::from(log)).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "logName":"projects/project/logs/testlogs",
+            "jsonPayload":{"message":"hello world","timestamp":"2020-01-01T12:30:00Z"},
+            "severity":100,
+            "labels":{"config_user_label_1":"value_1"},
+            "resource":{
+                "type":"generic_node",
+                "labels":{"namespace":"office"}},
+            "timestamp":"2020-01-01T12:30:00Z"
+        })
+    );
+}
+
+#[test]
+fn severity_remaps_strings() {
+    for &(s, n) in &[
+        ("EMERGENCY", 800), // Handles full upper case
+        ("EMERG", 800),     // Handles abbreviations
+        ("FATAL", 800),     // Handles highest alternate
+        ("alert", 700),     // Handles lower case
+        ("CrIt1c", 600),    // Handles mixed case and suffixes
+        ("err404", 500),    // Handles lower case and suffixes
+        ("warnings", 400),
+        ("notice", 300),
+        ("info", 200),
+        ("DEBUG2", 100), // Handles upper case and suffixes
+        ("trace", 100),  // Handles lowest alternate
+        ("nothing", 0),  // Maps unknown terms to DEFAULT
+        ("123", 100),    // Handles numbers in strings
+        ("-100", 0),     // Maps negatives to DEFAULT
+    ] {
+        assert_eq!(
+            remap_severity(s.into()),
+            Value::Integer(n),
+            "remap_severity({:?}) != {}",
+            s,
+            n
+        );
+    }
+}
+
+#[tokio::test]
+async fn correct_request() {
+    let uri: Uri = default_endpoint().parse().unwrap();
+
+    let transformer = Transformer::default();
+    let encoder = StackdriverLogsEncoder::new(
+        transformer,
+        Template::try_from("testlogs").unwrap(),
+        StackdriverLogName::Project("project".to_owned()),
+        StackdriverLabelConfig {
+            labels_key: None,
+            labels: HashMap::from([(
+                "config_user_label_1".to_owned(),
+                Template::try_from("value_1").unwrap(),
+            )]),
+        },
+        StackdriverResource {
+            type_: "generic_node".to_owned(),
+            labels: HashMap::from([(
+                "namespace".to_owned(),
+                Template::try_from("office").unwrap(),
+            )]),
+        },
+        None,
+    );
+
+    let log1 = [("message", "hello")].iter().copied().collect::<LogEvent>();
+    let log2 = [("message", "world")].iter().copied().collect::<LogEvent>();
+
+    let events = vec![Event::from(log1), Event::from(log2)];
+
+    let mut writer = Vec::new();
+    let (_, _) = encoder.encode_input(events, &mut writer).unwrap();
+
+    let body = Bytes::copy_from_slice(&writer);
+
+    let stackdriver_logs_service_request_builder = StackdriverLogsServiceRequestBuilder {
+        uri: uri.clone(),
+        auth: GcpAuthenticator::None,
+    };
+
+    let http_request = HttpRequest::new(
+        body,
+        EventFinalizers::default(),
+        RequestMetadata::default(),
+        (),
+    );
+
+    let request = stackdriver_logs_service_request_builder
+        .build(http_request)
+        .unwrap();
+
+    let (parts, body) = request.into_parts();
+    let json: serde_json::Value = serde_json::from_slice(&body[..]).unwrap();
+
+    assert_eq!(
+        &parts.uri.to_string(),
+        "https://logging.googleapis.com/v2/entries:write"
+    );
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "entries": [
+                {
+                    "logName": "projects/project/logs/testlogs",
+                    "severity": 0,
+                    "jsonPayload": {
+                        "message": "hello"
+                    },
+                    "labels": {
+                        "config_user_label_1": "value_1"
+                    },
+                    "resource": {
+                        "type": "generic_node",
+                        "labels": {
+                            "namespace": "office"
+                        }
+                    }
+                },
+                {
+                    "logName": "projects/project/logs/testlogs",
+                    "severity": 0,
+                    "jsonPayload": {
+                        "message": "world"
+                    },
+                    "labels": {
+                        "config_user_label_1": "value_1"
+                    },
+                    "resource": {
+                        "type": "generic_node",
+                        "labels": {
+                            "namespace": "office"
+                        }
+                    }
+                }
+            ]
+        })
+    );
+}
+
+#[tokio::test]
+async fn fails_missing_creds() {
+    let config: StackdriverConfig = toml::from_str(indoc! {r#"
+            project_id = "project"
+            log_id = "testlogs"
+            resource.type = "generic_node"
+            resource.namespace = "office"
+        "#})
+    .unwrap();
+    if config.build(SinkContext::default()).await.is_ok() {
+        panic!("config.build failed to error");
+    }
+}
+
+#[test]
+fn fails_invalid_log_names() {
+    toml::from_str::<StackdriverConfig>(indoc! {r#"
+            log_id = "testlogs"
+            resource.type = "generic_node"
+            resource.namespace = "office"
+        "#})
+    .expect_err("Config parsing failed to error with missing ids");
+
+    toml::from_str::<StackdriverConfig>(indoc! {r#"
+            project_id = "project"
+            folder_id = "folder"
+            log_id = "testlogs"
+            resource.type = "generic_node"
+            resource.namespace = "office"
+        "#})
+    .expect_err("Config parsing failed to error with extraneous ids");
+}


### PR DESCRIPTION
The OpenTelemetry sink has a number of short comings:

- It requires data to be in a very specific 'protobuf' format, which requires complex VRL
- doesn't support grpc
- no support for metrics

This PR is an attempt at solving some of these. A big part of it changing the foundations, to make metrics and grpc (or just http/json instead of http/protobuf) easier to implement

The first commit replaces the current sink with a copy of the stackdriver sink. The sink is currently built on the HTTP sink and I looked at making that re-usable but that seems tricky to do as it would need a way to get influence the encoding and batching. All other sinks seem to have their own 'sink infra', so using the same approach for this sink made sense to me
The 2nd commit does cleanup/renaming of the copied sink

The 3rd commit implements a basic encoder for logs. The data format to use here is still up for discussion. It currently uses the log format specified by opentelemetry, assuming fields like `attributes` and `resources`.

Commit 4 adds batching per event type, to make the correct types are sent to the correct endpoint. This makes it possible to have 1 opentelemetry sink that handles all 3 signals. Instead of 3 sinks, one for logs, one for traces and one for metrics.

---

The PR is far from finished but I want to get some feedback on it before continuing. E.g. is this (new sink) the right direction to go in.

There is also some overlap with #22550 from @brittonhayes but this could serve as the basis for that, as metrics support would just require extending the encoder

Config for sending dummy data to an otlp sink:

```
sources:
  generate_syslog:
    type: "demo_logs"
    format: "json"
    count: 1
    interval: 0.1

  otel:
    type: opentelemetry
    http:
      address: 127.0.0.1:4318
    grpc:
      address: 127.0.0.1:4317

transforms:
  remap_to_otel:
    type: remap
    inputs: [ 'generate_syslog' ]
    source: |
      . = {
        "attributes": {
          "string": "abc",
          "integer": 123,
          "array": [1,2,3],
        },
        "resource": { "source": "xyz" },
        "message": .message,
        "timestamp": .timestamp,
      }

sinks:
  console:
    type: console
    encoding:
      codec: json
    inputs:
    - otel

  otlp:
    inputs:
      - remap_to_otel
    type: opentelemetry
    uri: http://127.0.0.1:4318
```

results in:

```
{
  "attributes": {
    "array": [
      1,
      2,
      3
    ],
    "integer": 123,
    "string": "abc"
  },
  "dropped_attributes_count": 0,
  "message": "{\"host\":\"126.1.177.254\",\"user-identifier\":\"devankoshal\",\"datetime\":\"03/Apr/2025:23:40:45\",\"method\":\"PATCH\",\"request\":\"/do-not-access/needs-work\",\"protocol\":\"HTTP/1.0\",\"status\":\"500\",\"bytes\":10979,\"referer\":\"https://some.af/secret-info/open-sesame\"}",
  "observed_timestamp": "2025-04-03T21:40:46.129823Z",
  "resources": {
    "source": "henk"
  },
  "source_type": "opentelemetry",
  "timestamp": "2025-04-03T21:40:45.112009Z"
}