### PR TITLE
fix(website): Fixed documentation badges space on documentation

### DIFF
--- a/website/layouts/partials/badge.html
+++ b/website/layouts/partials/badge.html
@@ -11,7 +11,7 @@
 {{ $color := index $styles .color }}
 {{ with .href }}<a href="{{ . }}">{{ end }}
     <span {{ with .show }} x-show="{{ . }}" {{ end }}
-          class="{{ if .inline }}inline-{{ end }}flex items-center py-1 font-medium{{ if .large }} text-sm px-3{{ else }} text-xs px-2{{ end }} {{ if .rounded }} rounded-full{{ else }} rounded{{ end }} {{ $color }}">
+          class="{{ if .inline }}inline-{{ end }}flex items-center py-1 mr-1 font-medium{{ if .large }} text-sm px-3{{ else }} text-xs px-2{{ end }} {{ if .rounded }} rounded-full{{ else }} rounded{{ end }} {{ $color }}">
       {{ if .prefix }}
       {{ .prefix }}:&nbsp;<span class="font-bold">{{- .word -}}</span>
       {{ else }}


### PR DESCRIPTION
## Summary
fix(docs): Fixed documentation badges space on documentation

This change adds a mr-1 (margin-right) class to the badge container span to properly space badges when displayed inline, improving readability and visual layout in the documentation.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## How did you test this PR?
I built and previewed the documentation locally to verify that badges now have consistent spacing between each other without collapsing. The badges render correctly across different browsers and screen sizes.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the "no-changelog" label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- The CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
    - `./scripts/check_changelog_fragments.sh`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
