### PR TITLE
enhancement(observability): Add `_utilization_mean` buffer metrics

### DIFF
--- a/changelog.d/buffer_utilization_mean_metrics.enhancement.md
+++ b/changelog.d/buffer_utilization_mean_metrics.enhancement.md
@@ -1,0 +1,3 @@
+Added moving-mean gauges for source and transform buffers (`source_buffer_utilization_mean` and `transform_buffer_utilization_mean`), so observers can track an EWMA of buffer utilization in addition to the instant level.
+
+authors: bruceg

--- a/lib/vector-common/src/atomic.rs
+++ b/lib/vector-common/src/atomic.rs
@@ -1,0 +1,49 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use metrics::GaugeFn;
+
+/// Simple atomic wrapper for `f64` values.
+#[derive(Debug)]
+pub struct AtomicF64(AtomicU64);
+
+impl AtomicF64 {
+    /// Creates a new `AtomicF64` with the given initial value.
+    #[must_use]
+    pub fn new(init: f64) -> Self {
+        Self(AtomicU64::new(init.to_bits()))
+    }
+
+    pub fn load(&self, order: Ordering) -> f64 {
+        f64::from_bits(self.0.load(order))
+    }
+
+    #[expect(clippy::missing_panics_doc, reason = "fetch_update always succeeds")]
+    pub fn fetch_update(
+        &self,
+        set_order: Ordering,
+        fetch_order: Ordering,
+        mut f: impl FnMut(f64) -> f64,
+    ) -> f64 {
+        f64::from_bits(
+            self.0
+                .fetch_update(set_order, fetch_order, |x| {
+                    Some(f(f64::from_bits(x)).to_bits())
+                })
+                .expect("fetch_update always succeeds"),
+        )
+    }
+}
+
+impl GaugeFn for AtomicF64 {
+    fn increment(&self, amount: f64) {
+        self.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| value + amount);
+    }
+
+    fn decrement(&self, amount: f64) {
+        self.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| value - amount);
+    }
+
+    fn set(&self, value: f64) {
+        self.0.store(f64::to_bits(value), Ordering::Relaxed);
+    }
+}

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -59,6 +59,7 @@ pub mod shutdown;
 #[cfg(feature = "sensitive_string")]
 pub mod sensitive_string;
 
+pub mod atomic;
 pub mod trigger;
 
 #[macro_use]

--- a/lib/vector-common/src/lib.rs
+++ b/lib/vector-common/src/lib.rs
@@ -60,6 +60,7 @@ pub mod shutdown;
 pub mod sensitive_string;
 
 pub mod atomic;
+pub mod stats;
 pub mod trigger;
 
 #[macro_use]

