### PR TITLE
feat(websocket sink): add websocket_compression config option to websocket components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,8 +4733,23 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.11.1",
- "headers-core",
+ "headers-core 0.2.0",
  "http 0.2.9",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.11.1",
+ "headers-core 0.3.0",
+ "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
@@ -4747,6 +4762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.9",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -5221,7 +5245,7 @@ checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
  "bytes 1.11.1",
  "futures 0.3.31",
- "headers",
+ "headers 0.3.9",
  "http 0.2.9",
  "hyper 0.14.32",
  "openssl",
@@ -11488,19 +11512,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tungstenite 0.20.1",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
@@ -11509,6 +11520,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.23",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -12049,25 +12073,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes 1.11.1",
- "data-encoding",
- "http 0.2.9",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.68",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
@@ -12082,6 +12087,24 @@ dependencies = [
  "sha1",
  "thiserror 1.0.68",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "git+https://github.com/danielsufrindisler/tungstenite-rs.git?branch=permessage-deflate#9b09cbc7bb0e0a660de632029306c8206b3a4c6e"
+dependencies = [
+ "bytes 1.11.1",
+ "data-encoding",
+ "flate2",
+ "headers 0.4.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
  "utf-8",
 ]
 
@@ -12556,7 +12579,8 @@ dependencies = [
  "h2 0.4.12",
  "hash_hasher",
  "hashbrown 0.14.5",
- "headers",
+ "headers 0.3.9",
+ "headers 0.4.1",
  "heim",
  "hex",
  "hickory-proto 0.25.2",
@@ -12656,7 +12680,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tokio-test",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "toml 0.9.8",
  "tonic 0.11.0",
@@ -12670,6 +12694,7 @@ dependencies = [
  "tracing-limit",
  "tracing-subscriber",
  "tracing-tower",
+ "tungstenite 0.28.0",
  "typetag",
  "url",
  "uuid",
@@ -12701,7 +12726,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite 0.28.0",
  "url",
  "uuid",
 ]
@@ -12858,7 +12883,7 @@ dependencies = [
  "float_eq",
  "futures 0.3.31",
  "futures-util",
- "headers",
+ "headers 0.3.9",
  "http 0.2.9",
  "hyper-proxy",
  "indexmap 2.12.0",
@@ -12982,7 +13007,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.20.1",
+ "tokio-tungstenite 0.28.0",
  "tracing 0.1.41",
  "url",
  "uuid",
@@ -13262,7 +13287,7 @@ dependencies = [
  "bytes 1.11.1",
  "futures-channel",
  "futures-util",
- "headers",
+ "headers 0.3.9",
  "http 0.2.9",
  "hyper 0.14.32",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,8 @@ tempfile = "3.23.0"
 tokio = { version = "1.49.0", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false }
 tokio-test = "0.4.5"
-tokio-tungstenite = { version = "0.20.1", default-features = false }
+tokio-tungstenite = { version = "0.28.0", default-features = false }
+tungstenite = { git = "https://github.com/danielsufrindisler/tungstenite-rs.git", branch = "permessage-deflate" , default-features = false, features = ["deflate"] }
 toml = { version = "0.9.8", default-features = false, features = ["serde", "display", "parse"] }
 tonic = { version = "0.11", default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip"] }
 tonic-build = { version = "0.11", default-features = false, features = ["transport", "prost"] }
@@ -375,6 +376,7 @@ h2 = { version = "0.4.11", default-features = false, optional = true }
 hash_hasher = { version = "2.0.4", default-features = false }
 hashbrown = { version = "0.14.5", default-features = false, optional = true, features = ["ahash"] }
 headers = { version = "0.3.9", default-features = false }
+headers-04 = { version = "0.4.1", package = "headers", default-features = false }
 hostname = { version = "0.4.0", default-features = false }
 http = { version = "0.2.9", default-features = false }
 http-1 = { package = "http", version = "1.0", default-features = false, features = ["std"] }
@@ -425,6 +427,7 @@ syslog = { version = "6.1.1", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.6.0", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 tokio-postgres = { version = "0.7.13", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = { workspace = true, features = ["connect"], optional = true }
+tungstenite = { workspace = true, optional = true }
 toml.workspace = true
 hickory-proto = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
@@ -495,6 +498,7 @@ nix = { git = "https://github.com/vectordotdev/nix.git", branch = "memfd/gnu/mus
 # The `heim` crates depend on `ntapi` 0.3.7 on Windows, but that version has an
 # unaligned access bug fixed in the following revision.
 ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e38e5f154e6011dc9b270da6" }
+tungstenite = { git = "https://github.com/danielsufrindisler/tungstenite-rs.git", branch = "permessage-deflate" }
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
@@ -894,7 +898,7 @@ sinks-statsd = ["sinks-utils-udp", "tokio-util/net"]
 sinks-utils-udp = []
 sinks-vector = ["sinks-utils-udp", "dep:tonic", "protobuf-build", "dep:prost"]
 sinks-websocket = ["dep:tokio-tungstenite"]
-sinks-websocket-server = ["dep:tokio-tungstenite", "sources-utils-http-auth", "sources-utils-http-error", "sources-utils-http-prelude"]
+sinks-websocket-server = ["dep:tokio-tungstenite", "dep:tungstenite", "sources-utils-http-auth", "sources-utils-http-error", "sources-utils-http-prelude"]
 sinks-webhdfs = ["dep:opendal"]
 
 # Identifies that the build is a nightly build

--- a/src/common/http/error.rs
+++ b/src/common/http/error.rs
@@ -25,6 +25,15 @@ impl ErrorMessage {
         }
     }
 
+    /// Create a new `ErrorMessage` from HTTP status code and a message
+    #[allow(unused)] // triggered by check-component-features
+    pub fn new_http_1(code: http_1::StatusCode, message: String) -> Self {
+        ErrorMessage {
+            code: code.as_u16(),
+            message,
+        }
+    }
+
     /// Returns the HTTP status code
     #[allow(unused)] // triggered by check-component-features
     pub fn status_code(&self) -> http::StatusCode {

--- a/src/common/http/mod.rs
+++ b/src/common/http/mod.rs
@@ -5,6 +5,12 @@
 ))]
 pub mod server_auth;
 
+#[cfg(all(
+    feature = "sources-utils-http-auth",
+    feature = "sources-utils-http-error"
+))]
+pub mod server_auth_http1;
+
 #[cfg(feature = "sources-utils-http-error")]
 mod error;
 

--- a/src/common/http/server_auth_http1.rs
+++ b/src/common/http/server_auth_http1.rs
@@ -1,0 +1,646 @@
+//! Shared authentication config between components that use HTTP.
+use std::{collections::HashMap, fmt, net::SocketAddr};
+
+use bytes::Bytes;
+use headers_04::{Authorization, authorization::Credentials};
+use http_1::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
+use serde::{
+    Deserialize,
+    de::{Error, MapAccess, Visitor},
+};
+use vector_config::configurable_component;
+use vector_lib::{
+    TimeZone, compile_vrl,
+    event::{Event, LogEvent, VrlTarget},
+    sensitive_string::SensitiveString,
+};
+use vector_vrl_metrics::MetricsStorage;
+use vrl::{
+    compiler::{CompilationResult, CompileConfig, Program, runtime::Runtime},
+    core::Value,
+    prelude::TypeState,
+    value::{KeyString, ObjectMap},
+};
+
+use crate::format_vrl_diagnostics;
+
+use super::ErrorMessage;
+
+/// Configuration of the authentication strategy for server mode sinks and sources.
+///
+/// Use the HTTP authentication with HTTPS only. The authentication credentials are passed as an
+/// HTTP header without any additional encryption beyond what is provided by the transport itself.
+#[configurable_component(no_deser)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
+#[serde(tag = "strategy", rename_all = "snake_case")]
+pub enum HttpServerAuthConfig {
+    /// Basic authentication.
+    ///
+    /// The username and password are concatenated and encoded using [base64][base64].
+    ///
+    /// [base64]: https://en.wikipedia.org/wiki/Base64
+    Basic {
+        /// The basic authentication username.
+        #[configurable(metadata(docs::examples = "${USERNAME}"))]
+        #[configurable(metadata(docs::examples = "username"))]
+        username: String,
+
+        /// The basic authentication password.
+        #[configurable(metadata(docs::examples = "${PASSWORD}"))]
+        #[configurable(metadata(docs::examples = "password"))]
+        password: SensitiveString,
+    },
+
+    /// Custom authentication using VRL code.
+    ///
+    /// Takes in request and validates it using VRL code.
+    Custom {
+        /// The VRL boolean expression.
+        source: String,
+    },
+}
+
+// Custom deserializer implementation to default `strategy` to `basic`
+impl<'de> Deserialize<'de> for HttpServerAuthConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct HttpServerAuthConfigVisitor;
+
+        const FIELD_KEYS: [&str; 4] = ["strategy", "username", "password", "source"];
+
+        impl<'de> Visitor<'de> for HttpServerAuthConfigVisitor {
+            type Value = HttpServerAuthConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid authentication strategy (basic or custom)")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<HttpServerAuthConfig, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut fields: HashMap<&str, String> = HashMap::default();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    if let Some(field_index) = FIELD_KEYS.iter().position(|k| *k == key.as_str()) {
+                        if fields.contains_key(FIELD_KEYS[field_index]) {
+                            return Err(Error::duplicate_field(FIELD_KEYS[field_index]));
+                        }
+                        fields.insert(FIELD_KEYS[field_index], map.next_value()?);
+                    } else {
+                        return Err(Error::unknown_field(&key, &FIELD_KEYS));
+                    }
+                }
+
+                // Default to "basic" if strategy is missing
+                let strategy = fields
+                    .get("strategy")
+                    .map(String::as_str)
+                    .unwrap_or_else(|| "basic");
+
+                match strategy {
+                    "basic" => {
+                        let username = fields
+                            .remove("username")
+                            .ok_or_else(|| Error::missing_field("username"))?;
+                        let password = fields
+                            .remove("password")
+                            .ok_or_else(|| Error::missing_field("password"))?;
+                        Ok(HttpServerAuthConfig::Basic {
+                            username,
+                            password: SensitiveString::from(password),
+                        })
+                    }
+                    "custom" => {
+                        let source = fields
+                            .remove("source")
+                            .ok_or_else(|| Error::missing_field("source"))?;
+                        Ok(HttpServerAuthConfig::Custom { source })
+                    }
+                    _ => Err(Error::unknown_variant(strategy, &["basic", "custom"])),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(HttpServerAuthConfigVisitor)
+    }
+}
+
+impl HttpServerAuthConfig {
+    /// Builds an auth matcher based on provided configuration.
+    /// Used to validate configuration if needed, before passing it to the
+    /// actual component for usage.
+    pub fn build(
+        &self,
+        enrichment_tables: &vector_lib::enrichment::TableRegistry,
+        metrics_storage: &MetricsStorage,
+    ) -> crate::Result<HttpServerAuthMatcher> {
+        match self {
+            HttpServerAuthConfig::Basic { username, password } => {
+                Ok(HttpServerAuthMatcher::AuthHeader(
+                    Authorization::basic(username, password.inner()).0.encode(),
+                    "Invalid username/password",
+                ))
+            }
+            HttpServerAuthConfig::Custom { source } => {
+                let state = TypeState::default();
+
+                let mut config = CompileConfig::default();
+                config.set_custom(enrichment_tables.clone());
+                config.set_custom(metrics_storage.clone());
+                config.set_read_only();
+
+                let CompilationResult {
+                    program,
+                    warnings,
+                    config: _,
+                } = compile_vrl(source, &vector_vrl_functions::all(), &state, config)
+                    .map_err(|diagnostics| format_vrl_diagnostics(source, diagnostics))?;
+
+                if !program.final_type_info().result.is_boolean() {
+                    return Err("VRL conditions must return a boolean.".into());
+                }
+
+                if !warnings.is_empty() {
+                    let warnings = format_vrl_diagnostics(source, warnings);
+                    warn!(message = "VRL compilation warning.", %warnings);
+                }
+
+                Ok(HttpServerAuthMatcher::Vrl { program })
+            }
+        }
+    }
+}
+
+/// Built auth matcher with validated configuration
+/// Can be used directly in a component to validate authentication in HTTP requests
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum HttpServerAuthMatcher {
+    /// Matcher for comparing exact value of Authorization header
+    AuthHeader(HeaderValue, &'static str),
+    /// Matcher for running VRL script for requests, to allow for custom validation
+    Vrl {
+        /// Compiled VRL script
+        program: Program,
+    },
+}
+
+impl HttpServerAuthMatcher {
+    /// Compares passed headers to the matcher
+    pub fn handle_auth(
+        &self,
+        address: Option<&SocketAddr>,
+        headers: &HeaderMap<HeaderValue>,
+        path: &str,
+    ) -> Result<(), ErrorMessage> {
+        match self {
+            HttpServerAuthMatcher::AuthHeader(expected, err_message) => {
+                if let Some(header) = headers.get(AUTHORIZATION) {
+                    if expected == header {
+                        Ok(())
+                    } else {
+                        Err(ErrorMessage::new_http_1(
+                            StatusCode::UNAUTHORIZED,
+                            err_message.to_string(),
+                        ))
+                    }
+                } else {
+                    Err(ErrorMessage::new_http_1(
+                        StatusCode::UNAUTHORIZED,
+                        "No authorization header".to_owned(),
+                    ))
+                }
+            }
+            HttpServerAuthMatcher::Vrl { program } => {
+                self.handle_vrl_auth(address, headers, path, program)
+            }
+        }
+    }
+
+    fn handle_vrl_auth(
+        &self,
+        address: Option<&SocketAddr>,
+        headers: &HeaderMap<HeaderValue>,
+        path: &str,
+        program: &Program,
+    ) -> Result<(), ErrorMessage> {
+        let mut target = VrlTarget::new(
+            Event::Log(LogEvent::from_map(
+                ObjectMap::from([
+                    (
+                        "headers".into(),
+                        Value::Object(
+                            headers
+                                .iter()
+                                .map(|(k, v)| {
+                                    (
+                                        KeyString::from(k.to_string()),
+                                        Value::Bytes(Bytes::copy_from_slice(v.as_bytes())),
+                                    )
+                                })
+                                .collect::<ObjectMap>(),
+                        ),
+                    ),
+                    (
+                        "address".into(),
+                        address.map_or(Value::Null, |a| Value::from(a.ip().to_string())),
+                    ),
+                    ("path".into(), Value::from(path.to_owned())),
+                ]),
+                Default::default(),
+            )),
+            program.info(),
+            false,
+        );
+        let timezone = TimeZone::default();
+
+        let result = Runtime::default().resolve(&mut target, program, &timezone);
+        match result.map_err(|e| {
+            warn!("Handling auth failed: {}", e);
+            ErrorMessage::new_http_1(StatusCode::UNAUTHORIZED, "Auth failed".to_owned())
+        })? {
+            vrl::core::Value::Boolean(result) => {
+                if result {
+                    Ok(())
+                } else {
+                    Err(ErrorMessage::new_http_1(
+                        StatusCode::UNAUTHORIZED,
+                        "Auth failed".to_owned(),
+                    ))
+                }
+            }
+            _ => Err(ErrorMessage::new_http_1(
+                StatusCode::UNAUTHORIZED,
+                "Invalid return value".to_owned(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+    use crate::test_util::{addr::next_addr, random_string};
+
+    impl HttpServerAuthMatcher {
+        fn auth_header(self) -> (HeaderValue, &'static str) {
+            match self {
+                HttpServerAuthMatcher::AuthHeader(header_value, error_message) => {
+                    (header_value, error_message)
+                }
+                HttpServerAuthMatcher::Vrl { .. } => {
+                    panic!("Expected HttpServerAuthMatcher::AuthHeader")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn config_should_default_to_basic() {
+        let config: HttpServerAuthConfig = serde_yaml::from_str(indoc! { r#"
+            username: foo
+            password: bar
+            "#
+        })
+        .unwrap();
+
+        if let HttpServerAuthConfig::Basic { username, password } = config {
+            assert_eq!(username, "foo");
+            assert_eq!(password.inner(), "bar");
+        } else {
+            panic!("Expected HttpServerAuthConfig::Basic");
+        }
+    }
+
+    #[test]
+    fn config_should_support_explicit_basic_strategy() {
+        let config: HttpServerAuthConfig = serde_yaml::from_str(indoc! { r#"
+            strategy: basic
+            username: foo
+            password: bar
+            "#
+        })
+        .unwrap();
+
+        if let HttpServerAuthConfig::Basic { username, password } = config {
+            assert_eq!(username, "foo");
+            assert_eq!(password.inner(), "bar");
+        } else {
+            panic!("Expected HttpServerAuthConfig::Basic");
+        }
+    }
+
+    #[test]
+    fn config_should_support_custom_strategy() {
+        let config: HttpServerAuthConfig = serde_yaml::from_str(indoc! { r#"
+            strategy: custom
+            source: "true"
+            "#
+        })
+        .unwrap();
+
+        assert!(matches!(config, HttpServerAuthConfig::Custom { .. }));
+        if let HttpServerAuthConfig::Custom { source } = config {
+            assert_eq!(source, "true");
+        } else {
+            panic!("Expected HttpServerAuthConfig::Custom");
+        }
+    }
+
+    #[test]
+    fn build_basic_auth_should_always_work() {
+        let basic_auth = HttpServerAuthConfig::Basic {
+            username: random_string(16),
+            password: random_string(16).into(),
+        };
+
+        let matcher = basic_auth.build(&Default::default(), &Default::default());
+
+        assert!(matcher.is_ok());
+        assert!(matches!(
+            matcher.unwrap(),
+            HttpServerAuthMatcher::AuthHeader { .. }
+        ));
+    }
+
+    #[test]
+    fn build_basic_auth_should_use_username_password_related_message() {
+        let basic_auth = HttpServerAuthConfig::Basic {
+            username: random_string(16),
+            password: random_string(16).into(),
+        };
+
+        let (_, error_message) = basic_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap()
+            .auth_header();
+        assert_eq!("Invalid username/password", error_message);
+    }
+
+    #[test]
+    fn build_basic_auth_should_use_encode_basic_header() {
+        let username = random_string(16);
+        let password = random_string(16);
+        let basic_auth = HttpServerAuthConfig::Basic {
+            username: username.clone(),
+            password: password.clone().into(),
+        };
+
+        let (header, _) = basic_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap()
+            .auth_header();
+        assert_eq!(
+            Authorization::basic(&username, &password).0.encode(),
+            header
+        );
+    }
+
+    #[test]
+    fn build_custom_should_fail_on_invalid_source() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: "invalid VRL source".to_string(),
+        };
+
+        assert!(
+            custom_auth
+                .build(&Default::default(), &Default::default())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn build_custom_should_fail_on_non_boolean_return_type() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: indoc! {r#"
+                .success = true
+                .
+                "#}
+            .to_string(),
+        };
+
+        assert!(
+            custom_auth
+                .build(&Default::default(), &Default::default())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn build_custom_should_success_on_proper_source_with_boolean_return_type() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: indoc! {r#"
+                .headers.authorization == "Basic test"
+                "#}
+            .to_string(),
+        };
+
+        assert!(
+            custom_auth
+                .build(&Default::default(), &Default::default())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn basic_auth_matcher_should_return_401_when_missing_auth_header() {
+        let basic_auth = HttpServerAuthConfig::Basic {
+            username: random_string(16),
+            password: random_string(16).into(),
+        };
+
+        let matcher = basic_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &HeaderMap::new(), "/");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(401, error.code());
+        assert_eq!("No authorization header", error.message());
+    }
+
+    #[test]
+    fn basic_auth_matcher_should_return_401_and_with_wrong_credentials() {
+        let basic_auth = HttpServerAuthConfig::Basic {
+            username: random_string(16),
+            password: random_string(16).into(),
+        };
+
+        let matcher = basic_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Basic wrong"));
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(401, error.code());
+        assert_eq!("Invalid username/password", error.message());
+    }
+
+    #[test]
+    fn basic_auth_matcher_should_return_ok_for_correct_credentials() {
+        let username = random_string(16);
+        let password = random_string(16);
+        let basic_auth = HttpServerAuthConfig::Basic {
+            username: username.clone(),
+            password: password.clone().into(),
+        };
+
+        let matcher = basic_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            Authorization::basic(&username, &password).0.encode(),
+        );
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_return_ok_for_true_vrl_script_result() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: r#".headers.authorization == "test""#.to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("test"));
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_be_able_to_check_address() {
+        let (_guard, addr) = next_addr();
+        let addr_string = addr.ip().to_string();
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: format!(".address == \"{addr_string}\""),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let headers = HeaderMap::new();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_work_with_missing_address_too() {
+        let (_guard, addr) = next_addr();
+        let addr_string = addr.ip().to_string();
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: format!(".address == \"{addr_string}\""),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let headers = HeaderMap::new();
+        let result = matcher.handle_auth(None, &headers, "/");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_be_able_to_check_path() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: r#".path == "/ok""#.to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let headers = HeaderMap::new();
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/ok");
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_return_401_with_wrong_path() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: r#".path == "/ok""#.to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let headers = HeaderMap::new();
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/bad");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_return_401_for_false_vrl_script_result() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: r#".headers.authorization == "test""#.to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("wrong value"));
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(401, error.code());
+        assert_eq!("Auth failed", error.message());
+    }
+
+    #[test]
+    fn custom_auth_matcher_should_return_401_for_failed_script_execution() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: "abort".to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("test"));
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(401, error.code());
+        assert_eq!("Auth failed", error.message());
+    }
+}

--- a/src/http_1.rs
+++ b/src/http_1.rs
@@ -1,0 +1,116 @@
+//! Common HTTP code. Similar to [`crate::http`], but based on [`http`] 1.0 crate.
+#![allow(missing_docs)]
+
+use headers_04::{Authorization, HeaderMapExt};
+use http_1::{HeaderMap, Request, header::HeaderValue, request::Builder};
+use vector_lib::{configurable::configurable_component, sensitive_string::SensitiveString};
+
+#[cfg(feature = "aws-core")]
+use crate::aws::AwsAuthentication;
+
+/// Configuration of the authentication strategy for HTTP requests.
+///
+/// HTTP authentication should be used with HTTPS only, as the authentication credentials are passed as an
+/// HTTP header without any additional encryption beyond what is provided by the transport itself.
+#[configurable_component]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
+pub enum Auth {
+    /// Basic authentication.
+    ///
+    /// The username and password are concatenated and encoded using [base64][base64].
+    ///
+    /// [base64]: https://en.wikipedia.org/wiki/Base64
+    Basic {
+        /// The basic authentication username.
+        #[configurable(metadata(docs::examples = "${USERNAME}"))]
+        #[configurable(metadata(docs::examples = "username"))]
+        user: String,
+
+        /// The basic authentication password.
+        #[configurable(metadata(docs::examples = "${PASSWORD}"))]
+        #[configurable(metadata(docs::examples = "password"))]
+        password: SensitiveString,
+    },
+
+    /// Bearer authentication.
+    ///
+    /// The bearer token value (OAuth2, JWT, etc.) is passed as-is.
+    Bearer {
+        /// The bearer authentication token.
+        token: SensitiveString,
+    },
+
+    #[cfg(feature = "aws-core")]
+    /// AWS authentication.
+    Aws {
+        /// The AWS authentication configuration.
+        auth: AwsAuthentication,
+
+        /// The AWS service name to use for signing.
+        service: String,
+    },
+
+    /// Custom Authorization Header Value, will be inserted into the headers as `Authorization: < value >`
+    Custom {
+        /// Custom string value of the Authorization header
+        #[configurable(metadata(docs::examples = "${AUTH_HEADER_VALUE}"))]
+        #[configurable(metadata(docs::examples = "CUSTOM_PREFIX ${TOKEN}"))]
+        value: String,
+    },
+}
+
+pub trait MaybeAuth: Sized {
+    fn choose_one(&self, other: &Self) -> crate::Result<Self>;
+}
+
+impl MaybeAuth for Option<Auth> {
+    fn choose_one(&self, other: &Self) -> crate::Result<Self> {
+        if self.is_some() && other.is_some() {
+            Err("Two authorization credentials was provided.".into())
+        } else {
+            Ok(self.clone().or_else(|| other.clone()))
+        }
+    }
+}
+
+impl Auth {
+    pub fn apply<B>(&self, req: &mut Request<B>) {
+        self.apply_headers_map(req.headers_mut())
+    }
+
+    pub fn apply_builder(&self, mut builder: Builder) -> Builder {
+        if let Some(map) = builder.headers_mut() {
+            self.apply_headers_map(map)
+        }
+        builder
+    }
+
+    pub fn apply_headers_map(&self, map: &mut HeaderMap) {
+        match &self {
+            Auth::Basic { user, password } => {
+                let auth = Authorization::basic(user.as_str(), password.inner());
+                map.typed_insert(auth);
+            }
+            Auth::Bearer { token } => match Authorization::bearer(token.inner()) {
+                Ok(auth) => map.typed_insert(auth),
+                Err(error) => error!(message = "Invalid bearer token.", token = %token, %error),
+            },
+            Auth::Custom { value } => {
+                // The value contains just the value for the Authorization header
+                // Expected format: "SSWS token123" or "Bearer token123", etc.
+                match HeaderValue::from_str(value) {
+                    Ok(header_val) => {
+                        map.insert(http_1::header::AUTHORIZATION, header_val);
+                    }
+                    Err(error) => {
+                        error!(message = "Invalid custom auth header value.", value = %value, %error)
+                    }
+                }
+            }
+            #[cfg(feature = "aws-core")]
+            _ => {}
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub mod gcp;
 pub(crate) mod graph;
 pub mod heartbeat;
 pub mod http;
+pub mod http_1;
 #[allow(unreachable_pub)]
 #[cfg(any(feature = "sources-kafka", feature = "sinks-kafka"))]
 pub mod kafka;

--- a/src/sinks/websocket_server/config.rs
+++ b/src/sinks/websocket_server/config.rs
@@ -5,7 +5,9 @@ use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_compon
 use super::{buffering::MessageBufferingConfig, sink::WebSocketListenerSink};
 use crate::{
     codecs::EncodingConfig,
-    common::http::server_auth::HttpServerAuthConfig,
+    common::{
+        http::server_auth_http1::HttpServerAuthConfig, websocket::WebSocketCompressionConfig,
+    },
     config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
     sinks::{Healthcheck, VectorSink},
     tls::TlsEnableableConfig,
@@ -48,6 +50,9 @@ pub struct WebSocketListenerSinkConfig {
 
     #[configurable(derived)]
     pub auth: Option<HttpServerAuthConfig>,
+
+    #[configurable(derived)]
+    pub websocket_compression: Option<WebSocketCompressionConfig>,
 
     /// Configuration of internal metrics
     #[configurable(derived)]
@@ -136,6 +141,7 @@ impl Default for WebSocketListenerSinkConfig {
             message_buffering: None,
             subprotocol: Default::default(),
             auth: None,
+            websocket_compression: None,
             internal_metrics: InternalMetricsConfig::default(),
         }
     }


### PR DESCRIPTION
## Summary

Adds support for [permessage-deflate (RFC7692)][rfc7692] to websocket sink/source and websocket_server sink.

[rfc7692]: https://www.rfc-editor.org/rfc/rfc7692

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #23105

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

---
>Sponsored by [Quad9](https://quad9.net/)