### PR TITLE
feat(aggregate transform): Event-time based aggregation support

### DIFF
--- a/changelog.d/14015 _aggregation_by_event_time.feature.md
+++ b/changelog.d/14015 _aggregation_by_event_time.feature.md
@@ -1,0 +1,3 @@
+Feature: added support for aggregation driven by **event time**, allowing buckets to be aligned by metric timestamps instead of processing time.
+
+authors: adiwab

--- a/website/cue/reference/components/transforms/generated/aggregate.cue
+++ b/website/cue/reference/components/transforms/generated/aggregate.cue
@@ -32,4 +32,45 @@ generated: components: transforms: aggregate: configuration: {
 			}
 		}
 	}
+	clock: {
+        description: """
+            Aggregation clock source.
+
+            Determines whether buckets are aligned by Vector's processing time
+            or by the event's own timestamp.
+            """
+        required: false
+        type: string: {
+            default: "Processing"
+            enum: {
+                Processing: "Buckets are driven by Vector's wall clock (processing time)."
+                Event:      "Buckets are driven by each event's own timestamp (event time)."
+            }
+        }
+    }
+    allowed_lateness_ms: {
+        description: """
+            Allowed lateness for event-time processing.
+
+            Specifies how long to wait for late or out-of-order samples before closing an event-time bucket.
+            """
+        required: false
+        type: uint: default: 120000
+    }
+    emit_ts: {
+        description: """
+            Output timestamp mode.
+
+            Controls whether the emitted metric's timestamp is set to the start
+            or to the end of the bucket window.
+            """
+        required: false
+        type: string: {
+            default: "BucketStart"
+            enum: {
+                BucketStart: "Stamp the output at the start of the bucket window."
+                BucketEnd:   "Stamp the output at the end of the bucket window."
+            }
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/vectordotdev/vector/issues/14015

## Summary
1. **Event-time handling (absolute metrics in `Auto` and `Latest/Diff`):**
   - Now compares **event timestamps** and only replaces the stored value if the new sample is newer (or equal).
   - Prevents late/out-of-order samples from rolling back bucket values (Event clock only).

2. **Processing-time path:**
   - Absolute metrics in `Auto` and `Latest/Diff` are still replaced by the last **arriving** sample (no event-timestamp check yet).

3. **Other aggregation modes preserved:**
   - `Sum`, `Count` for incremental metrics unchanged.
   - `Max`, `Min`, `Mean`, `Stdev` continue to aggregate multiple samples per bucket.
   - `Diff` emits the difference between the current and previous bucket values.

4. **New configuration options:**
   - **`clock`**: choose bucket alignment by *Processing* (Vector wall clock) or *Event* (event timestamps).  
   - **`allowed_lateness_ms`**: wait time for late or out-of-order samples in event-time mode (default: 120s).  
   - **`emit_ts`**: set output timestamp to *BucketStart* or *BucketEnd*.  

**Important Notes**

- This is a draft implementation.
- It requires thorough testing (unit and integration) to verify correctness across modes, especially with late or out-of-order samples.
- There may be room for further optimization (e.g., reducing allocations, refining how late samples are handled).

## Vector configuration
prom_aggregate:
    type: aggregate
    inputs:
    - prometheus
    interval_ms: 60000
    mode: Latest
    clock: Event
    allowed_lateness_ms: 60000

## How did you test this PR?
I built the changes locally (win11 - Build 26100) and verified the results by sending metrics into InfluxDB and inspecting them in Grafana dashboards.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Related: #14015

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
