### PR TITLE
enhancement(kubernetes_logs source): Allow disabling listwatching of namespaces

### DIFF
--- a/changelog.d/22990_allow_not_watching_k8s_ns.enhancement.md
+++ b/changelog.d/22990_allow_not_watching_k8s_ns.enhancement.md
@@ -1,3 +1,3 @@
-Allow disabling listwatching of Kubernetes namespaces to reduce resource usage in clusters with large numbers of namespaces.
+Allow disabling listing of Kubernetes namespaces to reduce resource usage in clusters with large numbers of namespaces.
 
 authors: imbstack

--- a/changelog.d/22990_allow_not_watching_k8s_ns.enhancement.md
+++ b/changelog.d/22990_allow_not_watching_k8s_ns.enhancement.md
@@ -1,4 +1,3 @@
-Allow disabling listwatching of Kubernetes namespaces to reduce resource usage in clusters with
-large numbers of namespaces.
+Allow disabling listwatching of Kubernetes namespaces to reduce resource usage in clusters with large numbers of namespaces.
 
 authors: imbstack

--- a/changelog.d/22990_allow_not_watching_k8s_ns.enhancement.md
+++ b/changelog.d/22990_allow_not_watching_k8s_ns.enhancement.md
@@ -1,0 +1,4 @@
+Allow disabling listwatching of Kubernetes namespaces to reduce resource usage in clusters with
+large numbers of namespaces.
+
+authors: imbstack

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -1178,6 +1178,59 @@ mod tests {
     }
 
     #[test]
+    fn test_default_config_add_namespace_fields() {
+        let config = Config::default();
+        assert_eq!(config.add_namespace_fields, true);
+    }
+
+    #[test]
+    fn test_config_add_namespace_fields_disabled() {
+        let config = Config {
+            add_namespace_fields: false,
+            ..Default::default()
+        };
+        assert_eq!(config.add_namespace_fields, false);
+    }
+
+    #[test]
+    fn test_config_serialization_add_namespace_fields() {
+        // Test that the flag serializes/deserializes correctly from TOML
+        let toml_config = r#"
+            add_namespace_fields = false
+        "#;
+        let config: Config = toml::from_str(toml_config).unwrap();
+        assert_eq!(config.add_namespace_fields, false);
+        
+        let default_toml = "";
+        let default_config: Config = toml::from_str(default_toml).unwrap();
+        assert_eq!(default_config.add_namespace_fields, true);
+    }
+
+    #[test]
+    fn test_add_namespace_fields_affects_behavior() {
+        // Test that the config field properly controls namespace watching behavior
+        // This is a unit test for the conditional logic in the run method
+        let enabled_config = Config {
+            add_namespace_fields: true,
+            ..Default::default()
+        };
+        let disabled_config = Config {
+            add_namespace_fields: false,
+            ..Default::default()
+        };
+        
+        // The main validation is that the flag is passed through correctly
+        // and can be used in conditional logic
+        assert!(should_watch_namespaces(&enabled_config));
+        assert!(!should_watch_namespaces(&disabled_config));
+    }
+    
+    // Helper function to simulate the conditional logic from the run method
+    fn should_watch_namespaces(config: &Config) -> bool {
+        config.add_namespace_fields
+    }
+
+    #[test]
     fn prepare_exclude_paths() {
         let cases = vec![
             (

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -1200,7 +1200,7 @@ mod tests {
         "#;
         let config: Config = toml::from_str(toml_config).unwrap();
         assert_eq!(config.add_namespace_fields, false);
-        
+
         let default_toml = "";
         let default_config: Config = toml::from_str(default_toml).unwrap();
         assert_eq!(default_config.add_namespace_fields, true);
@@ -1218,13 +1218,13 @@ mod tests {
             add_namespace_fields: false,
             ..Default::default()
         };
-        
+
         // The main validation is that the flag is passed through correctly
         // and can be used in conditional logic
         assert!(should_watch_namespaces(&enabled_config));
         assert!(!should_watch_namespaces(&disabled_config));
     }
-    
+
     // Helper function to simulate the conditional logic from the run method
     fn should_watch_namespaces(config: &Config) -> bool {
         config.add_namespace_fields

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -111,7 +111,10 @@ pub struct Config {
     ///
     /// This can be useful to make Vector not pull in namespaces to reduce load on
     /// kube-apiserver and daemonset memory usage in clusters with  lots of namespaces.
+    /// In the case that this is set to `false`, fields based on namespace labels will not
+    /// be available.
     ///
+    #[serde(default = "default_add_namespace_fields")]
     add_namespace_fields: bool,
 
     /// The name of the Kubernetes [Node][node] that is running.
@@ -1056,6 +1059,11 @@ const fn default_max_read_bytes() -> usize {
 // We'd like to consume rotated pod log files first to release our file handle and let
 // the space be reclaimed
 const fn default_oldest_first() -> bool {
+    true
+}
+
+// We'd like to add these in all but clusters with very many namespaces
+const fn default_add_namespace_fields() -> bool {
     true
 }
 

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -1,6 +1,16 @@
 package metadata
 
 generated: components: sources: kubernetes_logs: configuration: {
+	add_namespace_fields: {
+		description: """
+			Specifies whether or not to enrich with namespace fields.
+
+			This can be useful to make Vector not pull in namespaces to reduce load on
+			kube-apiserver and daemonset memory usage in clusters with  lots of namespaces.
+			"""
+		required: false
+		type: bool: default: true
+	}
 	auto_partial_merge: {
 		description: """
 			Whether or not to automatically merge partial events.

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -7,6 +7,8 @@ generated: components: sources: kubernetes_logs: configuration: {
 
 			This can be useful to make Vector not pull in namespaces to reduce load on
 			kube-apiserver and daemonset memory usage in clusters with  lots of namespaces.
+			In the case that this is set to `false`, fields based on namespace labels will not
+			be available.
 			"""
 		required: false
 		type: bool: default: true


### PR DESCRIPTION
## Summary

On clusters with high numbers of namespaces, Vector's memory can grow rather large. Additionally the load that Vector puts on kube-apiserver can be rather heavy when rolling the Vector daemonset or otherwise have many Vector pods restarting. This change allows you to opt out of having namespace labels available for enrichment. I believe that if you try to use them with namespace listwatching disabled Vector will gracefully log an error rather than crash or something along those lines which feels like a good way to handle this scenario? 

This is my first contribution to Vector, I think I've read through the guidelines and such but am happy to make any changes you think would be best, this is just my guess at a good way to solve this issue for us.

## Vector configuration

There's quite significant amount of config on my test setup in our staging clusters. I can try to trim it down and get a test setup going if we'd be more comfortable with this change being tested that way first though.

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

I backported these changes (technically just `6389f2f0c16a157579e2cfe4662d280e8688608a`, the changes I made after that have not been deployed anywhere)  to 0.37.1 and built/deployed images based on this into our staging environment. This cut the memory usage of Vector pods in half in a cluster with many tens of thousands of namespaces. I have not tested the version of this based on master. I'm happy to get a test setup going to try this out if we really want to, the clusters I have available to me now need to be updated too significantly for me to want to bother with it on them at the moment.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Implements: #22990 

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
