### PR TITLE
fix(datadog_agent source): Drop superfluous error log and metric

### DIFF
--- a/changelog.d/fix-datadog-agent-source-sender-warning.fix.md
+++ b/changelog.d/fix-datadog-agent-source-sender-warning.fix.md
@@ -1,0 +1,5 @@
+Eliminated the "Source send cancelled." error and corresponding metric for the
+`datadog_agent` source, as Datadog Agent will always resend events when the
+connection is dropped without an HTTP response code.
+
+author: bruceg

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -16,7 +16,11 @@ use vector_lib::{
 };
 
 use super::{dot_graph::GraphConfig, schema, ComponentKey, ProxyConfig, Resource};
-use crate::{extra_context::ExtraContext, shutdown::ShutdownSignal, SourceSender};
+use crate::{
+    extra_context::ExtraContext,
+    shutdown::ShutdownSignal,
+    source_sender::{SourceOutputMode, SourceSender},
+};
 
 pub type BoxedSource = Box<dyn SourceConfig>;
 
@@ -117,6 +121,12 @@ pub trait SourceConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sy
     /// well as emit contextual warnings when end-to-end acknowledgements are enabled, but the
     /// topology as configured does not actually support the use of end-to-end acknowledgements.
     fn can_acknowledge(&self) -> bool;
+
+    /// What output mode should be used for the `SourceSender` created for this source.
+    fn output_mode(&self) -> SourceOutputMode {
+        // By default, keep the old standard behavior.
+        SourceOutputMode::Counting
+    }
 }
 
 dyn_clone::clone_trait_object!(SourceConfig);

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -124,8 +124,8 @@ pub trait SourceConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sy
 
     /// What output mode should be used for the `SourceSender` created for this source.
     fn output_mode(&self) -> SourceOutputMode {
-        // By default, keep the old standard behavior.
-        SourceOutputMode::Counting
+        // By default, use `Simple` mode. Only sources that use warp need `Counting` mode.
+        SourceOutputMode::Simple
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ pub mod validate;
 #[cfg(windows)]
 pub mod vector_windows;
 
-pub use source_sender::SourceSender;
+pub use source_sender::{SourceOutputMode, SourceSender};
 pub use vector_lib::{event, metrics, schema, tcp, tls};
 pub use vector_lib::{shutdown, Error, Result};
 

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     http::build_http_trace_layer,
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     tls::{MaybeTlsSettings, TlsEnableableConfig},
+    SourceOutputMode,
 };
 
 pub mod errors;
@@ -244,6 +245,10 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -61,7 +61,7 @@ use crate::{
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::{self},
     tls::{MaybeTlsSettings, TlsEnableableConfig},
-    SourceSender,
+    SourceOutputMode, SourceSender,
 };
 
 pub const LOGS: &str = "logs";
@@ -318,6 +318,13 @@ impl SourceConfig for DatadogAgentConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        // Datadog Agent will resend in the event of a non-fatal error, so we
+        // don't need to track if we dropped the connection. This is also the default,
+        // this override is just to make explicit the reasoning.
+        SourceOutputMode::Simple
     }
 }
 

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -42,6 +42,7 @@ use crate::{
         },
     },
     tls::TlsEnableableConfig,
+    SourceOutputMode,
 };
 
 /// Configuration for `heroku_logs` source.
@@ -222,6 +223,10 @@ impl SourceConfig for LogplexConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -35,6 +35,7 @@ use crate::{
         Encoding, HttpSource,
     },
     tls::TlsEnableableConfig,
+    SourceOutputMode,
 };
 
 /// Configuration for the `http` source.
@@ -66,6 +67,10 @@ impl SourceConfig for HttpConfig {
 
     fn can_acknowledge(&self) -> bool {
         self.0.can_acknowledge()
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 
@@ -410,6 +415,10 @@ impl SourceConfig for SimpleHttpConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -45,6 +45,7 @@ use crate::{
     serde::bool_or_struct,
     sources::{util::grpc::run_grpc_server_with_routes, Source},
     tls::{MaybeTlsSettings, TlsEnableableConfig},
+    SourceOutputMode,
 };
 
 use super::http_server::{build_param_matcher, remove_duplicates};
@@ -336,5 +337,9 @@ impl SourceConfig for OpentelemetryConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -36,6 +36,7 @@ use crate::{
         util::{http::HttpMethod, HttpSource},
     },
     tls::TlsEnableableConfig,
+    SourceOutputMode,
 };
 
 /// Configuration for the `prometheus_pushgateway` source.
@@ -115,6 +116,10 @@ impl SourceConfig for PrometheusPushgatewayConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -22,6 +22,7 @@ use crate::{
         util::{decode, http::HttpMethod, HttpSource},
     },
     tls::TlsEnableableConfig,
+    SourceOutputMode,
 };
 
 /// Configuration for the `prometheus_remote_write` source.
@@ -104,6 +105,10 @@ impl SourceConfig for PrometheusRemoteWriteConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -54,7 +54,7 @@ use crate::{
     serde::bool_or_struct,
     source_sender::ClosedError,
     tls::{MaybeTlsSettings, TlsEnableableConfig},
-    SourceSender,
+    SourceOutputMode, SourceSender,
 };
 
 mod acknowledgements;
@@ -283,6 +283,10 @@ impl SourceConfig for SplunkConfig {
 
     fn can_acknowledge(&self) -> bool {
         true
+    }
+
+    fn output_mode(&self) -> SourceOutputMode {
+        SourceOutputMode::Counting
     }
 }
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -52,7 +52,7 @@ use crate::{
     topology::task::TaskError,
     transforms::{SyncTransform, TaskTransform, Transform, TransformOutputs, TransformOutputsBuf},
     utilization::wrap,
-    SourceOutputMode, SourceSender,
+    SourceSender,
 };
 
 static ENRICHMENT_TABLES: LazyLock<vector_lib::enrichment::TableRegistry> =
@@ -245,7 +245,7 @@ impl<'a> Builder<'a> {
                 key.id()
             );
 
-            let mut builder = SourceSender::builder(SourceOutputMode::Counting)
+            let mut builder = SourceSender::builder(source.inner.output_mode())
                 .with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
             let mut pumps = Vec::new();
             let mut controls = HashMap::new();

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -52,7 +52,7 @@ use crate::{
     topology::task::TaskError,
     transforms::{SyncTransform, TaskTransform, Transform, TransformOutputs, TransformOutputsBuf},
     utilization::wrap,
-    SourceSender,
+    SourceOutputMode, SourceSender,
 };
 
 static ENRICHMENT_TABLES: LazyLock<vector_lib::enrichment::TableRegistry> =
@@ -245,7 +245,8 @@ impl<'a> Builder<'a> {
                 key.id()
             );
 
-            let mut builder = SourceSender::builder().with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
+            let mut builder = SourceSender::builder(SourceOutputMode::Counting)
+                .with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
             let mut pumps = Vec::new();
             let mut controls = HashMap::new();
             let mut schema_definitions = HashMap::with_capacity(source_outputs.len());


### PR DESCRIPTION
## Summary

This eliminates the "Source send cancelled." error and corresponding metric for the `datadog_agent` source, as Datadog Agent will always resend events when the connection is dropped without an HTTP response code.

As part of the fix, it also eliminates that error tracking from all sources except for those that use `warp`, as those are the only sources that could have the send cancelled by a dropped task.

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
