### PR TITLE
fix(parsing): Handling wrong timestamps in dnstap-parser

### DIFF
--- a/changelog.d/23048_fix_arith_logic_dnstap_parse.fix.md
+++ b/changelog.d/23048_fix_arith_logic_dnstap_parse.fix.md
@@ -1,0 +1,3 @@
+Added checks for integer operations with timestamps which used in `dnstap-parser::DnstapParser::parse`.
+
+authors: wooffie

--- a/lib/dnstap-parser/src/parser.rs
+++ b/lib/dnstap-parser/src/parser.rs
@@ -367,6 +367,10 @@ impl DnstapParser {
         message: Option<&Vec<u8>>,
         type_ids: &HashSet<i32>,
     ) -> Result<()> {
+        if time_sec > i64::MAX as u64 {
+            return Err(Error::from("Cannot parse timestamp"));
+        }
+
         let (time_in_nanosec, query_time_nsec) = match time_nsec {
             Some(nsec) => {
                 if let Some(time_in_ns) = (time_sec as i64)
@@ -1335,6 +1339,30 @@ mod tests {
         )
         .expect_err("Expected TrustDnsError.");
         assert!(e.to_string().contains("Protobuf message"));
+    }
+
+    #[test]
+    fn test_parse_dnstap_data_with_invalid_timestamp() {
+        fn test_one_timestamp_parse(time_sec: u64, time_nsec: Option<u32>) -> Result<()> {
+            let mut event = LogEvent::default();
+            let root = owned_value_path!();
+            let type_ids = HashSet::new();
+            DnstapParser::parse_dnstap_message_time(
+                &mut event, &root, time_sec, time_nsec, 0, None, &type_ids,
+            )
+        }
+        // okay case
+        assert!(test_one_timestamp_parse(1337, Some(42)).is_ok());
+        // overflow in cast (u64 -> i64)
+        assert!(test_one_timestamp_parse(u64::MAX, Some(42)).is_err());
+        assert!(test_one_timestamp_parse(u64::MAX, None).is_err());
+        // overflow in multiplication
+        assert!(test_one_timestamp_parse(i64::MAX as u64, Some(42)).is_err());
+        assert!(test_one_timestamp_parse(i64::MAX as u64, None).is_err());
+        // overflow in add
+        assert!(
+            test_one_timestamp_parse((i64::MAX / 1_000_000_000) as u64, Some(u32::MAX)).is_err()
+        )
     }
 
     #[test]


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

While parsing `dnstap` we can get panic while working with timestamps. Let's timestamp parse function returns Err for observe it. Maybe we should use more trivial construction and Err =)

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?

Reproducer:
```rust
#[test]
    fn repro_crash() {
        let mut log_event = LogEvent::default();
        let raw_dnstap_data = "KAJyAHICUgByMDAwMDAwMDAwMDAwMUAwMDAwMDAwMDAwMDAwMDAwMGD/////////rjAwMDAwMDAwMDAAcgJyAHIA";
        let dnstap_data = BASE64_STANDARD
            .decode(raw_dnstap_data)
            .expect("Invalid base64 encoded data.");
        let _parse_result = DnstapParser::parse(
            &mut log_event,
            Bytes::from(dnstap_data),
            DnsParserOptions::default(),
        );
        println!("{:?}",_parse_result);
    }
```

Trace:
```console
---- parser::tests::repro_crash stdout ----

thread 'parser::tests::repro_crash' panicked at lib/dnstap-parser/src/parser.rs:372:22:
attempt to multiply with overflow
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_const::panic_const_mul_overflow
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/panicking.rs:178:21
   3: dnstap_parser::parser::DnstapParser::parse_dnstap_message_time
             at ./src/parser.rs:372:22
   4: dnstap_parser::parser::DnstapParser::parse_dnstap_message
             at ./src/parser.rs:243:13
   5: dnstap_parser::parser::DnstapParser::parse
             at ./src/parser.rs:153:25
   6: dnstap_parser::parser::tests::repro_crash
             at ./src/parser.rs:1192:29
   7: dnstap_parser::parser::tests::repro_crash::{{closure}}
             at ./src/parser.rs:1186:21
   8: core::ops::function::FnOnce::call_once
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   9: core::ops::function::FnOnce::call_once
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    parser::tests::repro_crash
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
