### PR TITLE
chore(ci): auto-tag vdev on version bump in Cargo.toml

### DIFF
--- a/.github/workflows/vdev_autotag.yml
+++ b/.github/workflows/vdev_autotag.yml
@@ -23,13 +23,20 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create tag if version changed
         run: |
+          set -euo pipefail
+
           current=$(grep '^version = ' vdev/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          previous=$(git show HEAD~1:vdev/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+          previous=$(git show "${{ github.event.before }}":vdev/Cargo.toml 2>/dev/null | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/' || true)
+
+          if [ -z "$current" ]; then
+            echo "Could not parse current version from vdev/Cargo.toml" >&2
+            exit 1
+          fi
 
           if [ "$current" = "$previous" ]; then
             echo "vdev version unchanged ($current), skipping tag"
@@ -37,6 +44,6 @@ jobs:
           fi
 
           tag="vdev-v${current}"
-          echo "Version changed $previous -> $current, creating tag $tag"
+          echo "Version changed ${previous:-<none>} -> $current, creating tag $tag"
           git tag "$tag"
           git push origin "$tag"

--- a/.github/workflows/vdev_autotag.yml
+++ b/.github/workflows/vdev_autotag.yml
@@ -1,0 +1,34 @@
+name: Auto-tag vdev on version bump
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "vdev/Cargo.toml"
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Create tag if version changed
+        run: |
+          current=$(grep '^version = ' vdev/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          previous=$(git show HEAD~1:vdev/Cargo.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+          if [ "$current" = "$previous" ]; then
+            echo "vdev version unchanged ($current), skipping tag"
+            exit 0
+          fi
+
+          tag="vdev-v${current}"
+          echo "Version changed $previous -> $current, creating tag $tag"
+          git tag "$tag"
+          git push origin "$tag"

--- a/.github/workflows/vdev_autotag.yml
+++ b/.github/workflows/vdev_autotag.yml
@@ -8,15 +8,23 @@ on:
       - "vdev/Cargo.toml"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tag:
     runs-on: ubuntu-24.04
     steps:
+      - name: Generate token via GitHub App
+        id: generate_token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
+          private-key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create tag if version changed
         run: |

--- a/vdev/README.md
+++ b/vdev/README.md
@@ -14,6 +14,7 @@ Table of Contents:
 - [Running Tests](#running-tests)
   - [Running Integration tests](#running-integration-tests)
 - [Developing vdev](#developing-vdev)
+- [Releasing vdev](#releasing-vdev)
 
 ## Pre-requisites
 
@@ -80,3 +81,7 @@ cargo install -f --path vdev
 The CLI uses [Clap](https://github.com/clap-rs/clap) with the `derive` construction mechanism and is stored in the [commands](src/commands) directory.
 
 Every command group/namespace has its own directory with a `cli` module, including the root `vdev` command group. All commands have an `exec` method that provides the actual implementation, which in the case of command groups will be calling sub-commands.
+
+## Releasing vdev
+
+To release a new version of vdev, open a PR that bumps the `version` field in `vdev/Cargo.toml`. When the PR merges to `master`, CI automatically creates the `vdev-vX.Y.Z` tag, which triggers the publish workflow to build the binaries and publish the crate to crates.io.


### PR DESCRIPTION
## Summary

Previously, releasing vdev required manually creating and pushing a `vdev-vX.Y.Z` tag after merging a version bump — an easy step to forget and a source of friction. This closes the loop: a workflow now watches for merges to `master` that touch `vdev/Cargo.toml`, and automatically creates the tag, which triggers the existing `vdev_publish.yml` to build binaries and publish to crates.io.

The release process for maintainers is now just: open a PR bumping the version, merge it.

## How did you test this PR?

Validated in [vectordotdev/ci-sandbox](https://github.com/vectordotdev/ci-sandbox) on branch `pavlos/test-vdev-autotag`:
- Push 1: added the workflow + `vdev/Cargo.toml` at `0.3.4` — no tag created (no version change)
- Push 2: bumped to `0.3.5` — workflow fired, tag `vdev-v0.3.5` created and pushed successfully

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.