### PR TITLE
fix(buffers): wait 1s before panicking in test

### DIFF
--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -133,7 +133,7 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
                 // if the reader task finishes in time, extract its output
                 res = blocked_read => res,
                 // otherwise panics after 1s
-                _ = sleep(Duration::from_secs(1)) => {
+                () = sleep(Duration::from_secs(1)) => {
                     panic!("Reader not ready after 1s");
                 }
             };

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -2,7 +2,7 @@ use std::{io::Cursor, time::Duration};
 
 use futures::{stream, StreamExt};
 use tokio::{select, time::sleep};
-use tokio_test::{assert_pending, assert_ready, task::spawn};
+use tokio_test::{assert_pending, task::spawn};
 use tracing::Instrument;
 use vector_common::finalization::Finalizable;
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -1,7 +1,7 @@
-use std::io::Cursor;
+use std::{io::Cursor, time::Duration};
 
 use futures::{stream, StreamExt};
-use tokio::select;
+use tokio::{select, time::sleep};
 use tokio_test::{assert_pending, assert_ready, task::spawn};
 use tracing::Instrument;
 use vector_common::finalization::Finalizable;
@@ -133,7 +133,7 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
                 // if the reader task finishes in time, extract its output
                 res = blocked_read => res,
                 // otherwise panics after 1s
-                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                _ = sleep(Duration::from_secs(1)) => {
                     panic!("Reader not ready after 1s");
                 }
             };


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Test `reader_exits_cleanly_when_writer_done_and_in_flight_acks` was failing intermittently because it expects data to be immediately ready.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
`cargo nextest run -p vector-buffers reader_exits_cleanly_when_writer_done_and_in_flight_acks`

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
Related failed job: https://github.com/vectordotdev/vector/actions/runs/16504682382/job/46672140564

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
