### PR TITLE
chore(deps): Bump maxminddb from 0.25.0 to 0.26.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6063,15 +6063,16 @@ dependencies = [
 
 [[package]]
 name = "maxminddb"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144de2546bf4846c6c84b7f76be035f7ebbc1e7d40cfb05810ba45c129508321"
+checksum = "2a197e44322788858682406c74b0b59bf8d9b4954fe1f224d9a25147f1880bba"
 dependencies = [
  "ipnetwork",
  "log",
  "memchr",
  "serde",
  "simdutf8",
+ "thiserror 2.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,7 +348,7 @@ k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_26
 kube = { version = "0.93.0", default-features = false, features = ["client", "openssl-tls", "runtime"], optional = true }
 listenfd = { version = "1.0.2", default-features = false, optional = true }
 lru = { version = "0.13.0", default-features = false, optional = true }
-maxminddb = { version = "0.25.0", default-features = false, optional = true, features = ["simdutf8"] }
+maxminddb = { version = "0.26.0", default-features = false, optional = true, features = ["simdutf8"] }
 md-5 = { version = "0.10", default-features = false, optional = true }
 mongodb = { version = "2.8.2", default-features = false, features = ["tokio-runtime"], optional = true }
 async-nats = { version = "0.33.0", default-features = false, optional = true }

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, fs, net::IpAddr, sync::Arc, time::SystemTime};
 
 use maxminddb::{
     geoip2::{AnonymousIp, City, ConnectionType, Isp},
-    MaxMindDBError, Reader,
+    Reader,
 };
 use ordered_float::NotNan;
 use vector_lib::configurable::configurable_component;
@@ -134,7 +134,7 @@ impl Geoip {
         };
 
         match result {
-            Ok(_) | Err(MaxMindDBError::AddressNotFoundError(_)) => Ok(Geoip {
+            Ok(_) => Ok(Geoip {
                 last_modified: fs::metadata(&config.path)?.modified()?,
                 dbreader,
                 dbkind,
@@ -163,7 +163,7 @@ impl Geoip {
 
         match self.dbkind {
             DatabaseKind::Asn | DatabaseKind::Isp => {
-                let data = self.dbreader.lookup::<Isp>(ip).ok()?;
+                let data = self.dbreader.lookup::<Isp>(ip).ok()??;
 
                 add_field!("autonomous_system_number", data.autonomous_system_number);
                 add_field!(
@@ -174,7 +174,7 @@ impl Geoip {
                 add_field!("organization", data.organization);
             }
             DatabaseKind::City => {
-                let data = self.dbreader.lookup::<City>(ip).ok()?;
+                let data = self.dbreader.lookup::<City>(ip).ok()??;
 
                 add_field!(
                     "city_name",
@@ -224,12 +224,12 @@ impl Geoip {
                 add_field!("postal_code", data.postal.and_then(|p| p.code));
             }
             DatabaseKind::ConnectionType => {
-                let data = self.dbreader.lookup::<ConnectionType>(ip).ok()?;
+                let data = self.dbreader.lookup::<ConnectionType>(ip).ok()??;
 
                 add_field!("connection_type", data.connection_type);
             }
             DatabaseKind::AnonymousIp => {
-                let data = self.dbreader.lookup::<AnonymousIp>(ip).ok()?;
+                let data = self.dbreader.lookup::<AnonymousIp>(ip).ok()??;
 
                 add_field!("is_anonymous", data.is_anonymous);
                 add_field!("is_anonymous_vpn", data.is_anonymous_vpn);

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -4,7 +4,7 @@
 //! [maxmind]: https://maxmind.com
 use std::{fs, net::IpAddr, sync::Arc, time::SystemTime};
 
-use maxminddb::{MaxMindDBError, Reader};
+use maxminddb::Reader;
 use vector_lib::configurable::configurable_component;
 use vector_lib::enrichment::{Case, Condition, IndexHandle, Table};
 use vrl::value::{ObjectMap, Value};
@@ -57,7 +57,7 @@ impl Mmdb {
         let result = dbreader.lookup::<ObjectMap>(ip).map(|_| ());
 
         match result {
-            Ok(_) | Err(MaxMindDBError::AddressNotFoundError(_)) => Ok(Mmdb {
+            Ok(_) => Ok(Mmdb {
                 last_modified: fs::metadata(&config.path)?.modified()?,
                 dbreader,
                 config,
@@ -67,7 +67,7 @@ impl Mmdb {
     }
 
     fn lookup(&self, ip: IpAddr, select: Option<&[String]>) -> Option<ObjectMap> {
-        let data = self.dbreader.lookup::<ObjectMap>(ip).ok()?;
+        let data = self.dbreader.lookup::<ObjectMap>(ip).ok()??;
 
         if let Some(fields) = select {
             let mut filtered = Value::from(ObjectMap::new());


### PR DESCRIPTION
## Summary
Update code for breaking changes in maxminddb 0.26 – now instead of error in case IP was not found, maxminddb returns `None`.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Cargo test

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## References

- Closes #22758

