### PR TITLE
fix(buffers): Prevent negative buffer size and event gauges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12046,6 +12046,7 @@ dependencies = [
  "criterion",
  "crossbeam-queue",
  "crossbeam-utils",
+ "dashmap",
  "derivative",
  "fslock",
  "futures 0.3.31",

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.45.1", default-features = false, features = ["rt", "macro
 tracing = { version = "0.1.34", default-features = false, features = ["attributes"] }
 vector-config = { path = "../vector-config", default-features = false }
 vector-common = { path = "../vector-common", default-features = false, features = ["byte_size_of"] }
+dashmap = { version = "6.1", default-features = false }
 
 [dev-dependencies]
 clap.workspace = true

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -1,3 +1,6 @@
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use metrics::{counter, gauge, histogram, Histogram};
@@ -5,6 +8,24 @@ use vector_common::{
     internal_event::{error_type, InternalEvent},
     registered_event,
 };
+
+static BUFFER_COUNTERS: LazyLock<DashMap<usize, (AtomicI64, AtomicI64)>> =
+    LazyLock::new(DashMap::new);
+
+#[allow(clippy::cast_precision_loss)]
+fn update_buffer_gauge(stage: usize, events_delta: i64, bytes_delta: i64) {
+    let entry = BUFFER_COUNTERS
+        .entry(stage)
+        .or_insert_with(|| (AtomicI64::new(0), AtomicI64::new(0)));
+
+    let (events, bytes) = entry.value();
+
+    let new_events = (events.fetch_add(events_delta, Ordering::SeqCst) + events_delta).max(0);
+    let new_bytes = (bytes.fetch_add(bytes_delta, Ordering::SeqCst) + bytes_delta).max(0);
+
+    gauge!("buffer_events", "stage" => stage.to_string()).set(new_events as f64);
+    gauge!("buffer_byte_size", "stage" => stage.to_string()).set(new_bytes as f64);
+}
 
 pub struct BufferCreated {
     pub idx: usize,
@@ -39,9 +60,10 @@ impl InternalEvent for BufferEventsReceived {
             .increment(self.count);
         counter!("buffer_received_bytes_total", "stage" => self.idx.to_string())
             .increment(self.byte_size);
-        gauge!("buffer_events", "stage" => self.idx.to_string()).increment(self.count as f64);
-        gauge!("buffer_byte_size", "stage" => self.idx.to_string())
-            .increment(self.byte_size as f64);
+
+        let count_delta = i64::try_from(self.count).unwrap_or(i64::MAX);
+        let bytes_delta = i64::try_from(self.byte_size).unwrap_or(i64::MAX);
+        update_buffer_gauge(self.idx, count_delta, bytes_delta);
     }
 }
 
@@ -57,9 +79,10 @@ impl InternalEvent for BufferEventsSent {
         counter!("buffer_sent_events_total", "stage" => self.idx.to_string()).increment(self.count);
         counter!("buffer_sent_bytes_total", "stage" => self.idx.to_string())
             .increment(self.byte_size);
-        gauge!("buffer_events", "stage" => self.idx.to_string()).decrement(self.count as f64);
-        gauge!("buffer_byte_size", "stage" => self.idx.to_string())
-            .decrement(self.byte_size as f64);
+
+        let count_delta = i64::try_from(self.count).unwrap_or(i64::MAX);
+        let bytes_delta = i64::try_from(self.byte_size).unwrap_or(i64::MAX);
+        update_buffer_gauge(self.idx, -count_delta, -bytes_delta);
     }
 }
 
@@ -96,9 +119,10 @@ impl InternalEvent for BufferEventsDropped {
             "buffer_discarded_events_total", "intentional" => intentional_str,
         )
         .increment(self.count);
