### PR TITLE
feat(codecs): MessagePack decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,8 @@ dependencies = [
  "prost-reflect",
  "rand 0.9.2",
  "regex",
+ "rmp",
+ "rmp-serde",
  "rstest",
  "rust_decimal",
  "serde",
@@ -9607,22 +9609,19 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmp"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
 dependencies = [
- "byteorder",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
- "byteorder",
  "rmp",
  "serde",
 ]

--- a/changelog.d/msgpack_decoder.feature.md
+++ b/changelog.d/msgpack_decoder.feature.md
@@ -1,0 +1,3 @@
+Added MessagePack decoder codec `message_pack`.
+
+authors: Keuin

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -51,6 +51,9 @@ vector-config-macros = { path = "../vector-config-macros", default-features = fa
 vector-core = { path = "../vector-core", default-features = false, features = ["vrl"] }
 vector-vrl-functions.workspace = true
 toml = { version = "0.9.8", optional = true }
+rmp = "0.8.15"
+rmp-serde = "1.3.1"
+
 [dev-dependencies]
 futures.workspace = true
 indoc.workspace = true

--- a/lib/codecs/src/decoding/format/mod.rs
+++ b/lib/codecs/src/decoding/format/mod.rs
@@ -8,6 +8,7 @@ mod bytes;
 mod gelf;
 mod influxdb;
 mod json;
+mod msgpack;
 mod native;
 mod native_json;
 #[cfg(feature = "opentelemetry")]
@@ -23,6 +24,7 @@ use dyn_clone::DynClone;
 pub use gelf::{GelfDeserializer, GelfDeserializerConfig, GelfDeserializerOptions};
 pub use influxdb::{InfluxdbDeserializer, InfluxdbDeserializerConfig};
 pub use json::{JsonDeserializer, JsonDeserializerConfig, JsonDeserializerOptions};
+pub use msgpack::{MsgPackDeserializer, MsgPackDeserializerConfig};
 pub use native::{NativeDeserializer, NativeDeserializerConfig};
 pub use native_json::{
     NativeJsonDeserializer, NativeJsonDeserializerConfig, NativeJsonDeserializerOptions,

--- a/lib/codecs/src/decoding/format/msgpack.rs
+++ b/lib/codecs/src/decoding/format/msgpack.rs
@@ -1,0 +1,196 @@
+use super::Deserializer;
+use bytes::Bytes;
+use chrono::Utc;
+use derivative::Derivative;
+use smallvec::{SmallVec, smallvec};
+use vector_core::config::DataType;
+use vector_core::event::LogEvent;
+use vector_core::{
+    config::{LogNamespace, log_schema},
+    event::Event,
+    schema,
+};
+use vrl::prelude::Kind;
+
+/// Deserializer that builds `Event`s from a byte frame containing MsgPack.
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Default)]
+pub struct MsgPackDeserializer;
+
+impl MsgPackDeserializer {
+    /// Create a `MsgPackDeserializer` instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Config used to build an `MsgPackDeserializer`.
+/// Note that currently there is no configuration for this decoder.
+#[derive(Debug, Clone, Default)]
+pub struct MsgPackDeserializerConfig;
+
+impl MsgPackDeserializerConfig {
+    /// Return the type of event build by this deserializer.
+    pub fn output_type(&self) -> DataType {
+        DataType::Log
+    }
+
+    /// The schema produced by the deserializer.
+    pub fn schema_definition(&self, log_namespace: LogNamespace) -> schema::Definition {
+        match log_namespace {
+            LogNamespace::Legacy => {
+                let mut definition =
+                    schema::Definition::empty_legacy_namespace().unknown_fields(Kind::any());
+
+                if let Some(timestamp_key) = log_schema().timestamp_key() {
+                    definition = definition.try_with_field(
+                        timestamp_key,
+                        // The decoder will try to insert a new `timestamp`-type value into the
+                        // "timestamp_key" field, but only if that field doesn't already exist.
+                        Kind::any().or_timestamp(),
+                        Some("timestamp"),
+                    );
+                }
+                definition
+            }
+            LogNamespace::Vector => {
+                schema::Definition::new_with_default_metadata(Kind::any(), [log_namespace])
+            }
+        }
+    }
+}
+
+impl Deserializer for MsgPackDeserializer {
+    fn parse(
+        &self,
+        bytes: Bytes,
+        log_namespace: LogNamespace,
+    ) -> vector_common::Result<SmallVec<[Event; 1]>> {
+        let vrl_value: vrl::value::Value = rmp_serde::from_slice(&bytes)?;
+        let mut events: SmallVec<[Event; 1]> = if let vrl::value::Value::Array(array) = vrl_value {
+            array
+                .into_iter()
+                .map(|elem| Event::Log(LogEvent::from(elem)))
+                .collect()
+        } else {
+            smallvec![Event::Log(LogEvent::from(vrl_value))]
+        };
+        let events = match log_namespace {
+            LogNamespace::Vector => events,
+            LogNamespace::Legacy => {
+                let timestamp = Utc::now();
+
+                if let Some(timestamp_key) = log_schema().timestamp_key_target_path() {
+                    for event in &mut events {
+                        let log = event.as_mut_log();
+                        if !log.contains(timestamp_key) {
+                            log.insert(timestamp_key, timestamp);
+                        }
+                    }
+                }
+
+                events
+            }
+        };
+
+        Ok(events)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use vector_core::config::log_schema;
+    use vrl::core::Value;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_msgpack() {
+        let input = Bytes::from_static(b"\x81\xA3\x66\x6F\x6F\x7B");
+        let deserializer = MsgPackDeserializer::default();
+
+        for namespace in [LogNamespace::Legacy, LogNamespace::Vector] {
+            let events = deserializer.parse(input.clone(), namespace).unwrap();
+            let mut events = events.into_iter();
+
+            {
+                let event = events.next().unwrap();
+                let log = event.as_log();
+                assert_eq!(log["foo"], 123.into());
+                assert_eq!(
+                    log.get((
+                        lookup::PathPrefix::Event,
+                        log_schema().timestamp_key().unwrap()
+                    ))
+                    .is_some(),
+                    namespace == LogNamespace::Legacy
+                );
+            }
+
+            assert_eq!(events.next(), None);
+        }
+    }
+
+    #[test]
+    fn deserialize_non_object_vector_namespace() {
+        let input = Bytes::from_static(b"\xC0");
+        let deserializer = MsgPackDeserializer::default();
+
+        let namespace = LogNamespace::Vector;
+        let events = deserializer.parse(input.clone(), namespace).unwrap();
+        let mut events = events.into_iter();
+
+        let event = events.next().unwrap();
+        let log = event.as_log();
+        assert_eq!(log["."], Value::Null);
+
+        assert_eq!(events.next(), None);
+    }
+
+    #[test]
+    fn deserialize_msgpack_array() {
+        let input =
+            Bytes::from_static(b"\x92\x81\xA3\x66\x6F\x6F\x7B\x81\xA3\x62\x61\x72\xCD\x01\xC8");
+        let deserializer = MsgPackDeserializer::default();
+        for namespace in [LogNamespace::Legacy, LogNamespace::Vector] {
+            let events = deserializer.parse(input.clone(), namespace).unwrap();
+            let mut events = events.into_iter();
+
+            {
+                let event = events.next().unwrap();
+                let log = event.as_log();
+                assert_eq!(log["foo"], 123.into());
+                assert_eq!(
+                    log.get((
+                        lookup::PathPrefix::Event,
+                        log_schema().timestamp_key().unwrap()
+                    ))
+                    .is_some(),
+                    namespace == LogNamespace::Legacy
+                );
+            }
+
+            {
+                let event = events.next().unwrap();
+                let log = event.as_log();
+                assert_eq!(log["bar"], 456.into());
+                assert_eq!(
+                    log.get(log_schema().timestamp_key_target_path().unwrap())
+                        .is_some(),
+                    namespace == LogNamespace::Legacy
+                );
+            }
+
+            assert_eq!(events.next(), None);
+        }
+    }
+
+    #[test]
+    fn deserialize_error_invalid_msgpack() {
+        let input = Bytes::from_static(b"\x92\x81\xA3\x66");
+        let deserializer = MsgPackDeserializer::default();
+
+        for namespace in [LogNamespace::Legacy, LogNamespace::Vector] {
+            assert!(deserializer.parse(input.clone(), namespace).is_err());
+        }
+    }
+}

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -175,6 +175,7 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         DeserializerConfig::Vrl { .. } => unimplemented!(),
         #[cfg(feature = "codecs-opentelemetry")]
         DeserializerConfig::Otlp { .. } => SerializerConfig::Otlp,
+        DeserializerConfig::MessagePack => todo!(),
     };
 
     serializer_config


### PR DESCRIPTION
## Summary
This patch adds [MessagePack](https://msgpack.org) decoder. MessagePack is a JSON-like binary format.

## Vector configuration

```toml
[sources.in]
type = "stdin"
decoding.codec = "message_pack"

[sinks.out]
type = "console"
inputs = ["in"]
encoding.codec = "json"
```

## How did you test this PR?

I tested it with:

1. Unit test
2. Manual test with above config and MessagePack data:

```
\x87\xA3\x69\x6E\x74\x01\xA5\x66\x6C\x6F\x61\x74\xCB\x3F\xE0\x00\x00\x00\x00\x00\x00\xA7\x62\x6F\x6F\x6C\x65\x61\x6E\xC3\xA4\x6E\x75\x6C\x6C\xC0\xA6\x73\x74\x72\x69\x6E\x67\xA7\x66\x6F\x6F\x20\x62\x61\x72\xA5\x61\x72\x72\x61\x79\x92\xA3\x66\x6F\x6F\xA3\x62\x61\x72\xA6\x6F\x62\x6A\x65\x63\x74\x82\xA3\x66\x6F\x6F\x01\xA3\x62\x61\x7A\xCB\x3F\xE0\x00\x00\x00\x00\x00\x00
```

This is:

```json
{
	"int": 1,
	"float": 0.5,
	"boolean": true,
	"null": null,
	"string": "foo bar",
	"array": [
		"foo",
		"bar"
	],
	"object": {
		"foo": 1,
		"baz": 0.5
	}
}
```

```
\x92\x81\xA3\x76\x61\x6C\x01\x81\xA3\x76\x61\x6C\x02
```

This is:

```json
[{"val": 1}, {"val": 2}]
```

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
