### PR TITLE
enhancement(observability): Add metrics to measure transform processing time

### DIFF
--- a/changelog.d/component_processing_time-metrics.enhancement.md
+++ b/changelog.d/component_processing_time-metrics.enhancement.md
@@ -1,0 +1,5 @@
+Added the `component_processing_time_seconds` histogram and
+`component_processing_time_mean_seconds` gauge internal_metrics, exposing the
+time an event spends in a single transform including the transform buffer.
+
+authors: bruceg

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -112,7 +112,7 @@ impl<T> Bufferable for T where T: InMemoryBufferable + Encodable {}
 pub trait BufferInstrumentation<T: Bufferable>: Send + Sync + 'static {
     /// Called immediately before the item is emitted to the underlying buffer.
     /// The underlying type is stored in an `Arc`, so we cannot have `&mut self`.
-    fn on_send(&self, item: &T);
+    fn on_send(&self, item: &mut T);
 }
 
 pub trait EventCount {

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -205,9 +205,13 @@ impl<T: Bufferable> BufferSender<T> {
     }
 
     #[async_recursion]
-    pub async fn send(&mut self, item: T, send_reference: Option<Instant>) -> crate::Result<()> {
+    pub async fn send(
+        &mut self,
+        mut item: T,
+        send_reference: Option<Instant>,
+    ) -> crate::Result<()> {
         if let Some(instrumentation) = self.custom_instrumentation.as_ref() {
-            instrumentation.on_send(&item);
+            instrumentation.on_send(&mut item);
         }
         let item_sizing = self
             .usage_instrumentation

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -156,9 +156,10 @@ pub struct GlobalOptions {
     /// The alpha value for the exponential weighted moving average (EWMA) of transform processing
     /// time metrics.
     ///
-    /// This controls how quickly the `event_processing_time_mean_seconds` gauge responds to new
-    /// observations. Values closer to 1.0 retain more of the previous value, leading to slower
-    /// adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+    /// This controls how quickly the `component_processing_time_mean_seconds` and
+    /// `event_processing_time_mean_seconds` gauges respond to new observations. Values closer to
+    /// 1.0 retain more of the previous value, leading to slower adjustments. The default value of
+    /// 0.9 is equivalent to a "half life" of 6-7 measurements.
     ///
     /// Must be between 0 and 1 exclusively (0 < alpha < 1).
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -4,6 +4,7 @@
 
 use std::{iter, slice, sync::Arc, vec};
 
+use chrono::Utc;
 use futures::{Stream, stream};
 #[cfg(test)]
 use quickcheck::{Arbitrary, Gen};
@@ -169,6 +170,15 @@ impl EventArray {
             for metric in metrics {
                 metric.metadata_mut().set_source_type(source_type);
             }
+        }
+    }
+
+    /// Sets the `last_transform_timestamp` in the metadata for all events in this array. This is
+    /// used to initialize the timestamp before the first transform so that component processing
+    /// time can be measured.
+    pub fn set_last_transform_timestamp(&mut self, timestamp: chrono::DateTime<Utc>) {
+        for mut event in self.iter_events_mut() {
+            event.metadata_mut().set_last_transform_timestamp(timestamp);
         }
     }
 

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -84,6 +84,11 @@ pub(super) struct Inner {
     #[derivative(PartialEq = "ignore")]
     #[serde(default, skip)]
     pub(crate) ingest_timestamp: Option<DateTime<Utc>>,
+
+    /// The timestamp when the event last entered a transform buffer.
+    #[derivative(PartialEq = "ignore")]
+    #[serde(default, skip)]
+    pub(crate) last_transform_timestamp: Option<DateTime<Utc>>,
 }
 
 /// Metric Origin metadata for submission to Datadog.
@@ -256,6 +261,17 @@ impl EventMetadata {
     pub fn set_ingest_timestamp(&mut self, timestamp: DateTime<Utc>) {
         self.get_mut().ingest_timestamp = Some(timestamp);
     }
+
+    /// Returns the timestamp of the last transform buffer enqueue operation, if it exists.
+    #[must_use]
+    pub fn last_transform_timestamp(&self) -> Option<DateTime<Utc>> {
+        self.0.last_transform_timestamp
+    }
+
+    /// Sets the transform enqueue timestamp to the provided value.
+    pub fn set_last_transform_timestamp(&mut self, timestamp: DateTime<Utc>) {
+        self.get_mut().last_transform_timestamp = Some(timestamp);
+    }
 }
 
 impl Default for Inner {
@@ -272,6 +288,7 @@ impl Default for Inner {
             datadog_origin_metadata: None,
             source_event_id: Some(Uuid::new_v4()),
             ingest_timestamp: None,
+            last_transform_timestamp: None,
         }
     }
 }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -689,6 +689,7 @@ impl From<Metadata> for EventMetadata {
             datadog_origin_metadata,
             source_event_id,
             ingest_timestamp: None,
+            last_transform_timestamp: None,
         }))
     }
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -290,6 +290,28 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _processing_time_tags
 		}
