### PR TITLE
feat(file sink): add options to truncate files in some conditions

### DIFF
--- a/benches/files.rs
+++ b/benches/files.rs
@@ -60,6 +60,7 @@ fn benchmark_files_no_partitions(c: &mut Criterion) {
                         acknowledgements: Default::default(),
                         timezone: Default::default(),
                         internal_metrics: Default::default(),
+                        truncate: Default::default(),
                     },
                 );
 

--- a/src/expiring_hash_map.rs
+++ b/src/expiring_hash_map.rs
@@ -50,6 +50,17 @@ where
         self.map.get(k).map(|(v, _)| v)
     }
 
+    /// Get a reference to the value by key with the expiration information.
+    pub fn get_with_deadline<Q>(&self, k: &Q) -> Option<(&V, Instant)>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let (value, delay_queue_key) = self.map.get(k)?;
+        let deadline = self.expiration_queue.deadline(delay_queue_key);
+        Some((value, deadline.into()))
+    }
+
     /// Get a mut reference to the value by key.
     pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::num::NonZeroU64;
 use std::time::{Duration, Instant};
 
 use async_compression::tokio::write::{GzipEncoder, ZstdEncoder};
@@ -14,6 +15,7 @@ use tokio::{
     io::AsyncWriteExt,
 };
 use tokio_util::codec::Encoder as _;
+use tokio_util::time::delay_queue::Expired;
 use vector_lib::codecs::{
     TextSerializerConfig,
     encoding::{Framer, FramingConfig},
@@ -88,6 +90,26 @@ pub struct FileSinkConfig {
     #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: FileInternalMetricsConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub truncate: FileTruncateConfig,
+}
+
+/// Configuration for truncating files.
+#[configurable_component]
+#[derive(Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FileTruncateConfig {
+    /// If this is set, files will be truncated after being closed for set amount of seconds.
+    #[serde(default)]
+    pub after_closetime_secs: Option<NonZeroU64>,
+    /// If this is set, files will be truncated after set amount of seconds of no modifications.
+    #[serde(default)]
+    pub after_modifiedtime_secs: Option<NonZeroU64>,
+    /// If this is set, files will be truncated after set amount of seconds regardless of the state.
+    #[serde(default)]
+    pub after_secs: Option<NonZeroU64>,
 }
 
 impl GenerateConfig for FileSinkConfig {
@@ -100,6 +122,7 @@ impl GenerateConfig for FileSinkConfig {
             acknowledgements: Default::default(),
             timezone: Default::default(),
             internal_metrics: Default::default(),
+            truncate: Default::default(),
         })
         .unwrap()
     }
@@ -131,7 +154,12 @@ pub enum Compression {
     None,
 }
 
