### PR TITLE
enhancement(datadog_agent source): Add control for metric name splitting

### DIFF
--- a/changelog.d/23986_datadog_agent_split_metric_namespace.enhancement.md
+++ b/changelog.d/23986_datadog_agent_split_metric_namespace.enhancement.md
@@ -1,0 +1,4 @@
+Added a new `split_metric_namespace` option to the `datadog_agent` source to
+optionally disable the existing default metric name split behavior.
+
+authors: bruceg

--- a/src/sources/datadog_agent/metrics.rs
+++ b/src/sources/datadog_agent/metrics.rs
@@ -89,6 +89,7 @@ fn sketches_service(
                                 api_token,
                                 query_params.dd_api_key,
                             ),
+                            source.split_metric_namespace,
                             &source.events_received,
                         )
                     });
@@ -130,6 +131,7 @@ fn series_v1_service(
                             // Currently metrics do not have schemas defined, so for now we just pass a
                             // default one.
                             &Arc::new(schema::Definition::default_legacy_namespace()),
+                            source.split_metric_namespace,
                             &source.events_received,
                         )
                     });
@@ -168,6 +170,7 @@ fn series_v2_service(
                                 api_token,
                                 query_params.dd_api_key,
                             ),
+                            source.split_metric_namespace,
                             &source.events_received,
                         )
                     });
