### PR TITLE
feat(codecs): Support GELF chunking for encoding

### DIFF
--- a/changelog.d/13292_gelf_encoding_chunking.enhancement.md
+++ b/changelog.d/13292_gelf_encoding_chunking.enhancement.md
@@ -1,0 +1,3 @@
+The `gelf` encoding format now supports [chunking](https://go2docs.graylog.org/current/getting_in_log_data/gelf.html#chunking) when used with the `socket` sink in `udp` mode. The maximum chunk size can be configured using `encoding.gelf.max_chunk_size`.
+
+authors: aramperes

--- a/lib/codecs/src/encoding/chunking/gelf.rs
+++ b/lib/codecs/src/encoding/chunking/gelf.rs
@@ -92,6 +92,7 @@ mod tests {
         let chunker = Chunker::Gelf(GelfChunker {
             max_chunk_size: GELF_CHUNK_HEADERS_LENGTH + 4,
         });
+        // Input for 5 chunks of 4 bytes: [1234] [1234] [1234] [1234] [123]
         let input = Bytes::from("1234123412341234123");
         let chunks = chunker.chunk(input).unwrap();
         assert_eq!(chunks.len(), 5);

--- a/lib/codecs/src/encoding/chunking/gelf.rs
+++ b/lib/codecs/src/encoding/chunking/gelf.rs
@@ -8,11 +8,19 @@ const GELF_MAX_TOTAL_CHUNKS: usize = 128;
 const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
 const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
 
-/// Chunks with GELF native chunking format.
-/// Supports up to 128 chunks, each up to 8192 bytes (minus 12 bytes, for headers).
+/// Chunks with GELF native chunking format, as documented from the [source][source].
+/// Supports up to 128 chunks, each with a maximum size that can be configured.
+///
+/// [source]: https://go2docs.graylog.org/current/getting_in_log_data/gelf.html#chunking
 #[derive(Clone, Debug)]
 pub struct GelfChunker {
-    /// Max chunk size.
+    /// Max chunk size. This must be at least 13 bytes (12 bytes for headers + N bytes for data).
+    /// There is no specific upper limit, since it depends on the transport protocol and network interface settings.
+    /// Most networks will limit IP frames to 64KiB; however, the actual payload size limit will be lower due to UDP and GELF headers.
+    ///
+    /// For safety it is not recommended to set this value any higher than 65,500 bytes unless your network supports [Jumbograms][jumbogram].
+    ///
+    /// [jumbogram]: https://en.wikipedia.org/wiki/Jumbogram
     pub max_chunk_size: usize,
 }
 

--- a/lib/codecs/src/encoding/chunking/gelf.rs
+++ b/lib/codecs/src/encoding/chunking/gelf.rs
@@ -1,0 +1,112 @@
+use std::vec;
+
+use super::Chunking;
+use bytes::{BufMut, Bytes, BytesMut};
+use tracing::trace;
+
+const GELF_MAX_TOTAL_CHUNKS: usize = 128;
+const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
+const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
+
+/// Chunks with GELF native chunking format.
+/// Supports up to 128 chunks, each up to 8192 bytes (minus 12 bytes, for headers).
+#[derive(Clone, Debug)]
+pub struct GelfChunker {
+    /// Max chunk size.
+    pub max_chunk_size: usize,
+}
+
+impl Chunking for GelfChunker {
+    fn chunk(&self, bytes: Bytes) -> Result<Vec<Bytes>, vector_common::Error> {
+        if bytes.len() > self.max_chunk_size {
+            let chunk_size = self.max_chunk_size - GELF_CHUNK_HEADERS_LENGTH;
+            let message_id: u64 = rand::random();
+            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
+
+            trace!(
+                message_id = message_id,
+                chunk_count = chunk_count,
+                chunk_size = chunk_size,
+                "Generating chunks for GELF."
+            );
+
+            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
+                return Err(vector_common::Error::from(format!(
+                    "Too many chunks to generate for GELF: {}, max: {}",
+                    chunk_count, GELF_MAX_TOTAL_CHUNKS
+                )));
+            }
+
+            // Split into chunks and add headers to each slice.
+            // Map with index to determine sequence number.
+            let chunks = bytes
+                .chunks(chunk_size)
+                .enumerate()
+                .map(|(i, chunk)| {
+                    let framed = Bytes::copy_from_slice(chunk);
+                    let sequence_number = i as u8;
+                    let sequence_count = chunk_count as u8;
+
+                    let mut headers = BytesMut::with_capacity(GELF_CHUNK_HEADERS_LENGTH);
+                    headers.put_slice(&GELF_MAGIC_BYTES);
+                    headers.put_u64(message_id);
+                    headers.put_u8(sequence_number);
+                    headers.put_u8(sequence_count);
+
+                    [headers.freeze(), framed].concat().into()
+                })
+                .collect();
+            Ok(chunks)
+        } else {
+            Ok(vec![bytes])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Chunking, GELF_CHUNK_HEADERS_LENGTH, GELF_MAGIC_BYTES, GelfChunker};
+    use crate::encoding::Chunker;
+
+    #[test]
+    fn test_gelf_chunker_noop() {
+        let chunker = Chunker::Gelf(GelfChunker {
+            max_chunk_size: 8192,
+        });
+        let input = Bytes::from("1234123412341234123");
+        let chunks = chunker.chunk(input.clone()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], input);
+    }
+
+    #[test]
+    fn test_gelf_chunker_chunk() {
+        let chunker = Chunker::Gelf(GelfChunker {
+            max_chunk_size: GELF_CHUNK_HEADERS_LENGTH + 4,
+        });
+        let input = Bytes::from("1234123412341234123");
+        let chunks = chunker.chunk(input).unwrap();
+        assert_eq!(chunks.len(), 5);
+
+        for i in 0..chunks.len() {
+            if i < 4 {
+                assert_eq!(chunks[i].len(), GELF_CHUNK_HEADERS_LENGTH + 4);
+            } else {
+                assert_eq!(chunks[i].len(), GELF_CHUNK_HEADERS_LENGTH + 3);
+            }
+            // Bytes 0 and 1: Magic bytes
+            assert_eq!(chunks[i][0..2], GELF_MAGIC_BYTES);
+            // Bytes 2 to 9: Random ID (not checked)
+            // Byte 10: Sequence number
+            assert_eq!(chunks[i][10], i as u8);
+            // Byte 11: Sequence count
+            assert_eq!(chunks[i][11], chunks.len() as u8);
+            // Payload bytes
+            if i < 4 {
+                assert_eq!(&chunks[i][GELF_CHUNK_HEADERS_LENGTH..], b"1234");
+            } else {
+                assert_eq!(&chunks[i][GELF_CHUNK_HEADERS_LENGTH..], b"123");
+            }
+        }
+    }
+}

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -15,7 +15,7 @@ pub trait Chunker {
 }
 
 /// Does not chunk.
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct NoopChunker;
 
 impl Chunker for NoopChunker {
@@ -27,6 +27,7 @@ impl Chunker for NoopChunker {
 
 /// Chunks with GELF native chunking format.
 /// Supports up to 128 chunks, each up to 8192 bytes (minus 12 bytes, for headers).
+#[derive(Clone, Debug)]
 pub struct GelfChunker {
     mtu: usize,
 }
@@ -82,6 +83,24 @@ impl Chunker for GelfChunker {
             Ok(chunks)
         } else {
             Ok(vec![bytes])
+        }
+    }
+}
+
+/// Chunkers.
+#[derive(Clone, Debug)]
+pub enum Chunkers {
+    /// No chunking (pass-through).
+    Noop(NoopChunker),
+    /// Chunking in GELF format.
+    Gelf(GelfChunker),
+}
+
+impl Chunker for Chunkers {
+    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
+        match self {
+            Chunkers::Noop(chunker) => chunker.chunk(bytes),
+            Chunkers::Gelf(chunker) => chunker.chunk(bytes),
         }
     }
 }

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -1,92 +1,19 @@
-//! A collection of formats that can be used to chunk events into multiple byte frames.
+//! For chunking.
 
