### PR TITLE
feat(redis sink): add Redis SET support for redis sink

### DIFF
--- a/changelog.d/redis_set_in_sink.feature.md
+++ b/changelog.d/redis_set_in_sink.feature.md
@@ -1,0 +1,3 @@
+Adds support for the Redis SET command in the Redis sink.
+
+authors: potoo0

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -44,6 +44,11 @@ pub enum DataTypeConfig {
     ///
     /// Redis channels function in a pub/sub fashion, allowing many-to-many broadcasting and receiving.
     Channel,
+
+    /// The Redis `string` type.
+    ///
+    /// This resembles a sequence of bytes.
+    String,
 }
 
 /// List-specific options.

--- a/src/sinks/redis/mod.rs
+++ b/src/sinks/redis/mod.rs
@@ -59,6 +59,11 @@ pub enum DataType {
     ///
     /// Redis channels function in a pub/sub fashion, allowing many-to-many broadcasting and receiving.
     Channel,
+
+    /// The Redis `string` type.
+    ///
+    /// This resembles a sequence of bytes..
+    String,
 }
 
 /// Wrapper for an `Event` that also stored the rendered key.

--- a/src/sinks/redis/service.rs
+++ b/src/sinks/redis/service.rs
@@ -68,6 +68,13 @@ impl Service<RedisRequest> for RedisService {
                         pipe.publish(kv.key, kv.value.as_ref());
                     }
                 }
+                super::DataType::String => {
+                    if count > 1 {
+                        pipe.atomic().set(kv.key, kv.value.as_ref());
+                    } else {
+                        pipe.set(kv.key, kv.value.as_ref());
+                    }
+                }
             }
         }
 

--- a/src/sinks/redis/sink.rs
+++ b/src/sinks/redis/sink.rs
@@ -272,6 +272,7 @@ impl RedisSink {
         };
 
         let data_type = match config.data_type {
+            DataTypeConfig::String => super::DataType::String,
             DataTypeConfig::Channel => super::DataType::Channel,
             DataTypeConfig::List => super::DataType::List(list_method.unwrap_or_default()),
             DataTypeConfig::SortedSet => {

--- a/website/cue/reference/components/sinks/generated/redis.cue
+++ b/website/cue/reference/components/sinks/generated/redis.cue
@@ -83,6 +83,11 @@ generated: components: sinks: redis: configuration: {
 					This resembles a priority queue, where messages can be pushed and popped with an
 					associated score.
 					"""
+				string: """
+					The Redis `string` type.
+
+					This resembles a sequence of bytes.
+					"""
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR adds support for the Redis [SET command](https://redis.io/docs/latest/commands/set/) in the Redis sink.

## Vector configuration

```yml
sinks:
  redis:
    type: redis
    endpoint: redis://127.0.0.1:6379
    inputs: ...
    encoding:
      codec: json
    key: "testing"
    data_type: string
```

## How did you test this PR?

Via redis integration tests, and manual testing.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