-        gauge!("buffer_events", "stage" => self.idx.to_string()).decrement(self.count as f64);
-        gauge!("buffer_byte_size", "stage" => self.idx.to_string())
-            .decrement(self.byte_size as f64);
+
+        let count_delta = i64::try_from(self.count).unwrap_or(i64::MAX);
+        let bytes_delta = i64::try_from(self.byte_size).unwrap_or(i64::MAX);
+        update_buffer_gauge(self.idx, -count_delta, -bytes_delta);
     }
 }
 
@@ -115,7 +139,6 @@ impl InternalEvent for BufferReadError {
             error_code = self.error_code,
             error_type = error_type::READER_FAILED,
             stage = "processing",
-
         );
         counter!(
             "buffer_errors_total", "error_code" => self.error_code,
@@ -135,5 +158,109 @@ registered_event! {
 
     fn emit(&self, duration: Duration) {
         self.send_duration.record(duration);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use super::*;
+    use std::thread;
+
+    static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn reset_counters() {
+        BUFFER_COUNTERS.clear();
+    }
+
+    fn get_counter_values(stage: usize) -> (i64, i64) {
+        match BUFFER_COUNTERS.get(&stage) {
+            Some(counters) => {
+                let events = counters.0.load(Ordering::Relaxed);
+                let bytes = counters.1.load(Ordering::Relaxed);
+                (events, bytes)
+            }
+            None => (0, 0),
+        }
+    }
+
+    #[test]
+    fn test_increment() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        update_buffer_gauge(0, 10, 1024);
+        let (events, bytes) = get_counter_values(0);
+        assert_eq!(events, 10);
+        assert_eq!(bytes, 1024);
+    }
+
+    #[test]
+    fn test_increment_and_decrement() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        update_buffer_gauge(1, 100, 2048);
+        update_buffer_gauge(1, -50, -1024);
+        let (events, bytes) = get_counter_values(1);
+        assert_eq!(events, 50);
+        assert_eq!(bytes, 1024);
+    }
+
+    #[test]
+    fn test_internal_counter_can_be_negative() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        update_buffer_gauge(2, 5, 100);
+        update_buffer_gauge(2, -10, -200);
+        let (events, bytes) = get_counter_values(2);
+        assert_eq!(events, -5);
+        assert_eq!(bytes, -100);
+    }
+
+    #[test]
+    fn test_multiple_stages_are_independent() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        update_buffer_gauge(0, 10, 100);
+        update_buffer_gauge(1, 20, 200);
+        let (events0, bytes0) = get_counter_values(0);
+        let (events1, bytes1) = get_counter_values(1);
+        assert_eq!(events0, 10);
+        assert_eq!(bytes0, 100);
+        assert_eq!(events1, 20);
+        assert_eq!(bytes1, 200);
+    }
+
+    #[test]
+    fn test_multithreaded_updates_are_correct() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_counters();
+
+        let num_threads = 10;
+        let increments_per_thread = 1000;
+        let mut handles = vec![];
+
+        for _ in 0..num_threads {
+            let handle = thread::spawn(move || {
+                for _ in 0..increments_per_thread {
+                    update_buffer_gauge(0, 1, 10);
+                }
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let (final_events, final_bytes) = get_counter_values(0);
+        let expected_events = i64::from(num_threads * increments_per_thread);
+        let expected_bytes = i64::from(num_threads * increments_per_thread * 10);
+
+        assert_eq!(final_events, expected_events);
+        assert_eq!(final_bytes, expected_bytes);
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a bug where the `vector_buffer_byte_size` and `vector_buffer_events` gauges could report negative values under certain race conditions. It introduces a concurrent, centralized state tracker to ensure the reported metric values are always greater than or equal to zero.

The bug is periodic and not consistently reproducible, as it appears to be a race condition related to system load and timing. The exact steps to trigger it are currently unknown.

## How did you test this PR?
Unit tests were added to the `internal_events.rs` file. These tests verify the logic for single-threaded updates and confirm the solution is free of race conditions via a multi-threaded test. 
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Closes: #21702
<!--
- Related: #<issue number>
- Related: #<PR number>


## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
