### PR TITLE
fix(website): use ` instead of " in aws guide

### DIFF
--- a/website/content/en/guides/aws/aws-secrets-manager.md
+++ b/website/content/en/guides/aws/aws-secrets-manager.md
@@ -203,12 +203,12 @@ Vector retrieves the entire secret and makes individual key-value pairs availabl
 
 - Ensure the backend name in `SECRET[backend_name.key]` exactly matches the section name in your config.
 
-#### "Key does not exist" error
+#### `Key does not exist` error
 
 - Verify the key name exists in your AWS Secrets Manager secret.
 - Check that the secret contains valid JSON.
 
-#### "Secret could not be retrieved" error
+#### `Secret could not be retrieved` error
 
 - Verify AWS credentials have the correct permissions.
 - Check that the secret ID and ARN are correct.


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
As title states

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
`make serve`
Go to
`localhost:1313/guides/aws/aws-secrets-manager/`

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
