### PR TITLE
feat(unit tests): respect color flag for tests (recreated)

### DIFF
--- a/changelog.d/23717_vector_test_color.feature.md
+++ b/changelog.d/23717_vector_test_color.feature.md
@@ -1,0 +1,3 @@
+Disable ANSI color for `vector test` when running non-interactively. Honor `--color {auto|always|never}` and `VECTOR_COLOR`; VRL diagnostics no longer include ANSI sequences when color is disabled.
+
+authors: VanjaRo

--- a/src/app.rs
+++ b/src/app.rs
@@ -206,6 +206,9 @@ impl Application {
             opts.root.internal_log_rate_limit,
         );
 
+        // Set global color preference for downstream modules
+        crate::set_global_color(color);
+
         // Can only log this after initializing the logging subsystem
         if opts.root.openssl_no_probe {
             debug!(
@@ -511,7 +514,7 @@ pub fn build_runtime(threads: Option<usize>, thread_name: &str) -> Result<Runtim
         .unwrap_or_else(|_| panic!("double thread initialization"));
     rt_builder.worker_threads(threads);
 
-    debug!(messaged = "Building runtime.", worker_threads = threads);
+    debug!(message = "Building runtime.", worker_threads = threads);
     Ok(rt_builder.build().expect("Unable to create async runtime"))
 }
 

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -160,7 +160,12 @@ impl HttpServerAuthConfig {
                     warnings,
                     config: _,
                 } = compile_vrl(source, &functions, &state, config).map_err(|diagnostics| {
-                    Formatter::new(source, diagnostics).colored().to_string()
+                    let fmt = Formatter::new(source, diagnostics);
+                    if crate::use_color() {
+                        fmt.colored().to_string()
+                    } else {
+                        fmt.to_string()
+                    }
                 })?;
 
                 if !program.final_type_info().result.is_boolean() {
@@ -168,7 +173,12 @@ impl HttpServerAuthConfig {
                 }
 
                 if !warnings.is_empty() {
-                    let warnings = Formatter::new(source, warnings).colored().to_string();
+                    let fmt = Formatter::new(source, warnings);
+                    let warnings = if crate::use_color() {
+                        fmt.colored().to_string()
+                    } else {
+                        fmt.to_string()
+                    };
                     warn!(message = "VRL compilation warning.", %warnings);
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,13 +155,28 @@ pub fn get_slugified_app_name() -> String {
 /// Sets the global color preference for diagnostics and CLI output.
 /// This should be called once during application startup.
 pub fn set_global_color(enabled: bool) {
-    let _ = USE_COLOR.set(enabled);
+    if let Err(e) = USE_COLOR.set(enabled) {
+        error!(message = "Failed to set global color", %e);
+    }
 }
 
 /// Returns true if color output is globally enabled.
 /// Defaults to false if not set.
 pub fn use_color() -> bool {
     *USE_COLOR.get_or_init(|| false)
+}
+
+/// Formats VRL diagnostics honoring the global color setting.
+pub fn format_vrl_diagnostics(
+    source: &str,
+    diagnostics: impl Into<vrl::diagnostic::Diagnostics>,
+) -> String {
+    let formatter = vrl::diagnostic::Formatter::new(source, diagnostics);
+    if use_color() {
+        formatter.colored().to_string()
+    } else {
+        formatter.to_string()
+    }
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub fn get_slugified_app_name() -> String {
 /// This should be called once during application startup.
 pub fn set_global_color(enabled: bool) {
     if let Err(e) = USE_COLOR.set(enabled) {
-        error!(message = "Failed to set global color", %e);
+        error!(message = "Failed to set global color.", %e);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ pub use source_sender::SourceSender;
 pub use vector_lib::{Error, Result, event, metrics, schema, shutdown, tcp, tls};
 
 static APP_NAME_SLUG: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+static USE_COLOR: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 /// The name used to identify this Vector application.
 ///
@@ -149,6 +150,18 @@ pub fn get_slugified_app_name() -> String {
     APP_NAME_SLUG
         .get_or_init(|| get_app_name().to_lowercase().replace(' ', "-"))
         .clone()
+}
+
+/// Sets the global color preference for diagnostics and CLI output.
+/// This should be called once during application startup.
+pub fn set_global_color(enabled: bool) {
+    let _ = USE_COLOR.set(enabled);
+}
+
+/// Returns true if color output is globally enabled.
+/// Defaults to false if not set.
+pub fn use_color() -> bool {
+    *USE_COLOR.get_or_init(|| false)
 }
 
 /// The current version of Vector in simplified format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub fn use_color() -> bool {
 /// Formats VRL diagnostics honoring the global color setting.
 pub fn format_vrl_diagnostics(
     source: &str,
-    diagnostics: impl Into<vrl::diagnostic::Diagnostics>,
+    diagnostics: impl Into<vrl::diagnostic::DiagnosticList>,
 ) -> String {
     let formatter = vrl::diagnostic::Formatter::new(source, diagnostics);
     if use_color() {

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -248,17 +248,23 @@ impl Query {
             match compile_vrl(param.value(), functions, &state, config) {
                 Ok(compilation_result) => {
                     if !compilation_result.warnings.is_empty() {
-                        let warnings = Formatter::new(param.value(), compilation_result.warnings)
-                            .colored()
-                            .to_string();
+                        let fmt = Formatter::new(param.value(), compilation_result.warnings);
+                        let warnings = if crate::use_color() {
+                            fmt.colored().to_string()
+                        } else {
+                            fmt.to_string()
+                        };
                         warn!(message = "VRL compilation warnings.", %warnings, internal_log_rate_limit = true);
                     }
                     Some(compilation_result.program)
                 }
                 Err(diagnostics) => {
-                    let error = Formatter::new(param.value(), diagnostics)
-                        .colored()
-                        .to_string();
+                    let fmt = Formatter::new(param.value(), diagnostics);
+                    let error = if crate::use_color() {
+                        fmt.colored().to_string()
+                    } else {
+                        fmt.to_string()
+                    };
                     warn!(message = "VRL compilation failed.", %error, internal_log_rate_limit = true);
                     None
                 }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -24,7 +24,7 @@ use vrl::{
         runtime::{Runtime, Terminate},
         state::ExternalEnv,
     },
-    diagnostic::{DiagnosticMessage, Formatter, Note},
+    diagnostic::{DiagnosticMessage, Note},
     path,
     path::ValuePath,
     value::{Kind, Value},
@@ -37,6 +37,7 @@ use crate::{
         TransformOutput, log_schema,
     },
     event::{Event, TargetEvents, VrlTarget},
+    format_vrl_diagnostics,
     internal_events::{RemapMappingAbort, RemapMappingError},
     schema,
     transforms::{SyncTransform, Transform, TransformOutputsBuf},
@@ -228,24 +229,11 @@ impl RemapConfig {
         config.set_custom(MeaningList::default());
 
         let res = compile_vrl(&source, &functions, &state, config)
-            .map_err(|diagnostics| {
-                let fmt = Formatter::new(&source, diagnostics);
-                if crate::use_color() {
-                    fmt.colored().to_string()
-                } else {
-                    fmt.to_string()
-                }
-            })
+            .map_err(|diagnostics| format_vrl_diagnostics(&source, diagnostics))
             .map(|result| {
-                let fmt = Formatter::new(&source, result.warnings);
-                let warnings = if crate::use_color() {
-                    fmt.colored().to_string()
-                } else {
-                    fmt.to_string()
-                };
                 (
                     result.program,
-                    warnings,
+                    format_vrl_diagnostics(&source, result.warnings),
                     result.config.get_custom::<MeaningList>().unwrap().clone(),
                 )
             });

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -228,11 +228,24 @@ impl RemapConfig {
         config.set_custom(MeaningList::default());
 
         let res = compile_vrl(&source, &functions, &state, config)
-            .map_err(|diagnostics| Formatter::new(&source, diagnostics).colored().to_string())
+            .map_err(|diagnostics| {
+                let fmt = Formatter::new(&source, diagnostics);
+                if crate::use_color() {
+                    fmt.colored().to_string()
+                } else {
+                    fmt.to_string()
+                }
+            })
             .map(|result| {
+                let fmt = Formatter::new(&source, result.warnings);
+                let warnings = if crate::use_color() {
+                    fmt.colored().to_string()
+                } else {
+                    fmt.to_string()
+                };
                 (
                     result.program,
-                    Formatter::new(&source, result.warnings).to_string(),
+                    warnings,
                     result.config.get_custom::<MeaningList>().unwrap().clone(),
                 )
             });


### PR DESCRIPTION
## Summary
- `vector test` now disables ANSI color when non-interactive (e.g., CI), preventing escape codes in logs.
- All VRL diagnostics (compile errors/warnings, runtime errors) respect the global color setting.
- Minor: fix a logging field typo in runtime init debug message.

## Vector configuration
```bash
# Default (auto): color enabled only when stdout is a TTY
vector test

# Force enable color
vector --color always test

# Force disable color
vector --color never test

# Using environment variable
VECTOR_COLOR=always vector test
VECTOR_COLOR=never vector test

# Non-interactive scenario (auto → no color)
vector test | tee out.txt
```

## How did you test this PR?

- Verified TTY detection: `--color auto` shows ANSI when run in an interactive terminal, and no ANSI when piped/redirected.
- Forced behaviors validated with `--color always|never` and `VECTOR_COLOR=always|never`.
- Confirmed VRL diagnostics across `validate`, conditions (`src/conditions/vrl.rs`), `remap` transform, HTTP server auth, and HTTP client query parameters show colored output only when enabled.
- Ensured `init_logging` and downstream modules receive the same global color preference via `set_global_color(...)`.
- Spot-checked that CI-like environments (piped output) produce log lines without ANSI sequences.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: https://github.com/vectordotdev/vector/issues/23717
