### PR TITLE
enhancement(enriching): add from and to date search to enrichment tables

### DIFF
--- a/changelog.d/22926_enrichment_function_single_bounded_date_range_search.enhancement.md
+++ b/changelog.d/22926_enrichment_function_single_bounded_date_range_search.enhancement.md
@@ -1,0 +1,3 @@
+The [enrichment functions](https://vector.dev/docs/reference/vrl/functions/#enrichment-functions) now support single-bounded date range search. There are no changes to the function signatures. 
+
+authors: nzxwang

--- a/changelog.d/22926_enrichment_function_single_bounded_date_range_search.enhancement.md
+++ b/changelog.d/22926_enrichment_function_single_bounded_date_range_search.enhancement.md
@@ -1,3 +1,3 @@
-The [enrichment functions](https://vector.dev/docs/reference/vrl/functions/#enrichment-functions) now support bounded date range filtering using optional `from` and `to` parameters. There are no changes to the function signatures. 
+The [enrichment functions](https://vector.dev/docs/reference/vrl/functions/#enrichment-functions) now support bounded date range filtering using optional `from` and `to` parameters. There are no changes to the function signatures.
 
 authors: nzxwang

--- a/changelog.d/22926_enrichment_function_single_bounded_date_range_search.enhancement.md
+++ b/changelog.d/22926_enrichment_function_single_bounded_date_range_search.enhancement.md
@@ -1,3 +1,3 @@
-The [enrichment functions](https://vector.dev/docs/reference/vrl/functions/#enrichment-functions) now support single-bounded date range search. There are no changes to the function signatures. 
+The [enrichment functions](https://vector.dev/docs/reference/vrl/functions/#enrichment-functions) now support bounded date range filtering using optional `from` and `to` parameters. There are no changes to the function signatures. 
 
 authors: nzxwang

--- a/lib/enrichment/src/lib.rs
+++ b/lib/enrichment/src/lib.rs
@@ -26,6 +26,16 @@ pub enum Condition<'a> {
         from: chrono::DateTime<chrono::Utc>,
         to: chrono::DateTime<chrono::Utc>,
     },
+    /// The date in the field is greater than or equal to from.
+    FromDate {
+        field: &'a str,
+        from: chrono::DateTime<chrono::Utc>,
+    },
+    /// The date in the field is less than or equal to to.
+    ToDate {
+        field: &'a str,
+        to: chrono::DateTime<chrono::Utc>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/lib/enrichment/src/lib.rs
+++ b/lib/enrichment/src/lib.rs
@@ -31,7 +31,7 @@ pub enum Condition<'a> {
         field: &'a str,
         from: chrono::DateTime<chrono::Utc>,
     },
-    /// The date in the field is less than or equal to to.
+    /// The date in the field is less than or equal to `to`.
     ToDate {
         field: &'a str,
         to: chrono::DateTime<chrono::Utc>,

--- a/lib/enrichment/src/lib.rs
+++ b/lib/enrichment/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Condition<'a> {
         from: chrono::DateTime<chrono::Utc>,
         to: chrono::DateTime<chrono::Utc>,
     },
-    /// The date in the field is greater than or equal to from.
+    /// The date in the field is greater than or equal to `from`.
     FromDate {
         field: &'a str,
         from: chrono::DateTime<chrono::Utc>,

--- a/website/cue/reference/remap/functions.cue
+++ b/website/cue/reference/remap/functions.cue
@@ -74,7 +74,7 @@ remap: {
 		   performance perspective.
 
 		2. **Date range search**. The given field must be greater than or equal to the `from` date
-		   and less than or equal to the `to` date. A date range search involves
+		   and/or less than or equal to the `to` date. A date range search involves
 		   sequentially scanning through the rows that have been located using any exact match
 		   criteria. This can be an expensive operation if there are many rows returned by any exact
 		   match criteria. Therefore, use date ranges as the _only_ criteria when the enrichment


### PR DESCRIPTION
## Summary
This PR resolves https://github.com/vectordotdev/vector/issues/21881 by enhancing the [enrichment functions](https://vector.dev/docs/reference/vrl/functions/#enrichment-functions) with support for single-bounded date range search. It's implementation is the addition of `FromDate` and `ToDate` to the `enum Condition` and their respective handling. 

Sidenote: I've been using vector for 1.5 years now but have never contributed nor written anything in rust before. I would like to become more knowledgeable of the codebase and a more active contributor so I welcome all feedback. Thank you in advance.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
I ran unit tests:
```
cargo vdev test finds_row finds_rows_with_index_case_sensitive finds_rows_with_index_case_insensitive finds_row_between_dates finds_row_from_date finds_row_to_date
###
Summary [   5.404s] 8 tests run: 8 passed, 2374 skipped
```

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

