### PR TITLE
enhancement(observability): Standardize buffer size metric names

### DIFF
--- a/changelog.d/buffer_size_metrics.deprecation.md
+++ b/changelog.d/buffer_size_metrics.deprecation.md
@@ -1,0 +1,10 @@
+Buffers now emit metric names for sizes that better follow the metric naming standard specification
+while keeping the old related gauges available for a transition period. Operators should update
+dashboards/alerts to the new variants as the legacy names are now deprecated.
+
+* `buffer_max_size_bytes` deprecates `buffer_max_byte_size`
+* `buffer_max_size_events` deprecates `buffer_max_event_size`
+* `buffer_size_bytes` deprecates `buffer_byte_size`
+* `buffer_size_events` deprecates `buffer_events`
+
+authors: bruceg

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -68,8 +68,8 @@ When possible, Vector will error at start-up when a removed configuration option
 
 When introducing a deprecation into Vector, the pull request introducing the deprecation should:
 
-- Add a note to the Deprecations section of the upgrade guide for the next release with a description and
-  directions for transitioning if applicable.
+- Add a note to the Deprecations section of the upgrade guide in `website/content/en/highlights` for
+  the next release with a description and directions for transitioning if applicable.
 - Copy the same note from the previous step, to a changelog fragment, with type="deprecation". See the changelog
   fragment [README.md](../changelog.d/README.md) for details.
 - Add a deprecation note to the docs. Typically, this means adding `deprecation: "description of the deprecation"`
@@ -80,7 +80,7 @@ When introducing a deprecation into Vector, the pull request introducing the dep
   the new name will be appended with the text `(formerly OldName)`.
 - Add a log message to Vector that is logged at the `WARN` level starting with the word `DEPRECATION` if Vector detects
   the deprecated configuration or feature being used (when possible).
-- Add the deprecation to [DEPRECATIONS.md](DEPRECATIONS.md) to track migration (if applicable) and removal
+- Add the deprecation to [docs/DEPRECATIONS.md](../docs/DEPRECATIONS.md) to track migration (if applicable) and removal
 
 When removing a deprecation in a subsequent release, the pull request should:
 
@@ -90,4 +90,4 @@ When removing a deprecation in a subsequent release, the pull request should:
   for transitioning if applicable.
 - Copy the same note from the previous step, to a changelog fragment, with type="breaking". See the changelog
   fragment [README.md](../changelog.d/README.md) for details.
-- Remove the deprecation from [DEPRECATIONS.md](DEPRECATIONS.md)
+- Remove the deprecation from [docs/DEPRECATIONS.md](../docs/DEPRECATIONS.md)

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -15,6 +15,7 @@ For example:
 ## To be deprecated
 
 - `v0.50.0` | `http-server-encoding` | The `encoding` field will be removed. Use `decoding` and `framing` instead.
+- `v0.53.0` | `buffer-bytes-events-metrics` | The `buffer_byte_size` and `buffer_events` gauges are deprecated in favor of the `buffer_size_bytes`/`buffer_size_events` metrics described in `docs/specs/buffer.md`.
 
 ## To be migrated
 

--- a/docs/specs/buffer.md
+++ b/docs/specs/buffer.md
@@ -42,8 +42,8 @@ _All buffers_ MUST emit a `BufferCreated` event upon creation. To avoid stale me
   - `max_size_bytes` - the max size of the buffer in bytes if relevant
   - `max_size_events` - the max size of the buffer in number of events if relevant
 - Metric
-  - MUST emit the `buffer_max_event_size` gauge (in-memory buffers) if the defined `max_size_events` value is present
-  - MUST emit the `buffer_max_byte_size` gauge (disk buffers) if the defined `max_size_bytes` value is present
+  - MUST emit the `buffer_max_size_events` gauge (in-memory buffers) if the defined `max_size_events` value is present, and emit `buffer_max_event_size` for backward compatibility
+  - MUST emit the `buffer_max_size_bytes` gauge (disk buffers) if the defined `max_size_bytes` value is present, and emit `buffer_max_byte_size` for backward compatibility
 
 #### BufferEventsReceived
 
