### PR TITLE
feat(new transform): add `stdio` transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,7 +3080,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot 0.12.4",
- "rustix 1.0.1",
+ "rustix 1.1.3",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -3880,6 +3880,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -6330,9 +6336,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libflate"
@@ -6481,9 +6487,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "listenfd"
@@ -9798,15 +9804,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.2",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -11257,7 +11263,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.0.1",
+ "rustix 1.1.3",
  "windows-sys 0.61.0",
 ]
 
@@ -12806,6 +12812,7 @@ dependencies = [
  "vector-vrl-metrics",
  "vrl",
  "warp",
+ "which 8.0.0",
  "windows-service",
  "wiremock",
  "zstd 0.13.2",
@@ -13606,6 +13613,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.3",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14149,6 +14167,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -488,6 +488,7 @@ tokio-test = "0.4.4"
 tower-test = "0.4.0"
 vector-lib = { workspace = true, features = ["test"] }
 vrl.workspace = true
+which = "8"
 
 wiremock = "0.6.4"
 zstd = { version = "0.13.0", default-features = false }
@@ -728,18 +729,19 @@ transforms = ["transforms-logs", "transforms-metrics"]
 transforms-logs = [
   "transforms-aws_ec2_metadata",
   "transforms-dedupe",
+  "transforms-exclusive-route",
   "transforms-filter",
-  "transforms-window",
   "transforms-log_to_metric",
   "transforms-lua",
   "transforms-metric_to_log",
   "transforms-reduce",
   "transforms-remap",
   "transforms-route",
-  "transforms-exclusive-route",
   "transforms-sample",
+  "transforms-stdio",
   "transforms-throttle",
-  "transforms-trace_to_log"
+  "transforms-trace_to_log",
+  "transforms-window",
 ]
 transforms-metrics = [
   "transforms-aggregate",
@@ -756,20 +758,21 @@ transforms-metrics = [
 transforms-aggregate = []
 transforms-aws_ec2_metadata = ["dep:arc-swap"]
 transforms-dedupe = ["transforms-impl-dedupe"]
+transforms-exclusive-route = []
 transforms-filter = []
 transforms-incremental_to_absolute = []
-transforms-window = []
 transforms-log_to_metric = []
 transforms-lua = ["dep:mlua", "vector-lib/lua"]
 transforms-metric_to_log = []
 transforms-reduce = ["transforms-impl-reduce"]
 transforms-remap = []
 transforms-route = []
-transforms-exclusive-route = []
 transforms-sample = ["transforms-impl-sample"]
+transforms-stdio = []
 transforms-tag_cardinality_limit = ["dep:bloomy", "dep:hashbrown"]
 transforms-throttle = ["dep:governor"]
 transforms-trace_to_log = []
+transforms-window = []
 
 # Implementations of transforms
 transforms-impl-sample = []

--- a/changelog.d/new_stdio_transform.feature.md
+++ b/changelog.d/new_stdio_transform.feature.md
@@ -1,0 +1,5 @@
+Add a new transform that pipes events through external processes via stdin/stdout, enabling
+integration with any command-line tool. The external process can be configured to run in
+streaming-mode, scheduled-mode, or per-event-mode.
+
+authors: JeanMertz

--- a/lib/vector-lookup/src/lib.rs
+++ b/lib/vector-lookup/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use vrl::{
     event_path, metadata_path, owned_value_path, path,
-    path::{OwnedTargetPath, OwnedValuePath, PathPrefix},
+    path::{OwnedTargetPath, OwnedValuePath, PathPrefix, ValuePath},
 };
 
 pub mod lookup_v2;

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -27,6 +27,8 @@ pub mod metric_to_log;
 pub mod remap;
 #[cfg(feature = "transforms-route")]
 pub mod route;
+#[cfg(feature = "transforms-stdio")]
+pub mod stdio;
 #[cfg(feature = "transforms-tag_cardinality_limit")]
 pub mod tag_cardinality_limit;
 #[cfg(feature = "transforms-throttle")]

--- a/src/transforms/stdio/config.rs
+++ b/src/transforms/stdio/config.rs
@@ -1,0 +1,330 @@
+use std::{collections::HashMap, path::PathBuf, time::Duration};
+
+use vector_config::configurable_component;
+use vector_lib::codecs::{
+    JsonSerializerConfig,
+    decoding::{self, DeserializerConfig},
+};
+
+use crate::{
+    codecs::{EncodingConfigWithFraming, Transformer},
+    serde::default_decoding,
+};
+
+/// Configuration for the `stdio` transform.
+#[configurable_component(transform("stdio", "Transform events via an external process."))]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub(super) struct StdioConfig {
+    #[configurable(derived)]
+    #[serde(default)]
+    pub mode: Mode,
+
+    #[configurable(derived)]
+    pub scheduled: Option<ScheduledConfig>,
+
+    #[configurable(derived)]
+    pub streaming: Option<StreamingConfig>,
+
+    #[configurable(derived)]
+    pub per_event: Option<PerEventConfig>,
+
+    #[configurable(derived)]
+    #[serde(flatten)]
+    pub command: CommandConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub stdin: StdinConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub stdout: StdoutConfig,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub stderr: StderrConfig,
+}
+
+impl Default for StdioConfig {
+    fn default() -> Self {
+        StdioConfig {
+            mode: Mode::Scheduled,
+            scheduled: Some(ScheduledConfig::default()),
+            streaming: Some(StreamingConfig::default()),
+            per_event: Some(PerEventConfig::default()),
+            command: CommandConfig::default(),
+            stdin: StdinConfig::default(),
+            stdout: StdoutConfig::default(),
+            stderr: StderrConfig::default(),
+        }
+    }
+}
+
+impl_generate_config_from_default!(StdioConfig);
+
+/// Configuration options for scheduled commands.
+#[configurable_component]
+#[derive(Clone, Copy, Debug)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ScheduledConfig {
+    /// The interval, in seconds, between scheduled command runs.
+    ///
+    /// If the command takes longer than `exec_interval_secs` to run, it is
+    /// killed.
+    #[serde(default = "default_exec_interval_secs")]
+    pub exec_interval_secs: f64,
+
+    /// The maximum number of events to buffer before the oldest events are
+    /// dropped.
+    #[serde(default = "default_buffer_size")]
+    pub buffer_size: usize,
+}
+
+impl Default for ScheduledConfig {
+    fn default() -> Self {
+        Self {
+            exec_interval_secs: default_exec_interval_secs(),
+            buffer_size: default_buffer_size(),
+        }
+    }
+}
+
+/// Configuration options for streaming commands.
+#[configurable_component]
+#[derive(Clone, Copy, Debug)]
+#[serde(deny_unknown_fields)]
+pub(super) struct StreamingConfig {
+    /// Whether or not the command should be rerun if the command exits.
+    #[serde(default = "default_respawn_on_exit")]
+    pub respawn_on_exit: bool,
+
+    /// The amount of time, in seconds, before rerunning a streaming command that exited.
+    #[serde(default = "default_respawn_interval_secs")]
+    pub respawn_interval_secs: u64,
+}
+
+impl Default for StreamingConfig {
+    fn default() -> Self {
+        Self {
+            respawn_on_exit: default_respawn_on_exit(),
+            respawn_interval_secs: default_respawn_interval_secs(),
+        }
+    }
+}
+
+impl StreamingConfig {
+    pub(super) const fn respawn_interval(&self) -> Duration {
+        Duration::from_secs(self.respawn_interval_secs)
+    }
+}
+
+/// Configuration options for per-event commands.
+#[configurable_component]
+#[derive(Clone, Copy, Debug)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PerEventConfig {
+    /// The maximum number of concurrent processes to run.
+    ///
+    /// - A value of `0` is an invalid configuration.
+    /// - A value of `1` will process events in order.
+    /// - A value greater than `1` processes events concurrently and unordered.
+    #[serde(default = "default_max_concurrent_processes")]
+    pub max_concurrent_processes: usize,
+}
+
+impl Default for PerEventConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_processes: default_max_concurrent_processes(),
+        }
+    }
+}
+
+/// Configuration needed to spawn a process.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CommandConfig {
+    /// The command to run, plus any arguments required.
+    #[configurable(metadata(docs::examples = "cat"))]
+    pub command: Vec<String>,
+
+    /// Custom environment variables to set or update when running the command.
+    /// If a variable name already exists in the environment, its value is replaced.
+    #[serde(default)]
+    #[configurable(metadata(docs::additional_props_description = "An environment variable."))]
+    #[configurable(metadata(docs::examples = "environment_examples()"))]
+    pub environment: Option<HashMap<String, String>>,
+
+    /// Whether or not to clear the environment before setting custom environment variables.
+    #[serde(default = "default_clear_environment")]
+    pub clear_environment: bool,
+
+    /// The directory in which to run the command.
+    pub working_directory: Option<PathBuf>,
+}
+
+impl Default for CommandConfig {
+    fn default() -> Self {
+        Self {
+            command: vec!["cat".to_owned()],
+            environment: None,
+            clear_environment: default_clear_environment(),
+            working_directory: None,
+        }
+    }
+}
+
+/// Configuration for stdin of the child process.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub(super) struct StdinConfig {
+    /// The encoding configuration to use for encoding events to stdin.
+    #[serde(flatten)]
+    pub encoding: EncodingConfigWithFraming,
+}
+
+impl Default for StdinConfig {
+    fn default() -> Self {
+        Self {
+            encoding: EncodingConfigWithFraming::new(
+                None,
+                JsonSerializerConfig::default().into(),
+                Transformer::default(),
+            ),
+        }
+    }
+}
+
+/// Configuration for stdout of the child process.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub(super) struct StdoutConfig {
+    /// The framing to use for encoding events to stdout.
+    #[configurable(derived)]
+    #[serde(default)]
+    pub framing: Option<decoding::FramingConfig>,
+
+    /// The codec to use for decoding events from stdout.
+    #[configurable(derived)]
+    #[serde(default = "default_decoding")]
+    pub decoding: DeserializerConfig,
+
+    /// The namespace to use for logs. This overrides the global setting.
+    #[serde(default)]
+    #[configurable(metadata(docs::hidden))]
+    pub log_namespace: Option<bool>,
+}
+
+impl Default for StdoutConfig {
+    fn default() -> Self {
+        Self {
+            framing: None,
+            decoding: default_decoding(),
+            log_namespace: None,
+        }
+    }
+}
+
+/// Configuration for stderr of the child process.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub(super) struct StderrConfig {
+    #[configurable(derived)]
+    pub mode: StderrMode,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub framing: Option<decoding::FramingConfig>,
+
+    #[configurable(derived)]
+    #[serde(default = "default_decoding")]
+    pub decoding: DeserializerConfig,
+
+    /// The namespace to use for logs. This overrides the global setting.
+    #[serde(default)]
+    #[configurable(metadata(docs::hidden))]
+    pub log_namespace: Option<bool>,
+}
+
+impl Default for StderrConfig {
+    fn default() -> Self {
+        Self {
+            mode: StderrMode::Forward,
+            framing: None,
+            decoding: default_decoding(),
+            log_namespace: None,
+        }
+    }
+}
+
+/// How to handle stderr output from the command.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum StderrMode {
+    /// Forward stderr output into the event stream. The event will have the
+    /// `stream` metadata field set to `stderr`.
+    Forward,
+
+    /// Discard all stderr output from the command.
+    Drop,
+}
+
+/// Mode of operation for running the command.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum Mode {
+    /// The command runs continuously, receiving events over stdin and producing
+    /// events over stdout.
+    ///
+    /// The command can optionally be restarted automatically if it exits.
+    #[default]
+    Streaming,
+
+    /// The command is run on a schedule, receiving a batch of events over stdin
+    /// and producing zero or more events over stdout. It then shuts down and
+    /// waits for the timer to elapse before running again.
+    Scheduled,
+
+    /// The command is started and stopped for each individual event, receiving
+    /// a single event over stdin and producing zero or more events over stdout.
+    ///
+    /// WARNING: This mode spawns a new process for each event. This is not
+    /// recommended for high-throughput use cases.
+    PerEvent,
+}
+
+const fn default_exec_interval_secs() -> f64 {
+    60.
+}
+
+const fn default_respawn_interval_secs() -> u64 {
+    5
+}
+
+const fn default_respawn_on_exit() -> bool {
+    true
+}
+
+const fn default_clear_environment() -> bool {
+    false
+}
+
+const fn default_buffer_size() -> usize {
+    1000
+}
+
+const fn default_max_concurrent_processes() -> usize {
+    50
+}
+
+fn environment_examples() -> HashMap<String, String> {
+    HashMap::<_, _>::from_iter([
+        ("LANG".to_owned(), "es_ES.UTF-8".to_owned()),
+        ("TZ".to_owned(), "Etc/UTC".to_owned()),
+        ("PATH".to_owned(), "/bin:/usr/bin:/usr/local/bin".to_owned()),
+    ])
+}

