### PR TITLE
docs(vrl): Add vrl bitwise operators AND, OR and NOT documentation

### DIFF
--- a/website/cue/reference/remap/expressions/bitwise.cue
+++ b/website/cue/reference/remap/expressions/bitwise.cue
@@ -1,0 +1,58 @@
+package metadata
+
+remap: expressions: bitwise: {
+	title: "Bitwise"
+	description: """
+		A _bitwise_ expression performs an operation directly on the individual bits of integer operands.
+		"""
+	return: """
+		Returns the result of the expression as defined by the operator.
+		"""
+
+	grammar: {
+		source: """
+			expression ~ operator ~ expression
+			"""
+		definitions: {
+			expression: {
+				description: """
+					The `expression` can be any expression that returns an integer.
+					"""
+			}
+			operator: {
+				description: """
+					The `operator` defines the operation performed on the left-hand-side and right-hand-side operands.
+					"""
+				enum: {
+					"&":  "Bitwise AND. Operates on `int` type."
+					"^":  "Bitwise OR. Operates on `int` type."
+					"~":  "Bitwise NOT. Operates on `int` type."
+				}
+			}
+		}
+	}
+
+	examples: [
+		{
+			title: "AND"
+			source: #"""
+				1 & 5
+				"""#
+			return: 1
+		},
+		{
+			title: "OR"
+			source: #"""
+				1 ^ 4
+				"""#
+			return: 5
+		},
+		{
+			title: "NOT"
+			source: #"""
+				~5
+				"""#
+			return: -6
+		}
+	]
+}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Sibling PR for vectordotdev/vrl#1504 which aims to add AND, OR and NOT bitwise operators.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

See  vectordotdev/vrl#1504.