@@ -58,8 +58,8 @@ _All buffers_ MUST emit a `BufferEventsReceived` event:
 - Metric
   - MUST increment the `buffer_received_events_total` counter by the defined `count`
   - MUST increment the `buffer_received_bytes_total` counter by the defined `byte_size`
-  - MUST increment the `buffer_events` gauge by the defined `count`
-  - MUST increment the `buffer_byte_size` gauge by the defined `byte_size`
+  - MUST increment the `buffer_size_events` gauge by the defined `count`, and emit `buffer_events` for backward compatibility
+  - MUST increment the `buffer_size_bytes` gauge by the defined `byte_size`, and emit `buffer_byte_size` for backward compatibility
 
 #### BufferEventsSent
 
@@ -71,8 +71,8 @@ _All buffers_ MUST emit a `BufferEventsSent` event after sending one or more Vec
 - Metric
   - MUST increment the `buffer_sent_events_total` counter by the defined `count`
   - MUST increment the `buffer_sent_bytes_total` counter by the defined `byte_size`
-  - MUST decrement the `buffer_events` gauge by the defined `count`
-  - MUST decrement the `buffer_byte_size` gauge by the defined `byte_size`
+  - MUST decrement the `buffer_size_events` gauge by the defined `count`, and emit `buffer_events` for backward compatibility
+  - MUST decrement the `buffer_size_bytes` gauge by the defined `byte_size`, and emit `buffer_byte_size` for backward compatibility
 
 #### BufferError
 