-use std::vec;
-
-use bytes::BufMut;
-use tracing::trace;
-
-const GELF_MAX_CHUNK_SIZE: usize = 8192;
-const GELF_MAX_TOTAL_CHUNKS: usize = 128;
-const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
-const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
-
-/// For chunking.
+/// A trait for implement chunking logic over a source frame `bytes`, into a variable number of frames.
 pub trait Chunker {
-    /// Chunks the input into frames.
+    /// Chunks the input `bytes` frame into a variable number of frames.
     fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error>;
 }
 
-/// Chunks with GELF native chunking format.
-/// Supports up to 128 chunks, each up to 8192 bytes (minus 12 bytes, for headers).
-#[derive(Clone, Debug)]
-pub struct GelfChunker {
-    /// Max chunk size.
-    pub max_chunk_size: usize,
-}
-
-impl Default for GelfChunker {
-    fn default() -> Self {
-        Self {
-            max_chunk_size: GELF_MAX_CHUNK_SIZE,
-        }
-    }
-}
-
-impl Chunker for GelfChunker {
-    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
-        if bytes.len() > self.max_chunk_size {
-            let chunk_size = self.max_chunk_size - GELF_CHUNK_HEADERS_LENGTH;
-            let message_id: u64 = rand::random();
-            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
-
-            trace!(
-                message_id = message_id,
-                chunk_count = chunk_count,
-                chunk_size = chunk_size,
-                "Generating chunks for GELF."
-            );
-
-            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
-                return Err(vector_common::Error::from(format!(
-                    "Too many chunks to generate for GELF: {}, max: {}",
-                    chunk_count, GELF_MAX_TOTAL_CHUNKS
-                )));
-            }
-
-            // Split into chunks and add headers to each slice.
-            // Map with index to determine sequence number.
-            let chunks = bytes
-                .chunks(chunk_size)
-                .enumerate()
-                .map(|(i, chunk)| {
-                    let framed = bytes::Bytes::copy_from_slice(chunk);
-                    let sequence_number = i as u8;
-                    let sequence_count = chunk_count as u8;
-
-                    let mut headers = bytes::BytesMut::with_capacity(GELF_CHUNK_HEADERS_LENGTH);
-                    headers.put_slice(&GELF_MAGIC_BYTES);
-                    headers.put_u64(message_id);
-                    headers.put_u8(sequence_number);
-                    headers.put_u8(sequence_count);
-
-                    [headers.freeze(), framed].concat().into()
-                })
-                .collect();
-            Ok(chunks)
-        } else {
-            Ok(vec![bytes])
-        }
-    }
-}
-
-/// Chunkers.
+/// Chunker implementations.
 #[derive(Clone, Debug, Default)]
 pub enum Chunkers {
     /// No chunking (pass-through).
     #[default]
     Noop,
     /// Chunking in GELF format.
-    Gelf(GelfChunker),
+    Gelf(crate::encoding::GelfChunker),
 }
 
 impl Chunker for Chunkers {

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -1,19 +1,92 @@
-//! For chunking.
+//! A collection of formats that can be used to chunk events into multiple byte frames.
 
-/// A trait for implement chunking logic over a source frame `bytes`, into a variable number of frames.
+use std::vec;
+
+use bytes::BufMut;
+use tracing::trace;
+
+const GELF_MAX_CHUNK_SIZE: usize = 8192;
+const GELF_MAX_TOTAL_CHUNKS: usize = 128;
+const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
+const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
+
+/// For chunking.
 pub trait Chunker {
-    /// Chunks the input `bytes` frame into a variable number of frames.
+    /// Chunks the input into frames.
     fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error>;
 }
 
-/// Chunker implementations.
+/// Chunks with GELF native chunking format.
+/// Supports up to 128 chunks, each up to 8192 bytes (minus 12 bytes, for headers).
+#[derive(Clone, Debug)]
+pub struct GelfChunker {
+    /// Max chunk size.
+    pub max_chunk_size: usize,
+}
+
+impl Default for GelfChunker {
+    fn default() -> Self {
+        Self {
+            max_chunk_size: GELF_MAX_CHUNK_SIZE,
+        }
+    }
+}
+
+impl Chunker for GelfChunker {
+    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
+        if bytes.len() > self.max_chunk_size {
+            let chunk_size = self.max_chunk_size - GELF_CHUNK_HEADERS_LENGTH;
+            let message_id: u64 = rand::random();
+            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
+
+            trace!(
+                message_id = message_id,
+                chunk_count = chunk_count,
+                chunk_size = chunk_size,
+                "Generating chunks for GELF."
+            );
+
+            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
+                return Err(vector_common::Error::from(format!(
+                    "Too many chunks to generate for GELF: {}, max: {}",
+                    chunk_count, GELF_MAX_TOTAL_CHUNKS
+                )));
+            }
+
+            // Split into chunks and add headers to each slice.
+            // Map with index to determine sequence number.
+            let chunks = bytes
+                .chunks(chunk_size)
+                .enumerate()
+                .map(|(i, chunk)| {
+                    let framed = bytes::Bytes::copy_from_slice(chunk);
+                    let sequence_number = i as u8;
+                    let sequence_count = chunk_count as u8;
+
+                    let mut headers = bytes::BytesMut::with_capacity(GELF_CHUNK_HEADERS_LENGTH);
+                    headers.put_slice(&GELF_MAGIC_BYTES);
+                    headers.put_u64(message_id);
+                    headers.put_u8(sequence_number);
+                    headers.put_u8(sequence_count);
+
+                    [headers.freeze(), framed].concat().into()
+                })
+                .collect();
+            Ok(chunks)
+        } else {
+            Ok(vec![bytes])
+        }
+    }
+}
+
+/// Chunkers.
 #[derive(Clone, Debug, Default)]
 pub enum Chunkers {
     /// No chunking (pass-through).
     #[default]
     Noop,
     /// Chunking in GELF format.
-    Gelf(crate::encoding::GelfChunker),
+    Gelf(GelfChunker),
 }
 
 impl Chunker for Chunkers {

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -1,0 +1,69 @@
+//! A collection of formats that can be used to chunk events into multiple byte frames.
+
+use bytes::BufMut;
+
+/// For chunking.
+pub trait Chunker {
+    /// Chunks the input into frames.
+    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error>;
+}
+
+/// Does not chunk.
+#[derive(Default)]
+pub struct NoopChunker;
+
+impl Chunker for NoopChunker {
+    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
+        // No-op chunking implementation
+        Ok(vec![bytes])
+    }
+}
+
+/// Chunks with GELF native chunking format. Supports up to 128 chunks, each up to 8192 bytes (minus 12 for headers).
+pub struct GelfChunker;
+
+impl Default for GelfChunker {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl Chunker for GelfChunker {
+    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
+        // GELF chunking implementation
+        let chunk_size = 8192 - 12;
+        if bytes.len() > chunk_size {
+            let message_id: u64 = rand::random();
+
+            // Split into chunks of (8192-12) and add chunking headers to each slice.
+            // Map with index to determine sequence number.
+            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
+
+            if chunk_count > 128 {
+                panic!("too many chunks!"); // todo: don't panic.
+            }
+
+            let chunks = bytes
+                .chunks(chunk_size)
+                .enumerate()
+                .map(|(i, chunk)| {
+                    let framed = bytes::Bytes::copy_from_slice(chunk);
+                    let magic_bytes = [0x1e, 0x0f];
+                    let sequence_number = i as u8;
+                    let sequence_count = chunk_count as u8;
+
+                    let mut headers = bytes::BytesMut::with_capacity(12);
+                    headers.put_slice(&magic_bytes);
+                    headers.put_u64(message_id);
+                    headers.put_u8(sequence_number);
+                    headers.put_u8(sequence_count);
+
+                    [headers.freeze(), framed].concat().into()
+                })
+                .collect();
+            Ok(chunks)
+        } else {
+            Ok(vec![bytes])
+        }
+    }
+}

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -1,20 +1,25 @@
-//! A collection of formats that can be used to chunk events into multiple byte frames.
+//! Optional extension for encoding formats to support chunking, used when the sink transport (e.g., UDP) has a payload size limit.
+//!
+//! Chunking allows large encoded events to be split into smaller frames, ensuring compatibility with transports that cannot send large payloads in a single datagram or packet.
 
 mod gelf;
 
 use bytes::Bytes;
 pub use gelf::GelfChunker;
 