--- a/src/transforms/stdio/exec.rs
+++ b/src/transforms/stdio/exec.rs
@@ -1,0 +1,496 @@
+use std::{
+    collections::VecDeque,
+    fmt, io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{Stream, StreamExt, future::Either, stream};
+use pin_project::pin_project;
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore, mpsc},
+    time::{Instant, MissedTickBehavior, interval_at},
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::codec::{FramedRead, FramedWrite};
+use vector_lib::{
+    codecs::encoding,
+    config::{LogNamespace, log_schema},
+    event::Event,
+    internal_event::{ComponentEventsDropped, INTENTIONAL, UNINTENTIONAL},
+    lookup::{
+        metadata_path, path,
+        path::{PathPrefix, ValuePath as _},
+    },
+};
+
+use crate::{
+    codecs::{Decoder, Encoder},
+    transforms::stdio::{
+        config::{CommandConfig, Mode, PerEventConfig, ScheduledConfig, StreamingConfig},
+        process::{OsSpawner, Process, Spawner},
+        session::{ChildSession, OutputStreamItem, SessionOutcome},
+    },
+};
+
+/// Type alias for production use.
+pub(super) type OsExecTask = ExecTask<OsSpawner>;
+
+#[derive(Clone)]
+pub(super) struct ExecTask<S: Spawner> {
+    /// Command configuration.
+    pub command: CommandConfig,
+
+    /// Operating mode.
+    pub mode: Mode,
+
+    /// Scheduled mode configuration.
+    pub scheduled: Option<ScheduledConfig>,
+
+    /// Streaming mode configuration.
+    pub streaming: Option<StreamingConfig>,
+
+    /// Per-event mode configuration.
+    pub per_event: Option<PerEventConfig>,
+
+    /// Whether to capture stderr.
+    pub capture_stderr: bool,
+
+    /// Process spawner.
+    pub spawner: S,
+
+    /// Encoder for stdin.
+    pub stdin_encoder: Encoder<encoding::Framer>,
+
+    /// Decoder for stdout.
+    pub stdout_decoder: Decoder,
+
+    /// Decoder for stderr (None if stderr is dropped).
+    pub stderr_decoder: Option<Decoder>,
+}
+
+impl<S: Spawner> ExecTask<S> {
+    pub(super) fn tag_event(&self, event: &mut Event, kind: StdStream) {
+        let Event::Log(log) = event else { return };
+
+        let (namespace, tag) = match kind {
+            StdStream::Stdout => (&self.stdout_decoder.log_namespace, "stdout"),
+            StdStream::Stderr => {
+                let Some(decoder) = &self.stderr_decoder else {
+                    return;
+                };
+
+                (&decoder.log_namespace, "stderr")
+            }
+        };
+
+        match namespace {
+            LogNamespace::Vector => {
+                log.insert(metadata_path!("vector", "stream"), tag);
+            }
+            LogNamespace::Legacy => {
+                if let Some(metadata_key) = log_schema().metadata_key() {
+                    log.insert(
+                        (PathPrefix::Event, metadata_key.concat(path!("stream"))),
+                        tag,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Spawns the process via the spawner. Returns [`SpawnError`] when spawning
+    /// fails.
+    #[inline]
+    fn spawn_process(&self) -> Result<S::Process, SpawnError> {
+        self.spawner
+            .spawn(&self.command, self.capture_stderr)
+            .map_err(SpawnError::Spawn)
+    }
+
+    /// Takes a raw spawned process and wraps it into a [`ChildSession`].
+    ///
+    /// This centralizes the logic for framing Stdin and framing + merging
+    /// Stdout/Stderr.
+    fn create_child_session(
+        &self,
+        mut process: S::Process,
+    ) -> Result<
+        ChildSession<
+            S::Process,
+            impl Stream<Item = OutputStreamItem> + Send + Unpin + 'static + use<S>,
+        >,
+        SpawnError,
+    > {
+        let stdin = process.take_stdin().ok_or(SpawnError::NoStdin)?;
+        let stdout = process.take_stdout().ok_or(SpawnError::NoStdout)?;
+        let stderr = process.take_stderr();
+
+        let stdin_writer = FramedWrite::new(stdin, self.stdin_encoder.clone());
+        let output_stream = self.build_output_stream(stdout, stderr);
+
+        Ok(ChildSession::new(process, stdin_writer, output_stream))
+    }
+
+    /// Build the output stream from the stdout and stderr streams.
+    ///
+    /// If stderr is not configured, it is ignored.
+    fn build_output_stream(
+        &self,
+        stdout: <S::Process as Process>::Stdout,
+        stderr: Option<<S::Process as Process>::Stderr>,
+    ) -> impl Stream<Item = OutputStreamItem> + Send + Unpin + 'static + use<S>
+    where
+        S::Process: Process,
+    {
+        let stdout_stream = FramedRead::new(stdout, self.stdout_decoder.clone())
+            .map(|res| (res, StdStream::Stdout));
+
+        match (stderr, self.stderr_decoder.clone()) {
+            (Some(stderr), Some(decoder)) => {
+                let stderr_stream =
+                    FramedRead::new(stderr, decoder).map(|res| (res, StdStream::Stderr));
+
+                Either::Left(stream::select(stdout_stream, stderr_stream))
+            }
+            _ => Either::Right(stdout_stream),
+        }
+    }
+
+    /// Handles the "Streaming" logic: spawning, retrying on transient errors,
+    /// and giving up on fatal errors.
+    ///
+    /// Returns `None` if a fatal error occurs (should stop processing).
+    async fn spawn_streaming_session(
+        &self,
+        config: &StreamingConfig,
+    ) -> Option<
+        ChildSession<S::Process, impl Stream<Item = OutputStreamItem> + Send + Unpin + 'static>,
+    > {
+        loop {
+            match self
+                .spawn_process()
+                .and_then(|process| self.create_child_session(process))
+            {
+                Ok(session) => return Some(session),
+                Err(SpawnError::Spawn(error)) if is_fatal_io_error(&error) => {
+                    error!(
+                        error = error.to_string(),
+                        "Fatal error spawning process (will stop retrying)"
+                    );
+
+                    return None;
+                }
+                Err(error) => error!(
+                    error = error.to_string(),
+                    "Failed to spawn process, retrying"
+                ),
+            }
+
+            // Sleep before retrying transient errors
+            tokio::time::sleep(config.respawn_interval()).await;
+        }
+    }
+
+    /// Centralized logic to decode raw output chunks into tagged Events.
+    fn decode_child_output<T>(
+        &self,
+        output: T,
+    ) -> impl Stream<Item = Event> + Send + 'static + use<S, T>
+    where
+        T: Stream<Item = OutputStreamItem> + Send + 'static,
+    {
+        let task = Arc::new(self.clone());
+
+        output.flat_map(move |(result, stream_kind)| {
+            let task = Arc::clone(&task);
+            match result {
+                Ok((events, _)) => Either::Left(stream::iter(events).map(move |mut event| {
+                    task.tag_event(&mut event, stream_kind);
+                    event
+                })),
+                Err(error) => {
+                    warn!(
+                        error = error.to_string(),
+                        stream = stream_kind.as_str(),
+                        "Decoding error"
+                    );
+                    Either::Right(stream::empty())
+                }
+            }
+        })
+    }
+
+    /// Runs the `per_event` mode.
+    pub(super) fn run_per_event(
+        self,
+        input: Pin<Box<dyn Stream<Item = Event> + Send>>,
+    ) -> impl Stream<Item = Event> + Send {
+        let task = Arc::new(self);
+
+        let concurrency_limit = task
+            .per_event
+            .map(|c| c.max_concurrent_processes)
+            .unwrap_or(50);
+
+        let semaphore = Arc::new(Semaphore::new(concurrency_limit));
+
+        input
+            .map(move |event| {
+                let task = Arc::clone(&task);
+                let semaphore = Arc::clone(&semaphore);
+
+                async move {
+                    // Acquire permit before spawning.
+                    //
+                    // This limits the number of active streams/processes.
+                    let Ok(permit) = semaphore.acquire_owned().await else {
+                        // Semaphore closed (unreachable?).
+                        return Either::Left(stream::empty());
+                    };
+
+                    let session = task
+                        .spawn_process()
+                        .and_then(|process| task.create_child_session(process));
+
+                    let session = match session {
+                        Ok(session) => session,
+                        Err(error) => {
+                            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                                count: 1,
+                                reason: &format!("Failed to spawn child process: {error}."),
+                            });
+
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                            return Either::Left(stream::empty());
+                        }
+                    };
+
+                    let stream = task.decode_child_output(session.into_output_stream(Some(event)));
+                    Either::Right(PermitStream { stream, permit })
+                }
+            })
+            .buffered(concurrency_limit)
+            .flatten_unordered(concurrency_limit)
+    }
+
+    /// Runs the `scheduled` mode.
+    pub(super) fn run_scheduled(
+        self,
+        mut input: Pin<Box<dyn Stream<Item = Event> + Send>>,
+    ) -> impl Stream<Item = Event> + Send {
+        let task = Arc::new(self);
+        let ScheduledConfig {
+            exec_interval_secs,
+            buffer_size,
+        } = task.scheduled.unwrap_or_default();
+
+        let exec_interval = Duration::from_secs_f64(exec_interval_secs);
+        let (tx, rx) = mpsc::channel(10);
+
+        tokio::spawn(async move {
+            let mut buffer: VecDeque<Event> = VecDeque::with_capacity(buffer_size);
+            let start = Instant::now() + exec_interval;
+            let mut ticker = interval_at(start, exec_interval);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            let flush_batch = |batch: Vec<Event>| {
+                let count = batch.len();
+                if count == 0 {
+                    return;
+                }
+
+                let session = task
+                    .spawn_process()
+                    .and_then(|p| task.create_child_session(p));
+
+                let session = match session {
+                    Ok(session) => session,
+                    Err(error) => {
+                        emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                            count,
+                            reason: &format!("Failed to spawn child process: {error}."),
+                        });
+
+                        return;
+                    }
+                };
+
+                let tx = tx.clone();
+                let task = Arc::clone(&task);
+
+                // Spawn execution to ensure the main loop keeps buffering.
+                tokio::spawn(async move {
+                    let mut stream =
+                        task.decode_child_output(session.into_output_stream_batch(batch));
+
+                    let _ = tokio::time::timeout(exec_interval, async {
+                        while let Some(event) = stream.next().await {
+                            if tx.send(event).await.is_err() {
+                                break;
+                            }
+                        }
+                    })
+                    .await;
+                });
+            };
+
+            loop {
+                // If buffer is empty, wait for input. This avoids consuming a
+                // 'tick' when there is no work to do.
+                if buffer.is_empty() {
+                    match input.next().await {
+                        Some(event) => buffer.push_back(event),
+                        None => break, // EOF
+                    }
+                }
+
+                tokio::select! {
+                    biased;
+
+                    event = input.next() => match event {
+                        Some(event) => {
+                            if buffer.len() >= buffer_size {
+                                buffer.pop_front();
+                                emit!(ComponentEventsDropped::<INTENTIONAL> {
+                                    count: 1,
+                                    reason: "Buffer was full.",
+                                });
+                            }
+                            buffer.push_back(event);
+                        }
+
+                        // Upstream closed.
+                        None => {
+                            // Ensure we flush the buffer before shutting down.
+                            flush_batch(buffer.drain(..).collect());
+                            break;
+                        }
+                    },
+
+                    _ = ticker.tick() => flush_batch(buffer.drain(..).collect()),
+                }
+            }
+        });
+
+        ReceiverStream::new(rx)
+    }
+
+    /// Runs the `streaming` mode.
+    pub(super) fn run_streaming(
+        self,
+        input: Pin<Box<dyn Stream<Item = Event> + Send>>,
+    ) -> impl Stream<Item = Event> + Send {
+        let task = Arc::new(self);
+        let config = task.streaming.unwrap_or_default();
+        let (tx, rx) = mpsc::channel(10);
+
+        tokio::spawn(async move {
+            let mut input = input;
+
+            // spawn_streaming_session handles the retry logic internally. If it
+            // returns None, it means a fatal error occurred.
+            while let Some(session) = task.spawn_streaming_session(&config).await {
+                let outcome = session.run(&mut input, &tx, &task).await;
+
+                match outcome {
+                    SessionOutcome::InputExhausted | SessionOutcome::DownstreamClosed => break,
+                    SessionOutcome::ChildExited => {
+                        if !config.respawn_on_exit {
+                            break;
+                        }
+
+                        tokio::time::sleep(config.respawn_interval()).await;
+                    }
+                }
+            }
+        });
+
+        ReceiverStream::new(rx)
+    }
+}
+
+/// Determines if an IO error is fatal (should stop the component) or transient
+/// (should retry).
+fn is_fatal_io_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::NotFound
+            | io::ErrorKind::PermissionDenied
+            | io::ErrorKind::IsADirectory
+            | io::ErrorKind::InvalidInput
+    )
+}
+
+/// A stream wrapper that holds a semaphore permit.
+///
+/// The permit is dropped when the stream is dropped.
+#[pin_project]
+struct PermitStream<S> {
+    #[pin]
+    stream: S,
+    permit: OwnedSemaphorePermit,
+}
+
+impl<S: Stream> Stream for PermitStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().stream.poll_next(cx)
+    }
+}
+
+/// The standard-stream from which an event was captured.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(super) enum StdStream {
+    /// The stdout stream.
+    Stdout,
+
+    /// The stderr stream.
+    Stderr,
+}
+
+impl StdStream {
+    /// Returns the string representation of the stream.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            StdStream::Stdout => "stdout",
+            StdStream::Stderr => "stderr",
+        }
+    }
+}
+
+/// Error type returned when spawning a process.
+#[derive(Debug)]
+pub(super) enum SpawnError {
+    /// Failed to spawn the process.
+    Spawn(io::Error),
+
+    /// Failed to capture stdin.
+    NoStdin,
+
+    /// Failed to capture stdout.
+    NoStdout,
+}
+
+impl std::error::Error for SpawnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SpawnError::Spawn(e) => Some(e),
+            SpawnError::NoStdin => None,
+            SpawnError::NoStdout => None,
+        }
+    }
+}
+
+impl fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SpawnError::Spawn(_) => write!(f, "failed to spawn process"),
+            SpawnError::NoStdin => write!(f, "failed to capture stdin"),
+            SpawnError::NoStdout => write!(f, "failed to capture stdout"),
+        }
+    }
+}

