### PR TITLE
chore(ci): temporarily remove homebrew publish step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -835,15 +835,3 @@ jobs:
         with:
           name: vector-${{ env.VECTOR_VERSION }}-SHA256SUMS
           path: target/artifacts/vector-${{ env.VECTOR_VERSION }}-SHA256SUMS
-
-  publish-homebrew:
-    name: Publish to Homebrew
-    # We only publish versioned releases to Homebrew.
-    if: ${{ inputs.channel == 'release' }}
-    uses: ./.github/workflows/publish-homebrew.yml
-    needs:
-      - generate-publish-metadata
-      - publish-s3
-    with:
-      git_ref: ${{ inputs.git_ref }}
-      vector_version: ${{ needs.generate-publish-metadata.outputs.vector_version }}


### PR DESCRIPTION
## Summary
Temporarily removes the `publish-homebrew` job from the publish workflow as step 1 of fixing the homebrew publishing process.

This PR addresses issue #24139 by removing the automatic homebrew publishing step from the main publish workflow. This is a temporary measure to prevent automatic homebrew updates while the homebrew publishing process is being fixed.

## Changes
- Removed the `publish-homebrew` job from `.github/workflows/publish.yml`

## Related Issue
Related #24139 (step 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)