-/// For chunking.
+
+/// Trait for encoding formats that optionally support chunking, for use with sinks that have payload size limits (such as UDP).
+///
+/// Chunking is an extension to the standard `Encoder` trait, allowing large encoded events to be split into multiple frames for transmission.
 pub trait Chunking {
     /// Chunks the input into frames.
     fn chunk(&self, bytes: Bytes) -> Result<Vec<Bytes>, vector_common::Error>;
 }
 
-/// Chunking implementations.
+/// Implementations of chunking strategies for supported formats.
 #[derive(Clone, Debug)]
 pub enum Chunker {
-    /// Chunking in GELF format.
+    /// GELF chunking implementation.
     Gelf(GelfChunker),
 }
 

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -1,10 +1,12 @@
 //! A collection of formats that can be used to chunk events into multiple byte frames.
 
 use bytes::BufMut;
+use tracing::trace;
 
 const GELF_MAX_CHUNK_SIZE: usize = 8192;
 const GELF_MAX_TOTAL_CHUNKS: usize = 128;
 const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
+const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
 
 /// For chunking.
 pub trait Chunker {
@@ -42,25 +44,34 @@ impl Chunker for GelfChunker {
         if bytes.len() > self.mtu {
             let chunk_size = self.mtu - GELF_CHUNK_HEADERS_LENGTH;
             let message_id: u64 = rand::random();
+            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
+
+            trace!(
+                message_id = message_id,
+                chunk_count = chunk_count,
+                chunk_size = chunk_size,
+                "Generating chunks for GELF."
+            );
+
+            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
+                return Err(vector_common::Error::from(format!(
+                    "Too many chunks to generate for GELF: {}, max: {}",
+                    chunk_count, GELF_MAX_TOTAL_CHUNKS
+                )));
+            }
 
             // Split into chunks and add headers to each slice.
             // Map with index to determine sequence number.
-            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
-            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
-                panic!("too many chunks!"); // todo: don't panic.
-            }
-
             let chunks = bytes
                 .chunks(chunk_size)
                 .enumerate()
                 .map(|(i, chunk)| {
                     let framed = bytes::Bytes::copy_from_slice(chunk);
-                    let magic_bytes = [0x1e, 0x0f];
                     let sequence_number = i as u8;
                     let sequence_count = chunk_count as u8;
 
                     let mut headers = bytes::BytesMut::with_capacity(GELF_CHUNK_HEADERS_LENGTH);
-                    headers.put_slice(&magic_bytes);
+                    headers.put_slice(&GELF_MAGIC_BYTES);
                     headers.put_u64(message_id);
                     headers.put_u8(sequence_number);
                     headers.put_u8(sequence_count);

--- a/lib/codecs/src/encoding/chunking/mod.rs
+++ b/lib/codecs/src/encoding/chunking/mod.rs
@@ -1,73 +1,14 @@
 //! A collection of formats that can be used to chunk events into multiple byte frames.
 
-use std::vec;
+mod gelf;
 
-use bytes::BufMut;
-use tracing::trace;
-
-const GELF_MAX_TOTAL_CHUNKS: usize = 128;
-const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
-const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
+use bytes::Bytes;
+pub use gelf::GelfChunker;
 
 /// For chunking.
 pub trait Chunking {
     /// Chunks the input into frames.
-    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error>;
-}
-
-/// Chunks with GELF native chunking format.
-/// Supports up to 128 chunks, each up to 8192 bytes (minus 12 bytes, for headers).
-#[derive(Clone, Debug)]
-pub struct GelfChunker {
-    /// Max chunk size.
-    pub max_chunk_size: usize,
-}
-
-impl Chunking for GelfChunker {
-    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
-        if bytes.len() > self.max_chunk_size {
-            let chunk_size = self.max_chunk_size - GELF_CHUNK_HEADERS_LENGTH;
-            let message_id: u64 = rand::random();
-            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
-
-            trace!(
-                message_id = message_id,
-                chunk_count = chunk_count,
-                chunk_size = chunk_size,
-                "Generating chunks for GELF."
-            );
-
-            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
-                return Err(vector_common::Error::from(format!(
-                    "Too many chunks to generate for GELF: {}, max: {}",
-                    chunk_count, GELF_MAX_TOTAL_CHUNKS
-                )));
-            }
-
-            // Split into chunks and add headers to each slice.
-            // Map with index to determine sequence number.
-            let chunks = bytes
-                .chunks(chunk_size)
-                .enumerate()
-                .map(|(i, chunk)| {
-                    let framed = bytes::Bytes::copy_from_slice(chunk);
-                    let sequence_number = i as u8;
-                    let sequence_count = chunk_count as u8;
-
-                    let mut headers = bytes::BytesMut::with_capacity(GELF_CHUNK_HEADERS_LENGTH);
-                    headers.put_slice(&GELF_MAGIC_BYTES);
-                    headers.put_u64(message_id);
-                    headers.put_u8(sequence_number);
-                    headers.put_u8(sequence_count);
-
-                    [headers.freeze(), framed].concat().into()
-                })
-                .collect();
-            Ok(chunks)
-        } else {
-            Ok(vec![bytes])
-        }
-    }
+    fn chunk(&self, bytes: Bytes) -> Result<Vec<Bytes>, vector_common::Error>;
 }
 
 /// Chunking implementations.
@@ -78,59 +19,9 @@ pub enum Chunker {
 }
 
 impl Chunking for Chunker {
-    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
+    fn chunk(&self, bytes: Bytes) -> Result<Vec<Bytes>, vector_common::Error> {
         match self {
             Chunker::Gelf(chunker) => chunker.chunk(bytes),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::encoding::{
-        Chunking, GelfChunker,
-        chunking::{GELF_CHUNK_HEADERS_LENGTH, GELF_MAGIC_BYTES},
-    };
-
-    #[test]
-    fn test_gelf_chunker_noop() {
-        let chunker = GelfChunker {
-            max_chunk_size: 8192,
-        };
-        let input = bytes::Bytes::from("1234123412341234123");
-        let chunks = chunker.chunk(input.clone()).unwrap();
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0], input);
-    }
-
-    #[test]
-    fn test_gelf_chunker_chunk() {
-        let chunker = GelfChunker {
-            max_chunk_size: GELF_CHUNK_HEADERS_LENGTH + 4,
-        };
-        let input = bytes::Bytes::from("1234123412341234123");
-        let chunks = chunker.chunk(input).unwrap();
-        assert_eq!(chunks.len(), 5);
-
-        for i in 0..chunks.len() {
-            if i < 4 {
-                assert_eq!(chunks[i].len(), GELF_CHUNK_HEADERS_LENGTH + 4);
-            } else {
-                assert_eq!(chunks[i].len(), GELF_CHUNK_HEADERS_LENGTH + 3);
-            }
-            // Bytes 0 and 1: Magic bytes
-            assert_eq!(chunks[i][0..2], GELF_MAGIC_BYTES);
-            // Bytes 2 to 9: Random ID (not checked)
-            // Byte 10: Sequence number
-            assert_eq!(chunks[i][10], i as u8);
-            // Byte 11: Sequence count
-            assert_eq!(chunks[i][11], chunks.len() as u8);
-            // Payload bytes
-            if i < 4 {
-                assert_eq!(&chunks[i][GELF_CHUNK_HEADERS_LENGTH..], b"1234");
-            } else {
-                assert_eq!(&chunks[i][GELF_CHUNK_HEADERS_LENGTH..], b"123");
-            }
         }
     }
 }

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -21,18 +21,18 @@ pub struct GelfSerializerOptions {
     /// Note, the first 12 bytes are reserved for the GELF header, and are included in this limit.
     /// This value is also the threshold where datagrams will start being chunked.
     #[configurable(validation(range(min = 13, max = 65535)))]
-    #[serde(default = "max_chunk_size")]
+    #[serde(default = "default_max_chunk_size")]
     pub max_chunk_size: usize,
 }
 
-const fn max_chunk_size() -> usize {
+const fn default_max_chunk_size() -> usize {
     8192
 }
 
 impl Default for GelfSerializerOptions {
     fn default() -> Self {
         Self {
-            max_chunk_size: max_chunk_size(),
+            max_chunk_size: default_max_chunk_size(),
         }
     }
 }

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -17,10 +17,10 @@ use vector_core::{
 #[configurable_component]
 #[derive(Debug, Clone)]
 pub struct GelfSerializerOptions {
-    /// When chunking is used on sinks that require it (such as `udp`), sets the maximum size of individual chunk packets.
-    /// Note, the first 12 bytes are reserved for the GELF header, and are included in this limit.
-    /// This value is also the threshold where datagrams will start being chunked.
-    #[configurable(validation(range(min = 13, max = 65535)))]
+    /// Maximum size for each GELF chunked datagram (including 12-byte header).
+    /// Chunking starts when datagrams exceed this size.
+    /// For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+    #[configurable(validation(range(min = 13)))]
     #[serde(default = "default_max_chunk_size")]
     pub max_chunk_size: usize,
 }

--- a/lib/codecs/src/encoding/format/gelf.rs
+++ b/lib/codecs/src/encoding/format/gelf.rs
@@ -1,4 +1,4 @@
-use crate::encoding::GelfChunker;
+use crate::encoding::Chunker;
 use crate::gelf::GELF_TARGET_PATHS;
 use crate::{VALID_FIELD_REGEX, gelf_fields::*};
 use bytes::{BufMut, BytesMut};
@@ -12,6 +12,14 @@ use vector_core::{
     schema,
 };
 use vector_config_macros::configurable_component;
+
+use std::vec;
+
+use tracing::trace;
+
+const GELF_MAX_TOTAL_CHUNKS: usize = 128;
+const GELF_CHUNK_HEADERS_LENGTH: usize = 12;
+const GELF_MAGIC_BYTES: [u8; 2] = [0x1e, 0x0f];
 
 /// Config used to build a `GelfSerializer`.
 #[configurable_component]
@@ -135,6 +143,61 @@ impl Encoder<Event> for GelfSerializer {
         let writer = buffer.writer();
         serde_json::to_writer(writer, &log)?;
         Ok(())
+    }
+}
+
+/// Chunks with GELF native chunking format.
+/// Supports up to 128 chunks, each of a maximum configurable size.
+#[derive(Clone, Debug)]
+pub struct GelfChunker {
+    /// Max chunk size.
+    pub max_chunk_size: usize,
+}
+
+impl Chunker for GelfChunker {
+    fn chunk(&self, bytes: bytes::Bytes) -> Result<Vec<bytes::Bytes>, vector_common::Error> {
+        if bytes.len() > self.max_chunk_size {
+            let chunk_size = self.max_chunk_size - GELF_CHUNK_HEADERS_LENGTH;
+            let message_id: u64 = rand::random();
+            let chunk_count = (bytes.len() + chunk_size - 1) / chunk_size;
+
+            trace!(
+                message_id = message_id,
+                chunk_count = chunk_count,
+                chunk_size = chunk_size,
+                "Generating chunks for GELF."
+            );
+
+            if chunk_count > GELF_MAX_TOTAL_CHUNKS {
+                return Err(vector_common::Error::from(format!(
+                    "Too many chunks to generate for GELF: {}, max: {}",
+                    chunk_count, GELF_MAX_TOTAL_CHUNKS
+                )));
+            }
+
+            // Split into chunks and add headers to each slice.
+            // Map with index to determine sequence number.
+            let chunks = bytes
+                .chunks(chunk_size)
+                .enumerate()
+                .map(|(i, chunk)| {
+                    let framed = bytes::Bytes::copy_from_slice(chunk);
+                    let sequence_number = i as u8;
+                    let sequence_count = chunk_count as u8;
+
+                    let mut headers = bytes::BytesMut::with_capacity(GELF_CHUNK_HEADERS_LENGTH);
+                    headers.put_slice(&GELF_MAGIC_BYTES);
+                    headers.put_u64(message_id);
+                    headers.put_u8(sequence_number);
+                    headers.put_u8(sequence_count);
+
+                    [headers.freeze(), framed].concat().into()
+                })
+                .collect();
+            Ok(chunks)
+        } else {
+            Ok(vec![bytes])
+        }
     }
 }
 

--- a/lib/codecs/src/encoding/format/mod.rs
+++ b/lib/codecs/src/encoding/format/mod.rs
@@ -22,7 +22,7 @@ pub use self::csv::{CsvSerializer, CsvSerializerConfig};
 pub use avro::{AvroSerializer, AvroSerializerConfig, AvroSerializerOptions};
 pub use cef::{CefSerializer, CefSerializerConfig};
 use dyn_clone::DynClone;
-pub use gelf::{GelfChunker, GelfSerializer, GelfSerializerConfig};
+pub use gelf::{GelfSerializer, GelfSerializerConfig};
 pub use json::{JsonSerializer, JsonSerializerConfig, JsonSerializerOptions};
 pub use logfmt::{LogfmtSerializer, LogfmtSerializerConfig};
 pub use native::{NativeSerializer, NativeSerializerConfig};

--- a/lib/codecs/src/encoding/format/mod.rs
+++ b/lib/codecs/src/encoding/format/mod.rs
@@ -22,7 +22,7 @@ pub use self::csv::{CsvSerializer, CsvSerializerConfig};
 pub use avro::{AvroSerializer, AvroSerializerConfig, AvroSerializerOptions};
 pub use cef::{CefSerializer, CefSerializerConfig};
 use dyn_clone::DynClone;
-pub use gelf::{GelfSerializer, GelfSerializerConfig};
+pub use gelf::{GelfChunker, GelfSerializer, GelfSerializerConfig};
 pub use json::{JsonSerializer, JsonSerializerConfig, JsonSerializerOptions};
 pub use logfmt::{LogfmtSerializer, LogfmtSerializerConfig};
 pub use native::{NativeSerializer, NativeSerializerConfig};

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -521,6 +521,14 @@ impl Serializer {
             }
         }
     }
