### PR TITLE
feat(platforms): add s390x architecture support

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -24,6 +24,7 @@ jobs:
           - armv7-unknown-linux-musleabihf
           - arm-unknown-linux-gnueabi
           - arm-unknown-linux-musleabi
+          - s390x-unknown-linux-gnu
     steps:
       - name: (PR review) Set latest commit status as pending
         if: ${{ github.event_name == 'pull_request_review' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -264,6 +264,34 @@ jobs:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
           path: target/artifacts/vector*
 
+  build-s390x-unknown-linux-gnu-packages:
+    name: Build Vector for s390x-unknown-linux-gnu (.tar.gz, DEB, RPM)
+    runs-on: release-builder-linux
+    timeout-minutes: 60
+    needs: generate-publish-metadata
+    env:
+      VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
+      VECTOR_BUILD_DESC: ${{ needs.generate-publish-metadata.outputs.vector_build_desc }}
+      CHANNEL: ${{ needs.generate-publish-metadata.outputs.vector_release_channel }}
+    steps:
+      - name: Checkout Vector
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.git_ref }}
+      - name: Bootstrap runner environment (Ubuntu-specific)
+        run: sudo -E bash scripts/environment/bootstrap-ubuntu-24.04.sh
+      - name: Bootstrap runner environment (generic)
+        run: bash scripts/environment/prepare.sh --modules=rustup,cross
+      - name: Build Vector
+        env:
+          DOCKER_PRIVILEGED: "true"
+        run: make package-s390x-unknown-linux-gnu-all
+      - name: Stage package artifacts for publish
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-s390x-unknown-linux-gnu
+          path: target/artifacts/vector*
+
   build-apple-darwin-packages:
     name: Build Vector for ${{ matrix.architecture }}-apple-darwin (.tar.gz)
     runs-on: ${{ matrix.runner }}
@@ -501,6 +529,7 @@ jobs:
       - build-armv7-unknown-linux-gnueabihf-packages
       - build-arm-unknown-linux-gnueabi-packages
       - build-arm-unknown-linux-musleabi-packages
+      - build-s390x-unknown-linux-gnu-packages
       - deb-verify
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -572,9 +601,14 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
           path: target/artifacts
+      - name: Download staged package artifacts (s390x-unknown-linux-gnu)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-s390x-unknown-linux-gnu
+          path: target/artifacts
       - name: Build and publish Docker images
         env:
-          PLATFORM: "linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6"
+          PLATFORM: "linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/s390x"
           REPOS: "timberio/vector,ghcr.io/vectordotdev/vector"
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
@@ -599,6 +633,7 @@ jobs:
       - build-armv7-unknown-linux-gnueabihf-packages
       - build-arm-unknown-linux-gnueabi-packages
       - build-arm-unknown-linux-musleabi-packages
+      - build-s390x-unknown-linux-gnu-packages
       - deb-verify
       - rpm-verify
       - macos-verify
@@ -660,6 +695,11 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
           path: target/artifacts
+      - name: Download staged package artifacts (s390x-unknown-linux-gnu)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-s390x-unknown-linux-gnu
+          path: target/artifacts
       - name: Publish artifacts to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
@@ -684,6 +724,7 @@ jobs:
       - build-armv7-unknown-linux-musleabihf-packages
       - build-arm-unknown-linux-gnueabi-packages
       - build-arm-unknown-linux-musleabi-packages
+      - build-s390x-unknown-linux-gnu-packages
       - deb-verify
       - rpm-verify
       - macos-verify
@@ -750,6 +791,11 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
           path: target/artifacts
+      - name: Download staged package artifacts (s390x-unknown-linux-gnu)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-s390x-unknown-linux-gnu
+          path: target/artifacts
       - name: Publish release to GitHub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -771,6 +817,7 @@ jobs:
       - build-armv7-unknown-linux-musleabihf-packages
       - build-arm-unknown-linux-gnueabi-packages
       - build-arm-unknown-linux-musleabi-packages
+      - build-s390x-unknown-linux-gnu-packages
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
     steps:
@@ -827,6 +874,11 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: vector-${{ env.VECTOR_VERSION }}-arm-unknown-linux-musleabi
+          path: target/artifacts
+      - name: Download staged package artifacts (s390x-unknown-linux-gnu)
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-s390x-unknown-linux-gnu
           path: target/artifacts
       - name: Generate SHA256 checksums for artifacts
         run: make sha256sum

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ depends = "libc6 (>= 2.18)"
 [package.metadata.deb.variants.aarch64-unknown-linux-musl]
 depends = ""
 
