### PR TITLE
fix(splunk_hec): validate and flatten fields

### DIFF
--- a/changelog.d/24152_splunk_hec_fields.fix.md
+++ b/changelog.d/24152_splunk_hec_fields.fix.md
@@ -1,0 +1,12 @@
+The `splunk_hec` sink now flattens nested objects and arrays.
+
+Previously the Splunk HEC api would reject events that contained them.
+
+Notable changes:
+
+- Objects will be flattened
+- Arrays that contain objects or arrays will be flattened
+- Flat arrays are permitted
+- Numbers will be stringified
+
+authors: matt-simons

--- a/src/sinks/splunk_hec/logs/encoder.rs
+++ b/src/sinks/splunk_hec/logs/encoder.rs
@@ -1,16 +1,18 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 use bytes::BytesMut;
 use serde::Serialize;
 use tokio_util::codec::Encoder as _;
 use vector_lib::{
-    EstimatedJsonEncodedSizeOf, config::telemetry, request_metadata::GroupedCountByteSize,
+    EstimatedJsonEncodedSizeOf, config::telemetry, event::Value,
+    request_metadata::GroupedCountByteSize,
 };
 
 use super::sink::HecProcessedEvent;
 use crate::{
     codecs::Transformer,
-    event::{Event, LogEvent},
+    event::Event,
     internal_events::SplunkEventEncodeError,
     sinks::{splunk_hec::common::EndpointTarget, util::encoding::Encoder},
 };
@@ -27,7 +29,7 @@ pub enum HecEvent<'a> {
 pub struct HecData<'a> {
     #[serde(flatten)]
     pub event: HecEvent<'a>,
-    pub fields: LogEvent,
+    pub fields: BTreeMap<String, Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,7 +43,11 @@ pub struct HecData<'a> {
 }
 
 impl<'a> HecData<'a> {
-    pub const fn new(event: HecEvent<'a>, fields: LogEvent, time: Option<f64>) -> Self {
+    pub const fn new(
+        event: HecEvent<'a>,
+        fields: BTreeMap<String, Value>,
+        time: Option<f64>,
+    ) -> Self {
         Self {
             event,
             fields,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The `splunk_hec` sink now flattens objects and arrays. Presently Vector sends nested objects and arrays that the Splunk HEC api rejects. Integers also also silently dropped. Due to this behaviour, any indexed fields that are not at the top level of the Vector log event cannot be referenced.

Flattening is preferable to silently dropping nested objects and arrays as there's no data loss. It is also particularly useful for indexing fields with unknown names at runtime. For example Kubernetes pod labels.

I'd also just like to preface that I am a Rust novice and this is my first PR, so apologies if I have missed the mark here.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

Tested against my own Splunk environment with the above config.

Verified the valid field inputs using a local instance of Splunk. Although the Splunk documentation states only strings and string arrays are valid, I found the following types were accepted:
- string
- float
- boolean
- null
- flat arrays consisting of any of the above types

Integers are silently dropped from the fields.

Nested arrays or objects resulted in the event being rejected (400 response code).

```
❯ curl -H "Authorization: Splunk TOKEN" -d '{"index": "my-index", "fields": {"string": "foo", "number": 1, "float": 1.23, "true": true, "false": false, "null": null, "flat_array": ["one", "2", false]}, "event": "Validation", "sourcetype": "manual"}' https://hec.local/services/collector
{"text":"Success","code":0}

❯ curl -H "Authorization: Splunk TOKEN" -d '{"index": "my-index", "fields": {"string": "foo", "number": 1, "float": 1.23, "true": true, "false": false, "null": null, "flat_array": ["one", "2", false], "nested_array": ["foo", ["bar"]]}, "event": "Validation", "sourcetype": "manual"}' https://hec.local/services/collector
{"text":"Error in handling indexed fields","code":15,"invalid-event-number":0}

❯ curl -H "Authorization: Splunk TOKEN" -d '{"index": "my-index", "fields": {"string": "foo", "number": 1, "float": 1.23, "true": true, "false": false, "null": null, "flat_array": ["one", "2", false], "nested_object": {"foo": "bar"}}, "event": "Validation", "sourcetype": "manual"}' https://hec.local/services/collector
{"text":"Error in handling indexed fields","code":15,"invalid-event-number":0}
```

I've maintained the previous Vector behaviour for all the existing working types (string, float, boolean, null) i.e. They do not get stringified. Integers are however now stringified so they do not get dropped.

Note: Splunk itself has no types once the event has been indexed so there is no side effect of stringifying.

I've also added additional test cases for various types.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #24152

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->