### PR TITLE
fix(nats source): prevent slow consumer log explosion

### DIFF
--- a/changelog.d/24229_nats_slow_consumer_suppress.fix.md
+++ b/changelog.d/24229_nats_slow_consumer_suppress.fix.md
@@ -1,0 +1,6 @@
+The `nats` source now suppresses high-frequency slow consumer warnings that could generate
+millions of logs per minute when subscription capacity was exceeded. These events are now
+logged at INFO level with rate limiting and tracked via a `nats_slow_consumer_events_total`
+metric.
+
+authors: benjamin-awd

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -91,6 +91,8 @@ mod metric_to_log;
 mod mongodb_metrics;
 #[cfg(feature = "sinks-mqtt")]
 mod mqtt;
+#[cfg(feature = "sources-nats")]
+mod nats;
 #[cfg(feature = "sources-nginx_metrics")]
 mod nginx_metrics;
 mod open;
@@ -246,6 +248,8 @@ pub(crate) use self::lua::*;
 pub(crate) use self::metric_to_log::*;
 #[cfg(feature = "sinks-mqtt")]
 pub(crate) use self::mqtt::*;
+#[cfg(feature = "sources-nats")]
+pub(crate) use self::nats::*;
 #[cfg(feature = "sources-nginx_metrics")]
 pub(crate) use self::nginx_metrics::*;
 #[cfg(any(

