### PR TITLE
fix(ci): K8S E2E tests skipping changes.yml in MQ

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -44,6 +44,8 @@ on:
         value: ${{ jobs.source.outputs.install }}
       k8s:
         value: ${{ jobs.source.outputs.k8s }}
+      website_only:
+        value: ${{ jobs.source.outputs.website_only }}
       all-int:
         value: ${{ jobs.int_tests.outputs.all-tests }}
       amqp:
@@ -141,7 +143,7 @@ jobs:
       markdown: ${{ steps.filter.outputs.markdown }}
       install: ${{ steps.filter.outputs.install }}
       k8s: ${{ steps.filter.outputs.k8s }}
-      website_only: ${{ steps.filter.outputs.website == 'true' && steps.filter.outputs.other == 'false' }}
+      website_only: ${{ steps.filter.outputs.website == 'true' && steps.filter.outputs.not_website == 'false' }}
     steps:
     - uses: actions/checkout@v4
 
@@ -198,7 +200,6 @@ jobs:
             - "src/sources/kubernetes_logs/**"
           website:
             - "website/**"
-          # any change _not_ under website/
           not_website:
             - "**"
             - "!website/**"

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -53,12 +53,20 @@ env:
 jobs:
   changes:
     # Only evaluate files changed on pull request trigger
-    if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/changes.yml
-    with:
-      base_ref: ${{ github.event.pull_request.base.ref }}
-      head_ref: ${{ github.event.pull_request.head.ref }}
-    secrets: inherit
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # need at least two commits so HEAD^ is available
+          fetch-depth: 2
+      - name: Identify changes
+        uses: ./.github/workflows/changes.yml
+        with:
+          # for PRs, use the branch names; for merge_group, diff parent vs HEAD
+          base_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || format('{0}^', github.sha) }}
+          head_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref  || github.sha }}
+        secrets: inherit
 
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     needs: changes
-    # Run this job even if `changes` job is skipped (non- pull request/merge queue trigger)
-    if: ${{ !failure() && !cancelled() && ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.changes.outputs.k8s == 'true') }}
+    # Run this job even if `changes` job is skipped
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.k8s != 'false' }}
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
@@ -129,8 +129,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: changes
-    # Run this job even if `changes` job is skipped (non- pull request/merge queue trigger)
-    if: ${{ !failure() && !cancelled() && ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.changes.outputs.k8s == 'true') }}
+    # Run this job even if `changes` job is skipped
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.k8s != 'false' }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     needs: changes
     # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s != 'false' || needs.changes.outputs.website_only != 'true') }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' }}
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
@@ -135,7 +135,7 @@ jobs:
     timeout-minutes: 5
     needs: changes
     # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s != 'false' || needs.changes.outputs.website_only != 'true') }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -73,11 +73,6 @@ jobs:
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
       CARGO_INCREMENTAL: 0
     steps:
-      - name: debug
-        run: |
-          echo "website_only: ${{ needs.changes.outputs.website_only }}"
-          echo "k8s: ${{ needs.changes.outputs.k8s }}"
-
       - name: (PR review) Set latest commit status as pending
         if: ${{ github.event_name == 'pull_request_review' }}
         uses: myrotvorets/set-commit-status-action@v2.0.1

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -73,6 +73,11 @@ jobs:
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
       CARGO_INCREMENTAL: 0
     steps:
+      - name: debug
+        run: |
+          echo "website_only: ${{ needs.changes.outputs.website_only }}"
+          echo "k8s: ${{ needs.changes.outputs.k8s }}"
+
       - name: (PR review) Set latest commit status as pending
         if: ${{ github.event_name == 'pull_request_review' }}
         uses: myrotvorets/set-commit-status-action@v2.0.1

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -54,18 +54,11 @@ jobs:
   changes:
     # Only evaluate files changed on pull request trigger
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          # need at least two commits so HEAD^ is available
-          fetch-depth: 2
-      - name: Identify changes
-        uses: ./.github/workflows/changes.yml
-        with:
-          base_ref: ${{ github.event.merge_group.base_ref || github.event.pull_request.base.ref }}
-          head_ref: ${{ github.event.merge_group.head_ref || github.event.pull_request.head.ref }}
-        secrets: inherit
+    uses: ./.github/workflows/changes.yml
+    with:
+      base_ref: ${{ github.event.merge_group.base_ref || github.event.pull_request.base.ref }}
+      head_ref: ${{ github.event.merge_group.head_ref || github.event.pull_request.head.ref }}
+    secrets: inherit
 
   build-x86_64-unknown-linux-gnu:
     name: Build - x86_64-unknown-linux-gnu

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     needs: changes
-    # Run this job even if `changes` job is skipped (non- pull request trigger)
-    if: ${{ !failure() && !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.k8s == 'true') }}
+    # Run this job even if `changes` job is skipped (non- pull request/merge queue trigger)
+    if: ${{ !failure() && !cancelled() && ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.changes.outputs.k8s == 'true') }}
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
@@ -129,8 +129,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: changes
-    # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.k8s == 'true') }}
+    # Run this job even if `changes` job is skipped (non- pull request/merge queue trigger)
+    if: ${{ !failure() && !cancelled() && ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.changes.outputs.k8s == 'true') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     needs: changes
     # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s != 'false' || needs.changes.website_only != 'true') }}
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s != 'false' || needs.changes.outputs.website_only != 'true') }}
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
@@ -130,7 +130,7 @@ jobs:
     timeout-minutes: 5
     needs: changes
     # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s != 'false' || needs.changes.website_only != 'true') }}
+    if: ${{ !failure() && !cancelled() && (needs.changes.outputs.k8s != 'false' || needs.changes.outputs.website_only != 'true') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -63,9 +63,8 @@ jobs:
       - name: Identify changes
         uses: ./.github/workflows/changes.yml
         with:
-          # for PRs, use the branch names; for merge_group, diff parent vs HEAD
-          base_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || format('{0}^', github.sha) }}
-          head_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref  || github.sha }}
+          base_ref: ${{ github.event.merge_group.base_ref || github.event.pull_request.base.ref }}
+          head_ref: ${{ github.event.merge_group.head_ref || github.event.pull_request.head.ref }}
         secrets: inherit
 
   build-x86_64-unknown-linux-gnu:


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
changes.yml check is being skipped in the merge queue making the check always run even when not necessary

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
