### PR TITLE
fix(kubernetes_logs source): remove limit if use apiserver cache

### DIFF
--- a/changelog.d/22921_remove_limit_if_use_apiserver_cache.fix.md
+++ b/changelog.d/22921_remove_limit_if_use_apiserver_cache.fix.md
@@ -1,0 +1,3 @@
+Fixed a `kubernetes source` bug where `use_apiserver_cache=true` but there is no `resourceVersion=0` parameters in list request.
+
+authors: xiao

--- a/changelog.d/22921_remove_limit_if_use_apiserver_cache.fix.md
+++ b/changelog.d/22921_remove_limit_if_use_apiserver_cache.fix.md
@@ -1,3 +1,3 @@
-Fixed a `kubernetes source` bug where `use_apiserver_cache=true` but there is no `resourceVersion=0` parameters in list request.
+Fixed a `kubernetes source` bug where `use_apiserver_cache=true` but there is no `resourceVersion=0` parameters in list request. As [the issue](https://github.com/kube-rs/kube/issues/1743) mentioned, when there are `resourceVersion =0` and `!page_size.is_none` in the `ListParams` fields, the parameter `resourceVersion=0` will be ignored by `kube-rs` sdk. If no parameter `resourceVersion` passed to the apiserver, the apiserver will list pods from ETCD instead of in memory cache.
 
-authors: xiao
+authors: xiaozongyang

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -695,11 +695,7 @@ impl Source {
             watcher::ListSemantic::MostRecent
         };
 
-        let page_size = if use_apiserver_cache {
-            None
-        } else {
-            Some(500)
-        };
+        let page_size = if use_apiserver_cache { None } else { Some(500) };
 
         let pod_watcher = watcher(
             pods,
@@ -707,7 +703,7 @@ impl Source {
                 field_selector: Some(field_selector),
                 label_selector: Some(label_selector),
                 list_semantic: list_semantic.clone(),
-                page_size: page_size.clone(),
+                page_size,
                 ..Default::default()
             },
         )
@@ -727,17 +723,13 @@ impl Source {
         // -----------------------------------------------------------------
 
         let namespaces = Api::<Namespace>::all(client.clone());
-        let page_size = if use_apiserver_cache {
-            None
-        } else {
-            Some(500)
-        };
+        let page_size = if use_apiserver_cache { None } else { Some(500) };
         let ns_watcher = watcher(
             namespaces,
             watcher::Config {
                 label_selector: Some(namespace_label_selector),
                 list_semantic: list_semantic.clone(),
-                page_size: page_size.clone(),
+                page_size,
                 ..Default::default()
             },
         )
@@ -761,7 +753,7 @@ impl Source {
             watcher::Config {
                 field_selector: Some(node_selector),
                 list_semantic,
-                page_size: page_size.clone(),
+                page_size,
                 ..Default::default()
             },
         )

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -695,12 +695,19 @@ impl Source {
             watcher::ListSemantic::MostRecent
         };
 
+        let limit = if use_apiserver_cache {
+            None
+        } else {
+            Some(500)
+        };
+
         let pod_watcher = watcher(
             pods,
             watcher::Config {
                 field_selector: Some(field_selector),
                 label_selector: Some(label_selector),
                 list_semantic: list_semantic.clone(),
+                page_size: limit,
                 ..Default::default()
             },
         )

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -695,7 +695,7 @@ impl Source {
             watcher::ListSemantic::MostRecent
         };
 
-        let limit = if use_apiserver_cache {
+        let page_size = if use_apiserver_cache {
             None
         } else {
             Some(500)
@@ -707,11 +707,12 @@ impl Source {
                 field_selector: Some(field_selector),
                 label_selector: Some(label_selector),
                 list_semantic: list_semantic.clone(),
-                page_size: limit,
+                page_size: page_size.clone(),
                 ..Default::default()
             },
         )
         .backoff(watcher::DefaultBackoff::default());
+
         let pod_store_w = reflector::store::Writer::default();
         let pod_state = pod_store_w.as_reader();
         let pod_cacher = MetaCache::new();

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -727,11 +727,17 @@ impl Source {
         // -----------------------------------------------------------------
 
         let namespaces = Api::<Namespace>::all(client.clone());
+        let page_size = if use_apiserver_cache {
+            None
+        } else {
+            Some(500)
+        };
         let ns_watcher = watcher(
             namespaces,
             watcher::Config {
                 label_selector: Some(namespace_label_selector),
                 list_semantic: list_semantic.clone(),
+                page_size: page_size.clone(),
                 ..Default::default()
             },
         )
@@ -755,6 +761,7 @@ impl Source {
             watcher::Config {
                 field_selector: Some(node_selector),
                 list_semantic,
+                page_size: page_size.clone(),
                 ..Default::default()
             },
         )

--- a/website/cue/reference/components/sources/base/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/base/kubernetes_logs.cue
@@ -100,7 +100,7 @@ base: components: sources: kubernetes_logs: configuration: {
 
 			If your files share a common header that is not always a fixed size,
 
-			If the file has less than this amount of lines, it won’t be read at all.
+			If the file has less than this amount of lines, it won't be read at all.
 			"""
 		required: false
 		type: uint: {


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

1. configure a kubernetes_log source with `use_apiserver_cache = true`
2. collect pod logs and print logs to stdout
3. check k8s audit logs that if the list pods/nodes API use cache or not

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References
- https://github.com/vectordotdev/vector/issues/16797
- https://github.com/kube-rs/kube/issues/1743


<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