--- a/src/internal_events/nats.rs
+++ b/src/internal_events/nats.rs
@@ -1,0 +1,26 @@
+use metrics::counter;
+use tracing::info;
+use vector_lib::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct NatsSlowConsumerEventReceived {
+    pub subscription_id: u64,
+    pub component_id: String,
+}
+
+impl InternalEvent for NatsSlowConsumerEventReceived {
+    fn emit(self) {
+        info!(
+            message = "NATS slow consumer for subscription.",
+            subscription_id = %self.subscription_id,
+            component_id = %self.component_id,
+            internal_log_rate_secs = 10,
+        );
+        counter!(
+            "nats_slow_consumer_events_total",
+            "component_id" => self.component_id,
+            "subscription_id" => self.subscription_id.to_string(),
+        )
+        .increment(1);
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes log spam due to Vector becoming a slow consumer on NATS.

Before:
```
2025-11-13T14:01:52.886481Z  INFO vector::app: Log level is enabled. level="info"
2025-11-13T14:01:52.887850Z  INFO vector::app: Loading configs. paths=["config/vector_balance_queue.yaml"]
2025-11-13T14:02:03.942990Z  INFO source{component_kind="source" component_id=all component_type=nats}: async_nats::connector: connected successfully server=4222 max_payload=10000000
2025-11-13T14:02:03.943557Z  INFO async_nats: event: connected
2025-11-13T14:02:04.073658Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.073690Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.073694Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.073695Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.073697Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.073699Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.144530Z  INFO vector::topology::running: Running healthchecks.
2025-11-13T14:02:04.144566Z  INFO vector::topology::builder: Healthcheck passed.
2025-11-13T14:02:04.144778Z  INFO vector: Vector has started. debug="false" version="0.50.0" arch="aarch64" revision="9053198 2025-09-23 14:18:50.944442940"
2025-11-13T14:02:04.144806Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
2025-11-13T14:02:04.204249Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.204263Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.204265Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.204288Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332758Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332782Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332787Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332790Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332793Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332796Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332800Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332803Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332807Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332840Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332845Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332848Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332851Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332854Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332857Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332860Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332863Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332923Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332928Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332932Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332936Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.332939Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.468818Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.468898Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.468912Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.468920Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.468929Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.468937Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.469007Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.469140Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.469179Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.469485Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.469515Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.469525Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.594734Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.594772Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.596935Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.596991Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.596997Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.597032Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.597037Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.597056Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.597088Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.723686Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.723792Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.723800Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724301Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724336Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724342Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724345Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724347Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724350Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724353Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724355Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724358Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.724438Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.852972Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853005Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853067Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853080Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853085Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853088Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853091Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853093Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853096Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853110Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853861Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853957Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853967Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.853971Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993254Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993275Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993278Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993281Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993283Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993286Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993288Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993291Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.993293Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.994500Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.994506Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.994509Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.994511Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.994514Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:04.994516Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.113489Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122468Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122575Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122582Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122585Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122587Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122588Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122591Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122593Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122615Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122621Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122623Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.122624Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.239981Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.243857Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247549Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247709Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247739Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247744Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247748Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247752Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247756Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247760Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247764Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247768Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247942Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247958Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.247963Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.363675Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374218Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374267Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374275Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374280Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374284Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374357Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374388Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374394Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374399Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374499Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374515Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374519Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374524Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.374528Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517612Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517680Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517693Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517701Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517709Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517717Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517724Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517732Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.517739Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518313Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518345Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518354Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518363Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518370Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518445Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518468Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518475Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518753Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.518781Z  INFO async_nats: event: slow consumers for subscription 1
^C2025-11-13T14:02:05.621920Z  INFO vector::signal: Signal received. signal="SIGINT"
2025-11-13T14:02:05.622106Z  INFO vector: Vector has stopped.
2025-11-13T14:02:05.622262Z  INFO source{component_kind="source" component_id=all component_type=nats}: vector::sources::nats::source: Shutdown signal received. Draining NATS subscription...
2025-11-13T14:02:05.623604Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="all, process_message, print" time_remaining="59 seconds left"
2025-11-13T14:02:05.646773Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.646831Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.646837Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T14:02:05.646852Z  INFO source{component_kind="source" component_id=all component_type=nats}: vector::sources::nats::source: NATS source drained and shut down gracefully.
2025-11-13T14:02:05.647548Z  INFO async_nats: event: closed
```

After:
```
2025-11-13T13:55:39.537620Z  INFO vector::app: Log level is enabled. level="info"
2025-11-13T13:55:39.539042Z  INFO vector::app: Loading configs. paths=["config/vector_balance_queue.yaml"]
2025-11-13T13:55:40.454355Z  INFO source{component_kind="source" component_id=all component_type=nats}: async_nats::connector: connected successfully server=4222 max_payload=10000000
2025-11-13T13:55:40.455675Z  INFO async_nats: event: connected
2025-11-13T13:55:40.668162Z  INFO vector::topology::running: Running healthchecks.
2025-11-13T13:55:40.668389Z  INFO vector::topology::builder: Healthcheck passed.
2025-11-13T13:55:40.668550Z  INFO vector: Vector has started. debug="true" version="0.52.0" arch="aarch64" revision=""
2025-11-13T13:55:40.668587Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
2025-11-13T13:55:40.727544Z  INFO async_nats: Internal log [event: connected] is being suppressed to avoid flooding.
2025-11-13T13:55:40.727595Z  INFO vector::internal_events::nats: NATS slow consumer for subscription. subscription_id=1 component_id=all internal_log_rate_secs=10
2025-11-13T13:55:40.727642Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] is being suppressed to avoid flooding.
2025-11-13T13:55:50.688214Z  INFO async_nats: Internal log [event: connected] has been suppressed 5551 times.
2025-11-13T13:55:50.688263Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T13:55:50.688359Z  INFO async_nats: Internal log [event: connected] is being suppressed to avoid flooding.
2025-11-13T13:55:50.916928Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] has been suppressed 5716 times.
2025-11-13T13:55:50.917027Z  INFO vector::internal_events::nats: NATS slow consumer for subscription. subscription_id=1 component_id=all internal_log_rate_secs=10
2025-11-13T13:55:50.917183Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] is being suppressed to avoid flooding.
2025-11-13T13:56:00.875089Z  INFO async_nats: Internal log [event: connected] has been suppressed 6288 times.
2025-11-13T13:56:00.875193Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T13:56:00.875461Z  INFO async_nats: Internal log [event: connected] is being suppressed to avoid flooding.
2025-11-13T13:56:01.178854Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] has been suppressed 6302 times.
2025-11-13T13:56:01.179032Z  INFO vector::internal_events::nats: NATS slow consumer for subscription. subscription_id=1 component_id=all internal_log_rate_secs=10
2025-11-13T13:56:01.179675Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] is being suppressed to avoid flooding.
2025-11-13T13:56:10.942588Z  INFO async_nats: Internal log [event: connected] has been suppressed 6840 times.
2025-11-13T13:56:10.942706Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T13:56:10.943331Z  INFO async_nats: Internal log [event: connected] is being suppressed to avoid flooding.
2025-11-13T13:56:11.181243Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] has been suppressed 6944 times.
2025-11-13T13:56:11.181329Z  INFO vector::internal_events::nats: NATS slow consumer for subscription. subscription_id=1 component_id=all internal_log_rate_secs=10
2025-11-13T13:56:11.181406Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] is being suppressed to avoid flooding.
2025-11-13T13:56:21.114208Z  INFO async_nats: Internal log [event: connected] has been suppressed 6371 times.
2025-11-13T13:56:21.114301Z  INFO async_nats: event: slow consumers for subscription 1
2025-11-13T13:56:21.114704Z  INFO async_nats: Internal log [event: connected] is being suppressed to avoid flooding.
^C2025-11-13T13:56:21.184854Z  INFO vector::signal: Signal received. signal="SIGINT"
2025-11-13T13:56:21.184985Z  INFO vector: Vector has stopped.
2025-11-13T13:56:21.185138Z  INFO source{component_kind="source" component_id=all component_type=nats}: vector::sources::nats::source: Shutdown signal received. Draining NATS subscription...
2025-11-13T13:56:21.185240Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="all, print, process_message" time_remaining="59 seconds left"
2025-11-13T13:56:21.391822Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] has been suppressed 6231 times.
2025-11-13T13:56:21.391971Z  INFO vector::internal_events::nats: NATS slow consumer for subscription. subscription_id=1 component_id=all internal_log_rate_secs=10
2025-11-13T13:56:21.392126Z  INFO source{component_kind="source" component_id=all component_type=nats}: vector::sources::nats::source: NATS source drained and shut down gracefully.
2025-11-13T13:56:21.392171Z  INFO vector::internal_events::nats: Internal log [NATS slow consumer for subscription.] is being suppressed to avoid flooding.
```

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```yaml
sources:
  all:
    type: nats
    connection_name: all
    queue: test
    subject: data.>
    url: nats://nats-server.com:4222
    auth:
      strategy: user_password
      user_password:
        user: foo
        password: bar
    subscriber_capacity: 1

transforms:
  process_message:
    type: remap
    inputs: [all]
    source: |
      . = parse_json!(string!(.message))

sinks:
  print:
    type: blackhole
    inputs: [process_message]
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
via unit tests, running locally

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

If a user were using a metric to track the number of times the "slow consumer" message appeared in the logs, this would be a breaking change.

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Closes #24229


## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
