### PR TITLE
enhancement(splunk_hec sink): Use a response cookie to route ack checks to the same Splunk indexer

### DIFF
--- a/changelog.d/19417_splunk_hec_sink_accept_cookies_acks.enhancement.md
+++ b/changelog.d/19417_splunk_hec_sink_accept_cookies_acks.enhancement.md
@@ -1,0 +1,3 @@
+Added support for a returned cookie from a Splunk HEC response to be used when querying for acknowledgement statuses.
+
+authors: jvperrin

--- a/src/sinks/splunk_hec/common/acknowledgements.rs
+++ b/src/sinks/splunk_hec/common/acknowledgements.rs
@@ -44,10 +44,11 @@ pub struct HecClientAcknowledgementsConfig {
     /// Once reached, the sink begins applying backpressure.
     pub max_pending_acks: NonZeroU64,
 
-    /// The name of a cookie to extract from the Splunk HEC response to use when querying for acknowledgements.
+    /// Specifies the name of a cookie to extract from the Splunk HEC response and use when querying for acknowledgements.
     ///
     /// This is useful when using a load balancer in front of multiple Splunk indexers in a cluster because the
-    /// request to check for acknowledgements needs to go to the same indexer that originally received the data.
+    /// request to check for acknowledgements needs to go to the same indexer that originally received the data,
+    /// and the cookie can help with that routing.
     ///
     /// If empty, no cookie will be extracted.
     pub cookie_name: String,

--- a/src/sinks/splunk_hec/common/service.rs
+++ b/src/sinks/splunk_hec/common/service.rs
@@ -32,9 +32,10 @@ use crate::{
 
 pub struct HecService<S> {
     pub inner: S,
-    ack_finalizer_tx: Option<mpsc::Sender<(u64, oneshot::Sender<EventStatus>)>>,
+    ack_finalizer_tx: Option<mpsc::Sender<(u64, String, oneshot::Sender<EventStatus>)>>,
     ack_slots: PollSemaphore,
     current_ack_slot: Option<OwnedSemaphorePermit>,
+    indexer_acknowledgements: HecClientAcknowledgementsConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -63,7 +64,7 @@ where
                 rx,
                 ack_client,
                 Arc::clone(&http_request_builder),
-                indexer_acknowledgements,
+                indexer_acknowledgements.clone(),
             ));
             Some(tx)
         } else {
@@ -76,6 +77,7 @@ where
             ack_finalizer_tx: tx,
             ack_slots,
             current_ack_slot: None,
+            indexer_acknowledgements,
         }
     }
 }
