### PR TITLE
feat(ci): add RUST_BACKTRACE/CARGO_TERM_COLOR to setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,10 +90,18 @@ runs:
                    "${{ inputs.wasm-pack }}"; do
           if [[ "$val" == "true" ]]; then
             rust="true"
+            break
           fi
         done
 
         echo "NEEDS_RUST=$rust" >> "$GITHUB_ENV"
+
+        if [[ "$rust" == "true" ]]; then
+          echo "RUST_BACKTRACE=full" >> "$GITHUB_ENV"
+          # Set nice CI colors
+          echo "CARGO_TERM_COLOR=always" >> "$GITHUB_ENV"
+        fi
+
 
     - name: Enable rust matcher
       if: ${{ env.NEEDS_RUST == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ env:
   CONTAINER_TOOL: "docker"
   DD_ENV: "ci"
   DD_API_KEY: ${{ secrets.DD_API_KEY }}
-  RUST_BACKTRACE: full
-  CARGO_TERM_COLOR: always
   VECTOR_LOG: vector=debug
   VERBOSE: true
   CI: true


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This should make it so every action that is using the custom setup action doesn't need to set these up. This should add color to rust jobs automatically

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Let CI run and verify that output is colorized

## Change Type
- [ ] Bug fix
- [x] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.


<!--
## References

- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

