### PR TITLE
chore(ci): bump cargo deny to 0.18.9

### DIFF
--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -163,8 +163,8 @@ if contains_module cargo-nextest; then
 fi
 
 if contains_module cargo-deny; then
-  if ! cargo-deny --version 2>/dev/null | grep -q '^cargo-deny 0.16.2'; then
-    cargo "${install[@]}" cargo-deny --version 0.16.2 --force --locked
+  if ! cargo-deny --version 2>/dev/null | grep -q '^cargo-deny 0.18.9'; then
+    cargo "${install[@]}" cargo-deny --version 0.18.9 --force --locked
   fi
 fi
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
As title states. Deny failed due to a CVSS v4 which is unsupported by v0.16.x

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
`make check-deny`

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/20389548050/attempts/1
<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

