### PR TITLE
fix(vrl playground): various fixes and enhancements

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -260,5 +260,7 @@ jobs:
             template website
             website
             website deps
-
+            
+            vrl playground
+            
             opentelemetry lib

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -260,7 +260,7 @@ jobs:
             template website
             website
             website deps
-            
+
             vrl playground
-            
+
             opentelemetry lib

--- a/lib/vector-vrl/web-playground/build.rs
+++ b/lib/vector-vrl/web-playground/build.rs
@@ -65,9 +65,13 @@ fn write_vrl_constants(lockfile: &Lockfile, output_file: &mut File) {
                     .precise()
                     .expect("git reference should have precise")
                     .to_string();
+
+                let mut url = vrl_source.url().to_string();
+                url = url.trim_end_matches(".git").trim_end_matches('/').to_string();
+
                 (
                     precise.clone(),
-                    Some(format!("{}/tree/{precise}", vrl_source.url())),
+                    Some(format!("{url}/tree/{precise}")),
                 )
             }
             SourceKind::Registry if vrl_source.is_default_registry() => {

--- a/lib/vector-vrl/web-playground/build.rs
+++ b/lib/vector-vrl/web-playground/build.rs
@@ -67,12 +67,12 @@ fn write_vrl_constants(lockfile: &Lockfile, output_file: &mut File) {
                     .to_string();
 
                 let mut url = vrl_source.url().to_string();
-                url = url.trim_end_matches(".git").trim_end_matches('/').to_string();
+                url = url
+                    .trim_end_matches(".git")
+                    .trim_end_matches('/')
+                    .to_string();
 
-                (
-                    precise.clone(),
-                    Some(format!("{url}/tree/{precise}")),
-                )
+                (precise.clone(), Some(format!("{url}/tree/{precise}")))
             }
             SourceKind::Registry if vrl_source.is_default_registry() => {
                 let version = vrl_dep.version.to_string();

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -1,5 +1,5 @@
-import init, { run_vrl, vrl_version, vrl_link, vector_version, vector_link } from "./pkg/vector_vrl_web_playground.js";
-import { vrlLanguageDefinition, vrlThemeDefinition } from "./vrl-highlighter.js";
+import init, {run_vrl, vector_link, vector_version, vrl_link, vrl_version} from "./pkg/vector_vrl_web_playground.js";
+import {vrlLanguageDefinition, vrlThemeDefinition} from "./vrl-highlighter.js";
 
 const PROGRAM_EDITOR_DEFAULT_VALUE = `# Remove some fields
 del(.foo)
@@ -26,176 +26,210 @@ const EVENT_EDITOR_DEFAULT_VALUE = `{
 
 const OUTPUT_EDITOR_DEFAULT_VALUE = `{}`;
 
-const ERROR_INVALID_JSONL_EVENT_MSG = `Error attempting to parse the following string into valid JSON\n
+const ERROR_INVALID_JSONL_EVENT_MSG = `Error attempting to parse the following string into valid JSON
+
 String: {{str}}
-\nEnsure that the Event editor contains valid JSON
-\nCommon mistakes:\n
-  Trailing Commas\n  Last line is a newline or whitespace\n  Unbalanced curly braces
-  If using JSONL (one log per line), ensure each line is valid JSON\n
-You can try validating your JSON here: https://jsonlint.com/ \n`;
+
+Ensure that the Event editor contains valid JSON
+
+Common mistakes:
+  Trailing Commas
+  Last line is a newline or whitespace
+  Unbalanced curly braces
+  If using JSONL (one log per line), ensure each line is valid JSON
+
+You can try validating your JSON here: https://jsonlint.com/
+`;
+
+function loadMonaco() {
+    return new Promise((resolve, reject) => {
+        // require is provided by loader.min.js.
+        require.config({
+            paths: {vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs"},
+        });
+        require(["vs/editor/editor.main"], () => resolve(window.monaco), reject);
+    });
+}
 
 export class VrlWebPlayground {
+    static async create() {
+        const instance = new VrlWebPlayground(true);
+        await instance._initAsync();
+        return instance;
+    }
 
-    constructor() {
-        let temp = init().then(() => {
-            this.run_vrl = run_vrl;
-            this.vector_version = vector_version();
-            this.vector_link = vector_link();
+    constructor(_internal = false) {
+        if (!_internal) {
+            // Prefer factory: VrlWebPlayground.create()
+            this._initAsync(); // fire-and-forget fallback
+        }
+    }
 
-            this.vrl_version = vrl_version();
-            this.vrl_link = vrl_link();
+    async _initAsync() {
+        // Load wasm/runtime
+        await init();
 
-            // require is provided by loader.min.js.
-            require.config({
-                paths: { vs: "https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs" },
-            });
-            // monaco and run_vrl will exist only inside this block
-            // due to http requests
-            // TODO: refactor function to be async and await on monaco and run_vrl
-            require(["vs/editor/editor.main"], () => {
-                this.monaco = monaco;
-                // set up vrl highlighting
-                this.monaco.languages.register( {id: 'vrl'} );
-                // Register a tokens provider for the language
-                this.monaco.editor.defineTheme('vrl-theme', vrlThemeDefinition);
-                this.monaco.languages.setMonarchTokensProvider('vrl', vrlLanguageDefinition);
-                this.eventEditor = this.createDefaultEditor("container-event", EVENT_EDITOR_DEFAULT_VALUE, "json", "vs-light");
-                this.outputEditor = this.createDefaultEditor("container-output", OUTPUT_EDITOR_DEFAULT_VALUE, "json", "vs-light");
-                this.programEditor = this.createDefaultEditor("container-program", PROGRAM_EDITOR_DEFAULT_VALUE, "vrl", "vrl-theme");
+        // Bind native funcs/versions
+        this.run_vrl = run_vrl;
+        this.vector_version = vector_version();
+        this.vector_link = vector_link();
+        this.vrl_version = vrl_version();
+        this.vrl_link = vrl_link();
 
+        // Load Monaco
+        this.monaco = await loadMonaco();
 
-                const queryString = window.location.search;
-                if (queryString.length != 0) {
-                    const urlParams = new URLSearchParams(queryString);
-                    const stateParam = decodeURIComponent(urlParams.get("state"));
+        // VRL lang + theme
+        this.monaco.languages.register({id: "vrl"});
+        this.monaco.editor.defineTheme("vrl-theme", vrlThemeDefinition);
+        this.monaco.languages.setMonarchTokensProvider("vrl", vrlLanguageDefinition);
 
-                    try {
-                        let urlState = JSON.parse(atob(stateParam));
+        // Editors
+        this.eventEditor = this.createDefaultEditor("container-event", EVENT_EDITOR_DEFAULT_VALUE, "json", "vs-light");
+        this.outputEditor = this.createDefaultEditor("container-output", OUTPUT_EDITOR_DEFAULT_VALUE, "json", "vs-light");
+        this.programEditor = this.createDefaultEditor("container-program", PROGRAM_EDITOR_DEFAULT_VALUE, "vrl", "vrl-theme");
 
-                        this.programEditor.setValue(urlState["program"]);
+        // Versions
+        this.addVersions();
 
-                        if (urlState["is_jsonl"] == true) {
-                            this.eventEditor.setValue(urlState["event"]);
-                        } else {
-                            this.eventEditor.setValue(JSON.stringify(urlState["event"], null, "\t"));
-                        }
+        // Handle shared state from URL (if present)
+        this._maybeLoadFromUrl();
+    }
 
-                        console.log("[DEBUG::queryStringLogic] Current Params:", JSON.parse(atob(stateParam)));
-                        let res = this.handleRunCode(JSON.parse(atob(stateParam)));
-                        console.log("[DEBUG::queryStringLogic] Running VRL with current Params:", res);
-                    } catch (e) {
-                        this.outputEditor.setValue(`Error reading the shared URL\n${e}`);
-                    }
-                }
+    _maybeLoadFromUrl() {
+        const qs = window.location.search;
+        if (!qs) return;
 
-                this.addVersions();
-            });
-        });
+        const urlParams = new URLSearchParams(qs);
+        const stateParam = urlParams.get("state");
+        if (!stateParam) return;
+
+        try {
+            const decoded = atob(decodeURIComponent(stateParam));
+            const urlState = JSON.parse(decoded);
+
+            if (typeof urlState.program === "string") {
+                this.programEditor.setValue(urlState.program);
+            }
+
+            if (urlState.is_jsonl === true && typeof urlState.event === "string") {
+                this.eventEditor.setValue(urlState.event);
+            } else if (urlState.event != null) {
+                this.eventEditor.setValue(JSON.stringify(urlState.event, null, "\t"));
+            }
+
+            // Run immediately with the provided state
+            const res = this.handleRunCode(urlState);
+            console.log("[DEBUG::queryStringLogic] Running VRL with current Params:", res);
+        } catch (e) {
+            this.disableJsonLinting();
+            this.outputEditor.setValue(`Error reading the shared URL\n${e}`);
+        }
     }
 
     addVersions() {
-        let vectorLinkElement = document.getElementById('vector-version-link');
-        vectorLinkElement.text = this.vector_version.substring(0, 8);
-        vectorLinkElement.href = this.vector_link;
+        const vectorLinkElement = document.getElementById("vector-version-link");
+        if (vectorLinkElement) {
+            vectorLinkElement.text = (this.vector_version || "").toString().substring(0, 8);
+            vectorLinkElement.href = this.vector_link || "#";
+        }
 
-        let vrlLinkElement = document.getElementById('vrl-version-link');
-        vrlLinkElement.text = this.vrl_version.substring(0, 8);
-        vrlLinkElement.href = this.vrl_link;
+        const vrlLinkElement = document.getElementById("vrl-version-link");
+        if (vrlLinkElement) {
+            vrlLinkElement.text = (this.vrl_version || "").toString().substring(0, 8);
+            vrlLinkElement.href = this.vrl_link || "#";
+        }
     }
 
     createDefaultEditor(elementId, value, language, theme) {
-        return this.monaco.editor.create(document.getElementById(elementId), {
-            value: value,
-            language: language,
-            theme: theme,
-            minimap: { enabled: false },
+        const el = document.getElementById(elementId);
+        if (!el) {
+            console.warn(`Editor container #${elementId} not found`);
+            return null;
+        }
+        return this.monaco.editor.create(el, {
+            value,
+            language,
+            theme,
+            minimap: {enabled: false},
             automaticLayout: true,
         });
+    }
+
+    _safeGet(editor, fallback = "") {
+        return editor?.getValue?.() ?? fallback;
     }
 
     getState() {
         if (this.eventEditorIsJsonl()) {
             return {
-                program: this.programEditor.getValue(),
+                program: this._safeGet(this.programEditor),
                 event: this.eventEditor.getModel().getLinesContent().join("\n"),
                 is_jsonl: true,
                 error: null,
             };
         }
 
-        const editorValue = this.eventEditor.getValue();
+        const editorValue = this._safeGet(this.eventEditor);
         try {
             return {
-                program: this.programEditor.getValue(),
-                event: JSON.parse((editorValue.length === 0) ? "{}" : editorValue),
+                program: this._safeGet(this.programEditor),
+                event: JSON.parse(editorValue.length === 0 ? "{}" : editorValue),
                 is_jsonl: false,
                 error: null,
             };
-        }
-        catch (error) {
-            console.error(error);
+        } catch (_err) {
             return {
-                program: this.programEditor.getValue(),
+                program: this._safeGet(this.programEditor),
                 event: null,
                 is_jsonl: false,
                 error: `Could not parse JSON event:\n${editorValue}`,
             };
         }
-        return state;
     }
 
     disableJsonLinting() {
-        this.monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-            validate: false
-        });
+        this.monaco.languages.json.jsonDefaults.setDiagnosticsOptions({validate: false});
     }
 
     enableJsonLinting() {
-        this.monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-            validate: true
-        });
+        this.monaco.languages.json.jsonDefaults.setDiagnosticsOptions({validate: true});
     }
 
     tryJsonParse(str) {
         try {
             return JSON.parse(str);
-        } catch (e) {
+        } catch (_e) {
             this.disableJsonLinting();
-            let err = ERROR_INVALID_JSONL_EVENT_MSG.toString().replace("{{str}}", str);
+            const err = ERROR_INVALID_JSONL_EVENT_MSG.toString().replace("{{str}}", str);
             this.outputEditor.setValue(err);
             throw new Error(err);
         }
     }
 
