### PR TITLE
fix(dev): Fix incorrect cue.sh path

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 #     2. In CI, ensuring that the .cue files are properly formatted.
 
 ROOT=$(git rev-parse --show-toplevel)
-CUE="${ROOT}/website/scripts/cue.sh"
+CUE="${ROOT}/scripts/cue.sh"
 
 read-all-docs() {
   ${CUE} list | sort | xargs cat -et


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
`website/scripts/cue.sh` was deleted but this path was never updated

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
NA

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Failed run: https://github.com/vectordotdev/vector/actions/runs/18287480920/job/52066219808
- Related: #23951 