### PR TITLE
fix(websocket_server sink): properly display client count in websocket_server debug logs

### DIFF
--- a/src/internal_events/websocket_server.rs
+++ b/src/internal_events/websocket_server.rs
@@ -14,7 +14,12 @@ pub struct WsListenerConnectionEstablished {
 
 impl InternalEvent for WsListenerConnectionEstablished {
     fn emit(self) {
-        debug!(message = "Websocket client connected. Client count: {self.client_count}");
+        debug!(
+            message = format!(
+                "Websocket client connected. Client count: {}",
+                self.client_count
+            )
+        );
         counter!("connection_established_total", &self.extra_tags).increment(1);
         gauge!("active_clients", &self.extra_tags).set(self.client_count as f64);
     }
@@ -67,7 +72,12 @@ pub struct WsListenerConnectionShutdown {
 
 impl InternalEvent for WsListenerConnectionShutdown {
     fn emit(self) {
-        info!(message = "Client connection closed. Client count: {self.client_count}.");
+        info!(
+            message = format!(
+                "Client connection closed. Client count: {}.",
+                self.client_count
+            )
+        );
         counter!("connection_shutdown_total", &self.extra_tags).increment(1);
         gauge!("active_clients", &self.extra_tags).set(self.client_count as f64);
     }


### PR DESCRIPTION

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).



---
>Sponsored by [Quad9](https://quad9.net/)