### PR TITLE
feat(opentelemetry source): Add JSON support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,6 +7038,8 @@ dependencies = [
  "ordered-float 4.6.0",
  "prost 0.12.6",
  "prost-build 0.12.6",
+ "serde",
+ "serde_json",
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "vector-core",

--- a/build.rs
+++ b/build.rs
@@ -137,8 +137,22 @@ fn main() {
             .btree_map(["."])
             .file_descriptor_set_path(protobuf_fds_path);
 
-        tonic_build::configure()
-            .protoc_arg("--experimental_allow_proto3_optional")
+        let mut builder =
+            tonic_build::configure().protoc_arg("--experimental_allow_proto3_optional");
+
+        for path in ["google.rpc.Status"] {
+            builder = builder
+                .type_attribute(path, "#[derive(serde::Serialize, serde::Deserialize)]")
+                .type_attribute(path, "#[serde(rename_all = \"camelCase\")]");
+        }
+
+        // TODO: fix
+        for path in ["google.rpc.Status.details"] {
+            builder =
+                builder.field_attribute(path, "#[serde(skip_serializing, skip_deserializing)]")
+        }
+
+        builder
             .compile_with_config(
                 prost_build,
                 &[

--- a/lib/opentelemetry-proto/Cargo.toml
+++ b/lib/opentelemetry-proto/Cargo.toml
@@ -15,7 +15,22 @@ chrono.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 lookup = { package = "vector-lookup", path = "../vector-lookup", default-features = false }
 ordered-float = { version = "4.6.0", default-features = false }
-prost .workspace = true
+prost.workspace = true
 tonic.workspace = true
 vrl.workspace = true
 vector-core = { path = "../vector-core", default-features = false }
+serde_json = { version = "1.0.140", optional = true, features = [
+  "raw_value",
+  "std",
+] }
+serde = { version = "1.0.219", optional = true, default-features = false, features = [
+  "alloc",
+  "derive",
+  "rc",
+] }
+
+[features]
+default = ["full"]
+full = ["with-serde"]
+
+with-serde = ['serde', 'serde_json']

--- a/lib/opentelemetry-proto/build.rs
+++ b/lib/opentelemetry-proto/build.rs
@@ -1,9 +1,101 @@
 use std::io::Error;
 
+// NOTE: Serde related attributes are copied from https://github.com/open-telemetry/opentelemetry-rust/
+
 fn main() -> Result<(), Error> {
-    tonic_build::configure()
+    let mut builder = tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        .type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"with-serde\", derive(serde::Serialize, serde::Deserialize))]",
+        )
+        .type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"with-serde\", serde(rename_all = \"camelCase\"))]",
+        );
+
+    // Optional numeric, string and array fields need to default to their default value otherwise
+    // JSON files without those field cannot deserialize
+    // we cannot add serde(default) to all generated types because enums cannot be annotated with serde(default)
+    for path in [
+        "trace.v1.Span",
+        "trace.v1.Span.Link",
+        "trace.v1.ScopeSpans",
+        "trace.v1.ResourceSpans",
+        "common.v1.InstrumentationScope",
+        "resource.v1.Resource",
+        "trace.v1.Span.Event",
+        "trace.v1.Status",
+        "logs.v1.LogRecord",
+        "logs.v1.ScopeLogs",
+        "logs.v1.ResourceLogs",
+        "metrics.v1.Metric",
+        "metrics.v1.ResourceMetrics",
+        "metrics.v1.ScopeMetrics",
+        "metrics.v1.Gauge",
+        "metrics.v1.Sum",
+        "metrics.v1.Histogram",
+        "metrics.v1.ExponentialHistogram",
+        "metrics.v1.Summary",
+        "metrics.v1.NumberDataPoint",
+        "metrics.v1.HistogramDataPoint",
+    ] {
+        builder = builder.type_attribute(
+            path,
+            "#[cfg_attr(feature = \"with-serde\", serde(default))]",
+        )
+    }
+
+    // special serializer and deserializer for traceId and spanId
+    // OTLP/JSON format uses hex string for traceId and spanId
+    // the proto file uses bytes for traceId and spanId
+    // Thus, special serializer and deserializer are needed
+    for path in [
+        "trace.v1.Span.trace_id",
+        "trace.v1.Span.span_id",
+        "trace.v1.Span.parent_span_id",
+        "trace.v1.Span.Link.trace_id",
+        "trace.v1.Span.Link.span_id",
+        "logs.v1.LogRecord.span_id",
+        "logs.v1.LogRecord.trace_id",
+        "metrics.v1.Exemplar.span_id",
+        "metrics.v1.Exemplar.trace_id",
+    ] {
+        builder = builder
+            .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_hex_string\", deserialize_with = \"crate::proto::serializers::deserialize_from_hex_string\"))]")
+    }
+
+    // special serializer and deserializer for timestamp
+    // OTLP/JSON format may uses string for timestamp
+    // the proto file uses u64 for timestamp
+    // Thus, special serializer and deserializer are needed
+    for path in [
+        "trace.v1.Span.start_time_unix_nano",
+        "trace.v1.Span.end_time_unix_nano",
+        "trace.v1.Span.Event.time_unix_nano",
+        "logs.v1.LogRecord.time_unix_nano",
+        "logs.v1.LogRecord.observed_time_unix_nano",
+        "metrics.v1.HistogramDataPoint.start_time_unix_nano",
+        "metrics.v1.HistogramDataPoint.time_unix_nano",
+        "metrics.v1.NumberDataPoint.start_time_unix_nano",
+        "metrics.v1.NumberDataPoint.time_unix_nano",
+    ] {
+        builder = builder
+            .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_u64_to_string\", deserialize_with = \"crate::proto::serializers::deserialize_string_to_u64\"))]")
+    }
+
+    // flatten
+    for path in [
+        "metrics.v1.Metric.data",
+        "metrics.v1.NumberDataPoint.value",
+        "common.v1.AnyValue.value",
+    ] {
+        builder =
+            builder.field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(flatten))]");
+    }
+
+    builder
         .compile(
             &[
                 "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",

--- a/lib/opentelemetry-proto/build.rs
+++ b/lib/opentelemetry-proto/build.rs
@@ -66,10 +66,9 @@ fn main() -> Result<(), Error> {
             .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_hex_string\", deserialize_with = \"crate::proto::serializers::deserialize_from_hex_string\"))]")
     }
 
-    // special serializer and deserializer for timestamp
-    // OTLP/JSON format may uses string for timestamp
-    // the proto file uses u64 for timestamp
-    // Thus, special serializer and deserializer are needed
+    // Note that according to Protobuf specs 64-bit integer numbers
+    // in JSON-encoded payloads are encoded as decimal strings, and
+    // either numbers or strings are accepted when decoding.
     for path in [
         "trace.v1.Span.start_time_unix_nano",
         "trace.v1.Span.end_time_unix_nano",
@@ -82,7 +81,7 @@ fn main() -> Result<(), Error> {
         "metrics.v1.NumberDataPoint.time_unix_nano",
     ] {
         builder = builder
-            .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_u64_to_string\", deserialize_with = \"crate::proto::serializers::deserialize_string_to_u64\"))]")
+            .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_u64_to_string\", deserialize_with = \"crate::proto::serializers::deserialize_from_str_or_u64_to_u64\"))]")
     }
 
     // flatten

