### PR TITLE
fix(ci): IT suite should run when manually evoked

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -114,8 +114,13 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
-            # Parse the JSON and check if the specific integration test should run.
-            should_run=$(jq '."${{ matrix.service }}"' int_tests_changes.json)
+            if [[ -f int_tests_changes.json ]]; then
+              # Parse the JSON and check if the specific integration test should run.
+              should_run=$(jq -r '."${{ matrix.service }}" // false' int_tests_changes.json)
+            else
+              # The `changes` job did not run (manual run) or the file is missing, default to false.
+              should_run=false
+            fi
 
             # Check if any of the three conditions is true
             if [[ "${{ github.event_name }}" == "merge_group" || \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,41 +46,8 @@ jobs:
       int_tests: true
     secrets: inherit
 
-  check-changes:
-    runs-on: ubuntu-latest
-    needs: changes
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - name: Download JSON artifact from changes.yml
-        uses: actions/download-artifact@v4
-        with:
-          name: int_tests_changes
-
-      - name: Check if all values are false
-        id: check
-        run: |
-          # Always run the suite when the PR is in the merge queue
-          if [[ "${{ github.event_name }}" == "merge_group" ]] ; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Check if all values are 'false'
-          json=$(cat int_tests_changes.json)
-          all_false=$(echo "$json" | jq -r 'to_entries | all(.value == false)')
-
-          if [[ "$all_false" == "true" ]]; then
-            echo "No changes detected. Skipping integration tests."
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          else
-            echo "Detected changes. Proceeding with integration tests."
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          fi
-
   check-secrets:
     runs-on: ubuntu-latest
-    needs: check-changes
     outputs:
       can_access_secrets: ${{ steps.secret_check.outputs.can_access_secrets }}
     steps:
@@ -152,6 +119,7 @@ jobs:
 
             # Check if any of the three conditions is true
             if [[ "${{ github.event_name }}" == "merge_group" || \
+                  "${{ github.event_name }}" == "workflow_dispatch" || \
                   "${{ needs.changes.outputs.dependencies }}" == "true" || \
                   "$should_run" == "true" ]]; then
               echo "Running test for ${{ matrix.service }}"
@@ -168,7 +136,6 @@ jobs:
     if: always()
     needs:
       - changes
-      - check-changes
       - setup
       - integration-tests
     env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,7 +140,6 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs:
-      - changes
       - setup
       - integration-tests
     env:


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

All tests were skipped for manual runs. This PR fixes that.
This PR also deletes the `check-changes` job since it's output was never used.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