--- a/src/transforms/stdio/mod.rs
+++ b/src/transforms/stdio/mod.rs
@@ -1,0 +1,913 @@
+mod config;
+mod exec;
+mod process;
+mod session;
+mod transform;
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::print_stderr)]
+
+    use std::{collections::HashMap, io, pin::Pin, time::Duration};
+
+    use futures::{Stream, StreamExt as _};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        sync::mpsc::{self, Receiver, Sender},
+        task::JoinSet,
+        time::{Instant, sleep, timeout},
+    };
+    use tokio_stream::wrappers::ReceiverStream;
+    use vector_lib::{
+        codecs::{
+            JsonDeserializerConfig, JsonSerializerConfig, NewlineDelimitedDecoderConfig,
+            NewlineDelimitedEncoderConfig, encoding,
+        },
+        config::LogNamespace,
+        transform::TaskTransform as _,
+    };
+    use vrl::core::Value;
+
+    use crate::{
+        codecs::{self, DecodingConfig},
+        event::{Event, LogEvent},
+        test_util::components::assert_transform_compliance,
+        transforms::{
+            stdio::{
+                config::{
+                    CommandConfig, Mode, PerEventConfig, ScheduledConfig, StdioConfig,
+                    StreamingConfig,
+                },
+                exec::ExecTask,
+                process::mock::MockSpawnerBuilder,
+            },
+            test::create_topology,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_integration() {
+        struct TestCase {
+            mode: Mode,
+            command: Vec<&'static str>,
+            tx: Vec<&'static str>,
+            rx: Vec<&'static str>,
+            scheduled: Option<ScheduledConfig>,
+            per_event: Option<PerEventConfig>,
+            vars: HashMap<&'static str, &'static str>,
+            clear_vars: bool,
+        }
+
+        impl Default for TestCase {
+            fn default() -> Self {
+                Self {
+                    mode: Mode::PerEvent,
+                    command: vec!["cat"],
+                    tx: vec![],
+                    rx: vec![],
+                    scheduled: None,
+                    per_event: None,
+                    vars: HashMap::new(),
+                    clear_vars: false,
+                }
+            }
+        }
+
+        let cases = vec![
+            (
+                "per-event",
+                TestCase {
+                    mode: Mode::PerEvent,
+                    per_event: Some(PerEventConfig {
+                        // Guarantee ordering of events.
+                        max_concurrent_processes: 1,
+                    }),
+                    command: vec!["cat"],
+                    tx: vec!["hello", "world"],
+                    rx: vec![r#"{"message":"hello"}"#, r#"{"message":"world"}"#],
+                    ..Default::default()
+                },
+            ),
+            (
+                "streaming",
+                TestCase {
+                    mode: Mode::Streaming,
+                    command: vec!["cat"],
+                    tx: vec!["hello", "world"],
+                    rx: vec![r#"{"message":"hello"}"#, r#"{"message":"world"}"#],
+                    ..Default::default()
+                },
+            ),
+            (
+                "scheduled",
+                TestCase {
+                    mode: Mode::Scheduled,
+                    command: vec!["cat"],
+                    tx: vec!["hello", "world"],
+                    rx: vec![r#"{"message":"hello"}"#, r#"{"message":"world"}"#],
+                    scheduled: Some(ScheduledConfig {
+                        exec_interval_secs: 0.1,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ),
+            (
+                "environment variables",
+                TestCase {
+                    mode: Mode::PerEvent,
+                    command: vec!["echo $TEST_VAR"],
+                    tx: vec!["trigger"],
+                    rx: vec!["test_value"],
+                    vars: HashMap::from([("TEST_VAR", "test_value")]),
+                    ..Default::default()
+                },
+            ),
+            (
+                "clear environment variables",
+                TestCase {
+                    mode: Mode::PerEvent,
+                    command: vec![r#"echo "PATH=$PATH""#],
+                    tx: vec!["trigger"],
+                    rx: vec!["PATH="],
+                    clear_vars: true,
+                    ..Default::default()
+                },
+            ),
+        ];
+
+        for (
+            name,
+            TestCase {
+                mode,
+                command,
+                tx,
+                rx,
+                scheduled,
+                per_event,
+                vars,
+                clear_vars,
+            },
+        ) in cases
+        {
+            eprintln!("running test case {}", name);
+
+            if command.is_empty() || which::which(command[0]).is_err() {
+                eprintln!(
+                    "Skipping integration test '{}' because command {:?} is not available",
+                    name, command
+                );
+
+                continue;
+            }
+
+            assert_transform_compliance(async {
+                let config = StdioConfig {
+                    mode,
+                    command: CommandConfig {
+                        command: command.into_iter().map(str::to_owned).collect(),
+                        environment: (!vars.is_empty()).then_some(
+                            vars.into_iter()
+                                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                                .collect(),
+                        ),
+                        clear_environment: clear_vars,
+                        ..Default::default()
+                    },
+                    scheduled,
+                    per_event,
+                    ..Default::default()
+                };
+
+                let (stream_tx, stream_rx) = mpsc::channel(1);
+                let (topology, mut out) =
+                    create_topology(ReceiverStream::new(stream_rx), config).await;
+
+                for event in tx {
+                    send_event(&stream_tx, event).await;
+                }
+                for event in rx {
+                    assert_eq!(
+                        &Value::from(event),
+                        recv_event(&mut out)
+                            .await
+                            .expect("Expected an event but got None")
+                            .as_log()
+                            .get("message")
+                            .unwrap()
+                    );
+                }
+
+                drop(stream_tx);
+                topology.stop().await;
+
+                assert_eq!(out.recv().await, None);
+            })
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stdout_success() {
+        for mode in [Mode::PerEvent, Mode::Streaming, Mode::Scheduled] {
+            let case = TestCase {
+                mode,
+                capture_stderr: false,
+                scheduled: Some(ScheduledConfig {
+                    exec_interval_secs: 0.1,
+                    buffer_size: 10,
+                }),
+                streaming: Some(StreamingConfig {
+                    // Ensure Streaming mode exits when input closes and child
+                    // exits.
+                    respawn_on_exit: false,
+                    respawn_interval_secs: 0,
+                }),
+                per_event: None,
+                stderr_decoder: None,
+                spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                    let mut handle = builder.expect_spawn(false);
+
+                    joins.spawn(async move {
+                        let mut buf = vec![0u8; 4096];
+                        while let Ok(n) = handle.stdin.read(&mut buf).await {
+                            if n == 0 {
+                                break;
+                            }
+                            let _ = handle.stdout.write_all(&buf[..n]).await;
+                        }
+
+                        handle.exit(0);
+                    });
+                },
+                runner: async |tx: Sender<Event>, rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                    let msg = "test_message";
+                    send_event(&tx, msg).await;
+                    drop(tx);
+
+                    let events: Vec<_> = rx.collect().await;
+
+                    assert_eq!(events.len(), 1);
+                    assert_eq!(
+                        events[0].as_log().get("message").unwrap(),
+                        &Value::from(msg)
+                    );
+                },
+            };
+
+            case.run().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_respawn() {
+        let case = TestCase {
+            mode: Mode::Streaming,
+            capture_stderr: false,
+            scheduled: None,
+            streaming: Some(StreamingConfig {
+                respawn_on_exit: true,
+                respawn_interval_secs: 0,
+            }),
+            per_event: None,
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                // First process exits immediately
+                let handle1 = builder.expect_spawn(false);
+                joins.spawn(async move {
+                    handle1.exit(1);
+                });
+
+                // Second process after respawn prints to stdout
+                let mut handle2 = builder.expect_spawn(false);
+                joins.spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    if let Ok(n) = handle2.stdin.read(&mut buf).await {
+                        let _ = handle2.stdout.write_all(&buf[..n]).await;
+                    }
+                    handle2.exit(0);
+                });
+            },
+            runner: async |tx: Sender<Event>, mut rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                // Send event (should go to second process)
+                tx.send(Event::from(LogEvent::from("after_respawn")))
+                    .await
+                    .unwrap();
+
+                let event = timeout(Duration::from_secs(1), rx.next())
+                    .await
+                    .unwrap()
+                    .unwrap();
+
+                assert_eq!(
+                    event.as_log().get("message").unwrap(),
+                    &Value::from("after_respawn")
+                );
+            },
+        };
+
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_scheduled_buffer_overflow() {
+        let case = TestCase {
+            mode: Mode::Scheduled,
+            capture_stderr: false,
+            scheduled: Some(ScheduledConfig {
+                // Set a large interval so the timer never fires during the test.
+                // We rely entirely on the buffer overflow logic happening
+                // during ingestion, and the "flush on shutdown" to emit the
+                // remaining events.
+                exec_interval_secs: 10.0,
+                buffer_size: 2,
+            }),
+            streaming: None,
+            per_event: None,
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                // We expect ONE spawn that receives the final batch of 2.
+                let mut handle = builder.expect_spawn(false);
+                joins.spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    while let Ok(n) = handle.stdin.read(&mut buf).await {
+                        if n == 0 {
+                            break;
+                        }
+                        handle.stdout.write_all(&buf[..n]).await.unwrap();
+                    }
+
+                    handle.exit(0);
+                });
+            },
+            runner: async |tx: Sender<Event>, rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                // Send 5 events, retaining the last 2.
+                for i in 1..=5 {
+                    let mut log = LogEvent::default();
+                    log.insert("counter", i);
+                    tx.send(Event::from(log)).await.unwrap();
+                }
+
+                // Close input stream to trigger the flush of [4, 5].
+                drop(tx);
+
+                let events: Vec<_> = rx.collect().await;
+                assert_eq!(events.len(), 2,);
+                assert_eq!(events[0].as_log().get("counter").unwrap(), &Value::from(4));
+                assert_eq!(events[1].as_log().get("counter").unwrap(), &Value::from(5));
+            },
+        };
+
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_scheduled_process_timeout() {
+        let exec_interval_secs = 0.2;
+
+        let case = TestCase {
+            mode: Mode::Scheduled,
+            capture_stderr: false,
+            scheduled: Some(ScheduledConfig {
+                exec_interval_secs,
+                buffer_size: 10,
+            }),
+            streaming: None,
+            per_event: None,
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                let handle1 = builder.expect_spawn(false);
+                joins.spawn(async move {
+                    // Keep the handle alive longer than `exec_interval_secs` to
+                    // ensure the component triggers the timeout logic before
+                    // this task exits naturally.
+                    sleep(Duration::from_secs_f64(exec_interval_secs + 0.1)).await;
+                    drop(handle1);
+                });
+
+                // A new process is spawned after the first one times out.
+                let mut handle2 = builder.expect_spawn(false);
+                joins.spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    while let Ok(n) = handle2.stdin.read(&mut buf).await {
+                        if n == 0 {
+                            break;
+                        }
+                        let _ = handle2.stdout.write_all(&buf[..n]).await;
+                    }
+                    handle2.exit(0);
+                });
+            },
+            runner: async |tx: Sender<Event>, mut rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                // First batch is sent to the first process, which hangs.
+                send_event(&tx, "batch_1").await;
+
+                // Wait for the first process to timeout. During this period, no
+                // events should be received.
+                let result =
+                    timeout(Duration::from_secs_f64(exec_interval_secs + 0.1), rx.next()).await;
+                assert!(result.is_err());
+
+                // Second batch is processed as expected by the second process.
+                send_event(&tx, "batch_2").await;
+
+                let event = timeout(Duration::from_secs(1), rx.next())
+                    .await
+                    .expect("Should receive output from Batch 2")
+                    .expect("Stream should not be closed");
+
+                assert_eq!(
+                    event.as_log().get("message").unwrap(),
+                    &Value::from("batch_2")
+                );
+            },
+        };
+
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_streaming_fatal_error_no_retry() {
+        let case = TestCase {
+            mode: Mode::Streaming,
+            capture_stderr: false,
+            scheduled: None,
+            streaming: Some(StreamingConfig {
+                respawn_on_exit: true,
+                respawn_interval_secs: 0,
+            }),
+            per_event: None,
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, _| {
+                // Even though `respawn_on_exit` is true, fatal errors stop the
+                // loop.
+                builder.expect_spawn_error(io::Error::new(io::ErrorKind::NotFound, "not found"));
+
+                // NO new processes are expected to spawn after the first one
+                // errors.
+            },
+            runner: async |_, mut rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                // The stream should close immediately upon encountering the
+                // fatal error
+                match timeout(Duration::from_secs(1), rx.next()).await {
+                    Ok(None) => {} // Pass: Stream closed
+                    Ok(Some(_)) => panic!("Should not receive events"),
+                    Err(_) => panic!("Stream hung (likely retrying infinitely)"),
+                }
+            },
+        };
+
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_scheduled_flush_on_shutdown() {
+        let case = TestCase {
+            mode: Mode::Scheduled,
+            capture_stderr: false,
+            // Set a long interval to ensure the ticker doesn't fire naturally.
+            scheduled: Some(ScheduledConfig {
+                exec_interval_secs: 10.0,
+                buffer_size: 10,
+            }),
+            streaming: None,
+            per_event: None,
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                // We expect a spawn because the shutdown should flush the
+                // buffer.
+                let mut handle = builder.expect_spawn(false);
+                joins.spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    if let Ok(n) = handle.stdin.read(&mut buf).await {
+                        let _ = handle.stdout.write_all(&buf[..n]).await;
+                    }
+                    handle.exit(0);
+                });
+            },
+            runner: async |tx: Sender<Event>, mut rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                send_event(&tx, "buffered_event").await;
+
+                // Close the input stream immediately.
+                drop(tx);
+
+                // We expect the component to flush the buffer before shutting
+                // down.
+                let event = timeout(Duration::from_secs(1), rx.next())
+                    .await
+                    .expect("Should not timeout waiting for flush")
+                    .expect("Stream should contain flushed event");
+
+                assert_eq!(
+                    event.as_log().get("message").unwrap(),
+                    &Value::from("buffered_event")
+                );
+            },
+        };
+
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_per_event_concurrency() {
+        let case = TestCase {
+            mode: Mode::PerEvent,
+            capture_stderr: false,
+            scheduled: None,
+            streaming: None,
+            per_event: None,
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                // Expect 5 concurrent spawns
+                for _ in 0..5 {
+                    let mut handle = builder.expect_spawn(false);
+                    joins.spawn(async move {
+                        // Wait for the process to actually read from stdin
+                        // (triggering the start of the sleep).
+                        let mut buf = [0u8; 1024];
+                        let _ = handle.stdin.read(&mut buf).await;
+
+                        // Simulate a slow process.
+                        sleep(Duration::from_millis(200)).await;
+                        // Write output so we get an event back
+                        let _ = handle.stdout.write_all(b"{\"message\":\"done\"}\n").await;
+                        handle.exit(0);
+                    });
+                }
+            },
+            runner: async |tx, mut rx| {
+                let start = Instant::now();
+
+                // Send 5 events rapidly
+                for i in 0..5 {
+                    send_event(&tx, &format!("trigger_{}", i)).await;
+                }
+
+                // Drop tx to close input stream.
+                drop(tx);
+
+                // Collect all 5 results.
+                for _ in 0..5 {
+                    let _ = timeout(Duration::from_secs(1), rx.next()).await.unwrap();
+                }
+
+                let elapsed = start.elapsed();
+
+                // If sequential: 5 * 200ms = 1000ms. If concurrent: ~200ms + overhead.
+                assert!(
+                    elapsed < Duration::from_millis(500),
+                    "Processes ran sequentially (took {:?})",
+                    elapsed
+                );
+            },
+        };
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_per_event_concurrency_limit() {
+        let case = TestCase {
+            mode: Mode::PerEvent,
+            capture_stderr: false,
+            scheduled: None,
+            streaming: None,
+            per_event: Some(PerEventConfig {
+                max_concurrent_processes: 2,
+            }),
+            stderr_decoder: None,
+            spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                // Expect 5 tasks
+                for _ in 0..5 {
+                    let mut handle = builder.expect_spawn(false);
+                    joins.spawn(async move {
+                        // Wait for the process to actually read from stdin
+                        // (triggering the start of the sleep).
+                        let mut buf = [0u8; 1024];
+                        let _ = handle.stdin.read(&mut buf).await;
+
+                        sleep(Duration::from_millis(100)).await;
+                        let _ = handle.stdout.write_all(b"{\"message\":\"done\"}\n").await;
+                        handle.exit(0);
+                    });
+                }
+            },
+            runner: async |tx: Sender<Event>, rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                let start = Instant::now();
+
+                for i in 0..5 {
+                    send_event(&tx, &format!("trigger_{}", i)).await;
+                }
+                drop(tx);
+
+                let events: Vec<_> = rx.collect().await;
+                assert_eq!(events.len(), 5, "Expected 5 successful events");
+
+                let elapsed = start.elapsed();
+
+                // 5 tasks, each taking ~100ms, two tasks running concurrently.
+                // The total time should be ~300ms.
+
+                assert!(
+                    elapsed > Duration::from_millis(200),
+                    "Processes ran too fast (concurrency limit likely ignored). Took: {:?}",
+                    elapsed
+                );
+
+                assert!(
+                    elapsed < Duration::from_millis(400),
+                    "Processes ran sequentially. Took: {:?}",
+                    elapsed
+                );
+            },
+        };
+
+        case.run().await;
+    }
+
+    #[tokio::test]
+    async fn test_decode_error() {
+        for mode in [Mode::PerEvent, Mode::Streaming, Mode::Scheduled] {
+            let case = TestCase {
+                mode,
+                capture_stderr: false,
+                scheduled: Some(ScheduledConfig {
+                    exec_interval_secs: 0.1,
+                    buffer_size: 2,
+                }),
+                streaming: Some(StreamingConfig {
+                    // We want the original process to not exit.
+                    respawn_on_exit: false,
+                    respawn_interval_secs: 0,
+                }),
+                per_event: None,
+                stderr_decoder: None,
+                spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                    // Only one process is spawned, it must not fail.
+                    let mut handle = builder.expect_spawn(false);
+
+                    joins.spawn(async move {
+                        let mut buf = vec![0u8; 100];
+                        let _ = handle.stdin.read(&mut buf).await;
+
+                        // Second event is invalid JSON.
+                        let _ = handle.stdout.write_all(b"{\"message\":\"good1\"}\n").await;
+                        let _ = handle.stdout.write_all(b"not json\n").await;
+                        let _ = handle.stdout.write_all(b"{\"message\":\"good2\"}\n").await;
+
+                        handle.exit(0);
+                    });
+                },
+                runner: async |tx: Sender<Event>, mut rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                    // Trigger the process.
+                    send_event(&tx, "start").await;
+
+                    // Expect first valid event.
+                    let e1 = timeout(Duration::from_secs(1), rx.next())
+                        .await
+                        .expect("Timeout waiting for 1st event")
+                        .expect("Stream closed unexpectedly");
+
+                    assert_eq!(e1.as_log().get("message").unwrap(), &Value::from("good1"));
+
+                    // Expect second valid event (skipping the invalid one).
+                    let e2 = timeout(Duration::from_secs(1), rx.next())
+                        .await
+                        .expect("Timeout waiting for 2nd event (decode error likely killed stream)")
+                        .expect("Stream closed unexpectedly");
+
+                    assert_eq!(e2.as_log().get("message").unwrap(), &Value::from("good2"));
+                },
+            };
+
+            case.run().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stderr_handling() {
+        for mode in [Mode::PerEvent, Mode::Streaming, Mode::Scheduled] {
+            for namespace in [LogNamespace::Legacy, LogNamespace::Vector] {
+                let case = TestCase {
+                    mode,
+                    capture_stderr: true,
+                    scheduled: Some(ScheduledConfig {
+                        exec_interval_secs: 0.1,
+                        buffer_size: 2,
+                    }),
+                    streaming: Some(StreamingConfig {
+                        respawn_on_exit: false,
+                        respawn_interval_secs: 0,
+                    }),
+                    per_event: None,
+                    stderr_decoder: Some(codecs::DecodingConfig::new(
+                        NewlineDelimitedDecoderConfig::default().into(),
+                        JsonDeserializerConfig::default().into(),
+                        namespace,
+                    )),
+                    spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                        let mut handle = builder.expect_spawn(true);
+                        joins.spawn(async move {
+                            let mut buf = vec![0u8; 4096];
+
+                            if let Ok(n) = handle.stdin.read(&mut buf).await {
+                                let _ = handle.stdout.write_all(&buf[..n]).await;
+
+                                // Also write to stderr
+                                if let Some(ref mut stderr) = handle.stderr {
+                                    let stderr_msg = b"{\"message\":\"stderr_output\"}\n";
+                                    let _ = stderr.write_all(stderr_msg).await;
+                                }
+                            }
+                            handle.exit(0);
+                        });
+                    },
+                    runner:
+                        async |tx: Sender<Event>, mut rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                            // Send an event
+                            send_event(&tx, "test_input").await;
+
+                            // Should receive events from both stdout and stderr, in
+                            // random order.
+                            let mut received_stdout = false;
+                            let mut received_stderr = false;
+
+                            for _ in 0..2 {
+                                if let Ok(Some(event)) =
+                                    timeout(Duration::from_secs(1), rx.next()).await
+                                {
+                                    let log = event.as_log();
+
+                                    // Check the stream tag.
+                                    let tag = log
+                                        .get("metadata.stream")
+                                        .or_else(|| log.get("%vector.stream"))
+                                        .expect("Missing stream tag");
+
+                                    match tag.to_string_lossy().as_ref() {
+                                        "stdout" => received_stdout = true,
+                                        "stderr" => received_stderr = true,
+                                        _ => {}
+                                    }
+                                }
+                            }
+
+                            assert!(received_stdout, "Mode {:?} missing stdout event", mode);
+                            assert!(received_stderr, "Mode {:?} missing stderr event", mode);
+                        },
+                };
+
+                case.run().await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stderr_ignored() {
+        for mode in [Mode::PerEvent, Mode::Streaming, Mode::Scheduled] {
+            let case = TestCase {
+                mode,
+                capture_stderr: false,
+                scheduled: Some(ScheduledConfig {
+                    exec_interval_secs: 0.1,
+                    buffer_size: 2,
+                }),
+                streaming: Some(StreamingConfig {
+                    respawn_on_exit: false,
+                    respawn_interval_secs: 0,
+                }),
+                per_event: None,
+                stderr_decoder: None,
+                spawner: |builder: &mut MockSpawnerBuilder, joins: &mut JoinSet<()>| {
+                    let mut handle = builder.expect_spawn(true);
+                    joins.spawn(async move {
+                        let mut buf = vec![0u8; 100];
+                        let _ = handle.stdin.read(&mut buf).await;
+
+                        // Write to stdout
+                        let _ = handle
+                            .stdout
+                            .write_all(b"{\"message\":\"from_stdout\"}\n")
+                            .await;
+
+                        // Write to stderr
+                        //
+                        // Fails with `BrokenPipe` because we're not capturing
+                        // stderr.
+                        if let Some(stderr) = handle.stderr.as_mut() {
+                            let res = stderr.write_all(b"{\"message\":\"from_stderr\"}\n").await;
+                            assert_eq!(res.unwrap_err().kind(), io::ErrorKind::BrokenPipe,);
+                        }
+
+                        handle.exit(0);
+                    });
+                },
+                runner: async |tx: Sender<Event>, rx: Pin<Box<dyn Stream<Item = Event>>>| {
+                    send_event(&tx, "trigger").await;
+
+                    // Close the input stream.
+                    drop(tx);
+
+                    let events: Vec<_> = rx.collect().await;
+                    assert_eq!(events.len(), 1);
+                    assert_eq!(
+                        events[0].as_log().get("message").unwrap(),
+                        &Value::from("from_stdout"),
+                    );
+                },
+            };
+            case.run().await;
+        }
+    }
+
+    fn create_test_encoder() -> codecs::Encoder<encoding::Framer> {
+        let serializer = JsonSerializerConfig::default().build().into();
+        let framer = NewlineDelimitedEncoderConfig.build().into();
+
+        codecs::Encoder::<encoding::Framer>::new(framer, serializer)
+    }
+
+    fn create_test_decoder() -> codecs::Decoder {
+        codecs::DecodingConfig::new(
+            NewlineDelimitedDecoderConfig::default().into(),
+            JsonDeserializerConfig::default().into(),
+            LogNamespace::Legacy,
+        )
+        .build()
+        .unwrap()
+    }
+
+    async fn send_event(tx: &Sender<Event>, message: &str) {
+        let mut log = LogEvent::default();
+        log.insert("message", message);
+
+        tx.send(Event::from(log)).await.unwrap();
+    }
+
+    async fn recv_event(out: &mut Receiver<Event>) -> Option<Event> {
+        timeout(Duration::from_secs(1), out.recv())
+            .await
+            .ok()
+            .flatten()
+    }
+
+    struct TestCase<
+        S: Fn(&mut MockSpawnerBuilder, &mut JoinSet<()>),
+        R: AsyncFnOnce(Sender<Event>, Pin<Box<dyn Stream<Item = Event>>>),
+    > {
+        mode: Mode,
+        capture_stderr: bool,
+        scheduled: Option<ScheduledConfig>,
+        streaming: Option<StreamingConfig>,
+        per_event: Option<PerEventConfig>,
+        stderr_decoder: Option<DecodingConfig>,
+        spawner: S,
+        runner: R,
+    }
+
+    impl<S, R> TestCase<S, R>
+    where
+        S: Fn(&mut MockSpawnerBuilder, &mut JoinSet<()>),
+        R: AsyncFnOnce(Sender<Event>, Pin<Box<dyn Stream<Item = Event>>>),
+    {
+        async fn run(self) {
+            let Self {
+                mode,
+                capture_stderr,
+                scheduled,
+                streaming,
+                per_event,
+                stderr_decoder,
+                spawner,
+                runner,
+            } = self;
+
+            let mut mock = MockSpawnerBuilder::new();
+            let mut joins = JoinSet::new();
+            spawner(&mut mock, &mut joins);
+
+            let task = ExecTask {
+                command: CommandConfig::default(),
+                mode,
+                scheduled,
+                streaming,
+                per_event,
+                capture_stderr,
+                spawner: mock.build(),
+                stdin_encoder: create_test_encoder(),
+                stdout_decoder: create_test_decoder(),
+                stderr_decoder: capture_stderr.then(|| {
+                    stderr_decoder
+                        .and_then(|v| v.build().ok())
+                        .unwrap_or_else(create_test_decoder)
+                }),
+            };
+
+            let (tx, rx) = mpsc::channel(10);
+            let input = ReceiverStream::new(rx);
+
+            let output = Box::new(task).transform(Box::pin(input));
+            runner(tx, output).await;
+            joins.join_all().await;
+        }
+    }
+}

