### PR TITLE
enhancement(datadog_agent source): Add request timeout support

### DIFF
--- a/changelog.d/datadog-agent-timeout.enhancement.md
+++ b/changelog.d/datadog-agent-timeout.enhancement.md
@@ -1,0 +1,3 @@
+Added support for configurable request timeouts to the `datadog_agent` source.
+
+authors: bruceg

--- a/changelog.d/datadog-agent-timeout.enhancement.md
+++ b/changelog.d/datadog-agent-timeout.enhancement.md
@@ -1,7 +1,7 @@
 Added support for configurable request timeouts to the `datadog_agent` source.
 
-This change also introduces two new internal metrics:
-	- `component_timed_out_events_total` - Counter tracking the number of events that timed out
-	- `component_timed_out_requests_total` - Counter tracking the number of requests that timed out
+    This change also introduces two new internal metrics:
+    - `component_timed_out_events_total` - Counter tracking the number of events that timed out
+    - `component_timed_out_requests_total` - Counter tracking the number of requests that timed out
 
 authors: bruceg

--- a/changelog.d/datadog-agent-timeout.enhancement.md
+++ b/changelog.d/datadog-agent-timeout.enhancement.md
@@ -1,3 +1,7 @@
 Added support for configurable request timeouts to the `datadog_agent` source.
 
+This change also introduces two new internal metrics:
+	- `component_timed_out_events_total` - Counter tracking the number of events that timed out
+	- `component_timed_out_requests_total` - Counter tracking the number of requests that timed out
+
 authors: bruceg

--- a/lib/vector-common/src/internal_event/component_events_timed_out.rs
+++ b/lib/vector-common/src/internal_event/component_events_timed_out.rs
@@ -1,51 +1,17 @@
 use metrics::{Counter, counter};
 
-use super::{Count, InternalEvent, InternalEventHandle, RegisterInternalEvent};
+use super::Count;
 
