### PR TITLE
chore(releasing): vdev prepare refactoring

### DIFF
--- a/scripts/generate-release-cue.rb
+++ b/scripts/generate-release-cue.rb
@@ -15,17 +15,33 @@
 require "json"
 require "time"
 require "optparse"
+require 'pathname'
 require_relative "util/commit"
 require_relative "util/git_log_commit"
 require_relative "util/printer"
 require_relative "util/release"
 require_relative "util/version"
 
+# Function to find the repository root by looking for .git directory
+def find_repo_root
+  # Get the absolute path of the current script
+  script_path = File.expand_path(__FILE__)
+  dir = Pathname.new(script_path).dirname
+
+  # Walk up the directory tree until we find .git or reach the filesystem root
+  loop do
+    return dir.to_s if File.exist?(File.join(dir, '.git'))
+    parent = dir.parent
+    raise "Could not find repository root (no .git directory found)" if parent == dir # Reached filesystem root
+    dir = parent
+  end
+end
+
 #
 # Constants
 #
 
-ROOT = ".."
+ROOT = find_repo_root
 RELEASE_REFERENCE_DIR = File.join(ROOT, "website", "cue", "reference", "releases")
 CHANGELOG_DIR = File.join(ROOT, "changelog.d")
 TYPES = ["chore", "docs", "feat", "fix", "enhancement", "perf"]

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -7,13 +7,13 @@ use anyhow::{anyhow, Result};
 use indoc::indoc;
 use reqwest::blocking::Client;
 use semver::Version;
-use std::fs;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::{env, fs};
 use toml::map::Map;
 use toml::Value;
 
@@ -45,36 +45,372 @@ pub struct Cli {
     debian_version: Option<String>,
 }
 
+struct Prepare {
+    new_vector_version: Version,
+    vrl_version: Version,
+    alpine_version: Option<String>,
+    debian_version: Option<String>,
+    repo_root: PathBuf,
+    latest_vector_version: Version,
+}
+
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        create_release_branches(&self.version)?;
-        pin_vrl_version(&self.vrl_version)?;
 