--- a/src/transforms/stdio/process.rs
+++ b/src/transforms/stdio/process.rs
@@ -1,0 +1,299 @@
+use std::{future::Future, io, process::Stdio};
+
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
+};
+
+use super::config::CommandConfig;
+
+/// Abstraction over process exit status.
+///
+/// We need this because [`std::process::ExitStatus`] cannot be constructed
+/// directly, making it impossible to use in tests.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ExitStatus {
+    code: Option<i32>,
+}
+
+impl ExitStatus {
+    #[cfg(test)]
+    const fn success() -> Self {
+        Self { code: Some(0) }
+    }
+
+    #[cfg(test)]
+    const fn from_code(code: i32) -> Self {
+        Self { code: Some(code) }
+    }
+
+    pub(super) const fn code(self) -> Option<i32> {
+        self.code
+    }
+
+    pub(super) const fn is_success(self) -> bool {
+        matches!(self.code, Some(0))
+    }
+}
+
+impl From<std::process::ExitStatus> for ExitStatus {
+    fn from(status: std::process::ExitStatus) -> Self {
+        Self {
+            code: status.code(),
+        }
+    }
+}
+
+/// Trait for spawning processes.
+pub trait Spawner: Clone + Send + Sync + 'static {
+    type Process: Process;
+
+    /// Spawn a process.
+    fn spawn(&self, config: &CommandConfig, capture_stderr: bool) -> io::Result<Self::Process>;
+}
+
+/// Trait representing a running process with I/O handles.
+pub trait Process: Send {
+    type Stdin: AsyncWrite + Unpin + Send + 'static;
+    type Stdout: AsyncRead + Unpin + Send + 'static;
+    type Stderr: AsyncRead + Unpin + Send + 'static;
+
+    fn take_stdin(&mut self) -> Option<Self::Stdin>;
+    fn take_stdout(&mut self) -> Option<Self::Stdout>;
+    fn take_stderr(&mut self) -> Option<Self::Stderr>;
+
+    /// Wait for the process to exit.
+    fn wait(&mut self) -> impl Future<Output = io::Result<ExitStatus>> + Send;
+}
+
+/// Production spawner using [`tokio::process`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OsSpawner;
+
+impl Spawner for OsSpawner {
+    type Process = OsProcess;
+
+    #[inline]
+    fn spawn(&self, config: &CommandConfig, capture_stderr: bool) -> io::Result<Self::Process> {
+        if config.command.is_empty() {
+            return Err(io::Error::other(
+                "command must contain at least one element",
+            ));
+        }
+
+        let mut cmd = Command::new(&config.command[0]);
+
+        if config.command.len() > 1 {
+            cmd.args(&config.command[1..]);
+        }
+
+        if config.clear_environment {
+            cmd.env_clear();
+        }
+
+        if let Some(envs) = &config.environment {
+            cmd.envs(envs);
+        }
+
+        if let Some(dir) = &config.working_directory {
+            cmd.current_dir(dir);
+        }
+
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(if capture_stderr {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+        cmd.kill_on_drop(true);
+
+        cmd.spawn().map(OsProcess)
+    }
+}
+
+/// Wrapper around [`tokio::process::Child`].
+pub struct OsProcess(Child);
+
+impl Process for OsProcess {
+    type Stdin = ChildStdin;
+    type Stdout = ChildStdout;
+    type Stderr = ChildStderr;
+
+    #[inline]
+    fn take_stdin(&mut self) -> Option<Self::Stdin> {
+        self.0.stdin.take()
+    }
+
+    #[inline]
+    fn take_stdout(&mut self) -> Option<Self::Stdout> {
+        self.0.stdout.take()
+    }
+
+    #[inline]
+    fn take_stderr(&mut self) -> Option<Self::Stderr> {
+        self.0.stderr.take()
+    }
+
+    async fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.0.wait().await.map(ExitStatus::from)
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
+    use tokio::{io::DuplexStream, sync::oneshot};
+
+    /// Handle returned to test code for controlling a mock process.
+    pub struct ProcessHandle {
+        /// Write here to provide data that the task will read from "stdout".
+        pub stdout: DuplexStream,
+
+        /// Write here to provide data that the task will read from "stderr".
+        pub stderr: Option<DuplexStream>,
+
+        /// Read here to see what the task wrote to "stdin".
+        pub stdin: DuplexStream,
+
+        /// Send here to make the process "exit".
+        pub exit_tx: oneshot::Sender<ExitStatus>,
+    }
+
+    impl ProcessHandle {
+        /// Signal exit with a specific code.
+        pub fn exit(self, code: i32) {
+            let _ = self.exit_tx.send(ExitStatus::from_code(code));
+        }
+    }
+
+    /// Builder for setting up mock processes.
+    #[derive(Default)]
+    pub struct MockSpawnerBuilder {
+        setups: VecDeque<Result<ProcessSetup, io::Error>>,
+    }
+
+    /// A collection of streams and channels of a mocked process.
+    struct ProcessSetup {
+        stdin: DuplexStream,
+        stdout: DuplexStream,
+        stderr: Option<DuplexStream>,
+        exit_rx: oneshot::Receiver<ExitStatus>,
+    }
+
+    impl MockSpawnerBuilder {
+        /// Create a new builder.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Queue a process to be spawned. Returns a handle for the test to
+        /// control it.
+        pub fn expect_spawn(&mut self, with_stderr: bool) -> ProcessHandle {
+            let (stdin_task, stdin_test) = tokio::io::duplex(8192);
+            let (stdout_test, stdout_task) = tokio::io::duplex(8192);
+            let (stderr_test, stderr_task) = if with_stderr {
+                let (a, b) = tokio::io::duplex(8192);
+                (Some(a), Some(b))
+            } else {
+                (None, None)
+            };
+
+            let (exit_tx, exit_rx) = oneshot::channel();
+
+            self.setups.push_back(Ok(ProcessSetup {
+                stdin: stdin_task,
+                stdout: stdout_task,
+                stderr: stderr_task,
+                exit_rx,
+            }));
+
+            ProcessHandle {
+                stdin: stdin_test,
+                stdout: stdout_test,
+                stderr: stderr_test,
+                exit_tx,
+            }
+        }
+
+        /// Queue a spawn failure. The next time the component tries to spawn,
+        /// it will receive this error immediately.
+        pub fn expect_spawn_error(&mut self, error: io::Error) {
+            self.setups.push_back(Err(error));
+        }
+
+        /// Create a new [`MockSpawner`] from the configured setups.
+        pub fn build(self) -> MockSpawner {
+            MockSpawner {
+                setups: Arc::new(Mutex::new(self.setups)),
+            }
+        }
+    }
+
+    /// Mock spawner that returns pre-configured mock processes.
+    #[derive(Clone)]
+    pub struct MockSpawner {
+        setups: Arc<Mutex<VecDeque<Result<ProcessSetup, io::Error>>>>,
+    }
+
+    impl Spawner for MockSpawner {
+        type Process = MockProcess;
+
+        fn spawn(
+            &self,
+            _config: &CommandConfig,
+            _capture_stderr: bool,
+        ) -> io::Result<Self::Process> {
+            self.setups
+                .lock()
+                .unwrap()
+                .pop_front()
+                .transpose()?
+                .map(|setup| MockProcess {
+                    stdin: Some(setup.stdin),
+                    stdout: Some(setup.stdout),
+                    stderr: setup.stderr,
+                    exit_rx: Some(setup.exit_rx),
+                })
+                .ok_or(io::Error::other("no more mock processes configured"))
+        }
+    }
+
+    pub struct MockProcess {
+        stdin: Option<DuplexStream>,
+        stdout: Option<DuplexStream>,
+        stderr: Option<DuplexStream>,
+        exit_rx: Option<oneshot::Receiver<ExitStatus>>,
+    }
+
+    impl Process for MockProcess {
+        type Stdin = DuplexStream;
+        type Stdout = DuplexStream;
+        type Stderr = DuplexStream;
+
+        fn take_stdin(&mut self) -> Option<Self::Stdin> {
+            self.stdin.take()
+        }
+
+        fn take_stdout(&mut self) -> Option<Self::Stdout> {
+            self.stdout.take()
+        }
+
+        fn take_stderr(&mut self) -> Option<Self::Stderr> {
+            self.stderr.take()
+        }
+
+        async fn wait(&mut self) -> io::Result<ExitStatus> {
+            match self.exit_rx.take() {
+                Some(rx) => rx.await.map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "process handle dropped")
+                }),
+                None => Ok(ExitStatus::success()),
+            }
+        }
+    }
+}

