### PR TITLE
fix!(metrics): limit utilization precision and reduce debug log frequency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
  "async-graphql",
  "futures-util",
  "serde_json",
- "warp 0.3.7",
+ "warp",
 ]
 
 [[package]]
@@ -624,13 +624,13 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.43.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8980b86fddaad5d28d128f4517b23fdacdcbd32c20f7149b5117e07ad65bb50f"
+checksum = "08f6da6d49a956424ca4e28fe93656f790d748b469eaccbc7488fec545315180"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.10.1",
- "futures-util",
+ "futures 0.3.31",
  "memchr",
  "nkeys",
  "nuid",
@@ -651,7 +651,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls 0.26.2",
- "tokio-stream",
  "tokio-util",
  "tokio-websockets",
  "tracing 0.1.41",
@@ -4503,23 +4502,8 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.10.1",
- "headers-core 0.2.0",
+ "headers-core",
  "http 0.2.9",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes 1.10.1",
- "headers-core 0.3.0",
- "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -4532,15 +4516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.9",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http 1.1.0",
 ]
 
 [[package]]
@@ -4990,7 +4965,7 @@ checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
  "bytes 1.10.1",
  "futures 0.3.31",
- "headers 0.3.9",
+ "headers",
  "http 0.2.9",
  "hyper 0.14.28",
  "openssl",
@@ -12119,7 +12094,7 @@ dependencies = [
  "h2 0.4.12",
  "hash_hasher",
  "hashbrown 0.14.5",
- "headers 0.3.9",
+ "headers",
  "heim",
  "hex",
  "hickory-proto",
@@ -12243,7 +12218,7 @@ dependencies = [
  "vector-lib",
  "vector-vrl-functions",
  "vrl",
- "warp 0.4.2",
+ "warp",
  "windows-service",
  "wiremock",
  "zstd 0.13.2",
@@ -12409,7 +12384,7 @@ dependencies = [
  "float_eq",
  "futures 0.3.31",
  "futures-util",
- "headers 0.3.9",
+ "headers",
  "http 0.2.9",
  "hyper-proxy",
  "indexmap 2.11.0",
@@ -12771,7 +12746,7 @@ dependencies = [
  "bytes 1.10.1",
  "futures-channel",
  "futures-util",
- "headers 0.3.9",
+ "headers",
  "http 0.2.9",
  "hyper 0.14.28",
  "log",
@@ -12785,33 +12760,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "tokio-util",
- "tower-service",
- "tracing 0.1.41",
-]
-
-[[package]]
-name = "warp"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d06d9202adc1f15d709c4f4a2069be5428aa912cc025d6f268ac441ab066b0"
-dependencies = [
- "bytes 1.10.1",
- "futures-util",
- "headers 0.4.1",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-body-util",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
  "tokio-util",
  "tower-service",
  "tracing 0.1.41",

--- a/changelog.d/utilization.breaking.md
+++ b/changelog.d/utilization.breaking.md
@@ -1,0 +1,3 @@
+The `utilization` metric is now capped at 4 decimal digit precision.
+
+authors: pront

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -5,6 +5,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(debug_assertions)]
+use std::sync::Arc;
+
 use futures::{Stream, StreamExt};
 use metrics::Gauge;
 use pin_project::pin_project;
@@ -70,6 +73,8 @@ pub(crate) struct Timer {
     gauge: Gauge,
     #[cfg(debug_assertions)]
     report_count: u32,
+    #[cfg(debug_assertions)]
+    component_id: Arc<str>,
 }
 
 /// A simple, specialized timer for tracking spans of waiting vs not-waiting
@@ -81,7 +86,7 @@ pub(crate) struct Timer {
 /// to be of uniform length and used to aggregate span data into time-weighted
 /// averages.
 impl Timer {
-    pub(crate) fn new(gauge: Gauge) -> Self {
+    pub(crate) fn new(gauge: Gauge, #[cfg(debug_assertions)] component_id: Arc<str>) -> Self {
         Self {
             overall_start: Instant::now(),
             span_start: Instant::now(),
@@ -91,6 +96,8 @@ impl Timer {
             gauge,
             #[cfg(debug_assertions)]
             report_count: 0,
+            #[cfg(debug_assertions)]
+            component_id,
         }
     }
 
@@ -132,8 +139,10 @@ impl Timer {
 
         #[cfg(debug_assertions)]
         {
-            if self.report_count % 6 == 0 {
-                debug!(utilization = %avg_rounded);
+            // Note that changing the reporting interval would also affect the actual metric reporting frequency.
+            // This check reduces debug log spamming.
+            if self.report_count % 5 == 0 {
+                debug!(component_id = %self.component_id, utilization = %avg_rounded);
             }
             self.report_count = self.report_count.wrapping_add(1);
         }
@@ -211,7 +220,14 @@ impl UtilizationEmitter {
         key: ComponentKey,
         gauge: Gauge,
     ) -> UtilizationComponentSender {
-        self.timers.insert(key.clone(), Timer::new(gauge));
+        self.timers.insert(
+            key.clone(),
+            Timer::new(
+                gauge,
+                #[cfg(debug_assertions)]
+                key.id().into(),
+            ),
+        );
         UtilizationComponentSender {
             timer_tx: self.timer_tx.clone(),
             component_key: key,

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -141,7 +141,7 @@ impl Timer {
         {
             // Note that changing the reporting interval would also affect the actual metric reporting frequency.
             // This check reduces debug log spamming.
-            if self.report_count % 5 == 0 {
+            if self.report_count.is_multiple_of(5) {
                 debug!(component_id = %self.component_id, utilization = %avg_rounded);
             }
             self.report_count = self.report_count.wrapping_add(1);


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The utilization gauge value precision is now capped.
Technically a breaking change but no one should rely on more precision for this metric.

This change mostly affects debug builds.


## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

Run a simple Vector config with `VECTOR_LOG=debug` and observe the logs:
```text
2025-10-03T20:43:34.286970Z DEBUG vector::utilization: component_id=console utilization=0.0002
2025-10-03T20:43:34.287131Z DEBUG vector::utilization: component_id=t0 utilization=0.0004
2025-10-03T20:43:34.287161Z DEBUG vector::utilization: component_id=t2 utilization=0.0002
2025-10-03T20:43:34.287188Z DEBUG vector::utilization: component_id=t1 utilization=0.0002
```

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

closes: https://github.com/vectordotdev/vector/issues/23828

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
