### PR TITLE
fix(ci): integration remove useless setup job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,8 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AWS_ACCESS_KEY_ID: "dummy"
-  AWS_SECRET_ACCESS_KEY: "dummy"
   CONTAINER_TOOL: "docker"
   DD_ENV: "ci"
   DD_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -62,22 +60,10 @@ jobs:
             echo "can_access_secrets=false" >> $GITHUB_OUTPUT
           fi
 
-  setup:
-    runs-on: ubuntu-latest
-    needs: check-secrets
-    if: ${{ github.event_name == 'merge_group' || needs.check-secrets.outputs.can_access_secrets == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run setup steps required by the IT suite
-        run: |
-          sudo -E bash scripts/ci-free-disk-space.sh
-
   integration-tests:
     runs-on: ubuntu-24.04
     needs:
       - changes
-      - setup
       - check-secrets
 
     if: ${{ !failure() && !cancelled() && (needs.check-secrets.outputs.can_access_secrets == 'true' || github.event_name == 'merge_group') }}
@@ -139,7 +125,6 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs:
-      - setup
       - integration-tests
     env:
       FAILED: ${{ contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Remove useless setup job in integration.yml. Since jobs run in separate pods that job was essentially doing nothing.
Somehow this job was being skipped in the MQ when PRs came in from external contributors which made it so the integration test job was also skipped

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
