### PR TITLE
fix(ci): Allow CLA check to pass on merge queue events

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
   merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
The CLA check is now required but wasn't running on merge_group events, blocking the merge queue. This change makes the check run and pass immediately for merge queue events since CLA is already verified on the PR.

## Vector configuration
N/A

## How did you test this PR?
Workflow logic review

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.