### PR TITLE
docs(file source): Clarify glob syntax in file source documentation

### DIFF
--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -234,6 +234,12 @@ components: sources: file: {
 				[Globbing](\(urls.globbing)) is supported in all provided file paths,
 				files will be autodiscovered continually at a rate defined by the
 				`glob_minimum_cooldown` option.
+
+				Vector uses the Rust [`glob` crate](\(urls.glob_crate)) for pattern matching.
+				Basic glob functionality should work as expected, including multiple wildcards in a
+				single path (e.g., `/opt/nomad/data/alloc/*/alloc/logs/monitor.std*.*`) and
+				recursive directory matching with `**` (e.g., `/var/lib/kubelet/pods/**/logs/*.log`).
+				See the [glob crate documentation](\(urls.glob_crate_pattern)) for complete syntax details.
 				"""
 		}
 

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -235,6 +235,8 @@ urls: {
 	github:                                     "https://github.com"
 	github_protected_branches:                  "https://help.github.com/en/github/administering-a-repository/about-protected-branches"
 	github_sign_commits:                        "https://help.github.com/en/github/authenticating-to-github/signing-commits"
+	glob_crate:                                 "https://crates.io/crates/glob"
+	glob_crate_pattern:                         "https://docs.rs/glob/latest/glob/struct.Pattern.html"
 	globbing:                                   "\(wikipedia)/wiki/Glob_(programming)"
 	glog:                                       "\(github)/google/glog"
 	graphql:                                    "https://graphql.org"


### PR DESCRIPTION
## Summary

Adds clarification to the file source documentation about glob pattern support, mentioning that Vector uses the Rust glob crate and providing examples of valid patterns.

## Vector configuration

NA

## How did you test this PR?

Documentation-only change. Verified CUE syntax is correct.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #4147