### PR TITLE
enhancement(observability): Add transform latency metrics

### DIFF
--- a/changelog.d/component_latency-metrics.enhancement.md
+++ b/changelog.d/component_latency-metrics.enhancement.md
@@ -1,0 +1,5 @@
+Added the `component_latency_seconds` histogram and
+`component_latency_mean_seconds` gauge internal metrics, exposing the time an
+event spends in a single transform including the transform buffer.
+
+authors: bruceg

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -143,15 +143,28 @@ pub struct GlobalOptions {
     /// The alpha value for the exponential weighted moving average (EWMA) of source and transform
     /// buffer utilization metrics.
     ///
-    /// This value specifies how much of the existing value is retained when each update is made.
-    /// Values closer to 1.0 result in the value adjusting slower to changes. The default value of
-    /// 0.9 is equivalent to a "half life" of 6-7 measurements.
+    /// This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
+    /// observations. Values closer to 1.0 retain more of the previous value, leading to slower
+    /// adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
     ///
-    /// Must be between 0 and 1 exclusive (0 < alpha < 1).
+    /// Must be between 0 and 1 exclusively (0 < alpha < 1).
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
     #[configurable(metadata(docs::advanced))]
     pub buffer_utilization_ewma_alpha: Option<f64>,
+
+    /// The alpha value for the exponential weighted moving average (EWMA) of transform latency
+    /// metrics.
+    ///
+    /// This controls how quickly the `component_latency_mean_seconds` gauge responds to new
+    /// observations. Values closer to 1.0 retain more of the previous value, leading to slower
+    /// adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+    ///
+    /// Must be between 0 and 1 exclusively (0 < alpha < 1).
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    #[configurable(validation(range(min = 0.0, max = 1.0)))]
+    #[configurable(metadata(docs::advanced))]
+    pub latency_ewma_alpha: Option<f64>,
 
     /// The interval, in seconds, at which the internal metrics cache for VRL is refreshed.
     /// This must be set to be able to access metrics in VRL functions.
@@ -311,6 +324,7 @@ impl GlobalOptions {
                 buffer_utilization_ewma_alpha: self
                     .buffer_utilization_ewma_alpha
                     .or(with.buffer_utilization_ewma_alpha),
+                latency_ewma_alpha: self.latency_ewma_alpha.or(with.latency_ewma_alpha),
                 metrics_storage_refresh_period: self
                     .metrics_storage_refresh_period
                     .or(with.metrics_storage_refresh_period),

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -2,7 +2,7 @@
 //! This module contains the definitions and wrapper types for handling
 //! arrays of type `Event`, in the various forms they may appear.
 
-use std::{iter, slice, sync::Arc, vec};
+use std::{iter, slice, sync::Arc, time::Instant, vec};
 
 use futures::{Stream, stream};
 #[cfg(test)]
@@ -169,6 +169,13 @@ impl EventArray {
             for metric in metrics {
                 metric.metadata_mut().set_source_type(source_type);
             }
+        }
+    }
+
+    /// Sets the `last_transform_timestamp` in the metadata for all events in this array.
+    pub fn set_last_transform_timestamp(&mut self, timestamp: Instant) {
+        for mut event in self.iter_events_mut() {
+            event.metadata_mut().set_last_transform_timestamp(timestamp);
         }
     }
 

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-use std::{borrow::Cow, collections::BTreeMap, fmt, sync::Arc};
+use std::{borrow::Cow, collections::BTreeMap, fmt, sync::Arc, time::Instant};
 
 use derivative::Derivative;
 use lookup::OwnedTargetPath;
@@ -78,6 +78,11 @@ pub(super) struct Inner {
     /// An internal vector id that can be used to identify this event across all components.
     #[derivative(PartialEq = "ignore")]
     pub(crate) source_event_id: Option<Uuid>,
+
+    /// The timestamp when the event last entered a transform buffer.
+    #[derivative(PartialEq = "ignore")]
+    #[serde(default, skip)]
+    pub(crate) last_transform_timestamp: Option<Instant>,
 }
 
 /// Metric Origin metadata for submission to Datadog.
@@ -239,6 +244,17 @@ impl EventMetadata {
     pub fn source_event_id(&self) -> Option<Uuid> {
         self.0.source_event_id
     }
+
+    /// Returns the timestamp of the last transform buffer enqueue operation, if it exists.
+    #[must_use]
+    pub fn last_transform_timestamp(&self) -> Option<Instant> {
+        self.0.last_transform_timestamp
+    }
+
+    /// Sets the transform enqueue timestamp to the provided value.
+    pub fn set_last_transform_timestamp(&mut self, timestamp: Instant) {
+        self.get_mut().last_transform_timestamp = Some(timestamp);
+    }
 }
 
 impl Default for Inner {
@@ -254,6 +270,7 @@ impl Default for Inner {
             dropped_fields: ObjectMap::new(),
             datadog_origin_metadata: None,
             source_event_id: Some(Uuid::new_v4()),
+            last_transform_timestamp: None,
         }
     }
 }

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -688,6 +688,7 @@ impl From<Metadata> for EventMetadata {
             dropped_fields: ObjectMap::new(),
             datadog_origin_metadata,
             source_event_id,
+            last_transform_timestamp: None,
         }))
     }
 }

