### PR TITLE
fix(integration test): fix `external` type in `networks` in docker compose file

### DIFF
--- a/vdev/src/testing/config.rs
+++ b/vdev/src/testing/config.rs
@@ -74,7 +74,7 @@ pub struct ComposeConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub volumes: BTreeMap<String, VolumeDefinition>,
     #[serde(default)]
-    pub networks: BTreeMap<String, BTreeMap<String, String>>,
+    pub networks: BTreeMap<String, BTreeMap<String, Value>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
+use serde_yaml::Value;
 use tempfile::{Builder, NamedTempFile};
 
 use super::{
@@ -257,8 +258,8 @@ impl Compose {
                 config.networks.insert(
                     "default".to_string(),
                     BTreeMap::from_iter([
-                        ("name".to_string(), network.clone()),
-                        ("external".to_string(), "true".to_string()),
+                        ("name".to_string(), Value::String(network.clone())),
+                        ("external".to_string(), Value::Bool(true)),
                     ]),
                 );
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

When I want to run any one of the integration test , I failed with the message `'str' object has no attribute 'get'`. I traced back to the [podman-compose source](https://github.com/containers/podman-compose/blob/v1.5.0/podman_compose.py#L1055) and it give me a hint to the error. It seems that the [`external` type](https://docs.docker.com/reference/compose-file/networks/#external) is boolean instead of string. However, our docker compose generator treat them as string type, which makes the podman compose failed to launch successfully. I fix here to given them concret type. I guess docker compose would tolerate it, but podman compose does not allow it.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

```bash
 make test-integration-loki
```

AS IS
```bash
❯ make test-integration-loki
cargo vdev --verbose integration test loki
Active environment: None
Executing: "podman" "network" "ls" "--format" "{{.Name}}"
Starting service environment
Executing: cd "/Users/mine/oss/vector/scripts/integration/loki" && CONFIG_VECTOR_IMAGE="vector-test-runner-loki-1.90:latest" CONFIG_VERSION="2.4.1" DOCKER_SOCKET="/var/run/docker.sock" RUST_VERSION="1.90" VECTOR_NETWORK="vector-integration-tests-loki" version="2.4.1" "podman" "compose" "--file" "/Users/mine/oss/vector/scripts/integration/loki/compose-temp-pow2zy.yaml" "up" "--detach"
  in working directory "/Users/mine/oss/vector/scripts/integration/loki"
  $CONFIG_VECTOR_IMAGE="vector-test-runner-loki-1.90:latest"
  $CONFIG_VERSION="2.4.1"
  $DOCKER_SOCKET="/var/run/docker.sock"
  $RUST_VERSION="1.90"
  $VECTOR_NETWORK="vector-integration-tests-loki"
  $version="2.4.1"
>>>> Executing external compose provider "/opt/homebrew/bin/podman-compose". Please see podman-compose(1) for how to disable this message. <<<<

ed8fa0212f82d7ce83ac4e38a43e4c308d48938437365e3ccf5ced8151be8008
Traceback (most recent call last):
  File "/opt/homebrew/bin/podman-compose", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 4256, in main
    asyncio.run(async_main())
    ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.6/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.6/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.6/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 4252, in async_main
    await podman_compose.run()
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 2072, in run
    retcode = await cmd(self, args)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 3170, in compose_up
    podman_args = await container_to_args(compose, cnt, detached=False, no_deps=args.no_deps)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 1183, in container_to_args
    podman_args.extend(get_net_args(compose, cnt))
                       ~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 1006, in get_net_args
    return get_net_args_from_networks(compose, cnt)
  File "/opt/homebrew/Cellar/podman-compose/1.5.0/libexec/lib/python3.13/site-packages/podman_compose.py", line 1055, in get_net_args_from_networks
    net_name = ext_desc.get("name") or net_desc.get("name") or default_net_name
               ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'
Error: executing /opt/homebrew/bin/podman-compose --file /Users/mine/oss/vector/scripts/integration/loki/compose-temp-pow2zy.yaml up --detach: exit status 1
Error: command: cd "/Users/mine/oss/vector/scripts/integration/loki" && CONFIG_VECTOR_IMAGE="vector-test-runner-loki-1.90:latest" CONFIG_VERSION="2.4.1" DOCKER_SOCKET="/var/run/docker.sock" RUST_VERSION="1.90" VECTOR_NETWORK="vector-integration-tests-loki" version="2.4.1" "podman" "compose" "--file" "/Users/mine/oss/vector/scripts/integration/loki/compose-temp-pow2zy.yaml" "up" "--detach"
  failed with exit code: 1
make: *** [test-integration-loki] Error 1
```

TO BE
```bash
❯ make test-integration-loki
cargo vdev --verbose integration test loki
Active environment: None
Executing: "podman" "network" "ls" "--format" "{{.Name}}"
Starting service environment
Executing: cd "/Users/mine/oss/vector/scripts/integration/loki" && CONFIG_VECTOR_IMAGE="vector-test-runner-loki-1.90:latest" CONFIG_VERSION="2.4.1" DOCKER_SOCKET="/var/run/docker.sock" RUST_VERSION="1.90" VECTOR_NETWORK="vector-integration-tests-loki" version="2.4.1" "podman" "compose" "--file" "/Users/mine/oss/vector/scripts/integration/loki/compose-temp-GZN1Vr.yaml" "up" "--detach"
  in working directory "/Users/mine/oss/vector/scripts/integration/loki"
  $CONFIG_VECTOR_IMAGE="vector-test-runner-loki-1.90:latest"
  $CONFIG_VERSION="2.4.1"
  $DOCKER_SOCKET="/var/run/docker.sock"
  $RUST_VERSION="1.90"
  $VECTOR_NETWORK="vector-integration-tests-loki"
  $version="2.4.1"
>>>> Executing external compose provider "/opt/homebrew/bin/podman-compose". Please see podman-compose(1) for how to disable this message. <<<<

7141f39cedc6f5eb79bd557993a99d9c60d77078c35e23e945c39fc0c7e1ebeb
loki_loki_1
Executing: "podman" "ps" "-a" "--format" "{{.Names}} {{.State}}"
Building image vector-test-runner-loki-1.90:latest
Executing: cd "/Users/mine/oss/vector" && "podman" "build" "--progress" "tty" "--pull" "--tag" "vector-test-runner-loki-1.90:latest" "--file" "/Users/mine/oss/vector/scripts/integration/Dockerfile" "--label" "vector-test-runner=true" "--build-arg" "RUST_VERSION=1.90" "--build-arg" "FEATURES=loki-integration-tests" "."
  in working directory "/Users/mine/oss/vector"
STEP 1/10: FROM docker.io/rust:1.90-slim-trixie
Trying to pull docker.io/library/rust:1.90-slim-trixie...
```

## Change Type
- [x] Bug fix
- [ ] New feature
- [] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
