### PR TITLE
feat(aws_s3 source): add custom SQS authentication option

### DIFF
--- a/changelog.d/aws_s3_custom_sqs_auth.enhancement.md
+++ b/changelog.d/aws_s3_custom_sqs_auth.enhancement.md
@@ -1,0 +1,7 @@
+The `aws_s3` source now supports configuring separate authentication credentials for SQS via the new `sqs.auth` configuration option. This enables cross-account scenarios where S3 buckets and SQS queues are in different AWS accounts or require different permission models.
+
+When `sqs.auth` is not specified, the source falls back to using the main `auth` configuration, maintaining full backwards compatibility with existing deployments.
+
+The `sqs.deferred.auth` option is also available for configuring separate authentication for the deferred message queue.
+
+authors: kfir


### PR DESCRIPTION
## Summary

Add support for configuring separate authentication credentials for SQS in the AWS S3 source via the new `sqs.auth` configuration option. This enables cross-account scenarios where S3 buckets and SQS queues are in different AWS accounts or require different permission models.

When `sqs.auth` is not specified, the source falls back to using the main `auth` configuration, maintaining full backwards compatibility with existing deployments.

Also adds `sqs.deferred.auth` for configuring separate authentication for the deferred message queue.

## Vector configuration

**Cross-account setup example:**
```toml
[sources.my_s3_source]
type = "aws_s3"
region = "us-east-1"

# S3 authentication (Account A)
auth.access_key_id = "AKIAACCOUNTAAAAAAA"
auth.secret_access_key = "AccountASecretKey"

# SQS configuration with separate auth (Account B)
sqs.queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
sqs.auth.access_key_id = "AKIAACCOUNTBBBBBBB"
sqs.auth.secret_access_key = "AccountBSecretKey"
```

**Backwards compatible - no `sqs.auth` specified:**
```toml
[sources.my_s3_source]
type = "aws_s3"
region = "us-east-1"
auth.access_key_id = "AKIAIOSFODNN7EXAMPLE"
auth.secret_access_key = "wJalrXUtnFEMI/K7MDENG"
sqs.queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
# SQS uses main auth - works exactly as before
```

**Deferred queue with separate auth:**
```toml
[sources.my_s3_source]
type = "aws_s3"
auth.access_key_id = "AKIAACCOUNTAAAAAAA"
auth.secret_access_key = "AccountASecretKey"

sqs.queue_url = "https://sqs.us-east-1.amazonaws.com/111111111111/primary-queue"
sqs.deferred.queue_url = "https://sqs.us-east-1.amazonaws.com/999999999999/deferred-queue"
sqs.deferred.max_age_secs = 300
sqs.deferred.auth.assume_role = "arn:aws:iam::999999999999:role/DeferredRole"
```

## How did you test this PR?

**Unit tests** (8 tests covering all authentication variants):
- Config parsing with custom auth (access keys, assume role, default)
- Deferred queue auth configuration
- Backwards compatibility (no sqs.auth specified)

```bash
cargo test --package vector --lib sources::aws_s3::sqs
```

**Integration tests** (3 tests with LocalStack):
- S3 and SQS with different credentials
- Backwards compatibility verification
- Deferred queue with separate auth

```bash
cargo vdev int test aws-s3
```

All tests pass locally. Integration tests compile successfully and will run in CI environment.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

**Changelog fragment:** `changelog.d/aws_s3_custom_sqs_auth.enhancement.md`

## References

- Closes: https://github.com/vectordotdev/vector/issues/23078

## Notes

**Implementation details:**
- Added `auth: Option<AwsAuthentication>` field to `sqs::Config` struct
- Added `auth: Option<AwsAuthentication>` field to `sqs::DeferredConfig` struct
- Modified client creation in `mod.rs` to use `sqs.auth.as_ref().unwrap_or(&self.auth)` pattern
- Created separate deferred SQS client when `sqs.deferred.auth` differs from main auth
- Used reference-based fallback (no cloning) for efficiency

**Files modified:**
- `src/sources/aws_s3/mod.rs` (+155 lines) - Client creation logic
- `src/sources/aws_s3/sqs.rs` (+152 lines) - Config structures and tests
- `changelog.d/aws_s3_custom_sqs_auth.enhancement.md` (new) - Changelog entry

**Design note:**
This implementation uses a simple fallback pattern where missing `sqs.auth` falls back to the main `auth` config. An alternative approach (PR #23079) adds an `AwsAuthentication::Fallback` variant to explicitly use AWS SDK default credentials even when main auth is configured. The current implementation covers 99% of use cases without requiring core AWS auth module changes.

---

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).