### PR TITLE
enhancement(file-source): Use notify-rs/notify for filesystem notifications

### DIFF
--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -13,6 +13,7 @@ winapi = { version = "0.3", features = ["winioctl"] }
 [dependencies]
 crc = "3.2.1"
 glob.workspace = true
+notify = "8.0.0"
 scan_fmt = "0.2.6"
 vector-common = { path = "../vector-common", default-features = false }
 vector-config = { path = "../vector-config", default-features = false }

--- a/lib/file-source/src/file_watcher/notify_watcher.rs
+++ b/lib/file-source/src/file_watcher/notify_watcher.rs
@@ -1,0 +1,170 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use tracing::{error, trace};
+
+use crate::FilePosition;
+
+/// Represents the state of a file being watched by the notify-based watcher
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct NotifyWatcherState {
+    /// Path to the file being watched
+    pub path: PathBuf,
+    /// Last known position in the file
+    pub file_position: FilePosition,
+    /// Last time the file was seen
+    pub last_seen: Instant,
+    /// Whether the file is currently being actively watched
+    pub is_active: bool,
+}
+
+/// A watcher implementation that uses notify-rs/notify for filesystem notifications
+/// instead of polling. This allows for more efficient file watching, especially
+/// for files that are not frequently updated.
+pub struct NotifyWatcher {
+    /// The underlying notify watcher
+    watcher: Option<Box<dyn Watcher>>,
+    /// Channel for receiving events from the watcher
+    event_rx: Option<std::sync::mpsc::Receiver<Result<Event, notify::Error>>>,
+    /// States of all files being watched
+    states: Arc<Mutex<Vec<NotifyWatcherState>>>,
+}
+
+impl NotifyWatcher {
+    /// Create a new NotifyWatcher
+    pub fn new() -> Result<Self, notify::Error> {
+        Ok(NotifyWatcher {
+            watcher: None,
+            event_rx: None,
+            states: Arc::new(Mutex::new(Vec::new())),
+        })
+    }
+
+    /// Initialize the watcher with a specific path
+    pub fn initialize(&mut self, path: &Path) -> Result<(), notify::Error> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher = notify::recommended_watcher(tx)?;
+
+        // Watch the parent directory of the file to catch renames, deletions, etc.
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        watcher.watch(parent, RecursiveMode::NonRecursive)?;
+
+        trace!(message = "Initialized notify watcher", ?path);
+
+        self.watcher = Some(Box::new(watcher));
+        self.event_rx = Some(rx);
+
+        Ok(())
+    }
+
+    /// Add a file to be watched in passive mode
+    pub fn watch_file(&mut self, path: PathBuf, file_position: FilePosition) -> Result<(), notify::Error> {
+        if self.watcher.is_none() {
+            self.initialize(&path)?;
+        }
+
+        let state = NotifyWatcherState {
+            path,
+            file_position,
+            last_seen: Instant::now(),
+            is_active: false,
+        };
+
+        let mut states = self.states.lock().unwrap();
+        states.push(state);
+
+        Ok(())
+    }
+
+    /// Check for any events on the watched files
+    pub fn check_events(&mut self) -> Vec<(PathBuf, EventKind)> {
+        let mut events = Vec::new();
+
+        if let Some(ref mut rx) = self.event_rx {
+            loop {
+                match rx.try_recv() {
+                    Ok(event) => {
+                        match event {
+                            Ok(event) => {
+                                trace!(message = "Received file event", ?event);
+                                for path in event.paths {
+                                    events.push((path, event.kind));
+                                }
+                            }
+                            Err(e) => {
+                                error!(message = "Error receiving file event", error = ?e);
+                            }
+                        }
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {
+                        // No more events to process
+                        break;
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        error!(message = "Notify watcher channel disconnected");
+                        break;
+                    }
+                }
+            }
+        }
+
+        events
+    }
+
+    /// Activate watching for a file
+    #[allow(dead_code)]
+    pub fn activate(&mut self, path: &Path) -> bool {
+        let mut states = self.states.lock().unwrap();
+        for state in states.iter_mut() {
+            if state.path == path {
+                state.is_active = true;
+                state.last_seen = Instant::now();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Deactivate watching for a file (switch to passive mode)
+    #[allow(dead_code)]
+    pub fn deactivate(&mut self, path: &Path, file_position: FilePosition) -> bool {
+        let mut states = self.states.lock().unwrap();
+        for state in states.iter_mut() {
+            if state.path == path {
+                state.is_active = false;
+                state.file_position = file_position;
+                state.last_seen = Instant::now();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Get the current file position for a path
+    #[allow(dead_code)]
+    pub fn get_file_position(&self, path: &Path) -> Option<FilePosition> {
+        let states = self.states.lock().unwrap();
+        for state in states.iter() {
+            if state.path == path {
+                return Some(state.file_position);
+            }
+        }
+        None
+    }
+
+    /// Update the file position for a path
+    #[allow(dead_code)]
+    pub fn update_file_position(&mut self, path: &Path, file_position: FilePosition) {
+        let mut states = self.states.lock().unwrap();
+        for state in states.iter_mut() {
+            if state.path == path {
+                state.file_position = file_position;
+                state.last_seen = Instant::now();
+                break;
+            }
+        }
+    }
+}

--- a/lib/file-source/src/fingerprinter.rs
+++ b/lib/file-source/src/fingerprinter.rs
@@ -802,6 +802,10 @@ mod test {
 
         fn emit_files_open(&self, _: usize) {}
 
+        fn emit_file_switched_to_passive(&self, _: &Path, _: u64) {}
+
+        fn emit_file_switched_to_active(&self, _: &Path, _: u64) {}
+
         fn emit_path_globbing_failed(&self, _: &Path, _: &Error) {}
     }
 }

--- a/lib/file-source/src/internal_events.rs
+++ b/lib/file-source/src/internal_events.rs
@@ -25,5 +25,9 @@ pub trait FileSourceInternalEvents: Send + Sync + Clone + 'static {
 
     fn emit_files_open(&self, count: usize);
 
+    fn emit_file_switched_to_passive(&self, path: &Path, file_position: u64);
+
+    fn emit_file_switched_to_active(&self, path: &Path, file_position: u64);
+
     fn emit_path_globbing_failed(&self, path: &Path, error: &Error);
 }

--- a/lib/file-source/src/lib.rs
+++ b/lib/file-source/src/lib.rs
@@ -16,6 +16,7 @@ pub mod paths_provider;
 pub use self::{
     checkpointer::{Checkpointer, CheckpointsView, CHECKPOINT_FILE_NAME},
     file_server::{calculate_ignore_before, FileServer, Line, Shutdown as FileServerShutdown},
+    file_watcher::WatcherState,
     fingerprinter::{FileFingerprint, FingerprintStrategy, Fingerprinter},
     internal_events::FileSourceInternalEvents,
 };

--- a/src/internal_events/file.rs
+++ b/src/internal_events/file.rs
@@ -575,6 +575,40 @@ mod source {
             emit!(FileOpen { count });
         }
 
+        fn emit_file_switched_to_passive(&self, file: &Path, file_position: u64) {
+            debug!(
+                message = "File switched to passive watching mode",
+                file = %file.display(),
+                position = %file_position,
+            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "files_passive_total",
+                    "file" => file.to_string_lossy().into_owned(),
+                )
+            } else {
+                counter!("files_passive_total")
+            }
+            .increment(1);
+        }
+
+        fn emit_file_switched_to_active(&self, file: &Path, file_position: u64) {
+            debug!(
+                message = "File switched to active watching mode",
+                file = %file.display(),
+                position = %file_position,
+            );
+            if self.include_file_metric_tag {
+                counter!(
+                    "files_active_total",
+                    "file" => file.to_string_lossy().into_owned(),
+                )
+            } else {
+                counter!("files_active_total")
+            }
+            .increment(1);
+        }
+
         fn emit_path_globbing_failed(&self, path: &Path, error: &Error) {
             emit!(PathGlobbingError { path, error });
         }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -569,6 +569,7 @@ pub fn file_source(
         emitter,
         handle: tokio::runtime::Handle::current(),
         rotate_wait: config.rotate_wait,
+        idle_timeout: Some(Duration::from_secs(60)), // Default to 60 seconds idle timeout
     };
 
     let event_metadata = EventMetadata {

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -830,6 +830,8 @@ impl Source {
             // A handle to the current tokio runtime
             handle: tokio::runtime::Handle::current(),
             rotate_wait,
+            // Default idle timeout for switching to passive mode
+            idle_timeout: Some(Duration::from_secs(60)),
         };
 
         let (file_source_tx, file_source_rx) = futures::channel::mpsc::channel::<Vec<Line>>(2);


### PR DESCRIPTION
This commit modifies the file-source library to use the cross-platform filesystem notification library for Rust (notify-rs/notify) instead of polling, and without holding an active file handle for idle files.

## Summary

1. Added notify-rs/notify as a dependency:
   - Added the notify crate to Cargo.toml

2. Created a new file watcher implementation using notify:
   - Created a new module file_watcher/notify_watcher.rs to implement a watcher using notify-rs
   - Implemented a state machine that can transition between active and passive watching states

3. Modified the FileWatcher struct:
   - Added a new enum for watcher state (Active, Passive)
   - Added fields to track the notify watcher when in passive mode
   - Implemented methods to transition between active and passive states

4. Updated the FileServer implementation:
   - Modified the file server to handle the new passive watching state
   - Implemented logic to transition files between active and passive states based on activity
   - Added a new configuration option idle_timeout to control when files switch to passive mode

5. Updated the internal events system:
   - Added events for when files switch between active and passive modes
   - Updated the event emitters to handle these new events

Benefits:
- Reduced resource usage by not holding open file handles for idle files
- Better scalability to handle a larger number of files
- Improved performance by using filesystem notifications instead of polling
- Maintained reliability by keeping checkpoints for all files

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Tested on Linux. To be tested on other OS's as supported by [notifyrs/notify](https://github.com/notify-rs/notify/) library. Currently:
-    Linux / Android: inotify
-    macOS: FSEvents or kqueue, see features
-    Windows: ReadDirectoryChangesW
-    iOS / FreeBSD / NetBSD / OpenBSD / DragonflyBSD: kqueue
-    All platforms: polling


## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them. To minimize round-trips see the following local checks:
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

- Closes: https://github.com/vectordotdev/vector/issues/3567

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