--- a/lib/vector-core/src/latency.rs
+++ b/lib/vector-core/src/latency.rs
@@ -1,0 +1,60 @@
+use std::time::Instant;
+
+use metrics::{Histogram, gauge, histogram};
+use vector_common::stats::EwmaGauge;
+
+use crate::event::EventArray;
+
+const COMPONENT_LATENCY: &str = "component_latency_seconds";
+const COMPONENT_LATENCY_MEAN: &str = "component_latency_mean_seconds";
+const DEFAULT_LATENCY_EWMA_ALPHA: f64 = 0.9;
+
+#[derive(Debug)]
+pub struct LatencyRecorder {
+    histogram: Histogram,
+    gauge: EwmaGauge,
+}
+
+impl LatencyRecorder {
+    pub fn new(ewma_alpha: Option<f64>) -> Self {
+        Self {
+            histogram: histogram!(COMPONENT_LATENCY),
+            gauge: EwmaGauge::new(
+                gauge!(COMPONENT_LATENCY_MEAN),
+                ewma_alpha.or(Some(DEFAULT_LATENCY_EWMA_ALPHA)),
+            ),
+        }
+    }
+
+    pub fn on_send(&self, events: &mut EventArray) {
+        let now = Instant::now();
+        let mut sum = 0.0;
+        let mut count = 0usize;
+
+        // Since all of the events in the array will most likely have entered and exited the
+        // component at close to the same time, we average all the latencies over the entire array
+        // and record it just once in the EWMA-backed gauge. If we were to record each latency
+        // individually, the gauge would effectively just reflect the latest array's latency,
+        // eliminating the utility of the EWMA averaging. However, we record the individual
+        // latencies in the histogram to get a more granular view of the latency distribution.
+        for mut event in events.iter_events_mut() {
+            let metadata = event.metadata_mut();
+            if let Some(previous) = metadata.last_transform_timestamp() {
+                let latency = now.saturating_duration_since(previous).as_secs_f64();
+                sum += latency;
+                count += 1;
+                self.histogram.record(latency);
+            }
+
+            metadata.set_last_transform_timestamp(now);
+        }
+        if count > 0 {
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "losing precision is acceptable here"
+            )]
+            let mean = sum / count as f64;
+            self.gauge.record(mean);
+        }
+    }
+}

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod config;
 pub mod event;
 pub mod fanout;
 pub mod ipallowlist;
+pub mod latency;
 pub mod metrics;
 pub mod partition;
 pub mod schema;

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -21,8 +21,8 @@ pub use vector_config::impl_generate_config_from_default;
 pub use vector_core::compile_vrl;
 pub use vector_core::{
     EstimatedJsonEncodedSizeOf, buckets, default_data_dir, emit, event, fanout, ipallowlist,
-    metric_tags, metrics, partition, quantiles, register, samples, schema, serde, sink, source,
-    source_sender, tcp, tls, transform,
+    latency, metric_tags, metrics, partition, quantiles, register, samples, schema, serde, sink,
+    source, source_sender, tcp, tls, transform,
 };
 pub use vector_lookup as lookup;
 pub use vector_stream as stream;

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -36,7 +36,7 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
         errors.extend(output_errors);
     }
 
