### PR TITLE
enhancement(http provider): allow environment interpolation from http provider config

### DIFF
--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -9,7 +9,7 @@ use vector_lib::configurable::configurable_component;
 
 use super::BuildResult;
 use crate::{
-    config::{self, interpolate, Format, ProxyConfig, provider::ProviderConfig},
+    config::{self, Format, ProxyConfig, interpolate, provider::ProviderConfig},
     http::HttpClient,
     signal,
     tls::{TlsConfig, TlsSettings},
@@ -154,9 +154,10 @@ async fn http_request_to_config_builder(
         })
         .collect::<std::collections::HashMap<String, String>>();
 
-    let config_str = interpolate(std::str::from_utf8(&config_str)
-        .map_err(|e| vec![e.to_string()])?,
-        &env_vars)?;
+    let config_str = interpolate(
+        std::str::from_utf8(&config_str).map_err(|e| vec![e.to_string()])?,
+        &env_vars,
+    )?;
 
     config::load(config_str.as_bytes().chunk(), *config_format)
 }


### PR DESCRIPTION
## Summary

adds a configuration option to the HTTP config provider to interpolate environment variables, similar to config file handling, but defaults to false

## Vector configuration

```
provider:
  type: http
  url: http://whatever
  interpolate_env: true
```


## How did you test this PR?
I have a docker-compose with a configuration service providing configuration to Vector, with remap files pointed to a relative mountpoint ( ie, `file: ${REMAPS}/whatever.vrl`, `docker run -e REMAPS=/path/to/volume` )

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](`https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md`).
- [X] No. A maintainer will apply the `no-changelog` label to this PR.

Http config provider is not yet documented, hence no end-user side-effects expected, and the default option is the current behaviour