### PR TITLE
fix(splunk_hec_logs splunk_hec_metrics sink): Force compression disabled in HEC indexer ack queries

### DIFF
--- a/src/sinks/splunk_hec/common/acknowledgements.rs
+++ b/src/sinks/splunk_hec/common/acknowledgements.rs
@@ -19,6 +19,7 @@ use crate::{
         SplunkIndexerAcknowledgementAPIError, SplunkIndexerAcknowledgementAckAdded,
         SplunkIndexerAcknowledgementAcksRemoved,
     },
+    sinks::util::Compression
 };
 
 /// Splunk HEC acknowledgement configuration.
@@ -96,6 +97,11 @@ impl HecAckClient {
         client: HttpClient,
         http_request_builder: Arc<HttpRequestBuilder>,
     ) -> Self {
+        let http_request_builder = Arc::new(HttpRequestBuilder{
+            compression: Compression::None,
+            ..(*http_request_builder).clone()
+        });
+
         Self {
             acks: HashMap::new(),
             retry_limit,

--- a/src/sinks/splunk_hec/common/service.rs
+++ b/src/sinks/splunk_hec/common/service.rs
@@ -178,6 +178,7 @@ impl ResponseExt for http::Response<Bytes> {
     }
 }
 
+#[derive(Clone)]
 pub struct HttpRequestBuilder {
     pub endpoint_target: EndpointTarget,
     pub endpoint: String,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
The Splunk HEC sinks run indexer ack querying on a separate spawned task, reusing the sink's original `HttpRequestBuilder`. However, the serialized indexer ack query bodies are raw bystreams, uncompressed. This leads to a situation where the sink, and thus the shared `HttpRequestBuilder`, are configured for compression, but the indexer ack query task sends uncompressed requests. This PR is a fix to clone the `HttpRequestBuilder` and force compression disabled, so no `Content-Encoding` header is sent.

A more comprehensive fix would be to pass the sink's configured `Writer` instance from the sink to the indexer ack task. The cloned `HttpRequestBuilder` in this PR would be removed, returning to using the original sink's `HttpRequestBuilder`. The indexer ack query request building would be reworked to compress the bytestream (if necessary) by the Writer before submitting that bytestream to the `HttpRequestBuilder`. Thus properly compressing the indexer ack query with the sink's configured compression.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```
data_dir: /tmp
api:
  enabled: false
sources:
  console_in:
    type: stdin
transforms:
  parse_json:
    type: remap
    inputs:
      - console_in
    source: |-
      .message = parse_json!(string!(.message))
sinks:
  hec_out:
    type: splunk_hec_logs
    inputs:
      - parse_json
    endpoint: http://localhost:8080
    default_token: abc123
    encoding:
      codec: json
    compression: gzip
    healthcheck:
      enabled: false
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
The change was tested by running against an emulated HEC via `nc` and manually verifying that the indexer ack query sent to the `/services/collector/ack` endpoint did not contain a `Content-Encoding` header.

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->
- Closes: #23559
- Related: #23559

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
