### PR TITLE
feat(sources): add access to client address in custom VRL auth

### DIFF
--- a/changelog.d/22850_custom_auth_address_access.feature.md
+++ b/changelog.d/22850_custom_auth_address_access.feature.md
@@ -1,0 +1,3 @@
+Enabled IP address access in VRL scripts of custom auth strategy for server components.
+
+authors: esensar Quad9DNS

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -1,5 +1,5 @@
 //! Shared authentication config between components that use HTTP.
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, net::SocketAddr};
 
 use bytes::Bytes;
 use headers::{authorization::Credentials, Authorization};
@@ -194,7 +194,11 @@ pub enum HttpServerAuthMatcher {
 
 impl HttpServerAuthMatcher {
     /// Compares passed headers to the matcher
-    pub fn handle_auth(&self, headers: &HeaderMap<HeaderValue>) -> Result<(), ErrorMessage> {
+    pub fn handle_auth(
+        &self,
+        address: Option<&SocketAddr>,
+        headers: &HeaderMap<HeaderValue>,
+    ) -> Result<(), ErrorMessage> {
         match self {
             HttpServerAuthMatcher::AuthHeader(expected, err_message) => {
                 if let Some(header) = headers.get(AUTHORIZATION) {
@@ -213,31 +217,40 @@ impl HttpServerAuthMatcher {
                     ))
                 }
             }
-            HttpServerAuthMatcher::Vrl { program } => self.handle_vrl_auth(headers, program),
+            HttpServerAuthMatcher::Vrl { program } => {
+                self.handle_vrl_auth(address, headers, program)
+            }
         }
     }
 
     fn handle_vrl_auth(
         &self,
+        address: Option<&SocketAddr>,
         headers: &HeaderMap<HeaderValue>,
         program: &Program,
     ) -> Result<(), ErrorMessage> {
         let mut target = VrlTarget::new(
             Event::Log(LogEvent::from_map(
-                ObjectMap::from([(
-                    "headers".into(),
-                    Value::Object(
-                        headers
-                            .iter()
-                            .map(|(k, v)| {
-                                (
-                                    KeyString::from(k.to_string()),
-                                    Value::Bytes(Bytes::copy_from_slice(v.as_bytes())),
-                                )
-                            })
-                            .collect::<ObjectMap>(),
+                ObjectMap::from([
+                    (
+                        "headers".into(),
+                        Value::Object(
+                            headers
+                                .iter()
+                                .map(|(k, v)| {
+                                    (
+                                        KeyString::from(k.to_string()),
+                                        Value::Bytes(Bytes::copy_from_slice(v.as_bytes())),
+                                    )
+                                })
+                                .collect::<ObjectMap>(),
+                        ),
                     ),
-                )]),
+                    (
+                        "address".into(),
+                        address.map_or(Value::Null, |a| Value::from(a.ip().to_string())),
+                    ),
+                ]),
                 Default::default(),
             )),
             program.info(),
@@ -270,7 +283,7 @@ impl HttpServerAuthMatcher {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_util::random_string;
+    use crate::test_util::{next_addr, random_string};
     use indoc::indoc;
 
     use super::*;
@@ -426,7 +439,7 @@ mod tests {
 
         let matcher = basic_auth.build(&Default::default()).unwrap();
 
-        let result = matcher.handle_auth(&HeaderMap::new());
+        let result = matcher.handle_auth(Some(&next_addr()), &HeaderMap::new());
 
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -445,7 +458,7 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("Basic wrong"));
-        let result = matcher.handle_auth(&headers);
+        let result = matcher.handle_auth(Some(&next_addr()), &headers);
 
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -469,7 +482,7 @@ mod tests {
             AUTHORIZATION,
             Authorization::basic(&username, &password).0.encode(),
         );
-        let result = matcher.handle_auth(&headers);
+        let result = matcher.handle_auth(Some(&next_addr()), &headers);
 
         assert!(result.is_ok());
     }
@@ -484,9 +497,41 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("test"));
-        let result = matcher.handle_auth(&headers);
+        let result = matcher.handle_auth(Some(&next_addr()), &headers);
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_be_able_to_check_address() {
+        let addr = next_addr();
+        let addr_string = addr.ip().to_string();
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: format!(".address == \"{addr_string}\""),
+        };
+
+        let matcher = custom_auth.build(&Default::default()).unwrap();
+
+        let headers = HeaderMap::new();
+        let result = matcher.handle_auth(Some(&next_addr()), &headers);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_work_with_missing_address_too() {
+        let addr = next_addr();
+        let addr_string = addr.ip().to_string();
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: format!(".address == \"{addr_string}\""),
+        };
+
+        let matcher = custom_auth.build(&Default::default()).unwrap();
+
+        let headers = HeaderMap::new();
+        let result = matcher.handle_auth(None, &headers);
+
+        assert!(result.is_err());
     }
 
     #[test]
@@ -499,7 +544,7 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("wrong value"));
-        let result = matcher.handle_auth(&headers);
+        let result = matcher.handle_auth(Some(&next_addr()), &headers);
 
         assert!(result.is_err());
         let error = result.unwrap_err();
@@ -517,7 +562,7 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_static("test"));
-        let result = matcher.handle_auth(&headers);
+        let result = matcher.handle_auth(Some(&next_addr()), &headers);
 
         assert!(result.is_err());
         let error = result.unwrap_err();

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -206,7 +206,7 @@ impl WebSocketListenerSink {
                 ));
                 return Ok(response);
             };
