### PR TITLE
feat(source: http_client):  #23338 Enable AWS authentication for the http_client source.

### DIFF
--- a/changelog.d/23338.feature.md
+++ b/changelog.d/23338.feature.md
@@ -1,0 +1,3 @@
+Enables AWS authentication for the http_client source.
+
+authors: johannesfloriangeiger

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -368,6 +368,16 @@ impl AwsAuthentication {
         }
     }
 
+    /// Returns the region for the credentials based on the authentication mechanism chosen.
+    pub fn region(&self) -> Option<Region> {
+        match self {
+            AwsAuthentication::AccessKey { region, .. }
+            | AwsAuthentication::File { region, .. }
+            | AwsAuthentication::Role { region, .. }
+            | AwsAuthentication::Default { region, .. } => region.clone().map(Region::new),
+        }
+    }
+
     #[cfg(test)]
     /// Creates dummy authentication for tests.
     pub fn test_auth() -> AwsAuthentication {

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -17,6 +17,8 @@ use std::{collections::HashMap, future::ready};
 use tokio_stream::wrappers::IntervalStream;
 use vector_lib::json_size::JsonSize;
 
+#[cfg(feature = "aws-core")]
+use crate::aws::sign_request_with_empty_body;
 use crate::http::{QueryParameterValue, QueryParameters};
 use crate::{
     http::{Auth, HttpClient},
@@ -28,6 +30,8 @@ use crate::{
     tls::TlsSettings,
     SourceSender,
 };
+#[cfg(feature = "aws-core")]
+use aws_config::meta::region::ProvideRegion;
 use vector_lib::shutdown::ShutdownSignal;
 use vector_lib::{config::proxy::ProxyConfig, event::Event, EstimatedJsonEncodedSizeOf};
 
@@ -194,79 +198,123 @@ pub(crate) async fn call<
                 auth.apply(&mut request);
             }
 
-            tokio::time::timeout(inputs.timeout, client.send(request))
-                .then(move |result| async move {
-                    match result {
-                        Ok(Ok(response)) => Ok(response),
-                        Ok(Err(error)) => Err(error.into()),
-                        Err(_) => Err(format!(
-                            "Timeout error: request exceeded {}s",
-                            inputs.timeout.as_secs_f64()
+            #[cfg(feature = "aws-core")]
+            let aws_auth = match &inputs.auth {
+                None => None,
+                Some(Auth::Aws { auth, service }) => Some((auth.clone(), service.clone())),
+                _ => None,
+            };
+
+            tokio::time::timeout(inputs.timeout, async move {
+                let request = request;
+
+                #[cfg(feature = "aws-core")]
+                let request = match aws_auth {
+                    None => request,
+                    Some((auth, service)) => {
+                        let mut signed_request = request;
+                        let default_region =
+                            crate::aws::region_provider(&ProxyConfig::default(), None)
+                                .expect("Region provider must be available")
+                                .region()
+                                .await;
+                        let region = auth
+                            .region()
+                            .or(default_region)
+                            .expect("Region must be specified");
+                        let credentials_provider = &auth
+                            .credentials_provider(region.clone(), &ProxyConfig::default(), None)
+                            .await
+                            .expect("Credentials provider must be available");
+                        sign_request_with_empty_body(
+                            service.as_str(),
+                            &mut signed_request,
+                            credentials_provider,
+                            Some(&region),
+                            false,
                         )
-                        .into()),
+                        .await
+                        .expect("Signing request failed");
+
+                        signed_request
                     }
-                })
-                .and_then(|response| async move {
-                    let (header, body) = response.into_parts();
-                    let body = hyper::body::to_bytes(body).await?;
-                    emit!(EndpointBytesReceived {
-                        byte_size: body.len(),
-                        protocol: "http",
-                        endpoint: endpoint.as_str(),
-                    });
-                    Ok((header, body))
-                })
-                .into_stream()
-                .filter_map(move |response| {
-                    ready(match response {
-                        Ok((header, body)) if header.status == hyper::StatusCode::OK => {
-                            context.on_response(&url, &header, &body).map(|mut events| {
-                                let byte_size = if events.is_empty() {
-                                    // We need to explicitly set the byte size
-                                    // to 0 since
-                                    // `estimated_json_encoded_size_of` returns
-                                    // at least 1 for an empty collection. For
-                                    // the purposes of the
-                                    // HttpClientEventsReceived event, we should
-                                    // emit 0 when there aren't any usable
-                                    // metrics.
-                                    JsonSize::zero()
-                                } else {
-                                    events.estimated_json_encoded_size_of()
-                                };
+                };
 
-                                emit!(HttpClientEventsReceived {
-                                    byte_size,
-                                    count: events.len(),
-                                    url: url.to_string()
-                                });
+                request
+            })
+            .and_then(move |request| tokio::time::timeout(inputs.timeout, client.send(request)))
+            .then(move |result| async move {
+                match result {
+                    Ok(Ok(response)) => Ok(response),
+                    Ok(Err(error)) => Err(error.into()),
+                    Err(_) => Err(format!(
+                        "Timeout error: request exceeded {}s",
+                        inputs.timeout.as_secs_f64()
+                    )
+                    .into()),
+                }
+            })
+            .and_then(|response| async move {
+                let (header, body) = response.into_parts();
+                let body = hyper::body::to_bytes(body).await?;
+                emit!(EndpointBytesReceived {
+                    byte_size: body.len(),
+                    protocol: "http",
+                    endpoint: endpoint.as_str(),
+                });
+                Ok((header, body))
+            })
+            .into_stream()
+            .filter_map(move |response| {
+                ready(match response {
+                    Ok((header, body)) if header.status == hyper::StatusCode::OK => {
+                        context.on_response(&url, &header, &body).map(|mut events| {
+                            let byte_size = if events.is_empty() {
+                                // We need to explicitly set the byte size
+                                // to 0 since
+                                // `estimated_json_encoded_size_of` returns
+                                // at least 1 for an empty collection. For
+                                // the purposes of the
+                                // HttpClientEventsReceived event, we should
+                                // emit 0 when there aren't any usable
+                                // metrics.
+                                JsonSize::zero()
+                            } else {
+                                events.estimated_json_encoded_size_of()
+                            };
 
-                                // We'll enrich after receiving the events so
-                                // that the byte sizes are accurate.
-                                context.enrich_events(&mut events);
-
-                                stream::iter(events)
-                            })
-                        }
-                        Ok((header, _)) => {
-                            context.on_http_response_error(&url, &header);
-                            emit!(HttpClientHttpResponseError {
-                                code: header.status,
-                                url: url.to_string(),
-                            });
-                            None
-                        }
-                        Err(error) => {
-                            emit!(HttpClientHttpError {
-                                error,
+                            emit!(HttpClientEventsReceived {
+                                byte_size,
+                                count: events.len(),
                                 url: url.to_string()
                             });
-                            None
-                        }
-                    })
+
+                            // We'll enrich after receiving the events so
+                            // that the byte sizes are accurate.
+                            context.enrich_events(&mut events);
+
+                            stream::iter(events)
+                        })
+                    }
+                    Ok((header, _)) => {
+                        context.on_http_response_error(&url, &header);
+                        emit!(HttpClientHttpResponseError {
+                            code: header.status,
+                            url: url.to_string(),
+                        });
+                        None
+                    }
+                    Err(error) => {
+                        emit!(HttpClientHttpError {
+                            error,
+                            url: url.to_string()
+                        });
+                        None
+                    }
                 })
-                .flatten()
-                .boxed()
+            })
+            .flatten()
+            .boxed()
         })
         .flatten_unordered(None)
         .boxed();


### PR DESCRIPTION
## Summary

See title, enables AWS authentication for the http_client source.

## Vector configuration

```
[sources.http_client]
type = "http_client"
endpoint = "<ENDPOINT>"
auth = {strategy = "aws", auth = {}, service = "aps"}
method = "POST"
headers.Content-Type = ["application/x-www-form-urlencoded"]
query.query = "up"

[sinks.blackhole]
type = "blackhole"
inputs = ["http_client"]
```

## How did you test this PR?

Manually. Get yourself an AWS Account, create an Amazon Managed Service for Prometheus workspace, get the Endpoint - query URL and use it in the config above. Run Vector and see it working (and not failing with a 403 like the current version).

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #23028
- 
<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
