### PR TITLE
feat(observability): add uptime seconds display to `vector top`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,9 +4702,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -4723,7 +4723,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing 0.1.41",
@@ -7800,7 +7800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -7846,7 +7846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.102",
@@ -11544,6 +11544,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 0.4.5",
  "http-serde",
+ "humantime",
  "hyper 0.14.28",
  "hyper-openssl 0.9.2",
  "hyper-proxy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amq-protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ flate2 = { version = "1.1.2", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3.31", default-features = false, features = ["compat", "io-compat", "std"], package = "futures" }
 glob = { version = "0.3.2", default-features = false }
 hickory-proto = { version = "0.25.2", default-features = false, features = ["dnssec-ring"] }
+humantime = { version = "2.2.0", default-features = false }
 indexmap = { version = "2.9.0", default-features = false, features = ["serde", "std"] }
 inventory = { version = "0.3" }
 indoc = { version = "2.0.6" }
@@ -345,6 +346,7 @@ http = { version = "0.2.9", default-features = false }
 http-1 = { package = "http", version = "1.0", default-features = false, features = ["std"] }
 http-serde = "1.1.3"
 http-body = { version = "0.4.5", default-features = false }
+humantime.workspace = true
 hyper = { version = "0.14.28", default-features = false, features = ["client", "runtime", "http1", "http2", "server", "stream"] }
 hyper-openssl = { version = "0.9.2", default-features = false }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["openssl-tls"] }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -293,6 +293,7 @@ http-serde,https://gitlab.com/kornelski/http-serde,Apache-2.0 OR MIT,Kornel <kor
 http-types,https://github.com/http-rs/http-types,MIT OR Apache-2.0,Yoshua Wuyts <yoshuawuyts@gmail.com>
 httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
+humantime,https://github.com/chronotope/humantime,MIT OR Apache-2.0,The humantime Authors
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
 hyper-named-pipe,https://github.com/fussybeaver/hyper-named-pipe,Apache-2.0,The hyper-named-pipe Authors
 hyper-openssl,https://github.com/sfackler/hyper-openssl,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>

--- a/changelog.d/23228_vector_top_uptime.feature.md
+++ b/changelog.d/23228_vector_top_uptime.feature.md
@@ -1,0 +1,3 @@
+Added vector uptime in seconds to `vector top`.
+
+authors: esensar Quad9DNS

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -164,7 +164,13 @@ impl<'a> Widgets<'a> {
     }
 
     /// Renders a title and the URL the dashboard is currently connected to.
