### PR TITLE
feat(config): allow setting max packet size for mqtt source and sink

### DIFF
--- a/changelog.d/23515_max_packet_size_mqtt.feature.md
+++ b/changelog.d/23515_max_packet_size_mqtt.feature.md
@@ -1,0 +1,3 @@
+Added an option to set max packet size for MQTT source and sink.
+
+authors: simplepad

--- a/src/common/mqtt.rs
+++ b/src/common/mqtt.rs
@@ -41,15 +41,10 @@ pub struct MqttCommonConfig {
     #[derivative(Default(value = "default_keep_alive()"))]
     pub keep_alive: u16,
 
-    /// Max incoming packet size
+    /// Max packet size
     #[serde(default = "default_max_packet_size")]
     #[derivative(Default(value = "default_max_packet_size()"))]
-    pub max_incoming_packet_size: usize,
-
-    /// Max outgoing packet size
-    #[serde(default = "default_max_packet_size")]
-    #[derivative(Default(value = "default_max_packet_size()"))]
-    pub max_outgoing_packet_size: usize,
+    pub max_packet_size: usize,
 
     /// TLS configuration.
     #[configurable(derived)]

--- a/src/common/mqtt.rs
+++ b/src/common/mqtt.rs
@@ -54,7 +54,6 @@ pub struct MqttCommonConfig {
     /// TLS configuration.
     #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
-
 }
 
 const fn default_port() -> u16 {

--- a/src/common/mqtt.rs
+++ b/src/common/mqtt.rs
@@ -41,7 +41,7 @@ pub struct MqttCommonConfig {
     #[derivative(Default(value = "default_keep_alive()"))]
     pub keep_alive: u16,
 
-    /// Max packet size
+    /// Maximum packet size
     #[serde(default = "default_max_packet_size")]
     #[derivative(Default(value = "default_max_packet_size()"))]
     pub max_packet_size: usize,

--- a/src/common/mqtt.rs
+++ b/src/common/mqtt.rs
@@ -41,9 +41,20 @@ pub struct MqttCommonConfig {
     #[derivative(Default(value = "default_keep_alive()"))]
     pub keep_alive: u16,
 
+    /// Max incoming packet size
+    #[serde(default = "default_max_packet_size")]
+    #[derivative(Default(value = "default_max_packet_size()"))]
+    pub max_incoming_packet_size: usize,
+
+    /// Max outgoing packet size
+    #[serde(default = "default_max_packet_size")]
+    #[derivative(Default(value = "default_max_packet_size()"))]
+    pub max_outgoing_packet_size: usize,
+
     /// TLS configuration.
     #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
+
 }
 
 const fn default_port() -> u16 {
@@ -52,6 +63,10 @@ const fn default_port() -> u16 {
 
 const fn default_keep_alive() -> u16 {
     60
+}
+
+const fn default_max_packet_size() -> usize {
+    10 * 1024
 }
 
 /// MQTT Error Types

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -148,7 +148,10 @@ impl MqttSinkConfig {
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(TlsSnafu)?;
         let mut options = MqttOptions::new(&client_id, &self.common.host, self.common.port);
         options.set_keep_alive(Duration::from_secs(self.common.keep_alive.into()));
-        options.set_max_packet_size(self.common.max_incoming_packet_size, self.common.max_outgoing_packet_size);
+        options.set_max_packet_size(
+            self.common.max_incoming_packet_size,
+            self.common.max_outgoing_packet_size,
+        );
         options.set_clean_session(self.clean_session);
         match (&self.common.user, &self.common.password) {
             (Some(user), Some(password)) => {

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -148,10 +148,7 @@ impl MqttSinkConfig {
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(TlsSnafu)?;
         let mut options = MqttOptions::new(&client_id, &self.common.host, self.common.port);
         options.set_keep_alive(Duration::from_secs(self.common.keep_alive.into()));
-        options.set_max_packet_size(
-            self.common.max_incoming_packet_size,
-            self.common.max_outgoing_packet_size,
-        );
+        options.set_max_packet_size(self.common.max_packet_size, self.common.max_packet_size);
         options.set_clean_session(self.clean_session);
         match (&self.common.user, &self.common.password) {
             (Some(user), Some(password)) => {

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -148,6 +148,7 @@ impl MqttSinkConfig {
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(TlsSnafu)?;
         let mut options = MqttOptions::new(&client_id, &self.common.host, self.common.port);
         options.set_keep_alive(Duration::from_secs(self.common.keep_alive.into()));
+        options.set_max_packet_size(self.common.max_incoming_packet_size, self.common.max_outgoing_packet_size);
         options.set_clean_session(self.clean_session);
         match (&self.common.user, &self.common.password) {
             (Some(user), Some(password)) => {

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -132,6 +132,7 @@ impl MqttSourceConfig {
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(TlsSnafu)?;
         let mut options = MqttOptions::new(client_id, &self.common.host, self.common.port);
         options.set_keep_alive(Duration::from_secs(self.common.keep_alive.into()));
+        options.set_max_packet_size(self.common.max_incoming_packet_size, self.common.max_outgoing_packet_size);
 
         options.set_clean_session(false);
         match (&self.common.user, &self.common.password) {

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -132,10 +132,7 @@ impl MqttSourceConfig {
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(TlsSnafu)?;
         let mut options = MqttOptions::new(client_id, &self.common.host, self.common.port);
         options.set_keep_alive(Duration::from_secs(self.common.keep_alive.into()));
-        options.set_max_packet_size(
-            self.common.max_incoming_packet_size,
-            self.common.max_outgoing_packet_size,
-        );
+        options.set_max_packet_size(self.common.max_packet_size, self.common.max_packet_size);
 
         options.set_clean_session(false);
         match (&self.common.user, &self.common.password) {

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -132,7 +132,10 @@ impl MqttSourceConfig {
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(TlsSnafu)?;
         let mut options = MqttOptions::new(client_id, &self.common.host, self.common.port);
         options.set_keep_alive(Duration::from_secs(self.common.keep_alive.into()));
-        options.set_max_packet_size(self.common.max_incoming_packet_size, self.common.max_outgoing_packet_size);
+        options.set_max_packet_size(
+            self.common.max_incoming_packet_size,
+            self.common.max_outgoing_packet_size,
+        );
 
         options.set_clean_session(false);
         match (&self.common.user, &self.common.password) {

--- a/website/cue/reference/components/sinks/generated/mqtt.cue
+++ b/website/cue/reference/components/sinks/generated/mqtt.cue
@@ -395,13 +395,8 @@ generated: components: sinks: mqtt: configuration: {
 		required:    false
 		type: uint: default: 60
 	}
-	max_incoming_packet_size: {
-		description: "Max incoming packet size"
-		required:    false
-		type: uint: default: 10240
-	}
-	max_outgoing_packet_size: {
-		description: "Max outgoing packet size"
+	max_packet_size: {
+		description: "Max packet size"
 		required:    false
 		type: uint: default: 10240
 	}

--- a/website/cue/reference/components/sinks/generated/mqtt.cue
+++ b/website/cue/reference/components/sinks/generated/mqtt.cue
@@ -395,6 +395,16 @@ generated: components: sinks: mqtt: configuration: {
 		required:    false
 		type: uint: default: 60
 	}
+	max_incoming_packet_size: {
+		description: "Max incoming packet size"
+		required:    false
+		type: uint: default: 10240
+	}
+	max_outgoing_packet_size: {
+		description: "Max outgoing packet size"
+		required:    false
+		type: uint: default: 10240
+	}
 	password: {
 		description: "MQTT password."
 		required:    false

--- a/website/cue/reference/components/sinks/generated/mqtt.cue
+++ b/website/cue/reference/components/sinks/generated/mqtt.cue
@@ -396,7 +396,7 @@ generated: components: sinks: mqtt: configuration: {
 		type: uint: default: 60
 	}
 	max_packet_size: {
-		description: "Max packet size"
+		description: "Maximum packet size"
 		required:    false
 		type: uint: default: 10240
 	}

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -448,6 +448,16 @@ generated: components: sources: mqtt: configuration: {
 		required:    false
 		type: uint: default: 60
 	}
+	max_incoming_packet_size: {
+		description: "Max incoming packet size"
+		required:    false
+		type: uint: default: 10240
+	}
+	max_outgoing_packet_size: {
+		description: "Max outgoing packet size"
+		required:    false
+		type: uint: default: 10240
+	}
 	password: {
 		description: "MQTT password."
 		required:    false

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -448,13 +448,8 @@ generated: components: sources: mqtt: configuration: {
 		required:    false
 		type: uint: default: 60
 	}
-	max_incoming_packet_size: {
-		description: "Max incoming packet size"
-		required:    false
-		type: uint: default: 10240
-	}
-	max_outgoing_packet_size: {
-		description: "Max outgoing packet size"
+	max_packet_size: {
+		description: "Max packet size"
 		required:    false
 		type: uint: default: 10240
 	}

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -449,7 +449,7 @@ generated: components: sources: mqtt: configuration: {
 		type: uint: default: 60
 	}
 	max_packet_size: {
-		description: "Max packet size"
+		description: "Maximum packet size"
 		required:    false
 		type: uint: default: 10240
 	}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Allow setting max packet size for mqtt source and sink. Before this PR it was using default value from rumqttc of 10240. I kept that default behavior in this PR as well, but now the user can specify a different value to accept/send longer messages.

Reference: https://github.com/bytebeamio/rumqtt/issues/924

Default values in rumqttc:
https://github.com/bytebeamio/rumqtt/blob/005f73caf0c2a808210fd73f2db6e1bc38652c5c/rumqttc/src/lib.rs#L504-L505

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```yaml
sources:
  src:
    type: mqtt
    host: localhost
    topic: v
    max_packet_size: 20000
sinks:
  out:
    type: console
    inputs:
      - src
    encoding:
      codec: json
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
I ran a local mqtt server (`mosquitto -v`) and sent it a big message with `python -c "print('a'*19000)" | mosquitto_pub -t vector -l`., which was then received by vector and outputted to the console. (NOTE: even though I set the value to 20000 in the config, it's not possible to actually send a 20000 byte message, because you also have to account for the header length. In my testing, the max possible message length was closer to 19993).

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #23511

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
