### PR TITLE
fix(core): `metrics-tag-values: full` made tags unmodifiable

### DIFF
--- a/changelog.d/23371_metric-tag-values-full-unmodifiable-tags.fix.md
+++ b/changelog.d/23371_metric-tag-values-full-unmodifiable-tags.fix.md
@@ -1,0 +1,3 @@
+Fix an issue where tags were not modifiable via VRL if `metrics-tag-values` was set to `full`.
+
+authors: thomasqueirozb

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -437,7 +437,7 @@ impl Target for VrlTarget {
                             }),
                             ["tags", field] => {
                                 if *multi_value_tags {
-                                    metric.series.remove_tag(field).map(|value| value.into())
+                                    metric.series.remove_tag(field).map(Into::into)
                                 } else {
                                     metric.remove_tag(field).map(Into::into)
                                 }

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -410,7 +410,7 @@ impl Target for VrlTarget {
                 VrlTarget::Metric {
                     ref mut metric,
                     value,
-                    multi_value_tags,
+                    multi_value_tags: _,
                 } => {
                     if target_path.path.is_root() {
                         return Err(MetricPathError::SetPathError.to_string());
@@ -435,13 +435,7 @@ impl Target for VrlTarget {
                                     .map(|(k, v)| (k, v.into()))
                                     .collect::<vrl::value::Value>()
                             }),
-                            ["tags", field] => {
-                                if *multi_value_tags {
-                                    metric.series.remove_tag(field).map(Into::into)
-                                } else {
-                                    metric.remove_tag(field).map(Into::into)
-                                }
-                            }
+                            ["tags", field] => metric.remove_tag(field).map(Into::into),
                             _ => {
                                 return Err(MetricPathError::InvalidPath {
                                     path: &target_path.path.to_string(),

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -612,12 +612,6 @@ fn precompute_metric_value(metric: &Metric, info: &ProgramInfo, multi_value_tags
         })
     }
 
-    let tags_getter: fn(&Metric) -> Option<Value> = if multi_value_tags {
-        get_multi_value_tags
-    } else {
-        get_single_value_tags
-    };
-
     let mut name = MetricProperty::new("name", |metric| Some(metric.name().to_owned().into()));
     let mut kind = MetricProperty::new("kind", |metric| Some(metric.kind().into()));
     let mut type_ = MetricProperty::new("type", |metric| Some(metric.value().clone().into()));
@@ -628,7 +622,14 @@ fn precompute_metric_value(metric: &Metric, info: &ProgramInfo, multi_value_tags
         MetricProperty::new("interval_ms", |metric| metric.interval_ms().map(Into::into));
     let mut timestamp =
         MetricProperty::new("timestamp", |metric| metric.timestamp().map(Into::into));
-    let mut tags = MetricProperty::new("tags", tags_getter);
+    let mut tags = MetricProperty::new(
+        "tags",
+        if multi_value_tags {
+            get_multi_value_tags
+        } else {
+            get_single_value_tags
+        },
+    );
 
     let mut map = ObjectMap::default();
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
`metrics-tag-values: full` made tags unmodifiable

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```yml
sources:
  s0:
    type: static_metrics
    interval_secs: 1
    metrics:
      - name: response_time
        kind: incremental
        value:
          counter:
            value: 1
        tags:
          a: "b"



transforms:
  default_transform:
    type: remap
    metric_tag_values: full # uncomment to break
    inputs:
      - s0
    source: |-
      .tags.a = "override"

sinks:
  console:
    type: console
    inputs:
      - default_transform
    target: stdout
    encoding:
      codec: json
      json:
        pretty: true
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Run the config and verified that the output tag contained `a: override`. Running this on master will just completely remove all tags.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Closes: #21512
<!--
- Related: #<issue number>
- Related: #<PR number>

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
