### PR TITLE
fix(azure auth): Restore non-connection string auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_identity"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f07bb0ee212021e75c3645e82d078e436b4b4184bde1295e9e81fcbcef923af"
+dependencies = [
+ "async-lock 3.4.0",
+ "async-trait",
+ "azure_core",
+ "futures 0.3.31",
+ "pin-project",
+ "serde",
+ "time",
+ "tracing 0.1.41",
+ "url",
+]
+
+[[package]]
 name = "azure_storage_blob"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12517,6 +12534,7 @@ dependencies = [
  "aws-types",
  "axum 0.6.20",
  "azure_core",
+ "azure_identity",
  "azure_storage_blob",
  "base64 0.22.1",
  "bloomy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ aws-smithy-types = { version = "1.2.11", default-features = false, features = ["
 
 # Azure
 azure_core = { version = "0.30", features = ["reqwest", "hmac_openssl"], optional = true }
+azure_identity = { version = "0.30", optional = true }
 
 # Azure Storage
 azure_storage_blob = { version = "0.7", optional = true }
@@ -851,7 +852,7 @@ sinks-aws_s3 = ["dep:base64", "dep:md-5", "aws-core", "dep:aws-sdk-s3"]
 sinks-aws_sqs = ["aws-core", "dep:aws-sdk-sqs"]
 sinks-aws_sns = ["aws-core", "dep:aws-sdk-sns"]
 sinks-axiom = ["sinks-http"]
-sinks-azure_blob = ["dep:azure_core", "dep:azure_storage_blob"]
+sinks-azure_blob = ["dep:azure_core", "dep:azure_identity", "dep:azure_storage_blob"]
 sinks-azure_monitor_logs = []
 sinks-blackhole = []
 sinks-chronicle = []

--- a/changelog.d/azure_blob_storage_account_auth.enhancement.md
+++ b/changelog.d/azure_blob_storage_account_auth.enhancement.md
@@ -1,0 +1,7 @@
+Enhance the `azure_blob` sink with a `storage_account` authentication mode in addition to `connection_string`, including support for Azure identity-based auth strategies (`default`, `environment`, `managed_identity`, `azure_cli`, and `workload_identity`) and optional custom endpoint configuration.
+
+Existing `connection_string` configurations continue to work unchanged. Exactly one of `connection_string` or `storage_account` must be set.
+
+When `auth` is not set, the sink defaults to `default` strategy and attempts credentials in order: environment (including workload identity), managed identity, then Azure CLI.
+
+authors: rjancewicz

--- a/src/sinks/azure_blob/test.rs
+++ b/src/sinks/azure_blob/test.rs
@@ -22,7 +22,10 @@ use crate::{
 
 fn default_config(encoding: EncodingConfigWithFraming) -> AzureBlobSinkConfig {
     AzureBlobSinkConfig {
-        connection_string: Default::default(),
+        connection_string: None,
+        storage_account: None,
+        endpoint: None,
+        auth: Default::default(),
         container_name: Default::default(),
         blob_prefix: Default::default(),
         blob_time_format: Default::default(),

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -1,26 +1,105 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
-use azure_core::error::Error as AzureCoreError;
-
-use crate::sinks::azure_common::connection_string::{Auth, ParsedConnectionString};
-use crate::sinks::azure_common::shared_key_policy::SharedKeyAuthorizationPolicy;
-use azure_core::http::Url;
+use azure_core::cloud::CustomConfiguration;
+use azure_core::credentials::{
+    AccessToken as IdentityAccessToken, Secret as IdentitySecret,
+    TokenCredential as IdentityTokenCredential, TokenRequestOptions,
+};
+use azure_core::error::{Error as AzureCoreError, ErrorKind as AzureCoreErrorKind};
+use azure_core::http::{
+    ClientMethodOptions, StatusCode, Url, policies::BearerTokenAuthorizationPolicy,
+};
+use azure_identity::{
+    AzureCliCredential, ClientAssertion, ClientAssertionCredential,
+    ClientAssertionCredentialOptions, ClientSecretCredential, ManagedIdentityCredential,
+    ManagedIdentityCredentialOptions, UserAssignedId, WorkloadIdentityCredential,
+    WorkloadIdentityCredentialOptions,
+};
 use azure_storage_blob::{BlobContainerClient, BlobContainerClientOptions};
-
-use azure_core::http::StatusCode;
 use bytes::Bytes;
 use futures::FutureExt;
 use snafu::Snafu;
+use vector_lib::configurable::configurable_component;
+use vector_lib::sensitive_string::SensitiveString;
 use vector_lib::{
     json_size::JsonSize,
     request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata},
     stream::DriverResponse,
 };
 
+use crate::sinks::azure_common::connection_string::{Auth, ParsedConnectionString};
+use crate::sinks::azure_common::shared_key_policy::SharedKeyAuthorizationPolicy;
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
     sinks::{Healthcheck, util::retries::RetryLogic},
 };
+
+/// Azure Blob Storage authentication strategies when using `storage_account`.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields, rename_all = "snake_case", tag = "strategy")]
+#[configurable(metadata(
+    docs::enum_tag_description = "The authentication strategy to use when `storage_account` is set."
+))]
+pub enum AzureBlobAuthConfig {
+    /// Use the DefaultAzureCredential chain (Environment -> Managed Identity -> Azure CLI).
+    Default,
+
+    /// Use credentials from environment variables (includes workload identity and client secret).
+    Environment,
+
+    /// Use managed identity credentials from IMDS.
+    ManagedIdentity {
+        /// The user-assigned managed identity client ID.
+        #[configurable(metadata(docs::examples = "${AZURE_CLIENT_ID}"))]
+        #[configurable(metadata(docs::examples = "00000000-0000-0000-0000-000000000000"))]
+        client_id: Option<String>,
+
+        /// The user-assigned managed identity object ID.
+        #[configurable(metadata(docs::examples = "00000000-0000-0000-0000-000000000000"))]
+        object_id: Option<String>,
+
+        /// The user-assigned managed identity ARM resource ID.
+        #[configurable(metadata(
+            docs::examples = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity"
+        ))]
+        msi_res_id: Option<String>,
+    },
+
+    /// Use the Azure CLI credential.
+    AzureCli,
+
+    /// Use a workload identity token (federated credentials).
+    WorkloadIdentity {
+        /// The Azure Active Directory tenant ID.
+        #[configurable(metadata(docs::examples = "${AZURE_TENANT_ID}"))]
+        #[configurable(metadata(docs::examples = "00000000-0000-0000-0000-000000000000"))]
+        tenant_id: String,
+
+        /// The Azure Active Directory client (application) ID.
+        #[configurable(metadata(docs::examples = "${AZURE_CLIENT_ID}"))]
+        #[configurable(metadata(docs::examples = "00000000-0000-0000-0000-000000000000"))]
+        client_id: String,
+
+        /// The federated token value.
+        #[configurable(metadata(docs::examples = "${AZURE_FEDERATED_TOKEN}"))]
+        token: Option<SensitiveString>,
+
+        /// Path to a federated token file.
+        #[configurable(metadata(docs::examples = "${AZURE_FEDERATED_TOKEN_FILE}"))]
+        token_file: Option<String>,
+
+        /// Override the Azure authority host.
+        #[configurable(metadata(docs::examples = "https://login.microsoftonline.com"))]
+        authority_host: Option<String>,
+    },
+}
+
+impl Default for AzureBlobAuthConfig {
+    fn default() -> Self {
+        Self::Default
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct AzureBlobRequest {
@@ -127,49 +206,531 @@ pub fn build_healthcheck(
 }
 
 pub fn build_client(
-    connection_string: String,
+    connection_string: Option<String>,
+    storage_account: Option<String>,
     container_name: String,
+    endpoint: Option<String>,
+    auth: &AzureBlobAuthConfig,
 ) -> crate::Result<Arc<BlobContainerClient>> {
-    // Parse connection string without legacy SDK
-    let parsed = ParsedConnectionString::parse(&connection_string)
-        .map_err(|e| format!("Invalid connection string: {e}"))?;
-    // Compose container URL (SAS appended if present)
-    let container_url = parsed
-        .container_url(&container_name)
-        .map_err(|e| format!("Failed to build container URL: {e}"))?;
-    let url = Url::parse(&container_url).map_err(|e| format!("Invalid container URL: {e}"))?;
+    match (connection_string, storage_account) {
+        (Some(connection_string), None) => {
+            let parsed = ParsedConnectionString::parse(&connection_string)
+                .map_err(|e| format!("Invalid connection string: {e}"))?;
+            let container_url = parsed
+                .container_url(&container_name)
+                .map_err(|e| format!("Failed to build container URL: {e}"))?;
+            let url =
+                Url::parse(&container_url).map_err(|e| format!("Invalid container URL: {e}"))?;
 
-    // Prepare options; attach Shared Key policy if needed
-    let mut options = BlobContainerClientOptions::default();
-    match parsed.auth() {
-        Auth::Sas { .. } | Auth::None => {
-            // No extra policy; SAS is in the URL already (or anonymous)
+            let mut options = BlobContainerClientOptions::default();
+            match parsed.auth() {
+                Auth::Sas { .. } | Auth::None => {}
+                Auth::SharedKey {
+                    account_name,
+                    account_key,
+                } => {
+                    let policy = SharedKeyAuthorizationPolicy::new(
+                        account_name,
+                        account_key,
+                        // Use an Azurite-supported storage service version.
+                        String::from("2025-11-05"),
+                    )
+                    .map_err(|e| format!("Failed to create SharedKey policy: {e}"))?;
+                    options
+                        .client_options
+                        .per_call_policies
+                        .push(Arc::new(policy));
+                }
+            }
+
+            build_container_client(url, options)
         }
-        Auth::SharedKey {
-            account_name,
-            account_key,
-        } => {
-            let policy = SharedKeyAuthorizationPolicy::new(
-                account_name,
-                account_key,
-                // Use an Azurite-supported storage service version
-                String::from("2025-11-05"),
-            )
-            .map_err(|e| format!("Failed to create SharedKey policy: {e}"))?;
+        (None, Some(storage_account)) => {
+            let container_url = match endpoint {
+                Some(endpoint) => format!("{}/{}", endpoint.trim_end_matches('/'), container_name),
+                None => format!(
+                    "https://{}.blob.core.windows.net/{}",
+                    storage_account, container_name
+                ),
+            };
+
+            let url =
+                Url::parse(&container_url).map_err(|e| format!("Invalid container URL: {e}"))?;
+            let mut options = BlobContainerClientOptions::default();
+            let bearer_policy = BearerTokenAuthorizationPolicy::new(
+                build_token_credential(auth)?,
+                ["https://storage.azure.com/.default"],
+            );
             options
                 .client_options
                 .per_call_policies
-                .push(Arc::new(policy));
-        }
-    }
+                .push(Arc::new(bearer_policy));
 
-    // Use reqwest v0.12 since Azure SDK only implements HttpClient for reqwest::Client v0.12.
-    options.client_options.transport = Some(azure_core::http::Transport::new(std::sync::Arc::new(
+            build_container_client(url, options)
+        }
+        (Some(_), Some(_)) => {
+            Err("only one of `connection_string` or `storage_account` may be set".into())
+        }
+        (None, None) => Err("either `connection_string` or `storage_account` must be set".into()),
+    }
+}
+
+fn build_container_client(
+    url: Url,
+    mut options: BlobContainerClientOptions,
+) -> crate::Result<Arc<BlobContainerClient>> {
+    // Azure SDK requires a reqwest 0.12 transport implementation.
+    options.client_options.transport = Some(azure_core::http::Transport::new(Arc::new(
         reqwest_12::ClientBuilder::new()
+            // Avoid macOS system proxy discovery panics in restricted runtimes.
+            .no_proxy()
             .build()
             .map_err(|e| format!("Failed to build reqwest client: {e}"))?,
     )));
-    let client =
-        BlobContainerClient::from_url(url, None, Some(options)).map_err(|e| format!("{e}"))?;
+
+    let client = BlobContainerClient::from_url(url, None, Some(options))
+        .map_err(|e| format!("Failed to create blob container client: {e}"))?;
     Ok(Arc::new(client))
+}
+
+#[derive(Debug)]
+struct ChainedTokenCredential {
+    credentials: Vec<Arc<dyn IdentityTokenCredential>>,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl IdentityTokenCredential for ChainedTokenCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        _options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<IdentityAccessToken> {
+        let mut errors = Vec::new();
+
+        for credential in &self.credentials {
+            match credential.get_token(scopes, None).await {
+                Ok(token) => return Ok(token),
+                Err(error) => errors.push(error.to_string()),
+            }
+        }
+
+        let detail = if errors.is_empty() {
+            "no credential sources configured".to_string()
+        } else {
+            errors.join("\n")
+        };
+
+        Err(AzureCoreError::with_message(
+            AzureCoreErrorKind::Credential,
+            format!(
+                "Multiple errors were encountered while attempting to authenticate:\n{}",
+                detail
+            ),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct StaticAssertion {
+    token: String,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ClientAssertion for StaticAssertion {
+    async fn secret(
+        &self,
+        _options: Option<ClientMethodOptions<'_>>,
+    ) -> azure_core::Result<String> {
+        Ok(self.token.clone())
+    }
+}
+
+fn apply_authority_host(
+    client_options: &mut azure_core::http::ClientOptions,
+    authority_host: &str,
+) {
+    let mut cloud = CustomConfiguration::default();
+    cloud.authority_host = authority_host.to_string();
+    client_options.cloud = Some(Arc::new(cloud.into()));
+}
+
+#[derive(Debug, Default)]
+struct EnvironmentIdentityVars {
+    tenant_id: Option<String>,
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    federated_token_file: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum EnvironmentIdentitySource {
+    ServicePrincipal {
+        tenant_id: String,
+        client_id: String,
+        client_secret: String,
+    },
+    WorkloadIdentity {
+        tenant_id: String,
+        client_id: String,
+        federated_token_file: String,
+    },
+}
+
+impl EnvironmentIdentityVars {
+    fn from_process_env() -> Self {
+        Self {
+            tenant_id: std::env::var("AZURE_TENANT_ID").ok(),
+            client_id: std::env::var("AZURE_CLIENT_ID").ok(),
+            client_secret: std::env::var("AZURE_CLIENT_SECRET").ok(),
+            federated_token_file: std::env::var("AZURE_FEDERATED_TOKEN_FILE").ok(),
+        }
+    }
+}
+
+fn build_environment_identity_credential(
+    required: bool,
+) -> crate::Result<Option<Arc<dyn IdentityTokenCredential>>> {
+    build_environment_identity_credential_with_vars(
+        EnvironmentIdentityVars::from_process_env(),
+        required,
+    )
+}
+
+fn build_environment_identity_credential_with_vars(
+    vars: EnvironmentIdentityVars,
+    required: bool,
+) -> crate::Result<Option<Arc<dyn IdentityTokenCredential>>> {
+    let source = resolve_environment_identity_source(vars, required)?;
+
+    match source {
+        Some(EnvironmentIdentitySource::ServicePrincipal {
+            tenant_id,
+            client_id,
+            client_secret,
+        }) => {
+            let credential = ClientSecretCredential::new(
+                &tenant_id,
+                client_id,
+                IdentitySecret::new(client_secret),
+                None,
+            )?;
+            Ok(Some(credential))
+        }
+        Some(EnvironmentIdentitySource::WorkloadIdentity {
+            tenant_id,
+            client_id,
+            federated_token_file,
+        }) => {
+            let mut options = WorkloadIdentityCredentialOptions::default();
+            options.client_id = Some(client_id);
+            options.tenant_id = Some(tenant_id);
+            options.token_file_path = Some(PathBuf::from(federated_token_file));
+            let credential = WorkloadIdentityCredential::new(Some(options))?;
+            Ok(Some(credential))
+        }
+        None => Ok(None),
+    }
+}
+
+fn resolve_environment_identity_source(
+    vars: EnvironmentIdentityVars,
+    required: bool,
+) -> crate::Result<Option<EnvironmentIdentitySource>> {
+    let EnvironmentIdentityVars {
+        tenant_id,
+        client_id,
+        client_secret,
+        federated_token_file,
+    } = vars;
+
+    if tenant_id.is_none()
+        && client_id.is_none()
+        && client_secret.is_none()
+        && federated_token_file.is_none()
+    {
+        if required {
+            return Err("environment auth requires AZURE_TENANT_ID and AZURE_CLIENT_ID".into());
+        }
+        return Ok(None);
+    }
+
+    let tenant_id = match tenant_id {
+        Some(value) => value,
+        None => {
+            if required {
+                return Err("environment auth requires AZURE_TENANT_ID".into());
+            }
+            return Ok(None);
+        }
+    };
+
+    let client_id = match client_id {
+        Some(value) => value,
+        None => {
+            if required {
+                return Err("environment auth requires AZURE_CLIENT_ID".into());
+            }
+            return Ok(None);
+        }
+    };
+
+    if let Some(secret) = client_secret {
+        return Ok(Some(EnvironmentIdentitySource::ServicePrincipal {
+            tenant_id,
+            client_id,
+            client_secret: secret,
+        }));
+    }
+
+    if let Some(token_file) = federated_token_file {
+        if token_file.trim().is_empty() {
+            if required {
+                return Err(
+                    "environment auth requires a non-empty AZURE_FEDERATED_TOKEN_FILE".into(),
+                );
+            }
+            return Ok(None);
+        }
+
+        return Ok(Some(EnvironmentIdentitySource::WorkloadIdentity {
+            tenant_id,
+            client_id,
+            federated_token_file: token_file,
+        }));
+    }
+
+    if required {
+        return Err(
+            "environment auth requires AZURE_CLIENT_SECRET or AZURE_FEDERATED_TOKEN_FILE".into(),
+        );
+    }
+
+    Ok(None)
+}
+
+fn build_token_credential(
+    auth: &AzureBlobAuthConfig,
+) -> crate::Result<Arc<dyn IdentityTokenCredential>> {
+    let credentials: Vec<Arc<dyn IdentityTokenCredential>> = match auth {
+        AzureBlobAuthConfig::Default => {
+            let mut credentials = Vec::new();
+            if let Some(credential) = build_environment_identity_credential(false)? {
+                credentials.push(credential);
+            }
+            credentials.push(ManagedIdentityCredential::new(None)?);
+            credentials.push(AzureCliCredential::new(None)?);
+            credentials
+        }
+        AzureBlobAuthConfig::Environment => {
+            let credential = build_environment_identity_credential(true)?
+                .ok_or("environment auth requires configured credentials")?;
+            vec![credential]
+        }
+        AzureBlobAuthConfig::ManagedIdentity {
+            client_id,
+            object_id,
+            msi_res_id,
+        } => {
+            let mut user_assigned_id = None;
+            if let Some(client_id) = client_id {
+                user_assigned_id = Some(UserAssignedId::ClientId(client_id.clone()));
+            }
+            if let Some(object_id) = object_id {
+                if user_assigned_id.is_some() {
+                    return Err(
+                        "managed_identity auth only supports one of `client_id`, `object_id`, or `msi_res_id`".into(),
+                    );
+                }
+                user_assigned_id = Some(UserAssignedId::ObjectId(object_id.clone()));
+            }
+            if let Some(msi_res_id) = msi_res_id {
+                if user_assigned_id.is_some() {
+                    return Err(
+                        "managed_identity auth only supports one of `client_id`, `object_id`, or `msi_res_id`".into(),
+                    );
+                }
+                user_assigned_id = Some(UserAssignedId::ResourceId(msi_res_id.clone()));
+            }
+
+            let options = ManagedIdentityCredentialOptions {
+                user_assigned_id,
+                ..Default::default()
+            };
+            vec![ManagedIdentityCredential::new(Some(options))?]
+        }
+        AzureBlobAuthConfig::AzureCli => vec![AzureCliCredential::new(None)?],
+        AzureBlobAuthConfig::WorkloadIdentity {
+            tenant_id,
+            client_id,
+            token,
+            token_file,
+            authority_host,
+        } => {
+            if token.is_some() && token_file.is_some() {
+                return Err(
+                    "workload_identity auth supports only one of `token` or `token_file`".into(),
+                );
+            }
+
+            match (token, token_file) {
+                (Some(token), None) => {
+                    let token_value = token.inner().to_owned();
+                    if token_value.trim().is_empty() {
+                        return Err("workload_identity auth requires a non-empty token".into());
+                    }
+
+                    let mut options = ClientAssertionCredentialOptions::default();
+                    if let Some(authority_host) = authority_host {
+                        apply_authority_host(&mut options.client_options, authority_host);
+                    }
+                    let assertion = StaticAssertion { token: token_value };
+                    let credential = ClientAssertionCredential::new(
+                        tenant_id.clone(),
+                        client_id.clone(),
+                        assertion,
+                        Some(options),
+                    )?;
+                    vec![credential]
+                }
+                (None, Some(token_file)) => {
+                    if token_file.trim().is_empty() {
+                        return Err("workload_identity auth requires a non-empty token_file".into());
+                    }
+
+                    let mut options = WorkloadIdentityCredentialOptions::default();
+                    if let Some(authority_host) = authority_host {
+                        apply_authority_host(
+                            &mut options.credential_options.client_options,
+                            authority_host,
+                        );
+                    }
+                    options.tenant_id = Some(tenant_id.clone());
+                    options.client_id = Some(client_id.clone());
+                    options.token_file_path = Some(PathBuf::from(token_file.clone()));
+                    let credential = WorkloadIdentityCredential::new(Some(options))?;
+                    vec![credential]
+                }
+                _ => {
+                    return Err(
+                        "workload_identity auth requires either `token` or `token_file`".into(),
+                    );
+                }
+            }
+        }
+    };
+
+    if credentials.is_empty() {
+        return Err("no credential sources available for authentication".into());
+    }
+
+    Ok(Arc::new(ChainedTokenCredential { credentials }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EnvironmentIdentitySource, EnvironmentIdentityVars, resolve_environment_identity_source,
+    };
+
+    #[test]
+    fn environment_identity_returns_none_when_unset_and_not_required() {
+        let result = resolve_environment_identity_source(EnvironmentIdentityVars::default(), false)
+            .expect("should not fail when not required");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn environment_identity_returns_none_when_partial_and_not_required() {
+        let result = resolve_environment_identity_source(
+            EnvironmentIdentityVars {
+                tenant_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+                client_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+                client_secret: None,
+                federated_token_file: None,
+            },
+            false,
+        )
+        .expect("should not fail when not required");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn environment_identity_requires_tenant_and_client_when_required() {
+        let error = resolve_environment_identity_source(EnvironmentIdentityVars::default(), true)
+            .expect_err("missing env vars should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "environment auth requires AZURE_TENANT_ID and AZURE_CLIENT_ID"
+        );
+    }
+
+    #[test]
+    fn environment_identity_accepts_service_principal_credentials() {
+        let result = resolve_environment_identity_source(
+            EnvironmentIdentityVars {
+                tenant_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+                client_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+                client_secret: Some("test-secret".to_string()),
+                federated_token_file: None,
+            },
+            true,
+        )
+        .expect("service principal env vars should resolve");
+
+        assert_eq!(
+            result,
+            Some(EnvironmentIdentitySource::ServicePrincipal {
+                tenant_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                client_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                client_secret: "test-secret".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn environment_identity_accepts_workload_identity_credentials() {
+        let result = resolve_environment_identity_source(
+            EnvironmentIdentityVars {
+                tenant_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+                client_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+                client_secret: None,
+                federated_token_file: Some("/var/run/secrets/azure/tokens/token".to_string()),
+            },
+            true,
+        )
+        .expect("workload identity env vars should resolve");
+
+        assert_eq!(
+            result,
+            Some(EnvironmentIdentitySource::WorkloadIdentity {
+                tenant_id: "00000000-0000-0000-0000-000000000000".to_string(),
+                client_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                federated_token_file: "/var/run/secrets/azure/tokens/token".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn environment_identity_requires_secret_or_token_file_when_required() {
+        let error = resolve_environment_identity_source(
+            EnvironmentIdentityVars {
+                tenant_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+                client_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+                client_secret: None,
+                federated_token_file: None,
+            },
+            true,
+        )
+        .expect_err("missing secret/token file should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "environment auth requires AZURE_CLIENT_SECRET or AZURE_FEDERATED_TOKEN_FILE"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
  Restore and harden non-`connection_string` authentication for the `azure_blob` sink while preserving the new Azure SDK migration path.

  This PR:
  - Adds `storage_account`-based auth support back alongside `connection_string`.
  - Adds `auth` strategies for `storage_account` mode: `default`, `environment`, `managed_identity`, `azure_cli`, and `workload_identity`.
  - Keeps the default chain behavior (`environment` including workload identity -> `managed identity` -> `Azure CLI`) when `auth` is unset.
  - Keeps `connection_string` behavior unchanged and enforces that exactly one of `connection_string` or `storage_account` must be set.
  - Adds validation and regression tests for auth/config edge cases.

## Vector configuration
### 1) Connection string (existing behavior)
```toml
[sources.in]
type = "demo_logs"
format = "json"

[sinks.azure_blob_out]
type = "azure_blob"
inputs = ["in"]
connection_string = "${AZURE_STORAGE_CONNECTION_STRING}"
container_name = "logs"
```
### 2) Storage account with default chain (AKS workload identity auto-detected if env is present)
```toml
[sources.in]
type = "demo_logs"
format = "json"

[sinks.azure_blob_out]
type = "azure_blob"
inputs = ["in"]
storage_account = "myaccount"
container_name = "logs"
```
auth omitted -> default chain:
environment (incl workload identity) -> managed identity -> Azure CLI

### 3) Storage account with explicit workload identity
```toml
[sources.in]
type = "demo_logs"
format = "json"

[sinks.azure_blob_out]
type = "azure_blob"
inputs = ["in"]
storage_account = "myaccount"
container_name = "logs"

[sinks.azure_blob_out.auth]
strategy = "workload_identity"
tenant_id = "${AZURE_TENANT_ID}"
client_id = "${AZURE_CLIENT_ID}"
token_file = "${AZURE_FEDERATED_TOKEN_FILE}"
```
## How did you test this PR?
- Unit tests for env/default auth resolution logic:
      - cargo test -p vector --lib azure_common::config::tests -- --nocapture
  - Azure Blob sink tests (including Azurite integration tests):
      - AZURE_ADDRESS=localhost cargo test -p vector --lib --features azure-blob-integration-tests azure_blob_ -- --nocapture
  - Test setup:
      - Azurite container running locally on localhost:10000 (blob endpoint).
  - Result:
      - 14 passed, 0 failed, 2 ignored in the Azure Blob test suite.
  - New auth/config validation coverage includes:
      - Reject both connection_string and storage_account together.
      - Reject missing both connection_string and storage_account.
      - Reject invalid endpoint URL in storage_account mode.

## Change Type
- [x] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

  - Related: #25187
  - Related: #25256

## Notes
  - This PR keeps the migrated Azure SDK client path intact (azure_core + azure_storage_blob) and does not reintroduce legacy SDK APIs.
  - Cargo.lock changed due Azure identity dependency usage under the Azure Blob sink feature.

<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
