### PR TITLE
chore(performance): Refactor `EventMetadata` deserialization from protobuf

### DIFF
--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -40,7 +40,7 @@ pub(super) struct Inner {
     pub(crate) secrets: Secrets,
 
     #[serde(default, skip)]
-    finalizers: EventFinalizers,
+    pub(crate) finalizers: EventFinalizers,
 
     /// The id of the source
     pub(crate) source_id: Option<Arc<ComponentKey>>,
@@ -60,7 +60,7 @@ pub(super) struct Inner {
     ///
     /// TODO(Jean): must not skip serialization to track schemas across restarts.
     #[serde(default = "default_schema_definition", skip)]
-    schema_definition: Arc<schema::Definition>,
+    pub(crate) schema_definition: Arc<schema::Definition>,
 
     /// A store of values that may be dropped during the encoding process but may be needed
     /// later on. The map is indexed by meaning.
@@ -68,7 +68,7 @@ pub(super) struct Inner {
     /// we need to ensure it is still available later on for emitting metrics tagged by the service.
     /// This field could almost be keyed by `&'static str`, but because it needs to be deserializable
     /// we have to use `String`.
-    dropped_fields: ObjectMap,
+    pub(crate) dropped_fields: ObjectMap,
 
     /// Metadata to track the origin of metrics. This is always `None` for log and trace events.
     /// Only a small set of Vector sources and transforms explicitly set this field.
@@ -264,7 +264,7 @@ impl Default for EventMetadata {
     }
 }
 
-fn default_schema_definition() -> Arc<schema::Definition> {
+pub(super) fn default_schema_definition() -> Arc<schema::Definition> {
     Arc::new(schema::Definition::new_with_default_metadata(
         Kind::any(),
         [LogNamespace::Legacy, LogNamespace::Vector],

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -16,6 +16,8 @@ pub use metric::Value as MetricValue;
 pub use proto_event::*;
 use vrl::value::{ObjectMap, Value as VrlValue};
 
+use super::EventFinalizers;
+use super::metadata::{Inner, default_schema_definition};
 use super::{EventMetadata, array, metric::MetricSketch};
 
 impl event_array::Events {
@@ -644,49 +646,49 @@ impl From<EventMetadata> for Metadata {
 
 impl From<Metadata> for EventMetadata {
     fn from(value: Metadata) -> Self {
-        let mut metadata = EventMetadata::default();
+        let Metadata {
+            value: metadata_value,
+            source_id,
+            source_type,
+            upstream_id,
+            secrets,
+            datadog_origin_metadata,
+            source_event_id,
+        } = value;
 
-        if let Some(value) = value.value.and_then(decode_value) {
-            *metadata.value_mut() = value;
-        }
-
-        if let Some(source_id) = value.source_id {
-            metadata.set_source_id(Arc::new(source_id.into()));
-        }
-
-        if let Some(source_type) = value.source_type {
-            metadata.set_source_type(source_type);
-        }
-
-        if let Some(upstream_id) = value.upstream_id {
-            metadata.set_upstream_id(Arc::new(upstream_id.into()));
-        }
-
-        if let Some(secrets) = value.secrets {
-            metadata.secrets_mut().merge(secrets.into());
-        }
-
-        if let Some(origin_metadata) = value.datadog_origin_metadata {
-            metadata = metadata.with_origin_metadata(origin_metadata.into());
-        }
-
-        let maybe_source_event_id = if value.source_event_id.is_empty() {
+        let metadata_value = metadata_value.and_then(decode_value);
+        let source_id = source_id.map(|s| Arc::new(s.into()));
+        let upstream_id = upstream_id.map(|id| Arc::new(id.into()));
+        let secrets = secrets.map(Into::into);
+        let datadog_origin_metadata = datadog_origin_metadata.map(Into::into);
+        let source_event_id = if source_event_id.is_empty() {
             None
         } else {
-            match Uuid::from_slice(&value.source_event_id) {
+            match Uuid::from_slice(&source_event_id) {
                 Ok(id) => Some(id),
                 Err(error) => {
                     error!(
-                        message = "Failed to parse source_event_id: {}",
-                        %error
+                        %error,
+                        source_event_id = %String::from_utf8_lossy(&source_event_id),
+                        "Failed to parse source_event_id.",
                     );
                     None
                 }
             }
         };
-        metadata = metadata.with_source_event_id(maybe_source_event_id);
 
-        metadata
+        EventMetadata(Arc::new(Inner {
+            value: metadata_value.unwrap_or_else(|| vrl::value::Value::Object(ObjectMap::new())),
+            secrets: secrets.unwrap_or_default(),
+            finalizers: EventFinalizers::default(),
+            source_id,
+            source_type: source_type.map(Into::into),
+            upstream_id,
+            schema_definition: default_schema_definition(),
+            dropped_fields: ObjectMap::new(),
+            datadog_origin_metadata,
+            source_event_id,
+        }))
     }
 }
 


### PR DESCRIPTION
## Summary

The existing code would create an `EventMetadata::default()` and then fill in the fields coming from the protobuf metadata. Unfortunately, this default creates several non-empty values, notably the `source_event_id`, which makes that construct take extra time, particularly since the incoming data will (almost?) always already have a `source_event_id` if the origin is another Vector instance.

While refactoring, I also changed the method to use destructuring to access the fields inside the source value to force the compiler to error if any fields are added later.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [X] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