-    if let Err(alpha_errors) = validation::check_buffer_utilization_ewma_alpha(&builder) {
+    if let Err(alpha_errors) = validation::check_values(&builder) {
         errors.extend(alpha_errors);
     }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -11,13 +11,27 @@ use super::{
 };
 use crate::config::schema;
 
-/// Minimum value (exclusive) for `utilization_ewma_alpha`.
+/// Minimum value (exclusive) for EWMA alpha options.
 /// The alpha value must be strictly greater than this value.
 const EWMA_ALPHA_MIN: f64 = 0.0;
 
-/// Maximum value (exclusive) for `utilization_ewma_alpha`.
+/// Maximum value (exclusive) for EWMA alpha options.
 /// The alpha value must be strictly less than this value.
 const EWMA_ALPHA_MAX: f64 = 1.0;
+
+/// Validates an optional EWMA alpha value and returns an error message if invalid.
+/// Returns `None` if the value is `None` or valid, otherwise returns an error message.
+fn validate_ewma_alpha(alpha: Option<f64>, field_name: &str) -> Option<String> {
+    if let Some(alpha) = alpha
+        && !(alpha > EWMA_ALPHA_MIN && alpha < EWMA_ALPHA_MAX)
+    {
+        Some(format!(
+            "Global `{field_name}` must be between 0 and 1 exclusive (0 < alpha < 1), got {alpha}"
+        ))
+    } else {
+        None
+    }
+}
 
 /// Check that provide + topology config aren't present in the same builder, which is an error.
 pub fn check_provider(config: &ConfigBuilder) -> Result<(), Vec<String>> {
@@ -155,17 +169,25 @@ pub fn check_resources(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     }
 }
 
-/// Validates that `buffer_utilization_ewma_alpha` value is within the valid range (0 < alpha < 1)
-/// for the global configuration.
-pub fn check_buffer_utilization_ewma_alpha(config: &ConfigBuilder) -> Result<(), Vec<String>> {
-    if let Some(alpha) = config.global.buffer_utilization_ewma_alpha
-        && (alpha <= EWMA_ALPHA_MIN || alpha >= EWMA_ALPHA_MAX)
+/// Validates that `*_ewma_alpha` values are within the valid range (0 < alpha < 1).
+pub fn check_values(config: &ConfigBuilder) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+
+    if let Some(error) = validate_ewma_alpha(
+        config.global.buffer_utilization_ewma_alpha,
+        "buffer_utilization_ewma_alpha",
+    ) {
+        errors.push(error);
+    }
+    if let Some(error) = validate_ewma_alpha(config.global.latency_ewma_alpha, "latency_ewma_alpha")
     {
-        Err(vec![format!(
-            "Global `buffer_utilization_ewma_alpha` must be between 0 and 1 exclusive (0 < alpha < 1), got {alpha}"
-        )])
-    } else {
+        errors.push(error);
+    }
+
+    if errors.is_empty() {
         Ok(())
+    } else {
+        Err(errors)
     }
 }
 

--- a/src/test_util/mock/sinks/completion.rs
+++ b/src/test_util/mock/sinks/completion.rs
@@ -1,0 +1,95 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use futures_util::{FutureExt, StreamExt, future, stream::BoxStream};
+use tokio::sync::oneshot::Sender;
+use vector_lib::{
+    config::{AcknowledgementsConfig, Input},
+    configurable::configurable_component,
+    event::Event,
+    sink::{StreamSink, VectorSink},
+};
+
+use crate::{
+    config::{SinkConfig, SinkContext},
+    sinks::Healthcheck,
+};
+
+/// Configuration for the `test_completion` sink.
+#[configurable_component(sink("test_completion", "Test (completion)."))]
+#[derive(Clone, Debug, Default)]
+pub struct CompletionSinkConfig {
+    #[serde(skip)]
+    expected: usize,
+
+    #[serde(skip)]
+    completion_tx: Arc<Mutex<Option<Sender<bool>>>>,
+}
+
+impl_generate_config_from_default!(CompletionSinkConfig);
+
+impl CompletionSinkConfig {
+    pub fn new(expected: usize, completion_tx: Sender<bool>) -> Self {
+        Self {
+            expected,
+            completion_tx: Arc::new(Mutex::new(Some(completion_tx))),
+        }
+    }
+}
+
+#[async_trait]
+#[typetag::serde(name = "test_completion")]
+impl SinkConfig for CompletionSinkConfig {
+    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let completion_tx = self
+            .completion_tx
+            .lock()
+            .expect("completion sink mutex poisoned")
+            .take();
+
+        let sink = CompletionSink {
+            remaining: self.expected,
+            completion_tx,
+        };
+        let healthcheck = future::ready(Ok(())).boxed();
+
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
+    }
+}
+
+struct CompletionSink {
+    remaining: usize,
+    completion_tx: Option<Sender<bool>>,
+}
+
+#[async_trait]
+impl StreamSink<Event> for CompletionSink {
+    async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+        while let Some(event) = input.next().await {
+            drop(event);
+
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                if self.remaining == 0
+                    && let Some(tx) = self.completion_tx.take()
+                {
+                    let _ = tx.send(true);
+                }
+            }
+        }
+
+        if let Some(tx) = self.completion_tx.take() {
+            let _ = tx.send(self.remaining == 0);
+        }
+
+        Ok(())
+    }
+}