-            match auth.handle_auth(req.headers()) {
+            match auth.handle_auth(Some(&addr), req.headers()) {
                 Ok(_) => {
                     extra_tags.append(&mut Self::extract_extra_tags(
                         &extra_tags_config,

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -132,7 +132,9 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
 
                         let events = auth_matcher
                             .as_ref()
-                            .map_or(Ok(()), |a| a.handle_auth(&headers))
+                            .map_or(Ok(()), |a| {
+                                a.handle_auth(addr.as_ref().map(|a| a.0).as_ref(), &headers)
+                            })
                             .and_then(|()| self.decode(encoding_header.as_deref(), body))
                             .and_then(|body| {
                                 emit!(HttpBytesReceived {
@@ -155,7 +157,9 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                                     path.as_str(),
                                     &headers,
                                     &query_parameters,
-                                    addr.map(|PeerAddr(inner_addr)| inner_addr).as_ref(),
+                                    addr.and_then(|a| enable_source_ip.then_some(a))
+                                        .map(|PeerAddr(inner_addr)| inner_addr)
+                                        .as_ref(),
                                 );
 
                                 events
@@ -182,7 +186,6 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
             let span = Span::current();
             let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
                 let remote_addr = conn.peer_addr();
-                let remote_addr_ref = enable_source_ip.then_some(remote_addr);
                 let svc = ServiceBuilder::new()
                     .layer(build_http_trace_layer(span.clone()))
                     .option_layer(keepalive_settings.max_connection_age_secs.map(|secs| {
@@ -193,11 +196,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                         )
                     }))
                     .map_request(move |mut request: hyper::Request<_>| {
-                        if let Some(remote_addr_inner) = remote_addr_ref.as_ref() {
-                            request
-                                .extensions_mut()
-                                .insert(PeerAddr::new(*remote_addr_inner));
-                        }
+                        request.extensions_mut().insert(PeerAddr::new(remote_addr));
 
                         request
                     })

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -1286,6 +1286,9 @@ components: {
 					authorization code using VRL. Here is an example that looks up the token in an
 					enrichment table backed by a CSV file.
 
+					Currently custom VRL auth has access to `headers` and `address` (IP address of the
+					client).
+
 					```yaml
 					\(kind)s:
 					  \(Name)_\(kind):


### PR DESCRIPTION
## Summary

This adds access to `address`, besides `headers` access in VRL scripts for custom auth strategy. This can be useful for additional logging or whitelisting/blacklisting addresses.
## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Besides the tests added to the codebase, I ran basic tests with `http_server` source component:

```yaml
sources:
  http_server_source:
    type: "http_server"
    address: "0.0.0.0:80"
    auth:
      strategy: "custom"
      source: |-
        log(.address)
        .headers.authorization == "test"

sinks:
  console:
    inputs: ["http_server_source"]
    target: "stdout"
    type: "console"
    acknowledgements:
      enabled: false
    encoding:
      codec: "json"
```

Tested by making calls via curl:
```
$ curl -X POST vector:80
{"code":401,"message":"Auth failed"}
$ curl -X POST vector:80 -H "Authorization: test"
```

Client address was visible in Vector logs.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

Custom VRL auth addition PR: https://github.com/vectordotdev/vector/pull/22236

---
>Sponsored by [Quad9](https://quad9.net/)
