### PR TITLE
feat(vdev): do not terminate before child on SIGINT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11373,6 +11373,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "itertools 0.14.0",
+ "libc",
  "log",
  "owo-colors",
  "paste",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -36,3 +36,6 @@ tempfile.workspace = true
 toml.workspace = true
 semver.workspace = true
 indoc.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/vdev/src/commands/exec.rs
+++ b/vdev/src/commands/exec.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Args;
 
 use crate::app::CommandExt as _;
+use crate::util;
 
 /// Execute a command within the repository
 #[derive(Args, Debug)]
@@ -15,6 +16,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
+        util::catch_sigs();
         let status = Command::new(&self.args[0])
             .in_repo()
             .args(&self.args[1..])

--- a/vdev/src/commands/run.rs
+++ b/vdev/src/commands/run.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, process::Command};
 use anyhow::{bail, Result};
 use clap::Args;
 
+use crate::util;
 use crate::{app::CommandExt as _, features};
 
 /// Run `vector` with the minimum set of features required by the config file
@@ -48,6 +49,7 @@ impl Cli {
             self.config.to_str().expect("Invalid config file name"),
         ]);
         command.args(self.args);
+        util::catch_sigs();
         command.check_run()
     }
 }

--- a/vdev/src/util.rs
+++ b/vdev/src/util.rs
@@ -12,6 +12,9 @@ use anyhow::{Context as _, Result};
 use serde::Deserialize;
 use serde_json::Value;
 
+#[cfg(unix)]
+use libc;
+
 pub static IS_A_TTY: LazyLock<bool> = LazyLock::new(|| std::io::stdout().is_terminal());
 
 #[derive(Deserialize)]
@@ -103,3 +106,13 @@ pub fn run_command(cmd: &str) -> String {
 
     String::from_utf8_lossy(&output.stdout).to_string()
 }
+
+#[cfg(unix)]
+pub(crate) fn catch_sigs() {
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_IGN);
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn catch_sigs() {}


### PR DESCRIPTION
The SIGINT(control-c) is sent to both the parent and child, as they're in the same group. The `vdev` process quits immediately, as its just waiting on the child. However the child will go through its shutdown process, which by default takes a minute if it cannot cleanly shutdown. During this minute your controlling terminal gets flooded with shutdown messages.
The way to stop it is to `kill` vector again, e.g. `pkill vector` but its annoying and could kill other vector instances.

This lets the vdev ignore the SIGINT and just rely on the parent to terminate after the child did.

Its currently only implemented on unix using the libc crate. Vector uses the nix crate, but that seemed a bit overkill for 2 lines.

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

Tested in terminal. 



## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