--- a/src/transforms/stdio/session.rs
+++ b/src/transforms/stdio/session.rs
@@ -1,0 +1,313 @@
+use futures::{SinkExt, Stream, StreamExt, future, stream};
+use std::ops::ControlFlow;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_util::codec::FramedWrite;
+use vector_lib::{
+    codecs::{decoding, encoding},
+    event::Event,
+    internal_event::{ComponentEventsDropped, UNINTENTIONAL},
+};
+
+use crate::{
+    codecs::Encoder,
+    transforms::stdio::{
+        exec::{ExecTask, StdStream},
+        process::{Process, Spawner},
+    },
+};
+
+pub(super) type DecodeResult = Result<(smallvec::SmallVec<[Event; 1]>, usize), decoding::Error>;
+pub(super) type OutputStreamItem = (DecodeResult, StdStream);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SessionOutcome {
+    ChildExited,
+    InputExhausted,
+    DownstreamClosed,
+}
+
+pub(super) struct ChildSession<P: Process, O> {
+    pub process: P,
+
+    // Sending side of the stdin writer
+    pub stdin_tx: Option<mpsc::Sender<Event>>,
+
+    // Handle to the background writer task
+    pub stdin_handle: Option<JoinHandle<()>>,
+
+    pub output_stream: O,
+
+    /// True if the input stream returned None (EOF).
+    pub input_exhausted: bool,
+}
+
+impl<P, O> ChildSession<P, O>
+where
+    P: Process + 'static,
+    O: Stream<Item = OutputStreamItem> + Send + Unpin + 'static,
+{
+    // Allow for double buffering to reduce context-switching overhead between
+    // the main loop and the writer task.
+    const STDIN_CHANNEL_CAPACITY: usize = 2;
+
+    pub fn new(
+        process: P,
+        stdin_writer: FramedWrite<P::Stdin, Encoder<encoding::Framer>>,
+        output_stream: O,
+    ) -> Self {
+        let (stdin_tx, stdin_rx) = mpsc::channel(Self::STDIN_CHANNEL_CAPACITY);
+        let stdin_handle = tokio::spawn(Self::stdin_writer_task(stdin_writer, stdin_rx));
+
+        Self {
+            process,
+            stdin_tx: Some(stdin_tx),
+            stdin_handle: Some(stdin_handle),
+            output_stream,
+            input_exhausted: false,
+        }
+    }
+
+    pub async fn stdin_writer_task(
+        mut writer: FramedWrite<P::Stdin, Encoder<encoding::Framer>>,
+        mut rx: mpsc::Receiver<Event>,
+    ) {
+        while let Some(event) = rx.recv().await {
+            let Err(error) = writer.send(event).await else {
+                // Successfully sent event, continue
+                continue;
+            };
+
+            // Close channel to prevent upstream from buffering more items
+            rx.close();
+
+            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                count: 1,
+                reason: &format!("Failed to write to child stdin: {error}"),
+            });
+
+            // Drain remaining items to report accurate drop counts
+            let mut dropped = 0;
+            while rx.recv().await.is_some() {
+                dropped += 1;
+            }
+
+            if dropped > 0 {
+                emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                    count: dropped,
+                    reason: "Child stdin closed unexpectedly",
+                });
+            }
+
+            break;
+        }
+    }
+
+    pub async fn run<S: Spawner<Process = P>>(
+        mut self,
+        input: &mut (impl Stream<Item = Event> + Unpin),
+        tx: &mpsc::Sender<Event>,
+        task: &ExecTask<S>,
+    ) -> SessionOutcome {
+        loop {
+            let input_pipeline = async {
+                match &self.stdin_tx {
+                    None => future::pending().await,
+                    Some(tx) => match tx.reserve().await {
+                        Err(_) => Err(InputStatus::ChannelClosed),
+                        Ok(permit) => match input.next().await {
+                            Some(event) => {
+                                permit.send(event);
+                                Ok(())
+                            }
+                            None => Err(InputStatus::Eof),
+                        },
+                    },
+                }
+            };
+
+            tokio::select! {
+                biased; // Prioritize reading output to prevent deadlocks on stdout buffers
+
+                output = self.output_stream.next() => match handle_output(output, tx, task).await {
+                    ControlFlow::Continue(()) => continue,
+                    ControlFlow::Break(SessionOutcome::ChildExited) => {
+                        self.wait_for_child().await;
+                        return self.determine_exit_reason();
+                    }
+                    ControlFlow::Break(outcome) => return outcome,
+                },
+
+                res = input_pipeline => match res {
+                    Ok(()) => {}
+                    Err(InputStatus::Eof) => {
+                        self.stdin_tx = None;
+                        self.input_exhausted = true;
+                    }
+                    Err(InputStatus::ChannelClosed) => self.stdin_tx = None,
+                },
+            }
+        }
+    }
+
+    pub async fn wait_for_child(&mut self) {
+        // Drop tx to signal the writer task to stop if it hasn't already
+        self.stdin_tx = None;
+
+        if let Some(handle) = self.stdin_handle.take() {
+            let _ = handle.await;
+        }
+
+        Self::close_process(&mut self.process).await;
+    }
+
+    pub const fn determine_exit_reason(&self) -> SessionOutcome {
+        if self.input_exhausted {
+            SessionOutcome::InputExhausted
+        } else {
+            SessionOutcome::ChildExited
+        }
+    }
+
+    /// Consumes the session and returns the output stream.
+    ///
+    /// This is optimized for short-lived sessions where we want to send a
+    /// single input (or no input), close stdin, and stream the results until
+    /// the process exits.
+    ///
+    /// The returned stream includes the logic to wait for the child process and
+    /// log exit statuses when the stream ends.
+    pub fn into_output_stream(
+        mut self,
+        input: Option<Event>,
+    ) -> impl Stream<Item = OutputStreamItem> {
+        if let Some(event) = input
+            && let Some(tx) = &self.stdin_tx
+        {
+            let _ = tx.try_send(event);
+        };
+
+        // Close Stdin immediately to signal EOF to the child
+        self.stdin_tx = None;
+
+        self.attach_teardown_logic()
+    }
+
+    #[allow(dead_code)]
+    pub fn into_output_stream_batch(
+        mut self,
+        batch: Vec<Event>,
+    ) -> impl Stream<Item = OutputStreamItem> {
+        let mut stdin_tx = self.stdin_tx.take();
+
+        // We must spawn a task to feed the batch because it might be larger
+        // than the channel capacity (2).
+        tokio::spawn(async move {
+            if let Some(tx) = stdin_tx.as_mut() {
+                for event in batch {
+                    if tx.send(event).await.is_err() {
+                        break;
+                    }
+                }
+            }
+
+            // tx is dropped here, closing stdin
+        });
+
+        self.attach_teardown_logic()
+    }
+
+    fn attach_teardown_logic(self) -> impl Stream<Item = OutputStreamItem> + Unpin {
+        let ChildSession {
+            output_stream,
+            mut stdin_handle,
+            mut process,
+            ..
+        } = self;
+
+        output_stream
+            .chain(
+                stream::once(async move {
+                    // Wait for the writer task to finish.
+                    if let Some(handle) = stdin_handle.take() {
+                        let _ = handle.await;
+                    }
+
+                    Self::close_process(&mut process).await;
+
+                    // Return an empty stream to signify the end.
+                    stream::empty()
+                })
+                .flatten(),
+            )
+            .boxed()
+    }
+
+    /// Close the process and log any errors.
+    async fn close_process(process: &mut P) {
+        match process.wait().await {
+            Ok(status) if !status.is_success() => error!(
+                status = status.code().unwrap_or(-1).to_string(),
+                "Child process exited with non-zero status"
+            ),
+            Err(error) => error!(
+                error = error.to_string(),
+                "Failed to wait for child process"
+            ),
+            _ => {}
+        }
+    }
+}
+
+/// Process output from the child.
+///
+/// Returns [`ControlFlow::Break`] if the session should end,
+/// [`ControlFlow::Continue`] otherwise.
+async fn handle_output<P, S>(
+    output: Option<OutputStreamItem>,
+    tx: &mpsc::Sender<Event>,
+    task: &ExecTask<S>,
+) -> ControlFlow<SessionOutcome, ()>
+where
+    P: Process + 'static,
+    S: Spawner<Process = P>,
+{
+    let Some((result, stream_kind)) = output else {
+        return ControlFlow::Break(SessionOutcome::ChildExited);
+    };
+
+    match result {
+        Ok((events, _byte_size)) => {
+            for mut event in events {
+                task.tag_event(&mut event, stream_kind);
+                if tx.send(event).await.is_err() {
+                    return ControlFlow::Break(SessionOutcome::DownstreamClosed);
+                }
+            }
+        }
+        Err(error) => {
+            warn!(
+                error = error.to_string(),
+                stream = stream_kind.as_str(),
+                "Decoding error"
+            );
+        }
+    }
+
+    ControlFlow::Continue(())
+}
+
+/// Status of the input stream.
+enum InputStatus {
+    /// The upstream channel has no more items to feed the process.
+    ///
+    /// We can close the stdin stream and allow the process to exit, while still
+    /// reading from the output stream for as long as it is still open.
+    Eof,
+
+    /// The input stream was closed.
+    ///
+    /// This does NOT mean that the process has exited, or that the output
+    /// stream has closed as well. We can still receive more events from the
+    /// process, but we can't send more events to the process.
+    ChannelClosed,
+}

