### PR TITLE
chore(codecs): Compare correct decoded byte size in Validator tests

### DIFF
--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -330,7 +330,6 @@ impl HttpResourceOutputContext<'_> {
                             loop {
                                 match decoder.decode_eof(&mut body) {
                                     Ok(Some((events, decoded_byte_size))) => {
-                                        dbg!(events.len());
                                         if should_reject {
                                             info!("HTTP server external output resource decoded {decoded_byte_size} bytes but test case configured to reject.");
                                         } else {

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -329,6 +329,8 @@ impl HttpResourceOutputContext<'_> {
                             let mut body = BytesMut::from(&body[..]);
                             loop {
                                 match decoder.decode_eof(&mut body) {
+                                    // `decoded_byte_size` is the decoded size of an individual frame. `byte_size` represents the size of the
+                                    // entire payload which may contain multiple frames and their delimiters.
                                     Ok(Some((events, decoded_byte_size))) => {
                                         if should_reject {
                                             info!("HTTP server external output resource decoded {decoded_byte_size} bytes but test case configured to reject.");

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -325,16 +325,18 @@ impl HttpResourceOutputContext<'_> {
                     match hyper::body::to_bytes(request.into_body()).await {
                         Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
                         Ok(body) => {
+                            let byte_size = body.len();
                             let mut body = BytesMut::from(&body[..]);
                             loop {
                                 match decoder.decode_eof(&mut body) {
-                                    Ok(Some((events, byte_size))) => {
+                                    Ok(Some((events, decoded_byte_size))) => {
+                                        dbg!(events.len());
                                         if should_reject {
-                                            info!("HTTP server external output resource decoded {byte_size} bytes but test case configured to reject.");
+                                            info!("HTTP server external output resource decoded {decoded_byte_size} bytes but test case configured to reject.");
                                         } else {
                                             let mut output_runner_metrics =
                                                 output_runner_metrics.lock().await;
-                                            info!("HTTP server external output resource decoded {byte_size} bytes.");
+                                            info!("HTTP server external output resource decoded {decoded_byte_size} bytes.");
 
                                             // Update the runner metrics for the received events. This will later
                                             // be used in the Validators, as the "expected" case.


### PR DESCRIPTION
## Summary
The byte size of the decoded frame was used in *received_bytes_total calculations when instead, total size of payload on the wire is desired for comparison against the matching telemetry metric.

## How did you test this PR?
Local unit test of my project which depends on Vector

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.