### PR TITLE
fix(internal): `AllocationGroupId::register` groups max limit increased to 256

### DIFF
--- a/changelog.d/17294_allocation_group_id_groups_max_limit_increased.fix.md
+++ b/changelog.d/17294_allocation_group_id_groups_max_limit_increased.fix.md
@@ -1,3 +1,3 @@
-Increase the `AllocationGroupId::register` groups max limit from 128 to 256
+Fix a Vector crash that occurred when the internal metrics generated a lot of  groups by increasing groups max limit from 128 to 256.
 
 authors: triggerhappy17

--- a/changelog.d/17294_allocation_group_id_groups_max_limit_increased.fix.md
+++ b/changelog.d/17294_allocation_group_id_groups_max_limit_increased.fix.md
@@ -1,0 +1,3 @@
+Increase the `AllocationGroupId::register` groups max limit from 128 to 256
+
+authors: triggerhappy17

--- a/changelog.d/17294_allocationgroupid_groups_max_limit_increased.fix.md
+++ b/changelog.d/17294_allocationgroupid_groups_max_limit_increased.fix.md
@@ -1,3 +1,0 @@
-Increase the `AllocationGroupId::register` groups max limit from 128 to 256
-
-authors: triggerhappy17

--- a/changelog.d/17294_allocationgroupid_groups_max_limit_increased.fix.md
+++ b/changelog.d/17294_allocationgroupid_groups_max_limit_increased.fix.md
@@ -1,3 +1,3 @@
-Increase the AllocationGroupId::register groups max limit from 128 to 256
+Increase the `AllocationGroupId::register` groups max limit from 128 to 256
 
 authors: triggerhappy17

--- a/changelog.d/17294_allocationgroupid_groups_max_limit_increased.fix.md
+++ b/changelog.d/17294_allocationgroupid_groups_max_limit_increased.fix.md
@@ -1,0 +1,3 @@
+Increase the AllocationGroupId::register groups max limit from 128 to 256
+
+authors: triggerhappy17

--- a/src/internal_telemetry/allocations/mod.rs
+++ b/src/internal_telemetry/allocations/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use self::allocator::{
     without_allocation_tracing, AllocationGroupId, AllocationLayer, GroupedTraceableAllocator,
 };
 
-const NUM_GROUPS: usize = 128;
+const NUM_GROUPS: usize = 256;
 
 // Allocations are not tracked during startup.
 // We use the Relaxed ordering for both stores and loads of this atomic as no other threads exist when
@@ -55,8 +55,8 @@ impl GroupMemStats {
     pub fn new() -> Self {
         let mut mutex = THREAD_LOCAL_REFS.lock().unwrap();
         let stats_ref: &'static GroupMemStatsStorage = Box::leak(Box::new(GroupMemStatsStorage {
-            allocations: arr![AtomicU64::new(0) ; 128],
-            deallocations: arr![AtomicU64::new(0) ; 128],
+            allocations: arr![AtomicU64::new(0) ; 256],
+            deallocations: arr![AtomicU64::new(0) ; 256],
         }));
         let group_mem_stats = GroupMemStats { stats: stats_ref };
         mutex.push(stats_ref);
@@ -84,7 +84,7 @@ impl GroupInfo {
     }
 }
 
-static GROUP_INFO: [Mutex<GroupInfo>; NUM_GROUPS] = arr![Mutex::new(GroupInfo::new()); 128];
+static GROUP_INFO: [Mutex<GroupInfo>; NUM_GROUPS] = arr![Mutex::new(GroupInfo::new()); 256];
 
 pub type Allocator<A> = GroupedTraceableAllocator<A, MainTracer>;
 
@@ -203,9 +203,6 @@ pub fn acquire_allocation_group_id(
         }
     }
 
-    // TODO: Technically, `NUM_GROUPS` is lower (128) than the upper bound for the
-    // `AllocationGroupId::register` call itself (253), so we can hardcode `NUM_GROUPS` here knowing
-    // it's the lower of the two values and will trigger first.. but this may not always be true.
     warn!("Maximum number of registrable allocation group IDs reached ({}). Allocations for component '{}' will be attributed to the root allocation group.", NUM_GROUPS, component_id);
     AllocationGroupId::ROOT
 }


### PR DESCRIPTION
This merge request should close out  #22851 & #17294. 

## Summary
vector would crash if AllocationGroupId::register() got called before NUM_GROUPS and allocate > 128. This PR increased NUM_GROUPS which prevents vector from crashing. 

## Change Type
- [-] Bug fix


## Is this a breaking change?
- [ -] No

## How did you test this PR?
Built and ran locally for over 24 hours with internal_metrics exposed and scraped by prometheus. Built in alpine container and running in a lab for 48 hours on a busy instance. No crash. Without this change we would see 0.46 crash within a couple of hours across all instances.

as per comments already in code:
// TODO: Technically, `NUM_GROUPS` is lower (128) than the upper bound for the
// `AllocationGroupId::register` call itself (253), so we can hardcode `NUM_GROUPS` here knowing
// it's the lower of the two values and will trigger first.. but this may not always be true.



## Does this PR include user facing changes?
- [ -] No. A maintainer will apply the "no-changelog" label to this PR.




## References
closes: #22851 
closes: #17294


