### PR TITLE
chore(deps): bump maxminddb to 0.27 after RUSTSEC-2025-0132

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6637,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "maxminddb"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a197e44322788858682406c74b0b59bf8d9b4954fe1f224d9a25147f1880bba"
+checksum = "7ef0551fc3e7345a6c854c1026b0ddada1e443e51f4fb4cdcf86cc1a71d4b337"
 dependencies = [
  "ipnetwork",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,7 +383,7 @@ k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_26
 kube = { version = "0.93.0", default-features = false, features = ["client", "openssl-tls", "runtime"], optional = true }
 listenfd = { version = "1.0.2", default-features = false, optional = true }
 lru = { version = "0.16.0", default-features = false }
-maxminddb = { version = "0.26.0", default-features = false, optional = true, features = ["simdutf8"] }
+maxminddb = { version = "0.27.0", default-features = false, optional = true, features = ["simdutf8"] }
 md-5 = { version = "0.10", default-features = false, optional = true }
 mongodb = { version = "3.3.0", default-features = false, optional = true, features = ["compat-3-0-0", "dns-resolver", "rustls-tls"] }
 async-nats = { version = "0.42.0", default-features = false, optional = true, features = ["ring"] }

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -56,7 +56,7 @@ impl Mmdb {
 
         // Check if we can read database with dummy Ip.
         let ip = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
-        let result = dbreader.lookup::<ObjectMap>(ip).map(|_| ());
+        let result = dbreader.lookup(ip)?.decode::<ObjectMap>().map(|_| ());
 
         match result {
             Ok(_) => Ok(Mmdb {
@@ -69,7 +69,7 @@ impl Mmdb {
     }
 
     fn lookup(&self, ip: IpAddr, select: Option<&[String]>) -> Option<ObjectMap> {
-        let data = self.dbreader.lookup::<ObjectMap>(ip).ok()??;
+        let data = self.dbreader.lookup(ip).ok()?.decode().ok()??;
 
         if let Some(fields) = select {
             let mut filtered = Value::from(ObjectMap::new());


### PR DESCRIPTION
## Summary

https://rustsec.org/advisories/RUSTSEC-2025-0132 has been released on Nov. 29th for `maxminddb 0.26`. `maxminddb 0.27` is marked as a safe upgrade.

The main change is that maxminddb now allows lazy decoding of values, and more ergonomic geoip values.

See inline comments for details

## Vector configuration

<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
 
I ran cargo test on a fresh clone. A few tests failed, this looks unrelated to the changes, more like something missing in my local environment.

```
secrets::exec::tests::test_exec_backend::case_1 (No such file or directory (os error 2))
secrets::exec::tests::test_exec_backend::case_2 (No such file or directory (os error 2))
secrets::exec::tests::test_exec_backend_missing_secrets (No such file or directory (os error 2))
```

I’ll wait for CI to confirm this is just a local env issue

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->




