### PR TITLE
chore(splunk_hec source): Refactor to support custom extractors

### DIFF
--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -690,7 +690,7 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
     /// Default time
     time: Time,
     /// Remaining extracted default values
-    extractors: E,
+    extractor: E,
     /// Event finalization
     batch: Option<BatchNotifier>,
     /// Splunk HEC Token for passthrough
@@ -730,7 +730,7 @@ impl<'de, R: JsonRead<'de>, E: Extractor> From<EventIteratorGenerator<'de, R>>
             channel: f.channel.map(Value::from),
             time: Time::Now(Utc::now()),
             token: f.meta.token.clone().map(Into::into),
-            extractors: E::new(f.meta, f.log_namespace),
+            extractor: E::new(f.meta, f.log_namespace),
             batch: f.batch,
             log_namespace: f.log_namespace,
             events_received: f.events_received,
@@ -834,7 +834,7 @@ impl<'de, R: JsonRead<'de>, E: Extractor> EventIterator<'de, R, E> {
         );
 
         // Extract default extracted fields
-        self.extractors.extract(&mut log, &mut json);
+        self.extractor.extract(&mut log, &mut json);
 
         // Add passthrough token if present
         if let Some(token) = &self.token

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -989,20 +989,20 @@ fn parse_timestamp(t: i64) -> Option<DateTime<Utc>> {
 
 /// MetaExtractor is a helper struct that extracts a field from the request and adds it to the log event metadata.
 /// It maintains last known extracted value of field and uses it in the absence of field.
-struct MetaExtractor {
+struct FieldExtractor {
     field: &'static str,
     to_field: OptionalValuePath,
     value: Option<Value>,
     log_namespace: LogNamespace,
 }
 
-impl MetaExtractor {
+impl FieldExtractor {
     const fn new(
         field: &'static str,
         to_field: OptionalValuePath,
         log_namespace: LogNamespace,
     ) -> Self {
-        MetaExtractor {
+        Self {
             field,
             to_field,
             value: None,
@@ -1016,7 +1016,7 @@ impl MetaExtractor {
         value: impl Into<Option<Value>>,
         log_namespace: LogNamespace,
     ) -> Self {
-        MetaExtractor {
+        Self {
             field,
             to_field,
             value: value.into(),
@@ -1061,7 +1061,7 @@ pub trait Extractor {
 }
 
 pub struct DefaultExtractor {
-    extractors: [MetaExtractor; 4],
+    extractors: [FieldExtractor; 4],
 }
 
 impl Extractor for DefaultExtractor {
@@ -1072,7 +1072,7 @@ impl Extractor for DefaultExtractor {
                 // 1. The host field is present in the event payload
                 // 2. The x-forwarded-for header is present in the incoming request
                 // 3. Use the `remote`: SocketAddr value provided by warp
-                MetaExtractor::new_with(
+                FieldExtractor::new_with(
                     "host",
                     log_schema().host_key().cloned().into(),
                     meta.remote_addr
@@ -1080,9 +1080,9 @@ impl Extractor for DefaultExtractor {
                         .map(Value::from),
                     log_namespace,
                 ),
-                MetaExtractor::new("index", OptionalValuePath::new(INDEX), log_namespace),
-                MetaExtractor::new("source", OptionalValuePath::new(SOURCE), log_namespace),
-                MetaExtractor::new(
+                FieldExtractor::new("index", OptionalValuePath::new(INDEX), log_namespace),
+                FieldExtractor::new("source", OptionalValuePath::new(SOURCE), log_namespace),
+                FieldExtractor::new(
                     "sourcetype",
                     OptionalValuePath::new(SOURCETYPE),
                     log_namespace,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -704,9 +704,9 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
 }
 
 pub struct RequestMeta {
-    token: Option<String>,
-    remote: Option<SocketAddr>,
-    remote_addr: Option<String>,
+    pub token: Option<String>,
+    pub remote: Option<SocketAddr>,
+    pub remote_addr: Option<String>,
 }
 
 /// Intermediate struct to generate an `EventIterator`

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -706,6 +706,7 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
     store_hec_token: bool,
 }
 
+#[derive(Debug, Clone)]
 pub struct RequestMeta {
     pub token: Option<String>,
     pub remote: Option<SocketAddr>,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR modifies the internal Splunk HEC source so that it can be extended with a custom set of extractors. It does not change the config or the behavior of the default implementation of the source.

## Detailed explanation
- a trait `Extractor` was created and added as a generic parameter to `SplunkSource`
- the array of `DefaultExtractor`s used in the `EventIterator` were grouped under a single `DefaultExtractor` type implementing `Extractor` and provided as the default type for the splunk source generic (the original `DefaultExtractor` type was renamed `MetaExtractor`)
- this `Extractor` trait provides a constructor which is called when instantiating the `EventIterator`, passing a `RequestMeta` object containing information about the request being processed (splunk token, remote address)
- the splunk source initialization logic was put out of the `SplunkConfig` into a `listen` method so that the SplunkSource can be easily initialized in a different context
- some methods declared in the `SplunkSource` impl which did not depend on the SplunkSource struct (`options`, `required_channel`, `lenient_json_content_type_check`) were moved to plain functions to avoid the need for calling them with `SplunkSource::<DefaultExtractor>::options()`
- 

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
