### PR TITLE
docs(internal): match cla link to gh workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,7 +338,7 @@ Vector requires all contributors to sign the Contributor License Agreement
 (CLA). This gives Vector the right to use your contribution as well as ensuring
 that you own your contributions and can use them for other purposes.
 
-The full text of the CLA can be found at [https://gist.github.com/bits-bot/55bdc97a4fdad52d97feb4d6c3d1d618](https://gist.github.com/bits-bot/55bdc97a4fdad52d97feb4d6c3d1d618).
+The full text of the CLA can be found [here](https://gist.github.com/bits-bot/55bdc97a4fdad52d97feb4d6c3d1d618).
 
 ### Granted rights and copyright assignment
 


### PR DESCRIPTION
## Summary
Update the link in the CLA from a broken link to the link in the github workflow


## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->