+[package.metadata.deb.variants.s390x-unknown-linux-gnu]
+depends = "libc6 (>= 2.15)"
+
 [workspace]
 members = [
   ".",
@@ -522,6 +525,7 @@ target-arm-unknown-linux-gnueabi = ["api", "api-client", "enrichment-tables", "r
 target-arm-unknown-linux-musleabi = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "secrets"]
 target-x86_64-unknown-linux-gnu = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "secrets"]
 target-x86_64-unknown-linux-musl = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"]
+target-s390x-unknown-linux-gnu = ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"]
 
 # Enables features that work only on systems providing `cfg(unix)`
 unix = ["tikv-jemallocator", "allocation-tracing"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -34,3 +34,6 @@ image = "vector-cross-env:arm-unknown-linux-gnueabi"
 
 [target.arm-unknown-linux-musleabi]
 image = "vector-cross-env:arm-unknown-linux-musleabi"
+
+[target.s390x-unknown-linux-gnu]
+image = "vector-cross-env:s390x-unknown-linux-gnu"

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,10 @@ build-arm-unknown-linux-gnueabi: target/arm-unknown-linux-gnueabi/release/vector
 build-arm-unknown-linux-musleabi: target/arm-unknown-linux-musleabi/release/vector ## Build a release binary for the arm-unknown-linux-musleabi triple.
 	@echo "Output to ${<}"
 
+.PHONY: build-s390x-unknown-linux-gnu
+build-s390x-unknown-linux-gnu: target/s390x-unknown-linux-gnu/release/vector ## Build a release binary for the s390x-unknown-linux-gnu triple.
+	@echo "Output to ${<}"
+
 .PHONY: build-graphql-schema
 build-graphql-schema: ## Generate the `schema.json` for Vector's GraphQL API
 	${MAYBE_ENVIRONMENT_EXEC} cargo run --bin graphql-schema --no-default-features --features=default-no-api-client
@@ -542,6 +546,9 @@ package-armv7-unknown-linux-gnueabihf-all: package-armv7-unknown-linux-gnueabihf
 .PHONY: package-arm-unknown-linux-gnueabi-all
 package-arm-unknown-linux-gnueabi-all: package-arm-unknown-linux-gnueabi package-deb-arm-gnu  # Build all arm-unknown-linux-gnueabihf GNU packages
 
+.PHONY: package-s390x-unknown-linux-gnu-all
+package-s390x-unknown-linux-gnu-all: package-s390x-unknown-linux-gnu package-deb-s390x package-rpm-s390x # Build all s390x GNU packages
+
 .PHONY: package-x86_64-unknown-linux-gnu
 package-x86_64-unknown-linux-gnu: target/artifacts/vector-${VERSION}-x86_64-unknown-linux-gnu.tar.gz ## Build an archive suitable for the `x86_64-unknown-linux-gnu` triple.
 	@echo "Output to ${<}."
@@ -574,6 +581,10 @@ package-arm-unknown-linux-gnueabi: target/artifacts/vector-${VERSION}-arm-unknow
 package-arm-unknown-linux-musleabi: target/artifacts/vector-${VERSION}-arm-unknown-linux-musleabi.tar.gz ## Build an archive suitable for the `arm-unknown-linux-musleabi` triple.
 	@echo "Output to ${<}."
 
+.PHONY: package-s390x-unknown-linux-gnu
+package-s390x-unknown-linux-gnu: target/artifacts/vector-${VERSION}-s390x-unknown-linux-gnu.tar.gz ## Build an archive suitable for the `s390x-unknown-linux-gnu` triple.
+	@echo "Output to ${<}."
+
 # debs
 
 .PHONY: package-deb-x86_64-unknown-linux-gnu
@@ -596,6 +607,10 @@ package-deb-armv7-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7-
 package-deb-arm-gnu: package-arm-unknown-linux-gnueabi ## Build the arm-unknown-linux-gnueabi deb package
 	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=arm-unknown-linux-gnueabi -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
 
+.PHONY: package-deb-s390x
+package-deb-s390x: package-s390x-unknown-linux-gnu ## Build the s390x deb package
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=s390x-unknown-linux-gnu -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package deb
+
 # rpms
 
 .PHONY: package-rpm-x86_64-unknown-linux-gnu
@@ -613,6 +628,10 @@ package-rpm-aarch64: package-aarch64-unknown-linux-gnu ## Build the aarch64 rpm 
 .PHONY: package-rpm-armv7hl-gnu
 package-rpm-armv7hl-gnu: package-armv7-unknown-linux-gnueabihf ## Build the armv7hl-unknown-linux-gnueabihf rpm package
 	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=armv7-unknown-linux-gnueabihf -e ARCH=armv7hl -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
+
+.PHONY: package-rpm-s390x
+package-rpm-s390x: package-s390x-unknown-linux-gnu ## Build the s390x rpm package
+	$(CONTAINER_TOOL) run -v  $(PWD):/git/vectordotdev/vector/ -e TARGET=s390x-unknown-linux-gnu -e VECTOR_VERSION $(ENVIRONMENT_UPSTREAM) cargo vdev package rpm
 
 ##@ Releasing
 


### PR DESCRIPTION
  ## Summary

  This PR adds complete s390x (IBM System/390) architecture support to Vector, enabling the project to be built, packaged, and published for s390x Linux systems. The implementation follows the existing patterns used for other architectures (aarch64, armv7, arm) and includes:

  - Cross-compilation configuration
  - CI/CD workflow integration for building packages
  - Package generation (tar.gz, DEB, RPM)
  - Multi-platform Docker image support
  - Integration with the publish workflow for S3, GitHub releases, and Docker Hub

  This change enables Vector to run natively on IBM Z and LinuxONE systems, expanding platform support for users in enterprise and mainframe environments.

  ## Vector configuration

  No Vector configuration changes are required. This PR only adds build and packaging infrastructure for the s390x architecture. Users on s390x systems will be able to use Vector with the same configuration options as other supported architectures.

  ## How did you test this PR?

  Testing approach:
  1. Verified all modified workflow files pass YAML validation
  2. Confirmed Cross.toml configuration follows the established pattern for other architectures
  3. Verified Makefile targets follow naming conventions used for arm/aarch64 targets
  4. Confirmed Cargo.toml metadata is consistent with other architecture variants
  5. Validated that the publish.yml workflow correctly includes s390x in all relevant jobs:
     - Build job for s390x packages
     - Artifact downloads in publish-docker, publish-s3, publish-github
     - SHA256 checksum generation
     - Docker multi-platform build with linux/s390x

  **Note**: Full end-to-end testing requires s390x hardware or emulation and will be validated through the CI pipeline once merged.

  ## Change Type
  - [ ] Bug fix
  - [x] New feature
  - [ ] Non-functional (chore, refactoring, docs)
  - [ ] Performance

  ## Is this a breaking change?
  - [ ] Yes
  - [x] No

  ## Does this PR include user facing changes?

  - [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
  - [x] No. A maintainer will apply the `no-changelog` label to this PR.

  **User-facing impact**: Users on s390x architecture will now be able to download and install pre-built Vector packages (tar.gz, DEB, RPM) and use the official Docker images on s390x systems.

  ## References

  N/A - This is a new platform support addition without an associated issue.

  ## Notes

  ### Implementation Details

  **Modified Files:**
  1. `.github/workflows/cross.yml` - Added s390x to cross-compilation matrix
  2. `.github/workflows/publish.yml` - Added complete s390x build and publish pipeline integration
  3. `Cross.toml` - Added s390x Docker image configuration for cross-compilation
  4. `Cargo.toml` - Added s390x target features and DEB package metadata
  5. `Makefile` - Added build, package, DEB, and RPM targets for s390x

  **Key Design Decisions:**
  - Follows the exact same pattern as existing architectures (arm, aarch64, armv7)
  - Uses the generic parameterized `scripts/cross/Dockerfile` (no architecture-specific dockerfile needed)
  - Includes full integration with all publish workflows (Docker, S3, GitHub releases, checksums)
  - Targets `s390x-unknown-linux-gnu` (GNU libc) which is the standard for enterprise s390x Linux distributions

  ### Pre-push Checklist Completed:
  - [x] `make fmt` - Code formatting applied
  - [x] Configuration files validated (YAML syntax, Makefile syntax, TOML syntax)
  - [x] Changes follow existing patterns and conventions
  - [ ] `make check-clippy` - N/A (no Rust code changes)
  - [ ] `make test` - N/A (no functional code changes)
  - [ ] `make build-licenses` - N/A (no dependency changes)
