### PR TITLE
fix(aws_kinesis_streams sink): metrics with partial failure retry exhausted

### DIFF
--- a/changelog.d/metrics_with_aws_kinesis_partial_failure_retry.fix.md
+++ b/changelog.d/metrics_with_aws_kinesis_partial_failure_retry.fix.md
@@ -1,0 +1,3 @@
+Fixed an issue in the AWS Kinesis sink where metrics were incorrectly reported when partial failures occurred and retries were exhausted.
+
+authors: lht

--- a/src/sinks/aws_kinesis/service.rs
+++ b/src/sinks/aws_kinesis/service.rs
@@ -53,11 +53,31 @@ pub struct RecordResult {
 
 impl DriverResponse for KinesisResponse {
     fn event_status(&self) -> EventStatus {
+        if self.failure_count > 0
+            && let GroupedCountByteSize::Untagged { size } = &self.events_byte_size
+            && size.0 == 0
+        {
+            // If there are failures and no successful events, return Rejected
+            // This happens when retries are exhausted and all events failed
+            return EventStatus::Rejected;
+        }
+        // Either no failures, or partial success (some events succeeded)
         EventStatus::Delivered
     }
 
     fn events_sent(&self) -> &GroupedCountByteSize {
         &self.events_byte_size
+    }
+
+    fn events_rejected(&self) -> Option<usize> {
+        if self.failure_count > 0 {
+            // Report the number of failed events for partial failure tracking
+            // This allows the driver to emit component_discarded_events_total
+            // for partial failures while still counting successful events
+            Some(self.failure_count)
+        } else {
+            None
+        }
     }
 }
 
@@ -78,9 +98,17 @@ where
     }
 
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
-    fn call(&mut self, mut requests: BatchKinesisRequest<R>) -> Self::Future {
-        let metadata = std::mem::take(requests.metadata_mut());
-        let events_byte_size = metadata.into_events_estimated_json_encoded_byte_size();
+    fn call(&mut self, requests: BatchKinesisRequest<R>) -> Self::Future {
+        let estimated_json_encoded_sizes: Vec<usize> = requests
+            .events
+            .iter()
+            .map(
+                |req| match req.get_metadata().events_estimated_json_encoded_byte_size() {
+                    GroupedCountByteSize::Untagged { size } => size.1.get(),
+                    GroupedCountByteSize::Tagged { .. } => 0,
+                },
+            )
+            .collect();
 
         let records = requests
             .events
@@ -92,11 +120,176 @@ where
         let stream_name = self.stream_name.clone();
 
         Box::pin(async move {
-            client.send(records, stream_name).await.map(|mut r| {
-                // augment the response
-                r.events_byte_size = events_byte_size;
-                r
-            })
+            let mut response = client.send(records, stream_name).await?;
+
+            // Calculate the byte size for successful events only
+            let successful_size: usize = {
+                if response.failed_records.is_empty() {
+                    // Fast path: no failures, sum all sizes
+                    estimated_json_encoded_sizes.iter().sum()
+                } else {
+                    // Build a HashSet of failed indices for O(1) lookup
+                    use std::collections::HashSet;
+                    let failed_indices: HashSet<usize> =
+                        response.failed_records.iter().map(|fr| fr.index).collect();
+
+                    // Sum sizes for all non-failed records
+                    estimated_json_encoded_sizes
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, size)| {
+                            if failed_indices.contains(&index) {
+                                None
+                            } else {
+                                Some(size)
+                            }
+                        })
+                        .sum()
+                }
+            };
+
+            let successful_count = estimated_json_encoded_sizes.len() - response.failure_count;
+            response.events_byte_size =
+                CountByteSize(successful_count, JsonSize::new(successful_size)).into();
+
+            Ok(response)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::EventStatus;
+    use vector_lib::{internal_event::CountByteSize, json_size::JsonSize};
+
+    #[test]
+    fn test_event_status_delivered_with_partial_success() {
+        // Scenario: 10 events sent, 7 succeeded, 3 failed
+        // events_byte_size reflects only the 7 successful events
+        #[cfg(feature = "sinks-aws_kinesis_streams")]
+        let failed_records = vec![
+            RecordResult {
+                index: 3,
+                success: false,
+                error_code: Some("ProvisionedThroughputExceededException".to_string()),
+                error_message: Some("Rate exceeded".to_string()),
+            },
+            RecordResult {
+                index: 7,
+                success: false,
+                error_code: Some("ProvisionedThroughputExceededException".to_string()),
+                error_message: Some("Rate exceeded".to_string()),
+            },
+            RecordResult {
+                index: 9,
+                success: false,
+                error_code: Some("InternalFailure".to_string()),
+                error_message: Some("Internal error".to_string()),
+            },
+        ];
+
+        let response = KinesisResponse {
+            failure_count: 3,
+            events_byte_size: CountByteSize(7, JsonSize::new(700)).into(), // Only 7 successful
+            #[cfg(feature = "sinks-aws_kinesis_streams")]
+            failed_records,
+        };
+
+        assert_eq!(
+            response.event_status(),
+            EventStatus::Delivered,
+            "Partial success should return Delivered (successful events are delivered)"
+        );
+
+        // Verify events_rejected reports the failed events
+        assert_eq!(
+            response.events_rejected(),
+            Some(3),
+            "events_rejected should report 3 failed events"
+        );
+
+        // Verify events_sent reflects only successful events
+        if let GroupedCountByteSize::Untagged { size } = response.events_sent() {
+            assert_eq!(size.0, 7, "events_sent should report 7 successful events");
+        } else {
+            panic!("Expected Untagged variant");
+        }
+    }
+
+    #[test]
+    fn test_event_status_delivered_when_no_failures() {
+        let response = KinesisResponse {
+            failure_count: 0,
+            events_byte_size: CountByteSize(10, JsonSize::new(1000)).into(),
+            #[cfg(feature = "sinks-aws_kinesis_streams")]
+            failed_records: vec![],
+        };
+
+        assert_eq!(
+            response.event_status(),
+            EventStatus::Delivered,
+            "Response with no failures should return Delivered status"
+        );
+
+        assert_eq!(
+            response.events_rejected(),
+            None,
+            "events_rejected should not report failed events"
+        );
+
+        if let GroupedCountByteSize::Untagged { size } = response.events_sent() {
+            assert_eq!(size.0, 10, "events_sent should report 10 successful events");
+            assert_eq!(size.1.get(), 1000, "events_sent should report 1000 bytes");
+        } else {
+            panic!("Expected Untagged variant");
+        }
+    }
+
+    #[test]
+    fn test_event_status_rejected_when_total_failure() {
+        // Scenario: All events failed
+        #[cfg(feature = "sinks-aws_kinesis_streams")]
+        let failed_records = vec![
+            RecordResult {
+                index: 0,
+                success: false,
+                error_code: Some("ProvisionedThroughputExceededException".to_string()),
+                error_message: Some("Rate exceeded".to_string()),
+            },
+            RecordResult {
+                index: 1,
+                success: false,
+                error_code: Some("ProvisionedThroughputExceededException".to_string()),
+                error_message: Some("Rate exceeded".to_string()),
+            },
+        ];
+
+        let response = KinesisResponse {
+            failure_count: 2,
+            events_byte_size: CountByteSize(0, JsonSize::new(0)).into(), // No successes
+            #[cfg(feature = "sinks-aws_kinesis_streams")]
+            failed_records,
+        };
+
+        assert_eq!(
+            response.event_status(),
+            EventStatus::Rejected,
+            "Total failure (no successful events) should return Rejected status"
+        );
+
+        assert_eq!(
+            response.events_rejected(),
+            Some(2),
+            "events_rejected should report 0 failed event"
+        );
+
+        // Verify events_sent is empty
+        if let GroupedCountByteSize::Untagged { size } = response.events_sent() {
+            assert_eq!(size.0, 0, "events_sent should report 0 successful event");
+            assert_eq!(size.1.get(), 0, "events_sent should report 0 byte");
+        } else {
+            panic!("Expected Untagged variant");
+        }
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
When the AWS Kinesis Streams sink experiences partial failures (PutRecords API responded 200 but with failed records), and retries exhausted. The failed records are not reflected in metrics.

**Example scenario:**
1. Initial batch: 10 events sent to Kinesis
2. First attempt: 7 succeed, 3 fail → retry with 3 events
3. Second attempt: 2 succeed, 1 fails → retry with 1 event
4. Final attempt: 1 fails (exhausted retries)

**Current behavior:**
- vector_component_sent_events_total: 10
- vector_component_sent_event_bytes_total: total bytes of the 10 events
- vector_component_discarded_events_total: 0

**Expected**
- vector_component_sent_events_total: 9
- vector_component_sent_event_bytes_total: total bytes of 9 events
- vector_component_discarded_events_total: 1

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```
  kinesis:
     type: aws_kinesis_streams
     inputs:
     - logs
     compression: gzip     
     request:
       concurrency: adaptive
       retry_attempts: 3
       retry_max_duration_secs: 5
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

Emit large volume of logs to a one-shard Kinesis stream until CloudWatch reports `PutRecords.ThrottledRecords`.
Confirm metric `component_discarded_events_total{component_kind="aws_kinesis_stream"}` is not zero.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
