### PR TITLE
fix(journald source): journalctl args in case of current_boot_only

### DIFF
--- a/changelog.d/18068_journalctl_all_boots.fix.md
+++ b/changelog.d/18068_journalctl_all_boots.fix.md
@@ -1,0 +1,4 @@
+Fixes `current_boot_only: false` for systemd >= 258 (journald source).
+Note that `current_boot_only` won't have an effect for systemd versions from 250 to 257.
+
+authors: bachorp

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -687,7 +687,10 @@ impl StartJournalctl {
         }
 
         if self.current_boot_only {
+            // required for systemd < 250, otherwise implied by --follow
             command.arg("--boot");
+        } else {
+            command.arg("--boot=all");
         }
 
         if let Some(cursor) = checkpoint {
@@ -1491,7 +1494,7 @@ mod tests {
         let cmd_line = format!("{command:?}");
         assert!(!cmd_line.contains("--directory="));
         assert!(!cmd_line.contains("--namespace="));
-        assert!(!cmd_line.contains("--boot"));
+        assert!(cmd_line.contains("--boot=all"));
         assert!(cmd_line.contains("--since=2000-01-01"));
 
         let journal_dir = None;


### PR DESCRIPTION
(Awaiting the release of systemd 258).

## Summary
Fixes https://github.com/vectordotdev/vector/issues/18068 for systemd > 257.
Relevant journalctl fix: https://github.com/systemd/systemd/pull/35252.

## Vector configuration
TODO

## How did you test this PR?
TODO

## Change Type
- [x] Bug fix

## Is this a breaking change?
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).

## References

Closes https://github.com/systemd/systemd/pull/35252.
