### PR TITLE
chore(releasing): update VRL changelog block insertion

### DIFF
--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -4,7 +4,6 @@
 use crate::git;
 use crate::util::run_command;
 use anyhow::{anyhow, Result};
-use indoc::indoc;
 use reqwest::blocking::Client;
 use semver::Version;
 use std::fs::File;
@@ -364,65 +363,25 @@ impl Prepare {
 
     fn append_vrl_changelog_to_release_cue(&self) -> Result<()> {
         debug!("append_vrl_changelog_to_release_cue");
-        let releases_path = &self.repo_root.join("website").join("cue").join("reference").join("releases");
-        let vector_version = &self.new_vector_version;
-        let release_cue_path = releases_path.join(format!("{vector_version}.cue"));
-        if !release_cue_path.is_file() {
-            return Err(anyhow!("{release_cue_path:?} not found"));
+
+        let releases_path = self.repo_root.join("website/cue/reference/releases");
+        let version = &self.new_vector_version;
+        let cue_path = releases_path.join(format!("{version}.cue"));
+        if !cue_path.is_file() {
+            return Err(anyhow!("{cue_path:?} not found"));
         }
 
         let vrl_changelog = get_latest_vrl_tag_and_changelog()?;
+        let vrl_changelog_block = format_vrl_changelog_block(&vrl_changelog);
 
-        let temp_file_path = releases_path.join(format!("{vector_version}.cue.tmp"));
-        let input_file = File::open(&release_cue_path)?;
-        let reader = BufReader::new(input_file);
-        let mut output_file = File::create(&temp_file_path)?;
+        let original = fs::read_to_string(&cue_path)?;
+        let updated = insert_block_after_changelog(&original, &vrl_changelog_block);
 
-        let indent = "\t".repeat(5);
-        let processed_changelog: String = vrl_changelog
-            .lines()
-            .map(|line| {
-                let line = line.trim();
-                if line.starts_with('#') {
-                    format!("{indent}#{line}")
-                } else {
-                    format!("{indent}{line}")
-                }
-            })
-            .collect::<Vec<String>>()
-            .join("\n");
+        let tmp_path = cue_path.with_extension("cue.tmp");
+        fs::write(&tmp_path, &updated)?;
+        fs::rename(&tmp_path, &cue_path)?;
 
-        // Format the new changelog entry
-        let vrl_cue_block = format!(
-            indoc! {r#"
-            {{
-                type: "feat"
-                description: """
-            {}
-                    """
-            }},
-        "#},
-            processed_changelog
-        );
-
-        let mut found_changelog = false;
-        let changelog_marker = "changelog: [";
-
-        // Read and write line by line
-        for line in reader.lines() {
-            let line = line?;
-            writeln!(output_file, "{line}")?;
-
-            // Check if this is the changelog line
-            if !found_changelog && line.trim().starts_with(changelog_marker) {
-                // Insert the new entry after the changelog opening
-                writeln!(output_file, "{vrl_cue_block}")?;
-                found_changelog = true;
-            }
-        }
-
-        fs::rename(&temp_file_path, &release_cue_path)?;
-        run_command(&format!("cue fmt {release_cue_path:?}"));
+        run_command(&format!("cue fmt {}", cue_path.display()));
         debug!("Successfully added VRL changelog to the release cue file.");
         Ok(())
     }
@@ -443,6 +402,45 @@ fn get_latest_version_from_vector_tags() -> Result<Version> {
     let version_str = latest_tag.trim_start_matches('v');
     Version::parse(version_str)
         .map_err(|e| anyhow::anyhow!("Failed to parse version from tag '{latest_tag}': {e}"))
+}
+
+fn format_vrl_changelog_block(changelog: &str) -> String {
+    let double_tab = "\t\t";
+    let body = changelog
+        .lines()
+        .map(|line| {
+            let line = line.trim();
+            if line.starts_with('#') {
+                format!("{double_tab}#{line}")
+            } else {
+                format!("{double_tab}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let opening = "\tvrl_changelog: \"\"\"";
+    let closing = format!("{double_tab}\"\"\"");
+
+    format!("{opening}\n{body}\n{closing}")
+}
+
+fn insert_block_after_changelog(original: &str, block: &str) -> String {
+    let mut result = Vec::new();
+    let mut inserted = false;
+
+    for line in original.lines() {
+        result.push(line.to_string());
+
+        // Insert *after* the line containing only the closing `]` (end of changelog array)
+        if !inserted && line.trim() == "]" {
+            result.push(String::new()); // empty line before
+            result.push(block.to_string());
+            inserted = true;
+        }
+    }
+
+    result.join("\n")
 }
 
 fn get_latest_vrl_tag_and_changelog() -> Result<String> {
@@ -496,4 +494,43 @@ fn get_latest_vrl_tag_and_changelog() -> Result<String> {
     }
 
     Ok(section.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::release::prepare::{format_vrl_changelog_block, insert_block_after_changelog};
+    use indoc::indoc;
+
+    #[test]
+    fn test_insert_block_after_changelog() {
+        let vrl_changelog = "### [0.2.0]\n- Feature\n- Fix";
+        let vrl_changelog_block = format_vrl_changelog_block(vrl_changelog);
+
+        let expected = concat!(
+        "\tvrl_changelog: \"\"\"\n",
+        "\t\t#### [0.2.0]\n",
+        "\t\t- Feature\n",
+        "\t\t- Fix\n",
+        "\t\t\"\"\""
+        );
+
+        assert_eq!(vrl_changelog_block, expected);
+
+        let original = indoc! {r#"
+            version: "1.2.3"
+            changelog: [
+                {
+                    type: "fix"
+                    description: "Some fix"
+                },
+            ]
+        "#};
+        let updated = insert_block_after_changelog(original, &vrl_changelog_block);
+
+        // Assert the last 5 lines match the VRL changelog block
+        let expected_lines_len = 5;
+        let updated_tail: Vec<&str> = updated.lines().rev().take(expected_lines_len).collect::<Vec<_>>().into_iter().rev().collect();
+        let expected_lines: Vec<&str> = vrl_changelog_block.lines().collect();
+        assert_eq!(updated_tail, expected_lines);
+    }
 }


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Recently the release CUE format changed. Now VRL changelog is separate from Vector changelog. This PR updates the prepare script to output the new format. 
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
