### PR TITLE
fix(okta): Source does not update `since` query every interval

### DIFF
--- a/src/sources/okta/client.rs
+++ b/src/sources/okta/client.rs
@@ -1,42 +1,39 @@
-use std::{sync::Arc, time::Duration};
+use std::collections::HashMap;
+use std::time::Duration;
 
 use bytes::{Bytes, BytesMut};
 use chrono::Utc;
-use futures::StreamExt as _;
-use futures_util::{FutureExt, Stream, stream};
+use futures_util::FutureExt;
 use http::Uri;
-use hyper::{Body, Request};
+use http::response::Parts as ResponseParts;
+use http::uri::Parts as UriParts;
 use percent_encoding::utf8_percent_encode;
 use serde_with::serde_as;
-use tokio::sync::Mutex;
-use tokio_stream::wrappers::IntervalStream;
 use tokio_util::codec::Decoder as _;
 use vector_lib::{
-    EstimatedJsonEncodedSizeOf,
     codecs::{
-        JsonDeserializerConfig, StreamDecodingError,
+        StreamDecodingError,
         decoding::{DeserializerConfig, FramingConfig},
     },
-    config::{LogNamespace, SourceOutput, proxy::ProxyConfig},
+    config::LogNamespace,
     configurable::configurable_component,
     event::Event,
-    json_size::JsonSize,
-    shutdown::ShutdownSignal,
-    tls::TlsConfig,
 };
 
 use crate::{
-    SourceSender,
+    Result,
     codecs::{Decoder, DecodingConfig},
-    config::{SourceConfig, SourceContext},
-    http::{HttpClient, HttpError},
-    internal_events::{
-        DecoderDeserializeError, EndpointBytesReceived, HttpClientEventsReceived,
-        HttpClientHttpError, HttpClientHttpResponseError, StreamClosedError,
-    },
+    config::{SourceConfig, SourceContext, SourceOutput},
+    serde::{default_decoding, default_framing_message_based},
     sources,
-    sources::util::http_client::{default_interval, default_timeout, warn_if_interval_too_low},
-    tls::TlsSettings,
+    sources::util::{
+        http::HttpMethod,
+        http_client::{
+            GenericHttpClientInputs, HttpClientBuilder, HttpClientContext, call, default_interval,
+            default_timeout, warn_if_interval_too_low,
+        },
+    },
+    tls::{TlsConfig, TlsSettings},
 };
 
 /// Configuration for the `okta` source.
