### PR TITLE
fix(vdev): remove --reuse-image

### DIFF
--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -32,7 +32,6 @@ Options:
   -v         Increase verbosity; repeat for more (e.g. -vv or -vvv)
   -e <ENV>   One or more environments to run (repeatable or comma-separated).
              If provided, these are used as TEST_ENVIRONMENTS instead of auto-discovery.
-  -b         Always build images (disables --reuse-image which is enabled by default)
 
 Notes:
   - All existing two-argument invocations remain compatible:
@@ -44,8 +43,7 @@ USAGE
 # Parse options
 # Note: options must come before positional args (standard getopts behavior)
 TEST_ENV=""
-REUSE_IMAGE="--reuse-image"
-while getopts ":hr:v:e:b" opt; do
+while getopts ":hr:v:e:" opt; do
   case "$opt" in
     h)
       usage
@@ -63,9 +61,6 @@ while getopts ":hr:v:e:b" opt; do
       ;;
     e)
       TEST_ENV="$OPTARG"
-      ;;
-    b)
-      REUSE_IMAGE=""
       ;;
     \?)
       echo "ERROR: unknown option: -$OPTARG" >&2
@@ -132,12 +127,12 @@ for TEST_ENV in "${TEST_ENVIRONMENTS[@]}"; do
   docker run --rm -v vector_target:/output/"${TEST_NAME}" alpine:3.20 \
     sh -c "rm -rf /output/${TEST_NAME}/*"
 
-  cargo vdev "${VERBOSITY}" "${TEST_TYPE}" start --build-all ${REUSE_IMAGE} "${TEST_NAME}" "${TEST_ENV}"
+  cargo vdev "${VERBOSITY}" "${TEST_TYPE}" start --build-all "${TEST_NAME}" "${TEST_ENV}"
   START_RET=$?
   print_compose_logs_on_failure "$START_RET"
 
   if [[ "$START_RET" -eq 0 ]]; then
-    cargo vdev "${VERBOSITY}" "${TEST_TYPE}" test --retries "$RETRIES" --build-all ${REUSE_IMAGE} "${TEST_NAME}" "${TEST_ENV}"
+    cargo vdev "${VERBOSITY}" "${TEST_TYPE}" test --retries "$RETRIES" --build-all "${TEST_NAME}" "${TEST_ENV}"
     RET=$?
     print_compose_logs_on_failure "$RET"
 
@@ -149,7 +144,7 @@ for TEST_ENV in "${TEST_ENVIRONMENTS[@]}"; do
   fi
 
   # Always stop the environment (best effort cleanup)
-  cargo vdev "${VERBOSITY}" "${TEST_TYPE}" stop --build-all ${REUSE_IMAGE} "${TEST_NAME}" || true
+  cargo vdev "${VERBOSITY}" "${TEST_TYPE}" stop --build-all "${TEST_NAME}" || true
 
   # Exit early on first failure
   if [[ "$RET" -ne 0 ]]; then