-enum OutFile {
+struct OutFile {
+    created_at: Instant,
+    inner: OutFileInner,
+}
+
+enum OutFileInner {
     Regular(File),
     Gzip(GzipEncoder<File>),
     Zstd(ZstdEncoder<File>),
@@ -139,35 +167,42 @@ enum OutFile {
 
 impl OutFile {
     fn new(file: File, compression: Compression) -> Self {
-        match compression {
-            Compression::None => OutFile::Regular(file),
-            Compression::Gzip => OutFile::Gzip(GzipEncoder::new(file)),
-            Compression::Zstd => OutFile::Zstd(ZstdEncoder::new(file)),
+        Self {
+            created_at: Instant::now(),
+            inner: match compression {
+                Compression::None => OutFileInner::Regular(file),
+                Compression::Gzip => OutFileInner::Gzip(GzipEncoder::new(file)),
+                Compression::Zstd => OutFileInner::Zstd(ZstdEncoder::new(file)),
+            },
         }
     }
 
     async fn sync_all(&mut self) -> Result<(), std::io::Error> {
-        match self {
-            OutFile::Regular(file) => file.sync_all().await,
-            OutFile::Gzip(gzip) => gzip.get_mut().sync_all().await,
-            OutFile::Zstd(zstd) => zstd.get_mut().sync_all().await,
+        match &mut self.inner {
+            OutFileInner::Regular(file) => file.sync_all().await,
+            OutFileInner::Gzip(gzip) => gzip.get_mut().sync_all().await,
+            OutFileInner::Zstd(zstd) => zstd.get_mut().sync_all().await,
         }
     }
 
     async fn shutdown(&mut self) -> Result<(), std::io::Error> {
-        match self {
-            OutFile::Regular(file) => file.shutdown().await,
-            OutFile::Gzip(gzip) => gzip.shutdown().await,
-            OutFile::Zstd(zstd) => zstd.shutdown().await,
+        match &mut self.inner {
+            OutFileInner::Regular(file) => file.shutdown().await,
+            OutFileInner::Gzip(gzip) => gzip.shutdown().await,
+            OutFileInner::Zstd(zstd) => zstd.shutdown().await,
         }
     }
 
     async fn write_all(&mut self, src: &[u8]) -> Result<(), std::io::Error> {
-        match self {
-            OutFile::Regular(file) => file.write_all(src).await,
-            OutFile::Gzip(gzip) => gzip.write_all(src).await,
-            OutFile::Zstd(zstd) => zstd.write_all(src).await,
+        match &mut self.inner {
+            OutFileInner::Regular(file) => file.write_all(src).await,
+            OutFileInner::Gzip(gzip) => gzip.write_all(src).await,
+            OutFileInner::Zstd(zstd) => zstd.write_all(src).await,
         }
+    }
+
+    const fn created_at(&self) -> Instant {
+        self.created_at
     }
 
     /// Shutdowns by flushing data, writing headers, and syncing all of that
@@ -210,6 +245,7 @@ pub struct FileSink {
     compression: Compression,
     events_sent: Registered<EventsSent>,
     include_file_metric_tag: bool,
+    truncation_config: FileTruncateConfig,
 }
 
 impl FileSink {
@@ -232,6 +268,7 @@ impl FileSink {
             compression: config.compression,
             events_sent: register!(EventsSent::from(Output(None))),
             include_file_metric_tag: config.internal_metrics.include_file_tag,
+            truncation_config: config.truncate.clone(),
         })
     }
 
@@ -298,22 +335,10 @@ impl FileSink {
                         // We do not poll map when it's empty, so we should
                         // never reach this branch.
                         None => unreachable!(),
-                        Some((mut expired_file, path)) => {
+                        Some((expired_file, path)) => {
                             // We got an expired file. All we really want is to
                             // flush and close it.
-                            if let Err(error) = expired_file.close().await {
-                                emit!(FileIoError {
-                                    error,
-                                    code: "failed_closing_file",
-                                    message: "Failed to close file.",
-                                    path: &path,
-                                    dropped_events: 0,
-                                });
-                            }
-                            drop(expired_file); // ignore close error
-                            emit!(FileOpen {
-                                count: self.files.len()
-                            });
+                            self.close_file(expired_file, path).await;
                         }
                     }
                 }
@@ -339,12 +364,48 @@ impl FileSink {
         let next_deadline = self.deadline_at();
         trace!(message = "Computed next deadline.", next_deadline = ?next_deadline, path = ?path);
 
-        let file = if let Some(file) = self.files.reset_at(&path, next_deadline) {
+        let mut truncate = false;
+        let bytes_path = BytesPath::new(path.clone());
+
+        if let Some(after_closetime_secs) = self.truncation_config.after_closetime_secs
+            && self.files.get(&path).is_none()
+            && let Ok(metadata) = fs::metadata(&bytes_path).await
+            && let Ok(time) = metadata
+                .modified()
+                .map_err(|_| ())
+                .and_then(|t| t.elapsed().map_err(|_| ()))
+            && time.as_secs() > after_closetime_secs.into()
+        {
+            truncate = true;
+        }
+
+        if let Some(after_secs) = self.truncation_config.after_secs
+            && let Some(file) = self.files.get(&path)
+            && (file.created_at().elapsed().as_secs() > after_secs.into())
+        {
+            truncate = true;
+        }
+
+        if let Some(after_modifiedtime_secs) = self.truncation_config.after_modifiedtime_secs
+            && let Some(previous_modification) = self
+                .files
+                .get_with_deadline(&path)
+                .and_then(|(_, deadline)| deadline.checked_sub(self.idle_timeout))
+            && previous_modification.elapsed().as_secs() > after_modifiedtime_secs.into()
+        {
+            truncate = true;
+        }
+
+        if truncate && let Some((file, path)) = self.files.remove(&path) {
+            self.close_file(file, path).await;
+        }
+
+        let file = if !truncate && let Some(file) = self.files.reset_at(&path, next_deadline) {
             trace!(message = "Working with an already opened file.", path = ?path);
             file
         } else {
             trace!(message = "Opening new file.", ?path);
-            let file = match open_file(BytesPath::new(path.clone())).await {
+            let file = match open_file(bytes_path, truncate).await {
                 Ok(file) => file,
                 Err(error) => {
                     // We couldn't open the file for this event.
@@ -396,9 +457,25 @@ impl FileSink {
             }
         }
     }
+
+    async fn close_file(&self, mut file: OutFile, path: Expired<Bytes>) {
+        if let Err(error) = file.close().await {
+            emit!(FileIoError {
+                error,
+                code: "failed_closing_file",
+                message: "Failed to close file.",
+                path: &path,
+                dropped_events: 0,
+            });
+        }
+        drop(file); // ignore close error
+        emit!(FileOpen {
+            count: self.files.len()
+        });
+    }
 }
 
-async fn open_file(path: impl AsRef<std::path::Path>) -> std::io::Result<File> {
+async fn open_file(path: impl AsRef<std::path::Path>, truncate: bool) -> std::io::Result<File> {
     let parent = path.as_ref().parent();
 
     if let Some(parent) = parent {
@@ -409,7 +486,8 @@ async fn open_file(path: impl AsRef<std::path::Path>) -> std::io::Result<File> {
         .read(false)
         .write(true)
         .create(true)
-        .append(true)
+        .append(!truncate)
+        .truncate(truncate)
         .open(path)
         .await
 }
@@ -481,6 +559,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (input, _events) = random_lines_with_stream(100, 64, None);
@@ -507,6 +586,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (input, _) = random_lines_with_stream(100, 64, None);
@@ -533,6 +613,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (input, _) = random_lines_with_stream(100, 64, None);
@@ -564,6 +645,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (mut input, _events) = random_events_with_stream(32, 8, None);
@@ -646,6 +728,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (mut input, _events) = random_lines_with_stream(10, 64, None);
@@ -702,6 +785,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (input, _events) = random_metrics_with_stream(100, None, None);
@@ -733,6 +817,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let metric_count = 3;
@@ -784,6 +869,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
+            truncate: Default::default(),
         };
 
         let (input, _events) = random_lines_with_stream(100, 64, None);

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -515,4 +515,25 @@ generated: components: sinks: file: configuration: {
 		required: false
 		type: string: examples: ["local", "America/New_York", "EST5EDT"]
 	}
+	truncate: {
+		description: "Configuration for truncating files."
+		required:    false
+		type: object: options: {
+			after_closetime_secs: {
+				description: "If this is set, files will be truncated after being closed for set amount of seconds."
+				required:    false
+				type: uint: {}
+			}
+			after_modifiedtime_secs: {
+				description: "If this is set, files will be truncated after set amount of seconds of no modifications."
+				required:    false
+				type: uint: {}
+			}
+			after_secs: {
+				description: "If this is set, files will be truncated after set amount of seconds regardless of the state."
+				required:    false
+				type: uint: {}
+			}
+		}
+	}
 }


### PR DESCRIPTION


## Summary
Adds new options to file sink to truncate output files in some conditions (after fixed amount of time, time after closing and time after last modification).

## Vector configuration
```yaml
sources:
  demo_logs_test:
    type: "demo_logs"
    format: "json"
    interval: 8

sinks:
  file:
    inputs: ["demo_logs_test"]
    type: "file"
    path: /etc/vector/test-data.txt
    acknowledgements:
      enabled: false
    encoding:
      codec: "json"
    idle_timeout_secs: 3
    truncate:
      # after_secs: 5
      # after_modifiedtime_secs: 5
      after_closetime_secs: 3
```

## How did you test this PR?
Used the above configuration (playing around with demo_logs `interval` and file sink `idle_timeout_secs`, to test out different truncate options) and observed the file creation times and content to ensure it gets truncated when conditions are met.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #22308

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

---
>Sponsored by [Quad9](https://quad9.net/)