### PR TITLE
feat(redis source): add reconnecting pubsub session for channel `data_type`

### DIFF
--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -1,5 +1,7 @@
 use futures_util::StreamExt;
-use snafu::{ResultExt, Snafu};
+use snafu::Snafu;
+use std::time::Duration;
+use tracing::{trace, warn, info};
 
 use crate::{
     internal_events::RedisReceiveEventError,
@@ -17,38 +19,225 @@ enum BuildError {
     Subscribe { source: redis::RedisError },
 }
 
+/// Defines how a pub/sub "session" ended.
+///
+/// A session = we connected to Redis, SUBSCRIBE'd to a channel,
+/// and started reading messages in a loop.
+enum SessionEnd {
+    /// Vector is shutting down; stop and don't reconnect.
+    Shutdown,
+    /// Redis connection dropped; we should reconnect.
+    Disconnected,
+    /// Downstream stopped accepting events; there's no point continuing.
+    DownstreamClosed,
+}
+
+/// Exponential backoff used between reconnect attempts.
+async fn backoff_exponential(exp: u32) {
+    let ms = if exp <= 4 { 2_u64.pow(exp + 5) } else { 1000 };
+    tokio::time::sleep(Duration::from_millis(ms)).await;
+}
+
 impl InputHandler {
+    /// Build the Redis `channel` source.
     pub(super) async fn subscribe(
         mut self,
         connection_info: ConnectionInfo,
     ) -> crate::Result<Source> {
-        let mut pubsub_conn = self
-            .client
-            .get_async_pubsub()
-            .await
-            .context(ConnectionSnafu {})?;
+        let client = self.client.clone();
+        let channel = self.key.clone();
+        let endpoint = connection_info.endpoint.to_string();
 
-        trace!(endpoint = %connection_info.endpoint.as_str(), "Connected.");
+        /// Open a pubsub connection and SUBSCRIBE to `channel`.
+        /// Returns a ready `PubSub` on success.
+        async fn connect_and_subscribe(
+            client: &redis::Client,
+            endpoint: &str,
+            channel: &str,
+        ) -> Result<redis::aio::PubSub, BuildError> {
+            // create pubsub connection
+            let mut pubsub_conn = client
+                .get_async_pubsub()
+                .await
+                .map_err(|source| BuildError::Connection { source })?;
 
-        pubsub_conn
-            .subscribe(&self.key)
-            .await
-            .context(SubscribeSnafu {})?;
-        trace!(endpoint = %connection_info.endpoint.as_str(), channel = %self.key, "Subscribed to channel.");
+            trace!(endpoint, "Connected.");
 
-        Ok(Box::pin(async move {
-            let shutdown = self.cx.shutdown.clone();
-            let mut pubsub_stream = pubsub_conn.on_message().take_until(shutdown);
-            while let Some(msg) = pubsub_stream.next().await {
-                match msg.get_payload::<String>() {
-                    Ok(line) => {
-                        if let Err(()) = self.handle_line(line).await {
-                            break;
+            // subscribe to the configured channel
+            pubsub_conn
+                .subscribe(channel)
+                .await
+                .map_err(|source| BuildError::Subscribe { source })?;
+
+            trace!(endpoint, channel, "Subscribed to channel.");
+
+            Ok(pubsub_conn)
+        }
+
+        async fn run_subscription_session<S>(
+            pubsub_conn: &mut redis::aio::PubSub,
+            channel: &str,
+            shutdown: &mut S,
+            handler: &mut InputHandler,
+            endpoint: &str,
+        ) -> SessionEnd
+        where
+            S: std::future::Future + Unpin,
+        {
+            let mut stream = pubsub_conn.on_message();
+
+            loop {
+                // One "step" in the session: either we got a message,
+                // Redis dropped us, or shutdown fired.
+                enum RecvEvent {
+                    Msg(redis::Msg),
+                    Shutdown,
+                    Disconnected,
+                }
+
+                let event = tokio::select! {
+                    maybe_msg = stream.next() => {
+                        match maybe_msg {
+                            Some(msg) => RecvEvent::Msg(msg),
+                            None => RecvEvent::Disconnected,
                         }
                     }
-                    Err(error) => emit!(RedisReceiveEventError::from(error)),
+                    _ = &mut *shutdown => {
+                        RecvEvent::Shutdown
+                    }
+                };
+
+                match event {
+                    RecvEvent::Msg(msg) => match msg.get_payload::<String>() {
+                        Ok(line) => {
+                            // If downstream is gone and won't take more data,
+                            // stop the source too.
+                            if let Err(()) = handler.handle_line(line).await {
+                                return SessionEnd::DownstreamClosed;
+                            }
+                        }
+                        Err(error) => {
+                            // Bad payload. We just log and keep going.
+                            emit!(RedisReceiveEventError::from(error));
+                        }
+                    },
+
+                    RecvEvent::Disconnected => {
+                        // Redis connection ended (e.g. server restart).
+                        // We'll reconnect in the outer loop.
+                        warn!(
+                            endpoint,
+                            channel,
+                            "Redis pubsub stream ended; will reconnect"
+                        );
+                        return SessionEnd::Disconnected;
+                    }
+
+                    RecvEvent::Shutdown => {
+                        // Vector shutdown. Caller will not reconnect.
+                        return SessionEnd::Shutdown;
+                    }
                 }
             }
+        }
+
+        Ok(Box::pin(async move {
+            // `shutdown` is a signal that resolves when Vector is stopping.
+            let mut shutdown = self.cx.shutdown.clone();
+
+            // retry counter for exponential backoff between reconnects
+            let mut retry: u32 = 0;
+
+            loop {
+                // connect + SUBSCRIBE
+                let mut pubsub_conn =
+                    match connect_and_subscribe(&client, &endpoint, &channel).await {
+                        Ok(conn) => {
+                            let was_reconnecting = retry > 0;
+
+                            if was_reconnecting {
+                                // we previously failed but now we're back
+                                info!(
+                                    endpoint = %endpoint,
+                                    channel  = %channel,
+                                    "Redis pubsub connection re-established and resubscribed"
+                                );
+                            } else {
+                                trace!(
+                                    endpoint = %endpoint,
+                                    channel  = %channel,
+                                    "Redis pubsub connection established"
+                                );
+                            }
+
+                            retry = 0;
+                            conn
+                        }
+                        Err(err) => {
+                            // failed to connect or SUBSCRIBE
+                            warn!(
+                                %err,
+                                endpoint = %endpoint,
+                                channel  = %channel,
+                                "Failed to establish subscription; will retry"
+                            );
+
+                            retry += 1;
+
+                            // back off before retrying, unless we're shutting down
+                            tokio::select! {
+                                _ = backoff_exponential(retry) => {
+                                    continue;
+                                }
+                                _ = &mut shutdown => {
+                                    break;
+                                }
+                            }
+                        }
+                    };
+
+                // run that session (receive messages, forward them, etc.)
+                let end_reason = run_subscription_session(
+                    &mut pubsub_conn,
+                    &channel,
+                    &mut shutdown,
+                    &mut self,
+                    &endpoint,
+                )
+                    .await;
+
+                match end_reason {
+                    SessionEnd::Shutdown => {
+                        // shutting down cleanly
+                        let _ = pubsub_conn.unsubscribe(&channel).await;
+                        break;
+                    }
+
+                    SessionEnd::DownstreamClosed => {
+                        // downstream closed, no point continuing
+                        let _ = pubsub_conn.unsubscribe(&channel).await;
+                        break;
+                    }
+
+                    SessionEnd::Disconnected => {
+                        // Redis dropped us. We'll try to reconnect after a backoff,
+                        // unless shutdown fires during that backoff.
+                        retry += 1;
+
+                        tokio::select! {
+                            _ = backoff_exponential(retry) => {
+                                let _ = pubsub_conn.unsubscribe(&channel).await;
+                                continue;
+                            }
+                            _ = &mut shutdown => {
+                                let _ = pubsub_conn.unsubscribe(&channel).await;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
             Ok(())
         }))
     }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR improves the reliability of the Redis channel `data_type`.
Previously, if the Redis server restarted or the connection was lost, Vector would stop consuming messages permanently until manually restarted.

This change introduces a session-based model that automatically reconnects, re-subscribes to the configured channel, and resumes message consumption without operator intervention. It also adds shutdown-aware backoff logic, graceful unsubscribe on shutdown, and clearer logs when recovery occurs.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

```toml
[sources.redis_sub]
type = "redis"
data_type = "channel"
key = "my-events"
url = "redis://127.0.0.1:6379"
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

Tested manually on local

<img width="1404" height="140" alt="Screenshot 2025-10-29 at 14 36 11" src="https://github.com/user-attachments/assets/8e1a4349-34f2-4f93-8fe6-8633b58677c2" />

## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->
Close #22615

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