--- a/src/test_util/mock/sinks/mod.rs
+++ b/src/test_util/mock/sinks/mod.rs
@@ -4,6 +4,9 @@ pub use self::backpressure::BackpressureSinkConfig;
 mod basic;
 pub use self::basic::BasicSinkConfig;
 
+mod completion;
+pub use self::completion::CompletionSinkConfig;
+
 mod error;
 pub use self::error::ErrorSinkConfig;
 

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -1,7 +1,7 @@
-use std::pin::Pin;
+use std::{pin::Pin, time::Duration};
 
 use async_trait::async_trait;
-use futures_util::Stream;
+use futures_util::{Stream, StreamExt as _};
 use vector_lib::{
     config::{DataType, Input, TransformOutput},
     configurable::configurable_component,
@@ -19,14 +19,28 @@ use crate::config::{GenerateConfig, OutputId, TransformConfig, TransformContext}
 pub struct NoopTransformConfig {
     #[configurable(derived)]
     transform_type: TransformType,
+
+    /// Optional per-event/array delay, in milliseconds.
+    ///
+    /// This is intended for tests that need deterministic, non-zero component latency.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    delay_ms: Option<u64>,
 }
 
 impl GenerateConfig for NoopTransformConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(&Self {
             transform_type: TransformType::Function,
+            delay_ms: None,
         })
         .unwrap()
+    }
+}
+
+impl NoopTransformConfig {
+    pub fn with_delay_ms(mut self, delay_ms: u64) -> Self {
+        self.delay_ms = Some(delay_ms);
+        self
     }
 }
 
@@ -52,37 +66,55 @@ impl TransformConfig for NoopTransformConfig {
     }
 
     async fn build(&self, _: &TransformContext) -> crate::Result<Transform> {
+        let delay = self.delay_ms.map(Duration::from_millis);
         match self.transform_type {
-            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform))),
-            TransformType::Synchronous => Ok(Transform::Synchronous(Box::new(NoopTransform))),
-            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform))),
+            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform { delay }))),
+            TransformType::Synchronous => {
+                Ok(Transform::Synchronous(Box::new(NoopTransform { delay })))
+            }
+            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform { delay }))),
         }
     }
 }
 
 impl From<TransformType> for NoopTransformConfig {
     fn from(transform_type: TransformType) -> Self {
-        Self { transform_type }
+        Self {
+            transform_type,
+            delay_ms: None,
+        }
     }
 }
 
 #[derive(Clone)]
