### PR TITLE
chore(nats source): make shared nats module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub mod kubernetes;
 pub mod line_agg;
 pub mod list;
 #[cfg(any(feature = "sources-nats", feature = "sinks-nats"))]
-pub(crate) mod nats;
+pub mod nats;
 pub mod net;
 #[allow(unreachable_pub)]
 pub(crate) mod proto;

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -1,3 +1,6 @@
+//! Shared helper functions for NATS source and sink.
+#![allow(missing_docs)]
+
 use nkeys::error::Error as NKeysError;
 use snafu::{ResultExt, Snafu};
 use vector_lib::configurable::configurable_component;
@@ -5,6 +8,7 @@ use vector_lib::sensitive_string::SensitiveString;
 
 use crate::tls::TlsEnableableConfig;
 
+/// Errors that can occur during NATS configuration.
 #[derive(Debug, Snafu)]
 pub enum NatsConfigError {
     #[snafu(display("NATS Auth Config Error: {}", source))]


### PR DESCRIPTION
## Summary
Derived from https://github.com/vectordotdev/vector/pull/23554

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.