--- a/lib/opentelemetry-proto/src/proto.rs
+++ b/lib/opentelemetry-proto/src/proto.rs
@@ -51,3 +51,61 @@ pub mod resource {
         tonic::include_proto!("opentelemetry.proto.resource.v1");
     }
 }
+
+#[cfg(all(feature = "with-serde"))]
+pub(crate) mod serializers {
+    use serde::de::{self, MapAccess, Visitor};
+    use serde::ser::{SerializeMap, SerializeStruct};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt;
+
+    // hex string <-> bytes conversion
+
+    pub fn serialize_to_hex_string<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_string = hex::encode(bytes);
+        serializer.serialize_str(&hex_string)
+    }
+
+    pub fn deserialize_from_hex_string<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BytesVisitor;
+
+        impl<'de> Visitor<'de> for BytesVisitor {
+            type Value = Vec<u8>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string representing hex-encoded bytes")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Vec<u8>, E>
+            where
+                E: de::Error,
+            {
+                hex::decode(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(BytesVisitor)
+    }
+
+    pub fn serialize_u64_to_string<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = value.to_string();
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize_string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        s.parse::<u64>().map_err(de::Error::custom)
+    }
+}

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 use std::{convert::Infallible, net::SocketAddr};
 
+use bytes::Buf;
 use bytes::Bytes;
 use futures_util::FutureExt;
 use http::StatusCode;
 use hyper::{service::make_service_fn, Server};