@@ -112,6 +114,7 @@ where
     fn call(&mut self, mut req: HecRequest) -> Self::Future {
         let ack_finalizer_tx = self.ack_finalizer_tx.clone();
         let ack_slot = self.current_ack_slot.take();
+        let cookie_name = self.indexer_acknowledgements.cookie_name.clone();
 
         let metadata = std::mem::take(req.metadata_mut());
         let events_count = metadata.event_count();
@@ -128,7 +131,42 @@ where
                         Ok(body) => {
                             if let Some(ack_id) = body.ack_id {
                                 let (tx, rx) = oneshot::channel();
-                                match ack_finalizer_tx.send((ack_id, tx)).await {
+
+                                // Extract cookies from response headers if available
+                                // For HTTP responses, we can access headers directly
+                                let cookie_string = if let Some(headers) = response.headers() {
+                                    if cookie_name.is_empty() {
+                                        String::new()
+                                    } else {
+                                        headers
+                                            .get_all(http::header::SET_COOKIE)
+                                            .iter()
+                                            .filter_map(|v| v.to_str().ok())
+                                            .find_map(|cookie_header| {
+                                                // Check if this header contains our target cookie
+                                                if cookie_header
+                                                    .starts_with(&format!("{}=", cookie_name))
+                                                {
+                                                    // Extract just the name + value part (before any semicolon)
+                                                    let value = cookie_header
+                                                        .split(';')
+                                                        .next()
+                                                        .unwrap_or(cookie_header);
+                                                    Some(value.trim().to_string())
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            .unwrap_or_default()
+                                    }
+                                } else {
+                                    // For other response types, use an empty cookie string
+                                    String::new()
+                                };
+
+                                debug!(message = "Cookie string.", cookie_string = %cookie_string);
+
+                                match ack_finalizer_tx.send((ack_id, cookie_string, tx)).await {
                                     Ok(_) => rx.await.unwrap_or(EventStatus::Rejected),
                                     // If we cannot send ack ids to the ack client, fall back to default behavior
                                     Err(error) => {
@@ -170,11 +208,16 @@ where
 
 pub trait ResponseExt {
     fn body(&self) -> &Bytes;
+    fn headers(&self) -> Option<&http::HeaderMap>;
 }
 
 impl ResponseExt for http::Response<Bytes> {
     fn body(&self) -> &Bytes {
         self.body()
+    }
+
+    fn headers(&self) -> Option<&http::HeaderMap> {
+        Some(self.headers())
     }
 }
 
@@ -378,7 +421,9 @@ mod tests {
             .respond_with(move |_: &Request| {
                 let ack_id =
                     acknowledgements_enabled.then(|| ACK_ID.fetch_add(1, Ordering::Relaxed));
-                ResponseTemplate::new(200).set_body_json(HecAckResponseBody { ack_id })
+                ResponseTemplate::new(200)
+                    .set_body_json(HecAckResponseBody { ack_id })
+                    .insert_header("Set-Cookie", "splunkd_cookie=test-cookie-value")
             })
             .mount(&mock_server)
             .await;

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -5,6 +5,18 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		description: "Splunk HEC acknowledgement configuration."
 		required:    false
 		type: object: options: {
+			cookie_name: {
+				description: """
+					The name of a cookie to extract from the Splunk HEC response to use when querying for acknowledgements.
+
+					This is useful when using a load balancer in front of multiple Splunk indexers in a cluster because the
+					request to check for acknowledgements needs to go to the same indexer that originally received the data.
+
+					If empty, no cookie will be extracted.
+					"""
+				required: false
+				type: string: default: ""
+			}
 			enabled: {
 				description: """
 					Whether or not end-to-end acknowledgements are enabled.

--- a/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_logs.cue
@@ -7,10 +7,11 @@ base: components: sinks: splunk_hec_logs: configuration: {
 		type: object: options: {
 			cookie_name: {
 				description: """
-					The name of a cookie to extract from the Splunk HEC response to use when querying for acknowledgements.
+					Specifies the name of a cookie to extract from the Splunk HEC response and use when querying for acknowledgements.
 
 					This is useful when using a load balancer in front of multiple Splunk indexers in a cluster because the
-					request to check for acknowledgements needs to go to the same indexer that originally received the data.
+					request to check for acknowledgements needs to go to the same indexer that originally received the data,
+					and the cookie can help with that routing.
 
 					If empty, no cookie will be extracted.
 					"""

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -7,10 +7,11 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 		type: object: options: {
 			cookie_name: {
 				description: """
-					The name of a cookie to extract from the Splunk HEC response to use when querying for acknowledgements.
+					Specifies the name of a cookie to extract from the Splunk HEC response and use when querying for acknowledgements.
 
 					This is useful when using a load balancer in front of multiple Splunk indexers in a cluster because the
-					request to check for acknowledgements needs to go to the same indexer that originally received the data.
+					request to check for acknowledgements needs to go to the same indexer that originally received the data,
+					and the cookie can help with that routing.
 
 					If empty, no cookie will be extracted.
 					"""

--- a/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/base/splunk_hec_metrics.cue
@@ -5,6 +5,18 @@ base: components: sinks: splunk_hec_metrics: configuration: {
 		description: "Splunk HEC acknowledgement configuration."
 		required:    false
 		type: object: options: {
+			cookie_name: {
+				description: """
+					The name of a cookie to extract from the Splunk HEC response to use when querying for acknowledgements.
+
+					This is useful when using a load balancer in front of multiple Splunk indexers in a cluster because the
+					request to check for acknowledgements needs to go to the same indexer that originally received the data.
+
+					If empty, no cookie will be extracted.
+					"""
+				required: false
+				type: string: default: ""
+			}
 			enabled: {
 				description: """
 					Whether or not end-to-end acknowledgements are enabled.


### PR DESCRIPTION
## Summary
This is particularly useful when running Splunk in a clustered environment with multiple indexer hosts. In this environment, acknowledgement IDs are frequently duplicated across multiple indexers (they all start at `0` and count upwards as they receive requests with the same `X-Splunk-Request-Channel` header, so there will be lots of reuse). One common way to distinguish between multiple hosts behind a load balancer is to return a cookie to specify which indexer to respond back to. This is the recommended way, for instance, to set up an AWS ELB for a Splunk indexer cluster such that it has cookie stickiness enabled:
https://docs.splunk.com/Documentation/AddOns/released/Firehose/ConfigureanELB https://community.splunk.com/t5/Getting-Data-In/How-to-configure-the-load-balancer-to-handle-HEC-data/td-p/742116

I'm not actually sure how acknowledgements would have worked with multiple indexers previously. From what I can tell, given the way it is structured with the hashmap keyed by ack ID, it would only ever work with single-indexer clusters due to the ack collision issue and not being able to find which indexer to properly query for acknowledgement details.

I'm also very new to writing Rust, so some of the stuff I've written might not be the best way to do things. Feedback is very welcome!

## Change Type
- [X] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
I tested with some added unit and integration tests, as well as this local config and running `cargo run --release -- --config test_config.yaml`. This was sending to our Splunk cluster with 50+ indexers behind an AWS ALB and no events were dropped or any error logs generated over ~ 10 hours:
```yaml
---
sources:
  demo_logs:
    type: demo_logs
    format: shuffle
    lines:
      - "jvperrin test log"
    sequence: true

sinks:
  splunk:
    type: splunk_hec_logs
    inputs:
      - demo_logs
    acknowledgements:
      enabled: true
      indexer_acknowledgements_enabled: true
      cookie_name: "AWSALB"
    healthcheck:
      enabled: true
    endpoint: "<REDACTED>"
    default_token: "<REDACTED>"
    index: "vector_poc"
    sourcetype: "jvperrin_test"
    encoding:
      codec: json
```

## Does this PR include user facing changes?
- [X] Yes. I've added a changelog entry

## References
- Closes: #19417