### PR TITLE
enhancement(observability)!: Expand internal histogram precision

### DIFF
--- a/changelog.d/expand-internal-histogram-precision.breaking.md
+++ b/changelog.d/expand-internal-histogram-precision.breaking.md
@@ -1,0 +1,5 @@
+Increased the number of buckets in internal histograms to reduce the smallest
+bucket down to approximately 0.000244 (2.0^-12). Since this shifts all the
+bucket values out, it may break VRL scripts that rely on the previous values.
+
+authors: bruceg

--- a/lib/vector-core/src/metrics/storage.rs
+++ b/lib/vector-core/src/metrics/storage.rs
@@ -31,15 +31,15 @@ impl<K> Storage<K> for VectorStorage {
 
 #[derive(Debug)]
 pub(super) struct Histogram {
-    buckets: Box<[(f64, AtomicU32); 20]>,
+    buckets: Box<[(f64, AtomicU32); 26]>,
     count: AtomicU64,
     sum: AtomicF64,
 }
 
 impl Histogram {
-    const MIN_BUCKET: f64 = 0.015_625; // (-6_f64).exp2() is not const yet
-    const MIN_BUCKET_EXP: f64 = -6.0;
-    const BUCKETS: usize = 20;
+    const MIN_BUCKET: f64 = 1.0 / (1 << 12) as f64; // f64::powi() is not const yet
+    const MIN_BUCKET_EXP: f64 = -12.0;
+    const BUCKETS: usize = 26;
 
     pub(crate) fn new() -> Self {
         // Box to avoid having this large array inline to the structure, blowing
@@ -52,25 +52,31 @@ impl Histogram {
         // long-tail. This also lets us find the right bucket to record into using simple
         // constant-time math operations instead of a loop-and-compare construct.
         let buckets = Box::new([
-            ((-6_f64).exp2(), AtomicU32::new(0)),
-            ((-5_f64).exp2(), AtomicU32::new(0)),
-            ((-4_f64).exp2(), AtomicU32::new(0)),
-            ((-3_f64).exp2(), AtomicU32::new(0)),
-            ((-2_f64).exp2(), AtomicU32::new(0)),
-            ((-1_f64).exp2(), AtomicU32::new(0)),
-            (0_f64.exp2(), AtomicU32::new(0)),
-            (1_f64.exp2(), AtomicU32::new(0)),
-            (2_f64.exp2(), AtomicU32::new(0)),
-            (3_f64.exp2(), AtomicU32::new(0)),
-            (4_f64.exp2(), AtomicU32::new(0)),
-            (5_f64.exp2(), AtomicU32::new(0)),
-            (6_f64.exp2(), AtomicU32::new(0)),
-            (7_f64.exp2(), AtomicU32::new(0)),
-            (8_f64.exp2(), AtomicU32::new(0)),
-            (9_f64.exp2(), AtomicU32::new(0)),
-            (10_f64.exp2(), AtomicU32::new(0)),
-            (11_f64.exp2(), AtomicU32::new(0)),
-            (12_f64.exp2(), AtomicU32::new(0)),
+            (2.0f64.powi(-12), AtomicU32::new(0)),
+            (2.0f64.powi(-11), AtomicU32::new(0)),
+            (2.0f64.powi(-10), AtomicU32::new(0)),
+            (2.0f64.powi(-9), AtomicU32::new(0)),
+            (2.0f64.powi(-8), AtomicU32::new(0)),
+            (2.0f64.powi(-7), AtomicU32::new(0)),
+            (2.0f64.powi(-6), AtomicU32::new(0)),
+            (2.0f64.powi(-5), AtomicU32::new(0)),
+            (2.0f64.powi(-4), AtomicU32::new(0)),
+            (2.0f64.powi(-3), AtomicU32::new(0)),
+            (2.0f64.powi(-2), AtomicU32::new(0)),
+            (2.0f64.powi(-1), AtomicU32::new(0)),
+            (2.0f64.powi(0), AtomicU32::new(0)),
+            (2.0f64.powi(1), AtomicU32::new(0)),
+            (2.0f64.powi(2), AtomicU32::new(0)),
+            (2.0f64.powi(3), AtomicU32::new(0)),
+            (2.0f64.powi(4), AtomicU32::new(0)),
+            (2.0f64.powi(5), AtomicU32::new(0)),
+            (2.0f64.powi(6), AtomicU32::new(0)),
+            (2.0f64.powi(7), AtomicU32::new(0)),
+            (2.0f64.powi(8), AtomicU32::new(0)),
+            (2.0f64.powi(9), AtomicU32::new(0)),
+            (2.0f64.powi(10), AtomicU32::new(0)),
+            (2.0f64.powi(11), AtomicU32::new(0)),
+            (2.0f64.powi(12), AtomicU32::new(0)),
             (f64::INFINITY, AtomicU32::new(0)),
         ]);
         Self {

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -256,7 +256,7 @@ mod tests {
                 // [`metrics::handle::Histogram::new`] are hard-coded. If this
                 // check fails you might look there and see if we've allowed
                 // users to set their own bucket widths.
-                assert_eq!(buckets[9].count, 2);
+                assert_eq!(buckets[15].count, 2);
                 assert_eq!(*count, 2);
                 assert_eq!(*sum, 11.0);
             }
@@ -273,8 +273,8 @@ mod tests {
                 // [`metrics::handle::Histogram::new`] are hard-coded. If this
                 // check fails you might look there and see if we've allowed
                 // users to set their own bucket widths.
-                assert_eq!(buckets[9].count, 1);
-                assert_eq!(buckets[10].count, 1);
+                assert_eq!(buckets[15].count, 1);
+                assert_eq!(buckets[16].count, 1);
                 assert_eq!(*count, 2);
                 assert_eq!(*sum, 16.1);
             }


### PR DESCRIPTION
## Summary

With the introduction of internal timing measurements in seconds as histograms, the lower bound of 2^-6 (~15ms) in the internal histogram storage is no longer precise enough to properly capture the required measurements. This change extends the smallest bucket down to 2^-12 (~244us), which is the inverse of the largest bucket of 2^12 (4096).

## Vector configuration

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance
- [X] Enhancement

## Is this a breaking change?
- [x] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