+    /**
+     * Treat as JSONL if there are >1 non-empty lines and at least the second non-empty
+     * line *appears* to be a JSON object. Robust to whitespace.
+     */
     eventEditorIsJsonl() {
-        if (this.eventEditor.getModel().getLineCount() > 1) {
-            let lines = this.eventEditor.getModel().getLinesContent();
+        const model = this.eventEditor?.getModel?.();
+        if (!model) return false;
 
-            // if the second line is a json object
-            // we assume the user is attempting to pass in JSONL
-            // in the event editor
-            if (lines[1][0] == "{" && lines[1][lines[1].length - 1] == "}") {
-                return true;
-            }
+        const rawLines = model.getLinesContent();
+        const lines = rawLines.map(l => l.trim()).filter(l => l.length > 0);
+        if (lines.length <= 1) return false;
 
-            return false;
-        }
+        const second = lines[1];
+        return second.startsWith("{") && second.endsWith("}");
     }
 
-    /**
-     *
-     * @param {object} input
-     *
-     * input param is optional
-     * input param is mainly used when we are parsing the
-     * url for state parameters (when a user shared their program)
-     *
-     * {
-     *     program: str,
-     *     event: object
-     * }
-     */
+    _getTimezoneOrDefault() {
+        const tzEl = document.getElementById("timezone-input");
+        return tzEl?.value && tzEl.value.trim().length > 0 ? tzEl.value.trim() : "Default";
+    }
+
     handleRunCode(input) {
+        // JSONL path short-circuit
         if (this.eventEditorIsJsonl()) {
             return this.handleRunCodeJsonl();
         }
@@ -203,75 +237,88 @@ export class VrlWebPlayground {
         if (input == null) {
             input = this.getState();
         }
+
         if (input.error) {
             this.disableJsonLinting();
             this.outputEditor.setValue(input.error);
             return input;
         }
 
-        const tz_input = document.getElementById('timezone-input');
-        // set default tz if nothing is set. this is going to use default timezone
-        let timezone = tz_input.value ? tz_input.value : (tz_input.value = "Default");
-        let res = this.run_vrl(input, timezone);
+        const timezone = this._getTimezoneOrDefault();
+        const res = this.run_vrl(input, timezone);
         console.log("[DEBUG::handleRunCode()] Printing out res: ", res);
-        if (res.result) {
+
+        if (res?.result != null) {
+            this.enableJsonLinting();
             this.outputEditor.setValue(JSON.stringify(res.result, null, "\t"));
-            if (res.elapsed_time !== null) {
-              document.getElementById("elapsed-time").textContent = `Duration: ${res.elapsed_time} milliseconds`;
-            }else {
-              document.getElementById("elapsed-time").textContent = "";
+
+            const elapsedEl = document.getElementById("elapsed-time");
+            if (elapsedEl) {
+                if (res.elapsed_time != null) {
+                    elapsedEl.textContent = `Duration: ${res.elapsed_time} milliseconds`;
+                } else {
+                    elapsedEl.textContent = "";
+                }
             }
-        } else if (res.msg) {
-            // disable json linting for error msgs
-            // since error msgs are not valid json
-            this.disableJsonLinting();
+        } else if (res?.msg) {
+            this.disableJsonLinting(); // errors are not JSON
             this.outputEditor.setValue(res.msg);
         }
+
         return res;
     }
 
     handleRunCodeJsonl() {
-        let inputs = [];
-        let program = this.programEditor.getValue();
-        let eventLines = this.eventEditor.getModel().getLinesContent();
+        const program = this._safeGet(this.programEditor);
+        const model = this.eventEditor?.getModel?.();
+        const rawLines = model ? model.getLinesContent() : [];
+        const lines = rawLines.map(l => l.trim()).filter(l => l.length > 0);
 
-        // each line in eventLines is a json object
-        // we will use the same program in the program editor
-        // and run it against each line
-        eventLines.forEach((line) => {
-            inputs.push({
-                program: program,
-                event: this.tryJsonParse(line)
-            })
-        });
+        const timezone = this._getTimezoneOrDefault();
 
-        let results = [];
-        inputs.forEach((input) => {
-            results.push(this.run_vrl(input));
-        })
+        // Build inputs while validating JSON per line
+        const inputs = lines.map(line => ({
+            program,
+            event: this.tryJsonParse(line),
+            is_jsonl: true,
+        }));
 
-        let outputs = [];
-        results.forEach((res) => {
-            if (res.output != null) {
-                outputs.push(JSON.stringify(res["result"], null, "\t"));
-            } else if (res.msg != null) {
-                outputs.push(res["msg"]);
+        // Run and collect results
+        const results = inputs.map(input => this.run_vrl(input, timezone));
+
+        const outputs = results.map(res => {
+            if (res?.result != null) {
+                return JSON.stringify(res.result, null, "\t");
+            } else if (res?.msg != null) {
+                return res.msg;
             }
+            return "Unknown result";
         });
+
+        // Output is not pure JSON (multiple objects / possible errors)
         this.disableJsonLinting();
         this.outputEditor.setValue(outputs.join("\n"));
+
         return results;
     }
 
     handleShareCode() {
-        let state = this.getState();
-        console.log("[DEBUG::handleShareCode()] Printing out state", state);
-        console.log(
-          "[DEBUG::handleShareCode()] Printing out base64 encoded state\n",
-          btoa(JSON.stringify(state))
-        );
-        window.history.pushState(state, "", `?state=${encodeURIComponent(btoa(JSON.stringify(state)))}`);
+        const state = this.getState();
+        try {
+            const encoded = encodeURIComponent(btoa(JSON.stringify(state)));
+            window.history.pushState(state, "", `?state=${encoded}`);
+            return true;
+        } catch (e) {
+            this.disableJsonLinting();
+            this.outputEditor.setValue(`Error encoding state for URL\n${e}`);
+            return false;
+    }
     }
 }
 
-window.vrlPlayground = new VrlWebPlayground();
+// Prefer the async factory to ensure everything is loaded before use:
+VrlWebPlayground.create().then(instance => {
+    window.vrlPlayground = instance;
+}).catch(err => {
+    console.error("Failed to initialize VrlWebPlayground:", err);
+});


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Mostly ChatGPT generated.

✅ Race conditions loading Monaco & wasm: wrapped in awaitable loaders.
✅ URL state parsing: guards against missing/invalid params.
✅ getState() bug: removed the stray return state; (undefined).
✅ JSONL detection/handling: more robust; trims/ignores blank lines; clearer errors.
✅ Result key mismatch: used res.result consistently (not res.output).
✅ Timezone element: don’t crash if #timezone-input is absent.
✅ Linting toggles: re-enable JSON linting after printing non-JSON errors.
✅ Version badges: don’t crash if the elements aren’t present.
✅ Safer defaults and small guardrails (e.g., lines[1] existence).

Also I fixed the broken VRL url link.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

```sh
 cd lib/vector-vrl/web-playground/
 wasm-pack -v  build --target web --out-dir public/pkg
 cd public && python3 -m http.server
```

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References


- Closes: #23754

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
