### PR TITLE
enhancement(websocket source): Micro-optimize send loop

### DIFF
--- a/changelog.d/optimize-websocket-source.enhancement.md
+++ b/changelog.d/optimize-websocket-source.enhancement.md
@@ -1,0 +1,3 @@
+Small optimization to the `websocket` source performance by avoiding getting a new time for every event in an array.
+
+authors: bruceg

--- a/src/sources/websocket/source.rs
+++ b/src/sources/websocket/source.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures::{Sink, Stream, StreamExt, pin_mut, sink::SinkExt};
 use snafu::Snafu;
 use tokio::time;
@@ -235,9 +235,10 @@ impl WebSocketSource {
                         kind,
                     });
 
+                    let now = Utc::now();
                     let events_with_meta = events.into_iter().map(|mut event| {
                         if let Event::Log(event) = &mut event {
-                            self.add_metadata(event);
+                            self.add_metadata(event, now);
                         }
                         event
                     });
@@ -255,10 +256,10 @@ impl WebSocketSource {
         }
     }
 
-    fn add_metadata(&self, event: &mut LogEvent) {
+    fn add_metadata(&self, event: &mut LogEvent, now: DateTime<Utc>) {
         self.params
             .log_namespace
-            .insert_standard_vector_source_metadata(event, WebSocketConfig::NAME, Utc::now());
+            .insert_standard_vector_source_metadata(event, WebSocketConfig::NAME, now);
     }
 
     async fn reconnect(


### PR DESCRIPTION
## Summary

Avoid calling `Utc::now()` in a loop and instead use the same timestamp for all the events.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

Unit tests, the change is pretty trivial.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [X] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
