### PR TITLE
docs(docker_logs source): add requirement for docker logs source

### DIFF
--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -70,7 +70,11 @@ components: sources: docker_logs: {
 	}
 
 	support: {
-		requirements: []
+		requirements: [
+			"""
+				This source requires permissions to run `docker`.  Please ensure the running user is part of the `docker` group.
+				""",
+		]
 		warnings: [
 			"""
 				To avoid collecting logs from itself when deployed as a container,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
I notice that the docker logs document does not have any requirements to tell the user the running user SHOULD be in the `docker` group, similar to how [journald](https://vector.dev/docs/reference/configuration/sources/journald/) did. I try to add the requirement here.

Also, I notice that the error is ambiguous when the running user is not in the `docker` group. I think it's due to the printed error.

print the error by `Display` trait

<img width="3008" height="592" alt="image" src="https://github.com/user-attachments/assets/d3988091-8ea3-4008-9bb5-9a2f5cf03c29" />

print the error by `Debug` trait [here](https://github.com/vectordotdev/vector/compare/master...titaneric:vector:feat/improve-docker-logs-error-logs)

<img width="3008" height="638" alt="image" src="https://github.com/user-attachments/assets/5e2beff0-cd23-4455-a932-e562a95947ed" />

However, I find that printing a debug error is not preferable in the [DEVELOPING.md](https://github.com/vectordotdev/vector/blob/master/docs/DEVELOPING.md#logging-style).

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```yaml
data_dir: vector-data
api:
  enabled: true
  graphql: true
  playground: false
  address: "127.0.0.1:8686"
sources:
  docker_logs:
    type: docker_logs
sinks:
  my_sink_id:
    type: console
    encoding:
      codec: raw_message
    inputs:
      - docker_logs
~
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

```bash
cd website
make quick-build
make serve
```

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
