### PR TITLE
feat(opentelemetry sink): add `use_otlp_encoding` option

### DIFF
--- a/lib/codecs/src/encoding/format/protobuf.rs
+++ b/lib/codecs/src/encoding/format/protobuf.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use crate::encoding::BuildError;
 use bytes::BytesMut;
 use prost_reflect::{MessageDescriptor, prost::Message as _};
 use tokio_util::codec::Encoder;
@@ -9,9 +10,10 @@ use vector_core::{
     event::{Event, Value},
     schema,
 };
-use vrl::protobuf::{descriptor::get_message_descriptor, encode::encode_message};
-
-use crate::encoding::BuildError;
+use vrl::protobuf::{
+    descriptor::{get_message_descriptor, get_message_descriptor_from_bytes},
+    encode::encode_message,
+};
 
 /// Config used to build a `ProtobufSerializer`.
 #[configurable_component]
@@ -70,6 +72,12 @@ impl ProtobufSerializer {
     /// Creates a new `ProtobufSerializer`.
     pub fn new(message_descriptor: MessageDescriptor) -> Self {
         Self { message_descriptor }
+    }
+
+    /// Creates a new serializer instance using the descriptor bytes directly.
+    pub fn new_from_bytes(desc_bytes: &[u8], message_type: &str) -> vector_common::Result<Self> {
+        let message_descriptor = get_message_descriptor_from_bytes(desc_bytes, message_type)?;
+        Ok(Self { message_descriptor })
     }
 
     /// Get a description of the message type used in serialization.

--- a/lib/codecs/src/encoding/mod.rs
+++ b/lib/codecs/src/encoding/mod.rs
@@ -293,6 +293,12 @@ pub enum SerializerConfig {
     Text(TextSerializerConfig),
 }
 
+impl Default for SerializerConfig {
+    fn default() -> Self {
+        Self::Json(JsonSerializerConfig::default())
+    }
+}
+
 impl From<AvroSerializerConfig> for SerializerConfig {
     fn from(config: AvroSerializerConfig) -> Self {
         Self::Avro { avro: config.avro }

--- a/lib/opentelemetry-proto/src/proto.rs
+++ b/lib/opentelemetry-proto/src/proto.rs
@@ -1,3 +1,10 @@
+pub const LOGS_REQUEST_MESSAGE_TYPE: &str =
+    "opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest";
+pub const TRACES_REQUEST_MESSAGE_TYPE: &str =
+    "opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest";
+pub const METRICS_REQUEST_MESSAGE_TYPE: &str =
+    "opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest";
+
 /// Service stub and clients.
 pub mod collector {
     pub mod trace {

--- a/src/codecs/encoding/config.rs
+++ b/src/codecs/encoding/config.rs
@@ -10,7 +10,7 @@ use crate::codecs::Transformer;
 
 /// Encoding configuration.
 #[configurable_component]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 /// Configures how events are encoded into raw bytes.
 /// The selected encoding also determines which input types (logs, metrics, traces) are supported.
 pub struct EncodingConfig {
@@ -60,7 +60,7 @@ where
 
 /// Encoding configuration.
 #[configurable_component]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct EncodingConfigWithFraming {
     #[configurable(derived)]

--- a/src/sources/opentelemetry/config.rs
+++ b/src/sources/opentelemetry/config.rs
@@ -1,8 +1,28 @@
 use std::net::SocketAddr;
 
+use crate::{
+    config::{
+        DataType, GenerateConfig, Resource, SourceAcknowledgementsConfig, SourceConfig,
+        SourceContext, SourceOutput,
+    },
+    http::KeepaliveConfig,
+    serde::bool_or_struct,
+    sources::{
+        Source,
+        http_server::{build_param_matcher, remove_duplicates},
+        opentelemetry::{
+            grpc::Service,
+            http::{build_warp_filter, run_http_server},
+        },
+        util::grpc::run_grpc_server_with_routes,
+    },
+};
 use futures::FutureExt;
 use futures_util::{TryFutureExt, future::join};
 use tonic::{codec::CompressionEncoding, transport::server::RoutesBuilder};
+use vector_lib::opentelemetry::proto::{
+    LOGS_REQUEST_MESSAGE_TYPE, METRICS_REQUEST_MESSAGE_TYPE, TRACES_REQUEST_MESSAGE_TYPE,
+};
 use vector_lib::{
     codecs::decoding::ProtobufDeserializer,
     config::{LegacyKey, LogNamespace, log_schema},
@@ -28,34 +48,9 @@ use vrl::{
     value::{Kind, kind::Collection},
 };
 
-use crate::{
-    config::{
-        DataType, GenerateConfig, Resource, SourceAcknowledgementsConfig, SourceConfig,
-        SourceContext, SourceOutput,
-    },
-    http::KeepaliveConfig,
-    serde::bool_or_struct,
-    sources::{
-        Source,
-        http_server::{build_param_matcher, remove_duplicates},
-        opentelemetry::{
-            grpc::Service,
-            http::{build_warp_filter, run_http_server},
-        },
-        util::grpc::run_grpc_server_with_routes,
-    },
-};
-
 pub const LOGS: &str = "logs";
 pub const METRICS: &str = "metrics";
 pub const TRACES: &str = "traces";
-
-pub const OTEL_PROTO_LOGS_REQUEST: &str =
-    "opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest";
-pub const OTEL_PROTO_TRACES_REQUEST: &str =
-    "opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest";
-pub const OTEL_PROTO_METRICS_REQUEST: &str =
-    "opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest";
 
 /// Configuration for the `opentelemetry` source.
 #[configurable_component(source("opentelemetry", "Receive OTLP data through gRPC or HTTP."))]
@@ -198,7 +193,7 @@ impl SourceConfig for OpentelemetryConfig {
 
         let grpc_tls_settings = MaybeTlsSettings::from_config(self.grpc.tls.as_ref(), true)?;
 
-        let log_deserializer = self.get_deserializer(OTEL_PROTO_LOGS_REQUEST)?;
+        let log_deserializer = self.get_deserializer(LOGS_REQUEST_MESSAGE_TYPE)?;
         let log_service = LogsServiceServer::new(Service {
             pipeline: cx.out.clone(),
             acknowledgements,
@@ -209,7 +204,7 @@ impl SourceConfig for OpentelemetryConfig {
         .accept_compressed(CompressionEncoding::Gzip)
         .max_decoding_message_size(usize::MAX);
 
-        let metric_deserializer = self.get_deserializer(OTEL_PROTO_METRICS_REQUEST)?;
+        let metric_deserializer = self.get_deserializer(METRICS_REQUEST_MESSAGE_TYPE)?;
         let metrics_service = MetricsServiceServer::new(Service {
             pipeline: cx.out.clone(),
             acknowledgements,
@@ -220,7 +215,7 @@ impl SourceConfig for OpentelemetryConfig {
         .accept_compressed(CompressionEncoding::Gzip)
         .max_decoding_message_size(usize::MAX);
 
-        let trace_deserializer = self.get_deserializer(OTEL_PROTO_TRACES_REQUEST)?;
+        let trace_deserializer = self.get_deserializer(TRACES_REQUEST_MESSAGE_TYPE)?;
         let trace_service = TraceServiceServer::new(Service {
             pipeline: cx.out.clone(),
             acknowledgements,

--- a/tests/data/e2e/opentelemetry/logs/vector_otlp.yaml
+++ b/tests/data/e2e/opentelemetry/logs/vector_otlp.yaml
@@ -19,6 +19,7 @@ sinks:
     inputs:
       - source0.logs
     type: opentelemetry
+    use_otlp_encoding: true
     protocol:
       type: http
       uri: http://otel-collector-sink:5318/v1/logs


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The main purpose of this feature is to simplify configuration from:

```yaml
otel_sink:
	inputs:
		- otel.logs
	type: opentelemetry
	protocol:
		type: http
		uri: http://localhost:5318/v1/logs
		method: post
		encoding:
			codec: protobuf
			protobuf:
				desc_file: path/to/opentelemetry-proto.desc
				message_type: opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
		framing:
			method: "bytes"
		request:
			headers:
				content-type: "application/x-protobuf"
```

to

```yaml
otel_sink:
  inputs:
    - source0.logs
  type: opentelemetry
  use_otlp_encoding: true
  protocol:
    type: http
    uri: http://otel-collector-sink:5318/v1/logs
    method: post
    batch:
      max_events: 1
    request:
      headers:
        content-type: application/json
```

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

E2E tests were adapted.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
