### PR TITLE
enhancement(splunk_hec source): Add raw_line_splitting option for NDJSON

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -309,6 +309,7 @@ Lifetouch
 linkerd
 localdomain
 localstack
+Logpush
 lookback
 lucene
 Lumia

--- a/changelog.d/splunk_hec_raw_line_splitting.enhancement.md
+++ b/changelog.d/splunk_hec_raw_line_splitting.enhancement.md
@@ -1,0 +1,2 @@
+Add `raw_line_splitting` option to `splunk_hec` source to split incoming requests to the `/services/collector/raw` endpoint on newlines, creating separate events for each line. This is useful when receiving newline-delimited JSON (NDJSON) from sources like CloudFlare Logpush.
+

--- a/changelog.d/splunk_hec_raw_line_splitting.enhancement.md
+++ b/changelog.d/splunk_hec_raw_line_splitting.enhancement.md
@@ -1,2 +1,3 @@
 Add `raw_line_splitting` option to `splunk_hec` source to split incoming requests to the `/services/collector/raw` endpoint on newlines, creating separate events for each line. This is useful when receiving newline-delimited JSON (NDJSON) from sources like CloudFlare Logpush.
 
+authors: clundquist-stripe

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -533,7 +533,9 @@ impl SplunkSource {
                             if let Some(token) = token.filter(|_| store_hec_token) {
                                 let token: Arc<str> = token.into();
                                 for event in &mut events {
-                                    event.metadata_mut().set_splunk_hec_token(Arc::clone(&token));
+                                    event
+                                        .metadata_mut()
+                                        .set_splunk_hec_token(Arc::clone(&token));
                                 }
                             }
 
@@ -1503,7 +1505,14 @@ mod tests {
         SocketAddr,
         PortGuard,
     ) {
-        source_with_options(token, valid_tokens, acknowledgements, store_hec_token, false).await
+        source_with_options(
+            token,
+            valid_tokens,
+            acknowledgements,
+            store_hec_token,
+            false,
+        )
+        .await
     }
 
     async fn source_with_options(


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

When receiving newline-delimited JSON (NDJSON) from services like CloudFlare Logpush via the `/services/collector/raw` endpoint, each line should be treated as a separate event. Without this option, the entire request body is treated as a single event, which is incorrect for NDJSON payloads.

This change introduces a `raw_line_splitting` configuration option to the `splunk_hec` source. When enabled, incoming requests to the raw endpoint are split on newlines, creating a separate event for each line. Empty lines are filtered out, and trailing newlines are handled correctly.

The option defaults to `false` to maintain backward compatibility with existing configurations.

Includes table-driven tests covering CloudFlare-style NDJSON payloads with various edge cases (multiple events, trailing newlines, empty lines).

See also

Issue | Title | Relevance
-- | -- | --
#22969 | Sink: Splunk HEC "raw" does not frame events | Related - The inverse problem (sink → source). enhancement complements this.
#17236 | splunk_hec source does not read metadata from query parame



## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```yaml
sources:
  cloudflare_logs:
    type: splunk_hec
    address: "0.0.0.0:8088"
    raw_line_splitting: true  # Split NDJSON on newlines

sinks:
  splunk:
    type: splunk_hec_logs
    inputs:
      - cloudflare_logs
    endpoint: "https://splunk.example.com:8088"
```


## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Unit tests.
I have not tested this integration wise getting real data from CloudFlare yet.


## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
