### PR TITLE
feat(ci): optimize integration tests by reusing test-runner images

### DIFF
--- a/.github/workflows/ci-integration-review.yml
+++ b/.github/workflows/ci-integration-review.yml
@@ -34,6 +34,7 @@ on:
 
 permissions:
   statuses: write
+  packages: write
 
 env:
   AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
@@ -80,8 +81,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
 
-  integration-tests:
+  build-test-runner:
     needs: prep-pr
+    uses: ./.github/workflows/build-test-runner.yml
+    with:
+      commit_sha: ${{ github.event.review.commit_id }}
+      checkout_ref: ${{ github.event.review.commit_id }}
+
+  integration-tests:
+    needs:
+      - prep-pr
+      - build-test-runner
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -99,9 +109,13 @@ jobs:
           submodules: "recursive"
           ref: ${{ github.event.review.commit_id }}
 
-      - run: bash scripts/environment/prepare.sh --modules=datadog-ci
+      - name: Pull test runner image
+        uses: ./.github/actions/pull-test-runner
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ github.event.review.commit_id }}
 
-      - run: docker image prune -af ; docker container prune -f
+      - run: bash scripts/environment/prepare.sh --modules=datadog-ci
 
       - name: Integration Tests - ${{ matrix.service }}
         if: ${{ startsWith(github.event.review.body, '/ci-run-integration-all')
@@ -114,7 +128,9 @@ jobs:
           command: bash scripts/run-integration-test.sh int ${{ matrix.service }}
 
   e2e-tests:
-    needs: prep-pr
+    needs:
+      - prep-pr
+      - build-test-runner
     runs-on: ubuntu-24.04-8core
     timeout-minutes: 30
     steps:
@@ -123,9 +139,14 @@ jobs:
           submodules: "recursive"
           ref: ${{ github.event.review.commit_id }}
 
+      - name: Pull test runner image
+        uses: ./.github/actions/pull-test-runner
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ github.event.review.commit_id }}
+
       - run: bash scripts/environment/prepare.sh --modules=datadog-ci
 
-      - run: docker image prune -af ; docker container prune -f
       - name: e2e-datadog-logs
         if: ${{ startsWith(github.event.review.body, '/ci-run-e2e-datadog-logs')
           || startsWith(github.event.review.body, '/ci-run-e2e-all')

--- a/.github/workflows/cleanup-ghcr-images.yml
+++ b/.github/workflows/cleanup-ghcr-images.yml
@@ -1,0 +1,38 @@
+# Cleanup GHCR Images
+#
+# This workflow cleans up old images from GitHub Container Registry
+# to prevent unlimited storage growth. It runs weekly and removes:
+# 1. Untagged images from all packages (intermediate build artifacts)
+# 2. Old test-runner versions (keeps 50 most recent, deletes up to 50 oldest)
+
+name: Cleanup Untagged GHCR Images
+
+on:
+  schedule:
+    # Run weekly on Sundays at 2 AM UTC
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Delete untagged vector images
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: vector
+          package-type: container
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: true
+        continue-on-error: true
+
+      - name: Delete old vector-test-runner images
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: test-runner
+          package-type: container
+          min-versions-to-keep: 5
+          num-old-versions-to-delete: 50

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
+permissions:
+  packages: write
+  contents: read
+
 env:
   CONTAINER_TOOL: "docker"
   DD_ENV: "ci"
@@ -43,10 +47,26 @@ jobs:
       e2e_tests: true
     secrets: inherit
 
+  build-test-runner:
+    needs: changes
+    if: |
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'merge_group' &&
+         (needs.changes.outputs.dependencies == 'true' ||
+          needs.changes.outputs.integration-yml == 'true' ||
+          needs.changes.outputs.int-tests-any == 'true' ||
+          needs.changes.outputs.e2e-tests-any == 'true'))
+      }}
+    uses: ./.github/workflows/build-test-runner.yml
+    with:
+      commit_sha: ${{ github.sha }}
+
   integration-tests:
     runs-on: ubuntu-24.04-8core
     needs:
       - changes
+      - build-test-runner
 
     if: ${{ !failure() && !cancelled() && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') }}
     strategy:
@@ -71,6 +91,12 @@ jobs:
         if: github.event_name == 'merge_group'
         with:
           name: int_tests_changes
+
+      - name: Pull test runner image
+        uses: ./.github/actions/pull-test-runner
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ github.sha }}
 
       - name: Run Integration Tests for ${{ matrix.service }}
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
@@ -109,6 +135,7 @@ jobs:
     runs-on: ubuntu-24.04-8core
     needs:
       - changes
+      - build-test-runner
     if: ${{ !failure() && !cancelled() && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') }}
     strategy:
       matrix:
@@ -125,6 +152,12 @@ jobs:
         if: github.event_name == 'merge_group'
         with:
           name: e2e_tests_changes
+
+      - name: Pull test runner image
+        uses: ./.github/actions/pull-test-runner
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ github.sha }}
 
       - name: Run E2E Tests for ${{ matrix.service }}
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Add GitHub Container Registry (GHCR) image reuse for integration test runners:
- Cache test-runner images in GHCR tagged by Rust version
- Reuse existing images when available to skip rebuild time
- Add cleanup workflow to remove untagged GHCR images
- Update ci-integration-review.yml to use cached images
- Update integration.yml workflow to push images to GHCR

This reduces CI time by avoiding redundant test-runner image builds when the Rust version hasn't changed.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

Run: https://github.com/vectordotdev/vector/actions/runs/18728652465/job/53420062320?pr=24052

Compare with https://github.com/vectordotdev/vector/actions/runs/16574626369

(ignore splunk failures, there's an open issue for those)

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
