### PR TITLE
fix(websocket source): treat websocket source tests as unit

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -169,6 +169,7 @@ jobs:
             stdin source
             syslog source
             vector source
+            websocket source
             aws_ec2_metadata transform
             dedupe transform
             filter transform

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -891,7 +891,6 @@ all-integration-tests = [
   "redis-integration-tests",
   "splunk-integration-tests",
   "webhdfs-integration-tests",
-  "websocket-integration-tests",
 ]
 
 amqp-integration-tests = ["sources-amqp", "sinks-amqp"]
@@ -958,7 +957,6 @@ redis-integration-tests = ["sinks-redis", "sources-redis"]
 splunk-integration-tests = ["sinks-splunk_hec"]
 dnstap-integration-tests = ["sources-dnstap", "dep:bollard"]
 webhdfs-integration-tests = ["sinks-webhdfs"]
-websocket-integration-tests = ["sources-websocket", "dep:tokio-tungstenite"]
 disable-resolv-conf = []
 shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-lua", "transforms-remap", "unix"]
 cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]

--- a/src/sources/websocket/source.rs
+++ b/src/sources/websocket/source.rs
@@ -439,9 +439,8 @@ impl PingManager {
     }
 }
 
-#[cfg(feature = "websocket-integration-tests")]
 #[cfg(test)]
-mod integration_test {
+mod tests {
     use crate::test_util::components::run_and_assert_source_error;
     use crate::{
         common::websocket::WebSocketCommonConfig,


### PR DESCRIPTION
## Summary
Realized that the WebSocket source tests should actually be unit tests instead of integration tests -- after looking at the merge queue I realized the tests weren't triggering (a little late but better than never I suppose)

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Related #23449