### PR TITLE
fix(postgresql_metrics source): Support PG17

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -87,6 +87,7 @@ CFFI
 CGP
 cgroups
 chartmuseum
+checkpointer
 chronosphere
 cicd
 Claranet

--- a/changelog.d/22094_postgresql_metrics_source_pg_17.enhancement.md
+++ b/changelog.d/22094_postgresql_metrics_source_pg_17.enhancement.md
@@ -1,0 +1,7 @@
+Updates the `postgresql_metrics` source to support PostgreSQL 17.
+
+When upgrading to PostgreSQL 17, some metric will effectively be renamed due to having been moved to
+another view. However, these metrics have, until now, not been collected on PostgreSQL 17+
+versions, so there is no actual breakage.
+
+authors: biggerfisch bahildebrand

--- a/changelog.d/22094_postgresql_metrics_source_pg_17.enhancement.md
+++ b/changelog.d/22094_postgresql_metrics_source_pg_17.enhancement.md
@@ -1,6 +1,6 @@
 Updates the `postgresql_metrics` source to support PostgreSQL 17.
 
-When upgrading to PostgreSQL 17, some metric will effectively be renamed due to having been moved to
+When upgrading to PostgreSQL 17, some metrics will effectively be renamed due to having been moved to
 another view. However, these metrics have, until now, not been collected on PostgreSQL 17+
 versions, so there is no actual breakage.
 

--- a/scripts/integration/postgres/test.yaml
+++ b/scripts/integration/postgres/test.yaml
@@ -13,7 +13,7 @@ runner:
     postgres_socket: /pg_socket
 
 matrix:
-  version: ['13.1']
+  version: ['13.1', '17.5']
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch

--- a/src/test_util/integration.rs
+++ b/src/test_util/integration.rs
@@ -25,4 +25,8 @@ pub mod postgres {
         std::env::var("PG_URL")
             .unwrap_or_else(|_| format!("postgres://vector:vector@{}/postgres", pg_host()))
     }
+
+    pub fn pg_version() -> String {
+        std::env::var("CONFIG_VERSION").expect("Need CONFIG_VERSION to be set")
+    }
 }

--- a/tests/data/postgres-init.sh
+++ b/tests/data/postgres-init.sh
@@ -8,9 +8,8 @@ chmod 600 /ssl/postgres.key
 
 cp /certs/intermediate_server/certs/postgres-chain.cert.pem /ssl/postgres.crt
 
-/docker-entrypoint.sh postgres \
+docker-entrypoint.sh postgres \
     -c ssl=on \
     -c ssl_key_file=/ssl/postgres.key \
     -c ssl_cert_file=/ssl/postgres.crt \
     -c ssl_ca_file=/ssl/postgres.crt
-

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -64,6 +64,7 @@ components: sources: postgresql_metrics: {
 				- `pg_stat_database`
 				- `pg_stat_database_conflicts`
 				- `pg_stat_bgwriter`
+				- `pg_stat_checkpointer` (For PostgreSQL >= v17)
 				"""
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes the `postgresql_metrics` source to support PostgreSQL 17.

In PG17, several metric values were moved from `pg_stat_bgwriter` to a new view,
`pg_stat_checkpointer`. This caused the existing queries here that feed the metrics to break, as
they relied on those columns being present.

To fix this, the source now inspects the version of the server and dynamically decides what metrics
to expect and what views may be queried for them.

Since the metric names include the name of the view they were sourced from, this does mean that
after this change ships, a user upgrading to PG 17 from a lower version would see some metrics
disappear and similar ones appear. However, without this change, no new metrics would appear (and
indeed, all of the `pg_stat_bgwriter` metrics would disappear), so this is not a net behavior
regression IMHO.

## Vector configuration

Did not test outside of integration testing yet at this time.

## How did you test this PR?

Updated integration tests to test against PostgreSQL versions 13.1 (the existing test setup) and
17.5 (the latest version that should now be supported). The updated tests consider the version under
test and expect different metrics to be present based on the version.

Did not test outside of integration testing yet at this time.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Closes: #22094

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).