+
+    /// Returns the chunking implementation for the serializer.
+    pub fn chunker(&self) -> Chunkers {
+        match self {
+            Serializer::Gelf(gelf) => Chunkers::Gelf(gelf.chunker()),
+            _ => Chunkers::Noop,
+        }
+    }
 }
 
 impl From<AvroSerializer> for Serializer {

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -8,10 +8,10 @@ pub mod framing;
 use std::fmt::Debug;
 
 use bytes::BytesMut;
-pub use chunking::{Chunker, Chunkers};
+pub use chunking::{Chunker, Chunkers, GelfChunker};
 pub use format::{
     AvroSerializer, AvroSerializerConfig, AvroSerializerOptions, CefSerializer,
-    CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfChunker, GelfSerializer, GelfSerializerConfig,
+    CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfSerializer, GelfSerializerConfig,
     JsonSerializer, JsonSerializerConfig, JsonSerializerOptions, LogfmtSerializer,
     LogfmtSerializerConfig, NativeJsonSerializer, NativeJsonSerializerConfig, NativeSerializer,
     NativeSerializerConfig, ProtobufSerializer, ProtobufSerializerConfig,

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -1,12 +1,14 @@
 //! A collection of support structures that are used in the process of encoding
 //! events into bytes.
 
+pub mod chunking;
 pub mod format;
 pub mod framing;
 
 use std::fmt::Debug;
 
 use bytes::BytesMut;
+pub use chunking::*;
 pub use format::{
     AvroSerializer, AvroSerializerConfig, AvroSerializerOptions, CefSerializer,
     CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfSerializer, GelfSerializerConfig,

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -8,10 +8,10 @@ pub mod framing;
 use std::fmt::Debug;
 
 use bytes::BytesMut;
-pub use chunking::{Chunker, Chunkers, GelfChunker};
+pub use chunking::{Chunker, Chunkers};
 pub use format::{
     AvroSerializer, AvroSerializerConfig, AvroSerializerOptions, CefSerializer,
-    CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfSerializer, GelfSerializerConfig,
+    CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfChunker, GelfSerializer, GelfSerializerConfig,
     JsonSerializer, JsonSerializerConfig, JsonSerializerOptions, LogfmtSerializer,
     LogfmtSerializerConfig, NativeJsonSerializer, NativeJsonSerializerConfig, NativeSerializer,
     NativeSerializerConfig, ProtobufSerializer, ProtobufSerializerConfig,

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -8,7 +8,7 @@ pub mod framing;
 use std::fmt::Debug;
 
 use bytes::BytesMut;
-pub use chunking::{Chunker, Chunkers, GelfChunker};
+pub use chunking::{Chunker, Chunking, GelfChunker};
 pub use format::{
     AvroSerializer, AvroSerializerConfig, AvroSerializerOptions, CefSerializer,
     CefSerializerConfig, CsvSerializer, CsvSerializerConfig, GelfSerializer, GelfSerializerConfig,
@@ -522,11 +522,11 @@ impl Serializer {
         }
     }
 
-    /// Returns the chunking implementation for the serializer.
-    pub fn chunker(&self) -> Chunkers {
+    /// Returns the chunking implementation for the serializer, if any is supported.
+    pub fn chunker(&self) -> Option<Chunker> {
         match self {
-            Serializer::Gelf(gelf) => Chunkers::Gelf(gelf.chunker()),
-            _ => Chunkers::Noop,
+            Serializer::Gelf(gelf) => Some(Chunker::Gelf(gelf.chunker())),
+            _ => None,
         }
     }
 }

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -167,7 +167,7 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         DeserializerConfig::Syslog { .. } => SerializerConfig::Logfmt,
         DeserializerConfig::Native => SerializerConfig::Native,
         DeserializerConfig::NativeJson { .. } => SerializerConfig::NativeJson,
-        DeserializerConfig::Gelf { .. } => SerializerConfig::Gelf,
+        DeserializerConfig::Gelf { .. } => SerializerConfig::Gelf(Default::default()),
         DeserializerConfig::Avro { avro } => SerializerConfig::Avro { avro: avro.into() },
         // TODO: Influxdb has no serializer yet
         DeserializerConfig::Influxdb { .. } => todo!(),
@@ -219,7 +219,7 @@ fn serializer_config_to_deserializer(
         SerializerConfig::Avro { .. } => todo!(),
         SerializerConfig::Cef { .. } => todo!(),
         SerializerConfig::Csv { .. } => todo!(),
-        SerializerConfig::Gelf => DeserializerConfig::Gelf(Default::default()),
+        SerializerConfig::Gelf { .. } => DeserializerConfig::Gelf(Default::default()),
         SerializerConfig::Json(_) => DeserializerConfig::Json(Default::default()),
         SerializerConfig::Logfmt => todo!(),
         SerializerConfig::Native => DeserializerConfig::Native,

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -1,6 +1,6 @@
 use vector_lib::codecs::{
     TextSerializerConfig,
-    encoding::{Framer, FramingConfig, Chunkers, GelfChunker, NoopChunker, SerializerConfig},
+    encoding::{Framer, FramingConfig, Chunkers, GelfChunker, SerializerConfig},
 };
 use vector_lib::configurable::configurable_component;
 
@@ -148,8 +148,8 @@ impl SinkConfig for SocketSinkConfig {
                 let serializer = encoding.build()?;
                 let encoder = Encoder::<()>::new(serializer);
                 let chunker = match encoding.config() {
-                    SerializerConfig::Gelf => Chunkers::Gelf(GelfChunker::default()),
-                    _ => Chunkers::Noop(NoopChunker::default()),
+                    SerializerConfig::Gelf(config) => Chunkers::Gelf(GelfChunker { max_chunk_size: config.gelf.max_chunk_size }),
+                    _ => Chunkers::default(),
                 };
                 config.build(transformer, encoder, chunker)
             }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -1,6 +1,6 @@
 use vector_lib::codecs::{
     TextSerializerConfig,
-    encoding::{Framer, FramingConfig, Chunkers, GelfChunker, SerializerConfig},
+    encoding::{Framer, FramingConfig},
 };
 use vector_lib::configurable::configurable_component;
 
@@ -146,11 +146,8 @@ impl SinkConfig for SocketSinkConfig {
             Mode::Udp(UdpMode { config, encoding }) => {
                 let transformer = encoding.transformer();
                 let serializer = encoding.build()?;
+                let chunker = serializer.chunker();
                 let encoder = Encoder::<()>::new(serializer);
-                let chunker = match encoding.config() {
-                    SerializerConfig::Gelf(config) => Chunkers::Gelf(GelfChunker { max_chunk_size: config.gelf.max_chunk_size }),
-                    _ => Chunkers::default(),
-                };
                 config.build(transformer, encoder, chunker)
             }
             #[cfg(unix)]

--- a/src/sinks/util/datagram.rs
+++ b/src/sinks/util/datagram.rs
@@ -9,7 +9,7 @@ use tokio::net::UdpSocket;
 use tokio::net::UnixDatagram;
 use tokio_util::codec::Encoder;
 use vector_lib::EstimatedJsonEncodedSizeOf;
-use vector_lib::codecs::encoding::Chunker;
+use vector_lib::codecs::encoding::{Chunker, Chunkers};
 use vector_lib::internal_event::RegisterInternalEvent;
 use vector_lib::internal_event::{ByteSize, BytesSent, InternalEventHandle};
 
@@ -33,13 +33,12 @@ pub enum DatagramSocket {
 
 pub async fn send_datagrams<
     E: Encoder<Event, Error = vector_lib::codecs::encoding::Error>,
-    C: Chunker,
 >(
     input: &mut Peekable<BoxStream<'_, Event>>,
     mut socket: DatagramSocket,
     transformer: &Transformer,
     encoder: &mut E,
-    chunker: &C,
+    chunker: &Chunkers,
     bytes_sent: &<BytesSent as RegisterInternalEvent>::Handle,
 ) {
     while let Some(mut event) = input.next().await {

--- a/src/sinks/util/datagram.rs
+++ b/src/sinks/util/datagram.rs
@@ -31,9 +31,7 @@ pub enum DatagramSocket {
     Unix(UnixDatagram, PathBuf),
 }
 
-pub async fn send_datagrams<
-    E: Encoder<Event, Error = vector_lib::codecs::encoding::Error>,
->(
+pub async fn send_datagrams<E: Encoder<Event, Error = vector_lib::codecs::encoding::Error>>(
     input: &mut Peekable<BoxStream<'_, Event>>,
     mut socket: DatagramSocket,
     transformer: &Transformer,

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -179,7 +179,12 @@ impl<E> UdpSink<E>
 where
     E: Encoder<Event, Error = vector_lib::codecs::encoding::Error> + Clone + Send + Sync,
 {
-    fn new(connector: UdpConnector, transformer: Transformer, encoder: E, chunker: Chunkers) -> Self {
+    fn new(
+        connector: UdpConnector,
+        transformer: Transformer,
+        encoder: E,
+        chunker: Chunkers,
+    ) -> Self {
         Self {
             connector,
             transformer,

--- a/src/sinks/util/udp.rs
+++ b/src/sinks/util/udp.rs
@@ -11,7 +11,7 @@ use tokio::{net::UdpSocket, time::sleep};
 use tokio_util::codec::Encoder;
 use vector_lib::configurable::configurable_component;
 use vector_lib::{
-    codecs::encoding::Chunkers,
+    codecs::encoding::Chunker,
     internal_event::{BytesSent, Protocol, Registered},
 };
 
@@ -85,7 +85,7 @@ impl UdpSinkConfig {
         + Send
         + Sync
         + 'static,
-        chunker: Chunkers,
+        chunker: Option<Chunker>,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
         let connector = self.build_connector()?;
         let sink = UdpSink::new(connector.clone(), transformer, encoder, chunker);
@@ -171,7 +171,7 @@ where
     connector: UdpConnector,
     transformer: Transformer,
     encoder: E,
-    chunker: Chunkers,
+    chunker: Option<Chunker>,
     bytes_sent: Registered<BytesSent>,
 }
 
@@ -183,7 +183,7 @@ where
         connector: UdpConnector,
         transformer: Transformer,
         encoder: E,
-        chunker: Chunkers,
+        chunker: Option<Chunker>,
     ) -> Self {
         Self {
             connector,

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -16,7 +16,7 @@ use tokio::{
     time::sleep,
 };
 use tokio_util::codec::Encoder;
-use vector_lib::codecs::encoding::NoopChunker;
+use vector_lib::codecs::encoding::Chunkers;
 use vector_lib::json_size::JsonSize;
 use vector_lib::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 use vector_lib::{
@@ -267,7 +267,6 @@ where
         let mut input = input.peekable();
 
         let mut encoder = self.encoder.clone();
-        let chunker = NoopChunker::default();
         while Pin::new(&mut input).peek().await.is_some() {
             let socket = match self.connector.connect_backoff().await {
                 UnixEither::Datagram(datagram) => datagram,
@@ -281,7 +280,7 @@ where
                 DatagramSocket::Unix(socket, self.connector.path.clone()),
                 &self.transformer,
                 &mut encoder,
-                &chunker,
+                &Chunkers::Noop,
                 &bytes_sent,
             )
             .await;

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -16,7 +16,7 @@ use tokio::{
     time::sleep,
 };
 use tokio_util::codec::Encoder;
-use vector_lib::codecs::encoding::GelfChunker;
+use vector_lib::codecs::encoding::NoopChunker;
 use vector_lib::json_size::JsonSize;
 use vector_lib::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 use vector_lib::{
@@ -267,7 +267,7 @@ where
         let mut input = input.peekable();
 
         let mut encoder = self.encoder.clone();
-        let chunker = GelfChunker::default();
+        let chunker = NoopChunker::default();
         while Pin::new(&mut input).peek().await.is_some() {
             let socket = match self.connector.connect_backoff().await {
                 UnixEither::Datagram(datagram) => datagram,

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -16,6 +16,7 @@ use tokio::{
     time::sleep,
 };
 use tokio_util::codec::Encoder;
+use vector_lib::codecs::encoding::GelfChunker;
 use vector_lib::json_size::JsonSize;
 use vector_lib::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 use vector_lib::{
@@ -266,6 +267,7 @@ where
         let mut input = input.peekable();
 
         let mut encoder = self.encoder.clone();
+        let chunker = GelfChunker::default();
         while Pin::new(&mut input).peek().await.is_some() {
             let socket = match self.connector.connect_backoff().await {
                 UnixEither::Datagram(datagram) => datagram,
@@ -279,6 +281,7 @@ where
                 DatagramSocket::Unix(socket, self.connector.path.clone()),
                 &self.transformer,
                 &mut encoder,
+                &chunker,
                 &bytes_sent,
             )
             .await;

--- a/src/sinks/util/unix.rs
+++ b/src/sinks/util/unix.rs
@@ -16,7 +16,6 @@ use tokio::{
     time::sleep,
 };
 use tokio_util::codec::Encoder;
-use vector_lib::codecs::encoding::Chunkers;
 use vector_lib::json_size::JsonSize;
 use vector_lib::{ByteSizeOf, EstimatedJsonEncodedSizeOf};
 use vector_lib::{
@@ -280,7 +279,7 @@ where
                 DatagramSocket::Unix(socket, self.connector.path.clone()),
                 &self.transformer,
                 &mut encoder,
-                &Chunkers::Noop,
+                &None,
                 &bytes_sent,
             )
             .await;

--- a/website/cue/reference/components/sinks/generated/amqp.cue
+++ b/website/cue/reference/components/sinks/generated/amqp.cue
@@ -318,6 +318,20 @@ generated: components: sinks: amqp: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
@@ -514,6 +514,20 @@ generated: components: sinks: aws_cloudwatch_logs: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/generated/aws_kinesis_firehose.cue
@@ -493,6 +493,20 @@ generated: components: sinks: aws_kinesis_firehose: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/generated/aws_kinesis_streams.cue
@@ -493,6 +493,20 @@ generated: components: sinks: aws_kinesis_streams: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -602,6 +602,20 @@ generated: components: sinks: aws_s3: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/aws_sns.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sns.cue
@@ -424,6 +424,20 @@ generated: components: sinks: aws_sns: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sqs.cue
@@ -424,6 +424,20 @@ generated: components: sinks: aws_sqs: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/azure_blob.cue
+++ b/website/cue/reference/components/sinks/generated/azure_blob.cue
@@ -450,6 +450,20 @@ generated: components: sinks: azure_blob: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/console.cue
+++ b/website/cue/reference/components/sinks/generated/console.cue
@@ -302,6 +302,20 @@ generated: components: sinks: console: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -322,6 +322,20 @@ generated: components: sinks: file: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
@@ -390,6 +390,20 @@ generated: components: sinks: gcp_chronicle_unstructured: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
@@ -463,6 +463,20 @@ generated: components: sinks: gcp_cloud_storage: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_pubsub.cue
@@ -369,6 +369,20 @@ generated: components: sinks: gcp_pubsub: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/http.cue
+++ b/website/cue/reference/components/sinks/generated/http.cue
@@ -545,6 +545,20 @@ generated: components: sinks: http: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/humio_logs.cue
+++ b/website/cue/reference/components/sinks/generated/humio_logs.cue
@@ -368,6 +368,20 @@ generated: components: sinks: humio_logs: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/kafka.cue
+++ b/website/cue/reference/components/sinks/generated/kafka.cue
@@ -357,6 +357,20 @@ generated: components: sinks: kafka: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/loki.cue
+++ b/website/cue/reference/components/sinks/generated/loki.cue
@@ -547,6 +547,20 @@ generated: components: sinks: loki: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/mqtt.cue
+++ b/website/cue/reference/components/sinks/generated/mqtt.cue
@@ -312,6 +312,20 @@ generated: components: sinks: mqtt: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/nats.cue
+++ b/website/cue/reference/components/sinks/generated/nats.cue
@@ -402,6 +402,20 @@ generated: components: sinks: nats: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/generated/opentelemetry.cue
@@ -548,6 +548,20 @@ generated: components: sinks: opentelemetry: configuration: protocol: {
 					required:    false
 					type: array: items: type: string: {}
 				}
+				gelf: {
+					description:   "The GELF Serializer Options."
+					relevant_when: "codec = \"gelf\""
+					required:      false
+					type: object: options: max_chunk_size: {
+						description: """
+																				Maximum size for each GELF chunked datagram (including 12-byte header).
+																				Chunking starts when datagrams exceed this size.
+																				For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+																				"""
+						required: false
+						type: uint: default: 8192
+					}
+				}
 				json: {
 					description:   "Options for the JsonSerializer."
 					relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/papertrail.cue
+++ b/website/cue/reference/components/sinks/generated/papertrail.cue
@@ -302,6 +302,20 @@ generated: components: sinks: papertrail: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/pulsar.cue
+++ b/website/cue/reference/components/sinks/generated/pulsar.cue
@@ -436,6 +436,20 @@ generated: components: sinks: pulsar: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/redis.cue
+++ b/website/cue/reference/components/sinks/generated/redis.cue
@@ -361,6 +361,20 @@ generated: components: sinks: redis: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/socket.cue
+++ b/website/cue/reference/components/sinks/generated/socket.cue
@@ -314,6 +314,20 @@ generated: components: sinks: socket: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
@@ -418,6 +418,20 @@ generated: components: sinks: splunk_hec_logs: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/webhdfs.cue
+++ b/website/cue/reference/components/sinks/generated/webhdfs.cue
@@ -368,6 +368,20 @@ generated: components: sinks: webhdfs: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/websocket.cue
+++ b/website/cue/reference/components/sinks/generated/websocket.cue
@@ -474,6 +474,20 @@ generated: components: sinks: websocket: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -358,6 +358,20 @@ generated: components: sinks: websocket_server: configuration: {
 				required:    false
 				type: array: items: type: string: {}
 			}
+			gelf: {
+				description:   "The GELF Serializer Options."
+				relevant_when: "codec = \"gelf\""
+				required:      false
+				type: object: options: max_chunk_size: {
+					description: """
+						Maximum size for each GELF chunked datagram (including 12-byte header).
+						Chunking starts when datagrams exceed this size.
+						For Graylog target, keep at or below 8192 bytes; for Vector target (`gelf` decoding with `chunked_gelf` framing), up to 65,500 bytes is recommended.
+						"""
+					required: false
+					type: uint: default: 8192
+				}
+			}
 			json: {
 				description:   "Options for the JsonSerializer."
 				relevant_when: "codec = \"json\""


### PR DESCRIPTION
## Summary

Implements the GELF [Chunking specification](https://go2docs.graylog.org/current/getting_in_log_data/gelf.html#chunking) when the `gelf` codec is used with the `socket` sink in `udp` mode. This increases the possible message size from 8KiB to 1MiB to Graylog UDP server, and up to 8MiB when used to bridge to another Vector instance over UDP.

### Implementation notes

- The new `Chunking` trait can be used to implement any chunking method. It requires the contract `chunk(Bytes) -> Vec<Bytes>`
- Passing a `Chunking` implementation (`Chunker`) to the UDP sink is optional, as to skip a `Vec` heap allocation when chunking is not needed, with the goal of maintaining performance for all other codecs that do not use chunking.
- `Chunking` is only ever called for the `socket` sink in UDP mode, but this could later be supported by any other sink that could benefit from it.

## Vector configuration

Client side Vector (sink):

```yaml
sources:
  in:
    type: http_server
    address: 0.0.0.0:8000
    codec: json

transforms:
  remap:
    type: remap
    inputs:
      - in
    source: .host = "vector"

sinks:
  sink_socket:
    type: socket
    inputs:
      - remap
    mode: udp
    address: 127.0.0.1:7008
    encoding:
      codec: gelf
      gelf:
        max_chunk_size: 65507  # localhost limit
```

Server side Vector (source):

```yaml
sources:
  in_udp:
    type: socket
    mode: udp
    address: 127.0.0.1:7008
    decoding:
      codec: gelf
    framing:
      method: chunked_gelf

sinks:
  sink_console:
    type: console
    inputs:
      - in_udp
    encoding:
      codec: json
```

## How did you test this PR?

Tested using the configs above, Vector-to-Vector. Confirmed that data sent through the "client" Vector (gelf sink) is replicated on the "server" side Vector (gelf source).

My main motivation for implementing this feature is to support Vector-to-Vector event bridging over UDP, for events larger than 64KiB.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: https://github.com/vectordotdev/vector/issues/13292
- Related: https://github.com/vectordotdev/vector/pull/20859
- Specification: https://go2docs.graylog.org/current/getting_in_log_data/gelf.html#chunking