-#[derive(Debug)]
-pub struct ComponentEventsTimedOut<'a> {
-    pub count: usize,
-    pub reason: &'a str,
-}
-
-impl InternalEvent for ComponentEventsTimedOut<'_> {
-    fn emit(self) {
-        let count = self.count;
-        self.register().emit(Count(count));
+crate::registered_event! {
+    ComponentEventsTimedOut {
+        reason: &'static str,
+    } => {
+        timed_out_events: Counter = counter!("component_timedout_events_total"),
+        timed_out_requests: Counter = counter!("component_timedout_requests_total"),
+        reason: &'static str = self.reason,
     }
 
-    fn name(&self) -> Option<&'static str> {
-        Some("ComponentEventsTimedOut")
-    }
-}
-
-impl<'a> From<&'a str> for ComponentEventsTimedOut<'a> {
-    fn from(reason: &'a str) -> Self {
-        Self { count: 0, reason }
-    }
-}
-
-impl<'a> RegisterInternalEvent for ComponentEventsTimedOut<'a> {
-    type Handle = TimedOutHandle<'a>;
-    fn register(self) -> Self::Handle {
-        Self::Handle {
-            timed_out_events: counter!("component_timedout_events_total"),
-            timed_out_requests: counter!("component_timedout_requests_total"),
-            reason: self.reason,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct TimedOutHandle<'a> {
-    timed_out_events: Counter,
-    timed_out_requests: Counter,
-    reason: &'a str,
-}
-
-impl InternalEventHandle for TimedOutHandle<'_> {
-    type Data = Count;
-    fn emit(&self, data: Self::Data) {
+    fn emit(&self, data: Count) {
         warn!(
             message = "Events timed out",
             events = data.0,

--- a/lib/vector-common/src/internal_event/component_events_timed_out.rs
+++ b/lib/vector-common/src/internal_event/component_events_timed_out.rs
@@ -6,8 +6,8 @@ crate::registered_event! {
     ComponentEventsTimedOut {
         reason: &'static str,
     } => {
-        timed_out_events: Counter = counter!("component_timedout_events_total"),
-        timed_out_requests: Counter = counter!("component_timedout_requests_total"),
+        timed_out_events: Counter = counter!("component_timed_out_events_total"),
+        timed_out_requests: Counter = counter!("component_timed_out_requests_total"),
         reason: &'static str = self.reason,
     }
 

--- a/lib/vector-common/src/internal_event/component_events_timed_out.rs
+++ b/lib/vector-common/src/internal_event/component_events_timed_out.rs
@@ -1,0 +1,57 @@
+use metrics::{Counter, counter};
+
+use super::{Count, InternalEvent, InternalEventHandle, RegisterInternalEvent};
+
+#[derive(Debug)]
+pub struct ComponentEventsTimedOut<'a> {
+    pub count: usize,
+    pub reason: &'a str,
+}
+
+impl InternalEvent for ComponentEventsTimedOut<'_> {
+    fn emit(self) {
+        let count = self.count;
+        self.register().emit(Count(count));
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        Some("ComponentEventsTimedOut")
+    }
+}
+
+impl<'a> From<&'a str> for ComponentEventsTimedOut<'a> {
+    fn from(reason: &'a str) -> Self {
+        Self { count: 0, reason }
+    }
+}
+
+impl<'a> RegisterInternalEvent for ComponentEventsTimedOut<'a> {
+    type Handle = TimedOutHandle<'a>;
+    fn register(self) -> Self::Handle {
+        Self::Handle {
+            timed_out_events: counter!("component_timedout_events_total"),
+            timed_out_requests: counter!("component_timedout_requests_total"),
+            reason: self.reason,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TimedOutHandle<'a> {
+    timed_out_events: Counter,
+    timed_out_requests: Counter,
+    reason: &'a str,
+}
+
+impl InternalEventHandle for TimedOutHandle<'_> {
+    type Data = Count;
+    fn emit(&self, data: Self::Data) {
+        warn!(
+            message = "Events timed out",
+            events = data.0,
+            reason = self.reason,
+        );
+        self.timed_out_events.increment(data.0 as u64);
+        self.timed_out_requests.increment(1);
+    }
+}

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -2,6 +2,7 @@ mod bytes_received;
 mod bytes_sent;
 pub mod cached_event;
 pub mod component_events_dropped;
+pub mod component_events_timed_out;
 mod events_received;
 mod events_sent;
 mod optional_tag;
@@ -15,6 +16,7 @@ pub use bytes_sent::BytesSent;
 #[allow(clippy::module_name_repetitions)]
 pub use cached_event::{RegisterTaggedInternalEvent, RegisteredEventCache};
 pub use component_events_dropped::{ComponentEventsDropped, INTENTIONAL, UNINTENTIONAL};
+pub use component_events_timed_out::ComponentEventsTimedOut;
 pub use events_received::{EventsReceived, EventsReceivedHandle};
 pub use events_sent::{DEFAULT_OUTPUT, EventsSent, TaggedEventsSent};
 pub use metrics::SharedString;

--- a/lib/vector-core/src/source_sender/builder.rs
+++ b/lib/vector-core/src/source_sender/builder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use metrics::{Histogram, histogram};
 use vector_buffers::topology::channel::LimitedReceiver;
@@ -12,6 +12,7 @@ pub struct Builder {
     default_output: Option<Output>,
     named_outputs: HashMap<String, Output>,
     lag_time: Option<Histogram>,
+    timeout: Option<Duration>,
 }
 
 impl Default for Builder {
@@ -21,6 +22,7 @@ impl Default for Builder {
             default_output: None,
             named_outputs: Default::default(),
             lag_time: Some(histogram!(LAG_TIME_NAME)),
+            timeout: None,
         }
     }
 }
@@ -29,6 +31,12 @@ impl Builder {
     #[must_use]
     pub fn with_buffer(mut self, n: usize) -> Self {
         self.buf_size = n;
+        self
+    }
+
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.timeout = timeout;
         self
     }
 
@@ -51,6 +59,7 @@ impl Builder {
                     lag_time,
                     log_definition,
                     output_id,
+                    self.timeout,
                 );
                 self.default_output = Some(output);
                 rx
@@ -62,6 +71,7 @@ impl Builder {
                     lag_time,
                     log_definition,
                     output_id,
+                    self.timeout,
                 );
                 self.named_outputs.insert(name, output);
                 rx

--- a/lib/vector-core/src/source_sender/mod.rs
+++ b/lib/vector-core/src/source_sender/mod.rs
@@ -13,7 +13,7 @@ mod sender;
 mod tests;
 
 pub use builder::Builder;
-pub use errors::{ClosedError, StreamSendError};
+pub use errors::SendError;
 use output::Output;
 pub use sender::{SourceSender, SourceSenderItem};
 

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -16,8 +16,8 @@ use vector_buffers::{
 use vector_common::{
     byte_size_of::ByteSizeOf,
     internal_event::{
-        self, ComponentEventsDropped, ComponentEventsTimedOut, CountByteSize, EventsSent,
-        InternalEventHandle as _, Registered, UNINTENTIONAL,
+        self, ComponentEventsDropped, ComponentEventsTimedOut, Count, CountByteSize, EventsSent,
+        InternalEventHandle as _, RegisterInternalEvent as _, Registered, UNINTENTIONAL,
     },
 };
 use vrl::value::Value;
@@ -59,10 +59,11 @@ impl UnsentEventCount {
     }
 
     fn timed_out(&mut self) {
-        internal_event::emit(ComponentEventsTimedOut {
-            count: self.count,
+        ComponentEventsTimedOut {
             reason: "Source send timed out.",
-        });
+        }
+        .register()
+        .emit(Count(self.count));
         self.count = 0;
     }
 }

--- a/lib/vector-core/src/source_sender/sender.rs
+++ b/lib/vector-core/src/source_sender/sender.rs
@@ -18,7 +18,7 @@ use vector_common::{
     json_size::JsonSize,
 };
 
-use super::{Builder, ClosedError, Output};
+use super::{Builder, Output, SendError};
 #[cfg(any(test, feature = "test"))]
 use super::{LAG_TIME_NAME, TEST_BUFFER_SIZE};
 use crate::{
@@ -201,14 +201,14 @@ impl SourceSender {
     /// Send an event to the default output.
     ///
     /// This internally handles emitting [EventsSent] and [ComponentEventsDropped] events.
-    pub async fn send_event(&mut self, event: impl Into<EventArray>) -> Result<(), ClosedError> {
+    pub async fn send_event(&mut self, event: impl Into<EventArray>) -> Result<(), SendError> {
         self.default_output_mut().send_event(event).await
     }
 
     /// Send a stream of events to the default output.
     ///
     /// This internally handles emitting [EventsSent] and [ComponentEventsDropped] events.
-    pub async fn send_event_stream<S, E>(&mut self, events: S) -> Result<(), ClosedError>
+    pub async fn send_event_stream<S, E>(&mut self, events: S) -> Result<(), SendError>
     where
         S: Stream<Item = E> + Unpin,
         E: Into<Event> + ByteSizeOf,
@@ -219,7 +219,7 @@ impl SourceSender {
     /// Send a batch of events to the default output.
     ///
     /// This internally handles emitting [EventsSent] and [ComponentEventsDropped] events.
-    pub async fn send_batch<I, E>(&mut self, events: I) -> Result<(), ClosedError>
+    pub async fn send_batch<I, E>(&mut self, events: I) -> Result<(), SendError>
     where
         E: Into<Event> + ByteSizeOf,
         I: IntoIterator<Item = E>,
@@ -231,7 +231,7 @@ impl SourceSender {
     /// Send a batch of events event to a named output.
     ///
     /// This internally handles emitting [EventsSent] and [ComponentEventsDropped] events.
-    pub async fn send_batch_named<I, E>(&mut self, name: &str, events: I) -> Result<(), ClosedError>
+    pub async fn send_batch_named<I, E>(&mut self, name: &str, events: I) -> Result<(), SendError>
     where
         E: Into<Event> + ByteSizeOf,
         I: IntoIterator<Item = E>,

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Duration, Utc};
 use rand::{Rng, rng};
+use std::time::{Duration as StdDuration, Instant};
 use tokio::time::timeout;
 use vrl::event_path;
 
@@ -97,7 +98,7 @@ async fn emit_and_test(make_event: impl FnOnce(DateTime<Utc>) -> Event) {
 #[tokio::test]
 async fn emits_component_discarded_events_total_for_send_event() {
     metrics::init_test();
-    let (mut sender, _recv) = SourceSender::new_test_sender_with_buffer(1);
+    let (mut sender, _recv) = SourceSender::new_test_sender_with_options(1, None);
 
     let event = Event::Metric(Metric::new(
         "name",
@@ -138,7 +139,7 @@ async fn emits_component_discarded_events_total_for_send_event() {
 #[expect(clippy::cast_precision_loss)]
 async fn emits_component_discarded_events_total_for_send_batch() {
     metrics::init_test();
-    let (mut sender, _recv) = SourceSender::new_test_sender_with_buffer(1);
+    let (mut sender, _recv) = SourceSender::new_test_sender_with_options(1, None);
 
     let expected_drop = 100;
     let events: Vec<Event> = (0..(CHUNK_SIZE + expected_drop))
@@ -159,18 +160,81 @@ async fn emits_component_discarded_events_total_for_send_batch() {
     .await;
     assert!(res.is_err(), "Send should have timed out.");
 
-    let component_discarded_events_total = Controller::get()
+    let metrics = get_component_metrics();
+    assert_no_metric(&metrics, "component_timedout_events_total");
+    assert_no_metric(&metrics, "component_timedout_requests_total");
+    assert_counter_metric(
+        &metrics,
+        "component_discarded_events_total",
+        expected_drop as f64,
+    );
+}
+
+#[tokio::test]
+async fn times_out_send_event_with_timeout() {
+    metrics::init_test();
+
+    let timeout_duration = StdDuration::from_millis(10);
+    let (mut sender, _recv) = SourceSender::new_test_sender_with_options(1, Some(timeout_duration));
+
+    let event = Event::Metric(Metric::new(
+        "name",
+        MetricKind::Absolute,
+        MetricValue::Gauge { value: 123.4 },
+    ));
+
+    sender
+        .send_event(event.clone())
+        .await
+        .expect("First send should succeed");
+
+    let start = Instant::now();
+    let result = sender.send_event(event).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        matches!(result, Err(SendError::Timeout)),
+        "Send should return a timeout error."
+    );
+    assert!(
+        elapsed >= timeout_duration,
+        "Send did not wait for the configured timeout"
+    );
+    assert!(elapsed <= timeout_duration * 2, "Send waited too long");
+
+    let metrics = get_component_metrics();
+    assert_no_metric(&metrics, "component_discarded_events_total");
+    assert_counter_metric(&metrics, "component_timedout_events_total", 1.0);
+    assert_counter_metric(&metrics, "component_timedout_requests_total", 1.0);
+}
+
+fn get_component_metrics() -> Vec<Metric> {
+    Controller::get()
         .expect("There must be a controller")
         .capture_metrics()
         .into_iter()
-        .filter(|metric| metric.name() == "component_discarded_events_total")
-        .collect::<Vec<_>>();
-    assert_eq!(component_discarded_events_total.len(), 1);
+        .filter(|metric| metric.name().starts_with("component_"))
+        .collect()
+}
 
-    let component_discarded_events_total = &component_discarded_events_total[0];
-    let MetricValue::Counter { value } = component_discarded_events_total.value() else {
-        panic!("component_discarded_events_total has invalid type")
+fn assert_no_metric(metrics: &[Metric], name: &str) {
+    assert!(
+        !metrics.iter().any(|metric| metric.name() == name),
+        "Metric {name} should not be present"
+    );
+}
+
+fn assert_counter_metric(metrics: &[Metric], name: &str, expected: f64) {
+    let mut filter = metrics.iter().filter(|metric| metric.name() == name);
+    let Some(metric) = filter.next() else {
+        panic!("Metric {name} should be present");
     };
-
-    assert_eq!(*value, expected_drop as f64,);
+    let MetricValue::Counter { value } = metric.value() else {
+        panic!("Metric {name} should be a counter");
+    };
+    assert_eq!(*value, expected);
+    assert!(
+        filter.next().is_none(),
+        "Only one {name} metric should be present"
+    );
 }

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -161,8 +161,8 @@ async fn emits_component_discarded_events_total_for_send_batch() {
     assert!(res.is_err(), "Send should have timed out.");
 
     let metrics = get_component_metrics();
-    assert_no_metric(&metrics, "component_timedout_events_total");
-    assert_no_metric(&metrics, "component_timedout_requests_total");
+    assert_no_metric(&metrics, "component_timed_out_events_total");
+    assert_no_metric(&metrics, "component_timed_out_requests_total");
     assert_counter_metric(
         &metrics,
         "component_discarded_events_total",
@@ -204,8 +204,8 @@ async fn times_out_send_event_with_timeout() {
 
     let metrics = get_component_metrics();
     assert_no_metric(&metrics, "component_discarded_events_total");
-    assert_counter_metric(&metrics, "component_timedout_events_total", 1.0);
-    assert_counter_metric(&metrics, "component_timedout_requests_total", 1.0);
+    assert_counter_metric(&metrics, "component_timed_out_events_total", 1.0);
+    assert_counter_metric(&metrics, "component_timed_out_requests_total", 1.0);
 }
 
 fn get_component_metrics() -> Vec<Metric> {

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap};
+use std::{cell::RefCell, collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use dyn_clone::DynClone;
@@ -120,6 +120,12 @@ pub trait SourceConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sy
     /// well as emit contextual warnings when end-to-end acknowledgements are enabled, but the
     /// topology as configured does not actually support the use of end-to-end acknowledgements.
     fn can_acknowledge(&self) -> bool;
+
+    /// If this source supports timeout returns from the `SourceSender` and the configuration
+    /// provides a timeout value, return it here and the `out` channel will be configured with it.
+    fn send_timeout(&self) -> Option<Duration> {
+        None
+    }
 }
 
 dyn_clone::clone_trait_object!(SourceConfig);

--- a/src/sources/aws_kinesis_firehose/errors.rs
+++ b/src/sources/aws_kinesis_firehose/errors.rs
@@ -35,15 +35,8 @@ pub enum RequestError {
         source: std::io::Error,
         request_id: String,
     },
-    #[snafu(display(
-        "Could not forward events for request {}, downstream is closed: {}",
-        request_id,
-        source
-    ))]
-    ShuttingDown {
-        source: vector_lib::source_sender::ClosedError,
-        request_id: String,
-    },
+    #[snafu(display("Could not forward events for request {request_id}, downstream is closed"))]
+    ShuttingDown { request_id: String },
     #[snafu(display("Unsupported encoding: {}", encoding))]
     UnsupportedEncoding {
         encoding: String,

--- a/src/sources/aws_kinesis_firehose/handlers.rs
+++ b/src/sources/aws_kinesis_firehose/handlers.rs
@@ -18,6 +18,7 @@ use vector_lib::{
         ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Registered,
     },
     lookup::{PathPrefix, metadata_path, path},
+    source_sender::SendError,
 };
 use vrl::compiler::SecretTarget;
 use warp::reject;
@@ -143,13 +144,16 @@ pub(super) async fn firehose(
                     }
 
                     let count = events.len();
-                    if let Err(error) = context.out.send_batch(events).await {
-                        emit!(StreamClosedError { count });
-                        let error = RequestError::ShuttingDown {
-                            request_id: request_id.clone(),
-                            source: error,
-                        };
-                        warp::reject::custom(error);
+                    match context.out.send_batch(events).await {
+                        Ok(()) => (),
+                        Err(SendError::Closed) => {
+                            emit!(StreamClosedError { count });
+                            let error = RequestError::ShuttingDown {
+                                request_id: request_id.clone(),
+                            };
+                            warp::reject::custom(error);
+                        }
+                        Err(SendError::Timeout) => unreachable!("No timeout is configured here"),
                     }
 
                     drop(batch);

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -158,8 +158,8 @@ pub struct DatadogAgentConfig {
     ///
     /// If not set, responses to completed requests will block indefinitely until connected
     /// transforms or sinks are ready to receive the events.
-    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
-    send_timeout_secs: Option<Duration>,
+    #[serde_as(as = "Option<serde_with::DurationSecondsWithFrac<f64>>")]
+    send_timeout_secs: Option<f64>,
 }
 
 impl GenerateConfig for DatadogAgentConfig {
@@ -346,7 +346,7 @@ impl SourceConfig for DatadogAgentConfig {
     }
 
     fn send_timeout(&self) -> Option<Duration> {
-        self.send_timeout_secs
+        self.send_timeout_secs.map(Duration::from_secs_f64)
     }
 }
 

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -157,7 +157,12 @@ pub struct DatadogAgentConfig {
     /// The timeout before responding to requests with a HTTP 503 Service Unavailable error.
     ///
     /// If not set, responses to completed requests will block indefinitely until connected
-    /// transforms or sinks are ready to receive the events.
+    /// transforms or sinks are ready to receive the events. When this happens, the sending Datadog
+    /// Agent will eventually time out the request and drop the connection, resulting Vector
+    /// generating an "Events dropped." error and incrementing the `component_discarded_events_total`
+    /// internal metric. By setting this option to a value less than the Agent's timeout, Vector
+    /// will instead respond to the Agent with a HTTP 503 Service Unavailable error, emit a warning,
+    /// and increment the `component_timedout_events_total` internal metric instead.
     #[serde_as(as = "Option<serde_with::DurationSecondsWithFrac<f64>>")]
     send_timeout_secs: Option<f64>,
 }

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -162,7 +162,7 @@ pub struct DatadogAgentConfig {
     /// generating an "Events dropped." error and incrementing the `component_discarded_events_total`
     /// internal metric. By setting this option to a value less than the Agent's timeout, Vector
     /// will instead respond to the Agent with a HTTP 503 Service Unavailable error, emit a warning,
-    /// and increment the `component_timedout_events_total` internal metric instead.
+    /// and increment the `component_timed_out_events_total` internal metric instead.
     #[serde_as(as = "Option<serde_with::DurationSecondsWithFrac<f64>>")]
     send_timeout_secs: Option<f64>,
 }

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -777,6 +777,29 @@ async fn send_timeout_returns_service_unavailable() {
     drop(rx);
 }
 
+#[test]
+fn parse_config_with_send_timeout_secs() {
+    let config = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address = "0.0.0.0:8012"
+            send_timeout_secs = 1.5
+        "#})
+    .unwrap();
+
+    assert_eq!(config.send_timeout_secs, Some(1.5));
+    assert_eq!(config.send_timeout(), Some(Duration::from_secs_f64(1.5)));
+}
+
+#[test]
+fn parse_config_without_send_timeout_secs() {
+    let config = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address = "0.0.0.0:8012"
+        "#})
+    .unwrap();
+
+    assert_eq!(config.send_timeout_secs, None);
+    assert_eq!(config.send_timeout(), None);
+}
+
 #[tokio::test]
 async fn ignores_disabled_acknowledgements() {
     assert_source_compliance(&HTTP_PUSH_SOURCE_TAGS, async {

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -3,6 +3,7 @@ use std::{
     iter::FromIterator,
     net::SocketAddr,
     str,
+    time::Duration,
 };
 
 use bytes::Bytes;
@@ -14,6 +15,7 @@ use ordered_float::NotNan;
 use prost::Message;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use similar_asserts::assert_eq;
+use tokio::time::timeout;
 use vector_lib::{
     codecs::{
         BytesDecoder, BytesDeserializer, CharacterDelimitedDecoderConfig,
@@ -63,6 +65,7 @@ const DD_API_SERIES_V1_PATH: &str = "/api/v1/series";
 const DD_API_SERIES_V2_PATH: &str = "/api/v2/series";
 const DD_API_SKETCHES_PATH: &str = "/api/beta/sketches";
 const DD_API_TRACES_PATH: &str = "/api/v0.2/traces";
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn test_logs_schema_definition() -> schema::Definition {
     schema::Definition::empty_legacy_namespace().with_event_field(
@@ -228,7 +231,60 @@ async fn source(
     SocketAddr,
     PortGuard,
 ) {
-    let (mut sender, recv) = SourceSender::new_test_finalize(status);
+    let (sender, recv) = SourceSender::new_test_finalize(status);
+    let (logs_output, metrics_output, address, guard) = source_with_sender(
+        sender,
+        status,
+        acknowledgements,
+        store_api_key,
+        multiple_outputs,
+        split_metric_namespace,
+    )
+    .await;
+    (recv, logs_output, metrics_output, address, guard)
+}
+
+async fn source_with_timeout(
+    status: EventStatus,
+    acknowledgements: bool,
+    store_api_key: bool,
+    multiple_outputs: bool,
+    split_metric_namespace: bool,
+    send_timeout: Duration,
+) -> (
+    impl Stream<Item = Event> + Unpin,
+    Option<impl Stream<Item = Event>>,
+    Option<impl Stream<Item = Event>>,
+    SocketAddr,
+    PortGuard,
+) {
+    let (sender, recv) = SourceSender::new_test_sender_with_options(1, Some(send_timeout));
+    let (logs_output, metrics_output, address, guard) = source_with_sender(
+        sender,
+        status,
+        acknowledgements,
+        store_api_key,
+        multiple_outputs,
+        split_metric_namespace,
+    )
+    .await;
+    let recv = recv.into_stream().flat_map(into_event_stream);
+    (recv, logs_output, metrics_output, address, guard)
+}
+
+async fn source_with_sender(
+    mut sender: SourceSender,
+    status: EventStatus,
+    acknowledgements: bool,
+    store_api_key: bool,
+    multiple_outputs: bool,
+    split_metric_namespace: bool,
+) -> (
+    Option<impl Stream<Item = Event>>,
+    Option<impl Stream<Item = Event>>,
+    SocketAddr,
+    PortGuard,
+) {
     let mut logs_output = None;
     let mut metrics_output = None;
     if multiple_outputs {
@@ -243,7 +299,7 @@ async fn source(
                 .flat_map(into_event_stream),
         );
     }
-    let (_guard, address) = next_addr();
+    let (guard, address) = next_addr();
     let config = toml::from_str::<DatadogAgentConfig>(&format!(
         indoc! { r#"
             address = "{}"
@@ -264,19 +320,23 @@ async fn source(
         config.build(context).await.unwrap().await.unwrap();
     });
     wait_for_tcp(address).await;
-    (recv, logs_output, metrics_output, address, _guard)
+    (logs_output, metrics_output, address, guard)
 }
 
 async fn send_with_path(address: SocketAddr, body: &str, headers: HeaderMap, path: &str) -> u16 {
-    reqwest::Client::new()
-        .post(format!("http://{address}{path}"))
-        .headers(headers)
-        .body(body.to_owned())
-        .send()
-        .await
-        .unwrap()
-        .status()
-        .as_u16()
+    timeout(
+        HTTP_REQUEST_TIMEOUT,
+        reqwest::Client::new()
+            .post(format!("http://{address}{path}"))
+            .headers(headers)
+            .body(body.to_owned())
+            .send(),
+    )
+    .await
+    .expect("send_with_path request timed out")
+    .unwrap()
+    .status()
+    .as_u16()
 }
 
 async fn send_and_collect(
@@ -676,6 +736,45 @@ async fn delivery_failure() {
         1,
     )
     .await;
+}
+
+#[tokio::test]
+async fn send_timeout_returns_service_unavailable() {
+    trace_init();
+    let (rx, _, _, addr, _guard) = source_with_timeout(
+        EventStatus::Delivered,
+        false,
+        true,
+        false,
+        true,
+        Duration::from_millis(50),
+    )
+    .await;
+
+    let body = serde_json::to_string(&[LogMsg {
+        message: Bytes::from("foo"),
+        timestamp: Utc
+            .timestamp_opt(123, 0)
+            .single()
+            .expect("invalid timestamp"),
+        hostname: Bytes::from("festeburg"),
+        status: Bytes::from("notice"),
+        service: Bytes::from("vector"),
+        ddsource: Bytes::from("curl"),
+        ddtags: Bytes::from("one,two,three"),
+    }])
+    .unwrap();
+
+    assert_eq!(
+        200,
+        send_with_path(addr, &body, HeaderMap::new(), DD_API_LOGS_V1_PATH).await
+    );
+
+    assert_eq!(
+        503,
+        send_with_path(addr, &body, HeaderMap::new(), DD_API_LOGS_V1_PATH).await
+    );
+    drop(rx);
 }
 
 #[tokio::test]
@@ -1498,6 +1597,7 @@ fn test_config_outputs_with_disabled_data_types() {
             split_metric_namespace: true,
             log_namespace: Some(false),
             keepalive: Default::default(),
+            send_timeout_secs: None,
         };
 
         let outputs: Vec<DataType> = config
@@ -1941,6 +2041,7 @@ fn test_config_outputs() {
             split_metric_namespace: true,
             log_namespace: Some(false),
             keepalive: Default::default(),
+            send_timeout_secs: None,
         };
 
         let mut outputs = config
@@ -2613,6 +2714,7 @@ impl ValidatableComponent for DatadogAgentConfig {
             split_metric_namespace: true,
             log_namespace: Some(false),
             keepalive: Default::default(),
+            send_timeout_secs: None,
         };
 
         let log_namespace: LogNamespace = config.log_namespace.unwrap_or_default().into();

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1778,7 +1778,7 @@ mod integration_test {
         delay: Duration,
         status: EventStatus,
     ) -> (SourceSender, impl Stream<Item = EventArray> + Unpin) {
-        let (pipe, recv) = SourceSender::new_test_sender_with_buffer(100);
+        let (pipe, recv) = SourceSender::new_test_sender_with_options(100, None);
         let recv = recv.into_stream();
         let recv = recv.then(move |item| async move {
             let mut events = item.events;

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -811,7 +811,7 @@ mod test {
         // shutdown.
         let (guard, addr) = next_addr();
 
-        let (source_tx, source_rx) = SourceSender::new_test_sender_with_buffer(10_000);
+        let (source_tx, source_rx) = SourceSender::new_test_sender_with_options(10_000, None);
         let source_key = ComponentKey::from("tcp_shutdown_infinite_stream");
         let (source_cx, mut shutdown) = SourceContext::new_shutdown(&source_key, source_tx);
 

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -543,7 +543,7 @@ mod test {
         });
 
         let component_key = ComponentKey::from("statsd_conversion_disabled");
-        let (tx, rx) = SourceSender::new_test_sender_with_buffer(4096);
+        let (tx, rx) = SourceSender::new_test_sender_with_options(4096, None);
         let (source_ctx, shutdown) = SourceContext::new_shutdown(&component_key, tx);
         let sink = statsd_config
             .build(source_ctx)
@@ -580,7 +580,7 @@ mod test {
         // packet we send has a lot of metrics per packet.  We could technically count them all up
         // and have a more accurate number here, but honestly, who cares?  This is big enough.
         let component_key = ComponentKey::from("statsd");
-        let (tx, rx) = SourceSender::new_test_sender_with_buffer(4096);
+        let (tx, rx) = SourceSender::new_test_sender_with_options(4096, None);
         let (source_ctx, shutdown) = SourceContext::new_shutdown(&component_key, tx);
         let sink = statsd_config
             .build(source_ctx)
@@ -674,7 +674,7 @@ mod test {
         // packet we send has a lot of metrics per packet.  We could technically count them all up
         // and have a more accurate number here, but honestly, who cares?  This is big enough.
         let component_key = ComponentKey::from("statsd");
-        let (tx, _rx) = SourceSender::new_test_sender_with_buffer(4096);
+        let (tx, _rx) = SourceSender::new_test_sender_with_options(4096, None);
         let (source_ctx, shutdown) = SourceContext::new_shutdown(&component_key, tx);
         let sink = statsd_config
             .build(source_ctx)

--- a/src/test_util/mock/mod.rs
+++ b/src/test_util/mock/mod.rs
@@ -31,12 +31,12 @@ pub fn backpressure_source(counter: &Arc<AtomicUsize>) -> BackpressureSourceConf
 }
 
 pub fn basic_source() -> (SourceSender, BasicSourceConfig) {
-    let (tx, rx) = SourceSender::new_test_sender_with_buffer(1);
+    let (tx, rx) = SourceSender::new_test_sender_with_options(1, None);
     (tx, BasicSourceConfig::new(rx))
 }
 
 pub fn basic_source_with_data(data: &str) -> (SourceSender, BasicSourceConfig) {
-    let (tx, rx) = SourceSender::new_test_sender_with_buffer(1);
+    let (tx, rx) = SourceSender::new_test_sender_with_options(1, None);
     (tx, BasicSourceConfig::new_with_data(rx, data))
 }
 
@@ -44,7 +44,7 @@ pub fn basic_source_with_event_counter(
     force_shutdown: bool,
 ) -> (SourceSender, BasicSourceConfig, Arc<AtomicUsize>) {
     let event_counter = Arc::new(AtomicUsize::new(0));
-    let (tx, rx) = SourceSender::new_test_sender_with_buffer(1);
+    let (tx, rx) = SourceSender::new_test_sender_with_options(1, None);
     let mut source = BasicSourceConfig::new_with_event_counter(rx, Arc::clone(&event_counter));
     source.set_force_shutdown(force_shutdown);
 
@@ -76,7 +76,7 @@ pub const fn backpressure_sink(num_to_consume: usize) -> BackpressureSinkConfig 
 }
 
 pub fn basic_sink(channel_size: usize) -> (impl Stream<Item = SourceSenderItem>, BasicSinkConfig) {
-    let (tx, rx) = SourceSender::new_test_sender_with_buffer(channel_size);
+    let (tx, rx) = SourceSender::new_test_sender_with_options(channel_size, None);
     let sink = BasicSinkConfig::new(tx, true);
     (rx.into_stream(), sink)
 }
@@ -88,7 +88,7 @@ pub fn basic_sink_with_data(
     impl Stream<Item = SourceSenderItem> + use<>,
     BasicSinkConfig,
 ) {
-    let (tx, rx) = SourceSender::new_test_sender_with_buffer(channel_size);
+    let (tx, rx) = SourceSender::new_test_sender_with_options(channel_size, None);
     let sink = BasicSinkConfig::new_with_data(tx, true, data);
     (rx.into_stream(), sink)
 }
@@ -96,7 +96,7 @@ pub fn basic_sink_with_data(
 pub fn basic_sink_failing_healthcheck(
     channel_size: usize,
 ) -> (impl Stream<Item = SourceSenderItem>, BasicSinkConfig) {
-    let (tx, rx) = SourceSender::new_test_sender_with_buffer(channel_size);
+    let (tx, rx) = SourceSender::new_test_sender_with_options(channel_size, None);
     let sink = BasicSinkConfig::new(tx, false);
     (rx.into_stream(), sink)
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -260,7 +260,9 @@ impl<'a> Builder<'a> {
                 key.id()
             );
 
-            let mut builder = SourceSender::builder().with_buffer(*SOURCE_SENDER_BUFFER_SIZE);
+            let mut builder = SourceSender::builder()
+                .with_buffer(*SOURCE_SENDER_BUFFER_SIZE)
+                .with_timeout(source.inner.send_timeout());
             let mut pumps = Vec::new();
             let mut controls = HashMap::new();
             let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
@@ -343,8 +345,6 @@ impl<'a> Builder<'a> {
             };
             let pump = Task::new(key.clone(), typetag, pump);
 
-            let pipeline = builder.build();
-
             let (shutdown_signal, force_shutdown_tripwire) = self
                 .shutdown_coordinator
                 .register_source(key, INTERNAL_SOURCES.contains(&typetag));
@@ -354,15 +354,14 @@ impl<'a> Builder<'a> {
                 globals: self.config.global.clone(),
                 enrichment_tables: enrichment_tables.clone(),
                 shutdown: shutdown_signal,
-                out: pipeline,
+                out: builder.build(),
                 proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, &source.proxy),
                 acknowledgements: source.sink_acknowledgements,
                 schema_definitions,
                 schema: self.config.schema,
                 extra_context: self.extra_context.clone(),
             };
-            let source = source.inner.build(context).await;
-            let server = match source {
+            let server = match source.inner.build(context).await {
                 Err(error) => {
                     self.errors.push(format!("Source \"{key}\": {error}"));
                     continue;

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -223,6 +223,8 @@ components: sources: datadog_agent: {
 	}
 
 	telemetry: metrics: {
+		component_timedout_events_total:      components.sources.internal_metrics.output.metrics.component_timedout_events_total
+		component_timedout_requests_total:    components.sources.internal_metrics.output.metrics.component_timedout_requests_total
 		http_server_handler_duration_seconds: components.sources.internal_metrics.output.metrics.http_server_handler_duration_seconds
 		http_server_requests_received_total:  components.sources.internal_metrics.output.metrics.http_server_requests_received_total
 		http_server_responses_sent_total:     components.sources.internal_metrics.output.metrics.http_server_responses_sent_total

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -225,7 +225,7 @@ components: sources: datadog_agent: {
 			body: """
 				When the Datadog Agent sends a request to this Vector source, and the source
 				blocks on sending the events in that request to the connected transforms or sinks,
-				the agent will eventually time out the request and drop the connection. When that
+				the Agent will eventually time out the request and drop the connection. When that
 				happens, by default, Vector will emit an "Events dropped." error and increment
 				the `component_discarded_events_total` internal metric.
 

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -239,14 +239,14 @@ components: sources: datadog_agent: {
 				value _less than_ the Agent's timeout, which defaults to 10 seconds.
 				This will cause Vector to respond to the Agent when such blockages occur with a HTTP 503
 				Service Unavailable response, emit a warning instead of an error,
-				and increment the `component_timedout_requests_total` internal metric.
+				and increment the `component_timed_out_requests_total` internal metric.
 				"""
 		}
 	}
 
 	telemetry: metrics: {
-		component_timedout_events_total:      components.sources.internal_metrics.output.metrics.component_timedout_events_total
-		component_timedout_requests_total:    components.sources.internal_metrics.output.metrics.component_timedout_requests_total
+		component_timed_out_events_total:     components.sources.internal_metrics.output.metrics.component_timed_out_events_total
+		component_timed_out_requests_total:   components.sources.internal_metrics.output.metrics.component_timed_out_requests_total
 		http_server_handler_duration_seconds: components.sources.internal_metrics.output.metrics.http_server_handler_duration_seconds
 		http_server_requests_received_total:  components.sources.internal_metrics.output.metrics.http_server_requests_received_total
 		http_server_responses_sent_total:     components.sources.internal_metrics.output.metrics.http_server_responses_sent_total

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -220,6 +220,28 @@ components: sources: datadog_agent: {
 				duration distribution).
 				"""
 		}
+		request_timeouts: {
+			title: "Request timeout handling"
+			body: """
+				When the Datadog Agent sends a request to this Vector source, and the source
+				blocks on sending the events in that request to the connected transforms or sinks,
+				the agent will eventually time out the request and drop the connection. When that
+				happens, by default, Vector will emit an "Events dropped." error and increment
+				the `component_discarded_events_total` internal metric.
+
+				However, while it is technically true that Vector has dropped the events, the
+				Agent will retry resending that request indefinitely, which means the events will
+				eventually be received unless the blockage above is permanent or the Agent is
+				killed before the request is accepted.
+
+				To prevent this potentially misleading telemetry, you can configure
+				the `send_timeout_secs` option to a
+				value _less than_ the Agent's timeout, which defaults to 10 seconds.
+				This will cause Vector to respond to the Agent when such blockages occur with a HTTP 503
+				Service Unavailable response, emit a warning instead of an error,
+				and increment the `component_timedout_requests_total` internal metric.
+				"""
+		}
 	}
 
 	telemetry: metrics: {

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -592,16 +592,7 @@ generated: components: sources: datadog_agent: configuration: {
 			transforms or sinks are ready to receive the events.
 			"""
 		required: false
-		type: object: options: {
-			nsecs: {
-				required: true
-				type: number: {}
-			}
-			secs: {
-				required: true
-				type: number: {}
-			}
-		}
+		type: float: {}
 	}
 	split_metric_namespace: {
 		description: """

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -594,7 +594,7 @@ generated: components: sources: datadog_agent: configuration: {
 			generating an "Events dropped." error and incrementing the `component_discarded_events_total`
 			internal metric. By setting this option to a value less than the Agent's timeout, Vector
 			will instead respond to the Agent with a HTTP 503 Service Unavailable error, emit a warning,
-			and increment the `component_timedout_events_total` internal metric instead.
+			and increment the `component_timed_out_events_total` internal metric instead.
 			"""
 		required: false
 		type: float: {}

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -584,6 +584,25 @@ generated: components: sources: datadog_agent: configuration: {
 		required: false
 		type: bool: default: false
 	}
+	send_timeout_secs: {
+		description: """
+			The timeout before responding to requests with a HTTP 503 Service Unavailable error.
+
+			If not set, responses to completed requests will block indefinitely until connected
+			transforms or sinks are ready to receive the events.
+			"""
+		required: false
+		type: object: options: {
+			nsecs: {
+				required: true
+				type: number: {}
+			}
+			secs: {
+				required: true
+				type: number: {}
+			}
+		}
+	}
 	split_metric_namespace: {
 		description: """
 			If this is set to `true`, metric names are split at the first '.' into a namespace and name.

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -589,7 +589,12 @@ generated: components: sources: datadog_agent: configuration: {
 			The timeout before responding to requests with a HTTP 503 Service Unavailable error.
 
 			If not set, responses to completed requests will block indefinitely until connected
-			transforms or sinks are ready to receive the events.
+			transforms or sinks are ready to receive the events. When this happens, the sending Datadog
+			Agent will eventually time out the request and drop the connection, resulting Vector
+			generating an "Events dropped." error and incrementing the `component_discarded_events_total`
+			internal metric. By setting this option to a value less than the Agent's timeout, Vector
+			will instead respond to the Agent with a HTTP 503 Service Unavailable error, emit a warning,
+			and increment the `component_timedout_events_total` internal metric instead.
 			"""
 		required: false
 		type: float: {}

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -84,13 +84,13 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
-		component_timedout_events_total: {
+		component_timed_out_events_total: {
 			description:       "The total number of events for which this source responded with a timeout error."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		component_timedout_requests_total: {
+		component_timed_out_requests_total: {
 			description:       "The total number of requests for which this source responded with a timeout error."
 			type:              "counter"
 			default_namespace: "vector"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -84,6 +84,18 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
+		component_timedout_events_total: {
+			description:       "The total number of events for which this source responded with a timeout error."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		component_timedout_requests_total: {
+			description:       "The total number of requests for which this source responded with a timeout error."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		connection_established_total: {
 			description:       "The total number of times a connection has been established."
 			type:              "counter"


### PR DESCRIPTION
## Summary

This change adds support for a configurable `send_timeout_secs` option to the `datadog_agent` source. When configured, the source will reject requests with a HTTP 503 response code after the configured time when the downstream buffer cannot accept the new events in time. It defaults to no timeout, preserving the existing behavior.

Without the timeout, the Datadog Agent will eventually drop the connection itself, which Vector will detect and report as an "Events dropped." error as well as incrementing the `component_events_dropped_total` metric. However, in both cases, either connection drop or explicit timeout, the Agent will continue to retry the request indefinitely. As such, this does not change the end result, only the reporting of it and the speed at which it is reported.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

There are internal unit tests that confirm the behavior with a running source.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
