### PR TITLE
fix(config): watch-config file events handling

### DIFF
--- a/changelog.d/23820_watch_config_handle_events.fix.md
+++ b/changelog.d/23820_watch_config_handle_events.fix.md
@@ -1,0 +1,3 @@
+Config watcher no longer ignores subsequent events during the delay period, but collects the changed paths and reloads the corresponding components.
+
+authors: nekorro


### PR DESCRIPTION
## Summary
Config watcher no longer ignores subsequent events during the delay period, but collects the changed paths and reloads the corresponding components.

## Vector configuration
`./config/sources.yaml`
```yaml
sources:
  test-source:
    type: demo_logs
    interval: 2
    format: json
```
`./config/transforms.yaml`
```yaml
transforms:
  test-embedded-vrl:
    type: "remap"
    source: |-
      .debug = "embedded_01"
    inputs:
      - test-source
  test-external-vrl:
    type: "remap"
    file: "./config/test.vrl"
    inputs:
      - test-source
```
`./config/sinks.yaml`
```yaml
sinks:
  console:
    inputs:
      - test-embedded-vrl
      - test-external-vrl
    target: stdout
    type: console
    encoding:
      codec: json
```

`./config/test.vrl`
```
.debug = "external_01"
```

## How did you test this PR?
1. Run vector with `vector -vv -C ./config -w`
2. Ensure that output contains events from both transforms
<img width="1550" height="90" alt="image" src="https://github.com/user-attachments/assets/1a5b9983-9728-45d7-9b2f-8929f367207a" />
<img width="1550" height="90" alt="image" src="https://github.com/user-attachments/assets/0b240fb5-db19-47b1-b491-dad0256575d9" />

3. Make copy of `config` folder `cp -R config config-copy`
4. Change content of `test.vrl` to `.debug = "external_01_modified"` inside `config-copy`
5. Change `source` of `test-embedded-vrl` to `.debug = "embedded_01_modified"` inside `config-copy`
6. Replace config folder with copy `rm -rf config && cp -R config-copy config`
7. Ensure that output contains events from both transforms with modified values
<img width="1400" height="90" alt="image" src="https://github.com/user-attachments/assets/d8f60577-37a7-4f08-ab3b-1a417ba69eb7" />
<img width="1550" height="90" alt="image" src="https://github.com/user-attachments/assets/e9e5340a-ebac-4c2a-987f-732a68bae60c" />
<img width="1550" height="90" alt="image" src="https://github.com/user-attachments/assets/1775fd68-2e90-4c6e-9dc9-445e055a5d3f" />

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #23820

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

