### PR TITLE
chore(config): Expose a public way to load a config from str

### DIFF
--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -220,10 +220,8 @@ where
     ) -> Result<(), Vec<String>> {
         if let Some(table) = self.load(input, format)? {
             self.merge(table, None)?;
-            Ok(())
-        } else {
-            Ok(())
         }
+        Ok(())
     }
 
     /// Deserializes a file with the provided format, and makes the result available via `take`.

--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -213,6 +213,19 @@ where
     /// Consumes Self, and returns the final, deserialized `T`.
     fn take(self) -> T;
 
+    fn load_from_str<R: std::io::Read>(
+        &mut self,
+        input: R,
+        format: Format,
+    ) -> Result<(), Vec<String>> {
+        if let Some(table) = self.load(input, format)? {
+            self.merge(table, None)?;
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+
     /// Deserializes a file with the provided format, and makes the result available via `take`.
     /// Returns a vector of non-fatal warnings on success, or a vector of error strings on failure.
     fn load_from_file(&mut self, path: &Path, format: Format) -> Result<(), Vec<String>> {

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -175,6 +175,49 @@ pub async fn load_from_paths_with_provider_and_secrets(
     Ok(new_config)
 }
 
+pub async fn load_from_str_with_secrets(
+    input: &str,
+    format: Format,
+    signal_handler: &mut signal::SignalHandler,
+    allow_empty: bool,
+) -> Result<Config, Vec<String>> {
+    // Load secret backends first
+    let mut secrets_backends_loader = load_secret_backends_from_input(input.as_bytes(), format)?;
+    // And then, if needed, retrieve secrets from configured backends
+    let mut builder = if secrets_backends_loader.has_secrets_to_retrieve() {
+        debug!(message = "Secret placeholders found, retrieving secrets from configured backends.");
+        let resolved_secrets = secrets_backends_loader
+            .retrieve(&mut signal_handler.subscribe())
+            .await
+            .map_err(|e| vec![e])?;
+        load_builder_from_input_with_secrets(input.as_bytes(), format, resolved_secrets)?
+    } else {
+        debug!(message = "No secret placeholder found, skipping secret resolution.");
+        load_builder_from_input(input.as_bytes(), format)?
+    };
+
+    builder.allow_empty = allow_empty;
+    signal_handler.clear();
+    let (new_config, build_warnings) = builder.build_with_warnings()?;
+
+    validation::check_buffer_preconditions(&new_config).await?;
+
+    for warning in build_warnings {
+        warn!("{}", warning);
+    }
+
+    Ok(new_config)
+}
+
+fn loader_from_input<T, L, R>(mut loader: L, input: R, format: Format) -> Result<T, Vec<String>>
+where
+    T: serde::de::DeserializeOwned,
+    L: Loader<T> + Process,
+    R: std::io::Read,
+{
+    loader.load_from_str(input, format).map(|_| loader.take())
+}
+
 /// Iterators over `ConfigPaths`, and processes a file/dir according to a provided `Loader`.
 fn loader_from_paths<T, L>(mut loader: L, config_paths: &[ConfigPath]) -> Result<T, Vec<String>>
 where
@@ -217,12 +260,27 @@ pub fn load_builder_from_paths(config_paths: &[ConfigPath]) -> Result<ConfigBuil
     loader_from_paths(ConfigBuilderLoader::new(), config_paths)
 }
 
+pub fn load_builder_from_input<R: std::io::Read>(
+    input: R,
+    format: Format,
+) -> Result<ConfigBuilder, Vec<String>> {
+    loader_from_input(ConfigBuilderLoader::new(), input, format)
+}
+
 /// Uses `ConfigBuilderLoader` to process `ConfigPaths`, performing secret replacement and deserializing to a `ConfigBuilder`
 pub fn load_builder_from_paths_with_secrets(
     config_paths: &[ConfigPath],
     secrets: HashMap<String, String>,
 ) -> Result<ConfigBuilder, Vec<String>> {
     loader_from_paths(ConfigBuilderLoader::with_secrets(secrets), config_paths)
+}
+
+pub fn load_builder_from_input_with_secrets<R: std::io::Read>(
+    input: R,
+    format: Format,
+    secrets: HashMap<String, String>,
+) -> Result<ConfigBuilder, Vec<String>> {
+    loader_from_input(ConfigBuilderLoader::with_secrets(secrets), input, format)
 }
 
 /// Uses `SourceLoader` to process `ConfigPaths`, deserializing to a toml `SourceMap`.
@@ -237,6 +295,13 @@ pub fn load_secret_backends_from_paths(
     config_paths: &[ConfigPath],
 ) -> Result<SecretBackendLoader, Vec<String>> {
     loader_from_paths(SecretBackendLoader::new(), config_paths)
+}
+
+pub fn load_secret_backends_from_input<R: std::io::Read>(
+    input: R,
+    format: Format,
+) -> Result<SecretBackendLoader, Vec<String>> {
+    loader_from_input(SecretBackendLoader::new(), input, format)
 }
 
 pub fn load_from_str(input: &str, format: Format) -> Result<Config, Vec<String>> {

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -260,7 +260,7 @@ pub fn load_builder_from_paths(config_paths: &[ConfigPath]) -> Result<ConfigBuil
     loader_from_paths(ConfigBuilderLoader::new(), config_paths)
 }
 
-pub fn load_builder_from_input<R: std::io::Read>(
+fn load_builder_from_input<R: std::io::Read>(
     input: R,
     format: Format,
 ) -> Result<ConfigBuilder, Vec<String>> {
@@ -275,7 +275,7 @@ pub fn load_builder_from_paths_with_secrets(
     loader_from_paths(ConfigBuilderLoader::with_secrets(secrets), config_paths)
 }
 
-pub fn load_builder_from_input_with_secrets<R: std::io::Read>(
+fn load_builder_from_input_with_secrets<R: std::io::Read>(
     input: R,
     format: Format,
     secrets: HashMap<String, String>,
@@ -297,7 +297,7 @@ pub fn load_secret_backends_from_paths(
     loader_from_paths(SecretBackendLoader::new(), config_paths)
 }
 
-pub fn load_secret_backends_from_input<R: std::io::Read>(
+fn load_secret_backends_from_input<R: std::io::Read>(
     input: R,
     format: Format,
 ) -> Result<SecretBackendLoader, Vec<String>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,9 +54,9 @@ pub use diff::ConfigDiff;
 pub use enrichment_table::{EnrichmentTableConfig, EnrichmentTableOuter};
 pub use format::{Format, FormatHint};
 pub use loading::{
-    COLLECTOR, CONFIG_PATHS, load, load_builder_from_paths, load_from_paths,
-    load_from_paths_with_provider_and_secrets, load_from_str, load_source_from_paths,
-    merge_path_lists, process_paths,
+    COLLECTOR, CONFIG_PATHS, load, load_builder_from_input_with_secrets, load_builder_from_paths,
+    load_from_paths, load_from_paths_with_provider_and_secrets, load_from_str,
+    load_from_str_with_secrets, load_source_from_paths, merge_path_lists, process_paths,
 };
 pub use provider::ProviderConfig;
 pub use secret::SecretBackend;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,9 +54,9 @@ pub use diff::ConfigDiff;
 pub use enrichment_table::{EnrichmentTableConfig, EnrichmentTableOuter};
 pub use format::{Format, FormatHint};
 pub use loading::{
-    COLLECTOR, CONFIG_PATHS, load, load_builder_from_input_with_secrets, load_builder_from_paths,
-    load_from_paths, load_from_paths_with_provider_and_secrets, load_from_str,
-    load_from_str_with_secrets, load_source_from_paths, merge_path_lists, process_paths,
+    COLLECTOR, CONFIG_PATHS, load, load_builder_from_paths, load_from_paths,
+    load_from_paths_with_provider_and_secrets, load_from_str, load_from_str_with_secrets,
+    load_source_from_paths, merge_path_lists, process_paths,
 };
 pub use provider::ProviderConfig;
 pub use secret::SecretBackend;

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
 use bytes::BytesMut;
-use futures::executor;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, process::Command, time};
@@ -121,15 +120,13 @@ impl SecretBackend for ExecBackend {
         secret_keys: HashSet<String>,
         signal_rx: &mut signal::SignalRx,
     ) -> crate::Result<HashMap<String, String>> {
-        let mut output = executor::block_on(async {
-            query_backend(
-                &self.command,
-                self.protocol.new_query(secret_keys.clone()),
-                self.timeout,
-                signal_rx,
-            )
-            .await
-        })?;
+        let mut output = query_backend(
+            &self.command,
+            self.protocol.new_query(secret_keys.clone()),
+            self.timeout,
+            signal_rx,
+        )
+        .await?;
         let mut secrets = HashMap::new();
         for k in secret_keys.into_iter() {
             if let Some(secret) = output.get_mut(&k) {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -97,7 +97,7 @@ pub struct SignalHandler {
 impl SignalHandler {
     /// Create a new signal handler with space for 128 control messages at a time, to
     /// ensure the channel doesn't overflow and drop signals.
-    fn new() -> (Self, SignalRx) {
+    pub fn new() -> (Self, SignalRx) {
         let (tx, rx) = broadcast::channel(128);
         let handler = Self {
             tx,


### PR DESCRIPTION
## Summary
This already exists via the `load_from_str` method, however this method does not invoke any secrets infrastructure therefore failing to load configs with strings like `SECRET[...]` as config values.

A new public method called `load_from_str_with_secrets` is exposed which mimics most of the logic in `load_from_paths_with_provider_and_secrets`. 

## Vector configuration
```
secret:
  exec_backend:
    type: "exec"
    command:
      [
        /Users/me/workspace/datadog-secret-backend/datadog-secret-backend,
      ]
    protocol:
      version: v1_1
      backend_type: file.json
      backend_config:
        file_path: /Users/me/workspace/datadog-secret-backend/secrets.json

sources:
  agent:
    type: "datadog_agent"
    address: "SECRET[exec_backend.SOURCE_DATADOG_AGENT_ADDRESS]"
...
```

## How did you test this PR?
Called the newly exposed method with the config above.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).