--- a/vdev/src/commands/compose_tests/start.rs
+++ b/vdev/src/commands/compose_tests/start.rs
@@ -10,7 +10,6 @@ pub(crate) fn exec(
     integration: &str,
     environment: Option<&String>,
     all_features: bool,
-    reuse_image: bool,
 ) -> Result<()> {
     let environment = if let Some(environment) = environment {
         environment.clone()
@@ -22,13 +21,5 @@ pub(crate) fn exec(
         env.clone()
     };
     debug!("Selected environment: {environment:#?}");
-    ComposeTest::generate(
-        local_config,
-        integration,
-        environment,
-        all_features,
-        reuse_image,
-        0,
-    )?
-    .start()
+    ComposeTest::generate(local_config, integration, environment, all_features, 0)?.start()
 }

--- a/vdev/src/commands/compose_tests/stop.rs
+++ b/vdev/src/commands/compose_tests/stop.rs
@@ -11,22 +11,13 @@ pub(crate) fn exec(
     local_config: ComposeTestLocalConfig,
     test_name: &str,
     all_features: bool,
-    reuse_image: bool,
 ) -> Result<()> {
     let (_test_dir, config) = ComposeTestConfig::load(local_config.directory, test_name)?;
     let active_environment =
         find_active_environment_for_integration(local_config.directory, test_name, &config)?;
 
     if let Some(environment) = active_environment {
-        ComposeTest::generate(
-            local_config,
-            test_name,
-            environment,
-            all_features,
-            reuse_image,
-            0,
-        )?
-        .stop()
+        ComposeTest::generate(local_config, test_name, environment, all_features, 0)?.stop()
     } else {
         println!("No environment for {test_name} is active.");
         Ok(())

--- a/vdev/src/commands/compose_tests/test.rs
+++ b/vdev/src/commands/compose_tests/test.rs
@@ -14,7 +14,6 @@ pub fn exec(
     integration: &str,
     environment: Option<&String>,
     all_features: bool,
-    reuse_image: bool,
     retries: u8,
     args: &[String],
 ) -> Result<()> {
@@ -40,7 +39,6 @@ pub fn exec(
             integration,
             environment,
             all_features,
-            reuse_image,
             retries,
         )?
         .test(args.to_owned())?;

--- a/vdev/src/commands/e2e/start.rs
+++ b/vdev/src/commands/e2e/start.rs
@@ -14,10 +14,6 @@ pub struct Cli {
     #[arg(short = 'a', long)]
     build_all: bool,
 
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
-
     /// The desired environment name to start. If omitted, the first environment name is used.
     environment: Option<String>,
 }
@@ -29,7 +25,6 @@ impl Cli {
             &self.test,
             self.environment.as_ref(),
             self.build_all,
-            self.reuse_image,
         )
     }
 }

--- a/vdev/src/commands/e2e/stop.rs
+++ b/vdev/src/commands/e2e/stop.rs
@@ -13,10 +13,6 @@ pub struct Cli {
     /// If true, remove the runner container compiled with all integration test features
     #[arg(short = 'a', long)]
     build_all: bool,
-
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
 }
 
 impl Cli {
@@ -25,7 +21,6 @@ impl Cli {
             ComposeTestLocalConfig::e2e(),
             &self.test,
             self.build_all,
-            self.reuse_image,
         )
     }
 }

--- a/vdev/src/commands/e2e/test.rs
+++ b/vdev/src/commands/e2e/test.rs
@@ -24,10 +24,6 @@ pub struct Cli {
     #[arg(short = 'a', long)]
     build_all: bool,
 
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
-
     /// Number of retries to allow on each integration test case.
     #[arg(short = 'r', long)]
     retries: Option<u8>,
@@ -43,7 +39,6 @@ impl Cli {
             &self.e2e_test,
             self.environment.as_ref(),
             self.build_all,
-            self.reuse_image,
             self.retries.unwrap_or_default(),
             &self.args,
         )

--- a/vdev/src/commands/integration/start.rs
+++ b/vdev/src/commands/integration/start.rs
@@ -14,10 +14,6 @@ pub struct Cli {
     #[arg(short = 'a', long)]
     build_all: bool,
 
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
-
     /// The desired environment name to start. If omitted, the first environment name is used.
     environment: Option<String>,
 }
@@ -29,7 +25,6 @@ impl Cli {
             &self.integration,
             self.environment.as_ref(),
             self.build_all,
-            self.reuse_image,
         )
     }
 }

--- a/vdev/src/commands/integration/stop.rs
+++ b/vdev/src/commands/integration/stop.rs
@@ -13,10 +13,6 @@ pub struct Cli {
     /// If true, remove the runner container compiled with all integration test features
     #[arg(short = 'a', long)]
     build_all: bool,
-
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
 }
 
 impl Cli {
@@ -25,7 +21,6 @@ impl Cli {
             ComposeTestLocalConfig::integration(),
             &self.integration,
             self.build_all,
-            self.reuse_image,
         )
     }
 }

