### PR TITLE
fix(parsing): Prometheus timestamp parse int overflow handle

### DIFF
--- a/changelog.d/fix_prometheus_timestamp_parse.fix.md
+++ b/changelog.d/fix_prometheus_timestamp_parse.fix.md
@@ -1,0 +1,3 @@
+Fixed possible interger overflows in timestamp parsing for `prometheus_parser::line::Metric::parse_timestamp`.
+
+authors: wooffie


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Change logic on `nom` parser in `prometheus-parser` crate. Now `PosOverflow`/`NegOverflow` don't result in panic.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

I added testcases, If delete changes you will see panic outer i64 range.
```console
  ---- line::test::test_parse_timestamp stdout ----

thread 'line::test::test_parse_timestamp' panicked at lib/prometheus-parser/src/line.rs:155:23:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: PosOverflow }
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/panicking.rs:75:14
   2: core::result::unwrap_failed
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/result.rs:1704:5
   3: core::result::Result<T,E>::unwrap
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:1109:23
   4: prometheus_parser::line::Metric::parse_timestamp::{{closure}}
             at ./src/line.rs:155:13
   5: nom::combinator::map::{{closure}}
             at /home/wooffie/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nom-7.1.3/src/combinator/mod.rs:80:16
   6: <F as nom::internal::Parser<I,O,E>>::parse
             at /home/wooffie/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nom-7.1.3/src/internal.rs:325:5
   7: nom::combinator::opt::{{closure}}
             at /home/wooffie/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nom-7.1.3/src/combinator/mod.rs:245:11
   8: prometheus_parser::line::Metric::parse_timestamp
             at ./src/line.rs:154:9
   9: prometheus_parser::line::test::test_parse_timestamp
             at ./src/line.rs:674:20
  10: prometheus_parser::line::test::test_parse_timestamp::{{closure}}
             at ./src/line.rs:666:30
  11: core::ops::function::FnOnce::call_once
             at /home/wooffie/.rustup/toolchains/1.85-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  12: core::ops::function::FnOnce::call_once
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    line::test::test_parse_timestamp
```
## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

- Closes: #23042


<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
