### PR TITLE
fix(gcp_pubsub source): fix metrics, shutdown behavior, re-enable IT tests

### DIFF
--- a/changelog.d/24133_gcp_pubsub_bytes_received_endpoint.enhancement.md
+++ b/changelog.d/24133_gcp_pubsub_bytes_received_endpoint.enhancement.md
@@ -1,0 +1,5 @@
+The `gcp_pubsub` source now includes the `endpoint` label (set to the full subscription path)
+on the `component_received_bytes_total` metric, consistent with other HTTP pull sources.
+Previously only the `protocol` label was present.
+
+authors: thomasqueirozb

--- a/changelog.d/24133_gcp_pubsub_shutdown_hang.fix.md
+++ b/changelog.d/24133_gcp_pubsub_shutdown_hang.fix.md
@@ -1,0 +1,7 @@
+Fixed a bug in the `gcp_pubsub` source where the source could hang indefinitely on shutdown
+when acknowledgements were enabled and a shutdown signal arrived while event batches were
+still pending acknowledgement. The internal finalizer stream terminated prematurely on
+shutdown, leaving pending acks unprocessable and preventing the shutdown condition from
+being satisfied.
+
+authors: thomasqueirozb

--- a/changelog.d/24133_gcp_pubsub_shutdown_hang.fix.md
+++ b/changelog.d/24133_gcp_pubsub_shutdown_hang.fix.md
@@ -1,7 +1,6 @@
-Fixed a bug in the `gcp_pubsub` source where the source could hang indefinitely on shutdown
-when acknowledgements were enabled and a shutdown signal arrived while event batches were
-still pending acknowledgement. The internal finalizer stream terminated prematurely on
-shutdown, leaving pending acks unprocessable and preventing the shutdown condition from
-being satisfied.
+Fixed bugs in the `gcp_pubsub` source where the source could fail to shut down cleanly when
+acknowledgements were enabled. The source now keeps the finalizer alive long enough to drain
+pending acknowledgements, and stops accepting new Pub/Sub batches after shutdown begins so it
+can finish shutting down under backlog or continuous publishing.
 
 authors: thomasqueirozb

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -16,7 +16,7 @@ use futures::{FutureExt, Stream, StreamExt, TryFutureExt, stream, stream::Future
 use http::uri::{InvalidUri, Scheme, Uri};
 use serde_with::serde_as;
 use snafu::{ResultExt, Snafu};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{
     Code, Request, Status,
@@ -65,6 +65,32 @@ const MAX_ACK_DEADLINE_SECS: u64 = 600;
 const ACK_QUEUE_SIZE: usize = 8;
 
 type Finalizer = UnorderedFinalizer<Vec<String>>;
+
+struct AckRequest {
+    ids: Vec<String>,
+    // Set during shutdown to wait until the request stream has pulled the final ack request.
+    consumed: Option<oneshot::Sender<()>>,
+}
+
+impl AckRequest {
+    const fn new(ids: Vec<String>) -> Self {
+        Self {
+            ids,
+            consumed: None,
+        }
+    }
+
+    fn new_with_consumed_signal(ids: Vec<String>) -> (Self, oneshot::Receiver<()>) {
+        let (sender, receiver) = oneshot::channel();
+        (
+            Self {
+                ids,
+                consumed: Some(sender),
+            },
+            receiver,
+        )
+    }
+}
 
 // prost emits some generated code that includes clones on `Arc`
 // objects, which causes a clippy ding on this block. We don't
@@ -536,13 +562,28 @@ impl PubsubSource {
                 receipts = ack_stream.next(), if pending_acks > 0 => match receipts {
                     Some((status, receipts)) => {
                         pending_acks -= 1;
+                        let shutdown_drained = shutting_down && pending_acks == 0;
                         if status == BatchStatus::Delivered {
-                            ack_ids_sender
-                                .send(receipts)
-                                .await
-                                .unwrap_or_else(|_| unreachable!("request stream never closes"));
+                            if shutdown_drained {
+                                let (request, consumed) =
+                                    AckRequest::new_with_consumed_signal(receipts);
+                                ack_ids_sender
+                                    .send(request)
+                                    .await
+                                    .unwrap_or_else(|_| unreachable!("request stream never closes"));
+                                if consumed.await.is_err() {
+                                    debug!(
+                                        "Ack request stream closed before final acknowledgement was consumed."
+                                    );
+                                }
+                            } else {
+                                ack_ids_sender
+                                    .send(AckRequest::new(receipts))
+                                    .await
+                                    .unwrap_or_else(|_| unreachable!("request stream never closes"));
+                            }
                         }
-                        if shutting_down && pending_acks == 0 {
+                        if shutdown_drained {
                             return State::Shutdown;
                         }
                     }
@@ -591,7 +632,7 @@ impl PubsubSource {
                     // in a new request with empty fields, effectively
                     // a keepalive.
                     ack_ids_sender
-                        .send(Vec::new())
+                        .send(AckRequest::new(Vec::new()))
                         .await
                         .unwrap_or_else(|_| unreachable!("request stream never closes"));
                 }
@@ -601,7 +642,7 @@ impl PubsubSource {
 
     fn request_stream(
         &self,
-        ack_ids: mpsc::Receiver<Vec<String>>,
+        ack_ids: mpsc::Receiver<AckRequest>,
     ) -> impl Stream<Item = proto::StreamingPullRequest> + 'static + use<> {
         let subscription = self.subscription.clone();
         let client_id = CLIENT_ID.clone();
@@ -619,13 +660,23 @@ impl PubsubSource {
             }
         })
         .chain(ack_ids.map(|chunks| {
+            let mut ack_ids = Vec::new();
+            for request in chunks {
+                ack_ids.extend(request.ids);
+                if let Some(consumed) = request.consumed
+                    && consumed.send(()).is_err()
+                {
+                    debug!("Ack request was consumed after shutdown completed.");
+                }
+            }
+
             // These "requests" serve only to send updates about
             // acknowledgements to the server. None of the above
             // fields need to be repeated and, in fact, will cause
             // an stream error and cancellation if they are
             // present.
             proto::StreamingPullRequest {
-                ack_ids: chunks.into_iter().flatten().collect(),
+                ack_ids,
                 ..Default::default()
             }
         }))
@@ -635,7 +686,7 @@ impl PubsubSource {
         &mut self,
         response: proto::StreamingPullResponse,
         finalizer: &Option<Finalizer>,
-        ack_ids: &mpsc::Sender<Vec<String>>,
+        ack_ids: &mpsc::Sender<AckRequest>,
         pending_acks: &mut usize,
         busy_flag: &Arc<AtomicBool>,
     ) {
@@ -656,7 +707,7 @@ impl PubsubSource {
             Err(_) => emit!(StreamClosedError { count }),
             Ok(()) => match notifier {
                 None => ack_ids
-                    .send(ids)
+                    .send(AckRequest::new(ids))
                     .await
                     .unwrap_or_else(|_| unreachable!("request stream never closes")),
                 Some(notifier) => {

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -523,6 +523,16 @@ impl PubsubSource {
         loop {
             tokio::select! {
                 biased;
+                _ = &mut self.shutdown, if !shutting_down => {
+                    if pending_acks == 0 {
+                        return State::Shutdown;
+                    }
+                    shutting_down = true;
+                    debug!(
+                        pending_acks,
+                        "Draining pending acknowledgements before shutting down."
+                    );
+                },
                 receipts = ack_stream.next(), if pending_acks > 0 => match receipts {
                     Some((status, receipts)) => {
                         pending_acks -= 1;
@@ -556,16 +566,6 @@ impl PubsubSource {
                     }
                     Some(Err(error)) => break translate_error(error),
                     None => break State::RetryNow,
-                },
-                _ = &mut self.shutdown, if !shutting_down => {
-                    if pending_acks == 0 {
-                        return State::Shutdown;
-                    }
-                    shutting_down = true;
-                    debug!(
-                        pending_acks,
-                        "Draining pending acknowledgements before shutting down."
-                    );
                 },
                 _ = self.token_generator.changed(), if !shutting_down => {
                     debug!("New authentication token generated, restarting stream.");

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -518,20 +518,33 @@ impl PubsubSource {
 
         let (finalizer, mut ack_stream) = Finalizer::maybe_new(self.acknowledgements, None);
         let mut pending_acks = 0;
+        let mut shutting_down = false;
 
         loop {
             tokio::select! {
                 biased;
-                receipts = ack_stream.next() => if let Some((status, receipts)) = receipts {
-                    pending_acks -= 1;
-                    if status == BatchStatus::Delivered {
-                        ack_ids_sender
-                            .send(receipts)
-                            .await
-                            .unwrap_or_else(|_| unreachable!("request stream never closes"));
+                receipts = ack_stream.next(), if pending_acks > 0 => match receipts {
+                    Some((status, receipts)) => {
+                        pending_acks -= 1;
+                        if status == BatchStatus::Delivered {
+                            ack_ids_sender
+                                .send(receipts)
+                                .await
+                                .unwrap_or_else(|_| unreachable!("request stream never closes"));
+                        }
+                        if shutting_down && pending_acks == 0 {
+                            return State::Shutdown;
+                        }
+                    }
+                    None => {
+                        warn!("Acknowledgement finalizer stream ended before all acknowledgements were processed.");
+                        if shutting_down {
+                            return State::Shutdown;
+                        }
+                        break State::RetryNow;
                     }
                 },
-                response = stream.next() => match response {
+                response = stream.next(), if !shutting_down => match response {
                     Some(Ok(response)) => {
                         self.handle_response(
                             response,
@@ -544,12 +557,21 @@ impl PubsubSource {
                     Some(Err(error)) => break translate_error(error),
                     None => break State::RetryNow,
                 },
-                _ = &mut self.shutdown, if pending_acks == 0 => return State::Shutdown,
-                _ = self.token_generator.changed() => {
+                _ = &mut self.shutdown, if !shutting_down => {
+                    if pending_acks == 0 {
+                        return State::Shutdown;
+                    }
+                    shutting_down = true;
+                    debug!(
+                        pending_acks,
+                        "Draining pending acknowledgements before shutting down."
+                    );
+                },
+                _ = self.token_generator.changed(), if !shutting_down => {
                     debug!("New authentication token generated, restarting stream.");
                     break State::RetryNow;
                 },
-                _ = tokio::time::sleep(self.keepalive) => {
+                _ = tokio::time::sleep(self.keepalive), if !shutting_down => {
                     if pending_acks == 0 {
                         // No pending acks, and no new data, so drop
                         // this stream if we aren't the only active

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -30,7 +30,7 @@ use vector_lib::{
     configurable::configurable_component,
     finalizer::UnorderedFinalizer,
     internal_event::{
-        ByteSize, BytesReceived, EventsReceived, InternalEventHandle as _, Protocol, Registered,
+        EventsReceived, Registered,
     },
     lookup::owned_value_path,
 };
@@ -46,8 +46,8 @@ use crate::{
     event::{BatchNotifier, BatchStatus, Event, MaybeAsLogMut, Value},
     gcp::{GcpAuthConfig, GcpAuthenticator, PUBSUB_URL, Scope},
     internal_events::{
-        GcpPubsubConnectError, GcpPubsubReceiveError, GcpPubsubStreamingPullError,
-        StreamClosedError,
+        EndpointBytesReceived, GcpPubsubConnectError, GcpPubsubReceiveError,
+        GcpPubsubStreamingPullError, StreamClosedError,
     },
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     shutdown::ShutdownSignal,
@@ -305,8 +305,8 @@ impl SourceConfig for PubsubConfig {
 
         let protocol = uri
             .scheme()
-            .map(|scheme| Protocol(scheme.to_string().into()))
-            .unwrap_or(Protocol::HTTP);
+            .map(|scheme| scheme.to_string())
+            .unwrap_or_else(|| "http".to_string());
 
         let source = PubsubSource {
             endpoint,
@@ -331,7 +331,7 @@ impl SourceConfig for PubsubConfig {
             concurrency: Default::default(),
             full_response_size: self.full_response_size,
             log_namespace,
-            bytes_received: register!(BytesReceived::from(protocol)),
+            protocol,
             events_received: register!(EventsReceived),
         }
         .run_all(self.max_concurrency, self.poll_time_seconds)
@@ -399,7 +399,7 @@ struct PubsubSource {
     concurrency: Arc<AtomicUsize>,
     full_response_size: usize,
     log_namespace: LogNamespace,
-    bytes_received: Registered<BytesReceived>,
+    protocol: String,
     events_received: Registered<EventsReceived>,
 }
 
@@ -519,7 +519,7 @@ impl PubsubSource {
         let mut stream = stream.into_inner();
 
         let (finalizer, mut ack_stream) =
-            Finalizer::maybe_new(self.acknowledgements, Some(self.shutdown.clone()));
+            Finalizer::maybe_new(self.acknowledgements, None);
         let mut pending_acks = 0;
 
         loop {
@@ -623,7 +623,11 @@ impl PubsubSource {
         if response.received_messages.len() >= self.full_response_size {
             busy_flag.store(true, Ordering::Relaxed);
         }
-        self.bytes_received.emit(ByteSize(response.size_of()));
+        emit!(EndpointBytesReceived {
+            byte_size: response.size_of(),
+            protocol: &self.protocol,
+            endpoint: &self.subscription,
+        });
 
         let (batch, notifier) = BatchNotifier::maybe_new_with_receiver(self.acknowledgements);
         let (events, ids) = self.parse_messages(response.received_messages, batch).await;
@@ -877,7 +881,6 @@ mod integration_tests {
         LazyLock::new(|| format!("{}/v1/projects/{}", *gcp::PUBSUB_ADDRESS, PROJECT));
     static ACK_DEADLINE: LazyLock<Duration> = LazyLock::new(|| Duration::from_secs(10)); // Minimum custom deadline allowed by Pub/Sub
 
-    #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
     #[tokio::test]
     async fn oneshot() {
         assert_source_compliance(&SOURCE_TAGS, async move {
@@ -889,7 +892,6 @@ mod integration_tests {
         .await;
     }
 
-    #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
     #[tokio::test]
     async fn shuts_down_before_data_received() {
         let (tester, mut rx, shutdown) = setup(EventStatus::Delivered).await;
@@ -902,7 +904,6 @@ mod integration_tests {
         assert_eq!(tester.pull_count(1).await, 1);
     }
 
-    #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
     #[tokio::test]
     async fn shuts_down_after_data_received() {
         assert_source_compliance(&SOURCE_TAGS, async move {
@@ -926,7 +927,6 @@ mod integration_tests {
         .await;
     }
 
-    #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
     #[tokio::test]
     async fn streams_data() {
         assert_source_compliance(&SOURCE_TAGS, async move {
@@ -940,7 +940,6 @@ mod integration_tests {
         .await;
     }
 
-    #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
     #[tokio::test]
     async fn sends_attributes() {
         assert_source_compliance(&SOURCE_TAGS, async move {
@@ -957,7 +956,6 @@ mod integration_tests {
         .await;
     }
 
-    #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
     #[tokio::test]
     async fn acks_received() {
         assert_source_compliance(&SOURCE_TAGS, async move {
@@ -1056,7 +1054,7 @@ mod integration_tests {
 
             let body = json!({
                 "topic": format!("projects/{}/topics/{}", PROJECT, this.topic),
-                "ackDeadlineSeconds": *ACK_DEADLINE,
+                "ackDeadlineSeconds": ACK_DEADLINE.as_secs(),
             });
             this.request(Method::PUT, "subscriptions/{sub}", body).await;
 
@@ -1153,7 +1151,7 @@ mod integration_tests {
         }
 
         async fn shutdown(&self, mut shutdown: shutdown::SourceShutdownCoordinator) {
-            let deadline = Instant::now() + Duration::from_secs(1);
+            let deadline = Instant::now() + Duration::from_secs(10);
             let shutdown = shutdown.shutdown_source(&self.component, deadline);
             assert!(shutdown.await);
         }
@@ -1167,7 +1165,7 @@ mod integration_tests {
         } = test_data;
 
         let events: Vec<Event> = tokio::time::timeout(
-            Duration::from_secs(1),
+            Duration::from_secs(30),
             test_util::collect_n_stream(rx, lines.len()),
         )
         .await

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -29,9 +29,7 @@ use vector_lib::{
     config::{LegacyKey, LogNamespace},
     configurable::configurable_component,
     finalizer::UnorderedFinalizer,
-    internal_event::{
-        EventsReceived, Registered,
-    },
+    internal_event::{EventsReceived, Registered},
     lookup::owned_value_path,
 };
 use vrl::{
@@ -518,8 +516,7 @@ impl PubsubSource {
         };
         let mut stream = stream.into_inner();
 
-        let (finalizer, mut ack_stream) =
-            Finalizer::maybe_new(self.acknowledgements, None);
+        let (finalizer, mut ack_stream) = Finalizer::maybe_new(self.acknowledgements, None);
         let mut pending_acks = 0;
 
         loop {

--- a/tests/integration/gcp/config/test.yaml
+++ b/tests/integration/gcp/config/test.yaml
@@ -1,5 +1,6 @@
 features:
   - gcp-integration-tests
+  - gcp-pubsub-integration-tests
 
 test_filter: "::gcp"
 


### PR DESCRIPTION
## Summary

Re-enables the 6 previously-ignored `gcp_pubsub` source integration tests from #24133. Simply removing the `#[ignore]` markers was not enough — the tests had four underlying bugs that needed to be fixed first.

**Bug 1 — `ackDeadlineSeconds` serialization (test infrastructure)**
The test code passed `*ACK_DEADLINE` (a `std::time::Duration`) directly to serde, which serialized it as `{"secs":10,"nanos":0}` instead of the integer `10` the Pub/Sub API expects. Changed to `ACK_DEADLINE.as_secs()`.

**Bug 2 — Shutdown hang / spin loop (production code)**
`run_once` called `Finalizer::maybe_new(self.acknowledgements, Some(self.shutdown.clone()))`. When shutdown fired while acknowledgements were still pending, the finalizer stream terminated immediately (dropping unprocessed acks). The select loop's shutdown arm has a `if pending_acks == 0` guard, so it could not fire; meanwhile `ack_stream.next()` returned `None` forever as the highest-priority biased arm, creating an infinite spin. Fixed by passing `None` — the finalizer stream now lives until all pending acks are processed before terminating.

**Bug 3 — Wrong metric event for compliance check (production code)**
`BytesReceived` emits `component_received_bytes_total` with only the `protocol` label. The `gcp_pubsub` source is tested as an HTTP pull source (`HTTP_PULL_SOURCE_TAGS = ["endpoint", "protocol"]`), so both labels are required. Changed to `emit!(EndpointBytesReceived { ... })` which emits both `protocol` and `endpoint` (set to the subscription path).

**Bug 4 — Thread-local metrics/events invisible to compliance check (test infrastructure)**
Adding `#[tokio::test(flavor = "multi_thread")]` (used as a workaround while debugging bug 2) caused all metrics and internal events to be recorded in worker-thread-local storage, while the compliance check read from the main test thread's storage. Reverted to the default single-thread runtime; this is safe now that the spin loop (bug 2) is fixed.

**Additional: missing feature flag**
`gcp-integration-tests` does not enable `sources-gcp_pubsub`. Added `gcp-pubsub-integration-tests` to `tests/integration/gcp/config/test.yaml` so the source tests are compiled and run.

## Vector configuration

NA

## How did you test this PR?

Ran the full GCP integration test suite via `cargo vdev int test gcp`. All 51 tests pass (6 previously-ignored source tests now included).

https://github.com/vectordotdev/vector/actions/runs/30291964525?pr=24278

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #24133