--- a/vdev/src/commands/integration/test.rs
+++ b/vdev/src/commands/integration/test.rs
@@ -24,10 +24,6 @@ pub struct Cli {
     #[arg(short = 'a', long)]
     build_all: bool,
 
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
-
     /// Number of retries to allow on each integration test case.
     #[arg(short = 'r', long)]
     retries: Option<u8>,
@@ -43,7 +39,6 @@ impl Cli {
             &self.integration,
             self.environment.as_ref(),
             self.build_all,
-            self.reuse_image,
             self.retries.unwrap_or_default(),
             &self.args,
         )

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -16,10 +16,6 @@ pub struct Cli {
     #[arg(short = 'C', long)]
     container: bool,
 
-    /// Reuse existing test runner image instead of rebuilding (useful in CI)
-    #[arg(long)]
-    reuse_image: bool,
-
     /// Environment variables in the form KEY[=VALUE]
     #[arg(short, long)]
     env: Option<Vec<String>>,
@@ -57,7 +53,6 @@ impl Cli {
             &BTreeMap::default(),
             None,
             &args,
-            self.reuse_image,
             false, // Don't pre-build Vector for direct test runs
         )
     }

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -58,7 +58,6 @@ pub trait TestRunner {
         inner_env: &Environment,
         features: Option<&[String]>,
         args: &[String],
-        reuse_image: bool,
         build: bool,
     ) -> Result<()>;
 }
@@ -107,7 +106,6 @@ pub trait ContainerTestRunner: TestRunner {
         &self,
         features: Option<&[String]>,
         config_environment_variables: &Environment,
-        reuse_image: bool,
         build: bool,
     ) -> Result<()> {
         match self.state()? {
@@ -120,7 +118,7 @@ pub trait ContainerTestRunner: TestRunner {
                 self.start()?;
             }
             RunnerState::Missing => {
-                self.build(features, config_environment_variables, reuse_image, build)?;
+                self.build(features, config_environment_variables, build)?;
                 self.create()?;
                 self.start()?;
             }
@@ -152,23 +150,9 @@ pub trait ContainerTestRunner: TestRunner {
         &self,
         features: Option<&[String]>,
         config_env_vars: &Environment,
-        reuse_image: bool,
         build: bool,
     ) -> Result<()> {
         let image_name = self.image_name();
-
-        // When reuse_image is true, skip build if image already exists (useful in CI).
-        // Otherwise, always rebuild to pick up local code changes.
-        if reuse_image {
-            let mut check_command = docker_command(["image", "inspect", &image_name]);
-            if check_command
-                .output()
-                .is_ok_and(|output| output.status.success())
-            {
-                info!("Image {image_name} already exists, skipping build");
-                return Ok(());
-            }
-        }
 
         let dockerfile = test_runner_dockerfile();
         let mut command =
@@ -252,10 +236,9 @@ where
         config_environment_variables: &Environment,
         features: Option<&[String]>,
         args: &[String],
-        reuse_image: bool,
         build: bool,
     ) -> Result<()> {
-        self.ensure_running(features, config_environment_variables, reuse_image, build)?;
+        self.ensure_running(features, config_environment_variables, build)?;
 
         let mut command = docker_command(["exec"]);
         if *IS_A_TTY {
@@ -413,7 +396,6 @@ impl TestRunner for LocalTestRunner {
         inner_env: &Environment,
         _features: Option<&[String]>,
         args: &[String],
-        _reuse_image: bool,
         _build: bool,
     ) -> Result<()> {
         let mut command = Command::new(TEST_COMMAND[0]);


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

| Scenario            | Current with --reuse-image | After removal (Docker native) |
  |---------------------|----------------------------|-------------------------------|
  | CI after pull       | Skips build (fast ✓)       | All layers cached (fast ✓)    |
  | Local, no changes   | Skips build (fast ✓)       | All layers cached (fast ✓)    |
  | Local, code changed | BUG: Uses stale image ✗    | Rebuilds changed layers ✓     |
  | Fresh build         | Builds (slow ✓)            | Builds (slow ✓)               |


## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

MQ 

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
