### PR TITLE
fix(parsing): Handling bad addresses in dsntap

### DIFF
--- a/changelog.d/fix_dnstap_extract_address_logic.fix.md
+++ b/changelog.d/fix_dnstap_extract_address_logic.fix.md
@@ -1,0 +1,3 @@
+Added checks to avoid possible panic while parsing address in `dnstap-parser::DnstapParser::parse_dnstap_message_socket_family`.
+
+authors: wooffie

--- a/lib/dnstap-parser/src/parser.rs
+++ b/lib/dnstap-parser/src/parser.rs
@@ -438,9 +438,15 @@ impl DnstapParser {
 
         if let Some(query_address) = dnstap_message.query_address.as_ref() {
             let source_address = if socket_family == 1 {
+                if query_address.len() < 4 {
+                    return Err(Error::from("Cannot parse query_address"));
+                }
                 let address_buffer: [u8; 4] = query_address[0..4].try_into()?;
                 IpAddr::V4(Ipv4Addr::from(address_buffer))
             } else {
+                if query_address.len() < 16 {
+                    return Err(Error::from("Cannot parse query_address"));
+                }
                 let address_buffer: [u8; 16] = query_address[0..16].try_into()?;
                 IpAddr::V6(Ipv6Addr::from(address_buffer))
             };
@@ -464,9 +470,15 @@ impl DnstapParser {
 
         if let Some(response_address) = dnstap_message.response_address.as_ref() {
             let response_addr = if socket_family == 1 {
+                if response_address.len() < 4 {
+                    return Err(Error::from("Cannot parse response_address"));
+                }
                 let address_buffer: [u8; 4] = response_address[0..4].try_into()?;
                 IpAddr::V4(Ipv4Addr::from(address_buffer))
             } else {
+                if response_address.len() < 16 {
+                    return Err(Error::from("Cannot parse response_address"));
+                }
                 let address_buffer: [u8; 16] = response_address[0..16].try_into()?;
                 IpAddr::V6(Ipv6Addr::from(address_buffer))
             };
@@ -1038,7 +1050,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use dnsmsg_parser::dns_message_parser::DnsParserOptions;
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, vec};
 
     #[test]
     fn test_parse_dnstap_data_with_query_message() {
@@ -1363,6 +1375,38 @@ mod tests {
         assert!(
             test_one_timestamp_parse((i64::MAX / 1_000_000_000) as u64, Some(u32::MAX)).is_err()
         )
+    }
+
+    #[test]
+    fn test_parse_dnstap_message_socket_family_bad_addr() {
+        // while parsing address is optional, but in this function assume otherwise
+        fn test_one_input(socket_family: i32, msg: DnstapMessage) -> Result<()> {
+            let mut event = LogEvent::default();
+            let root = owned_value_path!();
+            DnstapParser::parse_dnstap_message_socket_family(&mut event, &root, socket_family, &msg)
+        }
+        // all bad cases which can panic
+        {
+            let mut message = DnstapMessage::default();
+            message.query_address = Some(vec![]);
+            assert!(test_one_input(1, message).is_err());
+        }
+        {
+            let mut message = DnstapMessage::default();
+            message.query_address = Some(vec![]);
+            assert!(test_one_input(2, message).is_err());
+        }
+
+        {
+            let mut message = DnstapMessage::default();
+            message.response_address = Some(vec![]);
+            assert!(test_one_input(1, message).is_err());
+        }
+        {
+            let mut message = DnstapMessage::default();
+            message.response_address = Some(vec![]);
+            assert!(test_one_input(2, message).is_err());
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

In parsing `dnstap` we can deserialize address of bad length and after get panic. Added some checks...



## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

Testcase which show that this problem can be accessed outside crate:

```rust
    #[test]
    fn test_parse_dnstap_data_with_bad_address() {
        let a = [
            40, 4, 114, 56, 56, 42, 42, 42, 42, 42, 0, 0, 0, 0, 0, 0, 0, 185, 3, 0, 0, 0, 0, 0, 0,
            96, 64, 96, 96, 96, 96, 96, 96, 96, 96, 96, 96, 96, 96, 55, 55, 43, 55, 55, 54, 64,
            114, 42, 56, 0, 16, 2, 42, 0, 114, 4, 56, 56, 96, 96, 96, 96, 96, 56, 56, 2, 48, 0,
        ];
        let mut log_event = LogEvent::default();

        let _parse_result = DnstapParser::parse(
            &mut log_event,
            Bytes::copy_from_slice(&a),
            DnsParserOptions::default(),
        );
    }
```

And some trace:
```console
thread 'parser::tests::test_parse_dnstap_data_with_bad_address' panicked at lib/dnstap-parser/src/parser.rs:470:64:
range end index 16 out of range for slice of length 0
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/panicking.rs:75:14
   2: core::slice::index::slice_end_index_len_fail::do_panic::runtime
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/panic.rs:218:21
   3: core::slice::index::slice_end_index_len_fail::do_panic
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/intrinsics/mod.rs:3869:9
   4: core::slice::index::slice_end_index_len_fail
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/panic.rs:223:9
   5: <core::ops::range::Range<usize> as core::slice::index::SliceIndex<[T]>>::index
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:437:13
   6: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:16:9
   7: <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3361:9
   8: dnstap_parser::parser::DnstapParser::parse_dnstap_message_socket_family
             at ./src/parser.rs:470:64
   9: dnstap_parser::parser::DnstapParser::parse_dnstap_message
             at ./src/parser.rs:192:13
  10: dnstap_parser::parser::DnstapParser::parse
             at ./src/parser.rs:153:25
  11: dnstap_parser::parser::tests::test_parse_dnstap_data_with_bad_address
             at ./src/parser.rs:1377:25
  12: dnstap_parser::parser::tests::test_parse_dnstap_data_with_bad_address::{{closure}}
             at ./src/parser.rs:1369:49
  13: core::ops::function::FnOnce::call_once
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  14: core::ops::function::FnOnce::call_once
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    parser::tests::test_parse_dnstap_data_with_bad_address
```

I added some checks that can be return Err to be emited in main parsing function. Also testcases which cover all problems

**You can add just my testcases and see panic**

## Does this PR include user facing changes?

I dont care, at the team discretion

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
