### PR TITLE
feat(enrichment tables): add per-event ttl for memory enrichment table

### DIFF
--- a/src/enrichment_tables/memory/config.rs
+++ b/src/enrichment_tables/memory/config.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 use vector_lib::config::{AcknowledgementsConfig, DataType, Input, LogNamespace};
 use vector_lib::enrichment::Table;
 use vector_lib::id::ComponentKey;
+use vector_lib::lookup::lookup_v2::OptionalValuePath;
 use vector_lib::schema::{self};
 use vector_lib::{configurable::configurable_component, sink::VectorSink};
 use vrl::path::OwnedTargetPath;
@@ -61,6 +62,10 @@ pub struct MemoryConfig {
     #[configurable(derived)]
     #[serde(skip_serializing_if = "vector_lib::serde::is_default")]
     pub source_config: Option<MemorySourceConfig>,
+    /// Field to read from the incoming value to use as TTL override.
+    #[configurable(derived)]
+    #[serde(default)]
+    pub ttl_field: OptionalValuePath,
 
     #[serde(skip)]
     memory: Arc<Mutex<Option<Box<Memory>>>>,
@@ -86,6 +91,7 @@ impl Default for MemoryConfig {
             log_namespace: None,
             source_config: None,
             internal_metrics: InternalMetricsConfig::default(),
+            ttl_field: OptionalValuePath::none(),
         }
     }
 }

