### PR TITLE
enhancement(opentelemetry source): Support JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,6 +7038,8 @@ dependencies = [
  "ordered-float 4.6.0",
  "prost 0.12.6",
  "prost-build 0.12.6",
+ "serde",
+ "serde_json",
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "vector-core",

--- a/build.rs
+++ b/build.rs
@@ -142,13 +142,14 @@ fn main() {
 
         for path in ["google.rpc.Status"] {
             builder = builder
-                .type_attribute(path, "#[derive(serde::Serialize)]")
+                .type_attribute(path, "#[derive(serde::Serialize, serde::Deserialize)]")
                 .type_attribute(path, "#[serde(rename_all = \"camelCase\")]");
         }
 
         // TODO: fix
         for path in ["google.rpc.Status.details"] {
-            builder = builder.field_attribute(path, "#[serde(skip_serializing)]")
+            builder =
+                builder.field_attribute(path, "#[serde(skip_serializing, skip_deserializing)]")
         }
 
         builder

--- a/build.rs
+++ b/build.rs
@@ -137,8 +137,21 @@ fn main() {
             .btree_map(["."])
             .file_descriptor_set_path(protobuf_fds_path);
 
-        tonic_build::configure()
-            .protoc_arg("--experimental_allow_proto3_optional")
+        let mut builder =
+            tonic_build::configure().protoc_arg("--experimental_allow_proto3_optional");
+
+        for path in ["google.rpc.Status"] {
+            builder = builder
+                .type_attribute(path, "#[derive(serde::Serialize)]")
+                .type_attribute(path, "#[serde(rename_all = \"camelCase\")]");
+        }
+
+        // TODO: fix
+        for path in ["google.rpc.Status.details"] {
+            builder = builder.field_attribute(path, "#[serde(skip_serializing)]")
+        }
+
+        builder
             .compile_with_config(
                 prost_build,
                 &[

--- a/changelog.d/openteletry_json.feature.md
+++ b/changelog.d/openteletry_json.feature.md
@@ -1,0 +1,3 @@
+The `opentelemetry` source now support JSON Protobuf
+
+authors: fbs

--- a/lib/opentelemetry-proto/Cargo.toml
+++ b/lib/opentelemetry-proto/Cargo.toml
@@ -15,7 +15,22 @@ chrono.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 lookup = { package = "vector-lookup", path = "../vector-lookup", default-features = false }
 ordered-float = { version = "4.6.0", default-features = false }
-prost .workspace = true
+prost.workspace = true
 tonic.workspace = true
 vrl.workspace = true
 vector-core = { path = "../vector-core", default-features = false }
+serde_json = { version = "1.0.140", optional = true, features = [
+  "raw_value",
+  "std",
+] }
+serde = { version = "1.0.219", optional = true, default-features = false, features = [
+  "alloc",
+  "derive",
+  "rc",
+] }
+
+[features]
+default = ["full"]
+full = ["with-serde"]
+
+with-serde = ['serde', 'serde_json']

--- a/lib/opentelemetry-proto/build.rs
+++ b/lib/opentelemetry-proto/build.rs
@@ -1,9 +1,82 @@
 use std::io::Error;
 
+// NOTE: Serde related attributes are copied from https://github.com/open-telemetry/opentelemetry-rust/
+
 fn main() -> Result<(), Error> {
-    tonic_build::configure()
+    let mut builder = tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        .type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"with-serde\", derive(serde::Serialize, serde::Deserialize))]",
+        )
+        .type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"with-serde\", serde(rename_all = \"camelCase\"))]",
+        );
+
+    // Optional numeric, string and array fields need to default to their default value otherwise
+    // JSON files without those field cannot deserialize
+    // we cannot add serde(default) to all generated types because enums cannot be annotated with serde(default)
+    for path in [
+        "trace.v1.Span",
+        "trace.v1.Span.Link",
+        "trace.v1.ScopeSpans",
+        "trace.v1.ResourceSpans",
+        "common.v1.InstrumentationScope",
+        "resource.v1.Resource",
+        "trace.v1.Span.Event",
+        "trace.v1.Status",
+        "logs.v1.LogRecord",
+        "logs.v1.ScopeLogs",
+        "logs.v1.ResourceLogs",
+        "metrics.v1.Metric",
+        "metrics.v1.ResourceMetrics",
+        "metrics.v1.ScopeMetrics",
+        "metrics.v1.Gauge",
+        "metrics.v1.Sum",
+        "metrics.v1.Histogram",
+        "metrics.v1.ExponentialHistogram",
+        "metrics.v1.Summary",
+        "metrics.v1.NumberDataPoint",
+        "metrics.v1.HistogramDataPoint",
+    ] {
+        builder = builder.type_attribute(
+            path,
+            "#[cfg_attr(feature = \"with-serde\", serde(default))]",
+        )
+    }
+
+    // special serializer and deserializer for traceId and spanId
+    // OTLP/JSON format uses hex string for traceId and spanId
+    // the proto file uses bytes for traceId and spanId
+    // Thus, special serializer and deserializer are needed
+    for path in [
+        "trace.v1.Span.trace_id",
+        "trace.v1.Span.span_id",
+        "trace.v1.Span.parent_span_id",
+        "trace.v1.Span.Link.trace_id",
+        "trace.v1.Span.Link.span_id",
+        "logs.v1.LogRecord.span_id",
+        "logs.v1.LogRecord.trace_id",
+        "metrics.v1.Exemplar.span_id",
+        "metrics.v1.Exemplar.trace_id",
+    ] {
+        builder = builder
+            .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_hex_string\", deserialize_with = \"crate::proto::serializers::deserialize_from_hex_string\"))]")
+    }
+
+    // flatten
+    for path in [
+        "metrics.v1.Metric.data",
+        "metrics.v1.NumberDataPoint.value",
+        "common.v1.AnyValue.value",
+    ] {
+        builder =
+            builder.field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(flatten))]");
+    }
+
+    builder
         .compile(
             &[
                 "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -53,7 +53,7 @@ impl warp::reject::Reject for ApiError {}
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
-enum ContentType {
+pub(crate) enum ContentType {
     Protobuf,
     Json,
 }
@@ -66,6 +66,21 @@ impl TryFrom<String> for ContentType {
             "application/json" => Ok(ContentType::Json),
             _ => Err(()),
         }
+    }
+}
+
+impl From<ContentType> for String {
+    fn from(content_type: ContentType) -> Self {
+        match content_type {
+            ContentType::Protobuf => "application/x-protobuf".to_string(),
+            ContentType::Json => "application/json".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for ContentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", Into::<String>::into(*self))
     }
 }
 


### PR DESCRIPTION
Not finished yet as I need to add tests and check some behaviour against the spec. However its open for feedback.
---

## Summary

This adds HTTP/JSON support to the opentelemetry source as using the JSON protobuf encoding. This gives the user an alternative to the Binary protobuf encoding, for when binary protobuf is tricky to use.

https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding

The invididual commits have more details on the changes.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Currently tested with a JSON only sink, but will add tests later on.

```
  otel2:
    inputs:
      - into-otelpb2
    type: opentelemetry
    protocol:
      type: http
      uri: "http://localhost:4318/v1/logs"
      method: post
      framing:
        method: bytes
      encoding:
        codec: json
      headers:
        content-type: application/json
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

