### PR TITLE
fix(log_to_metric transform): fix config parsing

### DIFF
--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -46,7 +46,8 @@ const ORIGIN_SERVICE_VALUE: u32 = 3;
 #[serde(deny_unknown_fields)]
 pub struct LogToMetricConfig {
     /// A list of metrics to generate.
-    pub metrics: Vec<MetricConfig>,
+    pub metrics: Option<Vec<MetricConfig>>,
+
     /// Setting this flag changes the behavior of this transformation.<br />
     /// <p>Notably the `metrics` field will be ignored.</p>
     /// <p>All incoming events will be processed and if possible they will be converted to log events.
@@ -173,13 +174,14 @@ const fn default_kind() -> MetricKind {
 
 #[derive(Debug, Clone)]
 pub struct LogToMetric {
-    config: LogToMetricConfig,
+    pub metrics: Vec<MetricConfig>,
+    pub all_metrics: bool,
 }
 
 impl GenerateConfig for LogToMetricConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
-            metrics: vec![MetricConfig {
+            metrics: Some(vec![MetricConfig {
                 field: "field_name".try_into().expect("Fixed template"),
                 name: None,
                 namespace: None,
@@ -188,7 +190,7 @@ impl GenerateConfig for LogToMetricConfig {
                     increment_by_value: false,
                     kind: MetricKind::Incremental,
                 }),
-            }],
+            }]),
             all_metrics: Some(true),
         })
         .unwrap()
@@ -199,7 +201,10 @@ impl GenerateConfig for LogToMetricConfig {
 #[typetag::serde(name = "log_to_metric")]
 impl TransformConfig for LogToMetricConfig {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::function(LogToMetric::new(self.clone())))
+        Ok(Transform::function(LogToMetric {
+            metrics: self.metrics.clone().unwrap_or_default(),
+            all_metrics: self.all_metrics.unwrap_or_default(),
+        }))
     }
 
     fn input(&self) -> Input {
@@ -218,12 +223,6 @@ impl TransformConfig for LogToMetricConfig {
 
     fn enable_concurrency(&self) -> bool {
         true
-    }
-}
-
-impl LogToMetric {
-    pub const fn new(config: LogToMetricConfig) -> Self {
-        LogToMetric { config }
     }
 }
 
@@ -858,11 +857,8 @@ fn to_metrics(event: &Event) -> Result<Metric, TransformError> {
 impl FunctionTransform for LogToMetric {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         // Metrics are "all or none" for a specific log. If a single fails, none are produced.
-        let mut buffer = Vec::with_capacity(self.config.metrics.len());
-        if self
-            .config
-            .all_metrics
-            .is_some_and(|all_metrics| all_metrics)
+        let mut buffer = Vec::with_capacity(self.metrics.len());
+        if self.all_metrics
         {
             match to_metrics(&event) {
                 Ok(metric) => {
@@ -895,7 +891,7 @@ impl FunctionTransform for LogToMetric {
                 }
             }
         } else {
-            for config in self.config.metrics.iter() {
+            for config in self.metrics.iter() {
                 match to_metric_with_config(config, &event) {
                     Ok(metric) => {
                         buffer.push(Event::Metric(metric));
@@ -1819,12 +1815,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_gauge() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "gauge": {
@@ -1858,12 +1849,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_histogram() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "histogram": {
@@ -1937,12 +1923,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_distribution_histogram() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "distribution": {
@@ -1998,12 +1979,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_distribution_summary() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "distribution": {
@@ -2059,12 +2035,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_summary() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "summary": {
@@ -2122,12 +2093,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_counter() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "counter": {
@@ -2161,12 +2127,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_set() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "set": {
@@ -2202,12 +2163,7 @@ mod tests {
 
     #[tokio::test]
     async fn transform_all_metrics_optional_namespace() {
-        let config = parse_yaml_config(
-            r"
-            metrics: []
-            all_metrics: true
-            ",
-        );
+        let config = LogToMetricConfig { metrics: None, all_metrics: Some(true) };
 
         let json_str = r#"{
           "counter": {


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Now we can just specify `all_metrics` without the need for `metrics` field.

Future enhancement:
Allow both settings to work together.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

```yaml
sources:
  src0:
    type: "demo_logs"
    format: shuffle
    lines:
      - "{\"counter\": {\"value\": 1.0}, \"kind\": \"absolute\", \"name\": \"test.transform.gauge\", \"tags\": {\"env\": \"test_env\", \"host\": \"localhost\"}}"
    interval: 5

transforms:
  t0:
    type: remap
    inputs:
      - src0
    source: |
      . = parse_json!(.message)

  t1:
    type: "log_to_metric"
    inputs:
    - t0
    all_metrics: true

sinks:
  sink0:
    inputs:
      - t1
    target: stdout
    type: console
    encoding:
      codec: json
      json:
        pretty: true

```

The config above now loads without errors.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
