### PR TITLE
chore(ci): Ignore RUSTSEC-2025-0134 for rustls-pemfile

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,4 +48,6 @@ ignore = [
   { id = "RUSTSEC-2020-0168", reason = "mach is unmaintained" },
   { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained" },
   { id = "RUSTSEC-2025-0012", reason = "backoff is unmaintained" },
+  # rustls-pemfile is unmaintained. Blocked by both async-nats and http 1.0.0 upgrade.
+  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained" },
 ]


### PR DESCRIPTION
## Summary

Ignores RUSTSEC-2025-0134 advisory in deny.toml for the `rustls-pemfile` crate.

The advisory indicates that rustls-pemfile is unmaintained. The repository has been archived since August 2025, and users are encouraged to depend directly on the underlying PEM parsing code included in rustls-pki-types since 1.9.0.

This migration is currently blocked by:
- `async-nats` dependency
- http 1.0.0 upgrade

## Vector configuration

N/A

## How did you test this PR?

Ran `cargo deny check advisories` to verify the advisory is properly ignored and CI passes.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0134
- Failing CI: https://github.com/vectordotdev/vector/actions/runs/19983563635/job/57314207450
- References: #19179