--- a/lib/vector-buffers/src/internal_events.rs
+++ b/lib/vector-buffers/src/internal_events.rs
@@ -18,19 +18,34 @@ pub struct BufferCreated {
 impl InternalEvent for BufferCreated {
     #[expect(clippy::cast_precision_loss)]
     fn emit(self) {
+        let stage = self.idx.to_string();
         if self.max_size_events != 0 {
+            gauge!(
+                "buffer_max_size_events",
+                "buffer_id" => self.buffer_id.clone(),
+                "stage" => stage.clone(),
+            )
+            .set(self.max_size_events as f64);
+            // DEPRECATED: buffer-bytes-events-metrics
             gauge!(
                 "buffer_max_event_size",
                 "buffer_id" => self.buffer_id.clone(),
-                "stage" => self.idx.to_string(),
+                "stage" => stage.clone(),
             )
             .set(self.max_size_events as f64);
         }
         if self.max_size_bytes != 0 {
             gauge!(
+                "buffer_max_size_bytes",
+                "buffer_id" => self.buffer_id.clone(),
+                "stage" => stage.clone(),
+            )
+            .set(self.max_size_bytes as f64);
+            // DEPRECATED: buffer-bytes-events-metrics
+            gauge!(
                 "buffer_max_byte_size",
                 "buffer_id" => self.buffer_id,
-                "stage" => self.idx.to_string(),
+                "stage" => stage,
             )
             .set(self.max_size_bytes as f64);
         }
@@ -63,12 +78,26 @@ impl InternalEvent for BufferEventsReceived {
             "stage" => self.idx.to_string()
         )
         .increment(self.byte_size);
+        // DEPRECATED: buffer-bytes-events-metrics
         gauge!(
             "buffer_events",
             "buffer_id" => self.buffer_id.clone(),
             "stage" => self.idx.to_string()
         )
         .set(self.total_count as f64);
+        gauge!(
+            "buffer_size_events",
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        )
+        .set(self.total_count as f64);
+        gauge!(
+            "buffer_size_bytes",
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        )
+        .set(self.total_byte_size as f64);
+        // DEPRECATED: buffer-bytes-events-metrics
         gauge!(
             "buffer_byte_size",
             "buffer_id" => self.buffer_id,
@@ -103,12 +132,26 @@ impl InternalEvent for BufferEventsSent {
             "stage" => self.idx.to_string()
         )
         .increment(self.byte_size);
+        // DEPRECATED: buffer-bytes-events-metrics
         gauge!(
             "buffer_events",
             "buffer_id" => self.buffer_id.clone(),
             "stage" => self.idx.to_string()
         )
         .set(self.total_count as f64);
+        gauge!(
+            "buffer_size_events",
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        )
+        .set(self.total_count as f64);
+        gauge!(
+            "buffer_size_bytes",
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        )
+        .set(self.total_byte_size as f64);
+        // DEPRECATED: buffer-bytes-events-metrics
         gauge!(
             "buffer_byte_size",
             "buffer_id" => self.buffer_id,
@@ -170,12 +213,26 @@ impl InternalEvent for BufferEventsDropped {
             "intentional" => intentional_str,
         )
         .increment(self.byte_size);
+        // DEPRECATED: buffer-bytes-events-metrics
         gauge!(
             "buffer_events",
             "buffer_id" => self.buffer_id.clone(),
             "stage" => self.idx.to_string()
         )
         .set(self.total_count as f64);
+        gauge!(
+            "buffer_size_events",
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        )
+        .set(self.total_count as f64);
+        gauge!(
+            "buffer_size_bytes",
+            "buffer_id" => self.buffer_id.clone(),
+            "stage" => self.idx.to_string()
+        )
+        .set(self.total_byte_size as f64);
+        // DEPRECATED: buffer-bytes-events-metrics
         gauge!(
             "buffer_byte_size",
             "buffer_id" => self.buffer_id,

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -266,7 +266,7 @@ async fn emits_buffer_utilization_histogram_on_send_and_receive() {
         .into_iter()
         .filter(|metric| metric.name().starts_with("source_buffer_"))
         .collect();
-    assert_eq!(metrics.len(), 4, "expected 4 utilization metrics");
+    assert_eq!(metrics.len(), 5, "expected 5 utilization metrics");
 
     let find_metric = |name: &str| {
         metrics
@@ -288,6 +288,12 @@ async fn emits_buffer_utilization_histogram_on_send_and_receive() {
     let metric = find_metric("source_buffer_max_event_size");
     let MetricValue::Gauge { value } = metric.value() else {
         panic!("source_buffer_max_event_size should be a gauge");
+    };
+    assert_eq!(*value, buffer_size as f64);
+
+    let metric = find_metric("source_buffer_max_size_events");
+    let MetricValue::Gauge { value } = metric.value() else {
+        panic!("source_buffer_max_size_events should be a gauge");
     };
     assert_eq!(*value, buffer_size as f64);
 }

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -66,11 +66,12 @@ pub const HTTP_SINK_TAGS: [&str; 2] = ["endpoint", "protocol"];
 pub const AWS_SINK_TAGS: [&str; 2] = ["protocol", "region"];
 
 /// The set of suffixes that define the source/transform buffer metric family.
-const BUFFER_METRIC_SUFFIXES: [&str; 3] = [
-    // While hypothetically possible, the `max_byte_size` metric is never actually emitted, because
-    // both sources and transforms limit their buffers by event count. If we ever allow
-    // configuration by byte size, we will need to account for this in these tests.
+const BUFFER_METRIC_SUFFIXES: [&str; 4] = [
+    // While hypothetically possible, the `max_byte_size`/`max_size_bytes` metrics are never
+    // actually emitted, because both sources and transforms limit their buffers by event count. If
+    // we ever allow configuration by byte size, we will need to account for this in these tests.
     "max_event_size",
+    "max_size_events",
     "utilization",
     "utilization_level",
 ];

--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -469,8 +469,12 @@ components: {
 	}
 
 	#MetricOutput: [Name=string]: {
-		description:        string
-		relevant_when?:     string
+		description:    string
+		relevant_when?: string
+		deprecated:     bool | *false
+		if deprecated {
+			deprecated_message?: string
+		}
 		tags?:              #MetricTags
 		name?:              Name
 		type?:              #MetricType

--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -663,6 +663,8 @@ components: sinks: [Name=string]: {
 	telemetry: metrics: {
 		buffer_byte_size:                     components.sources.internal_metrics.output.metrics.buffer_byte_size
 		buffer_discarded_events_total:        components.sources.internal_metrics.output.metrics.buffer_discarded_events_total
+		buffer_size_bytes:                    components.sources.internal_metrics.output.metrics.buffer_size_bytes
+		buffer_size_events:                   components.sources.internal_metrics.output.metrics.buffer_size_events
 		buffer_events:                        components.sources.internal_metrics.output.metrics.buffer_events
 		buffer_received_events_total:         components.sources.internal_metrics.output.metrics.buffer_received_events_total
 		buffer_received_event_bytes_total:    components.sources.internal_metrics.output.metrics.buffer_received_event_bytes_total

--- a/website/cue/reference/components/sources.cue
+++ b/website/cue/reference/components/sources.cue
@@ -419,6 +419,8 @@ components: sources: [Name=string]: {
 		source_lag_time_seconds:              components.sources.internal_metrics.output.metrics.source_lag_time_seconds
 		source_buffer_max_byte_size:          components.sources.internal_metrics.output.metrics.source_buffer_max_byte_size
 		source_buffer_max_event_size:         components.sources.internal_metrics.output.metrics.source_buffer_max_event_size
+		source_buffer_max_size_bytes:         components.sources.internal_metrics.output.metrics.source_buffer_max_size_bytes
+		source_buffer_max_size_events:        components.sources.internal_metrics.output.metrics.source_buffer_max_size_events
 		source_buffer_utilization:            components.sources.internal_metrics.output.metrics.source_buffer_utilization
 		source_buffer_utilization_level:      components.sources.internal_metrics.output.metrics.source_buffer_utilization_level
 		source_buffer_utilization_mean:       components.sources.internal_metrics.output.metrics.source_buffer_utilization_mean

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -274,12 +274,28 @@ components: sources: internal_metrics: {
 			}
 		}
 		buffer_byte_size: {
-			description:       "The number of bytes current in the buffer."
+			description:        "The number of bytes currently in the buffer."
+			type:               "gauge"
+			default_namespace:  "vector"
+			tags:               _component_tags
+			deprecated:         true
+			deprecated_message: "This metric has been deprecated in favor of `buffer_size_bytes`."
+		}
+		buffer_events: {
+			description:        "The number of events currently in the buffer."
+			type:               "gauge"
+			default_namespace:  "vector"
+			tags:               _component_tags
+			deprecated:         true
+			deprecated_message: "This metric has been deprecated in favor of `buffer_size_events`."
+		}
+		buffer_size_bytes: {
+			description:       "The number of bytes currently in the buffer."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		buffer_events: {
+		buffer_size_events: {
 			description:       "The number of events currently in the buffer."
 			type:              "gauge"
 			default_namespace: "vector"
@@ -743,8 +759,28 @@ components: sources: internal_metrics: {
 			tags: _component_tags & {
 				output: _output
 			}
+			deprecated:         true
+			deprecated_message: "This metric has been deprecated in favor of `source_buffer_max_size_bytes`."
 		}
 		source_buffer_max_event_size: {
+			description:       "The maximum number of events the source buffer can hold. The outputs of the source send data to this buffer."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+			deprecated:         true
+			deprecated_message: "This metric has been deprecated in favor of `source_buffer_max_size_events`."
+		}
+		source_buffer_max_size_bytes: {
+			description:       "The maximum number of bytes the source buffer can hold. The outputs of the source send data to this buffer."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		source_buffer_max_size_events: {
 			description:       "The maximum number of events the source buffer can hold. The outputs of the source send data to this buffer."
 			type:              "gauge"
 			default_namespace: "vector"
@@ -876,6 +912,16 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		transform_buffer_max_byte_size: {
+			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+			deprecated:         true
+			deprecated_message: "This metric has been deprecated in favor of `transform_buffer_max_size_bytes`."
+		}
 		transform_buffer_max_event_size: {
 			description:       "The maximum number of events the buffer that feeds into a transform can hold."
 			type:              "gauge"
@@ -883,9 +929,19 @@ components: sources: internal_metrics: {
 			tags: _component_tags & {
 				output: _output
 			}
+			deprecated:         true
+			deprecated_message: "This metric has been deprecated in favor of `transform_buffer_max_size_events`."
 		}
-		transform_buffer_max_byte_size: {
+		transform_buffer_max_size_bytes: {
 			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				output: _output
+			}
+		}
+		transform_buffer_max_size_events: {
+			description:       "The maximum number of events the buffer that feeds into a transform can hold."
 			type:              "gauge"
 			default_namespace: "vector"
 			tags: _component_tags & {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -279,7 +279,7 @@ components: sources: internal_metrics: {
 			default_namespace:  "vector"
 			tags:               _component_tags
 			deprecated:         true
-			deprecated_message: "This metric has been deprecated in favor of `buffer_size_bytes`."
+			deprecated_message: "This metric has been deprecated in favor of [`buffer_size_bytes`](#buffer_size_bytes)."
 		}
 		buffer_events: {
 			description:        "The number of events currently in the buffer."
@@ -287,7 +287,7 @@ components: sources: internal_metrics: {
 			default_namespace:  "vector"
 			tags:               _component_tags
 			deprecated:         true
-			deprecated_message: "This metric has been deprecated in favor of `buffer_size_events`."
+			deprecated_message: "This metric has been deprecated in favor of [`buffer_size_events`](#buffer_size_events)."
 		}
 		buffer_size_bytes: {
 			description:       "The number of bytes currently in the buffer."
@@ -760,7 +760,7 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 			deprecated:         true
-			deprecated_message: "This metric has been deprecated in favor of `source_buffer_max_size_bytes`."
+			deprecated_message: "This metric has been deprecated in favor of [`source_buffer_max_size_bytes`](#source_buffer_max_size_bytes)."
 		}
 		source_buffer_max_event_size: {
 			description:       "The maximum number of events the source buffer can hold. The outputs of the source send data to this buffer."
@@ -770,7 +770,7 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 			deprecated:         true
-			deprecated_message: "This metric has been deprecated in favor of `source_buffer_max_size_events`."
+			deprecated_message: "This metric has been deprecated in favor of [`source_buffer_max_size_events`](#source_buffer_max_size_events)."
 		}
 		source_buffer_max_size_bytes: {
 			description:       "The maximum number of bytes the source buffer can hold. The outputs of the source send data to this buffer."
@@ -920,7 +920,7 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 			deprecated:         true
-			deprecated_message: "This metric has been deprecated in favor of `transform_buffer_max_size_bytes`."
+			deprecated_message: "This metric has been deprecated in favor of [`transform_buffer_max_size_bytes`](#transform_buffer_max_size_bytes)."
 		}
 		transform_buffer_max_event_size: {
 			description:       "The maximum number of events the buffer that feeds into a transform can hold."
@@ -930,7 +930,7 @@ components: sources: internal_metrics: {
 				output: _output
 			}
 			deprecated:         true
-			deprecated_message: "This metric has been deprecated in favor of `transform_buffer_max_size_events`."
+			deprecated_message: "This metric has been deprecated in favor of [`transform_buffer_max_size_events`](#transform_buffer_max_size_events)."
 		}
 		transform_buffer_max_size_bytes: {
 			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -20,8 +20,10 @@ components: transforms: [Name=string]: {
 		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		transform_buffer_max_event_size:      components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
 		transform_buffer_max_byte_size:       components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
+		transform_buffer_max_event_size:      components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
+		transform_buffer_max_size_bytes:      components.sources.internal_metrics.output.metrics.transform_buffer_max_size_bytes
+		transform_buffer_max_size_events:     components.sources.internal_metrics.output.metrics.transform_buffer_max_size_events
 		transform_buffer_utilization:         components.sources.internal_metrics.output.metrics.transform_buffer_utilization
 		transform_buffer_utilization_level:   components.sources.internal_metrics.output.metrics.transform_buffer_utilization_level
 		transform_buffer_utilization_mean:    components.sources.internal_metrics.output.metrics.transform_buffer_utilization_mean

--- a/website/layouts/partials/telemetry_output.html
+++ b/website/layouts/partials/telemetry_output.html
@@ -11,39 +11,63 @@
     {{ end }}
   </span>
 
-    {{ with $v.description }}
-    <div class="my-3 prose dark:prose-dark max-w-none">
-        {{ . | markdownify }}
+  {{ with $v.description }}
+  <div class="my-3 prose dark:prose-dark max-w-none">
+    {{ . | markdownify }}
+  </div>
+  {{ end }}
+
+  {{ if $v.deprecated }}
+  <div class="mt-3 border-2 rounded-md border-yellow-400 flex flex-col space-y-1.5 py-2 px-3">
+    <span>
+      {{ partial "heading.html" (dict "text" "Deprecated" "level" 5 "toc_hide" true) }}
+    </span>
+    <div class="flex space-x-5 items-center">
+      <div class="flex-shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" class="text-yellow-500 h-5 w-5" fill="none" viewBox="0 0 24 24"
+          stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <div class="prose dark:prose-dark max-w-none leading-snug">
+        {{ if $v.deprecated_message }}
+        {{ $v.deprecated_message | markdownify }}
+        {{ else }}
+        This metric is deprecated.
+        {{ end }}
+      </div>
     </div>
-    {{ end }}
+  </div>
+  {{ end }}
 
-    {{ with $v.tags }}
-    <div class="mt-3 border rounded dark:border-gray-700">
-        <div class="flex flex-col divide-y dark:divide-gray-700">
-            {{ range $k, $v := . }}
-            <div class="py-2.5 px-4">
-                <span class="flex justify-between items-center">
-                  <span class="font-mono font-semibold">
-                    {{ $k }}
-                  </span>
+  {{ with $v.tags }}
+  <div class="mt-3 border rounded dark:border-gray-700">
+    <div class="flex flex-col divide-y dark:divide-gray-700">
+      {{ range $k, $v := . }}
+      <div class="py-2.5 px-4">
+        <span class="flex justify-between items-center">
+          <span class="font-mono font-semibold">
+            {{ $k }}
+          </span>
 
-                  <span>
-                    {{ if not $v.required }}
-                    {{ partial "badge.html" (dict "word" "optional" "color" "blue") }}
-                    {{ end }}
-                  </span>
-                </span>
-
-                {{ with $v.description }}
-                <div class="prose dark:prose-dark">
-                    {{ . | markdownify }}
-                </div>
-                {{ end }}
-            </div>
+          <span>
+            {{ if not $v.required }}
+            {{ partial "badge.html" (dict "word" "optional" "color" "blue") }}
             {{ end }}
+          </span>
+        </span>
+
+        {{ with $v.description }}
+        <div class="prose dark:prose-dark">
+          {{ . | markdownify }}
         </div>
+        {{ end }}
+      </div>
+      {{ end }}
     </div>
-    {{ end }}
+  </div>
+  {{ end }}
 </div>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary

Many of the buffer size metric names have been specified (in `docs/specs/buffer.md`) in a way that conflicts with the metric naming specification (in `docs/specs/instrumentation.md`). In particular, the latter specifies that metric names should end with a unit (ex `_bytes` or `_events`) but the former placed the units within the name (ex `buffer_byte_size` or `buffer_max_event_size`). This latter leads to a confusing metric name which seems to report the maximum event size that may be buffered while in reality it is reporting the maximum size of the buffer in terms of events.

This change adds parallel metrics for these names that provide the standardized names. The existing names are thus deprecated and will be removed in a future version.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
