### PR TITLE
feat(websocket_server sink): add support for websocket subprotocol

### DIFF
--- a/changelog.d/22854_websocket_server_subprotocol_support.feature.md
+++ b/changelog.d/22854_websocket_server_subprotocol_support.feature.md
@@ -1,0 +1,3 @@
+Added support for `Sec-WebSocket-Protocol` header in `websocket_server` sink, for better support for clients that require this header.
+
+authors: esensar Quad9DNS

--- a/changelog.d/22854_websocket_server_subprotocol_support.feature.md
+++ b/changelog.d/22854_websocket_server_subprotocol_support.feature.md
@@ -1,3 +1,3 @@
-Added support for `Sec-WebSocket-Protocol` header in `websocket_server` sink, for better support for clients that require this header.
+Added support for the `Sec-WebSocket-Protocol` header in the `websocket_server` sink to better accommodate clients that require it.
 
 authors: esensar Quad9DNS

--- a/website/cue/reference/components/sinks/base/websocket_server.cue
+++ b/website/cue/reference/components/sinks/base/websocket_server.cue
@@ -801,6 +801,38 @@ base: components: sinks: websocket_server: configuration: {
 			}
 		}
 	}
+	subprotocol: {
+		description: "Configuration of websocket subprotocol handling."
+		required:    false
+		type: object: options: {
+			supported_subprotocols: {
+				description: """
+					List of supported `Sec-WebSocket-Protocol` values. First match out of requested
+					subprotocols will be accepted.
+					"""
+				relevant_when: "type = \"specific\""
+				required:      false
+				type: array: {
+					default: []
+					items: type: string: {}
+				}
+			}
+			type: {
+				description: "Enum for websocket subprotocol handling."
+				required:    false
+				type: string: {
+					default: "specific"
+					enum: {
+						any: "Supports any subprotocol that the client sends. First of the requested subprotocols will be accepted."
+						specific: """
+															Supports only listed subprotocols. If client doesn't send any of these, server will skip
+															`Sec-WebSocket-Protocol` header and the client can choose to close the connection then.
+															"""
+					}
+				}
+			}
+		}
+	}
 	tls: {
 		description: "Configures the TLS options for incoming/outgoing connections."
 		required:    false


### PR DESCRIPTION
## Summary

Adds support for `Sec-WebSocket-Protocol` header in websocket connection request. By default (and currently, before this feature), the server ignored this header and never put it in responses. It can be configured to accept any subprotocol and put it in response header (some clients will require this) and it can also be configured to only accept some subprotocols and ignore others. This only affects the connection requests, everything afterwards functions the same.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Ran Vector with following configuration:
```yaml
sources:
  demo_logs_test:
    type: "demo_logs"
    format: "json"

sinks:
  websocket_sink:
    inputs: ["demo_logs_test"]
    type: "websocket_listener"
    subprotocol:
        type: any
    address: "0.0.0.0:1234"
    encoding:
      codec: "json"
```

Without `subprotocol` option:
```
$ wscat --connect "ws://127.0.0.1:1234" --subprotocol "test"
error: Server sent no subprotocol
```

Without `subprotocol` option set to `any`:
```
$ wscat --connect "ws://127.0.0.1:1234" --subprotocol "test"
#... data ...
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


---
>Sponsored by [Quad9](https://quad9.net/)