--- a/lib/vector-common/src/stats.rs
+++ b/lib/vector-common/src/stats.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+
 /// Exponentially Weighted Moving Average
 #[derive(Clone, Copy, Debug)]
 pub struct Ewma {
@@ -7,11 +8,13 @@ pub struct Ewma {
 }
 
 impl Ewma {
+    #[must_use]
     pub const fn new(alpha: f64) -> Self {
         let average = None;
         Self { average, alpha }
     }
 
+    #[must_use]
     pub const fn average(&self) -> Option<f64> {
         self.average
     }
@@ -35,6 +38,7 @@ pub struct EwmaDefault {
 }
 
 impl EwmaDefault {
+    #[must_use]
     pub const fn new(alpha: f64, initial_value: f64) -> Self {
         Self {
             average: initial_value,
@@ -42,6 +46,7 @@ impl EwmaDefault {
         }
     }
 
+    #[must_use]
     pub const fn average(&self) -> f64 {
         self.average
     }
@@ -67,21 +72,25 @@ pub struct MeanVariance {
 }
 
 impl EwmaVar {
+    #[must_use]
     pub const fn new(alpha: f64) -> Self {
         let state = None;
         Self { state, alpha }
     }
 
+    #[must_use]
     pub const fn state(&self) -> Option<MeanVariance> {
         self.state
     }
 
     #[cfg(test)]
+    #[must_use]
     pub fn average(&self) -> Option<f64> {
         self.state.map(|state| state.mean)
     }
 
     #[cfg(test)]
+    #[must_use]
     pub fn variance(&self) -> Option<f64> {
         self.state.map(|state| state.variance)
     }
@@ -114,11 +123,16 @@ pub struct Mean {
 
 impl Mean {
     /// Update the and return the current average
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "We have to convert count to f64 for the calculation, it's okay to lose precision for very large counts."
+    )]
     pub fn update(&mut self, point: f64) {
         self.count += 1;
         self.mean += (point - self.mean) / self.count as f64;
     }
 
+    #[must_use]
     pub const fn average(&self) -> Option<f64> {
         match self.count {
             0 => None,

--- a/lib/vector-core/src/metrics/recency.rs
+++ b/lib/vector-core/src/metrics/recency.rs
@@ -63,8 +63,9 @@ use metrics_util::{
 };
 use parking_lot::Mutex;
 use quanta::{Clock, Instant};
+use vector_common::atomic::AtomicF64;
 
-use super::storage::{AtomicF64, Histogram};
+use super::storage::Histogram;
 
 /// The generation of a metric.
 ///

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -266,7 +266,7 @@ async fn emits_buffer_utilization_histogram_on_send_and_receive() {
         .into_iter()
         .filter(|metric| metric.name().starts_with("source_buffer_"))
         .collect();
-    assert_eq!(metrics.len(), 3, "expected 3 utilization metrics");
+    assert_eq!(metrics.len(), 4, "expected 4 utilization metrics");
 
     let find_metric = |name: &str| {
         metrics

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -10,8 +10,8 @@ pub use vector_buffers as buffers;
 #[cfg(feature = "test")]
 pub use vector_common::event_test_util;
 pub use vector_common::{
-    Error, NamedInternalEvent, Result, TimeZone, assert_event_data_eq, btreemap, byte_size_of,
-    byte_size_of::ByteSizeOf, conversion, encode_logfmt, finalization, finalizer, id,
+    Error, NamedInternalEvent, Result, TimeZone, assert_event_data_eq, atomic, btreemap,
+    byte_size_of, byte_size_of::ByteSizeOf, conversion, encode_logfmt, finalization, finalizer, id,
     impl_event_data_eq, internal_event, json_size, registered_event, request_metadata,
     sensitive_string, shutdown, trigger,
 };

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -13,7 +13,7 @@ pub use vector_common::{
     Error, NamedInternalEvent, Result, TimeZone, assert_event_data_eq, atomic, btreemap,
     byte_size_of, byte_size_of::ByteSizeOf, conversion, encode_logfmt, finalization, finalizer, id,
     impl_event_data_eq, internal_event, json_size, registered_event, request_metadata,
-    sensitive_string, shutdown, trigger,
+    sensitive_string, shutdown, stats, trigger,
 };
 pub use vector_config as configurable;
 pub use vector_config::impl_generate_config_from_default;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,6 @@ pub(crate) mod sink_ext;
 pub mod sinks;
 #[allow(unreachable_pub)]
 pub mod sources;
-pub mod stats;
 #[cfg(feature = "api-client")]
 #[allow(unreachable_pub)]
 pub mod tap;

--- a/src/sinks/util/adaptive_concurrency/controller.rs
+++ b/src/sinks/util/adaptive_concurrency/controller.rs
@@ -7,6 +7,7 @@ use std::{
 use tokio::sync::OwnedSemaphorePermit;
 use tower::timeout::error::Elapsed;
 use vector_lib::internal_event::{InternalEventHandle as _, Registered};
+use vector_lib::stats::{EwmaVar, Mean, MeanVariance};
 
 use super::{AdaptiveConcurrencySettings, instant_now, semaphore::ShrinkableSemaphore};
 #[cfg(test)]
@@ -18,7 +19,6 @@ use crate::{
         AdaptiveConcurrencyLimitData, AdaptiveConcurrencyObservedRtt,
     },
     sinks::util::retries::{RetryAction, RetryLogic},
-    stats::{EwmaVar, Mean, MeanVariance},
 };
 
 /// Shared class for `tokio::sync::Semaphore` that manages adjusting the

--- a/src/sources/util/net/tcp/request_limiter.rs
+++ b/src/sources/util/net/tcp/request_limiter.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-
-use crate::stats::EwmaDefault;
+use vector_lib::stats::EwmaDefault;
 
 const EWMA_WEIGHT: f64 = 0.1;
 const MINIMUM_PERMITS: usize = 2;

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -20,9 +20,7 @@ use tokio::{
     time::interval,
 };
 use tokio_stream::wrappers::IntervalStream;
-use vector_lib::{id::ComponentKey, shutdown::ShutdownSignal};
-
-use crate::stats;
+use vector_lib::{id::ComponentKey, shutdown::ShutdownSignal, stats};
 
 const UTILIZATION_EMITTER_DURATION: Duration = Duration::from_secs(5);
 

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -421,5 +421,6 @@ components: sources: [Name=string]: {
 		source_buffer_max_event_size:         components.sources.internal_metrics.output.metrics.source_buffer_max_event_size
 		source_buffer_utilization:            components.sources.internal_metrics.output.metrics.source_buffer_utilization
 		source_buffer_utilization_level:      components.sources.internal_metrics.output.metrics.source_buffer_utilization_level
+		source_buffer_utilization_mean:       components.sources.internal_metrics.output.metrics.source_buffer_utilization_mean
 	}
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -719,7 +719,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		source_buffer_max_byte_size: {
-			description:       "The maximum number of bytes the buffer that the source's outputs send into can hold."
+			description:       "The maximum number of bytes the source buffer can hold. The output(s) of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -727,7 +727,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_max_event_size: {
-			description:       "The maximum number of events the buffer that the source's outputs send into can hold."
+			description:       "The maximum number of events the source buffer can hold. The output(s) of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -735,7 +735,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_utilization: {
-			description:       "The utilization level of the buffer that the source's outputs send into."
+			description:       "The utilization level of the source buffer. The output(s) of the source send data to this buffer."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -743,7 +743,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_utilization_level: {
-			description:       "The current utilization level of the buffer that the source's outputs send into."
+			description:       "The current utilization level of the source buffer. The output(s) of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -751,7 +751,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_utilization_mean: {
-			description:       "The mean utilization level of the buffer that the source's outputs send into. This value is smoothed over time using an exponentially weighted moving average (EWMA)."
+			description:       "The mean utilization level of the source buffer. The output(s) of the source send data to this buffer. The mean utilization is smoothed over time using an exponentially weighted moving average (EWMA)."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -719,7 +719,7 @@ components: sources: internal_metrics: {
 			tags:              _component_tags
 		}
 		source_buffer_max_byte_size: {
-			description:       "The maximum number of bytes the source buffer can hold. The output(s) of the source send data to this buffer."
+			description:       "The maximum number of bytes the source buffer can hold. The outputs of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -727,7 +727,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_max_event_size: {
-			description:       "The maximum number of events the source buffer can hold. The output(s) of the source send data to this buffer."
+			description:       "The maximum number of events the source buffer can hold. The outputs of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -735,7 +735,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_utilization: {
-			description:       "The utilization level of the source buffer. The output(s) of the source send data to this buffer."
+			description:       "The utilization level of the source buffer. The outputs of the source send data to this buffer."
 			type:              "histogram"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -743,7 +743,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_utilization_level: {
-			description:       "The current utilization level of the source buffer. The output(s) of the source send data to this buffer."
+			description:       "The current utilization level of the source buffer. The outputs of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {
@@ -751,7 +751,7 @@ components: sources: internal_metrics: {
 			}
 		}
 		source_buffer_utilization_mean: {
-			description:       "The mean utilization level of the source buffer. The output(s) of the source send data to this buffer. The mean utilization is smoothed over time using an exponentially weighted moving average (EWMA)."
+			description:       "The mean utilization level of the source buffer. The outputs of the source send data to this buffer. The mean utilization is smoothed over time using an exponentially weighted moving average (EWMA)."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -750,6 +750,14 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 		}
+		source_buffer_utilization_mean: {
+			description:       "The mean utilization level of the buffer that the source's outputs send into. This value is smoothed over time using an exponentially weighted moving average (EWMA)."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
 		splunk_pending_acks: {
 			description:       "The number of outstanding Splunk HEC indexer acknowledgement acks."
 			type:              "gauge"
@@ -876,6 +884,14 @@ components: sources: internal_metrics: {
 		}
 		transform_buffer_utilization_level: {
 			description:       "The current utilization level of the buffer that feeds into a transform."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		transform_buffer_utilization_mean: {
+			description:       "The mean utilization level of the buffer that feeds into a transform. This value is smoothed over time using an exponentially weighted moving average (EWMA)."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -24,6 +24,7 @@ components: transforms: [Name=string]: {
 		transform_buffer_max_byte_size:       components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
 		transform_buffer_utilization:         components.sources.internal_metrics.output.metrics.transform_buffer_utilization
 		transform_buffer_utilization_level:   components.sources.internal_metrics.output.metrics.transform_buffer_utilization_level
+		transform_buffer_utilization_mean:    components.sources.internal_metrics.output.metrics.transform_buffer_utilization_mean
 		utilization:                          components.sources.internal_metrics.output.metrics.utilization
 	}
 }


### PR DESCRIPTION
## Summary

The source and transform buffer utilization metrics currently measure either the
instantaneous level or a histogram, neither of which is a reliable single-valued
reflection of the actual status. For this purpose, we introduce a `mean` metric
that uses the EWMA calculations to produce a simple moving average that will
better track the actual value.

## Vector configuration

```
[sources.metrics]
type = "internal_metrics"

[transforms.filter]
type = "filter"
inputs = ["metrics"]
condition.type = "is_metric"

[sinks.console]
type = "console"
inputs = ["filter"]
encoding.codec = "text"
```

## How did you test this PR?

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
