### PR TITLE
chore(sources): Refactor `struct SourceSender` a bit

### DIFF
--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -94,8 +94,8 @@ impl From<SourceSenderItem> for EventArray {
 
 pub struct Builder {
     buf_size: usize,
-    inner: Option<Inner>,
-    named_inners: HashMap<String, Inner>,
+    default_output: Option<Output>,
+    named_outputs: HashMap<String, Output>,
     lag_time: Option<Histogram>,
 }
 
@@ -103,8 +103,8 @@ impl Default for Builder {
     fn default() -> Self {
         Self {
             buf_size: CHUNK_SIZE,
-            inner: None,
-            named_inners: Default::default(),
+            default_output: None,
+            named_outputs: Default::default(),
             lag_time: Some(histogram!(LAG_TIME_NAME)),
         }
     }
@@ -129,25 +129,25 @@ impl Builder {
         };
         match output.port {
             None => {
-                let (inner, rx) = Inner::new_with_buffer(
+                let (output, rx) = Output::new_with_buffer(
                     self.buf_size,
                     DEFAULT_OUTPUT.to_owned(),
                     lag_time,
                     log_definition,
                     output_id,
                 );
-                self.inner = Some(inner);
+                self.default_output = Some(output);
                 rx
             }
             Some(name) => {
-                let (inner, rx) = Inner::new_with_buffer(
+                let (output, rx) = Output::new_with_buffer(
                     self.buf_size,
                     name.clone(),
                     lag_time,
                     log_definition,
                     output_id,
                 );
-                self.named_inners.insert(name, inner);
+                self.named_outputs.insert(name, output);
                 rx
             }
         }
@@ -155,16 +155,16 @@ impl Builder {
 
     pub fn build(self) -> SourceSender {
         SourceSender {
-            inner: self.inner.expect("no default output"),
-            named_inners: self.named_inners,
+            default_output: self.default_output.expect("no default output"),
+            named_outputs: self.named_outputs,
         }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct SourceSender {
-    inner: Inner,
-    named_inners: HashMap<String, Inner>,
+    default_output: Output,
+    named_outputs: HashMap<String, Output>,
 }
 
 impl SourceSender {
@@ -179,12 +179,12 @@ impl SourceSender {
             component: "test".to_string().into(),
             port: None,
         };
-        let (inner, rx) =
-            Inner::new_with_buffer(n, DEFAULT_OUTPUT.to_owned(), lag_time, None, output_id);
+        let (default_output, rx) =
+            Output::new_with_buffer(n, DEFAULT_OUTPUT.to_owned(), lag_time, None, output_id);
         (
             Self {
-                inner,
-                named_inners: Default::default(),
+                default_output,
+                named_outputs: Default::default(),
             },
             rx,
         )
@@ -252,7 +252,7 @@ impl SourceSender {
             component: "test".to_string().into(),
             port: Some(name.clone()),
         };
-        let (inner, recv) = Inner::new_with_buffer(100, name.clone(), None, None, output_id);
+        let (output, recv) = Output::new_with_buffer(100, name.clone(), None, None, output_id);
         let recv = recv.into_stream().map(move |mut item| {
             item.events.iter_events_mut().for_each(|mut event| {
                 let metadata = event.metadata_mut();
@@ -261,7 +261,7 @@ impl SourceSender {
             });
             item
         });
-        self.named_inners.insert(name, inner);
+        self.named_outputs.insert(name, output);
         recv
     }
 
@@ -269,7 +269,7 @@ impl SourceSender {
     ///
     /// This internally handles emitting [EventsSent] and [ComponentEventsDropped] events.
     pub async fn send_event(&mut self, event: impl Into<EventArray>) -> Result<(), ClosedError> {
-        self.inner.send_event(event).await
+        self.default_output.send_event(event).await
     }
 
     /// Send a stream of events to the default output.
@@ -280,7 +280,7 @@ impl SourceSender {
         S: Stream<Item = E> + Unpin,
         E: Into<Event> + ByteSizeOf,
     {
-        self.inner.send_event_stream(events).await
+        self.default_output.send_event_stream(events).await
     }
 
     /// Send a batch of events to the default output.
@@ -292,7 +292,7 @@ impl SourceSender {
         I: IntoIterator<Item = E>,
         <I as IntoIterator>::IntoIter: ExactSizeIterator,
     {
-        self.inner.send_batch(events).await
+        self.default_output.send_batch(events).await
     }
 
     /// Send a batch of events event to a named output.
@@ -304,7 +304,7 @@ impl SourceSender {
         I: IntoIterator<Item = E>,
         <I as IntoIterator>::IntoIter: ExactSizeIterator,
     {
-        self.named_inners
+        self.named_outputs
             .get_mut(name)
             .expect("unknown output")
             .send_batch(events)
@@ -354,9 +354,8 @@ impl Drop for UnsentEventCount {
 }
 
 #[derive(Clone)]
-struct Inner {
-    inner: LimitedSender<SourceSenderItem>,
-    output: String,
+struct Output {
+    sender: LimitedSender<SourceSenderItem>,
     lag_time: Option<Histogram>,
     events_sent: Registered<EventsSent>,
     /// The schema definition that will be attached to Log events sent through here
@@ -366,17 +365,17 @@ struct Inner {
     output_id: Arc<OutputId>,
 }
 
-impl fmt::Debug for Inner {
+impl fmt::Debug for Output {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Inner")
-            .field("inner", &self.inner)
-            .field("output", &self.output)
+        fmt.debug_struct("Output")
+            .field("sender", &self.sender)
+            .field("output_id", &self.output_id)
             // `metrics::Histogram` is missing `impl Debug`
             .finish()
     }
 }
 
-impl Inner {
+impl Output {
     fn new_with_buffer(
         n: usize,
         output: String,
@@ -387,8 +386,7 @@ impl Inner {
         let (tx, rx) = channel::limited(n);
         (
             Self {
-                inner: tx,
-                output: output.clone(),
+                sender: tx,
                 lag_time,
                 events_sent: register!(EventsSent::from(internal_event::Output(Some(
                     output.into()
@@ -419,7 +417,7 @@ impl Inner {
 
         let byte_size = events.estimated_json_encoded_size_of();
         let count = events.len();
-        self.inner
+        self.sender
             .send(SourceSenderItem {
                 events,
                 send_reference,


### PR DESCRIPTION
Prep work before pushing changes to the implementation. This should be entirely behavior neutral.