-        update_dockerfile_base_version(
-            &get_repo_root().join(ALPINE_DOCKERFILE),
+        let repo_root = get_repo_root();
+        env::set_current_dir(repo_root.clone())?;
+
+        let prepare = Prepare {
+            new_vector_version: self.version,
+            vrl_version: self.vrl_version,
+            alpine_version: self.alpine_version,
+            debian_version: self.debian_version,
+            repo_root,
+            latest_vector_version: get_latest_version_from_vector_tags()?,
+        };
+        prepare.run()
+    }
+}
+
+impl Prepare {
+    pub fn run(&self) -> Result<()> {
+        self.create_release_branches()?;
+        self.pin_vrl_version()?;
+
+        self.update_dockerfile_base_version(
+            &self.repo_root.join(ALPINE_DOCKERFILE),
             self.alpine_version.as_deref(),
             ALPINE_PREFIX,
         )?;
 
-        update_dockerfile_base_version(
-            &get_repo_root().join(DEBIAN_DOCKERFILE),
+        self.update_dockerfile_base_version(
+            &self.repo_root.join(DEBIAN_DOCKERFILE),
             self.debian_version.as_deref(),
             DEBIAN_PREFIX,
         )?;
 
-        generate_release_cue(&self.version)?;
+        self.generate_release_cue()?;
 
-        let latest_version = get_latest_version_from_vector_tags()?;
-        update_vector_version(&get_repo_root().join(KUBECLT_CUE_FILE), &latest_version, &self.version)?;
-        update_vector_version(&get_repo_root().join(INSTALL_SCRIPT), &latest_version, &self.version)?;
+        self.update_vector_version(&self.repo_root.join(KUBECLT_CUE_FILE))?;
+        self.update_vector_version(&self.repo_root.join(INSTALL_SCRIPT))?;
 
-        add_new_version_to_versions_cue(&self.version)?;
+        self.add_new_version_to_versions_cue()?;
 
-        create_new_release_md(&latest_version, &self.version)?;
+        self.create_new_release_md()?;
 
-        open_release_pr(&self.version)
+        self.open_release_pr()
+    }
+
+    /// Steps 1 & 2
+    fn create_release_branches(&self) -> Result<()> {
+        // Step 1: Create a new release branch
+        git::run_and_check_output(&["fetch"])?;
+        git::checkout_main_branch()?;
+
+        let new_version = &self.new_vector_version;
+        let release_branch = format!("v{}.{}", new_version.major, new_version.minor);
+        git::create_branch(release_branch.as_str())?;
+        git::push_and_set_upstream(release_branch.as_str())?;
+
+        // Step 2: Create a new release preparation branch
+        //         The branch website contains 'website' to generate vector.dev preview.
+        let release_preparation_branch = format!("website-prepare-v{new_version}");
+        git::create_branch(release_preparation_branch.as_str())?;
+        git::push_and_set_upstream(release_preparation_branch.as_str())?;
+        Ok(())
+    }
+
+    /// Step 3
+    fn pin_vrl_version(&self) -> Result<()> {
+        let cargo_toml_path = &self.repo_root.join("Cargo.toml");
+        let contents = fs::read_to_string(&cargo_toml_path).expect("Failed to read Cargo.toml");
+
+        // Needs this hybrid approach to preserve ordering.
+        let mut lines: Vec<String> = contents.lines().map(String::from).collect();
+
+        let vrl_version = self.vrl_version.to_string();
+        for line in &mut lines {
+            if line.trim().starts_with("vrl = { git = ") {
+                if let Ok(mut vrl_toml) = line.parse::<Value>() {
+                    let vrl_dependency: &mut Value = vrl_toml.get_mut("vrl").expect("line should start with 'vrl'");
+
+                    let mut new_dependency_value = Map::new();
+                    new_dependency_value.insert("version".to_string(), Value::String(vrl_version.clone()));
+                    let features = vrl_dependency.get("features").expect("missing 'features' key");
+                    new_dependency_value.insert("features".to_string(), features.clone());
+
+                    *line = format!("vrl = {}", Value::from(new_dependency_value));
+                }
+                break;
+            }
+        }
+
+        fs::write(&cargo_toml_path, lines.join("\n")).expect("Failed to write Cargo.toml");
+        run_command("cargo update -p vrl");
+        git::commit(&format!("chore(releasing): Pinned VRL version to {vrl_version}"))?;
+        Ok(())
+    }
+
+    /// Step 4 & 5: Update dockerfile versions.
+    /// TODO: investigate if this can be automated.
+    fn update_dockerfile_base_version(
+        &self,
+        dockerfile_path: &Path,
+        new_version: Option<&str>,
+        prefix: &str,
+    ) -> Result<()> {
+        if let Some(version) = new_version {
+            let contents = fs::read_to_string(dockerfile_path)?;
+
+            if !contents.starts_with(prefix) {
+                return Err(anyhow::anyhow!(
+                    "Dockerfile at {} does not start with {prefix}",
+                    dockerfile_path.display()
+                ));
+            }
+
+            let mut lines = contents.lines();
+            let first_line = lines.next().expect("File should have at least one line");
+            let rest = lines.collect::<Vec<&str>>().join("\n");
+
+            // Split into prefix, version, and suffix
+            // E.g. "FROM docker.io/alpine:", "3.21", " AS builder"
+            let after_prefix = first_line
+                .strip_prefix(prefix)
+                .ok_or_else(|| anyhow!("Failed to strip prefix in {}", dockerfile_path.display()))?;
+            let parts: Vec<&str> = after_prefix.splitn(2, ' ').collect();
+            let suffix = parts.get(1).unwrap_or(&"");
+
+            // Rebuild with new version
+            let updated_version_line = format!("{prefix}{version} {suffix}");
+            let new_contents = format!("{updated_version_line}\n{rest}");
+
+            fs::write(dockerfile_path, &new_contents)?;
+            git::commit(&format!(
+                "chore(releasing): Bump {} version to {version}",
+                dockerfile_path.strip_prefix(&self.repo_root).unwrap().display(),
+            ))?;
+        } else {
+            println!(
+                "No version specified for {dockerfile_path:?}; skipping update");
+        }
+        Ok(())
+    }
+
+    // Step 6
+    fn generate_release_cue(&self) -> Result<()> {
+        let script = self.repo_root.join(RELEASE_CUE_SCRIPT);
+        let new_vector_version = &self.new_vector_version;
+        if script.is_file() {
+            run_command(&format!("{} --new-version {new_vector_version} --no-interactive", script.to_string_lossy().as_ref()));
+        } else {
+            return Err(anyhow!("Script not found: {}", script.display()));
+        }
+
+        self.append_vrl_changelog_to_release_cue()?;
+        git::commit("chore(releasing): Generated release CUE file")?;
+        println!("Generated release CUE file");
+        Ok(())
+    }
+
+    /// Step 7 & 8: Replace old version with the new version.
+    fn update_vector_version(&self, file_path: &Path) -> Result<()> {
+        let contents = fs::read_to_string(file_path)
+            .map_err(|e| anyhow!("Failed to read {}: {}", file_path.display(), e))?;
+
+        let latest_version = &self.latest_vector_version;
+        let new_version = &self.new_vector_version;
+        let old_version_str = format!("{}.{}", latest_version.major, latest_version.minor);
+        let new_version_str = format!("{}.{}", new_version.major, new_version.minor);
+
+        if !contents.contains(&old_version_str) {
+            return Err(anyhow!("Could not find version {} to update in {}",
+                latest_version, file_path.display()));
+        }
+
+        let updated_contents = contents.replace(&latest_version.to_string(), &new_version.to_string());
+        let updated_contents = updated_contents.replace(&old_version_str, &new_version_str);
+
+        fs::write(file_path, updated_contents)
+            .map_err(|e| anyhow!("Failed to write {}: {}", file_path.display(), e))?;
+        git::commit(&format!(
+            "chore(releasing): Updated {} vector version to {new_version}",
+            file_path.strip_prefix(get_repo_root()).unwrap().display(),
+        ))?;
+
+        Ok(())
+    }
+
+    /// Step 9: Add new version to `versions.cue`
+    fn add_new_version_to_versions_cue(&self) -> Result<()> {
+        let cure_reference_path = &self.repo_root.join("website").join("cue").join("reference");
+        let versions_cue_path = cure_reference_path.join("versions.cue");
+        if !versions_cue_path.is_file() {
+            return Err(anyhow!("{versions_cue_path:?} not found"));
+        }
+
+        let vector_version = &self.new_vector_version;
+        let temp_file_path = cure_reference_path.join(format!("{vector_version}.cue.tmp"));
+        let input_file = File::open(&versions_cue_path)?;
+        let reader = BufReader::new(input_file);
+        let mut output_file = File::create(&temp_file_path)?;
+
+        for line in reader.lines() {
+            let line = line?;
+            writeln!(output_file, "{line}")?;
+            if line.contains("versions:") {
+                writeln!(output_file, "\t\"{vector_version}\",")?;
+            }
+        }
+
+        fs::rename(&temp_file_path, &versions_cue_path)?;
+
+        git::commit(&format!("chore(releasing): Add {vector_version} to versions.cue"))?;
+        Ok(())
+    }
+
+    /// Step 10: Create a new release md file
+    fn create_new_release_md(&self) -> Result<()> {
+        let releases_dir = get_repo_root()
+            .join("website")
+            .join("content")
+            .join("en")
+            .join("releases");
+
+        let old_version = &self.latest_vector_version;
+        let new_version = &self.new_vector_version;
+        let old_file_path = releases_dir.join(format!("{old_version}.md"));
+        if !old_file_path.exists() {
+            return Err(anyhow!("Source file not found: {}", old_file_path.display()));
+        }
+
+        let content = fs::read_to_string(&old_file_path)?;
+        let updated_content = content.replace(&old_version.to_string(), &new_version.to_string());
+        let lines: Vec<&str> = updated_content.lines().collect();
+        let mut updated_lines = Vec::new();
+        let mut weight_updated = false;
+
+        for line in lines {
+            if line.trim().starts_with("weight: ") && !weight_updated {
+                // Extract the current weight value
+                let weight_str = line.trim().strip_prefix("weight: ").ok_or_else(|| anyhow!("Invalid weight format"))?;
+                let weight: i32 = weight_str.parse().map_err(|e| anyhow!("Failed to parse weight: {}", e))?;
+                // Increase by 1
+                let new_weight = weight + 1;
+                updated_lines.push(format!("weight: {new_weight}"));
+                weight_updated = true;
+            } else {
+                updated_lines.push(line.to_string());
+            }
+        }
+
+        if !weight_updated {
+            eprintln!("Couldn't update 'weight' line from {old_file_path:?}");
+        }
+
+
+        let new_file_path = releases_dir.join(format!("{new_version}.md"));
+        let updated_content = updated_lines.join("\n");
+        fs::write(&new_file_path, updated_content)?;
+        git::commit(&format!("chore(releasing): Created release md file: {new_file_path:?}"))?;
+        Ok(())
+    }
+
+    /// Final step. Create a release prep PR against the release branch.
+    fn open_release_pr(&self) -> Result<()> {
+        git::push()?;
+
+        let new_vector_version = &self.new_vector_version;
+        let release_branch = format!("v{}.{}", new_vector_version.major, new_vector_version.minor);
+        let pr_title = format!("chore(releasing): prepare v{new_vector_version} release");
+        let pr_body = format!("This PR prepares the release for Vector v{new_vector_version}");
+        let current_branch = format!("website-prepare-v{new_vector_version}");
+        let gh_status = Command::new("gh")
+            .arg("pr")
+            .arg("create")
+            .arg("--base")
+            .arg(&release_branch)
+            .arg("--head")
+            .arg(&current_branch)
+            .arg("--title")
+            .arg(&pr_title)
+            .arg("--body")
+            .arg(&pr_body)
+            .current_dir(get_repo_root())
+            .status()?;
+        if !gh_status.success() {
+            return Err(anyhow!("Failed to create PR with gh CLI"));
+        }
+
+        println!("Successfully created PR against {release_branch}");
+        Ok(())
+    }
+
+    fn append_vrl_changelog_to_release_cue(&self) -> Result<()> {
+        let releases_path = &self.repo_root.join("website").join("cue").join("reference").join("releases");
+        let vector_version = &self.new_vector_version;
+        let release_cue_path = releases_path.join(format!("{vector_version}.cue"));
+        if !release_cue_path.is_file() {
+            return Err(anyhow!("{release_cue_path:?} not found"));
+        }
+
+        let vrl_changelog = get_latest_vrl_tag_and_changelog()?;
+
+        let temp_file_path = releases_path.join(format!("{vector_version}.cue.tmp"));
+        let input_file = File::open(&release_cue_path)?;
+        let reader = BufReader::new(input_file);
+        let mut output_file = File::create(&temp_file_path)?;
+
+        let indent = "\t".repeat(5);
+        let processed_changelog: String = vrl_changelog
+            .lines()
+            .map(|line| {
+                let line = line.trim();
+                if line.starts_with('#') {
+                    format!("{indent}#{line}")
+                } else {
+                    format!("{indent}{line}")
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        // Format the new changelog entry
+        let vrl_cue_block = format!(
+            indoc! {r#"
+            {{
+                type: "feat"
+                description: """
+            {}
+                    """
+            }},
+        "#},
+            processed_changelog
+        );
+
+        let mut found_changelog = false;
+        let changelog_marker = "changelog: [";
+
+        // Read and write line by line
+        for line in reader.lines() {
+            let line = line?;
+            writeln!(output_file, "{line}")?;
+
+            // Check if this is the changelog line
+            if !found_changelog && line.trim().starts_with(changelog_marker) {
+                // Insert the new entry after the changelog opening
+                writeln!(output_file, "{vrl_cue_block}")?;
+                found_changelog = true;
+            }
+        }
+
+        fs::rename(&temp_file_path, &release_cue_path)?;
+
+        Ok(())
     }
 }
+
+// FREE FUNCTIONS AFTER THIS LINE
 
 fn get_repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().to_path_buf()
@@ -89,300 +425,6 @@ fn get_latest_version_from_vector_tags() -> Result<Version> {
     let version_str = latest_tag.trim_start_matches('v');
     Version::parse(version_str)
         .map_err(|e| anyhow::anyhow!("Failed to parse version from tag '{latest_tag}': {e}"))
-}
-
-/// Steps 1 & 2
-fn create_release_branches(new_version: &Version) -> Result<()> {
-    // Step 1: Create a new release branch
-    git::run_and_check_output(&["fetch"])?;
-    git::checkout_main_branch()?;
-    let release_branch = format!("v{}.{}", new_version.major, new_version.minor);
-    git::create_branch(release_branch.as_str())?;
-    git::push_and_set_upstream(release_branch.as_str())?;
-
-    // Step 2: Create a new release preparation branch
-    //         The branch website contains 'website' to generate vector.dev preview.
-    let release_preparation_branch = format!("website-prepare-v{new_version}");
-    git::create_branch(release_preparation_branch.as_str())?;
-    git::push_and_set_upstream(release_preparation_branch.as_str())?;
-    Ok(())
-}
-
-/// Step 3
-fn pin_vrl_version(new_version: &Version) -> Result<()> {
-    let cargo_toml_path = get_repo_root().join("Cargo.toml");
-    let contents = fs::read_to_string(&cargo_toml_path).expect("Failed to read Cargo.toml");
-
-    // Needs this hybrid approach to preserve ordering.
-    let mut lines: Vec<String> = contents.lines().map(String::from).collect();
-
-    for line in &mut lines {
-        if line.trim().starts_with("vrl = { git = ") {
-            if let Ok(mut vrl_toml) = line.parse::<Value>() {
-                let vrl_dependency: &mut Value = vrl_toml.get_mut("vrl").expect("line should start with 'vrl'");
-
-                let mut new_dependency_value = Map::new();
-                new_dependency_value.insert("version".to_string(), Value::String(new_version.to_string()));
-                let features = vrl_dependency.get("features").expect("missing 'features' key");
-                new_dependency_value.insert("features".to_string(), features.clone());
-
-                *line = format!("vrl = {}", Value::from(new_dependency_value));
-            }
-            break;
-        }
-    }
-
-    fs::write(&cargo_toml_path, lines.join("\n")).expect("Failed to write Cargo.toml");
-    run_command("cargo update -p vrl");
-    git::commit(&format!("chore(releasing): Pinned VRL version to {new_version}"))?;
-    Ok(())
-}
-
-/// Step 4 & 5: Update dockerfile versions.
-/// TODO: investigate if this can be automated.
-fn update_dockerfile_base_version(
-    dockerfile_path: &Path,
-    new_version: Option<&str>,
-    prefix: &str,
-) -> Result<()> {
-    if let Some(version) = new_version {
-        let contents = fs::read_to_string(dockerfile_path)?;
-
-        if !contents.starts_with(prefix) {
-            return Err(anyhow::anyhow!(
-                "Dockerfile at {} does not start with {prefix}",
-                dockerfile_path.display()
-            ));
-        }
-
-        let mut lines = contents.lines();
-        let first_line = lines.next().expect("File should have at least one line");
-        let rest = lines.collect::<Vec<&str>>().join("\n");
-
-        // Split into prefix, version, and suffix
-        // E.g. "FROM docker.io/alpine:", "3.21", " AS builder"
-        let after_prefix = first_line
-            .strip_prefix(prefix)
-            .ok_or_else(|| anyhow!("Failed to strip prefix in {}", dockerfile_path.display()))?;
-        let parts: Vec<&str> = after_prefix.splitn(2, ' ').collect();
-        let suffix = parts.get(1).unwrap_or(&"");
-
-        // Rebuild with new version
-        let updated_version_line = format!("{prefix}{version} {suffix}");
-        let new_contents = format!("{updated_version_line}\n{rest}");
-
-        fs::write(dockerfile_path, &new_contents)?;
-        git::commit(&format!(
-            "chore(releasing): Bump {} version to {version}", dockerfile_path.strip_prefix(get_repo_root()).unwrap().display(),
-        ))?;
-    } else {
-        println!(
-            "No version specified for {dockerfile_path:?}; skipping update");
-    }
-    Ok(())
-}
-
-// Step 6
-fn generate_release_cue(new_version: &Version) -> Result<()> {
-    let script = get_repo_root().join(RELEASE_CUE_SCRIPT);
-    if script.is_file() {
-        run_command(&format!("{} --new-version {new_version} --no-interactive", script.to_string_lossy().as_ref()));
-    } else {
-        return Err(anyhow!("Script not found: {}", script.display()));
-    }
-
-    let vrl_changelog = get_latest_vrl_tag_and_changelog()?;
-    append_vrl_changelog_to_release_cue(new_version, vrl_changelog.as_str())?;
-    git::commit("chore(releasing): Generated release CUE file")?;
-    println!("Generated release CUE file");
-    Ok(())
-}
-
-/// Step 7 & 8: Replace old version with the new version.
-fn update_vector_version(file_path: &Path, latest_version: &Version, new_version: &Version) -> Result<()> {
-    let contents = fs::read_to_string(file_path)
-        .map_err(|e| anyhow!("Failed to read {}: {}", file_path.display(), e))?;
-
-    let old_version_str = format!("{}.{}", latest_version.major, latest_version.minor);
-    let new_version_str = format!("{}.{}", new_version.major, new_version.minor);
-
-    if !contents.contains(&old_version_str) {
-        return Err(anyhow!("Could not find version {} to update in {}",
-            latest_version, file_path.display()));
-    }
-
-    let updated_contents = contents.replace(&latest_version.to_string(), &new_version.to_string());
-    let updated_contents = updated_contents.replace(&old_version_str, &new_version_str);
-
-    fs::write(file_path, updated_contents)
-        .map_err(|e| anyhow!("Failed to write {}: {}", file_path.display(), e))?;
-    git::commit(&format!(
-        "chore(releasing): Updated {} vector version to {new_version}",
-        file_path.strip_prefix(get_repo_root()).unwrap().display(),
-    ))?;
-
-    Ok(())
-}
-
-/// Step 9: Add new version to `versions.cue`
-fn add_new_version_to_versions_cue(vector_version: &Version) -> Result<()> {
-    let cure_reference_path = get_repo_root().join("website").join("cue").join("reference");
-    let versions_cue_path = cure_reference_path.join("versions.cue");
-    if !versions_cue_path.is_file() {
-        return Err(anyhow!("{versions_cue_path:?} not found"));
-    }
-
-    let temp_file_path = cure_reference_path.join(format!("{vector_version}.cue.tmp"));
-    let input_file = File::open(&versions_cue_path)?;
-    let reader = BufReader::new(input_file);
-    let mut output_file = File::create(&temp_file_path)?;
-
-    for line in reader.lines() {
-        let line = line?;
-        writeln!(output_file, "{line}")?;
-        if line.contains("versions:") {
-            writeln!(output_file, "\t\"{vector_version}\",")?;
-        }
-    }
-
-    fs::rename(&temp_file_path, &versions_cue_path)?;
-
-    git::commit(&format!("chore(releasing): Add {vector_version} to versions.cue"))?;
-    Ok(())
-}
-
-/// Step 10: Create a new release md file
-fn create_new_release_md(old_version: &Version, new_version: &Version) -> Result<()> {
-    let releases_dir = get_repo_root()
-        .join("website")
-        .join("content")
-        .join("en")
-        .join("releases");
-
-    let old_file_path = releases_dir.join(format!("{old_version}.md"));
-    if !old_file_path.exists() {
-        return Err(anyhow!("Source file not found: {}", old_file_path.display()));
-    }
-
-    let content = fs::read_to_string(&old_file_path)?;
-    let updated_content = content.replace(&old_version.to_string(), &new_version.to_string());
-    let lines: Vec<&str> = updated_content.lines().collect();
-    let mut updated_lines = Vec::new();
-    let mut weight_updated = false;
-
-    for line in lines {
-        if line.trim().starts_with("weight: ") && !weight_updated {
-            // Extract the current weight value
-            let weight_str = line.trim().strip_prefix("weight: ").ok_or_else(|| anyhow!("Invalid weight format"))?;
-            let weight: i32 = weight_str.parse().map_err(|e| anyhow!("Failed to parse weight: {}", e))?;
-            // Increase by 1
-            let new_weight = weight + 1;
-            updated_lines.push(format!("weight: {new_weight}"));
-            weight_updated = true;
-        } else {
-            updated_lines.push(line.to_string());
-        }
-    }
-
-    if !weight_updated {
-        eprintln!("Couldn't update 'weight' line from {old_file_path:?}");
-    }
-
-
-    let new_file_path = releases_dir.join(format!("{new_version}.md"));
-    let updated_content = updated_lines.join("\n");
-    fs::write(&new_file_path, updated_content)?;
-    git::commit(&format!("chore(releasing): Created release md file: {new_file_path:?}"))?;
-    Ok(())
-}
-
-/// Final step. Create a release prep PR against the release branch.
-fn open_release_pr(new_version: &Version) -> Result<()> {
-    git::push()?;
-
-    let release_branch = format!("v{}.{}", new_version.major, new_version.minor);
-    let pr_title = format!("chore(releasing): prepare v{new_version} release");
-    let pr_body = format!("This PR prepares the release for Vector v{new_version}");
-    let current_branch = format!("website-prepare-v{new_version}");
-    let gh_status = Command::new("gh")
-        .arg("pr")
-        .arg("create")
-        .arg("--base")
-        .arg(&release_branch)
-        .arg("--head")
-        .arg(&current_branch)
-        .arg("--title")
-        .arg(&pr_title)
-        .arg("--body")
-        .arg(&pr_body)
-        .current_dir(get_repo_root())
-        .status()?;
-    if !gh_status.success() {
-        return Err(anyhow!("Failed to create PR with gh CLI"));
-    }
-
-    println!("Successfully created PR against {release_branch}");
-    Ok(())
-}
-
-fn append_vrl_changelog_to_release_cue(vector_version: &Version, vrl_changelog: &str) -> Result<()> {
-    let releases_path = get_repo_root().join("website").join("cue").join("reference").join("releases");
-    let release_cue_path = releases_path.join(format!("{vector_version}.cue"));
-    if !release_cue_path.is_file() {
-        return Err(anyhow!("{release_cue_path:?} not found"));
-    }
-
-    let temp_file_path = releases_path.join(format!("{vector_version}.cue.tmp"));
-    let input_file = File::open(&release_cue_path)?;
-    let reader = BufReader::new(input_file);
-    let mut output_file = File::create(&temp_file_path)?;
-
-    let indent = "\t".repeat(5);
-    let processed_changelog: String = vrl_changelog
-        .lines()
-        .map(|line| {
-            let line = line.trim();
-            if line.starts_with('#') {
-                format!("{indent}#{line}")
-            } else {
-                format!("{indent}{line}")
-            }
-        })
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    // Format the new changelog entry
-    let vrl_cue_block = format!(
-        indoc! {r#"
-            {{
-                type: "feat"
-                description: """
-            {}
-                    """
-            }},
-        "#},
-        processed_changelog
-    );
-
-    let mut found_changelog = false;
-    let changelog_marker = "changelog: [";
-
-    // Read and write line by line
-    for line in reader.lines() {
-        let line = line?;
-        writeln!(output_file, "{line}")?;
-
-        // Check if this is the changelog line
-        if !found_changelog && line.trim().starts_with(changelog_marker) {
-            // Insert the new entry after the changelog opening
-            writeln!(output_file, "{vrl_cue_block}")?;
-            found_changelog = true;
-        }
-    }
-
-    fs::rename(&temp_file_path, &release_cue_path)?;
-
-    Ok(())
 }
 
 fn get_latest_vrl_tag_and_changelog() -> Result<String> {


### PR DESCRIPTION
Refactoring to avoid passing arguments repeatedly.
Improved `generate-release-cue.rb` to discover repo root instead of using a hardcoded one.