--- a/src/transforms/stdio/transform.rs
+++ b/src/transforms/stdio/transform.rs
@@ -1,0 +1,156 @@
+use std::pin::Pin;
+
+use futures::Stream;
+use vector_lib::{
+    codecs::encoding,
+    config::{DataType, Input, OutputId, TransformOutput},
+    event::Event,
+    schema,
+    transform::{TaskTransform, Transform},
+};
+
+use crate::{
+    codecs::{DecodingConfig, Encoder, SinkType},
+    config::{TransformConfig, TransformContext},
+    transforms::stdio::{
+        config::{Mode, StderrMode, StdioConfig},
+        exec::{ExecTask, OsExecTask},
+        process::{OsSpawner, Spawner},
+    },
+};
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "stdio")]
+impl TransformConfig for StdioConfig {
+    async fn build(&self, cx: &TransformContext) -> crate::Result<Transform> {
+        let (framer, serializer) = self.stdin.encoding.build(SinkType::StreamBased)?;
+        let stdin_encoder = Encoder::<encoding::Framer>::new(framer, serializer);
+
+        let stdout_decoder = DecodingConfig::new(
+            self.stdout
+                .framing
+                .clone()
+                .unwrap_or(self.stdout.decoding.default_stream_framing()),
+            self.stdout.decoding.clone(),
+            cx.log_namespace(self.stdout.log_namespace),
+        )
+        .build()?;
+
+        let stderr_decoder = matches!(self.stderr.mode, StderrMode::Forward)
+            .then_some(DecodingConfig::new(
+                self.stderr
+                    .framing
+                    .clone()
+                    .unwrap_or(self.stderr.decoding.default_stream_framing()),
+                self.stderr.decoding.clone(),
+                cx.log_namespace(self.stderr.log_namespace),
+            ))
+            .map(|config| config.build())
+            .transpose()?;
+
+        Ok(Transform::event_task(OsExecTask {
+            command: self.command.clone(),
+            mode: self.mode,
+            scheduled: self.scheduled,
+            streaming: self.streaming,
+            per_event: self.per_event,
+            capture_stderr: matches!(self.stderr.mode, StderrMode::Forward),
+            spawner: OsSpawner,
+            stdin_encoder,
+            stdout_decoder,
+            stderr_decoder,
+        }))
+    }
+
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn outputs(
+        &self,
+        _: &TransformContext,
+        input_definitions: &[(OutputId, schema::Definition)],
+    ) -> Vec<TransformOutput> {
+        vec![TransformOutput::new(
+            DataType::all_bits(),
+            input_definitions
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )]
+    }
+
+    fn enable_concurrency(&self) -> bool {
+        true
+    }
+
+    fn validate(&self, _: &schema::Definition) -> Result<(), Vec<String>> {
+        let mut errors = vec![];
+
+        if self
+            .per_event
+            .is_some_and(|c| c.max_concurrent_processes == 0)
+        {
+            errors.push("per_event.max_concurrent_processes must be greater than 0");
+        }
+
+        if self.command.command.is_empty() {
+            errors.push("command must contain at least one element");
+        }
+
+        if errors.is_empty() {
+            return Ok(());
+        }
+
+        Err(errors.into_iter().map(str::to_string).collect())
+    }
+}
+
+impl<S: Spawner> TaskTransform<Event> for ExecTask<S> {
+    fn transform(
+        self: Box<Self>,
+        task: Pin<Box<dyn Stream<Item = Event> + Send>>,
+    ) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+        match self.mode {
+            Mode::PerEvent => Box::pin(self.run_per_event(task)),
+            Mode::Scheduled => Box::pin(self.run_scheduled(task)),
+            Mode::Streaming => Box::pin(self.run_streaming(task)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vector_lib::schema::Definition;
+
+    use crate::transforms::stdio::config::PerEventConfig;
+
+    use super::*;
+
+    #[test]
+    fn test_config_validation() {
+        let mut config = StdioConfig::default();
+
+        config.command.command = vec!["echo".into()];
+        assert!(config.validate(&Definition::any()).is_ok());
+
+        config.per_event = Some(PerEventConfig {
+            max_concurrent_processes: 0,
+        });
+        let result = config.validate(&Definition::any());
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err()[0],
+            "per_event.max_concurrent_processes must be greater than 0"
+        );
+        config.per_event = None;
+
+        config.command.command = vec![];
+        let result = config.validate(&Definition::any());
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err()[0],
+            "command must contain at least one element"
+        );
+    }
+}


