### PR TITLE
fix(sources): Handle sources with no default output

### DIFF
--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -163,8 +163,8 @@ impl Builder {
 
 #[derive(Debug, Clone)]
 pub struct SourceSender {
-    // The default output is optional because two sources, `datadog_agent` and `opentelemetry`
-    // can be configured to only output to named outputs.
+    // The default output is optional because some sources, e.g. `datadog_agent`
+    // and `opentelemetry`, can be configured to only output to named outputs.
     default_output: Option<Output>,
     named_outputs: HashMap<String, Output>,
 }

--- a/src/source_sender/mod.rs
+++ b/src/source_sender/mod.rs
@@ -155,7 +155,7 @@ impl Builder {
 
     pub fn build(self) -> SourceSender {
         SourceSender {
-            default_output: self.default_output.expect("no default output"),
+            default_output: self.default_output,
             named_outputs: self.named_outputs,
         }
     }
@@ -163,7 +163,9 @@ impl Builder {
 
 #[derive(Debug, Clone)]
 pub struct SourceSender {
-    default_output: Output,
+    // The default output is optional because two sources, `datadog_agent` and `opentelemetry`
+    // can be configured to only output to named outputs.
+    default_output: Option<Output>,
     named_outputs: HashMap<String, Output>,
 }
 
@@ -183,7 +185,7 @@ impl SourceSender {
             Output::new_with_buffer(n, DEFAULT_OUTPUT.to_owned(), lag_time, None, output_id);
         (
             Self {
-                default_output,
+                default_output: Some(default_output),
                 named_outputs: Default::default(),
             },
             rx,
@@ -265,11 +267,16 @@ impl SourceSender {
         recv
     }
 
+    /// Get a mutable reference to the default output, panicking if none exists.
+    fn default_output_mut(&mut self) -> &mut Output {
+        self.default_output.as_mut().expect("no default output")
+    }
+
     /// Send an event to the default output.
     ///
     /// This internally handles emitting [EventsSent] and [ComponentEventsDropped] events.
     pub async fn send_event(&mut self, event: impl Into<EventArray>) -> Result<(), ClosedError> {
-        self.default_output.send_event(event).await
+        self.default_output_mut().send_event(event).await
     }
 
     /// Send a stream of events to the default output.
@@ -280,7 +287,7 @@ impl SourceSender {
         S: Stream<Item = E> + Unpin,
         E: Into<Event> + ByteSizeOf,
     {
-        self.default_output.send_event_stream(events).await
+        self.default_output_mut().send_event_stream(events).await
     }
 
     /// Send a batch of events to the default output.
@@ -292,7 +299,7 @@ impl SourceSender {
         I: IntoIterator<Item = E>,
         <I as IntoIterator>::IntoIter: ExactSizeIterator,
     {
-        self.default_output.send_batch(events).await
+        self.default_output_mut().send_batch(events).await
     }
 
     /// Send a batch of events event to a named output.


### PR DESCRIPTION
## Summary

There exist sources that can be configured to output events entirely to non-default ports. The refactoring to `struct SourceSender` in #23089 failed to take this into account. This PR reverts the changes to the `default_output` handling in the builder and `SourceSender` with the addition of a small cleanup of its own.

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
<!-- Please describe your testing plan here.
Sharing information about your setup and the Vector configuration(s) you used (when applicable) is highly recommended.
Providing this information upfront will facilitate a smoother review process. -->

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).
