### PR TITLE
enhancement(sources): Add internal metric to record source buffer utilization

### DIFF
--- a/changelog.d/source-sender-utilization-metric.enhancement.md
+++ b/changelog.d/source-sender-utilization-metric.enhancement.md
@@ -1,4 +1,9 @@
-Added a metric to record the utilization level of the buffer that all sources send into.
-This new metric is called `source_sender_buffer_utilization`.
+Added the following metrics to record the utilization level of the buffer that
+all sources send into:
+
+- `source_buffer_max_byte_size`
+- `source_buffer_max_event_size`
+- `source_buffer_utilization`
+- `source_buffer_utilization_level`
 
 authors: bruceg

--- a/changelog.d/source-sender-utilization-metric.enhancement.md
+++ b/changelog.d/source-sender-utilization-metric.enhancement.md
@@ -1,0 +1,4 @@
+Added a metric to record the utilization level of the buffer that all sources send into.
+This new metric is called `source_sender_buffer_utilization`.
+
+authors: bruceg

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -11,6 +11,7 @@ use std::{
 use async_stream::stream;
 use crossbeam_queue::{ArrayQueue, SegQueue};
 use futures::Stream;
+use metrics::{Histogram, histogram};
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
 use crate::{InMemoryBufferable, config::MemoryBufferSize};
@@ -94,6 +95,7 @@ struct Inner<T> {
     limit: MemoryBufferSize,
     limiter: Arc<Semaphore>,
     read_waker: Arc<Notify>,
+    depth: Option<Histogram>,
 }
 
 impl<T> Clone for Inner<T> {
@@ -103,6 +105,53 @@ impl<T> Clone for Inner<T> {
             limit: self.limit,
             limiter: self.limiter.clone(),
             read_waker: self.read_waker.clone(),
+            depth: self.depth.clone(),
+        }
+    }
+}
+
+impl<T: InMemoryBufferable> Inner<T> {
+    fn new(limit: MemoryBufferSize, metric_name: Option<(&'static str, &str)>) -> Self {
+        let read_waker = Arc::new(Notify::new());
+        match limit {
+            MemoryBufferSize::MaxEvents(max_events) => Inner {
+                data: Arc::new(ArrayQueue::new(max_events.get())),
+                limit,
+                limiter: Arc::new(Semaphore::new(max_events.get())),
+                read_waker,
+                depth: metric_name.map(|(name, output)| {
+                    histogram!(
+                            name,
+                            "max_events" => max_events.to_string(),
+                            "output" => output.to_string()
+                    )
+                }),
+            },
+            MemoryBufferSize::MaxSize(max_bytes) => Inner {
+                data: Arc::new(SegQueue::new()),
+                limit,
+                limiter: Arc::new(Semaphore::new(max_bytes.get())),
+                read_waker,
+                depth: metric_name.map(|(name, output)| {
+                    histogram!(
+                        name,
+                        "max_bytes" => max_bytes.to_string(),
+                        "output" => output.to_string()
+                    )
+                }),
+            },
+        }
+    }
+
+    fn send_with_permit(&mut self, total: usize, permits: OwnedSemaphorePermit, item: T) {
+        self.data.push((permits, item));
+        self.read_waker.notify_one();
+        // Due to the race between getting the available capacity, acquiring the permits, and the
+        // above push, the total may be inaccurate. Record it anyways as the histogram totals will
+        // _eventually_ converge on a true picture of the buffer utilization.
+        if let Some(histogram) = self.depth.as_ref() {
+            #[expect(clippy::cast_precision_loss)]
+            histogram.record(total as f64);
         }
     }
 }
@@ -115,7 +164,7 @@ pub struct LimitedSender<T> {
 
 impl<T: InMemoryBufferable> LimitedSender<T> {
     #[allow(clippy::cast_possible_truncation)]
-    fn get_required_permits_for_item(&self, item: &T) -> u32 {
+    fn calc_required_permits(&self, item: &T) -> (usize, usize, u32) {
         // We have to limit the number of permits we ask for to the overall limit since we're always
         // willing to store more items than the limit if the queue is entirely empty, because
         // otherwise we might deadlock ourselves by not being able to send a single item.
@@ -123,7 +172,8 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
             MemoryBufferSize::MaxSize(max_size) => (max_size, item.allocated_bytes()),
             MemoryBufferSize::MaxEvents(max_events) => (max_events, item.event_count()),
         };
-        cmp::min(limit.get(), value) as u32
+        let limit = limit.get();
+        (limit, value, cmp::min(limit, value) as u32)
     }
 
     /// Gets the number of items that this channel could accept.
@@ -139,23 +189,22 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
     /// with the given `item`.
     pub async fn send(&mut self, item: T) -> Result<(), SendError<T>> {
         // Calculate how many permits we need, and wait until we can acquire all of them.
-        let permits_required = self.get_required_permits_for_item(&item);
-        let Ok(permits) = self
+        let (limit, count, permits_required) = self.calc_required_permits(&item);
+        let in_use = limit - self.available_capacity();
+        match self
             .inner
             .limiter
             .clone()
             .acquire_many_owned(permits_required)
             .await
-        else {
-            return Err(SendError(item));
-        };
-
-        self.inner.data.push((permits, item));
-        self.inner.read_waker.notify_one();
-
-        trace!("Sent item.");
-
-        Ok(())
+        {
+            Ok(permits) => {
+                self.inner.send_with_permit(in_use + count, permits, item);
+                trace!("Sent item.");
+                Ok(())
+            }
+            Err(_) => Err(SendError(item)),
+        }
     }
 
     /// Attempts to send an item into the channel.
@@ -172,28 +221,24 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
     /// Will panic if adding ack amount overflows.
     pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
         // Calculate how many permits we need, and try to acquire them all without waiting.
-        let permits_required = self.get_required_permits_for_item(&item);
-        let permits = match self
+        let (limit, count, permits_required) = self.calc_required_permits(&item);
+        let in_use = limit - self.available_capacity();
+        match self
             .inner
             .limiter
             .clone()
             .try_acquire_many_owned(permits_required)
         {
-            Ok(permits) => permits,
-            Err(ae) => {
-                return match ae {
-                    TryAcquireError::NoPermits => Err(TrySendError::InsufficientCapacity(item)),
-                    TryAcquireError::Closed => Err(TrySendError::Disconnected(item)),
-                };
+            Ok(permits) => {
+                self.inner.send_with_permit(in_use + count, permits, item);
+                trace!("Attempt to send item succeeded.");
+                Ok(())
             }
-        };
-
-        self.inner.data.push((permits, item));
-        self.inner.read_waker.notify_one();
-
-        trace!("Attempt to send item succeeded.");
-
-        Ok(())
+            Err(ae) => match ae {
+                TryAcquireError::NoPermits => Err(TrySendError::InsufficientCapacity(item)),
+                TryAcquireError::Closed => Err(TrySendError::Disconnected(item)),
+            },
+        }
     }
 }
 
@@ -269,21 +314,9 @@ impl<T> Drop for LimitedReceiver<T> {
 
 pub fn limited<T: InMemoryBufferable + fmt::Debug>(
     limit: MemoryBufferSize,
+    metric_name_output: Option<(&'static str, &str)>,
 ) -> (LimitedSender<T>, LimitedReceiver<T>) {
-    let inner = match limit {
-        MemoryBufferSize::MaxEvents(max_events) => Inner {
-            data: Arc::new(ArrayQueue::new(max_events.get())),
-            limit,
-            limiter: Arc::new(Semaphore::new(max_events.get())),
-            read_waker: Arc::new(Notify::new()),
-        },
-        MemoryBufferSize::MaxSize(max_size) => Inner {
-            data: Arc::new(SegQueue::new()),
-            limit,
-            limiter: Arc::new(Semaphore::new(max_size.get())),
-            read_waker: Arc::new(Notify::new()),
-        },
-    };
+    let inner = Inner::new(limit, metric_name_output);
 
     let sender = LimitedSender {
         inner: inner.clone(),
@@ -310,7 +343,8 @@ mod tests {
 
     #[tokio::test]
     async fn send_receive() {
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(2, tx.available_capacity());
 
@@ -344,9 +378,8 @@ mod tests {
         let max_allowed_bytes = msg_size * max_elements;
 
         // With this configuration a maximum of exactly 10 messages can fit in the channel
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxSize(
-            NonZeroUsize::new(max_allowed_bytes).unwrap(),
-        ));
+        let limit = MemoryBufferSize::MaxSize(NonZeroUsize::new(max_allowed_bytes).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(max_allowed_bytes, tx.available_capacity());
 
@@ -379,7 +412,8 @@ mod tests {
 
     #[test]
     fn sender_waits_for_more_capacity_when_none_available() {
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(1, tx.available_capacity());
 
@@ -440,7 +474,8 @@ mod tests {
 
     #[test]
     fn sender_waits_for_more_capacity_when_partial_available() {
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(7).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(7).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(7, tx.available_capacity());
 
@@ -528,7 +563,8 @@ mod tests {
 
     #[test]
     fn empty_receiver_returns_none_when_last_sender_drops() {
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(1, tx.available_capacity());
 
@@ -570,8 +606,8 @@ mod tests {
 
     #[test]
     fn receiver_returns_none_once_empty_when_last_sender_drops() {
-        let (tx, mut rx) =
-            limited::<Sample>(MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap());
+        let (tx, mut rx) = limited::<Sample>(limit, None);
 
         assert_eq!(1, tx.available_capacity());
 
@@ -600,7 +636,8 @@ mod tests {
 
     #[test]
     fn oversized_send_allowed_when_empty() {
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(1, tx.available_capacity());
 
@@ -632,7 +669,8 @@ mod tests {
 
     #[test]
     fn oversized_send_allowed_when_partial_capacity() {
-        let (mut tx, mut rx) = limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
+        let (mut tx, mut rx) = limited(limit, None);
 
         assert_eq!(2, tx.available_capacity());
 

--- a/lib/vector-buffers/src/variants/in_memory.rs
+++ b/lib/vector-buffers/src/variants/in_memory.rs
@@ -44,7 +44,7 @@ where
 
         usage_handle.set_buffer_limits(max_bytes, max_size);
 
-        let (tx, rx) = limited(self.capacity);
+        let (tx, rx) = limited(self.capacity, None);
         Ok((tx.into(), rx.into()))
     }
 }

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -30,6 +30,8 @@ use crate::{
     schema::Definition,
 };
 
+const UTILIZATION_METRIC_NAME: &str = "source_sender_buffer_utilization";
+
 /// UnsentEvents tracks the number of events yet to be sent in the buffer. This is used to
 /// increment the appropriate counters when a future is not polled to completion. Particularly,
 /// this is known to happen in a Warp server when a client sends a new HTTP request on a TCP
@@ -114,7 +116,8 @@ impl Output {
         output_id: OutputId,
         timeout: Option<Duration>,
     ) -> (Self, LimitedReceiver<SourceSenderItem>) {
-        let (tx, rx) = channel::limited(MemoryBufferSize::MaxEvents(NonZeroUsize::new(n).unwrap()));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(n).unwrap());
+        let (tx, rx) = channel::limited(limit, Some((UTILIZATION_METRIC_NAME, &output)));
         (
             Self {
                 sender: tx,

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -30,7 +30,7 @@ use crate::{
     schema::Definition,
 };
 
-const UTILIZATION_METRIC_PREFIX: &str = "source_sender_buffer";
+const UTILIZATION_METRIC_PREFIX: &str = "source_buffer";
 
 /// UnsentEvents tracks the number of events yet to be sent in the buffer. This is used to
 /// increment the appropriate counters when a future is not polled to completion. Particularly,

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -30,7 +30,7 @@ use crate::{
     schema::Definition,
 };
 
-const UTILIZATION_METRIC_NAME: &str = "source_sender_buffer_utilization";
+const UTILIZATION_METRIC_PREFIX: &str = "source_sender_buffer";
 
 /// UnsentEvents tracks the number of events yet to be sent in the buffer. This is used to
 /// increment the appropriate counters when a future is not polled to completion. Particularly,
@@ -117,7 +117,7 @@ impl Output {
         timeout: Option<Duration>,
     ) -> (Self, LimitedReceiver<SourceSenderItem>) {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(n).unwrap());
-        let (tx, rx) = channel::limited(limit, Some((UTILIZATION_METRIC_NAME, &output)));
+        let (tx, rx) = channel::limited(limit, Some((UTILIZATION_METRIC_PREFIX, &output)));
         (
             Self {
                 sender: tx,

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -264,7 +264,7 @@ async fn emits_buffer_utilization_histogram_on_send_and_receive() {
         .expect("metrics controller available")
         .capture_metrics()
         .into_iter()
-        .filter(|metric| metric.name().starts_with("source_sender_buffer_"))
+        .filter(|metric| metric.name().starts_with("source_buffer_"))
         .collect();
     assert_eq!(metrics.len(), 3, "expected 3 utilization metrics");
 
@@ -275,19 +275,19 @@ async fn emits_buffer_utilization_histogram_on_send_and_receive() {
             .unwrap_or_else(|| panic!("missing metric: {name}"))
     };
 
-    let metric = find_metric("source_sender_buffer_utilization");
+    let metric = find_metric("source_buffer_utilization");
     let tags = metric.tags().expect("utilization histogram has tags");
     assert_eq!(tags.get("output"), Some("_default"));
 
-    let metric = find_metric("source_sender_buffer_utilization_level");
+    let metric = find_metric("source_buffer_utilization_level");
     let MetricValue::Gauge { value } = metric.value() else {
-        panic!("source_sender_buffer_utilization_level should be a gauge");
+        panic!("source_buffer_utilization_level should be a gauge");
     };
     assert_eq!(*value, 2.0);
 
-    let metric = find_metric("source_sender_buffer_max_event_size");
+    let metric = find_metric("source_buffer_max_event_size");
     let MetricValue::Gauge { value } = metric.value() else {
-        panic!("source_sender_buffer_max_event_size should be a gauge");
+        panic!("source_buffer_max_event_size should be a gauge");
     };
     assert_eq!(*value, buffer_size as f64);
 }

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -240,6 +240,7 @@ fn assert_counter_metric(metrics: &[Metric], name: &str, expected: f64) {
 }
 
 #[tokio::test]
+#[expect(clippy::cast_precision_loss)]
 async fn emits_buffer_utilization_histogram_on_send_and_receive() {
     metrics::init_test();
     let buffer_size = 2;
@@ -259,30 +260,34 @@ async fn emits_buffer_utilization_histogram_on_send_and_receive() {
     assert!(recv.next().await.is_some());
     assert!(recv.next().await.is_some());
 
-    let utilization_metrics = Controller::get()
+    let metrics: Vec<_> = Controller::get()
         .expect("metrics controller available")
         .capture_metrics()
         .into_iter()
-        .filter(|metric| metric.name() == "source_sender_buffer_utilization")
-        .collect::<Vec<_>>();
-    assert_eq!(
-        utilization_metrics.len(),
-        1,
-        "expected a single utilization histogram"
-    );
+        .filter(|metric| metric.name().starts_with("source_sender_buffer_"))
+        .collect();
+    assert_eq!(metrics.len(), 3, "expected 3 utilization metrics");
 
-    let metric = &utilization_metrics[0];
-    let tags = metric.tags().expect("utilization histogram has tags");
-    let max_events = buffer_size.to_string();
-    assert_eq!(tags.get("output"), Some("_default"));
-    assert_eq!(tags.get("max_events"), Some(max_events.as_str()));
-
-    let MetricValue::AggregatedHistogram { count, sum, .. } = metric.value() else {
-        panic!("source_sender_buffer_utilization should be a histogram");
+    let find_metric = |name: &str| {
+        metrics
+            .iter()
+            .find(|m| m.name() == name)
+            .unwrap_or_else(|| panic!("missing metric: {name}"))
     };
-    assert_eq!(*count, 2, "one sample per send expected");
-    assert!(
-        (*sum - 3.0).abs() <= 0.001,
-        "unexpected histogram sum: expected 3.0, got {sum}"
-    );
+
+    let metric = find_metric("source_sender_buffer_utilization");
+    let tags = metric.tags().expect("utilization histogram has tags");
+    assert_eq!(tags.get("output"), Some("_default"));
+
+    let metric = find_metric("source_sender_buffer_utilization_level");
+    let MetricValue::Gauge { value } = metric.value() else {
+        panic!("source_sender_buffer_utilization_level should be a gauge");
+    };
+    assert_eq!(*value, 2.0);
+
+    let metric = find_metric("source_sender_buffer_max_event_size");
+    let MetricValue::Gauge { value } = metric.value() else {
+        panic!("source_sender_buffer_max_event_size should be a gauge");
+    };
+    assert_eq!(*value, buffer_size as f64);
 }

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -67,8 +67,8 @@ pub const AWS_SINK_TAGS: [&str; 2] = ["protocol", "region"];
 
 /// The list of source sender buffer metrics that must be emitted.
 const SOURCE_SENDER_BUFFER_METRICS: [&str; 2] = [
-    "source_sender_buffer_utilization",
-    "source_sender_buffer_utilization_level",
+    "source_buffer_utilization",
+    "source_buffer_utilization_level",
 ];
 
 /// This struct is used to describe a set of component tests.

--- a/src/test_util/mock/sources/basic.rs
+++ b/src/test_util/mock/sources/basic.rs
@@ -45,9 +45,8 @@ pub struct BasicSourceConfig {
 
 impl Default for BasicSourceConfig {
     fn default() -> Self {
-        let (_, receiver) = limited(MemoryBufferSize::MaxEvents(
-            NonZeroUsize::new(1000).unwrap(),
-        ));
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(1000).unwrap());
+        let (_, receiver) = limited(limit, None);
         Self {
             receiver: Arc::new(Mutex::new(Some(receiver))),
             event_counter: None,

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -417,6 +417,9 @@ components: sources: [Name=string]: {
 		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		source_lag_time_seconds:              components.sources.internal_metrics.output.metrics.source_lag_time_seconds
-		source_sender_buffer_utilization:     components.sources.internal_metrics.output.metrics.source_sender_buffer_utilization
+		source_buffer_max_byte_size:          components.sources.internal_metrics.output.metrics.source_buffer_max_byte_size
+		source_buffer_max_event_size:         components.sources.internal_metrics.output.metrics.source_buffer_max_event_size
+		source_buffer_utilization:            components.sources.internal_metrics.output.metrics.source_buffer_utilization
+		source_buffer_utilization_level:      components.sources.internal_metrics.output.metrics.source_buffer_utilization_level
 	}
 }

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -417,5 +417,6 @@ components: sources: [Name=string]: {
 		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
 		source_lag_time_seconds:              components.sources.internal_metrics.output.metrics.source_lag_time_seconds
+		source_sender_buffer_utilization:     components.sources.internal_metrics.output.metrics.source_sender_buffer_utilization
 	}
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -718,15 +718,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		source_sender_buffer_max_event_size: {
-			description:       "The maximum number of events the buffer that the source's outputs send into can hold."
-			type:              "gauge"
-			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
-		}
-		source_sender_buffer_max_byte_size: {
+		source_buffer_max_byte_size: {
 			description:       "The maximum number of bytes the buffer that the source's outputs send into can hold."
 			type:              "gauge"
 			default_namespace: "vector"
@@ -734,7 +726,15 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 		}
-		source_sender_buffer_utilization: {
+		source_buffer_max_event_size: {
+			description:       "The maximum number of events the buffer that the source's outputs send into can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		source_buffer_utilization: {
 			description:       "The utilization level of the buffer that the source's outputs send into."
 			type:              "histogram"
 			default_namespace: "vector"
@@ -742,7 +742,7 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 		}
-		source_sender_buffer_utilization_level: {
+		source_buffer_utilization_level: {
 			description:       "The current utilization level of the buffer that the source's outputs send into."
 			type:              "gauge"
 			default_namespace: "vector"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -718,20 +718,36 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		source_sender_buffer_max_event_size: {
+			description:       "The maximum number of events the buffer that the source's outputs send into can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		source_sender_buffer_max_byte_size: {
+			description:       "The maximum number of bytes the buffer that the source's outputs send into can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
 		source_sender_buffer_utilization: {
 			description:       "The utilization level of the buffer that the source's outputs send into."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags: _component_tags & {
 				output: _output
-				max_bytes: {
-					description: "The maximum number of bytes the buffer can hold."
-					required:    false
-				}
-				max_events: {
-					description: "The maximum number of events the buffer can hold."
-					required:    false
-				}
+			}
+		}
+		source_sender_buffer_utilization_level: {
+			description:       "The current utilization level of the buffer that the source's outputs send into."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
 			}
 		}
 		splunk_pending_acks: {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -719,7 +719,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		source_sender_buffer_utilization: {
-			description:       "The utilization level of the buffer that all sources send into."
+			description:       "The utilization level of the buffer that the source's outputs send into."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags: _component_tags & {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -718,6 +718,22 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		source_sender_buffer_utilization: {
+			description:       "The utilization level of the buffer that all sources send into."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+				max_bytes: {
+					description: "The maximum number of bytes the buffer can hold."
+					required:    false
+				}
+				max_events: {
+					description: "The maximum number of events the buffer can hold."
+					required:    false
+				}
+			}
+		}
 		splunk_pending_acks: {
 			description:       "The number of outstanding Splunk HEC indexer acknowledgement acks."
 			type:              "gauge"


### PR DESCRIPTION
## Summary

Added a metric to record the utilization level of the buffer that all sources send into. This new metric is called `source_sender_buffer_utilization`.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

PR includes unit tests and component tests.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
