### PR TITLE
fix(file source): improve change detection for rarely modified files

### DIFF
--- a/changelog.d/file_source_max_read_backoff.fix.md
+++ b/changelog.d/file_source_max_read_backoff.fix.md
@@ -1,0 +1,5 @@
+The `file` and `kubernetes_logs` sources now check file modification times during file discovery runs and immediately read modified files, fixing an issue where infrequently modified files could take 10+ seconds to be read. This improvement is most effective with the `file` source and its default `glob_minimum_cooldown_ms` value of 1000 ms; values of 10000 ms (10 seconds) or more provide no benefit.
+
+The previously hardcoded maximum backoff interval for reading inactive files is now configurable via `max_read_backoff_ms` (default: 2048 ms).
+
+authors: htrendev

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use std::{
     io::{self, SeekFrom},
     path::PathBuf,
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 use tokio::{
     fs::File,
@@ -61,6 +61,7 @@ pub struct FileWatcher {
     last_read_attempt: Instant,
     last_read_success: Instant,
     read_retry_delay: Duration,
+    last_modified: Instant,
     last_seen: Instant,
     max_line_bytes: usize,
     line_delimiter: Bytes,
@@ -171,6 +172,7 @@ impl FileWatcher {
             last_read_attempt: ts,
             last_read_success: ts,
             read_retry_delay: EOF_READ_BACKOFF_MIN,
+            last_modified: ts,
             last_seen: ts,
             max_line_bytes,
             line_delimiter,
@@ -337,12 +339,23 @@ impl FileWatcher {
     }
 
     #[inline]
+    pub fn set_modified(&mut self, modified: Option<SystemTime>) {
+        if let Some(ts) = modified
+            .and_then(|mtime| mtime.elapsed().ok())
+            .and_then(|diff| Instant::now().checked_sub(diff))
+        {
+            self.last_modified = ts;
+        }
+    }
+
+    #[inline]
     pub fn should_read(&self) -> bool {
         if self.reached_eof && self.last_read_attempt.elapsed() < self.read_retry_delay {
             return false;
         }
 
         self.last_read_success.elapsed() < Duration::from_secs(10)
+            || self.last_modified.elapsed() < Duration::from_secs(10)
             || self.last_read_attempt.elapsed() > Duration::from_secs(10)
     }
 

--- a/lib/file-source/src/file_watcher/tests/mod.rs
+++ b/lib/file-source/src/file_watcher/tests/mod.rs
@@ -235,6 +235,7 @@ fn watcher_for_timing() -> FileWatcher {
         last_read_attempt: now,
         last_read_success: now,
         read_retry_delay: EOF_READ_BACKOFF_MIN,
+        last_modified: now,
         last_seen: now,
         max_line_bytes: 1024,
         line_delimiter: Bytes::from_static(b"\n"),

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -165,8 +165,8 @@ pub struct FileConfig {
     /// The maximum interval between checks for new content in inactive files.
     ///
     /// Files are considered inactive when no new data has been read. Such files are then checked
-    /// less frequently for new data. This sets the upper limit for the delay before attempting to
-    /// read such files again, improving performance while still eventually detecting new content.
+    /// less frequently for new data. This setting defines the upper limit on how long to wait
+    /// before rechecking, improving performance while still detecting changes.
     #[serde(default = "default_max_read_backoff_ms")]
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
     #[configurable(metadata(docs::type_unit = "milliseconds"))]

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -162,6 +162,17 @@ pub struct FileConfig {
     #[configurable(metadata(docs::human_name = "Glob Minimum Cooldown"))]
     pub glob_minimum_cooldown_ms: Duration,
 
+    /// The maximum interval between checks for new content in inactive files.
+    ///
+    /// Files are considered inactive when no new data has been read. Such files are then checked
+    /// less frequently for new data. This sets the upper limit for the delay before attempting to
+    /// read such files again, improving performance while still eventually detecting new content.
+    #[serde(default = "default_max_read_backoff_ms")]
+    #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+    #[configurable(metadata(docs::type_unit = "milliseconds"))]
+    #[configurable(metadata(docs::human_name = "Inactive Files Read Backoff Interval"))]
+    pub max_read_backoff_ms: Duration,
+
     #[configurable(derived)]
     #[serde(alias = "fingerprinting", default)]
     fingerprint: FingerprintConfig,
@@ -259,6 +270,10 @@ const fn default_read_from() -> ReadFromConfig {
 
 const fn default_glob_minimum_cooldown_ms() -> Duration {
     Duration::from_millis(1000)
+}
+
+const fn default_max_read_backoff_ms() -> Duration {
+    Duration::from_millis(2048)
 }
 
 const fn default_multi_line_timeout() -> u64 {
@@ -371,6 +386,7 @@ impl Default for FileConfig {
             offset_key: None,
             data_dir: None,
             glob_minimum_cooldown_ms: default_glob_minimum_cooldown_ms(),
+            max_read_backoff_ms: default_max_read_backoff_ms(),
             message_start_indicator: None,
             multi_line_timeout: default_multi_line_timeout(), // millis
             multiline: None,
@@ -504,6 +520,7 @@ pub fn file_source(
         .collect::<Vec<PathBuf>>();
     let ignore_before = calculate_ignore_before(config.ignore_older_secs);
     let glob_minimum_cooldown = config.glob_minimum_cooldown_ms;
+    let max_read_backoff = config.max_read_backoff_ms;
     let (ignore_checkpoints, read_from) = reconcile_position_options(
         config.start_at_beginning,
         config.ignore_checkpoints,
@@ -544,6 +561,7 @@ pub fn file_source(
         line_delimiter: line_delimiter_as_bytes,
         data_dir,
         glob_minimum_cooldown,
+        max_read_backoff,
         fingerprinter: Fingerprinter::new(strategy, config.max_line_bytes, config.ignore_not_found),
         oldest_first: config.oldest_first,
         remove_after: config.remove_after_secs.map(Duration::from_secs),
@@ -875,6 +893,7 @@ mod tests {
             },
             data_dir: Some(data_dir),
             glob_minimum_cooldown_ms: Duration::from_millis(100),
+            max_read_backoff_ms: Duration::from_millis(200),
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
             },
@@ -894,6 +913,7 @@ mod tests {
               - /var/log/**/*.log
             file_key: file
             glob_minimum_cooldown_ms: 1000
+            max_read_backoff_ms: 2048
             multi_line_timeout: 1000
             max_read_bytes: 2048
             line_delimiter: "\n"

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -234,8 +234,8 @@ pub struct Config {
     /// The maximum interval between checks for new content in inactive files.
     ///
     /// Files are considered inactive when no new data has been read. Such files are then checked
-    /// less frequently for new data. This sets the upper limit for the delay before attempting to
-    /// read such files again, improving performance while still eventually detecting new content.
+    /// less frequently for new data. This setting defines the upper limit on how long to wait
+    /// before rechecking, improving performance while still detecting changes.
     #[serde(default = "default_max_read_backoff_ms")]
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
     #[configurable(metadata(docs::type_unit = "milliseconds"))]

--- a/website/cue/reference/components/sources/generated/file.cue
+++ b/website/cue/reference/components/sources/generated/file.cue
@@ -243,6 +243,20 @@ generated: components: sources: file: configuration: {
 			unit:    "bytes"
 		}
 	}
+	max_read_backoff_ms: {
+		description: """
+			The maximum interval between checks for new content in inactive files.
+
+			Files are considered inactive when no new data has been read. Such files are then checked
+			less frequently for new data. This sets the upper limit for the delay before attempting to
+			read such files again, improving performance while still eventually detecting new content.
+			"""
+		required: false
+		type: uint: {
+			default: 2048
+			unit:    "milliseconds"
+		}
+	}
 	max_read_bytes: {
 		description: """
 			Max amount of bytes to read from a single file before switching over to the next file.

--- a/website/cue/reference/components/sources/generated/file.cue
+++ b/website/cue/reference/components/sources/generated/file.cue
@@ -248,8 +248,8 @@ generated: components: sources: file: configuration: {
 			The maximum interval between checks for new content in inactive files.
 
 			Files are considered inactive when no new data has been read. Such files are then checked
-			less frequently for new data. This sets the upper limit for the delay before attempting to
-			read such files again, improving performance while still eventually detecting new content.
+			less frequently for new data. This setting defines the upper limit on how long to wait
+			before rechecking, improving performance while still detecting changes.
 			"""
 		required: false
 		type: uint: {

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -215,6 +215,20 @@ generated: components: sources: kubernetes_logs: configuration: {
 		required: false
 		type: uint: unit: "bytes"
 	}
+	max_read_backoff_ms: {
+		description: """
+			The maximum interval between checks for new content in inactive files.
+
+			Files are considered inactive when no new data has been read. Such files are then checked
+			less frequently for new data. This sets the upper limit for the delay before attempting to
+			read such files again, improving performance while still eventually detecting new content.
+			"""
+		required: false
+		type: uint: {
+			default: 2048
+			unit:    "milliseconds"
+		}
+	}
 	max_read_bytes: {
 		description: """
 			Max amount of bytes to read from a single file before switching over to the next file.

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -220,8 +220,8 @@ generated: components: sources: kubernetes_logs: configuration: {
 			The maximum interval between checks for new content in inactive files.
 
 			Files are considered inactive when no new data has been read. Such files are then checked
-			less frequently for new data. This sets the upper limit for the delay before attempting to
-			read such files again, improving performance while still eventually detecting new content.
+			less frequently for new data. This setting defines the upper limit on how long to wait
+			before rechecking, improving performance while still detecting changes.
 			"""
 		required: false
 		type: uint: {


### PR DESCRIPTION
## Summary
This fixes an issue where infrequently modified files could take 10-12 seconds to be read after a change. It takes advantage of the fact that file discovery (at least for the `file` source) runs every 1s by default. The discovery process now inspects file metadata and reads any modified files sooner.

- Added tracking of file modification times during file discovery to detect file changes sooner.
- Modified fingerprinter to return both fingerprint and metadata to enable reuse of the existing metadata without any additional file checks.
- Updated `should_read()` logic to trigger reads based on file modification time in addition to existing conditions. This is the key change that was delaying the change detection before.
- Introduced new configurable `max_read_backoff_ms` parameter (previously hardcoded to 2048).

## Vector configuration
```yaml
data_dir: "/tmp/vector"
sources:
  test_log:
    type: "file"
    glob_minimum_cooldown_ms: 500
    max_read_backoff_ms: 500
    include:
      - "/tmp/test.log"
sinks:
  console_logs:
    inputs: [ "test_log" ]
    type: "console"
    encoding:
      codec: "text"
```

## How did you test this PR?
`echo "test line of data" >> /tmp/test.log` and monitored the console output of vector to confirm that there was no unexpected delay in detecting the changes in the file. Then waited for 10+ seconds to make sure that the file is considered inactive and repeated the `echo` test to again confirm that there was no unexpected delay.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Closes: #23195
- Related: #19585 (possibly relevant due to the now configurable backoff interval)
<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