-struct NoopTransform;
+struct NoopTransform {
+    delay: Option<Duration>,
+}
 
 impl FunctionTransform for NoopTransform {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
+        if let Some(delay) = self.delay {
+            std::thread::sleep(delay);
+        }
         output.push(event);
     }
 }
 
 impl<T> TaskTransform<T> for NoopTransform
 where
-    T: EventContainer + 'static,
+    T: EventContainer + Send + 'static,
 {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn futures_util::Stream<Item = T> + Send>>,
     ) -> Pin<Box<dyn Stream<Item = T> + Send>> {
-        Box::pin(task)
+        if let Some(delay) = self.delay {
+            Box::pin(task.then(move |item| async move {
+                tokio::time::sleep(delay).await;
+                item
+            }))
+        } else {
+            Box::pin(task)
+        }
     }
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -26,6 +26,7 @@ use vector_lib::{
         },
     },
     internal_event::{self, CountByteSize, EventsSent, InternalEventHandle as _, Registered},
+    latency::LatencyRecorder,
     schema::Definition,
     source_sender::{CHUNK_SIZE, SourceSenderItem},
     transform::update_runtime_schema_definition,
@@ -742,7 +743,14 @@ impl<'a> Builder<'a> {
         let sender = self
             .utilization_registry
             .add_component(node.key.clone(), gauge!("utilization"));
-        let runner = Runner::new(t, input_rx, sender, node.input_details.data_type(), outputs);
+        let runner = Runner::new(
+            t,
+            input_rx,
+            sender,
+            node.input_details.data_type(),
+            outputs,
+            LatencyRecorder::new(self.config.global.latency_ewma_alpha),
+        );
         let transform = if node.enable_concurrency {
             runner.run_concurrently().boxed()
         } else {
@@ -807,6 +815,7 @@ impl<'a> Builder<'a> {
             component: key.clone(),
             port: None,
         });
+        let latency_recorder = LatencyRecorder::new(self.config.global.latency_ewma_alpha);
 
         // Task transforms can only write to the default output, so only a single schema def map is needed
         let schema_definition_map = outputs
@@ -825,6 +834,7 @@ impl<'a> Builder<'a> {
                 for event in events.iter_events_mut() {
                     update_runtime_schema_definition(event, &output_id, &schema_definition_map);
                 }
+                latency_recorder.on_send(&mut events);
                 (events, Instant::now())
             })
             .inspect(move |(events, _): &(EventArray, Instant)| {
@@ -1108,6 +1118,7 @@ struct Runner {
     input_type: DataType,
     outputs: TransformOutputs,
     timer_tx: UtilizationComponentSender,
+    latency_recorder: LatencyRecorder,
     events_received: Registered<EventsReceived>,
 }
 
@@ -1118,6 +1129,7 @@ impl Runner {
         timer_tx: UtilizationComponentSender,
         input_type: DataType,
         outputs: TransformOutputs,
+        latency_recorder: LatencyRecorder,
     ) -> Self {
         Self {
             transform,
@@ -1125,6 +1137,7 @@ impl Runner {
             input_type,
             outputs,
             timer_tx,
+            latency_recorder,
             events_received: register!(EventsReceived),
         }
     }
@@ -1140,6 +1153,7 @@ impl Runner {
 
     async fn send_outputs(&mut self, outputs_buf: &mut TransformOutputsBuf) -> crate::Result<()> {
         self.timer_tx.try_send_start_wait();
+        outputs_buf.for_each_array_mut(|array| self.latency_recorder.on_send(array));
         self.outputs.send(outputs_buf).await
     }
 

--- a/src/topology/test/latency_metrics.rs
+++ b/src/topology/test/latency_metrics.rs
@@ -1,0 +1,147 @@
+use std::time::Instant;
+use tokio::{
+    sync::oneshot,
+    time::{Duration, timeout},
+};
+use vector_lib::metrics::Controller;
+
+use crate::{
+    config::Config,
+    event::{Event, LogEvent, Metric, MetricValue},
+    test_util::{
+        mock::{
+            basic_source,
+            sinks::CompletionSinkConfig,
+            transforms::{NoopTransformConfig, TransformType},
+        },
+        start_topology, trace_init,
+    },
+};
+
+const EVENT_COUNT: usize = 100;
+const TRANSFORM_DELAY_MS: u64 = 10;
+const SOURCE_ID: &str = "latency_source";
+const TRANSFORM_ID: &str = "latency_delay";
+const TRANSFORM_TYPE: &str = "test_noop";
+const TRANSFORM_KIND: &str = "transform";
+const SINK_ID: &str = "latency_sink";
+
+struct LatencyTestRun {
+    metrics: Vec<Metric>,
+    elapsed_time: f64,
+}
+
+#[tokio::test]
+async fn component_latency_metrics_emitted() {
+    let run = run_latency_topology().await;
+
+    assert_histogram_count(
+        &run.metrics,
+        "component_latency_seconds",
+        has_component_tags,
+    );
+    assert_gauge_range(
+        &run.metrics,
+        "component_latency_mean_seconds",
+        has_component_tags,
+        TRANSFORM_DELAY_MS as f64 / 1000.0,
+        run.elapsed_time,
+    );
+}
+
+async fn run_latency_topology() -> LatencyTestRun {
+    trace_init();
+
+    let controller = Controller::get().expect("metrics controller");
+    controller.reset();
+
+    let (mut source_tx, source_config) = basic_source();
+    let transform_config =
+        NoopTransformConfig::from(TransformType::Task).with_delay_ms(TRANSFORM_DELAY_MS);
+    let (sink_done_tx, sink_done_rx) = oneshot::channel();
+    let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
+
+    let mut config = Config::builder();
+    config.add_source(SOURCE_ID, source_config);
+    config.add_transform(TRANSFORM_ID, &[SOURCE_ID], transform_config);
+    config.add_sink(SINK_ID, &[TRANSFORM_ID], sink_config);
+
+    let start_time = Instant::now();
+    let (topology, _) = start_topology(config.build().unwrap(), false).await;
+
+    for idx in 0..EVENT_COUNT {
+        let event = Event::Log(LogEvent::from(format!("payload-{idx}")));
+        source_tx.send_event(event).await.unwrap();
+    }
+
+    drop(source_tx);
+
+    let completed = timeout(Duration::from_secs(5), sink_done_rx)
+        .await
+        .expect("timed out waiting for completion sink to finish")
+        .expect("completion sink sender dropped");
+    assert!(
+        completed,
+        "completion sink finished before receiving all events"
+    );
+
+    topology.stop().await;
+    let elapsed_time = start_time.elapsed().as_secs_f64();
+
+    LatencyTestRun {
+        metrics: controller.capture_metrics(),
+        elapsed_time,
+    }
+}
+
+fn assert_histogram_count(metrics: &[Metric], metric_name: &str, tags_match: fn(&Metric) -> bool) {
+    let histogram = metrics
+        .iter()
+        .find(|metric| metric.name() == metric_name && tags_match(metric))
+        .unwrap_or_else(|| panic!("{metric_name} histogram missing"));
+
+    match histogram.value() {
+        MetricValue::AggregatedHistogram { count, .. } => {
+            assert_eq!(
+                *count, EVENT_COUNT as u64,
+                "histogram count should match number of events"
+            );
+        }
+        other => panic!("expected aggregated histogram, got {other:?}"),
+    }
+}
+
+fn assert_gauge_range(
+    metrics: &[Metric],
+    metric_name: &str,
+    tags_match: fn(&Metric) -> bool,
+    expected_min: f64,
+    elapsed_time: f64,
+) {
+    let gauge = metrics
+        .iter()
+        .find(|metric| metric.name() == metric_name && tags_match(metric))
+        .unwrap_or_else(|| panic!("{metric_name} gauge missing"));
+
+    match gauge.value() {
+        MetricValue::Gauge { value } => {
+            assert!(
+                *value >= expected_min,
+                "expected mean latency to be >= {expected_min}, got {value}"
+            );
+            assert!(
+                *value < elapsed_time,
+                "expected mean latency ({value}) to be less than elapsed time ({elapsed_time})"
+            );
+        }
+        other => panic!("expected gauge metric, got {other:?}"),
+    }
+}
+
+fn has_component_tags(metric: &Metric) -> bool {
+    metric.tags().is_some_and(|tags| {
+        tags.get("component_id") == Some(TRANSFORM_ID)
+            && tags.get("component_type") == Some(TRANSFORM_TYPE)
+            && tags.get("component_kind") == Some(TRANSFORM_KIND)
+    })
+}

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -39,6 +39,7 @@ mod crash;
 mod doesnt_reload;
 #[cfg(all(feature = "sources-http_server", feature = "sinks-http"))]
 mod end_to_end;
+mod latency_metrics;
 #[cfg(all(
     feature = "sources-prometheus",
     feature = "sinks-prometheus",

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -273,6 +273,28 @@ components: sources: internal_metrics: {
 				reason: _reason
 			}
 		}
+		component_latency_seconds: {
+			description: """
+				The elapsed time, in fractional seconds, that an event spends in a single transform.
+
+				This includes both the time spent queued in the transform’s input buffer and the time spent executing the transform itself.
+				"""
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
+		component_latency_mean_seconds: {
+			description: """
+				The mean elapsed time, in fractional seconds, that an event spends in a single transform.
+
+				This includes both the time spent queued in the transform’s input buffer and the time spent executing the transform itself.
+
+				This value is smoothed over time using an exponentially weighted moving average (EWMA).
+				"""
+			type:              "gauge"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
 		buffer_byte_size: {
 			description:        "The number of bytes currently in the buffer."
 			type:               "gauge"

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -15,11 +15,13 @@ components: transforms: [Name=string]: {
 	telemetry: metrics: {
 		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
 		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
+		component_latency_mean_seconds:       components.sources.internal_metrics.output.metrics.component_latency_mean_seconds
+		component_latency_seconds:            components.sources.internal_metrics.output.metrics.component_latency_seconds
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
 		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		transform_buffer_max_byte_size:       components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
 		transform_buffer_max_event_size:      components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
 		transform_buffer_max_size_bytes:      components.sources.internal_metrics.output.metrics.transform_buffer_max_size_bytes

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -706,11 +706,11 @@ generated: configuration: configuration: {
 			The alpha value for the exponential weighted moving average (EWMA) of source and transform
 			buffer utilization metrics.
 
-			This value specifies how much of the existing value is retained when each update is made.
-			Values closer to 1.0 result in the value adjusting slower to changes. The default value of
-			0.9 is equivalent to a "half life" of 6-7 measurements.
+			This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
+			observations. Values closer to 1.0 retain more of the previous value, leading to slower
+			adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
 
-			Must be between 0 and 1 exclusive (0 < alpha < 1).
+			Must be between 0 and 1 exclusively (0 < alpha < 1).
 			"""
 		required: false
 		type: float: {}
@@ -828,6 +828,20 @@ generated: configuration: configuration: {
 
 			Set this to a value larger than your `internal_metrics` scrape interval (default 5 minutes)
 			so metrics live long enough to be emitted and captured.
+			"""
+		required: false
+		type: float: {}
+	}
+	latency_ewma_alpha: {
+		description: """
+			The alpha value for the exponential weighted moving average (EWMA) of transform latency
+			metrics.
+
+			This controls how quickly the `component_latency_mean_seconds` gauge responds to new
+			observations. Values closer to 1.0 retain more of the previous value, leading to slower
+			adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+
+			Must be between 0 and 1 exclusively (0 < alpha < 1).
 			"""
 		required: false
 		type: float: {}


### PR DESCRIPTION
## Summary

This adds the `component_latency_seconds` histogram and `component_latency_mean_seconds` gauge internal metrics, exposing the time an event spends in a single transform including the transform buffer.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

Tested with a unit test plus a simple `internal_metrics` => transforms => `console` pipeline. We will be doing some more interesting load validation before merging.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
