### PR TITLE
feat(sinks): log response body when HTTP response failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf19e729cdbd51af9a397fb9ef8ac8378007b797f8273cfbfdf45dcaa316167b"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -12558,6 +12558,7 @@ dependencies = [
  "base64 0.22.1",
  "bloomy",
  "bollard",
+ "brotli",
  "byteorder",
  "bytes 1.10.1",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -438,6 +438,7 @@ heim = { git = "https://github.com/vectordotdev/heim.git", branch = "update-nix"
 mlua = { version = "0.10.5", default-features = false, features = ["lua54", "send", "vendored", "macros"], optional = true }
 sysinfo = "0.37.2"
 byteorder = "1.5.0"
+brotli = "8.0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8.0"

--- a/changelog.d/display_sink_response_error_message.enhancement.md
+++ b/changelog.d/display_sink_response_error_message.enhancement.md
@@ -1,0 +1,3 @@
+Added HTTP response body previews to error logs. When an HTTP sink request fails and log level of target `sink-http-response` is set to `DEBUG`/`TRACE`, Vector will now attempt to decompress (gzip, zstd, br, deflate) and log the first 1024 characters of the response body to help troubleshooting.
+
+authors: Keuin

--- a/website/content/en/guides/developer/debugging.md
+++ b/website/content/en/guides/developer/debugging.md
@@ -35,6 +35,10 @@ You can set different verbosity levels for specific components:
 VECTOR_LOG=info,vector::sources::aws_s3=warn vector --config path/to/config.yaml
 ```
 
+There are some standalone log targets which may help you to debug:
+
+* `sink-http-response`: log sinks HTTP response body in `DEBUG` level.
+
 You can find more information on the syntax [here](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#usage-notes).
 
 ### Vector Tools


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This patch adds HTTP response body peek logic, reading for at most 1024 UTF-8 characters from HTTP response. It uses this utility function to log response from sink, when sink reports error. This helps user find out why the sink is not working more quickly.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

I use a local ClickHouse server as sink, standard input as source:

```toml
[sources.in]
type = "stdin"
decoding.codec = "json"

[sinks.out]
type = "clickhouse"
inputs = ["in"]
endpoint = "http://localhost:8123" 
database = "default"
table = "test_table"
auth.strategy = "basic"
auth.user = "default"
auth.password = ""
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

I spin up the test sink ClickHouse, which talks to Vector via HTTP.
I created test table with:
```sql
create table test_table(value Int64);
```
I configured Vector to write to that table. Then I spin up Vector, wrote data in stdin:

```json
{"value":"some_value"}
```

Since the data cannot be converted to `Int64`, ClickHouse reported an error. Without this patch, Vector won't tell you why. With this patch, Vector clearly showed what caused the error:

```
$ ./target/debug/vector --config test.toml
2026-01-01T09:11:04.813273Z  INFO vector::app: Log level is enabled. level="info"
2026-01-01T09:11:04.814745Z  INFO vector::app: Loading configs. paths=["test.toml"]
2026-01-01T09:11:04.823813Z  INFO vector::sources::file_descriptors: Capturing stdin.
2026-01-01T09:11:05.221184Z  INFO vector::topology::running: Running healthchecks.
2026-01-01T09:11:05.221550Z  INFO vector: Vector has started. debug="true" version="0.53.0" arch="aarch64" revision=""
2026-01-01T09:11:05.221584Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
2026-01-01T09:11:05.223805Z  INFO vector::topology::builder: Healthcheck passed.
{"value":"some_value"}
2026-01-01T09:11:12.763568Z  INFO vector_common::shutdown: All sources have finished.
2026-01-01T09:11:12.763684Z  INFO vector_common::shutdown: Internal log [All sources have finished.] is being suppressed to avoid flooding.
2026-01-01T09:11:12.763780Z  INFO vector::app: All sources have finished.
2026-01-01T09:11:12.763838Z  INFO vector: Vector has stopped.
2026-01-01T09:11:12.764996Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="out" time_remaining="59 seconds left"
2026-01-01T09:11:12.881649Z ERROR sink{component_kind="sink" component_id=out component_type=clickhouse}:request{request_id=1}: vector::sinks::util::retries: Not retriable; dropping the request. reason="response status: 400 Bad Request, body: Code: 27. DB::Exception: Cannot parse input: expected '\"' before: 'some_value\"}\\n': (while reading the value of key value): (at row 1)\n: While executing ParallelParsingBlockInputFormat. (CANNOT_PARSE_INPUT_ASSERTION_FAILED) (version 25.11.2.24 (official build))\n"
2026-01-01T09:11:12.881979Z ERROR sink{component_kind="sink" component_id=out component_type=clickhouse}:request{request_id=1}: vector_common::internal_event::service: Service call failed. No retries or retries exhausted. error=None request_id=1 error_type="request_failed" stage="sending"
2026-01-01T09:11:14.493112Z ERROR sink{component_kind="sink" component_id=out component_type=clickhouse}:request{request_id=1}: vector_common::internal_event::component_events_dropped: Events dropped intentional=false count=1 reason="Service call failed. No retries or retries exhausted."
```

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
