### PR TITLE
enhancement(transforms): Add internal metric to record buffer utilization

### DIFF
--- a/changelog.d/transform-buffer-utilization-metric.enhancement.md
+++ b/changelog.d/transform-buffer-utilization-metric.enhancement.md
@@ -1,0 +1,8 @@
+Added metrics to record the utilization level of the buffers that each transform receives from:
+
+- `transform_buffer_max_byte_size`
+- `transform_buffer_max_event_size`
+- `transform_buffer_utilization`
+- `transform_buffer_utilization_level`
+
+authors: bruceg

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -8,6 +8,9 @@ use std::{
     },
 };
 
+#[cfg(test)]
+use std::sync::Mutex;
+
 use async_stream::stream;
 use crossbeam_queue::{ArrayQueue, SegQueue};
 use futures::Stream;
@@ -90,6 +93,18 @@ where
 }
 
 #[derive(Clone, Debug)]
+pub struct ChannelMetricMetadata {
+    prefix: &'static str,
+    output: Option<String>,
+}
+
+impl ChannelMetricMetadata {
+    pub fn new(prefix: &'static str, output: Option<String>) -> Self {
+        Self { prefix, output }
+    }
+}
+
+#[derive(Clone, Debug)]
 struct Metrics {
     histogram: Histogram,
     gauge: Gauge,
@@ -98,21 +113,47 @@ struct Metrics {
     // field, so we need to suppress the warning here.
     #[expect(dead_code)]
     max_gauge: Gauge,
+    #[cfg(test)]
+    recorded_values: Arc<Mutex<Vec<usize>>>,
 }
 
 impl Metrics {
     #[expect(clippy::cast_precision_loss)] // We have to convert buffer sizes for a gauge, it's okay to lose precision here.
-    fn new(limit: MemoryBufferSize, prefix: &'static str, output: &str) -> Self {
+    fn new(limit: MemoryBufferSize, metadata: ChannelMetricMetadata) -> Self {
+        let ChannelMetricMetadata { prefix, output } = metadata;
         let (gauge_suffix, max_value) = match limit {
             MemoryBufferSize::MaxEvents(max_events) => ("_max_event_size", max_events.get() as f64),
             MemoryBufferSize::MaxSize(max_bytes) => ("_max_byte_size", max_bytes.get() as f64),
         };
-        let max_gauge = gauge!(format!("{prefix}{gauge_suffix}"), "output" => output.to_string());
-        max_gauge.set(max_value);
-        Self {
-            histogram: histogram!(format!("{prefix}_utilization"), "output" => output.to_string()),
-            gauge: gauge!(format!("{prefix}_utilization_level"), "output" => output.to_string()),
-            max_gauge,
+        if let Some(label_value) = output {
+            let max_gauge = gauge!(
+                format!("{prefix}{gauge_suffix}"),
+                "output" => label_value.clone()
+            );
+            max_gauge.set(max_value);
+            Self {
+                histogram: histogram!(
+                    format!("{prefix}_utilization"),
+                    "output" => label_value.clone()
+                ),
+                gauge: gauge!(
+                    format!("{prefix}_utilization_level"),
+                    "output" => label_value
+                ),
+                max_gauge,
+                #[cfg(test)]
+                recorded_values: Arc::new(Mutex::new(Vec::new())),
+            }
+        } else {
+            let max_gauge = gauge!(format!("{prefix}{gauge_suffix}"));
+            max_gauge.set(max_value);
+            Self {
+                histogram: histogram!(format!("{prefix}_utilization")),
+                gauge: gauge!(format!("{prefix}_utilization_level")),
+                max_gauge,
+                #[cfg(test)]
+                recorded_values: Arc::new(Mutex::new(Vec::new())),
+            }
         }
     }
 
@@ -120,6 +161,10 @@ impl Metrics {
     fn record(&self, value: usize) {
         self.histogram.record(value as f64);
         self.gauge.set(value as f64);
+        #[cfg(test)]
+        if let Ok(mut recorded) = self.recorded_values.lock() {
+            recorded.push(value);
+        }
     }
 }
 
@@ -145,10 +190,9 @@ impl<T> Clone for Inner<T> {
 }
 
 impl<T: InMemoryBufferable> Inner<T> {
-    fn new(limit: MemoryBufferSize, metric_name_output: Option<(&'static str, &str)>) -> Self {
+    fn new(limit: MemoryBufferSize, metric_metadata: Option<ChannelMetricMetadata>) -> Self {
         let read_waker = Arc::new(Notify::new());
-        let metrics =
-            metric_name_output.map(|(prefix, output)| Metrics::new(limit, prefix, output));
+        let metrics = metric_metadata.map(|metadata| Metrics::new(limit, metadata));
         match limit {
             MemoryBufferSize::MaxEvents(max_events) => Inner {
                 data: Arc::new(ArrayQueue::new(max_events.get())),
@@ -167,6 +211,11 @@ impl<T: InMemoryBufferable> Inner<T> {
         }
     }
 
+    /// Records a send after acquiring all required permits.
+    ///
+    /// The `total` value represents the channel utilization after this send completes.  It may be
+    /// greater than the configured limit because the channel intentionally allows a single
+    /// oversized payload to flow through rather than forcing the sender to split it.
     fn send_with_permit(&mut self, total: usize, permits: OwnedSemaphorePermit, item: T) {
         self.data.push((permits, item));
         self.read_waker.notify_one();
@@ -335,9 +384,9 @@ impl<T> Drop for LimitedReceiver<T> {
 
 pub fn limited<T: InMemoryBufferable + fmt::Debug>(
     limit: MemoryBufferSize,
-    metric_name_output: Option<(&'static str, &str)>,
+    metric_metadata: Option<ChannelMetricMetadata>,
 ) -> (LimitedSender<T>, LimitedReceiver<T>) {
-    let inner = Inner::new(limit, metric_name_output);
+    let inner = Inner::new(limit, metric_metadata);
 
     let sender = LimitedSender {
         inner: inner.clone(),
@@ -355,7 +404,7 @@ mod tests {
     use tokio_test::{assert_pending, assert_ready, task::spawn};
     use vector_common::byte_size_of::ByteSizeOf;
 
-    use super::limited;
+    use super::{ChannelMetricMetadata, limited};
     use crate::{
         MemoryBufferSize,
         test::MultiEventRecord,
@@ -389,6 +438,22 @@ mod tests {
         // Now our receive should have been woken up, and should immediately be ready.
         assert!(recv.is_woken());
         assert_eq!(Some(Sample::new(42)), assert_ready!(recv.poll()));
+    }
+
+    #[tokio::test]
+    async fn records_utilization_on_send() {
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
+        let (mut tx, mut rx) = limited(
+            limit,
+            Some(ChannelMetricMetadata::new("test_channel", None)),
+        );
+
+        let metrics = tx.inner.metrics.as_ref().unwrap().recorded_values.clone();
+
+        tx.send(Sample::new(1)).await.expect("send should succeed");
+        assert_eq!(metrics.lock().unwrap().last().copied(), Some(1));
+
+        let _ = rx.next().await;
     }
 
     #[test]

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -125,34 +125,30 @@ impl Metrics {
             MemoryBufferSize::MaxEvents(max_events) => ("_max_event_size", max_events.get() as f64),
             MemoryBufferSize::MaxSize(max_bytes) => ("_max_byte_size", max_bytes.get() as f64),
         };
+        let max_gauge_name = format!("{prefix}{gauge_suffix}");
+        let histogram_name = format!("{prefix}_utilization");
+        let gauge_name = format!("{prefix}_utilization_level");
+        #[cfg(test)]
+        let recorded_values = Arc::new(Mutex::new(Vec::new()));
         if let Some(label_value) = output {
-            let max_gauge = gauge!(
-                format!("{prefix}{gauge_suffix}"),
-                "output" => label_value.clone()
-            );
+            let max_gauge = gauge!(max_gauge_name, "output" => label_value.clone());
             max_gauge.set(max_value);
             Self {
-                histogram: histogram!(
-                    format!("{prefix}_utilization"),
-                    "output" => label_value.clone()
-                ),
-                gauge: gauge!(
-                    format!("{prefix}_utilization_level"),
-                    "output" => label_value
-                ),
+                histogram: histogram!(histogram_name, "output" => label_value.clone()),
+                gauge: gauge!(gauge_name, "output" => label_value.clone()),
                 max_gauge,
                 #[cfg(test)]
-                recorded_values: Arc::new(Mutex::new(Vec::new())),
+                recorded_values,
             }
         } else {
-            let max_gauge = gauge!(format!("{prefix}{gauge_suffix}"));
+            let max_gauge = gauge!(max_gauge_name);
             max_gauge.set(max_value);
             Self {
-                histogram: histogram!(format!("{prefix}_utilization")),
-                gauge: gauge!(format!("{prefix}_utilization_level")),
+                histogram: histogram!(histogram_name),
+                gauge: gauge!(gauge_name),
                 max_gauge,
                 #[cfg(test)]
-                recorded_values: Arc::new(Mutex::new(Vec::new())),
+                recorded_values,
             }
         }
     }

--- a/lib/vector-buffers/src/topology/channel/mod.rs
+++ b/lib/vector-buffers/src/topology/channel/mod.rs
@@ -2,7 +2,9 @@ mod limited_queue;
 mod receiver;
 mod sender;
 
-pub use limited_queue::{LimitedReceiver, LimitedSender, SendError, limited};
+pub use limited_queue::{
+    ChannelMetricMetadata, LimitedReceiver, LimitedSender, SendError, limited,
+};
 pub use receiver::*;
 pub use sender::*;
 

--- a/lib/vector-buffers/src/topology/channel/tests.rs
+++ b/lib/vector-buffers/src/topology/channel/tests.rs
@@ -90,7 +90,7 @@ where
 #[tokio::test]
 async fn test_sender_block() {
     // Get a non-overflow buffer in blocking mode with a capacity of 3.
-    let (mut tx, rx, _) = build_buffer(3, WhenFull::Block, None).await;
+    let (mut tx, rx, _) = build_buffer(3, WhenFull::Block, None);
 
     // We should be able to send three messages through unimpeded.
     assert_current_send_capacity(&mut tx, Some(3), None);
@@ -113,7 +113,7 @@ async fn test_sender_block() {
 #[tokio::test]
 async fn test_sender_drop_newest() {
     // Get a non-overflow buffer in "drop newest" mode with a capacity of 3.
-    let (mut tx, rx, _) = build_buffer(3, WhenFull::DropNewest, None).await;
+    let (mut tx, rx, _) = build_buffer(3, WhenFull::DropNewest, None);
 
     // We should be able to send three messages through unimpeded.
     assert_current_send_capacity(&mut tx, Some(3), None);
@@ -138,7 +138,7 @@ async fn test_sender_drop_newest() {
 async fn test_sender_overflow_block() {
     // Get an overflow buffer, where the overflow buffer is in blocking mode, and both the base
     // and overflow buffers have a capacity of 2.
-    let (mut tx, rx, _) = build_buffer(2, WhenFull::Overflow, Some(WhenFull::Block)).await;
+    let (mut tx, rx, _) = build_buffer(2, WhenFull::Overflow, Some(WhenFull::Block));
 
     // We should be able to send four message through unimpeded -- two for the base sender, and
     // two for the overflow sender.
@@ -164,7 +164,7 @@ async fn test_sender_overflow_block() {
 async fn test_sender_overflow_drop_newest() {
     // Get an overflow buffer, where the overflow buffer is in "drop newest" mode, and both the
     // base and overflow buffers have a capacity of 2.
-    let (mut tx, rx, _) = build_buffer(2, WhenFull::Overflow, Some(WhenFull::DropNewest)).await;
+    let (mut tx, rx, _) = build_buffer(2, WhenFull::Overflow, Some(WhenFull::DropNewest));
 
     // We should be able to send four message through unimpeded -- two for the base sender, and
     // two for the overflow sender.
@@ -190,7 +190,7 @@ async fn test_sender_overflow_drop_newest() {
 #[tokio::test]
 async fn test_buffer_metrics_normal() {
     // Get a regular blocking buffer.
-    let (mut tx, rx, handle) = build_buffer(5, WhenFull::Block, None).await;
+    let (mut tx, rx, handle) = build_buffer(5, WhenFull::Block, None);
 
     // Send three items through, and make sure the buffer usage stats reflect that.
     assert_current_send_capacity(&mut tx, Some(5), None);
@@ -217,7 +217,7 @@ async fn test_buffer_metrics_normal() {
 #[tokio::test]
 async fn test_buffer_metrics_drop_newest() {
     // Get a buffer that drops the newest items when full.
-    let (mut tx, rx, handle) = build_buffer(2, WhenFull::DropNewest, None).await;
+    let (mut tx, rx, handle) = build_buffer(2, WhenFull::DropNewest, None);
 
     // Send three items through, and make sure the buffer usage stats reflect that.
     assert_current_send_capacity(&mut tx, Some(2), None);

--- a/lib/vector-buffers/src/topology/test_util.rs
+++ b/lib/vector-buffers/src/topology/test_util.rs
@@ -137,7 +137,7 @@ impl error::Error for BasicError {}
 /// If `mode` is set to `WhenFull::Overflow`, then the buffer will be set to overflow mode, with
 /// another in-memory channel buffer being used as the overflow buffer.  The overflow buffer will
 /// also use the same capacity as the outer buffer.
-pub(crate) async fn build_buffer(
+pub(crate) fn build_buffer(
     capacity: usize,
     mode: WhenFull,
     overflow_mode: Option<WhenFull>,
@@ -154,27 +154,25 @@ pub(crate) async fn build_buffer(
                 NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
                 overflow_mode,
                 handle.clone(),
-            )
-            .await;
+                None,
+            );
             let (mut base_sender, mut base_receiver) = TopologyBuilder::standalone_memory_test(
                 NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
                 WhenFull::Overflow,
                 handle.clone(),
-            )
-            .await;
+                None,
+            );
             base_sender.switch_to_overflow(overflow_sender);
             base_receiver.switch_to_overflow(overflow_receiver);
 
             (base_sender, base_receiver)
         }
-        m => {
-            TopologyBuilder::standalone_memory_test(
-                NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
-                m,
-                handle.clone(),
-            )
-            .await
-        }
+        m => TopologyBuilder::standalone_memory_test(
+            NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
+            m,
+            handle.clone(),
+            None,
+        ),
     };
 
     (tx, rx, handle)

--- a/lib/vector-buffers/src/variants/in_memory.rs
+++ b/lib/vector-buffers/src/variants/in_memory.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, num::NonZeroUsize};
+use std::error::Error;
 
 use async_trait::async_trait;
 
@@ -21,7 +21,8 @@ impl MemoryBuffer {
         MemoryBuffer { capacity }
     }
 
-    pub fn with_max_events(n: NonZeroUsize) -> Self {
+    #[cfg(test)]
+    pub fn with_max_events(n: std::num::NonZeroUsize) -> Self {
         Self {
             capacity: MemoryBufferSize::MaxEvents(n),
         }

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -482,28 +482,28 @@ mod tests {
         test_util::{collect_ready, collect_ready_events},
     };
 
-    async fn build_sender_pair(
+    fn build_sender_pair(
         capacity: usize,
     ) -> (BufferSender<EventArray>, BufferReceiver<EventArray>) {
         TopologyBuilder::standalone_memory(
             NonZeroUsize::new(capacity).expect("capacity must be nonzero"),
             WhenFull::Block,
             &Span::current(),
+            None,
         )
-        .await
     }
 
-    async fn build_sender_pairs(
+    fn build_sender_pairs(
         capacities: &[usize],
     ) -> Vec<(BufferSender<EventArray>, BufferReceiver<EventArray>)> {
         let mut pairs = Vec::new();
         for capacity in capacities {
-            pairs.push(build_sender_pair(*capacity).await);
+            pairs.push(build_sender_pair(*capacity));
         }
         pairs
     }
 
-    async fn fanout_from_senders(
+    fn fanout_from_senders(
         capacities: &[usize],
     ) -> (
         Fanout,
@@ -511,7 +511,7 @@ mod tests {
         Vec<BufferReceiver<EventArray>>,
     ) {
         let (mut fanout, control) = Fanout::new();
-        let pairs = build_sender_pairs(capacities).await;
+        let pairs = build_sender_pairs(capacities);
 
         let mut receivers = Vec::new();
         for (i, (sender, receiver)) in pairs.into_iter().enumerate() {
@@ -522,13 +522,13 @@ mod tests {
         (fanout, control, receivers)
     }
 
-    async fn add_sender_to_fanout(
+    fn add_sender_to_fanout(
         fanout: &mut Fanout,
         receivers: &mut Vec<BufferReceiver<EventArray>>,
         sender_id: usize,
         capacity: usize,
     ) {
-        let (sender, receiver) = build_sender_pair(capacity).await;
+        let (sender, receiver) = build_sender_pair(capacity);
         receivers.push(receiver);
 
         fanout.add(ComponentKey::from(sender_id.to_string()), sender);
@@ -542,13 +542,13 @@ mod tests {
             .expect("sending control message should not fail");
     }
 
-    async fn replace_sender_in_fanout(
+    fn replace_sender_in_fanout(
         control: &UnboundedSender<ControlMessage>,
         receivers: &mut [BufferReceiver<EventArray>],
         sender_id: usize,
         capacity: usize,
     ) -> BufferReceiver<EventArray> {
-        let (sender, receiver) = build_sender_pair(capacity).await;
+        let (sender, receiver) = build_sender_pair(capacity);
         let old_receiver = mem::replace(&mut receivers[sender_id], receiver);
 
         control
@@ -567,13 +567,13 @@ mod tests {
         old_receiver
     }
 
-    async fn start_sender_replace(
+    fn start_sender_replace(
         control: &UnboundedSender<ControlMessage>,
         receivers: &mut [BufferReceiver<EventArray>],
         sender_id: usize,
         capacity: usize,
     ) -> (BufferReceiver<EventArray>, BufferSender<EventArray>) {
-        let (sender, receiver) = build_sender_pair(capacity).await;
+        let (sender, receiver) = build_sender_pair(capacity);
         let old_receiver = mem::replace(&mut receivers[sender_id], receiver);
 
         control
@@ -616,7 +616,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_writes_to_all() {
-        let (mut fanout, _, receivers) = fanout_from_senders(&[2, 2]).await;
+        let (mut fanout, _, receivers) = fanout_from_senders(&[2, 2]);
         let events = make_event_array(2);
 
         let clones = events.clone();
@@ -632,7 +632,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_notready() {
-        let (mut fanout, _, mut receivers) = fanout_from_senders(&[2, 1, 2]).await;
+        let (mut fanout, _, mut receivers) = fanout_from_senders(&[2, 1, 2]);
         let events = make_events(2);
 
         // First send should immediately complete because all senders have capacity:
@@ -661,7 +661,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_grow() {
-        let (mut fanout, _, mut receivers) = fanout_from_senders(&[4, 4]).await;
+        let (mut fanout, _, mut receivers) = fanout_from_senders(&[4, 4]);
         let events = make_events(3);
 
         // Send in the first two events to our initial two senders:
@@ -675,7 +675,7 @@ mod tests {
             .expect("should not fail");
 
         // Now add a third sender:
-        add_sender_to_fanout(&mut fanout, &mut receivers, 2, 4).await;
+        add_sender_to_fanout(&mut fanout, &mut receivers, 2, 4);
 
         // Send in the last event which all three senders will now get:
         fanout
@@ -696,7 +696,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_shrink() {
-        let (mut fanout, control, receivers) = fanout_from_senders(&[4, 4]).await;
+        let (mut fanout, control, receivers) = fanout_from_senders(&[4, 4]);
         let events = make_events(3);
 
         // Send in the first two events to our initial two senders:
@@ -772,7 +772,7 @@ mod tests {
         ];
 
         for (sender_id, should_complete, expected_last_seen) in cases {
-            let (mut fanout, control, mut receivers) = fanout_from_senders(&[2, 1, 2]).await;
+            let (mut fanout, control, mut receivers) = fanout_from_senders(&[2, 1, 2]);
 
             // First send should immediately complete because all senders have capacity:
             let mut first_send = spawn(fanout.send(events[0].clone().into(), None));
@@ -827,7 +827,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_replace() {
-        let (mut fanout, control, mut receivers) = fanout_from_senders(&[4, 4, 4]).await;
+        let (mut fanout, control, mut receivers) = fanout_from_senders(&[4, 4, 4]);
         let events = make_events(3);
 
         // First two sends should immediately complete because all senders have capacity:
@@ -841,7 +841,7 @@ mod tests {
             .expect("should not fail");
 
         // Replace the first sender with a brand new one before polling again:
-        let old_first_receiver = replace_sender_in_fanout(&control, &mut receivers, 0, 4).await;
+        let old_first_receiver = replace_sender_in_fanout(&control, &mut receivers, 0, 4);
 
         // And do the third send which should also complete since all senders still have capacity:
         fanout
@@ -868,7 +868,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_wait() {
-        let (mut fanout, control, mut receivers) = fanout_from_senders(&[4, 4]).await;
+        let (mut fanout, control, mut receivers) = fanout_from_senders(&[4, 4]);
         let events = make_events(3);
 
         // First two sends should immediately complete because all senders have capacity:
@@ -881,7 +881,7 @@ mod tests {
         // doesn't let any writes through until we replace it properly.  We get back the receiver
         // we've replaced, but also the sender that we want to eventually install:
         let (old_first_receiver, new_first_sender) =
-            start_sender_replace(&control, &mut receivers, 0, 4).await;
+            start_sender_replace(&control, &mut receivers, 0, 4);
 
         // Third send should return pending because now we have an in-flight replacement:
         let mut third_send = spawn(fanout.send(events[2].clone().into(), None));

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -11,7 +11,7 @@ use metrics::Histogram;
 use tracing::Span;
 use vector_buffers::{
     config::MemoryBufferSize,
-    topology::channel::{self, LimitedReceiver, LimitedSender},
+    topology::channel::{self, ChannelMetricMetadata, LimitedReceiver, LimitedSender},
 };
 use vector_common::{
     byte_size_of::ByteSizeOf,
@@ -117,7 +117,8 @@ impl Output {
         timeout: Option<Duration>,
     ) -> (Self, LimitedReceiver<SourceSenderItem>) {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(n).unwrap());
-        let (tx, rx) = channel::limited(limit, Some((UTILIZATION_METRIC_PREFIX, &output)));
+        let metrics = ChannelMetricMetadata::new(UTILIZATION_METRIC_PREFIX, Some(output.clone()));
+        let (tx, rx) = channel::limited(limit, Some(metrics));
         (
             Self {
                 sender: tx,

--- a/lib/vector-tap/src/controller.rs
+++ b/lib/vector-tap/src/controller.rs
@@ -356,7 +356,12 @@ async fn tap_handler(
                             // target for the component, and spawn our transformer task which will
                             // wrap each event payload with the necessary metadata before forwarding
                             // it to our global tap receiver.
-                            let (tap_buffer_tx, mut tap_buffer_rx) = TopologyBuilder::standalone_memory(TAP_BUFFER_SIZE, WhenFull::DropNewest, &Span::current()).await;
+                            let (tap_buffer_tx, mut tap_buffer_rx) = TopologyBuilder::standalone_memory(
+                                TAP_BUFFER_SIZE,
+                                WhenFull::DropNewest,
+                                &Span::current(),
+                                None,
+                            );
                             let mut tap_transformer = TapTransformer::new(tx.clone(), output.clone());
 
                             tokio::spawn(async move {

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -225,7 +225,7 @@ fn extract_table_component_keys(
         .collect()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "enrichment-tables-memory"))]
 mod tests {
     use crate::config::ConfigBuilder;
     use indoc::indoc;

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -65,11 +65,35 @@ pub const HTTP_SINK_TAGS: [&str; 2] = ["endpoint", "protocol"];
 /// The standard set of tags for all `AWS`-based sinks.
 pub const AWS_SINK_TAGS: [&str; 2] = ["protocol", "region"];
 
-/// The list of source sender buffer metrics that must be emitted.
-const SOURCE_SENDER_BUFFER_METRICS: [&str; 2] = [
-    "source_buffer_utilization",
-    "source_buffer_utilization_level",
+/// The set of suffixes that define the source/transform buffer metric family.
+const BUFFER_METRIC_SUFFIXES: [&str; 3] = [
+    // While hypothetically possible, the `max_byte_size` metric is never actually emitted, because
+    // both sources and transforms limit their buffers by event count. If we ever allow
+    // configuration by byte size, we will need to account for this in these tests.
+    "max_event_size",
+    "utilization",
+    "utilization_level",
 ];
+
+/// Buffer metric requirements shared between sources and transforms.
+#[derive(Clone, Copy)]
+struct BufferMetricRequirement {
+    prefix: &'static str,
+    suffixes: &'static [&'static str],
+    required_tags: &'static [&'static str],
+}
+
+const SOURCE_BUFFER_METRIC_REQUIREMENT: BufferMetricRequirement = BufferMetricRequirement {
+    prefix: "source_buffer_",
+    suffixes: &BUFFER_METRIC_SUFFIXES,
+    required_tags: &["output"],
+};
+
+const TRANSFORM_BUFFER_METRIC_REQUIREMENT: BufferMetricRequirement = BufferMetricRequirement {
+    prefix: "transform_buffer_",
+    suffixes: &BUFFER_METRIC_SUFFIXES,
+    required_tags: &[],
+};
 
 /// This struct is used to describe a set of component tests.
 pub struct ComponentTests<'a, 'b, 'c> {
@@ -79,8 +103,8 @@ pub struct ComponentTests<'a, 'b, 'c> {
     tagged_counters: &'b [&'b str],
     /// The list of counter metrics (with no particular tags) that must be incremented
     untagged_counters: &'c [&'c str],
-    /// Whether the source sender metrics must be emitted
-    require_source_sender_metrics: bool,
+    /// Optional buffer metric validation requirements.
+    buffer_metrics: Option<BufferMetricRequirement>,
 }
 
 /// The component test specification for all sources.
@@ -93,7 +117,7 @@ pub static SOURCE_TESTS: LazyLock<ComponentTests> = LazyLock::new(|| ComponentTe
         "component_sent_events_total",
         "component_sent_event_bytes_total",
     ],
-    require_source_sender_metrics: true,
+    buffer_metrics: Some(SOURCE_BUFFER_METRIC_REQUIREMENT),
 });
 
 /// The component error test specification (sources and sinks).
@@ -101,7 +125,7 @@ pub static COMPONENT_TESTS_ERROR: LazyLock<ComponentTests> = LazyLock::new(|| Co
     events: &["Error"],
     tagged_counters: &["component_errors_total"],
     untagged_counters: &[],
-    require_source_sender_metrics: false,
+    buffer_metrics: None,
 });
 
 /// The component test specification for all transforms.
@@ -114,7 +138,7 @@ pub static TRANSFORM_TESTS: LazyLock<ComponentTests> = LazyLock::new(|| Componen
         "component_sent_events_total",
         "component_sent_event_bytes_total",
     ],
-    require_source_sender_metrics: false,
+    buffer_metrics: Some(TRANSFORM_BUFFER_METRIC_REQUIREMENT),
 });
 
 /// The component test specification for sinks that are push-based.
@@ -126,7 +150,7 @@ pub static SINK_TESTS: LazyLock<ComponentTests> = LazyLock::new(|| {
             "component_sent_events_total",
             "component_sent_event_bytes_total",
         ],
-        require_source_sender_metrics: false,
+        buffer_metrics: None,
     }
 });
 
@@ -139,7 +163,7 @@ pub static DATA_VOLUME_SINK_TESTS: LazyLock<ComponentTests> = LazyLock::new(|| {
             "component_sent_event_bytes_total",
         ],
         untagged_counters: &[],
-        require_source_sender_metrics: false,
+        buffer_metrics: None,
     }
 });
 
@@ -151,7 +175,7 @@ pub static NONSENDING_SINK_TESTS: LazyLock<ComponentTests> = LazyLock::new(|| Co
         "component_sent_event_bytes_total",
     ],
     untagged_counters: &[],
-    require_source_sender_metrics: false,
+    buffer_metrics: None,
 });
 
 /// The component test specification for components with multiple outputs.
@@ -163,7 +187,7 @@ pub static COMPONENT_MULTIPLE_OUTPUTS_TESTS: LazyLock<ComponentTests> =
             "component_sent_event_bytes_total",
         ],
         untagged_counters: &[],
-        require_source_sender_metrics: false,
+        buffer_metrics: None,
     });
 
 impl ComponentTests<'_, '_, '_> {
@@ -174,8 +198,8 @@ impl ComponentTests<'_, '_, '_> {
         test.emitted_all_events(self.events);
         test.emitted_all_counters(self.tagged_counters, tags);
         test.emitted_all_counters(self.untagged_counters, &[]);
-        if self.require_source_sender_metrics {
-            test.emitted_source_sender_metrics();
+        if let Some(requirement) = self.buffer_metrics {
+            test.emitted_buffer_metrics(requirement);
         }
         if !test.errors.is_empty() {
             panic!(
@@ -269,21 +293,29 @@ impl ComponentTester {
         }
     }
 
-    fn emitted_source_sender_metrics(&mut self) {
-        let mut partial_matches = Vec::new();
-        let mut missing: HashSet<&str> = SOURCE_SENDER_BUFFER_METRICS.iter().copied().collect();
-
-        for metric in self
-            .metrics
+    fn emitted_buffer_metrics(&mut self, requirement: BufferMetricRequirement) {
+        let expected: HashSet<String> = requirement
+            .suffixes
             .iter()
-            .filter(|m| SOURCE_SENDER_BUFFER_METRICS.contains(&m.name()))
-        {
+            .map(|suffix| format!("{}{}", requirement.prefix, suffix))
+            .collect();
+
+        let mut missing = expected.clone();
+        let mut partial_matches = Vec::new();
+
+        for metric in self.metrics.iter().filter(|m| expected.contains(m.name())) {
             let tags = metric.tags();
-            let has_output_tag = tags.is_some_and(|t| t.contains_key("output"));
             let is_histogram = matches!(metric.value(), MetricValue::AggregatedHistogram { .. });
             let is_gauge = matches!(metric.value(), MetricValue::Gauge { .. });
 
-            if (is_histogram || is_gauge) && has_output_tag {
+            let missing_tags: Vec<_> = requirement
+                .required_tags
+                .iter()
+                .copied()
+                .filter(|tag| tags.is_none_or(|t| !t.contains_key(tag)))
+                .collect();
+
+            if (is_histogram || is_gauge) && missing_tags.is_empty() {
                 missing.remove(metric.name());
                 continue;
             }
@@ -296,8 +328,13 @@ impl ComponentTester {
             if !is_histogram && !is_gauge {
                 reasons.push(format!("unexpected type `{}`", metric.value().as_name()));
             }
-            if !has_output_tag {
-                reasons.push("missing `output` tag".to_string());
+            if !missing_tags.is_empty() {
+                reasons.push(format!(
+                    "missing {}",
+                    missing_tags
+                        .iter()
+                        .format_with(", ", |tag, fmt| fmt(&format!("`{tag}`")))
+                ));
             }
             let detail = if reasons.is_empty() {
                 String::new()
@@ -312,9 +349,20 @@ impl ComponentTester {
 
         if !missing.is_empty() {
             let partial = partial_matches.join("");
+            let tag_clause = if requirement.required_tags.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " with tag {}",
+                    requirement
+                        .required_tags
+                        .iter()
+                        .format_with(", ", |tag, fmt| fmt(&format!("`{tag}`")))
+                )
+            };
             self.errors.push(format!(
-                "  - Missing metric `{}*` with tag `output`{partial}",
-                missing.iter().join(", ")
+                "  - Missing metric `{}`{tag_clause}{partial}",
+                missing.iter().sorted().join(", ")
             ));
         }
     }
@@ -598,7 +646,7 @@ pub async fn assert_sink_error_with_events<T>(
         events,
         tagged_counters: &["component_errors_total"],
         untagged_counters: &[],
-        require_source_sender_metrics: false,
+        buffer_metrics: None,
     };
     assert_sink_error_with_component_tests(&component_tests, tags, f).await
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -22,7 +22,7 @@ use vector_lib::{
         BufferType, WhenFull,
         topology::{
             builder::TopologyBuilder,
-            channel::{BufferReceiver, BufferSender},
+            channel::{BufferReceiver, BufferSender, ChannelMetricMetadata},
         },
     },
     config::LogNamespace,
@@ -62,6 +62,7 @@ pub(crate) static SOURCE_SENDER_BUFFER_SIZE: LazyLock<usize> =
 
 const READY_ARRAY_CAPACITY: NonZeroUsize = NonZeroUsize::new(CHUNK_SIZE * 4).unwrap();
 pub(crate) const TOPOLOGY_BUFFER_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
+const TRANSFORM_CHANNEL_METRIC_PREFIX: &str = "transform_buffer";
 
 static TRANSFORM_CONCURRENCY_LIMIT: LazyLock<usize> = LazyLock::new(|| {
     crate::app::worker_threads()
@@ -470,6 +471,7 @@ impl<'a> Builder<'a> {
                 component_id = %key.id(),
                 component_type = %transform.inner.get_component_name(),
             );
+            let _span = span.enter();
 
             // Create a map of the outputs to the list of possible definitions from those outputs.
             let schema_definitions = transform
@@ -517,17 +519,19 @@ impl<'a> Builder<'a> {
                 Ok(transform) => transform,
             };
 
-            let (input_tx, input_rx) =
-                TopologyBuilder::standalone_memory(TOPOLOGY_BUFFER_SIZE, WhenFull::Block, &span)
-                    .await;
+            let metrics = ChannelMetricMetadata::new(TRANSFORM_CHANNEL_METRIC_PREFIX, None);
+            let (input_tx, input_rx) = TopologyBuilder::standalone_memory(
+                TOPOLOGY_BUFFER_SIZE,
+                WhenFull::Block,
+                &span,
+                Some(metrics),
+            );
 
             self.inputs
                 .insert(key.clone(), (input_tx, node.inputs.clone()));
 
-            let (transform_task, transform_outputs) = {
-                let _span = span.enter();
-                build_transform(transform, node, input_rx, &self.utilization_registry)
-            };
+            let (transform_task, transform_outputs) =
+                build_transform(transform, node, input_rx, &self.utilization_registry);
 
             self.outputs.extend(transform_outputs);
             self.tasks.insert(key.clone(), transform_task);

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -828,6 +828,38 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		transform_buffer_max_event_size: {
+			description:       "The maximum number of events the buffer that feeds into a transform can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		transform_buffer_max_byte_size: {
+			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		transform_buffer_utilization: {
+			description:       "The utilization level of the buffer that feeds into a transform."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		transform_buffer_utilization_level: {
+			description:       "The current utilization level of the buffer that feeds into a transform."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
 		uptime_seconds: {
 			description:       "The total number of seconds the Vector instance has been up."
 			type:              "gauge"

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -20,6 +20,10 @@ components: transforms: [Name=string]: {
 		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		transform_buffer_max_event_size:      components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
+		transform_buffer_max_byte_size:       components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
+		transform_buffer_utilization:         components.sources.internal_metrics.output.metrics.transform_buffer_utilization
+		transform_buffer_utilization_level:   components.sources.internal_metrics.output.metrics.transform_buffer_utilization_level
 		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 	}
 }


### PR DESCRIPTION
## Summary

This builds on the work in #24272 and adds support for transform buffer utilization. Since these are input buffers they omit the `output` label used by the buffers created by the source senders.

## Vector configuration

N/A

## How did you test this PR?

Ran a quick test dumping internal metrics to stdout and verified that the `transform_buffer_*` metrics appeared with the appropriate labels.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