-use prost::Message;
 use tokio::net::TcpStream;
 use tower::ServiceBuilder;
 use tracing::Span;
@@ -47,6 +47,7 @@ use super::{reply::protobuf, status::Status};
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ContentType {
     Protobuf,
+    Json,
 }
 
 #[derive(Debug)]
@@ -59,6 +60,7 @@ fn extract_content_type() -> impl warp::Filter<Extract = (ContentType,), Error =
         |content_type: String| async move {
             match content_type.as_str() {
                 "application/x-protobuf" => Ok(ContentType::Protobuf),
+                "application/json" => Ok(ContentType::Json),
                 _ => Err(warp::reject::custom(InvalidContentType)),
             }
         },
@@ -137,24 +139,27 @@ pub(crate) fn build_warp_filter(
         .and(warp::method())
         .and(warp::path::peek())
         .and(extract_content_type())
-        .then(|method, path: warp::filters::path::Peek, _ct| async move {
-            if method != hyper::Method::POST {
-                let reply = protobuf(Status {
-                    code: 2,
-                    message: "method not allowed, supported: [POST]".into(),
-                    ..Default::default()
-                });
-                warp::reply::with_status(reply, hyper::StatusCode::METHOD_NOT_ALLOWED)
-                    .into_response()
-            } else {
-                let reply = protobuf(Status {
-                    code: 2,
-                    message: format!("unknown route: {}", path.as_str()),
-                    ..Default::default()
-                });
-                warp::reply::with_status(reply, hyper::StatusCode::NOT_FOUND).into_response()
-            }
-        })
+        .then(
+            |method, path: warp::filters::path::Peek, ct: ContentType| async move {
+                if method != hyper::Method::POST {
+                    let status = Status {
+                        code: 2,
+                        message: "method not allowed, supported: [POST]".into(),
+                        ..Default::default()
+                    };
+
+                    serialize_response(ct, hyper::StatusCode::METHOD_NOT_ALLOWED, status)
+                } else {
+                    let status = Status {
+                        code: 2,
+                        message: format!("unknown route: {}", path.as_str()),
+                        ..Default::default()
+                    };
+
+                    serialize_response(ct, hyper::StatusCode::NOT_FOUND, status)
+                }
+            },
+        )
         .boxed();
 
     log_filters
@@ -197,23 +202,26 @@ fn build_warp_log_filter(
         .and(warp::header::headers_cloned())
         .and(warp::body::bytes())
         .and_then(
-            move |_, encoding_header: Option<String>, headers_config: HeaderMap, body: Bytes| {
+            move |ct: ContentType,
+                  encoding_header: Option<String>,
+                  headers_config: HeaderMap,
+                  body: Bytes| {
                 let events = decode(encoding_header.as_deref(), body)
                     .and_then(|body| {
                         bytes_received.emit(ByteSize(body.len()));
-                        decode_log_body(body, log_namespace, &events_received)
+                        decode_log_body(body, log_namespace, &events_received, ct)
                     })
                     .map(|mut events| {
                         enrich_events(&mut events, &headers, &headers_config, log_namespace);
                         events
                     });
 
-                handle_request(
+                handle_request::<ExportLogsServiceResponse>(
                     events,
                     acknowledgements,
                     out.clone(),
                     super::LOGS,
-                    ExportLogsServiceResponse::default(),
+                    ct,
                 )
             },
         )
@@ -231,20 +239,22 @@ fn build_warp_metrics_filter(
         .and(extract_content_type())
         .and(warp::header::optional::<String>("content-encoding"))
         .and(warp::body::bytes())
-        .and_then(move |_, encoding_header: Option<String>, body: Bytes| {
-            let events = decode(encoding_header.as_deref(), body).and_then(|body| {
-                bytes_received.emit(ByteSize(body.len()));
-                decode_metrics_body(body, &events_received)
-            });
+        .and_then(
+            move |ct: ContentType, encoding_header: Option<String>, body: Bytes| {
+                let events = decode(encoding_header.as_deref(), body).and_then(|body| {
+                    bytes_received.emit(ByteSize(body.len()));
+                    decode_metrics_body(body, &events_received, ct)
+                });
 
-            handle_request(
-                events,
-                acknowledgements,
-                out.clone(),
-                super::METRICS,
-                ExportMetricsServiceResponse::default(),
-            )
-        })
+                handle_request::<ExportMetricsServiceResponse>(
+                    events,
+                    acknowledgements,
+                    out.clone(),
+                    super::METRICS,
+                    ct,
+                )
+            },
+        )
         .boxed()
 }
 
@@ -259,33 +269,67 @@ fn build_warp_trace_filter(
         .and(extract_content_type())
         .and(warp::header::optional::<String>("content-encoding"))
         .and(warp::body::bytes())
-        .and_then(move |_, encoding_header: Option<String>, body: Bytes| {
-            let events = decode(encoding_header.as_deref(), body).and_then(|body| {
-                bytes_received.emit(ByteSize(body.len()));
-                decode_trace_body(body, &events_received)
-            });
+        .and_then(
+            move |ct: ContentType, encoding_header: Option<String>, body: Bytes| {
+                let events = decode(encoding_header.as_deref(), body).and_then(|body| {
+                    bytes_received.emit(ByteSize(body.len()));
+                    decode_trace_body(body, &events_received, ct)
+                });
 
-            handle_request(
-                events,
-                acknowledgements,
-                out.clone(),
-                super::TRACES,
-                ExportTraceServiceResponse::default(),
-            )
-        })
+                handle_request::<ExportTraceServiceResponse>(
+                    events,
+                    acknowledgements,
+                    out.clone(),
+                    super::TRACES,
+                    ct,
+                )
+            },
+        )
         .boxed()
+}
+
+fn deserialize_payload<'a, T>(content_type: ContentType, body: Bytes) -> Result<T, ErrorMessage>
+where
+    T: prost::Message + std::default::Default + serde::de::DeserializeOwned,
+{
+    let data: T = match content_type {
+        ContentType::Protobuf => T::decode(body).map_err(|error| {
+            ErrorMessage::new(
+                StatusCode::BAD_REQUEST,
+                format!("Could not decode request: {}", error),
+            )
+        }),
+        ContentType::Json => serde_json::from_reader(body.reader()).map_err(|error| {
+            ErrorMessage::new(
+                StatusCode::BAD_REQUEST,
+                format!("Could not decode request: {}", error),
+            )
+        }),
+    }?;
+    Ok(data)
+}
+
+fn serialize_response<T: serde::Serialize + prost::Message>(
+    content_type: ContentType,
+    status_code: hyper::StatusCode,
+    payload: T,
+) -> Response {
+    match content_type {
+        ContentType::Json => {
+            let mut resp = warp::reply::json(&payload).into_response();
+            *resp.status_mut() = status_code;
+            resp
+        }
+        ContentType::Protobuf => protobuf(status_code, payload).into_response(),
+    }
 }
 
 fn decode_trace_body(
     body: Bytes,
     events_received: &Registered<EventsReceived>,
+    content_type: ContentType,
 ) -> Result<Vec<Event>, ErrorMessage> {
-    let request = ExportTraceServiceRequest::decode(body).map_err(|error| {
-        ErrorMessage::new(
-            StatusCode::BAD_REQUEST,
-            format!("Could not decode request: {}", error),
-        )
-    })?;
+    let request = deserialize_payload::<ExportTraceServiceRequest>(content_type, body)?;
 
     let events: Vec<Event> = request
         .resource_spans
@@ -305,13 +349,9 @@ fn decode_log_body(
     body: Bytes,
     log_namespace: LogNamespace,
     events_received: &Registered<EventsReceived>,
+    content_type: ContentType,
 ) -> Result<Vec<Event>, ErrorMessage> {
-    let request = ExportLogsServiceRequest::decode(body).map_err(|error| {
-        ErrorMessage::new(
-            StatusCode::BAD_REQUEST,
-            format!("Could not decode request: {}", error),
-        )
-    })?;
+    let request = deserialize_payload::<ExportLogsServiceRequest>(content_type, body)?;
 
     let events: Vec<Event> = request
         .resource_logs
@@ -330,13 +370,9 @@ fn decode_log_body(
 fn decode_metrics_body(
     body: Bytes,
     events_received: &Registered<EventsReceived>,
+    content_type: ContentType,
 ) -> Result<Vec<Event>, ErrorMessage> {
-    let request = ExportMetricsServiceRequest::decode(body).map_err(|error| {
-        ErrorMessage::new(
-            StatusCode::BAD_REQUEST,
-            format!("Could not decode request: {}", error),
-        )
-    })?;
+    let request = deserialize_payload::<ExportMetricsServiceRequest>(content_type, body)?;
 
     let events: Vec<Event> = request
         .resource_metrics
@@ -352,23 +388,24 @@ fn decode_metrics_body(
     Ok(events)
 }
 
-async fn handle_request(
+async fn handle_request<T>(
     events: Result<Vec<Event>, ErrorMessage>,
     acknowledgements: bool,
     mut out: SourceSender,
     output: &str,
-    resp: impl Message,
-) -> Result<Response, Rejection> {
+    content_type: ContentType,
+) -> Result<Response, Rejection>
+where
+    T: prost::Message + serde::Serialize + std::default::Default,
+{
     let reply_with_status =
         |http_code: hyper::StatusCode, code: i32, message: String| -> Result<Response, Rejection> {
-            let mut resp = protobuf(Status {
+            let s = Status {
                 code,
                 message,
                 ..Default::default()
-            })
-            .into_response();
-            *resp.status_mut() = http_code;
-            Ok(resp)
+            };
+            Ok(serialize_response(content_type, http_code, s))
         };
 
     if let Err(err) = events {
@@ -394,9 +431,17 @@ async fn handle_request(
     };
 
     match receiver {
-        None => Ok(protobuf(resp).into_response()),
+        None => Ok(serialize_response(
+            content_type,
+            hyper::StatusCode::OK,
+            T::default(),
+        )),
         Some(receiver) => match receiver.await {
-            BatchStatus::Delivered => Ok(protobuf(resp).into_response()),
+            BatchStatus::Delivered => Ok(serialize_response(
+                content_type,
+                hyper::StatusCode::OK,
+                T::default(),
+            )),
             BatchStatus::Errored => reply_with_status(
                 hyper::StatusCode::INTERNAL_SERVER_ERROR,
                 2, // UNKNOWN - OTLP doesn't require use of status.code, but we can't encode a None here

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1250,6 +1250,175 @@ async fn delivery_error() {
 }
 
 #[tokio::test]
+async fn json_log_request() {
+    // JSON log payload with u64 timestamp
+    assert_source_compliance(&SOURCE_TAGS, async {
+        let env = build_otlp_test_env_status(LOGS, None, EventStatus::Rejected, false).await;
+
+        // from https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/#examples
+        let log = r#"
+            {
+              "resourceLogs": [
+                {
+                  "resource": {
+                    "attributes": [
+                      {
+                        "key": "resource-attr",
+                        "value": {
+                          "stringValue": "resource-attr-val-1"
+                        }
+                      }
+                    ]
+                  },
+                  "scopeLogs": [
+                    {
+                      "scope": {},
+                      "logRecords": [
+                        {
+                          "timeUnixNano": "1581452773000000789",
+                          "observedTimeUnixNano": 1581452773000000780,
+                          "severityNumber": 9,
+                          "severityText": "Info",
+                          "body": {
+                            "stringValue": "This is a log message"
+                          },
+                          "attributes": [
+                            {
+                              "key": "app",
+                              "value": {
+                                "stringValue": "server"
+                              }
+                            },
+                            {
+                              "key": "instance_num",
+                              "value": {
+                                "intValue": 1
+                              }
+                            }
+                          ],
+                          "droppedAttributesCount": 1,
+                          "traceId": "08040201000000000000000000000000",
+                          "spanId": "0102040800000000"
+                        },
+                        {
+                          "timeUnixNano": "1581452773000000789",
+                          "observedTimeUnixNano": 1581452773000000780,
+                          "severityNumber": 9,
+                          "severityText": "Info",
+                          "body": {
+                            "stringValue": "something happened"
+                          },
+                          "attributes": [
+                            {
+                              "key": "customer",
+                              "value": {
+                                "stringValue": "acme"
+                              }
+                            },
+                            {
+                              "key": "env",
+                              "value": {
+                                "stringValue": "dev"
+                              }
+                            }
+                          ],
+                          "droppedAttributesCount": 1,
+                          "traceId": "",
+                          "spanId": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }"#;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("http://{}/v1/logs", env.config.http.address,))
+            .header("Content-Type", "application/json")
+            .body(log)
+            .send()
+            .await
+            .expect("Failed to send log to Opentelemetry Collector.");
+
+        assert!(
+            res.status() == hyper::StatusCode::OK,
+            "Unexpected Status: {}",
+            res.status()
+        );
+
+        let mut output = test_util::collect_ready(env.output).await;
+        assert_eq!(output.len(), 2);
+        // clone to get rid of json_encoded_size_cache
+        let e2 = output.pop().unwrap().clone();
+        let e1 = output.pop().unwrap();
+
+        let schema_definitions = env
+            .config
+            .outputs(LogNamespace::Legacy)
+            .remove(0)
+            .schema_definition(true)
+            .expect("Failed to get schema definition");
+
+        schema_definitions.assert_valid_for_event(&e1);
+
+        let (v1, _) = e1.into_log().into_parts();
+        let ev1: Value = vec_into_btmap(vec![
+            ("message", "This is a log message".into()),
+            ("trace_id", "08040201000000000000000000000000".into()),
+            ("span_id", "0102040800000000".into()),
+            ("severity_number", 9.into()),
+            ("severity_text", "Info".into()),
+            ("dropped_attributes_count", 1.into()),
+            ("timestamp", Utc.timestamp_nanos(1581452773000000789).into()),
+            (
+                "observed_timestamp",
+                Utc.timestamp_nanos(1581452773000000780).into(),
+            ),
+            ("source_type", "opentelemetry".into()),
+            (
+                "resources",
+                vec_into_btmap(vec![("resource-attr", "resource-attr-val-1".into())]).into(),
+            ),
+            (
+                "attributes",
+                vec_into_btmap(vec![("app", "server".into()), ("instance_num", 1.into())]).into(),
+            ),
+        ])
+        .into();
+        assert_eq!(v1, ev1);
+
+        schema_definitions.assert_valid_for_event(&e2);
+
+        let (v2, _) = e2.into_log().into_parts();
+        let ev2: Value = vec_into_btmap(vec![
+            ("message", "something happened".into()),
+            ("severity_number", 9.into()),
+            ("severity_text", "Info".into()),
+            ("dropped_attributes_count", 1.into()),
+            ("timestamp", Utc.timestamp_nanos(1581452773000000789).into()),
+            (
+                "observed_timestamp",
+                Utc.timestamp_nanos(1581452773000000780).into(),
+            ),
+            ("source_type", "opentelemetry".into()),
+            (
+                "resources",
+                vec_into_btmap(vec![("resource-attr", "resource-attr-val-1".into())]).into(),
+            ),
+            (
+                "attributes",
+                vec_into_btmap(vec![("customer", "acme".into()), ("env", "dev".into())]).into(),
+            ),
+        ])
+        .into();
+        assert_eq!(v2, ev2);
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn http_headers() {
     assert_source_compliance(&SOURCE_TAGS, async {
         let grpc_addr = next_addr();


### PR DESCRIPTION
**This PR builds on #22957.** 

Once that is accepted I'll rebase this onto that. Opening this to show how the content-type handling from #22957 fits in.
This PR 'starts at' `otel-proto: support json serialization`

## Summary

This adds JSON Protobuf encoding support to the open telemetry source. The PR has two main parts:

1. adding JSON support to the types used. The implementation mostly stolen from opentelemetry-rust.
2. selecting the right encoding for both request and reply based on the content-type header.


## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
 
Both sending actual logs as well as with test cases

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

#22940 

## TODO

[] make sure traces and metrics have a test