### PR TITLE
chore(ci): use ci-docs-build flow instead of local docs flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust: true
-      - run: cd rust-doc && make docs
+      - run: cd rust-doc && make ci-docs-build
 
   test-vrl:
     name: VRL - Linux


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Use ci-docs-build flow instead of local docs flow. Right now we are documenting **_all_** crates on every authorized CI commit run. This is wasteful and Rust 1.91 made this check take at least 3x longer than before. We don't need to check that 3rd party crates are properly being documented.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Let CI run

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
