### PR TITLE
ci: skip integration and e2e workflows via label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ env:
 jobs:
 
   changes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci: assume ec')
     uses: ./.github/workflows/changes.yml
     with:
       source: false
@@ -60,7 +60,7 @@ jobs:
       needs.changes.outputs.e2e-datadog-logs == 'true' ||
       needs.changes.outputs.e2e-datadog-metrics == 'true' ||
       needs.changes.outputs.e2e-opentelemetry-logs == 'true'
-      )
+      ) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: assume ec'))
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -74,8 +74,9 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_APP_DATADOG_VECTOR_CI_APP_ID: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
+          ASSUME_EC: ${{ contains(github.event.pull_request.labels.*.name, 'ci: assume ec') }}
         run: |
-          if [[ "$GH_APP_DATADOG_VECTOR_CI_APP_ID" != "" ]] ; then
+          if [[ "$GH_APP_DATADOG_VECTOR_CI_APP_ID" != "" && "$ASSUME_EC" != "true" ]] ; then
             echo "PR_HAS_ACCESS_TO_SECRETS=true" >> "$GITHUB_ENV"
           else
             echo "PR_HAS_ACCESS_TO_SECRETS=false" >> "$GITHUB_ENV"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   changes:
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci: assume ec')) || github.event_name == 'merge_group'
     uses: ./.github/workflows/changes.yml
     with:
       source: true
@@ -53,8 +53,9 @@ jobs:
         id: secret_check
         env:
           GH_APP_DATADOG_VECTOR_CI_APP_ID: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
+          ASSUME_EC: ${{ contains(github.event.pull_request.labels.*.name, 'ci: assume ec') }}
         run: |
-          if [[ "$GH_APP_DATADOG_VECTOR_CI_APP_ID" != "" ]]; then
+          if [[ "$GH_APP_DATADOG_VECTOR_CI_APP_ID" != "" && "$ASSUME_EC" != "true" ]]; then
             echo "can_access_secrets=true" >> $GITHUB_OUTPUT
           else
             echo "can_access_secrets=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -51,7 +51,7 @@ env:
 jobs:
   changes:
     # Only evaluate files changed on pull request trigger
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci: assume ec')) || github.event_name == 'merge_group' }}
     uses: ./.github/workflows/changes.yml
     secrets: inherit
 
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 45
     needs: changes
     # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: assume ec')) }}
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
@@ -125,7 +125,7 @@ jobs:
     timeout-minutes: 5
     needs: changes
     # Run this job even if `changes` job is skipped
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: assume ec')) }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -182,7 +182,7 @@ jobs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
     # because `changes` job might be skipped
-    if: always() && needs.build-x86_64-unknown-linux-gnu.result == 'success' && needs.compute-k8s-test-plan.result == 'success'
+    if: always() && needs.build-x86_64-unknown-linux-gnu.result == 'success' && needs.compute-k8s-test-plan.result == 'success' && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: assume ec'))
     strategy:
       matrix: ${{ fromJson(needs.compute-k8s-test-plan.outputs.matrix) }}
       fail-fast: false
@@ -243,7 +243,7 @@ jobs:
       - build-x86_64-unknown-linux-gnu
       - compute-k8s-test-plan
       - test-e2e-kubernetes
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: assume ec'))
     env:
       FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
     steps:

--- a/changelog.d/ci_assume_ec_label.enhancement.md
+++ b/changelog.d/ci_assume_ec_label.enhancement.md
@@ -1,0 +1,3 @@
+Allow skipping integration and E2E workflows by applying the `ci: assume ec` label to pull requests.
+
+authors: openai


### PR DESCRIPTION
## Summary
- allow `ci: assume ec` label to skip integration and E2E test jobs
- document label usage in changelog

## Testing
- `./scripts/check_changelog_fragments.sh`
- `cargo fmt --all -- --check` *(fails: could not download rust toolchain)*
- `cargo check -p vector` *(fails: could not download rust toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_68b9ee3b95f4832d9e521a7aed7cf49c