### PR TITLE
fix(dnstap source): fix rcode 16 handling in dnsmsg-parser

### DIFF
--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -945,8 +945,8 @@ fn parse_response_code(rcode: u16) -> Option<&'static str> {
         9 => Some("NotAuth"),  // 9    NotAuth    Server Not Authoritative for zone    [RFC2136]
         10 => Some("NotZone"), // 10   NotZone    Name not contained in zone           [RFC2136]
         // backwards compat for 4 bit ResponseCodes so far.
-        // 16    BADVERS    Bad OPT Version    [RFC6891]
-        16 => Some("BADSIG"), // 16    BADSIG    TSIG Signature Failure               [RFC2845]
+        16 => Some("BADVERS"), // 16    BADVERS    Bad OPT Version    [RFC6891]
+        // 16    BADSIG    TSIG Signature Failure               [RFC2845]
         17 => Some("BADKEY"), // 17    BADKEY    Key not recognized                   [RFC2845]
         18 => Some("BADTIME"), // 18    BADTIME   Signature out of time window         [RFC2845]
         19 => Some("BADMODE"), // 19    BADMODE   Bad TKEY Mode                        [RFC2930]

--- a/lib/dnstap-parser/src/vrl_functions/parse_dnstap.rs
+++ b/lib/dnstap-parser/src/vrl_functions/parse_dnstap.rs
@@ -120,7 +120,7 @@ impl Function for ParseDnstap {
                                     "questionTypeId": 6
                                 }
                             ],
-                            "rcodeName": "BADSIG"
+                            "rcodeName": "BADVERS"
                         },
                         "responseAddress": "2001:502:7094::30",
                         "responsePort": 53,
@@ -295,7 +295,7 @@ mod tests {
                             questionTypeId: 6,
                         }
                         ],
-                        rcodeName: "BADSIG",
+                        rcodeName: "BADVERS",
                     },
                     responseAddress: "2001:502:7094::30",
                     responsePort: 53,

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -658,6 +658,7 @@ components: sources: dnstap: {
 									NXRRSet:   "RR Set that should exist does not"
 									NotAuth:   "Server Not Authoritative for zone"
 									NotZone:   "Name not contained in zone"
+									BADVERS:   "Bad OPT Version"
 									BADSIG:    "TSIG Signature Failure"
 									BADKEY:    "Key not recognized"
 									BADTIME:   "Signature out of time window"

--- a/website/cue/reference/remap/functions/parse_dnstap.cue
+++ b/website/cue/reference/remap/functions/parse_dnstap.cue
@@ -123,7 +123,7 @@ remap: functions: parse_dnstap: {
 							"questionTypeId": 6
 						},
 					]
-					"rcodeName": "BADSIG"
+					"rcodeName": "BADVERS"
 				}
 				"responseAddress": "2001:502:7094::30"
 				"responsePort":    53


### PR DESCRIPTION
## Summary

Changes RCODE 16 description to BADVERS instead of BADSIG, since BADSIG is used for TSIG RR (which is not parsed currently).

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Related https://www.iana.org/go/rfc6891
- Related: https://www.iana.org/go/rfc8945
- Closes: #22949
---
>Sponsored by [Quad9](https://quad9.net/)