### PR TITLE
feat(remap transform): make `--watch-config` watch external VRL files in `remap` transforms

### DIFF
--- a/changelog.d/9819_watch_remap_external_vrl.enhancement.md
+++ b/changelog.d/9819_watch_remap_external_vrl.enhancement.md
@@ -1,0 +1,3 @@
+Files specified in the `file` and `files` fields of `remap` transforms are now watched when `--watch-config` is enabled. Changes to these files automatically trigger a configuration reload, so there's no need to restart Vector.
+
+authors: nekorro

--- a/src/app.rs
+++ b/src/app.rs
@@ -533,6 +533,13 @@ pub async fn load_configs(
     let mut watched_component_paths = Vec::new();
 
     if let Some(watcher_conf) = watcher_conf {
+        for (name, transform) in config.transforms() {
+            let files = transform.inner.files_to_watch();
+            let component_config =
+                ComponentConfig::new(files.into_iter().cloned().collect(), name.clone());
+            watched_component_paths.push(component_config);
+        }
+
         for (name, sink) in config.sinks() {
             let files = sink.inner.files_to_watch();
             let component_config =
@@ -543,6 +550,10 @@ pub async fn load_configs(
         info!(
             message = "Starting watcher.",
             paths = ?watched_paths
+        );
+        info!(
+            message = "Components to watch.",
+            paths = ?watched_component_paths
         );
 
         // Start listening for config changes.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Display, Formatter},
+    fs,
     hash::Hash,
     net::SocketAddr,
     path::PathBuf,
@@ -83,9 +84,14 @@ pub struct ComponentConfig {
 }
 
 impl ComponentConfig {
-    pub const fn new(config_paths: Vec<PathBuf>, component_key: ComponentKey) -> Self {
+    pub fn new(config_paths: Vec<PathBuf>, component_key: ComponentKey) -> Self {
+        let canonicalized_paths = config_paths
+            .into_iter()
+            .filter_map(|p| fs::canonicalize(p).ok())
+            .collect();
+
         Self {
-            config_paths,
+            config_paths: canonicalized_paths,
             component_key,
         }
     }

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 use dyn_clone::DynClone;
@@ -252,6 +253,11 @@ pub trait TransformConfig: DynClone + NamedComponent + core::fmt::Debug + Send +
     /// nested under transforms of a specific type, or if such nesting is fundamentally disallowed.
     fn nestable(&self, _parents: &HashSet<&'static str>) -> bool {
         true
+    }
+
+    /// Gets the files to watch to trigger reload
+    fn files_to_watch(&self) -> Vec<&PathBuf> {
+        Vec::new()
     }
 }
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -383,6 +383,13 @@ impl TransformConfig for RemapConfig {
     fn enable_concurrency(&self) -> bool {
         true
     }
+
+    fn files_to_watch(&self) -> Vec<&PathBuf> {
+        self.file
+            .iter()
+            .chain(self.files.iter().flatten())
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
This change ensures that updates to VRL source code are respected when calculating configuration diffs. External VRL files referenced in remap transforms (via file or files fields) are now tracked when `--watch-config` is enabled, allowing Vector to reload the configuration automatically when these files change.


## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended. Providing this information upfront will facilitate a smoother review process. -->

### Test file field
Added a remap transform to config/vector.yaml :
```
transforms:
  remap_logs:
    type: remap
    file: vrl/vrl_one
    inputs:
      - demo_logs_one
```
Started Vector with `vector -vvv  -c config/vector.yaml -w`
Then, modified the `/vector/vrl/vrl_one` file.
Vector detected the change and reloaded the configuration automatically as expected.
<img width="1541" alt="test_1" src="https://github.com/user-attachments/assets/84def6b3-3479-4921-a6f7-e76140fd0b43" />

### Test files field
Added a remap transform to config/vector.yaml :
```
transforms:
  remap_logs:
    type: remap
    files:
      - vrl/vrl_one
      - vrl/vrl_two
    inputs:
      - demo_logs_one
```
Started Vector with `vector -vvv  -c config/vector.yaml -w`
Then, modified the `/vector/vrl/vrl_two` file.
Vector detected the change and reloaded the configuration automatically as expected.
<img width="1544" alt="test_2" src="https://github.com/user-attachments/assets/503826ad-f4b6-4559-88ef-ad2d2d8505d6" />


## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

- Ref: [#17283](https://github.com/vectordotdev/vector/issues/17283)
- Closes: [#9819](https://github.com/vectordotdev/vector/issues/9819)

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
