### PR TITLE
fix(ci): vdev caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -223,7 +223,7 @@ runs:
           ~/.cargo/bin/wasm-pack
           /usr/local/bin/markdownlint
           /usr/local/bin/datadog-ci
-        key: ${{ runner.os }}-prepare-binaries-${{ hashFiles('scripts/environment/prepare.sh', 'scripts/environment/binstall.sh', 'scripts/environment/release-flags.sh') }}
+        key: ${{ runner.os }}-prepare-binaries-${{ hashFiles('scripts/environment/*') }}
         restore-keys: |
           ${{ runner.os }}-prepare-binaries-
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Since `~/.cargo/bin` was being pulled in from cargo-cache then vdev was already present making the vdev cargo install fail because a previous version was already present.

This also adds the `cache-prepare-binaries` to maintain behavior with the caching of `~/.cargo/bin`.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Added `pull_request` to changes.yml which downloads cached vdev in commit 55a675c504d38c9de7a5b700e73da44e80af191f. Let CI run and verified that vdev was cached and not rebuilt and that `vdev int build` ran and didn't error with `command not found`. Commit reverted afterwards.

See [run](https://github.com/vectordotdev/vector/actions/runs/18982951745/job/54219807174?pr=24126)

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->