--- a/src/enrichment_tables/memory/source.rs
+++ b/src/enrichment_tables/memory/source.rs
@@ -97,7 +97,7 @@ impl MemorySource {
                             })
                             .filter_map(|(k, v)| {
                                 let mut event = Event::Log(LogEvent::from_map(
-                                    v.as_object_map(now, self.memory.config.ttl, k).ok()?,
+                                    v.as_object_map(now, k).ok()?,
                                     EventMetadata::default(),
                                 ));
                                 let log = event.as_mut_log();

--- a/src/enrichment_tables/memory/table.rs
+++ b/src/enrichment_tables/memory/table.rs
@@ -38,6 +38,7 @@ use super::source::MemorySource;
 pub struct MemoryEntry {
     value: String,
     update_time: CopyValue<Instant>,
+    ttl: u64,
 }
 
 impl ByteSizeOf for MemoryEntry {
@@ -47,13 +48,10 @@ impl ByteSizeOf for MemoryEntry {
 }
 
 impl MemoryEntry {
-    pub(super) fn as_object_map(
-        &self,
-        now: Instant,
-        total_ttl: u64,
-        key: &str,
-    ) -> Result<ObjectMap, String> {
-        let ttl = total_ttl.saturating_sub(now.duration_since(*self.update_time).as_secs());
+    pub(super) fn as_object_map(&self, now: Instant, key: &str) -> Result<ObjectMap, String> {
+        let ttl = self
+            .ttl
+            .saturating_sub(now.duration_since(*self.update_time).as_secs());
         Ok(ObjectMap::from([
             (
                 KeyString::from("key"),
@@ -71,8 +69,8 @@ impl MemoryEntry {
         ]))
     }
 
-    fn expired(&self, now: Instant, ttl: u64) -> bool {
-        now.duration_since(*self.update_time).as_secs() > ttl
+    fn expired(&self, now: Instant) -> bool {
+        now.duration_since(*self.update_time).as_secs() > self.ttl
     }
 }
 
@@ -119,9 +117,9 @@ impl Memory {
         let mut writer = self.write_handle.lock().expect("mutex poisoned");
         let now = Instant::now();
 
-        for (k, v) in value.into_iter() {
+        for (k, value) in value.into_iter() {
             let new_entry_key = String::from(k);
-            let Ok(v) = serde_json::to_string(&v) else {
+            let Ok(v) = serde_json::to_string(&value) else {
                 emit!(MemoryEnrichmentTableInsertFailed {
                     key: &new_entry_key,
                     include_key_metric_tag: self.config.internal_metrics.include_key_tag
@@ -131,6 +129,15 @@ impl Memory {
             let new_entry = MemoryEntry {
                 value: v,
                 update_time: now.into(),
+                ttl: self
+                    .config
+                    .ttl_field
+                    .path
+                    .as_ref()
+                    .and_then(|p| value.get(p))
+                    .and_then(|v| v.as_integer())
+                    .map(|v| v as u64)
+                    .unwrap_or(self.config.ttl),
             };
             let new_entry_size = new_entry_key.size_of() + new_entry.size_of();
             if let Some(max_byte_size) = self.config.max_byte_size
@@ -173,7 +180,7 @@ impl Memory {
         if let Some(reader) = self.get_read_handle().read() {
             for (k, v) in reader.iter() {
                 if let Some(entry) = v.get_one()
-                    && entry.expired(now, self.config.ttl)
+                    && entry.expired(now)
                 {
                     // Byte size is not reduced at this point, because the actual deletion
                     // will only happen at refresh time
@@ -274,8 +281,7 @@ impl Table for Memory {
                             key: &key,
                             include_key_metric_tag: self.config.internal_metrics.include_key_tag
                         });
-                        row.as_object_map(Instant::now(), self.config.ttl, &key)
-                            .map(|r| vec![r])
+                        row.as_object_map(Instant::now(), &key).map(|r| vec![r])
                     }
                     None => {
                         emit!(MemoryEnrichmentTableReadFailed {
@@ -377,6 +383,7 @@ mod tests {
     use std::slice::from_ref;
     use std::{num::NonZeroU64, time::Duration};
     use tokio::time;
+    use vector_lib::lookup::lookup_v2::OptionalValuePath;
 
     use vector_lib::{
         event::{EventContainer, MetricValue},
@@ -434,6 +441,7 @@ mod tests {
                 MemoryEntry {
                     value: "5".to_string(),
                     update_time: (Instant::now() - Duration::from_secs(secs_to_subtract)).into(),
+                    ttl,
                 },
             );
             handle.write_handle.refresh();
@@ -455,6 +463,64 @@ mod tests {
     }
 
     #[test]
+    fn calculates_ttl_override() {
+        let global_ttl = 100;
+        let ttl_override = 10;
+        let memory = Memory::new(build_memory_config(|c| {
+            c.ttl = global_ttl;
+            c.ttl_field = OptionalValuePath::new("ttl");
+        }));
+        memory.handle_value(ObjectMap::from([
+            (
+                "ttl_override".into(),
+                Value::from(ObjectMap::from([
+                    ("val".into(), Value::from(5)),
+                    ("ttl".into(), Value::from(ttl_override)),
+                ])),
+            ),
+            (
+                "default_ttl".into(),
+                Value::from(ObjectMap::from([("val".into(), Value::from(5))])),
+            ),
+        ]));
+
+        let default_condition = Condition::Equals {
+            field: "key",
+            value: Value::from("default_ttl"),
+        };
+        let override_condition = Condition::Equals {
+            field: "key",
+            value: Value::from("ttl_override"),
+        };
+
+        assert_eq!(
+            Ok(ObjectMap::from([
+                ("key".into(), Value::from("default_ttl")),
+                ("ttl".into(), Value::from(global_ttl)),
+                (
+                    "value".into(),
+                    Value::from(ObjectMap::from([("val".into(), Value::from(5))]))
+                ),
+            ])),
+            memory.find_table_row(Case::Sensitive, &[default_condition], None, None, None)
+        );
+        assert_eq!(
+            Ok(ObjectMap::from([
+                ("key".into(), Value::from("ttl_override")),
+                ("ttl".into(), Value::from(ttl_override)),
+                (
+                    "value".into(),
+                    Value::from(ObjectMap::from([
+                        ("val".into(), Value::from(5)),
+                        ("ttl".into(), Value::from(ttl_override))
+                    ]))
+                ),
+            ])),
+            memory.find_table_row(Case::Sensitive, &[override_condition], None, None, None)
+        );
+    }
+
+    #[test]
     fn removes_expired_records_on_scan_interval() {
         let ttl = 100;
         let memory = Memory::new(build_memory_config(|c| {
@@ -467,6 +533,7 @@ mod tests {
                 MemoryEntry {
                     value: "5".to_string(),
                     update_time: (Instant::now() - Duration::from_secs(ttl + 10)).into(),
+                    ttl,
                 },
             );
             handle.write_handle.refresh();
@@ -534,6 +601,7 @@ mod tests {
                 MemoryEntry {
                     value: "5".to_string(),
                     update_time: (Instant::now() - Duration::from_secs(ttl / 2)).into(),
+                    ttl,
                 },
             );
             handle.write_handle.refresh();

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -207,6 +207,12 @@ generated: configuration: configuration: {
 				required:      false
 				relevant_when: "type = \"memory\""
 			}
+			ttl_field: {
+				type: string: default: ""
+				description:   "Field to read from the incoming value to use as TTL override."
+				required:      false
+				relevant_when: "type = \"memory\""
+			}
 			locale: {
 				type: string: default: "en"
 				description: """


### PR DESCRIPTION
## Summary
Adds an optional `ttl_field` configuration to memory enrichment table, to allow overriding the global default TTL per event.

## Vector configuration
```yaml
enrichment_tables:
  memory_table:
    type: memory
    ttl: 60
    flush_interval: 5
    inputs: ["cache_generator"]
    ttl_field: "ttl"

sources:
  demo_logs_test:
    type: "demo_logs"
    format: "json"

transforms:
  demo_logs_processor:
    type: "remap"
    inputs: ["demo_logs_test"]
    source: |
      . = parse_json!(.message)
      userid = get!(., path: ["user-identifier"])

      # Look for existing value in the table, using "user-identifier" as key
      existing, err = get_enrichment_table_record("memory_table", { "key": userid })

      if err == null {
        . = existing.value
        .source = "cache"
        .ttl = existing.ttl
      } else {
        .referer = parse_url!(.referer)
        .referer.host = encode_punycode!(.referer.host)
        .source = "transform"
      }

  cache_generator:
    type: "remap"
    inputs: ["demo_logs_processor"]
    source: |
      existing, err = get_enrichment_table_record("memory_table", { "key": get!(., path: ["user-identifier"]) })
      if err != null {
        data = .
        # Generate a random TTL override
        data.ttl = random_int(1, 20)
        . = set!(value: {}, path: [get!(data, path: ["user-identifier"])], data: data)
      } else {
        . = {}
      }

# We can observe that ttl takes different values now and events also disappear at different times.
sinks:
  console:
    inputs: ["demo_logs_processor"]
    target: "stdout"
    type: "console"
    encoding:
      codec: "json"
```

## How did you test this PR?
Besides the added test, I ran the above configuration and observed the logged values, to see the TTL changes.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

---
>Sponsored by [Quad9](https://quad9.net/)