### PR TITLE
feat(clickhouse sink): add DNS auto-resolution for load balancing

### DIFF
--- a/changelog.d/23877_clickhouse_sink_dns_auto_resolution.feature.md
+++ b/changelog.d/23877_clickhouse_sink_dns_auto_resolution.feature.md
@@ -1,0 +1,3 @@
+The ClickHouse sink now supports DNS auto-resolution for load balancing, allowing automatic discovery and rotation of ClickHouse cluster nodes through DNS lookups. This enables better high availability and load distribution when connecting to ClickHouse clusters with multiple endpoints. The feature can be enabled by setting `auto_resolve_dns: true` in the ClickHouse sink configuration.
+
+authors: sebinsunny

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -112,10 +112,10 @@ fn connector(
     let tls_settings = MaybeTlsSettings::tls_client(tls_options)?;
 
     if proxy.enabled {
-        let proxy = build_proxy_connector(tls_settings, proxy)?;
+        let proxy = build_proxy_connector(tls_settings, proxy, false)?;
         Ok(HyperClientBuilder::new().build(proxy))
     } else {
-        let tls_connector = build_tls_connector(tls_settings)?;
+        let tls_connector = build_tls_connector(tls_settings, false)?;
         Ok(HyperClientBuilder::new().build(tls_connector))
     }
 }

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -11,6 +11,7 @@ use super::{
     service::{VectorRequest, VectorResponse, VectorService},
     sink::VectorSink,
 };
+use crate::http::AnyResolver;
 use crate::{
     config::{
         AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext,
@@ -209,8 +210,9 @@ pub fn with_default_scheme(address: &str, tls: bool) -> crate::Result<Uri> {
 fn new_client(
     tls_settings: &MaybeTlsSettings,
     proxy_config: &ProxyConfig,
-) -> crate::Result<hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>> {
-    let proxy = build_proxy_connector(tls_settings.clone(), proxy_config)?;
+) -> crate::Result<hyper::Client<ProxyConnector<HttpsConnector<HttpConnector<AnyResolver>>>, BoxBody>>
+{
+    let proxy = build_proxy_connector(tls_settings.clone(), proxy_config, false)?;
 
     Ok(hyper::Client::builder().http2_only(true).build(proxy))
 }

--- a/src/sinks/vector/service.rs
+++ b/src/sinks/vector/service.rs
@@ -14,6 +14,7 @@ use vector_lib::{
 };
 
 use super::VectorSinkError;
+use crate::http::AnyResolver;
 use crate::{
     Error,
     event::{EventFinalizers, EventStatus, Finalizable},
@@ -68,7 +69,10 @@ impl MetaDescriptive for VectorRequest {
 
 impl VectorService {
     pub fn new(
-        hyper_client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
+        hyper_client: hyper::Client<
+            ProxyConnector<HttpsConnector<HttpConnector<AnyResolver>>>,
+            BoxBody,
+        >,
         uri: Uri,
         compression: bool,
     ) -> Self {
@@ -135,7 +139,7 @@ impl Service<VectorRequest> for VectorService {
 #[derive(Clone, Debug)]
 pub struct HyperSvc {
     uri: Uri,
-    client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
+    client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector<AnyResolver>>>, BoxBody>,
 }
 
 impl Service<hyper::Request<BoxBody>> for HyperSvc {

--- a/website/cue/reference/components/sinks/generated/clickhouse.cue
+++ b/website/cue/reference/components/sinks/generated/clickhouse.cue
@@ -211,6 +211,19 @@ generated: components: sinks: clickhouse: configuration: {
 			}
 		}
 	}
+	auto_resolve_dns: {
+		description: """
+			Automatically resolve hostnames to all available IP addresses.
+
+			When enabled, the hostname in the endpoint will be resolved to all its IP addresses,
+			and Vector will load balance across all resolved IPs using round-robin rotation.
+			IP rotation occurs when establishing new connections, which happens when connection
+			pools are exhausted or connections expire (either due to Hyper's pool_idle_timeout
+			or when the server closes connections based on its keep_alive_timeout).
+			"""
+		required: false
+		type: bool: default: false
+	}
 	batch: {
 		description: "Event batching behavior."
 		required:    false


### PR DESCRIPTION
## Summary
Adds DNS auto-resolution support to the ClickHouse sink for automatic load balancing across multiple IP addresses. When enabled, the sink resolves hostnames to all available IPs and uses round-robin rotation to distribute requests across them.




## Vector configuration
```yaml
sinks:
  clickhouse:
    type: clickhouse
    endpoint: http://clickhouse.example.com:8123
    auto_resolve_dns: true
    table: mytable
    # ... other config
```
<img width="1012" height="510" alt="image" src="https://github.com/user-attachments/assets/94382b45-8af2-4c3a-b512-638d5c71a81e" />


## How did you test this PR?
- Tested with ClickHouse cluster behind a DNS hostname resolving to multiple IPs
- Verified round-robin rotation occurs when connections are established
- Confirmed backward compatibility (defaults to `false`)
- Tested with both HTTP and HTTPS endpoints

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Closes: #[issue number]

## Notes
- IP rotation occurs when establishing new connections (when connection pools are exhausted or connections expire)
- Uses Hyper's default pool_idle_timeout (90 seconds) for connection reuse
- DNS resolution happens per connection establishment, enabling round-robin load balancing
