### PR TITLE
chore(datadog service): add flattened and unflattened key examples to datadog_search tests

### DIFF
--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -836,6 +836,18 @@ mod test {
             ),
             // Float attribute match (negate w/-).
             ("-@a:0.75", log_event!["a" => 0.74], log_event!["a" => 0.75]),
+            // Attribute match with dot in name
+            (
+                "@a.b:x",
+                log_event!["a" => serde_json::json!({"b": "x"})],
+                Event::Log(LogEvent::from(Value::from(serde_json::json!({"a.b": "x"})))),
+            ),
+            // Attribute with dot in name (flattened key) - requires escaped quotes.
+            (
+                r#"@\"a.b\":x"#,
+                Event::Log(LogEvent::from(Value::from(serde_json::json!({"a.b": "x"})))),
+                log_event!["a" => serde_json::json!({"b": "x"})],
+            ),
             // Wildcard prefix.
             (
                 "*bla",


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Adds examples to the `datadog_search` unit test for matching attributes with flattened keys and unflattened ones. The logic for matching flattened keys is a bit tricky to follow (seems to be [this](https://github.com/vectordotdev/vrl/blob/main/src/path/jit.rs#L128-L162)) so this makes it easier to remember and check for.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
None - since this simply adds unit test cases 

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Ran the unit test 
```
❯ cargo test --package vector --lib conditions::datadog_search::test -- --show-output
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.18s
     Running unittests src/lib.rs (target/debug/deps/vector-9b54a6e270325134)

running 3 tests
test conditions::datadog_search::test::generate_config ... ok
test conditions::datadog_search::test::event_filter ... ok
test conditions::datadog_search::test::check_datadog ... ok

successes:

successes:
    conditions::datadog_search::test::check_datadog
    conditions::datadog_search::test::event_filter
    conditions::datadog_search::test::generate_config

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1779 filtered out; finished in 0.17s
```

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
