### PR TITLE
fix(core): Add deny_unknown_fields to TlsEnableableConfig

### DIFF
--- a/changelog.d/23187_tls_enableable_config_deny_unknown_fields.fix.md
+++ b/changelog.d/23187_tls_enableable_config_deny_unknown_fields.fix.md
@@ -1,0 +1,3 @@
+Add deny_unknown_fields to TlsEnableableConfig so vector will not run when unused/invalid args are supplied
+
+authors: thomasqueirozb

--- a/changelog.d/23187_tls_enableable_config_deny_unknown_fields.fix.md
+++ b/changelog.d/23187_tls_enableable_config_deny_unknown_fields.fix.md
@@ -1,3 +1,3 @@
-Unknown fields in the `tls` config are now rejected so these fields now need to be removed  for Vector to start successfully.
+Unknown fields in the `tls` config are now rejected so these fields now need to be removed for Vector to start successfully.
 
 authors: thomasqueirozb

--- a/changelog.d/23187_tls_enableable_config_deny_unknown_fields.fix.md
+++ b/changelog.d/23187_tls_enableable_config_deny_unknown_fields.fix.md
@@ -1,3 +1,3 @@
-Add deny_unknown_fields to TlsEnableableConfig so vector will not run when unused/invalid args are supplied
+Unknown fields in the `tls` config are now rejected so these fields now need to be removed  for Vector to start successfully.
 
 authors: thomasqueirozb

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -41,6 +41,7 @@ pub const TEST_PEM_CLIENT_KEY_PATH: &str =
 #[configurable_component]
 #[configurable(metadata(docs::advanced))]
 #[derive(Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TlsEnableableConfig {
     /// Whether or not to require TLS for incoming or outgoing connections.
     ///


### PR DESCRIPTION
<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

## Summary

Add deny_unknown_fields to TlsEnableableConfig so vector will not run when unused/invalid args are supplied

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

## How did you test this PR?

`cargo nextest run`

![image](https://github.com/user-attachments/assets/cf3b1fef-afe3-4da4-9719-ae1b12dfa2e2)


## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->


Fixes #23145

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
