### PR TITLE
chore(deps): Bump rkyv to 0.8.13 and bytecheck to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,8 +2227,20 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
 dependencies = [
- "bytecheck_derive",
- "ptr_meta",
+ "bytecheck_derive 0.6.11",
+ "ptr_meta 0.1.4",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive 0.8.2",
+ "ptr_meta 0.3.1",
+ "rancor",
  "simdutf8",
 ]
 
@@ -2241,6 +2253,17 @@ dependencies = [
  "proc-macro2 1.0.101",
  "quote 1.0.40",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2 1.0.101",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7023,6 +7046,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2 1.0.101",
+ "quote 1.0.40",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8675,7 +8718,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
 dependencies = [
- "ptr_meta_derive",
+ "ptr_meta_derive 0.1.4",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive 0.3.1",
 ]
 
 [[package]]
@@ -8687,6 +8739,17 @@ dependencies = [
  "proc-macro2 1.0.101",
  "quote 1.0.40",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2 1.0.101",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8916,6 +8979,15 @@ checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
+]
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta 0.3.1",
 ]
 
 [[package]]
@@ -9324,7 +9396,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
 dependencies = [
- "bytecheck",
+ "bytecheck 0.6.11",
+]
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck 0.8.2",
 ]
 
 [[package]]
@@ -9507,13 +9588,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
- "bytecheck",
+ "bytecheck 0.6.11",
  "bytes 1.10.1",
  "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
+ "ptr_meta 0.1.4",
+ "rend 0.4.1",
+ "rkyv_derive 0.7.45",
  "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e88acca7157d83d789836a3987dafc12bc3d88a050e54b8fe9ea4aaa29d20"
+dependencies = [
+ "bytecheck 0.8.2",
+ "bytes 1.10.1",
+ "hashbrown 0.16.0",
+ "indexmap 2.12.0",
+ "munge",
+ "ptr_meta 0.3.1",
+ "rancor",
+ "rend 0.5.3",
+ "rkyv_derive 0.8.13",
  "tinyvec",
  "uuid",
 ]
