### PR TITLE
fix(file source): Fix flaky test_oldest_first by ensuring distinct creation timestamps

### DIFF
--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2126,6 +2126,9 @@ mod tests {
         let mut older = File::create(&older_path).unwrap();
         older.sync_all().unwrap();
 
+        // Sleep to ensure the creation timestamps are different
+        sleep_500_millis().await;
+
         let newer_path = dir.path().join("a_newer_file");
         let mut newer = File::create(&newer_path).unwrap();
         newer.sync_all().unwrap();


### PR DESCRIPTION
## Summary
Fixes a flaky test in `sources::file::tests::test_oldest_first` that was failing intermittently due to a race condition in file creation timestamps.

The test creates two files sequentially and relies on the `oldest_first` flag to read them in creation-time order. On fast systems or certain filesystems, both files could be created with identical or very close timestamps, causing non-deterministic test ordering and failures.

The fix adds a 500ms sleep between creating the two test files to ensure their creation timestamps are guaranteed to be different.

## Vector configuration
N/A - This is a test-only change.

## How did you test this PR?
- Ran the test locally 5000x to verify it no longer exhibits flaky behavior

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our guidelines.
- [x] No. A maintainer will apply the `no-changelog` label to this PR.