### PR TITLE
feat(clickhouse sink): add DNS auto-resolution for load balancing

### DIFF
--- a/changelog.d/23877_clickhouse_sink_dns_auto_resolution.feature.md
+++ b/changelog.d/23877_clickhouse_sink_dns_auto_resolution.feature.md
@@ -1,0 +1,3 @@
+The ClickHouse sink now supports DNS auto-resolution for load balancing, allowing automatic discovery and rotation of ClickHouse cluster nodes through DNS lookups. This enables better high availability and load distribution when connecting to ClickHouse clusters with multiple endpoints.
+
+authors: sebinsunny

--- a/src/sinks/clickhouse/service.rs
+++ b/src/sinks/clickhouse/service.rs
@@ -17,6 +17,7 @@ use crate::{
         util::{
             http::{HttpRequest, HttpResponse, HttpRetryLogic, HttpServiceRequestBuilder},
             retries::RetryAction,
+            service::HealthLogic,
         },
     },
 };
@@ -326,5 +327,32 @@ mod tests {
             QuerySettingsConfig::default(),
         )
         .unwrap_err();
+    }
+}
+
+#[derive(Clone)]
+pub struct ClickhouseHealthLogic;
+
+impl HealthLogic for ClickhouseHealthLogic {
+    type Error = crate::Error;
+    type Response = HttpResponse;
+
+    fn is_healthy(&self, response: &Result<Self::Response, Self::Error>) -> Option<bool> {
+        match response {
+            Ok(response) => {
+                let status = response.http_response.status();
+                if status.is_success() {
+                    Some(true)
+                } else if status.is_server_error() {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            Err(error) => match error.downcast_ref::<HttpError>() {
+                Some(HttpError::CallRequest { .. }) => Some(false),
+                _ => None,
+            },
+        }
     }
 }

--- a/website/cue/reference/components/sinks/generated/clickhouse.cue
+++ b/website/cue/reference/components/sinks/generated/clickhouse.cue
@@ -204,6 +204,16 @@ generated: components: sinks: clickhouse: configuration: {
 			}
 		}
 	}
+	auto_resolve_dns: {
+		description: """
+			Automatically resolve hostnames to all available IP addresses.
+
+			When enabled, the hostname in the endpoint will be resolved to all its IP addresses,
+			and Vector will load balance across all resolved IPs.
+			"""
+		required: false
+		type: bool: default: false
+	}
 	batch: {
 		description: "Event batching behavior."
 		required:    false


### PR DESCRIPTION
## Summary
This PR implements DNS auto-resolution for load balancing in the ClickHouse sink, addressing issue #23877. The feature allows automatic discovery and rotation of ClickHouse cluster nodes through DNS lookups, enabling better high availability and load distribution when connecting to ClickHouse clusters with multiple endpoints.

## Vector configuration
```yaml
sinks:
  clickhouse:
    type: clickhouse
    inputs: [test]
    endpoint: "http://clickhouse-cluster.example.com:8123"
    database: "my_database"
    table: "my_table"
    auto_resolve_dns: true  # Enable DNS auto-resolution for load balancing
    # The sink will automatically resolve the DNS name and load balance across all resolved IPs
```

## How did you test this PR?
- Added integration tests in `src/sinks/clickhouse/integration_tests.rs` to verify DNS resolution functionality
- Tested with the ClickHouse service to ensure multiple IP addresses are properly discovered, and each batch request is forwarded randomly to an IP address.
```
dig +short clickhouse-sebin-vector-dev-sandbox.g.aivencloud.com

Output:
34.14.24.250
34.140.127.238
34.78.18.219
```

- Verified that resolved endpoints are IP addresses rather than hostnames
- Ran existing ClickHouse sink tests to ensure no regression

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #23877

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).