-    fn title(&'a self, f: &mut Frame, area: Rect, connection_status: &ConnectionStatus) {
+    fn title(
+        &'a self,
+        f: &mut Frame,
+        area: Rect,
+        connection_status: &ConnectionStatus,
+        uptime_secs: f64,
+    ) {
         let mut text = vec![
             Span::from(self.url_string),
             Span::styled(
@@ -174,6 +180,7 @@ impl<'a> Widgets<'a> {
             Span::from(" | "),
         ];
         text.extend(connection_status.as_ui_spans());
+        text.extend(vec![Span::from(format!(" | Uptime: {}s", uptime_secs))]);
 
         let text = vec![Line::from(text)];
 
@@ -327,7 +334,7 @@ impl<'a> Widgets<'a> {
             .constraints(self.constraints.clone())
             .split(size);
 
-        self.title(f, rects[0], &state.connection_status);
+        self.title(f, rects[0], &state.connection_status, state.uptime_secs);
 
         // Require a minimum of 80 chars of line width to display the table
         if size.width >= 80 {

--- a/src/top/dashboard.rs
+++ b/src/top/dashboard.rs
@@ -17,7 +17,7 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
     Frame, Terminal,
 };
-use std::io::stdout;
+use std::{io::stdout, time::Duration};
 use tokio::sync::oneshot;
 
 use super::{
@@ -169,7 +169,7 @@ impl<'a> Widgets<'a> {
         f: &mut Frame,
         area: Rect,
         connection_status: &ConnectionStatus,
-        uptime_secs: f64,
+        uptime: Duration,
     ) {
         let mut text = vec![
             Span::from(self.url_string),
@@ -180,7 +180,10 @@ impl<'a> Widgets<'a> {
             Span::from(" | "),
         ];
         text.extend(connection_status.as_ui_spans());
-        text.extend(vec![Span::from(format!(" | Uptime: {}s", uptime_secs))]);
+        text.extend(vec![Span::from(format!(
+            " | Uptime: {}",
+            humantime::format_duration(uptime)
+        ))]);
 
         let text = vec![Line::from(text)];
 
@@ -334,7 +337,7 @@ impl<'a> Widgets<'a> {
             .constraints(self.constraints.clone())
             .split(size);
 
-        self.title(f, rects[0], &state.connection_status, state.uptime_secs);
+        self.title(f, rects[0], &state.connection_status, state.uptime);
 
         // Require a minimum of 80 chars of line width to display the table
         if size.width >= 80 {

--- a/src/top/metrics.rs
+++ b/src/top/metrics.rs
@@ -397,6 +397,20 @@ async fn errors_totals(
     }
 }
 
+async fn uptime_changed(client: Arc<SubscriptionClient>, tx: state::EventTx) {
+    tokio::pin! {
+        let stream = client.uptime_subscription();
+    };
+
+    while let Some(Some(res)) = stream.next().await {
+        if let Some(d) = res.data {
+            _ = tx
+                .send(state::EventType::UptimeChanged(d.uptime.seconds))
+                .await;
+        }
+    }
+}
+
 /// Subscribe to each metrics channel through a separate client. This is a temporary workaround
 /// until client multiplexing is fixed. In future, we should be able to use a single client
 pub fn subscribe(
@@ -475,10 +489,11 @@ pub fn subscribe(
         )),
         tokio::spawn(errors_totals(
             Arc::clone(&client),
-            tx,
+            tx.clone(),
             interval,
             Arc::clone(&components_patterns),
         )),
+        tokio::spawn(uptime_changed(Arc::clone(&client), tx)),
     ]
 }
 

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -22,6 +22,7 @@ pub struct SentEventsMetric {
 #[derive(Debug)]
 pub enum EventType {
     InitializeState(State),
+    UptimeChanged(f64),
     ReceivedBytesTotals(Vec<IdentifiedMetric>),
     /// Interval + identified metric
     ReceivedBytesThroughputs(i64, Vec<IdentifiedMetric>),
@@ -76,6 +77,7 @@ impl ConnectionStatus {
 #[derive(Debug, Clone)]
 pub struct State {
     pub connection_status: ConnectionStatus,
+    pub uptime_secs: f64,
     pub components: BTreeMap<ComponentKey, ComponentRow>,
 }
 
@@ -83,6 +85,7 @@ impl State {
     pub const fn new(components: BTreeMap<ComponentKey, ComponentRow>) -> Self {
         Self {
             connection_status: ConnectionStatus::Pending,
+            uptime_secs: 0.0,
             components,
         }
     }
@@ -243,6 +246,9 @@ pub async fn updater(mut event_rx: EventRx) -> StateRx {
                 }
                 EventType::ConnectionUpdated(status) => {
                     state.connection_status = status;
+                }
+                EventType::UptimeChanged(uptime) => {
+                    state.uptime_secs = uptime;
                 }
             }
 

--- a/src/top/state.rs
+++ b/src/top/state.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 
 use chrono::{DateTime, Local};
 use ratatui::{
@@ -77,7 +80,7 @@ impl ConnectionStatus {
 #[derive(Debug, Clone)]
 pub struct State {
     pub connection_status: ConnectionStatus,
-    pub uptime_secs: f64,
+    pub uptime: Duration,
     pub components: BTreeMap<ComponentKey, ComponentRow>,
 }
 
@@ -85,7 +88,7 @@ impl State {
     pub const fn new(components: BTreeMap<ComponentKey, ComponentRow>) -> Self {
         Self {
             connection_status: ConnectionStatus::Pending,
-            uptime_secs: 0.0,
+            uptime: Duration::from_secs(0),
             components,
         }
     }
@@ -248,7 +251,7 @@ pub async fn updater(mut event_rx: EventRx) -> StateRx {
                     state.connection_status = status;
                 }
                 EventType::UptimeChanged(uptime) => {
-                    state.uptime_secs = uptime;
+                    state.uptime = Duration::from_secs_f64(uptime);
                 }
             }
 


### PR DESCRIPTION
## Summary
Adds an additional field in title of `vector top`, displaying process uptime in seconds.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
Just ran `vector top` with a running `vector` instance with `api` enabled.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

- Closes: #23226

---
>Sponsored by [Quad9](https://quad9.net/)
