### PR TITLE
feature: support multiple mqtt source topics

### DIFF
--- a/changelog.d/support_many_mqtt_source_topics.md
+++ b/changelog.d/support_many_mqtt_source_topics.md
@@ -1,0 +1,3 @@
+The mqtt source config field `topic` can be a list of mqtt topic strings instead of just a string. In this case, the mqtt source client will subscribe-many over the topics.
+
+authors: december1981

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -20,7 +20,7 @@ use crate::{
         TlsSnafu,
     },
     config::{SourceConfig, SourceContext, SourceOutput},
-    serde::{default_decoding, default_framing_message_based},
+    serde::{OneOrMany, default_decoding, default_framing_message_based},
 };
 
 use super::source::MqttSource;
@@ -34,11 +34,11 @@ pub struct MqttSourceConfig {
     #[serde(flatten)]
     pub common: MqttCommonConfig,
 
-    /// MQTT topic from which messages are to be read.
+    /// MQTT topic or topics from which messages are to be read.
     #[configurable(derived)]
     #[serde(default = "default_topic")]
     #[derivative(Default(value = "default_topic()"))]
-    pub topic: String,
+    pub topic: OneOrMany<String>,
 
     #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
@@ -65,8 +65,8 @@ pub struct MqttSourceConfig {
     pub topic_key: OptionalValuePath,
 }
 
-fn default_topic() -> String {
-    "vector".to_owned()
+fn default_topic() -> OneOrMany<String> {
+    OneOrMany::One("vector".into())
 }
 
 fn default_topic_key() -> OptionalValuePath {


### PR DESCRIPTION
## Summary
It would be good to be able to subscribe to multiple mqtt topics where we'd want to subscribe with eg `prefix-1/#` and `prefix-2/#` mqtt topic specs, without receiving data from the broker with topics beginning with `prefix-3...` (which would be a side effect of  subscribing with the one topic spec string `#`).

This change doesn't break current tests, but I've held off on adding any new tests in case this PR will not be approved.

## Change Type
- [ ] Bug fix
- [ X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ X] No

## Does this PR include user facing changes?

- [ X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
