### PR TITLE
enhancement(reduce transform): Refactor reduce transform logic

### DIFF
--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use crate::event::{LogEvent, Value};
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
+use dyn_clone::DynClone;
 use ordered_float::NotNan;
 use vector_lib::configurable::configurable_component;
 use vrl::path::OwnedTargetPath;
@@ -566,11 +567,13 @@ impl ReduceValueMerger for MinNumberMerger {
     }
 }
 
-pub trait ReduceValueMerger: std::fmt::Debug + Send + Sync {
+pub trait ReduceValueMerger: std::fmt::Debug + Send + Sync + DynClone {
     fn add(&mut self, v: Value) -> Result<(), String>;
     fn insert_into(self: Box<Self>, path: &OwnedTargetPath, v: &mut LogEvent)
         -> Result<(), String>;
 }
+
+dyn_clone::clone_trait_object!(ReduceValueMerger);
 
 impl From<Value> for Box<dyn ReduceValueMerger> {
     fn from(v: Value) -> Self {

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{hash_map, HashMap};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
@@ -19,7 +19,7 @@ use vector_lib::stream::expiration_map::{map_with_expiration, Emitter};
 use vrl::path::{parse_target_path, OwnedTargetPath};
 use vrl::prelude::KeyString;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ReduceState {
     events: usize,
     fields: HashMap<OwnedTargetPath, Box<dyn ReduceValueMerger>>,
@@ -132,7 +132,7 @@ impl ReduceState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Reduce {
     expire_after: Duration,
     flush_period: Duration,
@@ -244,18 +244,18 @@ impl Reduce {
 
     fn push_or_new_reduce_state(&mut self, event: LogEvent, discriminant: Discriminant) {
         match self.reduce_merge_states.entry(discriminant) {
-            hash_map::Entry::Vacant(entry) => {
+            Entry::Vacant(entry) => {
                 let mut state = ReduceState::new();
                 state.add_event(event, &self.merge_strategies);
                 entry.insert(state);
             }
-            hash_map::Entry::Occupied(mut entry) => {
+            Entry::Occupied(mut entry) => {
                 entry.get_mut().add_event(event, &self.merge_strategies);
             }
         };
     }
 
-    pub(crate) fn transform_one(&mut self, emitter: &mut Emitter<Event>, event: Event) {
+    pub fn transform_one(&mut self, emitter: &mut Emitter<Event>, event: Event) {
         let (starts_here, event) = match &self.starts_when {
             Some(condition) => condition.check(event),
             None => (false, event),
@@ -312,26 +312,37 @@ impl TaskTransform<Event> for Reduce {
     where
         Self: 'static,
     {
-        let flush_period = self.flush_period;
+        let transform_fn = move |me: &mut Box<Reduce>, event, emitter: &mut Emitter<Event>| {
+            me.transform_one(emitter, event);
+        };
 
-        Box::pin(map_with_expiration(
-            self,
-            input_rx,
-            flush_period,
-            |me: &mut Box<Reduce>, event, emitter: &mut Emitter<Event>| {
-                // called for each event
-                me.transform_one(emitter, event);
-            },
-            |me: &mut Box<Reduce>, emitter: &mut Emitter<Event>| {
-                // called periodically to check for expired events
-                me.flush_into(emitter);
-            },
-            |me: &mut Box<Reduce>, emitter: &mut Emitter<Event>| {
-                // called when the input stream ends
-                me.flush_all_into(emitter);
-            },
-        ))
+        construct_output_stream(self, input_rx, transform_fn)
     }
+}
+
+pub fn construct_output_stream(
+    reduce: Box<Reduce>,
+    input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
+    mut transform_fn: impl FnMut(&mut Box<Reduce>, Event, &mut Emitter<Event>) + Send + Sync + 'static,
+) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+where
+    Reduce: 'static,
+{
+    let flush_period = reduce.flush_period;
+    Box::pin(map_with_expiration(
+        reduce,
+        input_rx,
+        flush_period,
+        move |me, event, emitter| {
+            transform_fn(me, event, emitter);
+        },
+        |me, emitter| {
+            me.flush_into(emitter);
+        },
+        |me, emitter| {
+            me.flush_all_into(emitter);
+        },
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Refactors out the construction of the reduce processor's output stream into a reusable helper that can be used by other components. We want to pass in different `transform` functions to this helper so added this as a parameter.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Tested locally with vector pipeline

```
transforms:
  transform-0:
    inputs:
      - source-0
    type: reduce
    group_by:
      - input
    merge_strategies:
      input: "concat"
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them. To minimize round-trips see the following local checks:
  - `make check-all` is a good command to run locally. This check is
    defined [here](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454). Some of these
    checks might not be relevant to your PR. For Rust changes, at the very least you should run:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
