### PR TITLE
docs(codecs): Document the output type of each decoder

### DIFF
--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -237,14 +237,20 @@ impl tokio_util::codec::Decoder for Framer {
 #[configurable(metadata(docs::enum_tag_description = "The codec to use for decoding events."))]
 pub enum DeserializerConfig {
     /// Uses the raw bytes as-is.
+    ///
+    /// This decoder outputs logs.
     Bytes,
 
     /// Decodes the raw bytes as [JSON][json].
+    ///
+    /// This decoder outputs logs.
     ///
     /// [json]: https://www.json.org/
     Json(JsonDeserializerConfig),
 
     /// Decodes the raw bytes as [protobuf][protobuf].
+    ///
+    /// This decoder outputs logs.
     ///
     /// [protobuf]: https://protobuf.dev/
     Protobuf(ProtobufDeserializerConfig),
@@ -263,6 +269,8 @@ pub enum DeserializerConfig {
     ///
     /// Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
     /// [RFC 5424][rfc5424]-style format ("new" style, includes structured data).
+    ///
+    /// This decoder outputs logs.
     ///
     /// [rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
     /// [rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
@@ -302,16 +310,22 @@ pub enum DeserializerConfig {
     /// Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
     /// the codec may continue to relax the enforcement of specification.
     ///
+    /// This decoder outputs logs.
+    ///
     /// [gelf]: https://docs.graylog.org/docs/gelf
     /// [implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
     Gelf(GelfDeserializerConfig),
 
     /// Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
     ///
+    /// This decoder outputs metrics.
+    ///
     /// [influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
     Influxdb(InfluxdbDeserializerConfig),
 
     /// Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+    ///
+    /// This decoder outputs logs.
     ///
     /// [apache_avro]: https://avro.apache.org/
     Avro {
@@ -320,6 +334,8 @@ pub enum DeserializerConfig {
     },
 
     /// Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+    ///
+    /// This decoder outputs logs.
     ///
     /// [vrl]: https://vector.dev/docs/reference/vrl
     Vrl(VrlDeserializerConfig),

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -622,9 +622,15 @@ generated: components: sinks: websocket_server: configuration: {
 										avro: """
 																							Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+																							This decoder outputs logs.
+
 																							[apache_avro]: https://avro.apache.org/
 																							"""
-										bytes: "Uses the raw bytes as-is."
+										bytes: """
+																							Uses the raw bytes as-is.
+
+																							This decoder outputs logs.
+																							"""
 										gelf: """
 																							Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -640,16 +646,22 @@ generated: components: sinks: websocket_server: configuration: {
 																							Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 																							the codec may continue to relax the enforcement of specification.
 
+																							This decoder outputs logs.
+
 																							[gelf]: https://docs.graylog.org/docs/gelf
 																							[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 																							"""
 										influxdb: """
 																							Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+																							This decoder outputs metrics.
+
 																							[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 																							"""
 										json: """
 																							Decodes the raw bytes as [JSON][json].
+
+																							This decoder outputs logs.
 
 																							[json]: https://www.json.org/
 																							"""
@@ -684,6 +696,8 @@ generated: components: sinks: websocket_server: configuration: {
 										protobuf: """
 																							Decodes the raw bytes as [protobuf][protobuf].
 
+																							This decoder outputs logs.
+
 																							[protobuf]: https://protobuf.dev/
 																							"""
 										syslog: """
@@ -692,11 +706,15 @@ generated: components: sinks: websocket_server: configuration: {
 																							Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 																							[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+																							This decoder outputs logs.
+
 																							[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 																							[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 																							"""
 										vrl: """
 																							Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+																							This decoder outputs logs.
 
 																							[vrl]: https://vector.dev/docs/reference/vrl
 																							"""

--- a/website/cue/reference/components/sources/generated/amqp.cue
+++ b/website/cue/reference/components/sources/generated/amqp.cue
@@ -90,9 +90,15 @@ generated: components: sources: amqp: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -108,16 +114,22 @@ generated: components: sources: amqp: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -152,6 +164,8 @@ generated: components: sources: amqp: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -160,11 +174,15 @@ generated: components: sources: amqp: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/generated/aws_kinesis_firehose.cue
@@ -93,9 +93,15 @@ generated: components: sources: aws_kinesis_firehose: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -111,16 +117,22 @@ generated: components: sources: aws_kinesis_firehose: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -155,6 +167,8 @@ generated: components: sources: aws_kinesis_firehose: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -163,11 +177,15 @@ generated: components: sources: aws_kinesis_firehose: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/aws_s3.cue
+++ b/website/cue/reference/components/sources/generated/aws_s3.cue
@@ -208,9 +208,15 @@ generated: components: sources: aws_s3: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -226,16 +232,22 @@ generated: components: sources: aws_s3: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -270,6 +282,8 @@ generated: components: sources: aws_s3: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -278,11 +292,15 @@ generated: components: sources: aws_s3: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sources/generated/aws_sqs.cue
@@ -203,9 +203,15 @@ generated: components: sources: aws_sqs: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -221,16 +227,22 @@ generated: components: sources: aws_sqs: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -265,6 +277,8 @@ generated: components: sources: aws_sqs: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -273,11 +287,15 @@ generated: components: sources: aws_sqs: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -75,9 +75,15 @@ generated: components: sources: datadog_agent: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -93,16 +99,22 @@ generated: components: sources: datadog_agent: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -137,6 +149,8 @@ generated: components: sources: datadog_agent: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -145,11 +159,15 @@ generated: components: sources: datadog_agent: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/demo_logs.cue
+++ b/website/cue/reference/components/sources/generated/demo_logs.cue
@@ -54,9 +54,15 @@ generated: components: sources: demo_logs: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -72,16 +78,22 @@ generated: components: sources: demo_logs: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -116,6 +128,8 @@ generated: components: sources: demo_logs: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -124,11 +138,15 @@ generated: components: sources: demo_logs: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/exec.cue
+++ b/website/cue/reference/components/sources/generated/exec.cue
@@ -55,9 +55,15 @@ generated: components: sources: exec: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -73,16 +79,22 @@ generated: components: sources: exec: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -117,6 +129,8 @@ generated: components: sources: exec: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -125,11 +139,15 @@ generated: components: sources: exec: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/file_descriptor.cue
+++ b/website/cue/reference/components/sources/generated/file_descriptor.cue
@@ -45,9 +45,15 @@ generated: components: sources: file_descriptor: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -63,16 +69,22 @@ generated: components: sources: file_descriptor: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -107,6 +119,8 @@ generated: components: sources: file_descriptor: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -115,11 +129,15 @@ generated: components: sources: file_descriptor: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/generated/gcp_pubsub.cue
@@ -121,9 +121,15 @@ generated: components: sources: gcp_pubsub: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -139,16 +145,22 @@ generated: components: sources: gcp_pubsub: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -183,6 +195,8 @@ generated: components: sources: gcp_pubsub: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -191,11 +205,15 @@ generated: components: sources: gcp_pubsub: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/heroku_logs.cue
+++ b/website/cue/reference/components/sources/generated/heroku_logs.cue
@@ -118,9 +118,15 @@ generated: components: sources: heroku_logs: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -136,16 +142,22 @@ generated: components: sources: heroku_logs: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -180,6 +192,8 @@ generated: components: sources: heroku_logs: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -188,11 +202,15 @@ generated: components: sources: heroku_logs: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -120,9 +120,15 @@ generated: components: sources: http: configuration: {
 					avro: """
 						Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+						This decoder outputs logs.
+
 						[apache_avro]: https://avro.apache.org/
 						"""
-					bytes: "Uses the raw bytes as-is."
+					bytes: """
+						Uses the raw bytes as-is.
+
+						This decoder outputs logs.
+						"""
 					gelf: """
 						Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -138,16 +144,22 @@ generated: components: sources: http: configuration: {
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
+						This decoder outputs logs.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					influxdb: """
 						Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+						This decoder outputs metrics.
+
 						[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 						"""
 					json: """
 						Decodes the raw bytes as [JSON][json].
+
+						This decoder outputs logs.
 
 						[json]: https://www.json.org/
 						"""
@@ -182,6 +194,8 @@ generated: components: sources: http: configuration: {
 					protobuf: """
 						Decodes the raw bytes as [protobuf][protobuf].
 
+						This decoder outputs logs.
+
 						[protobuf]: https://protobuf.dev/
 						"""
 					syslog: """
@@ -190,11 +204,15 @@ generated: components: sources: http: configuration: {
 						Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+						This decoder outputs logs.
+
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 					vrl: """
 						Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+						This decoder outputs logs.
 
 						[vrl]: https://vector.dev/docs/reference/vrl
 						"""

--- a/website/cue/reference/components/sources/generated/http_client.cue
+++ b/website/cue/reference/components/sources/generated/http_client.cue
@@ -256,9 +256,15 @@ generated: components: sources: http_client: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -274,16 +280,22 @@ generated: components: sources: http_client: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -318,6 +330,8 @@ generated: components: sources: http_client: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -326,11 +340,15 @@ generated: components: sources: http_client: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -120,9 +120,15 @@ generated: components: sources: http_server: configuration: {
 					avro: """
 						Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+						This decoder outputs logs.
+
 						[apache_avro]: https://avro.apache.org/
 						"""
-					bytes: "Uses the raw bytes as-is."
+					bytes: """
+						Uses the raw bytes as-is.
+
+						This decoder outputs logs.
+						"""
 					gelf: """
 						Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -138,16 +144,22 @@ generated: components: sources: http_server: configuration: {
 						Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 						the codec may continue to relax the enforcement of specification.
 
+						This decoder outputs logs.
+
 						[gelf]: https://docs.graylog.org/docs/gelf
 						[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 						"""
 					influxdb: """
 						Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+						This decoder outputs metrics.
+
 						[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 						"""
 					json: """
 						Decodes the raw bytes as [JSON][json].
+
+						This decoder outputs logs.
 
 						[json]: https://www.json.org/
 						"""
@@ -182,6 +194,8 @@ generated: components: sources: http_server: configuration: {
 					protobuf: """
 						Decodes the raw bytes as [protobuf][protobuf].
 
+						This decoder outputs logs.
+
 						[protobuf]: https://protobuf.dev/
 						"""
 					syslog: """
@@ -190,11 +204,15 @@ generated: components: sources: http_server: configuration: {
 						Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 						[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+						This decoder outputs logs.
+
 						[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 						[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 						"""
 					vrl: """
 						Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+						This decoder outputs logs.
 
 						[vrl]: https://vector.dev/docs/reference/vrl
 						"""

--- a/website/cue/reference/components/sources/generated/kafka.cue
+++ b/website/cue/reference/components/sources/generated/kafka.cue
@@ -99,9 +99,15 @@ generated: components: sources: kafka: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -117,16 +123,22 @@ generated: components: sources: kafka: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -161,6 +173,8 @@ generated: components: sources: kafka: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -169,11 +183,15 @@ generated: components: sources: kafka: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -50,9 +50,15 @@ generated: components: sources: mqtt: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -68,16 +74,22 @@ generated: components: sources: mqtt: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -112,6 +124,8 @@ generated: components: sources: mqtt: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -120,11 +134,15 @@ generated: components: sources: mqtt: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/nats.cue
+++ b/website/cue/reference/components/sources/generated/nats.cue
@@ -142,9 +142,15 @@ generated: components: sources: nats: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -160,16 +166,22 @@ generated: components: sources: nats: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -204,6 +216,8 @@ generated: components: sources: nats: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -212,11 +226,15 @@ generated: components: sources: nats: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/pulsar.cue
+++ b/website/cue/reference/components/sources/generated/pulsar.cue
@@ -148,9 +148,15 @@ generated: components: sources: pulsar: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -166,16 +172,22 @@ generated: components: sources: pulsar: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -210,6 +222,8 @@ generated: components: sources: pulsar: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -218,11 +232,15 @@ generated: components: sources: pulsar: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/redis.cue
+++ b/website/cue/reference/components/sources/generated/redis.cue
@@ -60,9 +60,15 @@ generated: components: sources: redis: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -78,16 +84,22 @@ generated: components: sources: redis: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -122,6 +134,8 @@ generated: components: sources: redis: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -130,11 +144,15 @@ generated: components: sources: redis: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/socket.cue
+++ b/website/cue/reference/components/sources/generated/socket.cue
@@ -62,9 +62,15 @@ generated: components: sources: socket: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -80,16 +86,22 @@ generated: components: sources: socket: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -124,6 +136,8 @@ generated: components: sources: socket: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -132,11 +146,15 @@ generated: components: sources: socket: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/stdin.cue
+++ b/website/cue/reference/components/sources/generated/stdin.cue
@@ -45,9 +45,15 @@ generated: components: sources: stdin: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -63,16 +69,22 @@ generated: components: sources: stdin: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -107,6 +119,8 @@ generated: components: sources: stdin: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -115,11 +129,15 @@ generated: components: sources: stdin: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""

--- a/website/cue/reference/components/sources/generated/websocket.cue
+++ b/website/cue/reference/components/sources/generated/websocket.cue
@@ -232,9 +232,15 @@ generated: components: sources: websocket: configuration: {
 						avro: """
 															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
 
+															This decoder outputs logs.
+
 															[apache_avro]: https://avro.apache.org/
 															"""
-						bytes: "Uses the raw bytes as-is."
+						bytes: """
+															Uses the raw bytes as-is.
+
+															This decoder outputs logs.
+															"""
 						gelf: """
 															Decodes the raw bytes as a [GELF][gelf] message.
 
@@ -250,16 +256,22 @@ generated: components: sources: websocket: configuration: {
 															Going forward, Vector will use that [Go SDK][implementation] as the reference implementation, which means
 															the codec may continue to relax the enforcement of specification.
 
+															This decoder outputs logs.
+
 															[gelf]: https://docs.graylog.org/docs/gelf
 															[implementation]: https://github.com/Graylog2/go-gelf/blob/v2/gelf/reader.go
 															"""
 						influxdb: """
 															Decodes the raw bytes as an [Influxdb Line Protocol][influxdb] message.
 
+															This decoder outputs metrics.
+
 															[influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
 															"""
 						json: """
 															Decodes the raw bytes as [JSON][json].
+
+															This decoder outputs logs.
 
 															[json]: https://www.json.org/
 															"""
@@ -294,6 +306,8 @@ generated: components: sources: websocket: configuration: {
 						protobuf: """
 															Decodes the raw bytes as [protobuf][protobuf].
 
+															This decoder outputs logs.
+
 															[protobuf]: https://protobuf.dev/
 															"""
 						syslog: """
@@ -302,11 +316,15 @@ generated: components: sources: websocket: configuration: {
 															Decodes either as the [RFC 3164][rfc3164]-style format ("old" style) or the
 															[RFC 5424][rfc5424]-style format ("new" style, includes structured data).
 
+															This decoder outputs logs.
+
 															[rfc3164]: https://www.ietf.org/rfc/rfc3164.txt
 															[rfc5424]: https://www.ietf.org/rfc/rfc5424.txt
 															"""
 						vrl: """
 															Decodes the raw bytes as a string and passes them as input to a [VRL][vrl] program.
+
+															This decoder outputs logs.
 
 															[vrl]: https://vector.dev/docs/reference/vrl
 															"""


### PR DESCRIPTION
## Summary
This documents the output type (metric/logs/traces) generated by each decoder, based out the `output_type` methods in the decoder. Previously, this was only documented for the decoders that generated multiple types, but not for the ones that only generate logs or metrics.

## How did you test this PR?
Used `make generate-component-doc` to regenerate cue files (which I presume is the right thing to do for such a change, but it does not seem to be documented in CONTRIBUTING.md or other places I looked). Did not see how to generate actual HTML to see if the result looks ok.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.