### PR TITLE
chore(vector buffers): ignore flaky diskv2 test

### DIFF
--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -67,6 +67,17 @@ async fn basic_read_write_loop() {
     .await;
 }
 
+// run `cargo test --no-run -p vector-buffers`
+// copy output path should look like (target/debug/deps/vector_buffers-xxxx)
+// to test run:
+// ```
+// for i in $(seq 1 10000); do
+//   echo $i
+//   ./target/debug/deps/vector_buffers-xxxx reader_exits_cleanly_when_writer_done_and_in_flight_acks || break
+// done
+// ```
+// This test fails once in ~3000 runs
+#[ignore = "flaky"]
 #[tokio::test]
 async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
     let assertion_registry = install_tracing_helpers();
@@ -127,7 +138,7 @@ async fn reader_exits_cleanly_when_writer_done_and_in_flight_acks() {
             // Our blocked read should be woken up, and when we poll it, it should be also be ready,
             // albeit with a return value of `None`... because the writer is closed, and we read all
             // the records, so nothing is left. :)
-            assert!(blocked_read.is_woken());
+            assert!(blocked_read.is_woken()); // Panics here
 
             let second_read = select! {
                 // if the reader task finishes in time, extract its output


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This test fails once around every 3k runs when blocked_read is not yet woken. Need to investigate why that is

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
NA

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->


<!--
## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