@@ -44,6 +41,16 @@ use crate::{
 #[configurable_component(source("okta", "Pull Okta system logs via the Okta API",))]
 #[derive(Clone, Debug)]
 pub struct OktaConfig {
+    /// Decoder to use on each received message.
+    #[configurable(derived)]
+    #[serde(default = "default_decoding")]
+    pub decoding: DeserializerConfig,
+
+    /// Framing to use in the decoding.
+    #[configurable(derived)]
+    #[serde(default = "default_framing_message_based")]
+    pub framing: FramingConfig,
+
     /// The Okta subdomain to scrape
     #[configurable(metadata(docs::examples = "foo.okta.com"))]
     pub domain: String,
@@ -61,17 +68,17 @@ pub struct OktaConfig {
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub interval: Duration,
 
+    /// The time to look back for logs. This is used to determine the start time of the first
+    /// request (that is, the earliest log to fetch)
+    #[configurable(metadata(docs::human_name = "Since (seconds before now)"))]
+    pub since: Option<u64>,
+
     /// The timeout for each scrape request.
     #[serde(default = "default_timeout")]
     #[serde_as(as = "serde_with::DurationSecondsWithFrac<f64>")]
     #[serde(rename = "scrape_timeout_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Timeout"))]
     pub timeout: Duration,
-
-    /// The time to look back for logs. This is used to determine the start time of the first request
-    /// (that is, the earliest log to fetch)
-    #[configurable(metadata(docs::human_name = "Since (seconds before now)"))]
-    pub since: Option<u64>,
 
     /// TLS configuration.
     #[configurable(derived)]
@@ -86,6 +93,8 @@ pub struct OktaConfig {
 impl Default for OktaConfig {
     fn default() -> Self {
         Self {
+            decoding: default_decoding(),
+            framing: default_framing_message_based(),
             domain: "".to_string(),
             token: "".to_string(),
             interval: default_interval(),
@@ -99,34 +108,82 @@ impl Default for OktaConfig {
 
 impl_generate_config_from_default!(OktaConfig);
 
-fn find_rel_next_link(header: &str) -> Option<String> {
-    for part in header.split(',') {
-        let relpart: Vec<_> = part.split(';').collect();
-        if let Some(url) = relpart
-            .first()
-            .map(|s| s.trim().trim_matches(|c| c == '<' || c == '>'))
-            && part.contains("rel=\"next\"")
-        {
-            return Some(url.to_string());
+/// Request-specific context for Okta API scraping.
+#[derive(Clone)]
+struct OktaContext {
+    decoder: Decoder,
+    interval: Duration,
+    since: Option<u64>,
+}
+
+impl OktaContext {
+    /// Decode the events from the byte buffer
+    fn decode_events(&mut self, buf: &mut BytesMut) -> Vec<Event> {
+        let mut events = Vec::new();
+        loop {
+            match self.decoder.decode_eof(buf) {
+                Ok(Some((next, _))) => {
+                    events.extend(next);
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    // Error is logged by `crate::codecs::Decoder`, no further
+                    // handling is needed here.
+                    if !error.can_continue() {
+                        break;
+                    }
+                    break;
+                }
+            }
         }
+        events
     }
-    None
+}
+
+impl HttpClientBuilder for OktaContext {
+    type Context = OktaContext;
+
+    fn build(&self, _uri: &Uri) -> Self::Context {
+        self.clone()
+    }
+}
+
+impl HttpClientContext for OktaContext {
+    fn on_response(
+        &mut self,
+        _url: &Uri,
+        _header: &ResponseParts,
+        body: &Bytes,
+    ) -> Option<Vec<Event>> {
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(body);
+
+        let events = self.decode_events(&mut buf);
+
+        Some(events)
+    }
+
+    /// Retrieve the next batch of events for the interval window.
+    fn process_url(&self, url: &Uri) -> Option<Uri> {
+        let mut url_parts = UriParts::from(url.clone());
+        let since = match self.since {
+            Some(since) => Utc::now() - Duration::from_secs(since),
+            _ => Utc::now() - self.interval,
+        };
+        let path_and_query = format!(
+            "/api/v1/logs?since={}",
+            utf8_percent_encode(&since.to_rfc3339(), percent_encoding::NON_ALPHANUMERIC)
+        );
+        url_parts.path_and_query = Some(path_and_query.parse().ok()?);
+
+        Uri::from_parts(url_parts).ok()
+    }
 }
 
 #[async_trait::async_trait]
 #[typetag::serde(name = "okta")]
 impl SourceConfig for OktaConfig {
-    async fn build(&self, cx: SourceContext) -> crate::Result<sources::Source> {
-        let since = match self.since {
-            Some(since) => Utc::now() - Duration::from_secs(since),
-            _ => Utc::now(),
-        };
-
-        let path_and_query = format!(
-            "/api/v1/logs?since={}",
-            utf8_percent_encode(&since.to_rfc3339(), percent_encoding::NON_ALPHANUMERIC)
-        );
-
+    async fn build(&self, cx: SourceContext) -> Result<sources::Source> {
         let mut url_parts = Uri::try_from(&self.domain)
             .map_err(|_| {
                 format!(
@@ -136,36 +193,52 @@ impl SourceConfig for OktaConfig {
             })?
             .into_parts();
 
-        url_parts.path_and_query = Some(path_and_query.parse()?);
         if url_parts.scheme.is_none() {
             url_parts.scheme = Some(http::uri::Scheme::HTTPS);
         }
+        url_parts.path_and_query = Some("/".parse()?);
 
-        let url = Uri::from_parts(url_parts).map_err(|_| {
-            format!(
-                "Invalid domain: {}. Must be a valid Okta subdomain.",
-                self.domain
-            )
-        })?;
+        let urls = vec![Uri::from_parts(url_parts)?];
 
         let tls = TlsSettings::from_options(self.tls.as_ref())?;
 
+        let decoding = self.decoding.clone();
+        let framing = self.framing.clone();
         let log_namespace = cx.log_namespace(self.log_namespace);
+
+        let decoder = DecodingConfig::new(framing, decoding, log_namespace).build()?;
+
+        let context = OktaContext {
+            decoder,
+            interval: self.interval,
+            since: self.since,
+        };
 
         warn_if_interval_too_low(self.timeout, self.interval);
 
-        Ok(run(
-            url,
+        let mut headers = HashMap::new();
+        headers.insert(
+            http::header::AUTHORIZATION.to_string(),
+            vec![format!("SSWS {0}", self.token).to_string()],
+        );
+        headers.insert(
+            http::header::ACCEPT.to_string(),
+            vec!["application/json".to_string()],
+        );
+
+        let inputs = GenericHttpClientInputs {
+            urls,
+            interval: self.interval,
+            timeout: self.timeout,
+            headers,
+            content_type: "application/json".to_string(),
+            auth: None,
             tls,
-            cx.proxy,
-            self.token.clone(),
-            self.interval,
-            self.timeout,
-            log_namespace,
-            cx.shutdown,
-            cx.out,
-        )
-        .boxed())
+            proxy: cx.proxy.clone(),
+            shutdown: cx.shutdown,
+        };
+
+        Ok(call(inputs, context, cx.out, HttpMethod::Get).boxed())
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
@@ -173,249 +246,18 @@ impl SourceConfig for OktaConfig {
         // and is merged here.
         let log_namespace = global_log_namespace.merge(self.log_namespace);
 
+        let schema_definition = self
+            .decoding
+            .schema_definition(log_namespace)
+            .with_standard_vector_source_metadata();
+
         vec![SourceOutput::new_maybe_logs(
-            JsonDeserializerConfig::default().output_type(),
-            JsonDeserializerConfig::default().schema_definition(log_namespace),
+            self.decoding.output_type(),
+            schema_definition,
         )]
     }
 
     fn can_acknowledge(&self) -> bool {
         false
     }
-}
-
-fn enrich_events(events: &mut Vec<Event>, log_namespace: LogNamespace) {
-    let now = Utc::now();
-    for event in events {
-        log_namespace.insert_standard_vector_source_metadata(
-            event.as_mut_log(),
-            OktaConfig::NAME,
-            now,
-        );
-    }
-}
-
-type OktaRunResult =
-    Result<(http::response::Parts, Bytes, Option<Uri>), Box<dyn std::error::Error + Send + Sync>>;
-
-type OktaTimeoutResult =
-    Result<Result<http::Response<Body>, HttpError>, tokio::time::error::Elapsed>;
-
-async fn run_once(url: String, result: OktaTimeoutResult, timeout: Duration) -> OktaRunResult {
-    let mut next: Option<Uri> = None;
-    match result {
-        Ok(Ok(response)) => {
-            let (header, body) = response.into_parts();
-            if let Some(next_url) = header
-                .headers
-                .get_all("link")
-                .iter()
-                .filter_map(|v| v.to_str().ok())
-                .filter_map(find_rel_next_link)
-                .next()
-                .and_then(|next| Uri::try_from(next).ok())
-            {
-                next = Some(next_url);
-            };
-
-            let body = hyper::body::to_bytes(body).await?;
-
-            emit!(EndpointBytesReceived {
-                byte_size: body.len(),
-                protocol: "http",
-                endpoint: &url,
-            });
-            Ok((header, body, next))
-        }
-        Ok(Err(error)) => Err(error.into()),
-        Err(_) => Err(format!("Timeout error: request exceeded {}s", timeout.as_secs_f64()).into()),
-    }
-}
-
-fn handle_response(
-    response: OktaRunResult,
-    decoder: Decoder,
-    log_namespace: LogNamespace,
-    url: String,
-) -> Option<impl Stream<Item = Event> + Send + use<>> {
-    match response {
-        Ok((header, body, _)) if header.status == hyper::StatusCode::OK => {
-            let mut buf = BytesMut::new();
-            buf.extend_from_slice(&body);
-            let mut events = decode_events(&mut buf, decoder);
-            let byte_size = if events.is_empty() {
-                JsonSize::zero()
-            } else {
-                events.estimated_json_encoded_size_of()
-            };
-
-            emit!(HttpClientEventsReceived {
-                byte_size,
-                count: events.len(),
-                url,
-            });
-
-            if events.is_empty() {
-                return None;
-            }
-
-            enrich_events(&mut events, log_namespace);
-
-            Some(stream::iter(events))
-        }
-        Ok((header, _, _)) => {
-            emit!(HttpClientHttpResponseError {
-                code: header.status,
-                url,
-            });
-            None
-        }
-        Err(error) => {
-            emit!(HttpClientHttpError { error, url });
-            None
-        }
-    }
-}
-
-/// Calls the Okta system logs API and sends the events to the output stream.
-///
-/// Okta's API paginates with a `link` header that contains a url (in `rel=next`) to the next page of results,
-/// and will always return a `rel=next` link regardless of whether there are more results.
-/// This function fetches all pages until there are no more results (an empty JSON array) and finishes until
-/// the next interval
-/// The function will run until the `shutdown` signal is received.
-#[allow(clippy::too_many_arguments)] // internal function
-async fn run(
-    url: Uri,
-    tls: TlsSettings,
-    proxy: ProxyConfig,
-    token: String,
-    interval: Duration,
-    timeout: Duration,
-    log_namespace: LogNamespace,
-    shutdown: ShutdownSignal,
-    mut out: SourceSender,
-) -> Result<(), ()> {
-    let url_mutex = Arc::new(Mutex::new(url.clone()));
-    let decoder = DecodingConfig::new(
-        FramingConfig::Bytes,
-        DeserializerConfig::Json(JsonDeserializerConfig::default()),
-        log_namespace,
-    )
-    .build()
-    .map_err(|ref e| {
-        emit!(DecoderDeserializeError { error: e });
-    })?;
-
-    let client = HttpClient::new(tls, &proxy).map_err(|e| {
-        emit!(HttpClientHttpError {
-            error: Box::new(e),
-            url: url.to_string()
-        });
-    })?;
-
-    let mut stream = IntervalStream::new(tokio::time::interval(interval))
-        .take_until(shutdown)
-        .then(move |_| {
-            let client = client.clone();
-            let url_mutex = Arc::clone(&url_mutex);
-            let token = token.clone();
-            let decoder = decoder.clone();
-
-            async move {
-                stream::unfold((), move |_| {
-                    let url_mutex = Arc::clone(&url_mutex);
-                    let token = token.clone();
-                    let decoder = decoder.clone();
-                    let client = client.clone();
-
-                    async move {
-                        let (run_url, response): (String, OktaRunResult) = {
-                            // We update the actual URL based on the response the API returns
-                            // so the critical section is between here & when the request finishes
-                            let mut url_lock = url_mutex.lock().await;
-                            let url = url_lock.to_string();
-
-                            let mut request = match Request::get(&url).body(Body::empty()) {
-                                Ok(request) => request,
-                                Err(e) => {
-                                    emit!(HttpClientHttpError {
-                                        error: e.into(),
-                                        url: url.clone(),
-                                    });
-                                    return None;
-                                }
-                            };
-
-                            let headers = request.headers_mut();
-                            headers.insert(
-                                http::header::AUTHORIZATION,
-                                format!("SSWS {token}").parse().unwrap(),
-                            );
-                            headers
-                                .insert(http::header::ACCEPT, "application/json".parse().unwrap());
-                            headers.insert(
-                                http::header::CONTENT_TYPE,
-                                "application/json".parse().unwrap(),
-                            );
-
-                            let client = client.clone();
-                            let response = tokio::time::timeout(timeout, client.send(request))
-                                .then({
-                                    let url = url.clone();
-                                    move |result| run_once(url, result, timeout)
-                                })
-                                .await;
-
-                            if let Ok((_, _, Some(ref next))) = response {
-                                *url_lock = next.clone();
-                            }
-                            let new_url = url_lock.to_string();
-
-                            (new_url, response)
-                        };
-
-                        handle_response(response, decoder, log_namespace, run_url)
-                            .map(|events| (events, ()))
-                    }
-                })
-                .flatten()
-                .boxed()
-            }
-        })
-        .flatten_unordered(None)
-        .boxed();
-
-    match out.send_event_stream(&mut stream).await {
-        Ok(()) => {
-            debug!("Finished sending.");
-            Ok(())
-        }
-        Err(_) => {
-            let (count, _) = stream.size_hint();
-            emit!(StreamClosedError { count });
-            Err(())
-        }
-    }
-}
-
-fn decode_events(buf: &mut BytesMut, mut decoder: Decoder) -> Vec<Event> {
-    let mut events = Vec::new();
-    loop {
-        match decoder.decode_eof(buf) {
-            Ok(Some((next, _))) => {
-                events.extend(next);
-            }
-            Ok(None) => break,
-            Err(error) => {
-                // Error is logged by `crate::codecs::Decoder`, no further
-                // handling is needed here.
-                if !error.can_continue() {
-                    break;
-                }
-                break;
-            }
-        }
-    }
-    events
 }


### PR DESCRIPTION
## Summary
Currently, the Okta source component does not function as expected. Vector never updates the `since` API query parameter to bring in a new window of Okta logs; the static `since` value means that the window only grows and grows with each interval. Additionally, because an `until` parameter is never provided, the Okta API _always_ includes header links in the response instead of only on pagination. This leads to scenarios where Vector will quickly hit the Okta API rate limit.

This PR thus makes the following changes:
* Update `since` query every interval to bring in new logs.
* Remove dangery support for following header links.
* Rewrite the Okta implementation to look more like an HTTP Client source.
* Add Okta failure modes to the integration tests.

This is my first PR to Vector, and I'm very open to feedback! :smile: 

I associated this PR to an existing closed issue, where another PR started the Okta work. In building on top of that work, if it is more prudent to open a separate issue for what I'm seeing above, I'm happy to knock that out as well.

I did my best in trying to preserve the original intent with the `since` argument, but I wasn't able to find my way towards a better implementation with the structure of the code as-is.  I'm open to suggestions as to how to make this component feel more "Vector-native"!

Furthermore, it is worth disclosing that no AI tools were used in the development of this PR.

## Vector configuration
```yaml
api:
  address: 127.0.0.1:8686
  enabled: false
  playground: false

data_dir: /tmp/vector-data-dir

sources:
  okta:
    type: okta
    domain: ***.okta.com
    token: ***
    scrape_interval_secs: 300
    decoding:
      codec: json

sinks:
  debug:
    inputs: [okta]
    type: "console"
    encoding:
      codec: json
```

## How did you test this PR?
I built Vector and used the above configuration, alongside the `VECTOR_LOG=debug` flag, to diagnose and troubleshoot failures with the Okta source. For other components, I ran the test suite.

All changes have been human-tested with a release build of this branch against a live Okta environment.

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #22967

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).
