### PR TITLE
feat(vdev): add stderr to output

### DIFF
--- a/vdev/src/app.rs
+++ b/vdev/src/app.rs
@@ -1,4 +1,5 @@
 use std::ffi::{OsStr, OsString};
+use std::io::pipe;
 use std::{
     borrow::Cow, env, io::Read, path::PathBuf, process::Command, process::ExitStatus,
     process::Stdio, sync::LazyLock, sync::OnceLock, time::Duration,
@@ -6,6 +7,7 @@ use std::{
 
 use anyhow::{Context as _, Result, bail};
 use indicatif::{ProgressBar, ProgressStyle};
+use itertools::Itertools;
 use log::LevelFilter;
 
 use crate::{config::Config, git, platform, util};
@@ -74,95 +76,166 @@ pub fn version() -> Result<String> {
     Ok(version)
 }
 
-/// Overlay some extra helper functions onto `std::process::Command`
-pub trait CommandExt {
-    fn script(script: &str) -> Self;
-    fn in_repo(&mut self) -> &mut Self;
-    fn check_output(&mut self) -> Result<String>;
-    fn check_run(&mut self) -> Result<()>;
-    fn run(&mut self) -> Result<ExitStatus>;
-    fn wait(&mut self, message: impl Into<Cow<'static, str>>) -> Result<()>;
-    fn pre_exec(&self);
-    fn features(&mut self, features: &[String]) -> &mut Self;
+pub struct VDevCommand {
+    pub inner: Command,
 }
 
-impl CommandExt for Command {
+impl VDevCommand {
+    #[must_use]
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        Self {
+            inner: Command::new(program.as_ref()),
+        }
+    }
+
     /// Create a new command to execute the named script in the repository `scripts` directory.
     fn script(script: &str) -> Self {
         let path: PathBuf = [path(), "scripts", script].into_iter().collect();
         if cfg!(windows) {
             // On Windows, all scripts must be run through an explicit interpreter.
-            let mut command = Command::new(&*SHELL);
-            command.arg(path);
-            command
+            Self::new(&*SHELL).arg(path)
         } else {
             // On all other systems, we can run scripts directly.
-            Command::new(path)
+            Self::new(path)
         }
     }
+}
 
-    /// Set the command's working directory to the repository directory.
-    fn in_repo(&mut self) -> &mut Self {
-        self.current_dir(path())
+impl From<Command> for VDevCommand {
+    fn from(command: Command) -> Self {
+        Self { inner: command }
+    }
+}
+
+impl VDevCommand {
+    #[must_use]
+    pub fn arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
+        self.inner.arg(arg);
+        self
+    }
+
+    #[must_use]
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.inner.args(args);
+        self
+    }
+
+    #[must_use]
+    pub fn features(mut self, features: &[String]) -> Self {
+        self = self.arg("--no-default-features").arg("--features");
+        if features.is_empty() {
+            self = self.arg(platform::default_features());
+        } else {
+            self = self.arg(features.join(","));
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn in_repo(mut self) -> Self {
+        self.inner.current_dir(path());
+        self
+    }
+
+    #[must_use]
+    pub fn env<K, V>(mut self, key: K, val: V) -> Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.env(key, val);
+        self
+    }
+
+    #[must_use]
+    pub fn envs<I, K, V>(mut self, vars: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.envs(vars);
+        self
     }
 
     /// Run the command and capture its output.
-    fn check_output(&mut self) -> Result<String> {
-        // Set up the command's stdout to be piped, so we can capture it
+    pub fn check_output(self) -> Result<String> {
+        self.check_output_inner().map(|(_, output)| output)
+    }
+
+    /// Run the command and capture its output.
+    fn check_output_inner(mut self) -> Result<(ExitStatus, String)> {
+        let error_info = format!(
+            "\"{}\" {}",
+            self.inner.get_program().to_string_lossy(),
+            self.inner
+                .get_args()
+                .map(|arg| format!("\"{}\"", arg.to_string_lossy()))
+                .join(" ")
+        );
+
         self.pre_exec();
-        self.stdout(Stdio::piped());
+
+        // Set up the command's stdout/stderr to be piped, so we can capture it
+        let (mut reader, writer) = pipe()?;
+        let writer_clone = writer.try_clone()?;
+
+        self.inner.stdout(Stdio::from(writer));
+        self.inner.stderr(Stdio::from(writer_clone));
 
         // Spawn the process
-        let mut child = self.spawn()?;
-
-        // Read the output from child.stdout into a buffer
-        let mut buffer = Vec::new();
-        child.stdout.take().unwrap().read_to_end(&mut buffer)?;
+        let mut child = self
+            .inner
+            .spawn()
+            .with_context(|| format!("Failed to spawn process {error_info}"))?;
 
         // Catch the exit code
         let status = child.wait()?;
         // There are commands that might fail with stdout, but we probably do not
         // want to capture
-        // If the exit code is non-zero, return an error with the command, exit code, and stderr output
+        // If the exit code is non-zero, return an error with the command, exit code, and full output
+        drop(self.inner); // Drop inner to prevent deadlock when reading
+
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer).unwrap();
+        let output = String::from_utf8_lossy(&buffer);
+
         if !status.success() {
-            let stdout = String::from_utf8_lossy(&buffer);
             bail!(
-                "Command: {:?}\nfailed with exit code: {}\n\noutput:\n{}",
-                self,
+                "Command: {error_info}\nfailed with exit code: {}\n\noutput:\n{output}",
                 status.code().unwrap(),
-                stdout
             );
         }
 
         // If the command exits successfully, return the output as a string
-        Ok(String::from_utf8(buffer)?)
+        Ok((status, output.into_owned()))
     }
 
     /// Run the command and catch its exit code.
-    fn run(&mut self) -> Result<ExitStatus> {
+    pub fn run(self) -> Result<ExitStatus> {
         self.pre_exec();
-        self.status().map_err(Into::into)
+        self.check_output_inner()
+            .map_err(Into::into)
+            .map(|(status, _)| status)
     }
 
-    fn check_run(&mut self) -> Result<()> {
-        let status = self.run()?;
-        if status.success() {
-            Ok(())
-        } else {
-            let exit = status.code().unwrap();
-            bail!("command: {self:?}\n  failed with exit code: {exit}")
-        }
+    pub fn check_run(self) -> Result<()> {
+        self.run().map(|_| ())
     }
 
     /// Run the command, capture its output, and display a progress bar while it's
     /// executing. Intended to be used for long-running processes with little interaction.
-    fn wait(&mut self, message: impl Into<Cow<'static, str>>) -> Result<()> {
+    pub fn wait(&mut self, message: impl Into<Cow<'static, str>>) -> Result<()> {
         self.pre_exec();
 
         let progress_bar = get_progress_bar()?;
         progress_bar.set_message(message);
 
-        let result = self.output();
+        let result = self.inner.output();
         progress_bar.finish_and_clear();
 
         let Ok(output) = result else {
@@ -174,7 +247,7 @@ impl CommandExt for Command {
         } else {
             bail!(
                 "{}\nfailed with exit code: {}",
-                String::from_utf8(output.stdout)?,
+                String::from_utf8(output.stdout)?, // FIXME this can be improved
                 output.status.code().unwrap()
             )
         }
@@ -182,11 +255,10 @@ impl CommandExt for Command {
 
     /// Print out a pre-execution debug message.
     fn pre_exec(&self) {
-        debug!("Executing: {self:?}");
-        if let Some(cwd) = self.get_current_dir() {
+        if let Some(cwd) = self.inner.get_current_dir() {
             debug!("  in working directory {cwd:?}");
         }
-        for (key, value) in self.get_envs() {
+        for (key, value) in self.inner.get_envs() {
             let key = key.to_string_lossy();
             if let Some(value) = value {
                 debug!("  ${key}={:?}", value.to_string_lossy());
@@ -194,17 +266,6 @@ impl CommandExt for Command {
                 debug!("  unset ${key}");
             }
         }
-    }
-
-    fn features(&mut self, features: &[String]) -> &mut Self {
-        self.arg("--no-default-features");
-        self.arg("--features");
-        if features.is_empty() {
-            self.arg(platform::default_features());
-        } else {
-            self.arg(features.join(","));
-        }
-        self
     }
 }
 
@@ -216,12 +277,12 @@ pub fn exec<T: AsRef<OsStr>>(
     in_repo: bool,
 ) -> Result<()> {
     let mut command = match program.strip_prefix("scripts/") {
-        Some(script) => Command::script(script),
-        None => Command::new(program),
-    };
-    command.args(args);
+        Some(script) => VDevCommand::script(script),
+        None => VDevCommand::new(program),
+    }
+    .args(args);
     if in_repo {
-        command.in_repo();
+        command = command.in_repo();
     }
     command.check_run()
 }

--- a/vdev/src/commands/build/vector.rs
+++ b/vdev/src/commands/build/vector.rs
@@ -1,9 +1,7 @@
-use std::process::Command;
-
 use anyhow::Result;
 use clap::Args;
 
-use crate::{app::CommandExt as _, platform};
+use crate::{app::VDevCommand, platform};
 
 /// Build the `vector` executable.
 #[derive(Args, Debug)]
@@ -23,22 +21,17 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let mut command = Command::new("cargo");
-        command.in_repo();
-        command.arg("build");
+        let mut command = VDevCommand::new("cargo").in_repo().arg("build");
 
         if self.release {
-            command.arg("--release");
+            command = command.arg("--release");
         }
 
-        command.features(&self.feature);
-
         let target = self.target.unwrap_or_else(platform::default_target);
-        command.args(["--target", &target]);
+        command = command.features(&self.feature).args(["--target", &target]);
 
         waiting!("Building Vector");
-        command.check_run()?;
 
-        Ok(())
+        command.check_run()
     }
 }

--- a/vdev/src/commands/crate_versions.rs
+++ b/vdev/src/commands/crate_versions.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, collections::HashSet, process::Command};
+use std::{collections::HashMap, collections::HashSet};
 
 use anyhow::Result;
 use clap::Args;
 use itertools::Itertools as _;
 use regex::Regex;
 
-use crate::{app::CommandExt as _, util};
+use crate::{app::VDevCommand, util};
 
 /// Show information about crates versions pulled in by all dependencies
 #[derive(Args, Debug)]
@@ -25,7 +25,7 @@ impl Cli {
         let re_crate = Regex::new(r" (\S+) v([0-9.]+)").unwrap();
         let mut versions: HashMap<String, HashSet<String>> = HashMap::default();
 
-        for line in Command::new("cargo")
+        for line in VDevCommand::new("cargo")
             .arg("tree")
             .features(&self.feature)
             .check_output()?

--- a/vdev/src/commands/exec.rs
+++ b/vdev/src/commands/exec.rs
@@ -1,9 +1,7 @@
-use std::process::Command;
-
 use anyhow::Result;
 use clap::Args;
 
-use crate::app::CommandExt as _;
+use crate::app::VDevCommand;
 
 /// Execute a command within the repository
 #[derive(Args, Debug)]
@@ -15,7 +13,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let status = Command::new(&self.args[0])
+        let status = VDevCommand::new(&self.args[0])
             .in_repo()
             .args(&self.args[1..])
             .run()?;

--- a/vdev/src/commands/release/github.rs
+++ b/vdev/src/commands/release/github.rs
@@ -1,8 +1,7 @@
-use crate::app::CommandExt as _;
+use crate::app::VDevCommand;
 use crate::util;
-use anyhow::{anyhow, Ok, Result};
+use anyhow::{Result, anyhow};
 use glob::glob;
-use std::process::Command;
 
 /// Uploads target/artifacts to GitHub releases
 #[derive(clap::Args, Debug)]
@@ -21,25 +20,24 @@ impl Cli {
             .map_err(|e| anyhow!("failed to turn path into string: {:?}", e))?;
 
         let version = util::get_version()?;
-        let mut command = Command::new("gh");
-        command.in_repo();
-        command.args(
-            [
-                "release",
-                "--repo",
-                "vectordotdev/vector",
-                "create",
-                &format!("v{version}"),
-                "--title",
-                &format!("v{version}"),
-                "--notes",
-                &format!("[View release notes](https://vector.dev/releases/{version})"),
-            ]
-            .map(String::from)
-            .into_iter()
-            .chain(artifacts),
-        );
-        command.check_run()?;
-        Ok(())
+        VDevCommand::new("gh")
+            .in_repo()
+            .args(
+                [
+                    "release",
+                    "--repo",
+                    "vectordotdev/vector",
+                    "create",
+                    &format!("v{version}"),
+                    "--title",
+                    &format!("v{version}"),
+                    "--notes",
+                    &format!("[View release notes](https://vector.dev/releases/{version})"),
+                ]
+                .map(String::from)
+                .into_iter()
+                .chain(artifacts),
+            )
+            .check_run()
     }
 }

--- a/vdev/src/commands/run.rs
+++ b/vdev/src/commands/run.rs
@@ -1,9 +1,9 @@
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Args;
 
-use crate::{app::CommandExt as _, features};
+use crate::{app::VDevCommand, features};
 
 /// Run `vector` with the minimum set of features required by the config file
 #[derive(Args, Debug)]
@@ -37,17 +37,22 @@ impl Cli {
         let mut features = features::load_and_extract(&self.config)?;
         features.extend(self.feature);
         let features = features.join(",");
-        let mut command = Command::new("cargo");
-        command.args(["run", "--no-default-features", "--features", &features]);
-        if self.release {
-            command.arg("--release");
-        }
-        command.args([
-            "--",
-            "--config",
-            self.config.to_str().expect("Invalid config file name"),
+        let mut command = VDevCommand::new("cargo").args([
+            "run",
+            "--no-default-features",
+            "--features",
+            &features,
         ]);
-        command.args(self.args);
-        command.check_run()
+        if self.release {
+            command = command.arg("--release");
+        }
+        command
+            .args([
+                "--",
+                "--config",
+                self.config.to_str().expect("Invalid config file name"),
+            ])
+            .args(self.args)
+            .check_run()
     }
 }

--- a/vdev/src/environment.rs
+++ b/vdev/src/environment.rs
@@ -1,6 +1,7 @@
 use cfg_if::cfg_if;
 use std::collections::BTreeMap;
-use std::process::Command;
+
+use crate::app::VDevCommand;
 
 cfg_if! {
     if #[cfg(unix)] {
@@ -30,14 +31,18 @@ pub(crate) fn extract_present(environment: &Environment) -> BTreeMap<String, Str
         .collect()
 }
 
-pub(crate) fn append_environment_variables(command: &mut Command, environment: &Environment) {
+pub(crate) fn append_environment_variables(
+    mut command: VDevCommand,
+    environment: &Environment,
+) -> VDevCommand {
     for (key, value) in environment {
-        command.arg("--env");
+        command = command.arg("--env");
         match value {
-            Some(value) => command.arg(format!("{key}={value}")),
-            None => command.arg(key),
+            Some(value) => command = command.arg(format!("{key}={value}")),
+            None => command = command.arg(key),
         };
     }
+    command
 }
 
 cfg_if! {

--- a/vdev/src/git.rs
+++ b/vdev/src/git.rs
@@ -1,7 +1,7 @@
-use crate::app::CommandExt as _;
+use crate::app::VDevCommand;
 use anyhow::{Result, anyhow, bail};
 use git2::{BranchType, ErrorCode, Repository};
-use std::{collections::HashSet, process::Command};
+use std::collections::HashSet;
 
 pub fn current_branch() -> Result<String> {
     let output = run_and_check_output(&["rev-parse", "--abbrev-ref", "HEAD"])?;
@@ -95,46 +95,46 @@ pub fn get_modified_files() -> Result<Vec<String>> {
 }
 
 pub fn set_config_value(key: &str, value: &str) -> Result<String> {
-    Command::new("git")
+    VDevCommand::new("git")
         .args(["config", key, value])
-        .stdout(std::process::Stdio::null())
         .check_output()
 }
 
 /// Checks if the current directory's repo is clean
 pub fn check_git_repository_clean() -> Result<bool> {
-    Ok(Command::new("git")
+    Ok(VDevCommand::new("git")
         .args(["diff-index", "--quiet", "HEAD"])
-        .stdout(std::process::Stdio::null())
-        .status()
+        .run()
         .map(|status| status.success())?)
 }
 
 pub fn add_files_in_current_dir() -> Result<String> {
-    Command::new("git").args(["add", "."]).check_output()
+    VDevCommand::new("git").args(["add", "."]).check_output()
 }
 
 /// Commits changes from the current repo
 pub fn commit(commit_message: &str) -> Result<String> {
-    Command::new("git")
+    VDevCommand::new("git")
         .args(["commit", "--all", "--message", commit_message])
         .check_output()
 }
 
 /// Pushes changes from the current repo
 pub fn push() -> Result<String> {
-    Command::new("git").args(["push"]).check_output()
+    VDevCommand::new("git").args(["push"]).check_output()
 }
 
 pub fn push_and_set_upstream(branch_name: &str) -> Result<String> {
-    Command::new("git")
+    VDevCommand::new("git")
         .args(["push", "-u", "origin", branch_name])
         .check_output()
 }
 
 pub fn clone(repo_url: &str) -> Result<String> {
     // We cannot use capture_output since this will need to run in the CWD
-    Command::new("git").args(["clone", repo_url]).check_output()
+    VDevCommand::new("git")
+        .args(["clone", repo_url])
+        .check_output()
 }
 
 /// Walks up from the current working directory until it finds a `.git`
@@ -189,7 +189,7 @@ pub fn create_branch(branch_name: &str) -> Result<()> {
 }
 
 pub fn run_and_check_output(args: &[&str]) -> Result<String> {
-    Command::new("git").in_repo().args(args).check_output()
+    VDevCommand::new("git").in_repo().args(args).check_output()
 }
 
 fn is_warning_line(line: &str) -> bool {

--- a/vdev/src/testing/docker.rs
+++ b/vdev/src/testing/docker.rs
@@ -1,28 +1,24 @@
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
 use std::sync::LazyLock;
+
+use crate::app::VDevCommand;
 
 pub static CONTAINER_TOOL: LazyLock<OsString> =
     LazyLock::new(|| env::var_os("CONTAINER_TOOL").unwrap_or_else(detect_container_tool));
 
 pub(super) static DOCKER_SOCKET: LazyLock<PathBuf> = LazyLock::new(detect_docker_socket);
 
-pub fn docker_command<I: AsRef<OsStr>>(args: impl IntoIterator<Item = I>) -> Command {
-    let mut command = Command::new(&*CONTAINER_TOOL);
-    command.args(args);
-    command
+pub fn docker_command<I: AsRef<OsStr>>(args: impl IntoIterator<Item = I>) -> VDevCommand {
+    VDevCommand::new(&*CONTAINER_TOOL).args(args)
 }
 
 fn detect_container_tool() -> OsString {
     for tool in ["docker", "podman"] {
-        if Command::new(tool)
+        if VDevCommand::new(tool)
             .arg("version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .and_then(|mut child| child.wait())
+            .run()
             .is_ok_and(|status| status.success())
         {
             return OsString::from(String::from(tool));


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Several improvements to VDEV error handling.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
```
license_tool="$(which dd-rust-license-tool)"
mv "$license_tool" "$license_tool.bak"

cargo vdev build licenses
# You should see the following output:
# Error: Failed to spawn process "dd-rust-license-tool" "write"
# 
# Caused by:
#     No such file or directory (os error 2)

# Now we write a failing script into the license tool
echo -e '#!/bin/sh\necho "I am stdout"; >&2 echo "I am stderr"; exit 1' > "$license_tool"
chmod +x "$license_tool"

cargo vdev build licenses

# You should see the following output:
# Error: Failed to spawn process "dd-rust-license-tool" "write"
# failed with exit code: 1
# 
# output:
# I am stdout
# I am stderr

mv "$license_tool.bak" "$license_tool"
```

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
