### PR TITLE
fix(log_to_metric): support aggregated_histogram and aggregated_summary keys

### DIFF
--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -635,15 +635,15 @@ fn get_distribution_value(log: &LogEvent) -> Result<MetricValue, TransformError>
     })
 }
 
-fn get_histogram_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
+fn get_histogram_value(log: &LogEvent, key: &str) -> Result<MetricValue, TransformError> {
     let event_buckets = log
-        .get(event_path!("histogram", "buckets"))
+        .get(event_path!(key, "buckets"))
         .ok_or_else(|| TransformError::PathNotFound {
-            path: "histogram.buckets".to_string(),
+            path: format!("{}.buckets", key),
         })?
         .as_array()
         .ok_or_else(|| TransformError::ParseError {
-            path: "histogram.buckets".to_string(),
+            path: format!("{}.buckets", key),
             kind: TransformParseErrorKind::ArrayError,
         })?;
 
@@ -652,22 +652,22 @@ fn get_histogram_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
         let upper_limit = e_bucket
             .get(path!("upper_limit"))
             .ok_or_else(|| TransformError::PathNotFound {
-                path: "histogram.buckets.upper_limit".to_string(),
+                path: format!("{}.buckets.upper_limit", key),
             })?
             .as_float()
             .ok_or_else(|| TransformError::ParseError {
-                path: "histogram.buckets.upper_limit".to_string(),
+                path: format!("{}.buckets.upper_limit", key),
                 kind: TransformParseErrorKind::FloatError,
             })?;
 
         let count = e_bucket
             .get(path!("count"))
             .ok_or_else(|| TransformError::PathNotFound {
-                path: "histogram.buckets.count".to_string(),
+                path: format!("{}.buckets.count", key),
             })?
             .as_integer()
             .ok_or_else(|| TransformError::ParseError {
-                path: "histogram.buckets.count".to_string(),
+                path: format!("{}.buckets.count", key),
                 kind: TransformParseErrorKind::IntError,
             })?;
 
@@ -678,24 +678,24 @@ fn get_histogram_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
     }
 
     let count = log
-        .get(event_path!("histogram", "count"))
+        .get(event_path!(key, "count"))
         .ok_or_else(|| TransformError::PathNotFound {
-            path: "histogram.count".to_string(),
+            path: format!("{}.count", key),
         })?
         .as_integer()
         .ok_or_else(|| TransformError::ParseError {
-            path: "histogram.count".to_string(),
+            path: format!("{}.count", key),
             kind: TransformParseErrorKind::IntError,
         })?;
 
     let sum = log
-        .get(event_path!("histogram", "sum"))
+        .get(event_path!(key, "sum"))
         .ok_or_else(|| TransformError::PathNotFound {
-            path: "histogram.sum".to_string(),
+            path: format!("{}.sum", key),
         })?
         .as_float()
         .ok_or_else(|| TransformError::ParseError {
-            path: "histogram.sum".to_string(),
+            path: format!("{}.sum", key),
             kind: TransformParseErrorKind::FloatError,
         })?;
 
@@ -706,15 +706,15 @@ fn get_histogram_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
     })
 }
 
-fn get_summary_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
+fn get_summary_value(log: &LogEvent, key: &str) -> Result<MetricValue, TransformError> {
     let event_quantiles = log
-        .get(event_path!("summary", "quantiles"))
+        .get(event_path!(key, "quantiles"))
         .ok_or_else(|| TransformError::PathNotFound {
-            path: "summary.quantiles".to_string(),
+            path: format!("{}.quantiles", key),
         })?
         .as_array()
         .ok_or_else(|| TransformError::ParseError {
-            path: "summary.quantiles".to_string(),
+            path: format!("{}.quantiles", key),
             kind: TransformParseErrorKind::ArrayError,
         })?;
 
@@ -723,22 +723,22 @@ fn get_summary_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
         let quantile = e_quantile
             .get(path!("quantile"))
             .ok_or_else(|| TransformError::PathNotFound {
-                path: "summary.quantiles.quantile".to_string(),
+                path: format!("{}.quantiles.quantile", key),
             })?
             .as_float()
             .ok_or_else(|| TransformError::ParseError {
-                path: "summary.quantiles.quantile".to_string(),
+                path: format!("{}.quantiles.quantile", key),
                 kind: TransformParseErrorKind::FloatError,
             })?;
 
         let value = e_quantile
             .get(path!("value"))
             .ok_or_else(|| TransformError::PathNotFound {
-                path: "summary.quantiles.value".to_string(),
+                path: format!("{}.quantiles.value", key),
             })?
             .as_float()
             .ok_or_else(|| TransformError::ParseError {
-                path: "summary.quantiles.value".to_string(),
+                path: format!("{}.quantiles.value", key),
                 kind: TransformParseErrorKind::FloatError,
             })?;
 
@@ -749,24 +749,24 @@ fn get_summary_value(log: &LogEvent) -> Result<MetricValue, TransformError> {
     }
 
     let count = log
-        .get(event_path!("summary", "count"))
+        .get(event_path!(key, "count"))
         .ok_or_else(|| TransformError::PathNotFound {
-            path: "summary.count".to_string(),
+            path: format!("{}.count", key),
         })?
         .as_integer()
         .ok_or_else(|| TransformError::ParseError {
-            path: "summary.count".to_string(),
+            path: format!("{}.count", key),
             kind: TransformParseErrorKind::IntError,
         })?;
 
     let sum = log
-        .get(event_path!("summary", "sum"))
+        .get(event_path!(key, "sum"))
         .ok_or_else(|| TransformError::PathNotFound {
-            path: "summary.sum".to_string(),
+            path: format!("{}.sum", key),
         })?
         .as_float()
         .ok_or_else(|| TransformError::ParseError {
-            path: "summary.sum".to_string(),
+            path: format!("{}.sum", key),
             kind: TransformParseErrorKind::FloatError,
         })?;
 
@@ -829,10 +829,12 @@ fn to_metrics(event: &Event) -> Result<Metric, TransformError> {
             value = match key.as_str() {
                 "gauge" => Some(get_gauge_value(log)?),
                 "distribution" => Some(get_distribution_value(log)?),
-                "histogram" => Some(get_histogram_value(log)?),
-                "summary" => Some(get_summary_value(log)?),
+                "histogram" => Some(get_histogram_value(log, key)?),
+                "summary" => Some(get_summary_value(log, key)?),
                 "counter" => Some(get_counter_value(log)?),
                 "set" => Some(get_set_value(log)?),
+                "aggregated_histogram" => Some(get_histogram_value(log, key)?),
+                "aggregated_summary" => Some(get_summary_value(log, key)?),
                 _ => None,
             };
 


### PR DESCRIPTION
## Summary
Adds support for handling `aggregated_histogram` and `aggregated_summary` keys to the `log_to_metric` transform, ensuring round-trip compatibility with the `metric_to_log` transform that serializes objects to these `aggregated_`-prefixed key names.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

[todo]

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: #20494