### PR TITLE
chore(dev): enhancements to the patch release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -8,7 +8,7 @@ labels: "domain: releasing"
 Before the release:
 
 - [ ] Create a new release preparation branch from the current release branch
-  - `git fetch --all && git checkout v0.<current minor version> && git checkout -b website-prepare-v0-<minor>-<patch>
+  - `git fetch --all && git checkout v0.<current minor version> && git checkout -b website-prepare-v0-<current minor version>-<new patch>
 - [ ] Cherry-pick in all commits to be released from the associated release milestone
   - If any merge conflicts occur, attempt to solve them and if needed enlist the aid of those familiar with the conflicting commits.
 - [ ] Bump the release number in the `Cargo.toml` to the current version number

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -18,7 +18,7 @@ Before the release:
 - [ ] Update version number in `distribution/install.sh`
 - [ ] Add new version to `website/cue/reference/versions.cue`
 - [ ] Create new release md file by copying an existing one in `./website/content/en/releases/`.
-  - Update the version number and the increase the weight by 1.
+  - Update the version number to `v0.<current minor version>.<patch>` and increase the `weight` by 1.
 - [ ] Run `cargo check` to regenerate `Cargo.lock` file
 - [ ] Commit these changes
 - [ ] Open PR against the release branch (`v0.<current minor version>`) for review
@@ -30,9 +30,9 @@ On the day of release:
 - [ ] Rebase the release preparation branch on the release branch
   - Squash the release preparation commits (but not the cherry-picked commits!) to a single
     commit. This makes it easier to cherry-pick to master after the release.
-  - `git checkout prepare-v0.<new version number> && git rebase -i v0.<current minor version>`
+  - `git checkout website-prepare-v0-<current minor version>-<new patch> && git rebase -i v0.<current minor version>`
 - [ ] Merge release preparation branch into the release branch
-  - `git co v0.<current minor version> && git merge --ff-only prepare-v0.<current minor version>.<patch>`
+  - `git co v0.<current minor version> && git merge --ff-only website-prepare-v0-<current minor version>-<new patch>`
 - [ ] Tag new release
   - [ ] `git tag v0.<minor>.<patch> -a -m v0.<minor>.<patch>`
   - [ ] `git push origin v0.<minor>.<patch>`

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -8,7 +8,7 @@ labels: "domain: releasing"
 Before the release:
 
 - [ ] Create a new release preparation branch from the current release branch
-  - `git fetch && git checkout v0.<current minor version> && git checkout -b website-prepare-v0.<new version number>`
+  - `git fetch --all && git checkout v0.<current minor version> && git checkout -b website-prepare-v0-<minor>-<patch>
 - [ ] Cherry-pick in all commits to be released from the associated release milestone
   - If any merge conflicts occur, attempt to solve them and if needed enlist the aid of those familiar with the conflicting commits.
 - [ ] Bump the release number in the `Cargo.toml` to the current version number
@@ -17,11 +17,11 @@ Before the release:
         previous releases for examples).
 - [ ] Update version number in `distribution/install.sh`
 - [ ] Add new version to `website/cue/reference/versions.cue`
-- [ ] Create new release md file by copying an existing one in `./website/content/en/releases/` and
-      updating version number
+- [ ] Create new release md file by copying an existing one in `./website/content/en/releases/`.
+  - Update the version number and the increase the weight by 1.
 - [ ] Run `cargo check` to regenerate `Cargo.lock` file
 - [ ] Commit these changes
-- [ ] Open PR against the release branch (`v0.<new version number>`) for review
+- [ ] Open PR against the release branch (`v0.<current minor version>`) for review
 - [ ] PR approval
 
 On the day of release:


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
