### PR TITLE
feat(config): add a config options for healthcheck timeout

### DIFF
--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -1,8 +1,10 @@
 use std::cell::RefCell;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use dyn_clone::DynClone;
 use serde::Serialize;
+use serde_with::serde_as;
 use std::path::PathBuf;
 use vector_lib::buffers::{BufferConfig, BufferType};
 use vector_lib::configurable::attributes::CustomAttribute;
@@ -164,12 +166,18 @@ where
 }
 
 /// Healthcheck configuration.
+#[serde_as]
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(default)]
 pub struct SinkHealthcheckOptions {
     /// Whether or not to check the health of the sink when Vector starts up.
     pub enabled: bool,
+
+    /// Timeout duration for healthcheck in seconds.
+    #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
+    #[serde(default = "default_healthcheck_timeout")]
+    pub timeout: Duration,
 
     /// The full URI to make HTTP healthcheck requests to.
     ///
@@ -179,26 +187,34 @@ pub struct SinkHealthcheckOptions {
     pub uri: Option<UriSerde>,
 }
 
+const fn default_healthcheck_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
 impl Default for SinkHealthcheckOptions {
     fn default() -> Self {
         Self {
             enabled: true,
             uri: None,
+            timeout: default_healthcheck_timeout(),
         }
     }
 }
 
 impl From<bool> for SinkHealthcheckOptions {
     fn from(enabled: bool) -> Self {
-        Self { enabled, uri: None }
+        Self {
+            enabled,
+            ..Default::default()
+        }
     }
 }
 
 impl From<UriSerde> for SinkHealthcheckOptions {
     fn from(uri: UriSerde) -> Self {
         Self {
-            enabled: true,
             uri: Some(uri),
+            ..Default::default()
         }
     }
 }

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -256,9 +256,9 @@ impl GenerateConfig for KafkaSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "kafka")]
 impl SinkConfig for KafkaSinkConfig {
-    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let sink = KafkaSink::new(self.clone())?;
-        let hc = healthcheck(self.clone()).boxed();
+        let hc = healthcheck(self.clone(), cx.healthcheck.clone()).boxed();
         Ok((VectorSink::from_event_streamsink(sink), hc))
     }
 

--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -63,7 +63,9 @@ mod integration_test {
             headers_key: None,
             acknowledgements: Default::default(),
         };
-        self::sink::healthcheck(config).await.unwrap();
+        self::sink::healthcheck(config, Default::default())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -87,7 +89,9 @@ mod integration_test {
             headers_key: None,
             acknowledgements: Default::default(),
         };
-        self::sink::healthcheck(config).await.unwrap();
+        self::sink::healthcheck(config, Default::default())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -187,7 +191,7 @@ mod integration_test {
             acknowledgements: Default::default(),
         };
         config.clone().to_rdkafka()?;
-        self::sink::healthcheck(config.clone()).await?;
+        self::sink::healthcheck(config.clone(), Default::default()).await?;
         KafkaSink::new(config)
     }
 

--- a/website/cue/reference/components/base/sinks.cue
+++ b/website/cue/reference/components/base/sinks.cue
@@ -113,6 +113,14 @@ base: components: sinks: configuration: {
 				required:    false
 				type: bool: default: true
 			}
+			timeout: {
+				description: "Timeout duration for healthcheck in seconds."
+				required:    false
+				type: float: {
+					default: 10.0
+					unit:    "seconds"
+				}
+			}
 			uri: {
 				description: """
 					The full URI to make HTTP healthcheck requests to.


### PR DESCRIPTION
## Summary

Previously healthcheck timeout was hardcoded to 10 seconds (and for some components, hardcoded internally to some other values). This adds a configuration option for healthcheck timeout which applies to the global timeout, as well as some components.

The default should match existing behavior, except for the `kafka` sink, which previously had 3 seconds timeout, but now it will use global default of 10 seconds.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: #22907

---
>Sponsored by [Quad9](https://quad9.net/)