### PR DESCRIPTION
Hey all 👋 

For a project I am working on, I had a need for a transform similar to the `exec`-source, which supports converting events in a low-throughput environment using an external command-line tool. I figured you all might be interested in this new transform. If not, I'm happy to keep using this in my own fork.

## Summary

Add a new transform that pipes events through external processes via stdin/stdout, enabling integration with any command-line tool.

Supports three operating modes:

- Streaming: long-running process receiving continuous event flow
- Scheduled: periodic batch execution on a configurable interval
- Per Event: spawn a new process for each event with concurrency control

This transform is modeled after the `exec` source, but with some differences:

- It adds the `Per Event` run-mode, which spawns a new process for each event with concurrency control.
- Supports optional capturing of `stderr` output.
- It allows for configuring the `stdout` and `stderr` decoding, and supports framing and log namespaces.

The implementation tries to be efficient, correct and resilient, and comes with both integration and mocked unit tests to cover most edge cases.

## Vector configuration

```yaml
schema:
  log_namespace: true
sources:
  in:
    type: "stdin"
    decoding:
      codec: "json"
transforms:
  stdio:
    inputs:
      - "in"
    type: "stdio"
    command: ["jq", "-c", ".foo"]
    mode: "per_event"
    stdout:
      decoding:
        codec: "json"
sinks:
  out:
    inputs:
      - "stdio"
    type: "console"
    encoding:
      codec: "json"
```

## How did you test this PR?

```shell
$ echo '{"foo":true}' | vector -qqqq -c vector.yaml
true
```

```shell
$ cargo test --lib --no-default-features --features transforms-stdio transforms::stdio
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.37s
     Running unittests src/lib.rs (target/debug/deps/vector-425e5266330c4b61)

running 13 tests
test transforms::stdio::tests::test_streaming_fatal_error_no_retry ... ok
test transforms::stdio::transform::tests::test_config_validation ... ok
test transforms::stdio::tests::test_scheduled_flush_on_shutdown ... ok
test transforms::stdio::tests::test_scheduled_buffer_overflow ... ok
test transforms::stdio::tests::test_stdout_success ... ok
test transforms::stdio::tests::test_stderr_ignored ... ok
test transforms::stdio::tests::test_streaming_respawn ... ok
test transforms::stdio::tests::test_decode_error ... ok
test transforms::stdio::tests::test_per_event_concurrency ... ok
test transforms::stdio::tests::test_stderr_handling ... ok
test transforms::stdio::tests::test_per_event_concurrency_limit ... ok
test transforms::stdio::tests::test_integration ... ok
test transforms::stdio::tests::test_scheduled_process_timeout ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 276 filtered out; finished in 0.40s
```

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Ref: #1572