@@ -9527,6 +9627,17 @@ dependencies = [
  "proc-macro2 1.0.101",
  "quote 1.0.40",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6dffea3c91fa91a3c0fc8a061b0e27fef25c6304728038a6d6bcb1c58ba9bd"
+dependencies = [
+ "proc-macro2 1.0.101",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -9663,7 +9774,7 @@ dependencies = [
  "bytes 1.10.1",
  "num-traits",
  "rand 0.8.5",
- "rkyv",
+ "rkyv 0.7.45",
  "serde",
  "serde_json",
 ]
@@ -12747,7 +12858,7 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
- "bytecheck",
+ "bytecheck 0.8.2",
  "bytes 1.10.1",
  "clap",
  "crc32fast",
@@ -12769,7 +12880,7 @@ dependencies = [
  "proptest",
  "quickcheck",
  "rand 0.9.2",
- "rkyv",
+ "rkyv 0.8.13",
  "serde",
  "serde_yaml",
  "snafu 0.8.9",

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 async-recursion = "1.1.1"
 async-stream = "0.3.6"
 async-trait.workspace = true
-bytecheck = { version = "0.6.9", default-features = false, features = ["std"] }
+bytecheck = { version = "0.8", default-features = false }
 bytes.workspace = true
 crc32fast = { version = "1.5.0", default-features = false }
 crossbeam-queue = { version = "0.3.12", default-features = false, features = ["std"] }

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -24,7 +24,7 @@ memmap2 = { version = "0.9.8", default-features = false }
 metrics.workspace = true
 num-traits = { version = "0.2.19", default-features = false }
 paste.workspace = true
-rkyv = { version = "0.7.45", default-features = false, features = ["size_32", "std", "strict", "validation"] }
+rkyv = { version = "0.8.13", default-features = true, features = ["pointer_width_32", "std", "bytecheck"] }
 serde.workspace = true
 snafu.workspace = true
 tokio-util = { version = "0.7.0", default-features = false }

--- a/lib/vector-buffers/src/variants/disk_v2/backed_archive.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/backed_archive.rs
@@ -1,22 +1,11 @@
 use std::marker::PhantomData;
-#[cfg(test)]
-use std::pin::Pin;
 
-use bytecheck::CheckBytes;
 use rkyv::{
     Archive, Serialize,
-    access::{archived_root, check_archived_root},
-    api::high::HighSerializer,
-    util::AlignedVec,
+    access_unchecked,
 };
 
 use super::ser::{DeserializeError, SerializeError};
-
-/// A batteries-included serializer implementation.
-///
-/// Callers do not need to know or care about this, but it must be public as it is part of the
-/// `BackedArchive` API.
-pub type DefaultSerializer = HighSerializer<AlignedVec, rkyv::rancor::Error>;
 
 /// Backed wrapper for any type that implements [`Archive`][archive].
 ///
@@ -60,6 +49,7 @@ impl<B, T> BackedArchive<B, T>
 where
     B: AsRef<[u8]>,
     T: Archive,
+    T::Archived: rkyv::Portable + for<'a> bytecheck::CheckBytes<rkyv::rancor::Strategy<rkyv::validation::Validator<rkyv::validation::archive::ArchiveValidator<'a>, rkyv::validation::shared::SharedValidator>, rkyv::rancor::Error>>,
 {
     /// Deserializes the archived value from the backing store and wraps it.
     ///
@@ -67,13 +57,11 @@ where
     ///
     /// If the data in the backing store is not valid for `T`, an error variant will be returned.
     pub fn from_backing(backing: B) -> Result<BackedArchive<B, T>, DeserializeError>
-    where
-        T::Archived: for<'a> CheckBytes<rkyv::validation::validators::DefaultValidator<'a>>,
     {
-        // Validate that the input is, well, valid.
-        _ = check_archived_root::<T>(backing.as_ref())?;
+        // Validate the archived data using rkyv::access with CheckBytes
+        let _ = rkyv::access::<T::Archived, rkyv::rancor::Error>(backing.as_ref())
+            .map_err(|e| DeserializeError::InvalidStructure(e.to_string()))?;
 
-        // Now that we know the buffer fits T, we're good to go!
         Ok(Self {
             backing,
             _archive: PhantomData,
@@ -87,14 +75,15 @@ where
 
     /// Gets a reference to the archived value.
     pub fn get_archive_ref(&self) -> &T::Archived {
-        unsafe { archived_root::<T>(self.backing.as_ref()) }
+        // SAFETY: We validated the data in from_backing, so this is safe
+        unsafe { access_unchecked::<T::Archived>(self.backing.as_ref()) }
     }
 }
 
 impl<B, T> BackedArchive<B, T>
 where
     B: AsMut<[u8]>,
-    T: Archive,
+    T: Archive + for<'a> Serialize<rkyv::rancor::Strategy<rkyv::ser::Serializer<rkyv::util::AlignedVec, rkyv::ser::allocator::ArenaHandle<'a>, rkyv::ser::sharing::Share>, rkyv::rancor::Error>>,
 {
     /// Serializes the provided value to the backing store and wraps it.
     ///
@@ -105,8 +94,6 @@ where
     /// the value, an error variant will be returned defining the minimum size the backing store
     /// must be, as well containing the value that failed to get serialized.
     pub fn from_value(mut backing: B, value: T) -> Result<BackedArchive<B, T>, SerializeError<T>>
-    where
-        T: for<'a> Serialize<HighSerializer<AlignedVec, rkyv::rancor::Error>>,
     {
         // Serialize our value so we can shove it into the backing.
         let src_buf = rkyv::to_bytes::<rkyv::rancor::Error>(&value)
@@ -128,14 +115,5 @@ where
             backing,
             _archive: PhantomData,
         })
-    }
-
-    /// Gets a reference to the archived value.
-    #[cfg(test)]
-    pub fn get_archive_mut(&mut self) -> Pin<&mut T::Archived> {
-        use rkyv::access::archived_root_mut;
-
-        let pinned = Pin::new(self.backing.as_mut());
-        unsafe { archived_root_mut::<T>(pinned) }
     }
 }

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crc32fast::Hasher;
-use rkyv::{AlignedVec, archived_root};
+use rkyv::{util::AlignedVec, access::archived_root};
 use snafu::{ResultExt, Snafu};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use vector_common::{finalization::BatchNotifier, finalizer::OrderedFinalizer};

--- a/lib/vector-buffers/src/variants/disk_v2/record.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/record.rs
@@ -1,10 +1,8 @@
-use std::{mem, ptr::addr_of};
+use std::mem;
 
-use bytecheck::{CheckBytes, ErrorBox, StructCheckError};
 use crc32fast::Hasher;
 use rkyv::{
-    Archive, Archived, Serialize,
-    boxed::ArchivedBox,
+    Archive, Serialize,
 };
 
 use super::{
@@ -12,7 +10,7 @@ use super::{
     ser::{DeserializeError, try_as_archive},
 };
 
-pub const RECORD_HEADER_LEN: usize = align16(mem::size_of::<ArchivedRecord<'_>>() + 8);
+pub const RECORD_HEADER_LEN: usize = align16(mem::size_of::<ArchivedRecord>() + 8);
 
 /// Result of checking if a buffer contained a valid record.
 pub enum RecordStatus {
@@ -43,11 +41,8 @@ pub enum RecordStatus {
 ///
 /// Do not do any of the listed things unless you _absolutely_ know what you're doing. :)
 #[derive(Archive, Serialize, Debug)]
-// Switch back to the derived implementation of CheckBytes once the upstream ICE issue is fixed.
-//
-// Upstream issue: https://github.com/rkyv/rkyv/issues/221
-//#[archive_attr(derive(CheckBytes))]
-pub struct Record<'a> {
+#[rkyv(attr(derive(Debug)))]
+pub struct Record {
     /// The checksum of the record.
     ///
     /// The checksum is CRC32C(BE(id) + BE(metadata) + payload), where BE(x) returns a byte slice of
@@ -67,69 +62,26 @@ pub struct Record<'a> {
     /// The record payload.
     ///
     /// This is the encoded form of the actual record itself.
-    payload: &'a [u8],
+    payload: Vec<u8>,
 }
 
-// Manual implementation of CheckBytes required as the derived version currently causes an internal
-// compiler error.
-//
-// Upstream issue: https://github.com/rkyv/rkyv/issues/221
-impl<'a, C: ?Sized> CheckBytes<C> for ArchivedRecord<'a>
-where
-    <&'a [u8] as Archive>::Archived: CheckBytes<C>,
-{
-    type Error = StructCheckError;
-    unsafe fn check_bytes<'b>(
-        value: *const Self,
-        context: &mut C,
-    ) -> Result<&'b Self, Self::Error> {
-        unsafe {
-            Archived::<u32>::check_bytes(addr_of!((*value).checksum), context).map_err(|e| {
-                StructCheckError {
-                    field_name: "checksum",
-                    inner: ErrorBox::new(e),
-                }
-            })?;
-            Archived::<u64>::check_bytes(addr_of!((*value).id), context).map_err(|e| {
-                StructCheckError {
-                    field_name: "id",
-                    inner: ErrorBox::new(e),
-                }
-            })?;
-            Archived::<u32>::check_bytes(addr_of!((*value).metadata), context).map_err(|e| {
-                StructCheckError {
-                    field_name: "schema_metadata",
-                    inner: ErrorBox::new(e),
-                }
-            })?;
-            <&'a [u8] as Archive>::Archived::check_bytes(addr_of!((*value).payload), context).map_err(|e| {
-                StructCheckError {
-                    field_name: "payload",
-                    inner: ErrorBox::new(e),
-                }
-            })?;
-            Ok(&*value)
-        }
-    }
-}
-
-impl<'a> Record<'a> {
+impl Record {
     /// Creates a [`Record`] from the ID and payload, and calculates the checksum.
-    pub fn with_checksum(id: u64, metadata: u32, payload: &'a [u8], checksummer: &Hasher) -> Self {
+    pub fn with_checksum(id: u64, metadata: u32, payload: &[u8], checksummer: &Hasher) -> Self {
         let checksum = generate_checksum(checksummer, id, metadata, payload);
         Self {
             checksum,
             id,
             metadata,
-            payload,
+            payload: payload.to_vec(),
         }
     }
 }
 
-impl ArchivedRecord<'_> {
+impl ArchivedRecord {
     /// Gets the metadata of this record.
     pub fn metadata(&self) -> u32 {
-        self.metadata
+        self.metadata.into()
     }
 
     /// Gets the payload of this record.
@@ -139,13 +91,15 @@ impl ArchivedRecord<'_> {
 
     /// Verifies if the stored checksum of this record matches the record itself.
     pub fn verify_checksum(&self, checksummer: &Hasher) -> RecordStatus {
-        let calculated = generate_checksum(checksummer, self.id, self.metadata, &self.payload);
-        if self.checksum == calculated {
-            RecordStatus::Valid { id: self.id }
+        let calculated = generate_checksum(checksummer, self.id.into(), self.metadata.into(), &self.payload);
+        let checksum: u32 = self.checksum.into();
+        let id: u64 = self.id.into();
+        if checksum == calculated {
+            RecordStatus::Valid { id }
         } else {
             RecordStatus::Corrupted {
                 calculated,
-                actual: self.checksum,
+                actual: checksum,
             }
         }
     }
@@ -187,6 +141,6 @@ pub fn validate_record_archive(buf: &[u8], checksummer: &Hasher) -> RecordStatus
 /// will be returned.  Otherwise, the deserialization error encountered will be provided, which describes the error in a more verbose,
 /// debugging-oriented fashion.
 #[cfg_attr(test, instrument(skip_all, level = "trace"))]
-pub fn try_as_record_archive(buf: &[u8]) -> Result<&ArchivedRecord<'_>, DeserializeError> {
-    try_as_archive::<Record<'_>>(buf)
+pub fn try_as_record_archive(buf: &[u8]) -> Result<&ArchivedRecord, DeserializeError> {
+    try_as_archive::<Record>(buf)
 }

--- a/lib/vector-buffers/src/variants/disk_v2/ser.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ser.rs
@@ -1,11 +1,4 @@
-use std::fmt;
-
-use bytecheck::CheckBytes;
-use rkyv::{
-    Archive,
-    access::check_archived_root,
-    validation::{CheckArchiveError, validators::DefaultValidator},
-};
+use rkyv::{Archive, rancor::Error};
 
 /// Error that occurred during serialization.
 #[derive(Debug)]
@@ -46,6 +39,7 @@ pub enum DeserializeError {
     ///
     /// The backing store that was given is returned, along with an error string that briefly
     /// describes the error in a more verbose fashion, suitable for debugging.
+    #[allow(dead_code)]
     InvalidData(String),
 }
 
@@ -59,20 +53,9 @@ impl DeserializeError {
     }
 }
 
-impl<T, C> From<CheckArchiveError<T, C>> for DeserializeError
-where
-    T: fmt::Display,
-    C: fmt::Display,
-{
-    fn from(e: CheckArchiveError<T, C>) -> Self {
-        match e {
-            CheckArchiveError::ContextError(ce) => {
-                DeserializeError::InvalidStructure(ce.to_string())
-            }
-            CheckArchiveError::CheckBytesError(cbe) => {
-                DeserializeError::InvalidData(cbe.to_string())
-            }
-        }
+impl From<Error> for DeserializeError {
+    fn from(e: Error) -> Self {
+        DeserializeError::InvalidStructure(e.to_string())
     }
 }
 
@@ -89,8 +72,11 @@ where
 pub fn try_as_archive<'a, T>(buf: &'a [u8]) -> Result<&'a T::Archived, DeserializeError>
 where
     T: Archive,
-    T::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
+    T::Archived: rkyv::Portable + for<'b> bytecheck::CheckBytes<rkyv::rancor::Strategy<rkyv::validation::Validator<rkyv::validation::archive::ArchiveValidator<'b>, rkyv::validation::shared::SharedValidator>, rkyv::rancor::Error>>,
 {
     debug_assert!(!buf.is_empty());
-    check_archived_root::<T>(buf).map_err(Into::into)
+
+    // Use rkyv::access which performs CheckBytes validation in rkyv 0.8
+    rkyv::access::<T::Archived, Error>(buf)
+        .map_err(|e| DeserializeError::InvalidStructure(e.to_string()))
 }

--- a/lib/vector-buffers/src/variants/disk_v2/ser.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ser.rs
@@ -2,7 +2,8 @@ use std::fmt;
 
 use bytecheck::CheckBytes;
 use rkyv::{
-    Archive, check_archived_root,
+    Archive,
+    access::check_archived_root,
     validation::{CheckArchiveError, validators::DefaultValidator},
 };
 

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -11,14 +11,9 @@ use std::{
 use bytes::BufMut;
 use crc32fast::Hasher;
 use rkyv::{
-    AlignedVec, Infallible,
-    ser::{
-        Serializer,
-        serializers::{
-            AlignedSerializer, AllocScratch, AllocScratchError, BufferScratch, CompositeSerializer,
-            CompositeSerializerError, FallbackScratch,
-        },
-    },
+    util::AlignedVec,
+    rancor::Infallible,
+    api::high::HighSerializer,
 };
 use snafu::{ResultExt, Snafu};
 use tokio::io::{AsyncWrite, AsyncWriteExt};

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp::Ordering,
-    convert::Infallible as StdInfallible,
     fmt,
     io::{self, ErrorKind},
     marker::PhantomData,
@@ -10,11 +9,7 @@ use std::{
 
 use bytes::BufMut;
 use crc32fast::Hasher;
-use rkyv::{
-    util::AlignedVec,
-    rancor::Infallible,
-    api::high::HighSerializer,
-};
+use rkyv::util::AlignedVec;
 use snafu::{ResultExt, Snafu};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
@@ -174,18 +169,13 @@ impl<T: Bufferable + PartialEq> PartialEq for WriterError<T> {
     }
 }
 
-impl<T> From<CompositeSerializerError<StdInfallible, AllocScratchError, StdInfallible>>
-    for WriterError<T>
+impl<T> From<rkyv::rancor::Error> for WriterError<T>
 where
     T: Bufferable,
 {
-    fn from(e: CompositeSerializerError<StdInfallible, AllocScratchError, StdInfallible>) -> Self {
-        match e {
-            CompositeSerializerError::ScratchSpaceError(sse) => WriterError::FailedToSerialize {
-                reason: format!("insufficient space to serialize encoded record: {sse}"),
-            },
-            // Only our scratch space strategy is fallible, so we should never get here.
-            _ => unreachable!(),
+    fn from(e: rkyv::rancor::Error) -> Self {
+        WriterError::FailedToSerialize {
+            reason: format!("failed to serialize encoded record: {e}"),
         }
     }
 }
@@ -480,9 +470,7 @@ where
             Record::with_checksum(id, metadata, &self.encode_buf, &self.checksummer);
 
         // Push 8 dummy bytes where our length delimiter will sit.  We'll fix this up after
-        // serialization.  Notably, `AlignedSerializer` will report the serializer position as
-        // the length of its backing store, which now includes our 8 bytes, so we _subtract_
-        // those from the position when figuring out the actual value to write back after.
+        // serialization.
         //
         // We write it this way -- in the serializer buffer, and not as a separate write -- so that
         // we can do a single write but also so that we always have an aligned buffer.
@@ -491,18 +479,10 @@ where
 
         // Now serialize the record, which puts it into its archived form.  This is what powers our
         // ability to do zero-copy deserialization from disk.
-        let mut serializer = CompositeSerializer::new(
-            AlignedSerializer::new(&mut self.ser_buf),
-            FallbackScratch::new(
-                BufferScratch::new(&mut self.ser_scratch),
-                AllocScratch::new(),
-            ),
-            Infallible,
-        );
+        let serialized_record = rkyv::to_bytes::<rkyv::rancor::Error>(&wrapped_record)?;
+        self.ser_buf.extend_from_slice(&serialized_record);
 
-        let serialized_len = serializer
-            .serialize_value(&wrapped_record)
-            .map(|_| serializer.pos())?;
+        let serialized_len = self.ser_buf.len();
 
         // Sanity check before we do our length math.
         if serialized_len <= 8 || self.ser_buf.len() != serialized_len {


### PR DESCRIPTION
## Summary

Migrate vector-buffers from rkyv 0.7 to 0.8 and bytecheck from 0.6 to 0.8

## Vector configuration



## How did you test this PR?

Ran `cargo test --lib` in vector-buffers. 72/73 tests pass.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
