### PR TITLE
fix(vdev): remove `components` filter component docs check

### DIFF
--- a/vdev/src/commands/check/component_docs.rs
+++ b/vdev/src/commands/check/component_docs.rs
@@ -12,6 +12,7 @@ impl Cli {
         let dirty_component_files: Vec<String> = files
             .into_iter()
             .filter(|file| file.starts_with("website/cue/reference"))
+            .filter(|file| file.contains("generated/"))
             .collect();
 
         // If it is not empty, there are out-of-sync component Cue files in the current branch.


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Some generated files live under reference/generated and were being skipped in this check

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

This should now correctly fail
```
echo >> website/cue/reference/generated/configuration.cue && make check-component-docs
```

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Related: #23737

<!--
- Closes: #<issue number>
- Related: #<issue number>
-->
