### PR TITLE
fix(aws_cloudwatch_logs sink): increase cloudwatch logs max event size to match new aws limit of 1MB

### DIFF
--- a/changelog.d/22831_increase_cloudwatch_log_event_max_size.fix.md
+++ b/changelog.d/22831_increase_cloudwatch_log_event_max_size.fix.md
@@ -1,0 +1,3 @@
+Increase the max event size for `aws_cloudwatch_logs` sink based on newly increased limit from `AWS`
+
+authors: cahartma

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -18,10 +18,12 @@ use crate::{
     template::Template,
 };
 
-// Estimated maximum size of InputLogEvent with an empty message
+// Estimated maximum size of InputLogEvent is 50 bytes with an empty message
 const EVENT_SIZE_OVERHEAD: usize = 50;
-const MAX_EVENT_SIZE: usize = 256 * 1024;
-const MAX_MESSAGE_SIZE: usize = MAX_EVENT_SIZE - EVENT_SIZE_OVERHEAD;
+// Batch request overhead is added now that a single event can reach max batch size
+const BATCH_SIZE_OVERHEAD: usize = 26;
+const MAX_EVENT_SIZE: usize = 1024 * 1024;
+const MAX_MESSAGE_SIZE: usize = MAX_EVENT_SIZE - EVENT_SIZE_OVERHEAD - BATCH_SIZE_OVERHEAD;
 
 #[derive(Clone)]
 pub struct CloudwatchRequest {
@@ -99,7 +101,7 @@ impl CloudwatchRequestBuilder {
         }
         let message = String::from_utf8_lossy(&message_bytes).to_string();
 
-        if message.len() > MAX_MESSAGE_SIZE {
+        if message.len() >= MAX_MESSAGE_SIZE {
             emit!(AwsCloudwatchLogsMessageSizeError {
                 size: message.len(),
                 max_size: MAX_MESSAGE_SIZE,
@@ -127,7 +129,7 @@ impl CloudwatchRequestBuilder {
 /// source: <https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html>
 impl ByteSizeOf for CloudwatchRequest {
     fn size_of(&self) -> usize {
-        self.message.len() + 26
+        self.message.len() + BATCH_SIZE_OVERHEAD
     }
 
     fn allocated_bytes(&self) -> usize {
@@ -141,7 +143,7 @@ mod tests {
     use vector_lib::config::log_schema;
     use vector_lib::event::LogEvent;
 
-    use super::CloudwatchRequestBuilder;
+    use super::{CloudwatchRequestBuilder, MAX_MESSAGE_SIZE};
 
     #[test]
     fn test() {
@@ -159,5 +161,23 @@ mod tests {
         let request = request_builder.build(event.into()).unwrap();
         assert_eq!(request.timestamp, timestamp.timestamp_millis());
         assert_eq!(&request.message, message);
+    }
+
+    #[test]
+    fn test_rejects_oversized_log_event() {
+        let mut request_builder = CloudwatchRequestBuilder {
+            group_template: "group".try_into().unwrap(),
+            stream_template: "stream".try_into().unwrap(),
+            transformer: Default::default(),
+            encoder: Default::default(),
+        };
+
+        let timestamp = Utc::now();
+        let oversized = "X".repeat(MAX_MESSAGE_SIZE + 1);
+        let mut event = LogEvent::from(oversized);
+        event.insert(log_schema().timestamp_key_target_path().unwrap(), timestamp);
+
+        let request = request_builder.build(event.into());
+        assert!(request.is_none(), "Expected None for oversized log event");
     }
 }


### PR DESCRIPTION
## Summary
Resolves issue #22859 by increasing the max event size for cloudwatch log events to ~ 1MB.   This matches the new limit updated by [AWS](https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-cloudwatch-logs-increases-log-event-size-1-mb/).

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
Added one unit test but so far no functional tests have been run.

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References
- Closes: https://github.com/vectordotdev/vector/issues/22859

