### PR TITLE
fix(dev): correctly set HOSTNAME in docker environment

### DIFF
--- a/scripts/environment/entrypoint.sh
+++ b/scripts/environment/entrypoint.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
 # set HOSTNAME to container id for `cross`
-HOSTNAME="$(head -1 /proc/self/cgroup|cut -d/ -f3)"
-export HOSTNAME
+if [ -f /.docker-container-id ]; then
+  export HOSTNAME="$(cat /.docker-container-id)"
+fi
+
+if [ -z "$HOSTNAME" ]; then
+  echo "Failed to properly set HOSTNAME, cross may not work"
+  # Fallback if everything else fails
+  export HOSTNAME="$(hostname || echo init)"
+fi
 
 exec "$@"


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Looks like this stopped working with a docker update that happened in 2021. This is a partial fix since running `make environment` and then `make cross-*` is still not fully working

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
From a linux machine:

`make environment`

`make build-aarch64-unknown-linux-musl`

You should not see an error related to docker inspect and should now see an error related to wrap-rustc

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Related: #23428
<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
