### PR TITLE
chore(file sink): Remove `_config` suffix from `truncate_config`

### DIFF
--- a/benches/files.rs
+++ b/benches/files.rs
@@ -60,7 +60,7 @@ fn benchmark_files_no_partitions(c: &mut Criterion) {
                         acknowledgements: Default::default(),
                         timezone: Default::default(),
                         internal_metrics: Default::default(),
-                        truncate_config: Default::default(),
+                        truncate: Default::default(),
                     },
                 );
 

--- a/changelog.d/23671_file_sink_truncate.feature.md
+++ b/changelog.d/23671_file_sink_truncate.feature.md
@@ -1,3 +1,3 @@
-Added `truncate_config` options to `file` sink to truncate output files after some time.
+Added `truncate` options to `file` sink to truncate output files after some time.
 
 authors: esensar Quad9DNS

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -94,7 +94,7 @@ pub struct FileSinkConfig {
 
     #[configurable(derived)]
     #[serde(default)]
-    pub truncate_config: FileTruncateConfig,
+    pub truncate: FileTruncateConfig,
 }
 
 /// Configuration for truncating files.
@@ -123,7 +123,7 @@ impl GenerateConfig for FileSinkConfig {
             acknowledgements: Default::default(),
             timezone: Default::default(),
             internal_metrics: Default::default(),
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         })
         .unwrap()
     }
@@ -269,7 +269,7 @@ impl FileSink {
             compression: config.compression,
             events_sent: register!(EventsSent::from(Output(None))),
             include_file_metric_tag: config.internal_metrics.include_file_tag,
-            truncation_config: config.truncate_config.clone(),
+            truncation_config: config.truncate.clone(),
         })
     }
 
@@ -565,7 +565,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (input, _events) = random_lines_with_stream(100, 64, None);
@@ -592,7 +592,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (input, _) = random_lines_with_stream(100, 64, None);
@@ -619,7 +619,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (input, _) = random_lines_with_stream(100, 64, None);
@@ -651,7 +651,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (mut input, _events) = random_events_with_stream(32, 8, None);
@@ -734,7 +734,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (mut input, _events) = random_lines_with_stream(10, 64, None);
@@ -791,7 +791,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (input, _events) = random_metrics_with_stream(100, None, None);
@@ -823,7 +823,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let metric_count = 3;
@@ -875,7 +875,7 @@ mod tests {
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
-            truncate_config: Default::default(),
+            truncate: Default::default(),
         };
 
         let (input, _events) = random_lines_with_stream(100, 64, None);

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -529,7 +529,7 @@ generated: components: sinks: file: configuration: {
 		required: false
 		type: string: examples: ["local", "America/New_York", "EST5EDT"]
 	}
-	truncate_config: {
+	truncate: {
 		description: "Configuration for truncating files."
 		required:    false
 		type: object: options: {


### PR DESCRIPTION
This suffix is inconsistent with other component configuration option naming which lacks it.

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
