### PR TITLE
enhancement(deployment): include http provider config in containers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,10 +57,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 name = "vector"
 section = "admin"
 maintainer-scripts = "distribution/debian/scripts/"
-conf-files = ["/etc/vector/vector.yaml", "/etc/default/vector"]
+conf-files = ["/etc/vector/vector.yaml", "/etc/vector/vector-provider.yaml", "/etc/default/vector"]
 assets = [
   ["target/release/vector", "/usr/bin/", "755"],
   ["config/vector.yaml", "/etc/vector/vector.yaml", "644"],
+  ["config/vector-provider.yaml", "/etc/vector/vector-provider.yaml", "644"],
   ["config/examples/*", "/etc/vector/examples/", "644"],
   ["distribution/systemd/vector.service", "/lib/systemd/system/vector.service", "644"],
   ["distribution/systemd/vector.default", "/etc/default/vector", "600"],

--- a/config/vector-provider.yaml
+++ b/config/vector-provider.yaml
@@ -1,0 +1,3 @@
+provider:
+  type: "http"
+  url: "${VECTOR_CONFIG_URL}"

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -25,6 +25,7 @@ RUN apk --no-cache add ca-certificates tzdata
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.yaml /etc/vector/vector.yaml
+COPY --from=builder /vector/config/vector-provider.yaml /etc/vector/vector-provider.yaml
 COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -18,6 +18,7 @@ LABEL org.opencontainers.image.documentation="https://vector.dev/docs"
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
 COPY --from=builder /vector/config/vector.yaml /etc/vector/vector.yaml
+COPY --from=builder /vector/config/vector-provider.yaml /etc/vector/vector-provider.yaml
 COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test


### PR DESCRIPTION
Several container deployment platforms (ECS is one example) provide semantics for deploying containers, but lack the configmap semantic used to mount config into containers. This enhancement enables the use of the published containers configured via URL by modifying the container command and providing a location via an environment variable.

## Summary
This adds an additional minimal config to the container which uses the http provider and an environment variable to configure vector without modifying the filesystem.

## How did you test this PR?
Built a container with this config, and verified that deploying it with a specific env var and command produced the expected configuration. I may need to do some additional testing but am not set up to execute the full vector builds locally, and was hoping for a bit of feedback early.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