+		component_processing_time_seconds: {
+			description: """
+				The elapsed time, in fractional seconds, that an event spends in a single transform.
+
+				This includes both the time spent queued in the transform’s input buffer and the time spent executing the transform itself.
+				"""
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
+		component_processing_time_mean_seconds: {
+			description: """
+				The mean elapsed time, in fractional seconds, that an event spends in a single transform.
+
+				This includes both the time spent queued in the transform’s input buffer and the time spent executing the transform itself.
+
+				This value is smoothed over time using an exponentially weighted moving average (EWMA).
+				"""
+			type:              "gauge"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
 		buffer_byte_size: {
 			description:        "The number of bytes currently in the buffer."
 			type:               "gauge"

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -13,20 +13,22 @@ components: transforms: [Name=string]: {
 	configuration: generated.components.transforms.configuration
 
 	telemetry: metrics: {
-		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
-		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
-		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
-		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
-		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
-		transform_buffer_max_byte_size:       components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
-		transform_buffer_max_event_size:      components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
-		transform_buffer_max_size_bytes:      components.sources.internal_metrics.output.metrics.transform_buffer_max_size_bytes
-		transform_buffer_max_size_events:     components.sources.internal_metrics.output.metrics.transform_buffer_max_size_events
-		transform_buffer_utilization:         components.sources.internal_metrics.output.metrics.transform_buffer_utilization
-		transform_buffer_utilization_level:   components.sources.internal_metrics.output.metrics.transform_buffer_utilization_level
-		transform_buffer_utilization_mean:    components.sources.internal_metrics.output.metrics.transform_buffer_utilization_mean
-		utilization:                          components.sources.internal_metrics.output.metrics.utilization
+		component_discarded_events_total:       components.sources.internal_metrics.output.metrics.component_discarded_events_total
+		component_errors_total:                 components.sources.internal_metrics.output.metrics.component_errors_total
+		component_processing_time_mean_seconds: components.sources.internal_metrics.output.metrics.component_processing_time_mean_seconds
+		component_processing_time_seconds:      components.sources.internal_metrics.output.metrics.component_processing_time_seconds
+		component_received_event_bytes_total:   components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
+		component_received_events_count:        components.sources.internal_metrics.output.metrics.component_received_events_count
+		component_received_events_total:        components.sources.internal_metrics.output.metrics.component_received_events_total
+		component_sent_event_bytes_total:       components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		component_sent_events_total:            components.sources.internal_metrics.output.metrics.component_sent_events_total
+		transform_buffer_max_byte_size:         components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
+		transform_buffer_max_event_size:        components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
+		transform_buffer_max_size_bytes:        components.sources.internal_metrics.output.metrics.transform_buffer_max_size_bytes
+		transform_buffer_max_size_events:       components.sources.internal_metrics.output.metrics.transform_buffer_max_size_events
+		transform_buffer_utilization:           components.sources.internal_metrics.output.metrics.transform_buffer_utilization
+		transform_buffer_utilization_level:     components.sources.internal_metrics.output.metrics.transform_buffer_utilization_level
+		transform_buffer_utilization_mean:      components.sources.internal_metrics.output.metrics.transform_buffer_utilization_mean
+		utilization:                            components.sources.internal_metrics.output.metrics.utilization
 	}
 }

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -903,9 +903,10 @@ generated: configuration: configuration: {
 			The alpha value for the exponential weighted moving average (EWMA) of transform processing
 			time metrics.
 
-			This controls how quickly the `event_processing_time_mean_seconds` gauge responds to new
-			observations. Values closer to 1.0 retain more of the previous value, leading to slower
-			adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+			This controls how quickly the `component_processing_time_mean_seconds` and
+			`event_processing_time_mean_seconds` gauges respond to new observations. Values closer to
+			1.0 retain more of the previous value, leading to slower adjustments. The default value of
+			0.9 is equivalent to a "half life" of 6-7 measurements.
 
 			Must be between 0 and 1 exclusively (0 < alpha < 1).
 			"""


### PR DESCRIPTION
## Summary

Adds the `component_processing_time_seconds` histogram and `component_processing_time_mean_seconds` gauge internal_metrics, exposing the time an event spends in a single transform including the transform buffer.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

Unit tests and watching an `internal_metrics` => transform => `console` topology.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
