### PR TITLE
enhancement(nats source): call `drain()` during shutdown

### DIFF
--- a/changelog.d/21756_drain_events_when_shutdown_nats_source.enhancement.md
+++ b/changelog.d/21756_drain_events_when_shutdown_nats_source.enhancement.md
@@ -1,0 +1,3 @@
+The NATS source now drain subscriptions during shutdown, ensuring that in-flight and pending messages are processed.
+
+authors: benjamin-awd

--- a/src/sources/nats/integration_tests.rs
+++ b/src/sources/nats/integration_tests.rs
@@ -517,3 +517,74 @@ async fn nats_jetstream_consumer_not_found() {
         }
     }
 }
+
+#[tokio::test]
+async fn nats_shutdown_drain_messages() {
+    use tokio::time::{Duration, timeout};
+
+    let subject = format!("test-drain-{}", random_string(10));
+    let url =
+        std::env::var("NATS_ADDRESS").unwrap_or_else(|_| String::from("nats://localhost:4222"));
+    let conf = generate_source_config(&url, &subject);
+
+    let (shutdown_trigger, shutdown_signal, shutdown_done) = ShutdownSignal::new_wired();
+
+    let (nc, sub) = create_subscription(&conf).await.unwrap();
+    let nc_pub = nc.clone();
+    let (tx, rx) = SourceSender::new_test();
+    let decoder = DecodingConfig::new(
+        conf.framing.clone(),
+        conf.decoding.clone(),
+        LogNamespace::Legacy,
+    )
+    .build()
+    .unwrap();
+
+    let source_handle = tokio::spawn(run_nats_core(
+        conf.clone(),
+        nc,
+        sub,
+        decoder,
+        LogNamespace::Legacy,
+        shutdown_signal,
+        tx,
+    ));
+
+    nc_pub
+        .publish(subject.clone(), Bytes::from_static(b"msg1"))
+        .await
+        .unwrap();
+    nc_pub
+        .publish(subject.clone(), Bytes::from_static(b"msg2"))
+        .await
+        .unwrap();
+    nc_pub
+        .publish(subject.clone(), Bytes::from_static(b"msg3"))
+        .await
+        .unwrap();
+
+    // Ensure the messages are sent to the server before we trigger the shutdown
+    nc_pub.flush().await.unwrap();
+
+    // Trigger the graceful shutdown
+    shutdown_trigger.cancel();
+
+    // Publish another message *after* shutdown. This should be ignored by the draining source.
+    nc_pub
+        .publish(subject.clone(), Bytes::from_static(b"ignored"))
+        .await
+        .unwrap();
+    nc_pub.flush().await.unwrap();
+
+    let events = timeout(Duration::from_secs(5), collect_n(rx, 3))
+        .await
+        .expect("Test timed out waiting for drained messages.");
+
+    assert_eq!(events.len(), 3);
+    let msg = &events[0].as_log()[log_schema().message_key().unwrap().to_string()];
+    assert_eq!(*msg, "msg1".into());
+
+    // Verify the source has completed its work and the shutdown is fully done.
+    source_handle.await.unwrap().expect("Source task failed");
+    shutdown_done.await;
+}

--- a/src/sources/nats/source.rs
+++ b/src/sources/nats/source.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use async_nats::jetstream::consumer::pull::Stream as PullConsumerStream;
 use chrono::Utc;
-use futures::{StreamExt, pin_mut};
+use futures::StreamExt;
 use snafu::ResultExt;
 use tokio_util::codec::FramedRead;
 use vector_lib::{
@@ -151,34 +151,55 @@ pub async fn run_nats_jetstream(
 pub async fn run_nats_core(
     config: NatsSourceConfig,
     _connection: async_nats::Client,
-    subscriber: async_nats::Subscriber,
+    mut subscriber: async_nats::Subscriber,
     decoder: Decoder,
     log_namespace: LogNamespace,
-    shutdown: ShutdownSignal,
+    mut shutdown: ShutdownSignal,
     mut out: SourceSender,
 ) -> Result<(), ()> {
     let events_received = register!(EventsReceived);
     let bytes_received = register!(BytesReceived::from(Protocol::TCP));
-    let stream = subscriber.take_until(shutdown);
-    pin_mut!(stream);
 
-    while let Some(msg) = stream.next().await {
-        bytes_received.emit(ByteSize(msg.payload.len()));
-        let status = process_message(
-            &msg,
-            &config,
-            &decoder,
-            log_namespace,
-            &mut out,
-            &events_received,
-        )
-        .await;
+    loop {
+        tokio::select! {
+            biased;
 
-        if let ProcessingStatus::ChannelClosed = status {
-            // Downstream channel is closed, shut down the source.
-            return Err(());
+             _ = &mut shutdown => {
+                info!("Shutdown signal received. Draining NATS subscription...");
+                if let Err(err) = subscriber.drain().await {
+                    error!(message = "Failed to drain NATS subscription.", %err);
+                }
+            },
+
+            maybe_msg = subscriber.next() => {
+                match maybe_msg {
+                    Some(msg) => {
+                        bytes_received.emit(ByteSize(msg.payload.len()));
+                        let status = process_message(
+                            &msg,
+                            &config,
+                            &decoder,
+                            log_namespace,
+                            &mut out,
+                            &events_received,
+                        )
+                        .await;
+
+                        if let ProcessingStatus::ChannelClosed = status {
+                            return Err(());
+                        }
+                    },
+                    None => {
+                        // The stream has ended. This happens naturally after a successful
+                        // drain or if the connection is lost.
+                        break;
+                    }
+                }
+            }
         }
     }
+
+    info!("NATS source drained and shut down gracefully.");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
This PR enables the NATS source to drain messages when shutting down. Currently we unsubscribe, which is not as robust as draining before disconnect since inflight messages can be dropped. 

> Closing a connection (using close()), or unsubscribing from a subscription, are generally considered immediate requests. When you close or unsubscribe the library will halt messages in any pending queue or cache for subscribers. When you drain a subscription or connection, it will process any inflight and cached/pending messages before closing. 

More details here: https://docs.nats.io/using-nats/developer/receiving/drain

## How did you test this PR?
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
Ran this on a relatively high velocity NATS subject (messages redacted, but timestamp is the native timestamp created by Vector) with a console sink to stdout.

With this change, events are still handled even after the shutdown is triggered.

```
{"timestamp":"2025-08-22T11:00:58.831517Z", "payload: foo"}
{"timestamp":"2025-08-22T11:00:58.834378Z", "payload: bar"}
^C
2025-08-22T11:00:58.860597Z  INFO vector::signal: Signal received. signal="SIGINT"
2025-08-22T11:00:58.860687Z  INFO vector: Vector has stopped.
2025-08-22T11:00:58.860808Z  INFO source{component_kind="source" component_id=private component_type=nats}: vector::sources::nats::source: Shutdown signal received. Draining NATS subscription...
2025-08-22T11:00:58.862056Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="print, process_message, private, nats-private-v1" time_remaining="59 seconds left"
2025-08-22T11:00:58.876921Z  INFO source{component_kind="source" component_id=private component_type=nats}: vector::sources::nats::source: NATS source drained and shut down gracefully.
2025-08-22T11:00:58.877080Z  INFO async_nats: event: closed
{"timestamp":"2025-08-22T11:00:58.876851Z", "payload: baz"}
2025-08-22T11:00:58.877768Z  INFO async_nats: event: closed
```

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

Not sure about this one, I guess technically it's user-facing?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related to https://github.com/vectordotdev/vector/discussions/21756




## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
