### PR TITLE
enhancement(vdev): run fmt before commiting clippy fixes

### DIFF
--- a/vdev/src/commands/check/rust.rs
+++ b/vdev/src/commands/check/rust.rs
@@ -57,6 +57,7 @@ impl Cli {
         if self.fix {
             let has_changes = !git::get_modified_files()?.is_empty();
             if has_changes {
+                app::exec("cargo", ["fmt", "--all"], true)?;
                 git::commit("chore(vdev): apply vdev rust check fixes")?;
             }
         }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Run fmt before commiting clippy fixes. `clippy --fix` won't format files.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Updated rust-toolchain.toml to 1.91, committed and ran `cargo vdev check rust --fix`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.