### PR TITLE
fix(postgres sink): propertly disable postgres sink's healthcheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,7 +4838,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing 0.1.41",
@@ -5260,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",
@@ -8028,7 +8028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -8074,7 +8074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",

--- a/changelog.d/23111_postgres_sink_healthcheck_disabled.fix.md
+++ b/changelog.d/23111_postgres_sink_healthcheck_disabled.fix.md
@@ -1,0 +1,1 @@
+Fixes a bug where the healthcheck in the Postgres sink was not being propertly disabled.

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -268,7 +268,7 @@ pub trait SinkConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync
 
 dyn_clone::clone_trait_object!(SinkConfig);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SinkContext {
     pub healthcheck: SinkHealthcheckOptions,
     pub globals: GlobalOptions,

--- a/src/extra_context.rs
+++ b/src/extra_context.rs
@@ -8,7 +8,7 @@ use std::{
 
 /// Structure containing any extra data.
 /// The data is held in an [`Arc`] so is cheap to clone.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ExtraContext(Arc<HashMap<TypeId, ContextItem>>);
 
 type ContextItem = Box<dyn Any + Send + Sync>;

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -92,8 +92,7 @@ impl SinkConfig for PostgresConfig {
     async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         let connection_pool = PgPoolOptions::new()
             .max_connections(self.pool_size)
-            .connect(&self.endpoint)
-            .await?;
+            .connect_lazy(&self.endpoint)?;
 
         let healthcheck = healthcheck(connection_pool.clone()).boxed();
 

--- a/src/sinks/postgres/integration_tests.rs
+++ b/src/sinks/postgres/integration_tests.rs
@@ -7,7 +7,7 @@ use crate::{
         components::{
             run_and_assert_sink_compliance, run_and_assert_sink_error, COMPONENT_ERROR_TAGS,
         },
-        random_table_name, trace_init,
+        next_addr, random_table_name, trace_init,
     },
 };
 use chrono::{DateTime, Utc};
@@ -169,26 +169,44 @@ async fn healthcheck_passes() {
     trace_init();
     let (config, _table, _connection) = prepare_config().await;
     let (_sink, healthcheck) = config.build(SinkContext::default()).await.unwrap();
-    healthcheck.await.unwrap();
+    assert!(healthcheck.await.is_ok());
 }
 
-// This test does not actually fail in the healthcheck query, but in the connection pool creation at
-// `PostgresConfig::build`
 #[tokio::test]
-async fn healthcheck_fails() {
+async fn healthcheck_fails_unknown_host() {
     trace_init();
 
     let table = random_table_name();
-    let endpoint = "postgres://user:pass?host=/unknown_socket_path".to_string();
+    let endpoint = "postgres://unkown_host".to_string();
     let config_str = format!(
         r#"
             endpoint = "{endpoint}"
             table = "{table}"
         "#,
     );
-    let (config, _) = load_sink::<PostgresConfig>(&config_str).unwrap();
+    let (config, cx) = load_sink::<PostgresConfig>(&config_str).unwrap();
 
-    assert!(config.build(SinkContext::default()).await.is_err());
+    let (_sink, healthcheck) = config.build(cx).await.unwrap();
+    assert!(healthcheck.await.is_err());
+}
+
+#[tokio::test]
+async fn healthcheck_fails_timed_out() {
+    trace_init();
+
+    let free_addr = next_addr();
+    let endpoint = format!("postgres://{free_addr}");
+    let table = random_table_name();
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+        "#,
+    );
+    let (config, cx) = load_sink::<PostgresConfig>(&config_str).unwrap();
+
+    let (_sink, healthcheck) = config.build(cx).await.unwrap();
+    assert!(healthcheck.await.is_err());
 }
 
 #[tokio::test]

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -20,7 +20,7 @@ dunce = "1.0.5"
 glob.workspace = true
 hex = "0.4.3"
 indexmap.workspace = true
-indicatif = { version = "0.17.12", features = ["improved_unicode"] }
+indicatif = { version = "0.18.0", features = ["improved_unicode"] }
 itertools = "0.14.0"
 log = "0.4.27"
 # watch https://github.com/epage/anstyle for official interop with Clap


### PR DESCRIPTION
Closes #23111

# Testing

## Healthcheck enabled
This config fails with a healthcheck timeout
```yml
sources:
  in:
    type: http_server
    address: "0.0.0.0:8080"
    decoding:
      codec: json
sinks:
  postgres:
    type: postgres
    table: test
    endpoint: "psql://127.0.0.1:65535" # invalid when vector starts
    healthcheck:
      enabled: true # the important bit
    inputs:
      - in
```
<img width="1264" height="199" alt="image" src="https://github.com/user-attachments/assets/072fa9f0-c0d3-492f-b700-0f38cdc9a549" />

## Healthcheck disabled
```yml
sources:
  in:
    type: http_server
    address: "0.0.0.0:8080"
    decoding:
      codec: json
sinks:
  postgres:
    type: postgres
    table: test
    endpoint: "psql://127.0.0.1:65535" # invalid when vector starts
    healthcheck:
      enabled: false # the important bit
    inputs:
      - in
```
This config does not fail until we send an event through the sink, for example, with `curl -X POST -d '{"id":5,"message":"test2"}' localhost:8080` 
<img width="1233" height="408" alt="image" src="https://github.com/user-attachments/assets/213996c9-bf9d-47ef-a053-7728e13d3c90" />