@@ -180,6 +183,7 @@ fn series_v2_service(
 fn decode_datadog_sketches(
     body: Bytes,
     api_key: Option<Arc<str>>,
+    split_metric_namespace: bool,
     events_received: &Registered<EventsReceived>,
 ) -> Result<Vec<Event>, ErrorMessage> {
     if body.is_empty() {
@@ -191,7 +195,7 @@ fn decode_datadog_sketches(
         return Ok(Vec::new());
     }
 
-    let metrics = decode_ddsketch(body, &api_key).map_err(|error| {
+    let metrics = decode_ddsketch(body, &api_key, split_metric_namespace).map_err(|error| {
         ErrorMessage::new(
             StatusCode::UNPROCESSABLE_ENTITY,
             format!("Error decoding Datadog sketch: {error:?}"),
@@ -209,6 +213,7 @@ fn decode_datadog_sketches(
 fn decode_datadog_series_v2(
     body: Bytes,
     api_key: Option<Arc<str>>,
+    split_metric_namespace: bool,
     events_received: &Registered<EventsReceived>,
 ) -> Result<Vec<Event>, ErrorMessage> {
     if body.is_empty() {
@@ -220,7 +225,7 @@ fn decode_datadog_series_v2(
         return Ok(Vec::new());
     }
 
-    let metrics = decode_ddseries_v2(body, &api_key).map_err(|error| {
+    let metrics = decode_ddseries_v2(body, &api_key, split_metric_namespace).map_err(|error| {
         ErrorMessage::new(
             StatusCode::UNPROCESSABLE_ENTITY,
             format!("Error decoding Datadog sketch: {error:?}"),
@@ -256,13 +261,18 @@ fn get_event_metadata(metadata: Option<&Metadata>) -> EventMetadata {
 pub(crate) fn decode_ddseries_v2(
     frame: Bytes,
     api_key: &Option<Arc<str>>,
+    split_metric_namespace: bool,
 ) -> crate::Result<Vec<Event>> {
     let payload = MetricPayload::decode(frame)?;
     let decoded_metrics: Vec<Event> = payload
         .series
         .into_iter()
         .flat_map(|serie| {
-            let (namespace, name) = namespace_name_from_dd_metric(&serie.metric);
+            let (namespace, name) = if split_metric_namespace {
+                namespace_name_from_dd_metric(&serie.metric)
+            } else {
+                (None, serie.metric.as_str())
+            };
             let mut tags = into_metric_tags(serie.tags);
 
             let event_metadata = get_event_metadata(serie.metadata.as_ref());
@@ -402,6 +412,7 @@ fn decode_datadog_series_v1(
     body: Bytes,
     api_key: Option<Arc<str>>,
     schema_definition: &Arc<schema::Definition>,
+    split_metric_namespace: bool,
     events_received: &Registered<EventsReceived>,
 ) -> Result<Vec<Event>, ErrorMessage> {
     if body.is_empty() {
@@ -423,7 +434,14 @@ fn decode_datadog_series_v1(
     let decoded_metrics: Vec<Event> = metrics
         .series
         .into_iter()
-        .flat_map(|m| into_vector_metric(m, api_key.clone(), schema_definition))
+        .flat_map(|m| {
+            into_vector_metric(
+                m,
+                api_key.clone(),
+                schema_definition,
+                split_metric_namespace,
+            )
+        })
         .collect();
 
     events_received.emit(CountByteSize(
@@ -442,6 +460,7 @@ fn into_vector_metric(
     dd_metric: DatadogSeriesMetric,
     api_key: Option<Arc<str>>,
     schema_definition: &Arc<schema::Definition>,
+    split_metric_namespace: bool,
 ) -> Vec<Event> {
     let mut tags = into_metric_tags(dd_metric.tags.unwrap_or_default());
 
@@ -458,7 +477,11 @@ fn into_vector_metric(
         .device
         .and_then(|dev| tags.replace("device".into(), dev));
 
-    let (namespace, name) = namespace_name_from_dd_metric(&dd_metric.metric);
+    let (namespace, name) = if split_metric_namespace {
+        namespace_name_from_dd_metric(&dd_metric.metric)
+    } else {
+        (None, dd_metric.metric.as_str())
+    };
 
     match dd_metric.r#type {
         DatadogMetricType::Count => dd_metric
@@ -551,6 +574,7 @@ fn namespace_name_from_dd_metric(dd_metric_name: &str) -> (Option<&str>, &str) {
 pub(crate) fn decode_ddsketch(
     frame: Bytes,
     api_key: &Option<Arc<str>>,
+    split_metric_namespace: bool,
 ) -> crate::Result<Vec<Event>> {
     let payload = SketchPayload::decode(frame)?;
     // payload.metadata is always empty for payload coming from dd agents
@@ -581,7 +605,11 @@ pub(crate) fn decode_ddsketch(
                     )
                     .unwrap_or_else(AgentDDSketch::with_agent_defaults),
                 );
-                let (namespace, name) = namespace_name_from_dd_metric(&sketch_series.metric);
+                let (namespace, name) = if split_metric_namespace {
+                    namespace_name_from_dd_metric(&sketch_series.metric)
+                } else {
+                    (None, sketch_series.metric.as_str())
+                };
                 let mut metric = Metric::new_with_metadata(
                     name.to_string(),
                     MetricKind::Incremental,

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -55,6 +55,14 @@ use crate::{
     },
 };
 
+const DD_API_KEY: &str = "12345678abcdefgh12345678abcdefgh";
+const DD_API_LOGS_V1_PATH: &str = "/v1/input/";
+const DD_API_LOGS_V2_PATH: &str = "/api/v2/logs";
+const DD_API_SERIES_V1_PATH: &str = "/api/v1/series";
+const DD_API_SERIES_V2_PATH: &str = "/api/v2/series";
+const DD_API_SKETCHES_PATH: &str = "/api/beta/sketches";
+const DD_API_TRACES_PATH: &str = "/api/v0.2/traces";
+
 fn test_logs_schema_definition() -> schema::Definition {
     schema::Definition::empty_legacy_namespace().with_event_field(
         &owned_value_path!("a log field"),
@@ -101,6 +109,7 @@ fn test_decode_log_body() {
             Some(test_logs_schema_definition()),
             LogNamespace::Legacy,
             false,
+            true,
         );
 
         let events = decode_log_body(body, api_key, &source).unwrap();
@@ -156,6 +165,7 @@ fn test_decode_log_body_parse_ddtags() {
         Some(test_logs_schema_definition()),
         LogNamespace::Legacy,
         true,
+        true,
     );
 
     let events = decode_log_body(body, api_key, &source).unwrap();
@@ -192,6 +202,7 @@ fn test_decode_log_body_empty_object() {
         Some(test_logs_schema_definition()),
         LogNamespace::Legacy,
         false,
+        true,
     );
 
     let events = decode_log_body(body, api_key, &source).unwrap();
@@ -208,6 +219,7 @@ async fn source(
     acknowledgements: bool,
     store_api_key: bool,
     multiple_outputs: bool,
+    split_metric_namespace: bool,
 ) -> (
     impl Stream<Item = Event> + Unpin,
     Option<impl Stream<Item = Event>>,
@@ -237,9 +249,10 @@ async fn source(
             store_api_key = {}
             acknowledgements = {}
             multiple_outputs = {}
+            split_metric_namespace = {}
             trace_proto = "v1v2"
         "#},
-        address, store_api_key, acknowledgements, multiple_outputs
+        address, store_api_key, acknowledgements, multiple_outputs, split_metric_namespace
     ))
     .unwrap();
     let schema_definitions =
@@ -264,36 +277,52 @@ async fn send_with_path(address: SocketAddr, body: &str, headers: HeaderMap, pat
         .as_u16()
 }
 
+async fn send_and_collect(
+    address: SocketAddr,
+    body: String,
+    headers: HeaderMap,
+    path: &'static str,
+    rx: impl Stream<Item = Event> + Unpin,
+    expected_count: usize,
+) -> Vec<Event> {
+    spawn_collect_n(
+        async move {
+            assert_eq!(200, send_with_path(address, &body, headers, path).await);
+        },
+        rx,
+        expected_count,
+    )
+    .await
+}
+
+fn dd_api_key_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("dd-api-key", DD_API_KEY.parse().unwrap());
+    headers
+}
+
 #[tokio::test]
 async fn full_payload_v1() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("foo"),
-                            timestamp: Utc
-                                .timestamp_opt(123, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        HeaderMap::new(),
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("foo"),
+                timestamp: Utc
+                    .timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            HeaderMap::new(),
+            DD_API_LOGS_V1_PATH,
             rx,
             1,
         )
@@ -329,33 +358,25 @@ async fn full_payload_v1() {
 #[tokio::test]
 async fn full_payload_v2() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("foo"),
-                            timestamp: Utc
-                                .timestamp_opt(123, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        HeaderMap::new(),
-                        "/api/v2/logs"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("foo"),
+                timestamp: Utc
+                    .timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            HeaderMap::new(),
+            DD_API_LOGS_V2_PATH,
             rx,
             1,
         )
@@ -391,33 +412,25 @@ async fn full_payload_v2() {
 #[tokio::test]
 async fn no_api_key() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("foo"),
-                            timestamp: Utc
-                                .timestamp_opt(123, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        HeaderMap::new(),
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("foo"),
+                timestamp: Utc
+                    .timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            HeaderMap::new(),
+            DD_API_LOGS_V1_PATH,
             rx,
             1,
         )
@@ -453,33 +466,25 @@ async fn no_api_key() {
 #[tokio::test]
 async fn api_key_in_url() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("bar"),
-                            timestamp: Utc
-                                .timestamp_opt(456, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        HeaderMap::new(),
-                        "/v1/input/12345678abcdefgh12345678abcdefgh"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("bar"),
+                timestamp: Utc
+                    .timestamp_opt(456, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            HeaderMap::new(),
+            "/v1/input/12345678abcdefgh12345678abcdefgh",
             rx,
             1,
         )
@@ -504,7 +509,7 @@ async fn api_key_in_url() {
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
             assert_eq!(
                 event.metadata().schema_definition().as_ref(),
@@ -518,33 +523,25 @@ async fn api_key_in_url() {
 #[tokio::test]
 async fn api_key_in_query_params() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("bar"),
-                            timestamp: Utc
-                                .timestamp_opt(456, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        HeaderMap::new(),
-                        "/api/v2/logs?dd-api-key=12345678abcdefgh12345678abcdefgh"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("bar"),
+                timestamp: Utc
+                    .timestamp_opt(456, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            HeaderMap::new(),
+            "/api/v2/logs?dd-api-key=12345678abcdefgh12345678abcdefgh",
             rx,
             1,
         )
@@ -569,7 +566,7 @@ async fn api_key_in_query_params() {
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
             assert_eq!(
                 event.metadata().schema_definition().as_ref(),
@@ -583,39 +580,25 @@ async fn api_key_in_query_params() {
 #[tokio::test]
 async fn api_key_in_header() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
-
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("baz"),
-                            timestamp: Utc
-                                .timestamp_opt(789, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        headers,
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("baz"),
+                timestamp: Utc
+                    .timestamp_opt(789, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            dd_api_key_headers(),
+            DD_API_LOGS_V1_PATH,
             rx,
             1,
         )
@@ -640,7 +623,7 @@ async fn api_key_in_header() {
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
             assert_eq!(
                 event.metadata().schema_definition().as_ref(),
@@ -654,7 +637,7 @@ async fn api_key_in_header() {
 #[tokio::test]
 async fn delivery_failure() {
     trace_init();
-    let (rx, _, _, addr) = source(EventStatus::Rejected, true, true, false).await;
+    let (rx, _, _, addr) = source(EventStatus::Rejected, true, true, false, true).await;
 
     spawn_collect_n(
         async move {
@@ -676,7 +659,7 @@ async fn delivery_failure() {
                     }])
                     .unwrap(),
                     HeaderMap::new(),
-                    "/v1/input/"
+                    DD_API_LOGS_V1_PATH
                 )
                 .await
             );
@@ -690,33 +673,25 @@ async fn delivery_failure() {
 #[tokio::test]
 async fn ignores_disabled_acknowledgements() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Rejected, false, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Rejected, false, true, false, true).await;
 
-        let events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("foo"),
-                            timestamp: Utc
-                                .timestamp_opt(123, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        HeaderMap::new(),
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
+        let events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("foo"),
+                timestamp: Utc
+                    .timestamp_opt(123, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            HeaderMap::new(),
+            DD_API_LOGS_V1_PATH,
             rx,
             1,
         )
@@ -730,39 +705,25 @@ async fn ignores_disabled_acknowledgements() {
 #[tokio::test]
 async fn ignores_api_key() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, false, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, false, false, true).await;
 
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
-
-        let mut events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("baz"),
-                            timestamp: Utc
-                                .timestamp_opt(789, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        headers,
-                        "/v1/input/12345678abcdefgh12345678abcdefgh"
-                    )
-                    .await
-                );
-            },
+        let mut events = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("baz"),
+                timestamp: Utc
+                    .timestamp_opt(789, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            dd_api_key_headers(),
+            "/v1/input/12345678abcdefgh12345678abcdefgh",
             rx,
             1,
         )
@@ -798,13 +759,7 @@ async fn ignores_api_key() {
 #[tokio::test]
 async fn decode_series_endpoint_v1() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
-
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
         let dd_metric_request = DatadogSeriesRequest {
             series: vec![
@@ -868,19 +823,11 @@ async fn decode_series_endpoint_v1() {
                 },
             ],
         };
-        let events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&dd_metric_request).unwrap(),
-                        headers,
-                        "/api/v1/series"
-                    )
-                    .await
-                );
-            },
+        let events = send_and_collect(
+            addr,
+            serde_json::to_string(&dd_metric_request).unwrap(),
+            dd_api_key_headers(),
+            DD_API_SERIES_V1_PATH,
             rx,
             6,
         )
@@ -910,7 +857,7 @@ async fn decode_series_endpoint_v1() {
 
             assert_eq!(
                 &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             metric = events[1].as_metric();
@@ -936,7 +883,7 @@ async fn decode_series_endpoint_v1() {
 
             assert_eq!(
                 &events[1].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             metric = events[2].as_metric();
@@ -967,7 +914,7 @@ async fn decode_series_endpoint_v1() {
 
             assert_eq!(
                 &events[2].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             metric = events[3].as_metric();
@@ -1005,7 +952,7 @@ async fn decode_series_endpoint_v1() {
 
             assert_eq!(
                 &events[3].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
         }
     })
@@ -1015,13 +962,7 @@ async fn decode_series_endpoint_v1() {
 #[tokio::test]
 async fn decode_sketches() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
-
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
         let mut buf = Vec::new();
         let sketch = ddmetric_proto::sketch_payload::Sketch {
@@ -1058,20 +999,12 @@ async fn decode_sketches() {
         };
 
         sketch_payload.encode(&mut buf).unwrap();
-
-        let events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        unsafe { str::from_utf8_unchecked(&buf) },
-                        headers,
-                        "/api/beta/sketches"
-                    )
-                    .await
-                );
-            },
+        let body = unsafe { String::from_utf8_unchecked(buf) };
+        let events = send_and_collect(
+            addr,
+            body,
+            dd_api_key_headers(),
+            DD_API_SKETCHES_PATH,
             rx,
             1,
         )
@@ -1114,7 +1047,7 @@ async fn decode_sketches() {
 
             assert_eq!(
                 &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             let event_origin = &events[0].metadata().datadog_origin_metadata().unwrap();
@@ -1129,13 +1062,9 @@ async fn decode_sketches() {
 #[tokio::test]
 async fn decode_traces() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
+        let mut headers = dd_api_key_headers();
         headers.insert("X-Datadog-Reported-Languages", "ada".parse().unwrap());
 
         let mut buf_v1 = Vec::new();
@@ -1223,7 +1152,7 @@ async fn decode_traces() {
                         addr,
                         unsafe { str::from_utf8_unchecked(&buf_v1) },
                         headers.clone(),
-                        "/api/v0.2/traces"
+                        DD_API_TRACES_PATH
                     )
                     .await
                 );
@@ -1233,7 +1162,7 @@ async fn decode_traces() {
                         addr,
                         unsafe { str::from_utf8_unchecked(&buf_v2) },
                         headers,
-                        "/api/v0.2/traces"
+                        DD_API_TRACES_PATH
                     )
                     .await
                 );
@@ -1280,7 +1209,7 @@ async fn decode_traces() {
             );
             assert_eq!(
                 &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             let apm_event = events[1].as_trace();
@@ -1298,7 +1227,7 @@ async fn decode_traces() {
 
             assert_eq!(
                 &events[1].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             let trace_v2 = events[2].as_trace();
@@ -1360,7 +1289,7 @@ async fn decode_traces() {
             );
             assert_eq!(
                 &events[2].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
         }
     })
@@ -1370,39 +1299,26 @@ async fn decode_traces() {
 #[tokio::test]
 async fn split_outputs() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (_, rx_logs, rx_metrics, addr) = source(EventStatus::Delivered, true, true, true).await;
+        let (_, rx_logs, rx_metrics, addr) =
+            source(EventStatus::Delivered, true, true, true, true).await;
 
-        let mut headers_for_log = HeaderMap::new();
-        headers_for_log.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
-
-        let mut log_event = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&[LogMsg {
-                            message: Bytes::from("baz"),
-                            timestamp: Utc
-                                .timestamp_opt(789, 0)
-                                .single()
-                                .expect("invalid timestamp"),
-                            hostname: Bytes::from("festeburg"),
-                            status: Bytes::from("notice"),
-                            service: Bytes::from("vector"),
-                            ddsource: Bytes::from("curl"),
-                            ddtags: Bytes::from("one,two,three"),
-                        }])
-                        .unwrap(),
-                        headers_for_log,
-                        "/v1/input/"
-                    )
-                    .await
-                );
-            },
+        let mut log_event = send_and_collect(
+            addr,
+            serde_json::to_string(&[LogMsg {
+                message: Bytes::from("baz"),
+                timestamp: Utc
+                    .timestamp_opt(789, 0)
+                    .single()
+                    .expect("invalid timestamp"),
+                hostname: Bytes::from("festeburg"),
+                status: Bytes::from("notice"),
+                service: Bytes::from("vector"),
+                ddsource: Bytes::from("curl"),
+                ddtags: Bytes::from("one,two,three"),
+            }])
+            .unwrap(),
+            dd_api_key_headers(),
+            DD_API_LOGS_V1_PATH,
             rx_logs.unwrap(),
             1,
         )
@@ -1429,19 +1345,11 @@ async fn split_outputs() {
                 metadata: None,
             }],
         };
-        let mut metric_event = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        &serde_json::to_string(&dd_metric_request).unwrap(),
-                        headers_for_metric,
-                        "/api/v1/series"
-                    )
-                    .await
-                );
-            },
+        let mut metric_event = send_and_collect(
+            addr,
+            serde_json::to_string(&dd_metric_request).unwrap(),
+            headers_for_metric,
+            DD_API_SERIES_V1_PATH,
             rx_metrics.unwrap(),
             1,
         )
@@ -1493,7 +1401,7 @@ async fn split_outputs() {
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
                 &event.metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
             assert_eq!(
                 event.metadata().schema_definition().as_ref(),
@@ -1574,6 +1482,7 @@ fn test_config_outputs_with_disabled_data_types() {
             disable_metrics,
             disable_traces,
             parse_ddtags: false,
+            split_metric_namespace: true,
             log_namespace: Some(false),
             keepalive: Default::default(),
         };
@@ -2016,6 +1925,7 @@ fn test_config_outputs() {
             disable_metrics: false,
             disable_traces: false,
             parse_ddtags: false,
+            split_metric_namespace: true,
             log_namespace: Some(false),
             keepalive: Default::default(),
         };
@@ -2039,13 +1949,7 @@ fn test_config_outputs() {
 #[tokio::test]
 async fn decode_series_endpoint_v2() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
-        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false).await;
-
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "dd-api-key",
-            "12345678abcdefgh12345678abcdefgh".parse().unwrap(),
-        );
+        let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, true).await;
 
         let series = vec![
             ddmetric_proto::metric_payload::MetricSeries {
@@ -2117,20 +2021,12 @@ async fn decode_series_endpoint_v2() {
 
         let mut buf = Vec::new();
         series_payload.encode(&mut buf).unwrap();
-
-        let events = spawn_collect_n(
-            async move {
-                assert_eq!(
-                    200,
-                    send_with_path(
-                        addr,
-                        unsafe { str::from_utf8_unchecked(&buf) },
-                        headers,
-                        "/api/v2/series"
-                    )
-                    .await
-                );
-            },
+        let body = unsafe { String::from_utf8_unchecked(buf) };
+        let events = send_and_collect(
+            addr,
+            body,
+            dd_api_key_headers(),
+            DD_API_SERIES_V2_PATH,
             rx,
             4,
         )
@@ -2168,7 +2064,7 @@ async fn decode_series_endpoint_v2() {
 
             assert_eq!(
                 &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             metric = events[1].as_metric();
@@ -2198,7 +2094,7 @@ async fn decode_series_endpoint_v2() {
 
             assert_eq!(
                 &events[1].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             metric = events[2].as_metric();
@@ -2231,7 +2127,7 @@ async fn decode_series_endpoint_v2() {
 
             assert_eq!(
                 &events[2].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             metric = events[3].as_metric();
@@ -2263,7 +2159,7 @@ async fn decode_series_endpoint_v2() {
 
             assert_eq!(
                 &events[3].metadata().datadog_api_key().as_ref().unwrap()[..],
-                "12345678abcdefgh12345678abcdefgh"
+                DD_API_KEY
             );
 
             assert_eq!(
@@ -2501,6 +2397,183 @@ fn assert_tags(metric: &Metric, tags: MetricTags) {
     assert_eq!(metric.tags().expect("Missing tags"), &tags);
 }
 
+async fn test_series_v1_split_metric_namespace_impl(
+    split: bool,
+    expected_name: &str,
+    expected_namespace: Option<&str>,
+) {
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, split).await;
+
+    let dd_metric_request = DatadogSeriesRequest {
+        series: vec![DatadogSeriesMetric {
+            metric: "system.disk.free".to_string(),
+            r#type: DatadogMetricType::Gauge,
+            interval: None,
+            points: vec![DatadogPoint(1542182950, 42.0)],
+            tags: Some(vec!["foo:bar".to_string()]),
+            host: Some("test_host".to_string()),
+            source_type_name: None,
+            device: None,
+            metadata: None,
+        }],
+    };
+
+    let events = send_and_collect(
+        addr,
+        serde_json::to_string(&dd_metric_request).unwrap(),
+        dd_api_key_headers(),
+        DD_API_SERIES_V1_PATH,
+        rx,
+        1,
+    )
+    .await;
+
+    let metric = events[0].as_metric();
+    assert_eq!(metric.name(), expected_name);
+    assert_eq!(metric.namespace(), expected_namespace);
+}
+
+#[tokio::test]
+async fn series_v1_split_metric_namespace_true() {
+    assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+        test_series_v1_split_metric_namespace_impl(true, "disk.free", Some("system")).await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn series_v1_split_metric_namespace_false() {
+    assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+        test_series_v1_split_metric_namespace_impl(false, "system.disk.free", None).await;
+    })
+    .await;
+}
+
+async fn test_series_v2_split_metric_namespace_impl(
+    split: bool,
+    expected_name: &str,
+    expected_namespace: Option<&str>,
+) {
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, split).await;
+
+    let series = vec![ddmetric_proto::metric_payload::MetricSeries {
+        resources: vec![ddmetric_proto::metric_payload::Resource {
+            r#type: "host".to_string(),
+            name: "test_host".to_string(),
+        }],
+        metric: "system.disk.free".to_string(),
+        tags: vec!["foo:bar".to_string()],
+        points: vec![ddmetric_proto::metric_payload::MetricPoint {
+            value: 42.0,
+            timestamp: 1542182950,
+        }],
+        r#type: ddmetric_proto::metric_payload::MetricType::Gauge as i32,
+        unit: "".to_string(),
+        source_type_name: "".to_string(),
+        interval: 10,
+        metadata: None,
+    }];
+
+    let series_payload = ddmetric_proto::MetricPayload { series };
+
+    let mut buf = Vec::new();
+    series_payload.encode(&mut buf).unwrap();
+    let body = unsafe { String::from_utf8_unchecked(buf) };
+    let events = send_and_collect(
+        addr,
+        body,
+        dd_api_key_headers(),
+        DD_API_SERIES_V2_PATH,
+        rx,
+        1,
+    )
+    .await;
+
+    let metric = events[0].as_metric();
+    assert_eq!(metric.name(), expected_name);
+    assert_eq!(metric.namespace(), expected_namespace);
+}
+
+#[tokio::test]
+async fn series_v2_split_metric_namespace_true() {
+    assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+        test_series_v2_split_metric_namespace_impl(true, "disk.free", Some("system")).await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn series_v2_split_metric_namespace_false() {
+    assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+        test_series_v2_split_metric_namespace_impl(false, "system.disk.free", None).await;
+    })
+    .await;
+}
+
+async fn test_sketches_split_metric_namespace_impl(
+    split: bool,
+    expected_name: &str,
+    expected_namespace: Option<&str>,
+) {
+    let (rx, _, _, addr) = source(EventStatus::Delivered, true, true, false, split).await;
+
+    let mut buf = Vec::new();
+    let sketch = ddmetric_proto::sketch_payload::Sketch {
+        metric: "system.disk.free".to_string(),
+        tags: vec!["foo:bar".to_string()],
+        host: "test_host".to_string(),
+        distributions: Vec::new(),
+        dogsketches: vec![ddmetric_proto::sketch_payload::sketch::Dogsketch {
+            ts: 1542182950,
+            cnt: 2,
+            min: 16.0,
+            max: 31.0,
+            avg: 23.5,
+            sum: 74.0,
+            k: vec![1517, 1559],
+            n: vec![1, 1],
+        }],
+        metadata: None,
+    };
+
+    let sketch_payload = ddmetric_proto::SketchPayload {
+        metadata: None,
+        sketches: vec![sketch],
+    };
+
+    sketch_payload.encode(&mut buf).unwrap();
+    let body = unsafe { String::from_utf8_unchecked(buf) };
+    let events = send_and_collect(
+        addr,
+        body,
+        dd_api_key_headers(),
+        DD_API_SKETCHES_PATH,
+        rx,
+        1,
+    )
+    .await;
+
+    let metric = events[0].as_metric();
+    assert_eq!(metric.name(), expected_name);
+    assert_eq!(metric.namespace(), expected_namespace);
+}
+
+#[tokio::test]
+async fn sketches_split_metric_namespace_true() {
+    assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+        test_sketches_split_metric_namespace_impl(true, "disk.free", Some("system")).await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn sketches_split_metric_namespace_false() {
+    assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {
+        test_sketches_split_metric_namespace_impl(false, "system.disk.free", None).await;
+    })
+    .await;
+}
+
 impl ValidatableComponent for DatadogAgentConfig {
     fn validation_configuration() -> ValidationConfiguration {
         use crate::codecs::DecodingConfig;
@@ -2523,6 +2596,7 @@ impl ValidatableComponent for DatadogAgentConfig {
             disable_metrics: false,
             disable_traces: false,
             parse_ddtags: false,
+            split_metric_namespace: true,
             log_namespace: Some(false),
             keepalive: Default::default(),
         };

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -541,6 +541,16 @@ generated: components: sources: datadog_agent: configuration: {
 		required: false
 		type: bool: default: false
 	}
+	split_metric_namespace: {
+		description: """
+			If this is set to `true`, metric names are split at the first '.' into a namespace and name.
+			For example, `system.cpu.usage` would be split into namespace `system` and name `cpu.usage`.
+			If `false`, the full metric name is used without splitting. This may be useful if you are using a
+			default namespace for metrics in sinks connected to this source.
+			"""
+		required: false
+		type: bool: default: true
+	}
 	store_api_key: {
 		description: """
 			If this is set to `true`, when incoming events contain a Datadog API key, it is


### PR DESCRIPTION
## Summary

In #13176, the `datadog_agent` source had functionality introduced to automatically split the metric series name into namespace and name components on the first period in that name.  This change was done to address #12953 where a default namespace was configured being applied to a metrics sink, resulting in metrics from this source having an undesired prefix added.

Since all of the metric sinks will reproduce the metric series name based on both the namespace and name in the same way, this is a lossless transform. However, if we want to filter on the full name (ex in a remap VRL script etc), having the namespace split off becomes a problem.

To address this problem, this change introduces a `split_metric_namespace` option to the `datadog_agent` source. It defaults to `true`, which is the current behavior, so the change is entirely backward compatible with existing configs.

The bulk of the size of the change comes from the addition of new tests and refactoring existing tests to reduce duplicated code.

## Vector configuration

See unit tests

## How did you test this PR?

The unit tests were enhanced to verify the parsing operation for all metric sources.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
