### PR TITLE
chore(vrl)!: Bump vrl hash and fix datadog search tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13034,7 +13034,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vrl"
 version = "0.28.1"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=main#d19c4d06c3cbf93d5c44d70dac96c288d2937de4"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=main#5eafcc03be7fd864e51fe86dfc719e941de8e432"
 dependencies = [
  "aes",
  "aes-siv",

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -1268,9 +1268,9 @@ mod test {
             ),
             // negate OR of two values
             (
-                "-@field:value1 OR -@field:value2",
-                log_event!["field" => "value"],
-                log_event!["field" => "value2"],
+                "-@field1:value1 OR -@field2:value2",
+                log_event!["field1" => "value1"],
+                log_event!["field1" => "value1", "field2" => "value2"],
             ),
             // default AND of two values
             (


### PR DESCRIPTION
## Summary
Following https://github.com/vectordotdev/vrl/pull/1542, some datadog search queries are parsed differently by VRL. This PR bumps VRL and fixes the impacted unit tests.

Note that the VRL dependency update will cause Vector to interpret some datadog queries differently, which can impact some customers.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

CI

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [x] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

_Those changes are already mentioned in the VRL changelog_

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

- Related: https://github.com/vectordotdev/vrl/pull/1542

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
