### PR TITLE
chore(deps): bump indicatif to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -20,7 +20,7 @@ dunce = "1.0.5"
 glob.workspace = true
 hex = "0.4.3"
 indexmap.workspace = true
-indicatif = { version = "0.17.12", features = ["improved_unicode"] }
+indicatif = { version = "0.18.0", features = ["improved_unicode"] }
 itertools = "0.14.0"
 log = "0.4.27"
 # watch https://github.com/epage/anstyle for official interop with Clap


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This bumps indicatif to the latest version since 0.17.12 was yanked (only a semver incompatibility).
Changes: https://github.com/console-rs/indicatif/compare/0.17.12...0.18.0

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
`cargo vdev version`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->
