### PR TITLE
chore(enrichment tables): wrap enrichment errors in a custom type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,6 +3751,7 @@ dependencies = [
  "const-str",
  "dyn-clone",
  "indoc",
+ "snafu 0.8.9",
  "vector-vrl-category",
  "vrl",
 ]

--- a/lib/enrichment/Cargo.toml
+++ b/lib/enrichment/Cargo.toml
@@ -11,5 +11,6 @@ chrono.workspace = true
 const-str.workspace = true
 dyn-clone = { version = "1.0.20", default-features = false }
 indoc.workspace = true
+snafu.workspace = true
 vrl.workspace = true
 vector-vrl-category.workspace = true

--- a/lib/enrichment/src/test_util.rs
+++ b/lib/enrichment/src/test_util.rs
@@ -5,7 +5,7 @@ use std::{
 
 use vrl::value::{ObjectMap, Value};
 
-use crate::{Case, Condition, IndexHandle, Table, TableRegistry};
+use crate::{Case, Condition, Error, IndexHandle, Table, TableRegistry};
 
 #[derive(Debug, Clone)]
 pub(crate) struct DummyEnrichmentTable {
@@ -41,7 +41,7 @@ impl Table for DummyEnrichmentTable {
         _select: Option<&[String]>,
         _wildcard: Option<&Value>,
         _index: Option<IndexHandle>,
-    ) -> Result<ObjectMap, String> {
+    ) -> Result<ObjectMap, Error> {
         Ok(self.data.clone())
     }
 
@@ -52,11 +52,11 @@ impl Table for DummyEnrichmentTable {
         _select: Option<&[String]>,
         _wildcard: Option<&Value>,
         _index: Option<IndexHandle>,
-    ) -> Result<Vec<ObjectMap>, String> {
+    ) -> Result<Vec<ObjectMap>, Error> {
         Ok(vec![self.data.clone()])
     }
 
-    fn add_index(&mut self, _case: Case, fields: &[&str]) -> Result<IndexHandle, String> {
+    fn add_index(&mut self, _case: Case, fields: &[&str]) -> Result<IndexHandle, Error> {
         let mut indexes = self.indexes.lock().unwrap();
         indexes.push(fields.iter().map(|s| (*s).to_string()).collect());
         Ok(IndexHandle(indexes.len() - 1))

--- a/lib/vector-vrl/tests/src/test_enrichment.rs
+++ b/lib/vector-vrl/tests/src/test_enrichment.rs
@@ -13,7 +13,7 @@ impl enrichment::Table for TestEnrichmentTable {
         _select: Option<&[String]>,
         _wildcard: Option<&Value>,
         _index: Option<enrichment::IndexHandle>,
-    ) -> Result<ObjectMap, String> {
+    ) -> Result<ObjectMap, enrichment::Error> {
         let mut result = ObjectMap::new();
         result.insert("id".into(), Value::from(1));
         result.insert("firstname".into(), Value::from("Bob"));
@@ -29,7 +29,7 @@ impl enrichment::Table for TestEnrichmentTable {
         _select: Option<&[String]>,
         _wildcard: Option<&Value>,
         _index: Option<enrichment::IndexHandle>,
-    ) -> Result<Vec<ObjectMap>, String> {
+    ) -> Result<Vec<ObjectMap>, enrichment::Error> {
         let mut result1 = ObjectMap::new();
         result1.insert("id".into(), Value::from(1));
         result1.insert("firstname".into(), Value::from("Bob"));
@@ -47,7 +47,7 @@ impl enrichment::Table for TestEnrichmentTable {
         &mut self,
         _case: enrichment::Case,
         _fields: &[&str],
-    ) -> Result<enrichment::IndexHandle, String> {
+    ) -> Result<enrichment::IndexHandle, enrichment::Error> {
         Ok(enrichment::IndexHandle(1))
     }
 

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -7,7 +7,7 @@ use vector_lib::{
     TimeZone,
     configurable::configurable_component,
     conversion::Conversion,
-    enrichment::{Case, Condition, IndexHandle, Table},
+    enrichment::{Case, Condition, Error, IndexHandle, Table},
 };
 use vrl::value::{ObjectMap, Value};
 
@@ -384,7 +384,7 @@ impl File {
     }
 
     /// Order the fields in the index according to the position they are found in the header.
-    fn normalize_index_fields(&self, index: &[&str]) -> Result<Vec<usize>, String> {
+    fn normalize_index_fields(&self, index: &[&str]) -> Result<Vec<usize>, Error> {
         // Get the positions of the fields we are indexing
         let normalized = self
             .headers
@@ -400,7 +400,7 @@ impl File {
             .collect::<Vec<_>>();
 
         if normalized.len() != index.len() {
-            let missing = index
+            let fields = index
                 .iter()
                 .filter_map(|col| {
                     if self.headers.iter().any(|header| header == *col) {
@@ -409,9 +409,8 @@ impl File {
                         Some(col.to_string())
                     }
                 })
-                .collect::<Vec<_>>()
-                .join(", ");
-            Err(format!("field(s) '{missing}' missing from dataset"))
+                .collect();
+            Err(Error::MissingDatasetFields { fields })
         } else {
             Ok(normalized)
         }
@@ -426,7 +425,7 @@ impl File {
         &self,
         fieldidx: &[usize],
         case: Case,
-    ) -> Result<HashMap<u64, Vec<usize>, hash_hasher::HashBuildHasher>, String> {
+    ) -> Result<HashMap<u64, Vec<usize>, hash_hasher::HashBuildHasher>, Error> {
         let mut index = HashMap::with_capacity_and_hasher(
             self.data.len(),
             hash_hasher::HashBuildHasher::default(),
@@ -476,7 +475,7 @@ impl File {
         case: Case,
         condition: &'a [Condition<'a>],
         handle: IndexHandle,
-    ) -> Result<Option<&'a Vec<usize>>, String> {
+    ) -> Result<Option<&'a Vec<usize>>, Error> {
         // The index to use has been passed, we can use this to search the data.
         // We are assuming that the caller has passed an index that represents the fields
         // being passed in the condition.
@@ -502,7 +501,7 @@ impl File {
         wildcard: &'a Value,
         condition: &'a [Condition<'a>],
         handle: IndexHandle,
-    ) -> Result<Option<&'a Vec<usize>>, String> {
+    ) -> Result<Option<&'a Vec<usize>>, Error> {
         if let Some(result) = self.indexed(case, condition, handle)? {
             return Ok(Some(result));
         }
@@ -525,19 +524,21 @@ impl File {
 
 /// Adds the bytes from the given value to the hash.
 /// Each field is terminated by a `0` value to separate the fields
-fn hash_value(hasher: &mut seahash::SeaHasher, case: Case, value: &Value) -> Result<(), String> {
+fn hash_value(hasher: &mut seahash::SeaHasher, case: Case, value: &Value) -> Result<(), Error> {
     match value {
         Value::Bytes(bytes) => match case {
             Case::Sensitive => hasher.write(bytes),
             Case::Insensitive => hasher.write(
                 std::str::from_utf8(bytes)
-                    .map_err(|_| "column contains invalid utf".to_string())?
+                    .map_err(|source| Error::InvalidUtfInColumn { source })?
                     .to_lowercase()
                     .as_bytes(),
             ),
         },
         value => {
-            let bytes: bytes::Bytes = value.encode_as_bytes()?;
+            let bytes: bytes::Bytes = value
+                .encode_as_bytes()
+                .map_err(|details| Error::FailedToEncodeValue { details })?;
             hasher.write(&bytes);
         }
     }
@@ -548,7 +549,7 @@ fn hash_value(hasher: &mut seahash::SeaHasher, case: Case, value: &Value) -> Res
 }
 
 /// Returns an error if the iterator doesn't yield exactly one result.
-fn single_or_err<I, T>(mut iter: T) -> Result<I, String>
+fn single_or_err<I, T>(mut iter: T) -> Result<I, Error>
 where
     T: Iterator<Item = I>,
 {
@@ -556,9 +557,9 @@ where
 
     if iter.next().is_some() {
         // More than one row has been found.
-        Err("more than one row found".to_string())
+        Err(Error::MoreThanOneRowFound)
     } else {
-        result.ok_or_else(|| "no rows found".to_string())
+        result.ok_or(Error::NoRowsFound)
     }
 }
 
@@ -570,7 +571,7 @@ impl Table for File {
         select: Option<&'a [String]>,
         wildcard: Option<&Value>,
         index: Option<IndexHandle>,
-    ) -> Result<ObjectMap, String> {
+    ) -> Result<ObjectMap, Error> {
         match index {
             None => {
                 // No index has been passed so we need to do a Sequential Scan.
@@ -582,7 +583,7 @@ impl Table for File {
                 } else {
                     self.indexed(case, condition, handle)?
                 }
-                .ok_or_else(|| "no rows found in index".to_string())?
+                .ok_or(Error::NoRowsFound)?
                 .iter()
                 .map(|idx| &self.data[*idx]);
 
@@ -599,7 +600,7 @@ impl Table for File {
         select: Option<&'a [String]>,
         wildcard: Option<&Value>,
         index: Option<IndexHandle>,
-    ) -> Result<Vec<ObjectMap>, String> {
+    ) -> Result<Vec<ObjectMap>, Error> {
         match index {
             None => {
                 // No index has been passed so we need to do a Sequential Scan.
@@ -630,7 +631,7 @@ impl Table for File {
         }
     }
 
-    fn add_index(&mut self, case: Case, fields: &[&str]) -> Result<IndexHandle, String> {
+    fn add_index(&mut self, case: Case, fields: &[&str]) -> Result<IndexHandle, Error> {
         let normalized = self.normalize_index_fields(fields)?;
         match self
             .indexes
@@ -951,7 +952,9 @@ mod tests {
 
         let error = file.add_index(Case::Sensitive, &["apples", "field2", "bananas"]);
         assert_eq!(
-            Err("field(s) 'apples, bananas' missing from dataset".to_string()),
+            Err(Error::MissingDatasetFields {
+                fields: vec!["apples".into(), "bananas".into()],
+            }),
             error
         )
     }
@@ -1466,7 +1469,7 @@ mod tests {
         };
 
         assert_eq!(
-            Err("no rows found".to_string()),
+            Err(Error::NoRowsFound),
             file.find_table_row(Case::Sensitive, &[condition], None, None, None)
         );
     }
@@ -1493,7 +1496,7 @@ mod tests {
         };
 
         assert_eq!(
-            Err("no rows found in index".to_string()),
+            Err(Error::NoRowsFound),
             file.find_table_row(Case::Sensitive, &[condition], None, None, Some(handle))
         );
     }
@@ -1521,7 +1524,7 @@ mod tests {
         };
 
         assert_eq!(
-            Err("no rows found in index".to_string()),
+            Err(Error::NoRowsFound),
             file.find_table_row(
                 Case::Sensitive,
                 &[condition],

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -14,7 +14,7 @@ use ordered_float::NotNan;
 use serde::Deserialize;
 use vector_lib::{
     configurable::configurable_component,
-    enrichment::{Case, Condition, IndexHandle, Table},
+    enrichment::{Case, Condition, Error, IndexHandle, Table},
 };
 use vrl::value::{ObjectMap, Value};
 
@@ -272,13 +272,13 @@ impl Table for Geoip {
         select: Option<&[String]>,
         wildcard: Option<&Value>,
         index: Option<IndexHandle>,
-    ) -> Result<ObjectMap, String> {
+    ) -> Result<ObjectMap, Error> {
         let mut rows = self.find_table_rows(case, condition, select, wildcard, index)?;
 
         match rows.pop() {
             Some(row) if rows.is_empty() => Ok(row),
-            Some(_) => Err("More than 1 row found".to_string()),
-            None => Err("IP not found".to_string()),
+            Some(_) => Err(Error::MoreThanOneRowFound),
+            None => Err(Error::NoRowsFound),
         }
     }
 
@@ -292,21 +292,21 @@ impl Table for Geoip {
         select: Option<&[String]>,
         _wildcard: Option<&Value>,
         _: Option<IndexHandle>,
-    ) -> Result<Vec<ObjectMap>, String> {
+    ) -> Result<Vec<ObjectMap>, Error> {
         match condition.first() {
-            Some(_) if condition.len() > 1 => Err("Only one condition is allowed".to_string()),
+            Some(_) if condition.len() > 1 => Err(Error::OnlyOneConditionAllowed),
             Some(Condition::Equals { value, .. }) => {
                 let ip = value
                     .to_string_lossy()
                     .parse::<IpAddr>()
-                    .map_err(|_| "Invalid IP address".to_string())?;
+                    .map_err(|source| Error::InvalidAddress { source })?;
                 Ok(self
                     .lookup(ip, select)
                     .map(|values| vec![values])
                     .unwrap_or_default())
             }
-            Some(_) => Err("Only equality condition is allowed".to_string()),
-            None => Err("IP condition must be specified".to_string()),
+            Some(_) => Err(Error::OnlyEqualityConditionAllowed),
+            None => Err(Error::MissingCondition { kind: "IP" }),
         }
     }
 
@@ -315,11 +315,11 @@ impl Table for Geoip {
     ///
     /// # Errors
     /// Errors if the fields are not in the table.
-    fn add_index(&mut self, _: Case, fields: &[&str]) -> Result<IndexHandle, String> {
+    fn add_index(&mut self, _: Case, fields: &[&str]) -> Result<IndexHandle, Error> {
         match fields.len() {
-            0 => Err("IP field is required".to_string()),
+            0 => Err(Error::MissingRequiredField { field: "IP" }),
             1 => Ok(IndexHandle(0)),
-            _ => Err("Only one field is allowed".to_string()),
+            _ => Err(Error::OnlyOneFieldAllowed),
         }
     }
 


### PR DESCRIPTION
## Summary

The error type returned from the enrichment::Table trait methods results is a plain string which does not help to check if the lookup error is either caused by an invalid input, a row not found or multiple rows found. This PR wraps it in an enum which makes this explicit.

## How did you test this PR?
unit tests

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
