### PR TITLE
enhancement(observability): Add transform latency metrics

### DIFF
--- a/changelog.d/component_latency-metrics.enhancement.md
+++ b/changelog.d/component_latency-metrics.enhancement.md
@@ -1,0 +1,5 @@
+Added the `component_latency_seconds` histogram and
+`component_latency_mean_seconds` gauge internal metrics, exposing the time an
+event spends in a single transform including the transform buffer.
+
+authors: bruceg

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -143,15 +143,28 @@ pub struct GlobalOptions {
     /// The alpha value for the exponential weighted moving average (EWMA) of source and transform
     /// buffer utilization metrics.
     ///
-    /// This value specifies how much of the existing value is retained when each update is made.
-    /// Values closer to 1.0 result in the value adjusting slower to changes. The default value of
-    /// 0.9 is equivalent to a "half life" of 6-7 measurements.
+    /// This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
+    /// observations. Values closer to 1.0 retain more of the previous value, leading to slower
+    /// adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
     ///
-    /// Must be between 0 and 1 exclusive (0 < alpha < 1).
+    /// Must be between 0 and 1 exclusively (0 < alpha < 1).
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
     #[configurable(metadata(docs::advanced))]
     pub buffer_utilization_ewma_alpha: Option<f64>,
+
+    /// The alpha value for the exponential weighted moving average (EWMA) of transform latency
+    /// metrics.
+    ///
+    /// This controls how quickly the `component_latency_mean_seconds` gauge responds to new
+    /// observations. Values closer to 1.0 retain more of the previous value, leading to slower
+    /// adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+    ///
+    /// Must be between 0 and 1 exclusively (0 < alpha < 1).
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    #[configurable(validation(range(min = 0.0, max = 1.0)))]
+    #[configurable(metadata(docs::advanced))]
+    pub latency_ewma_alpha: Option<f64>,
 
     /// The interval, in seconds, at which the internal metrics cache for VRL is refreshed.
     /// This must be set to be able to access metrics in VRL functions.
@@ -311,6 +324,7 @@ impl GlobalOptions {
                 buffer_utilization_ewma_alpha: self
                     .buffer_utilization_ewma_alpha
                     .or(with.buffer_utilization_ewma_alpha),
+                latency_ewma_alpha: self.latency_ewma_alpha.or(with.latency_ewma_alpha),
                 metrics_storage_refresh_period: self
                     .metrics_storage_refresh_period
                     .or(with.metrics_storage_refresh_period),

--- a/lib/vector-core/src/event/array.rs
+++ b/lib/vector-core/src/event/array.rs
@@ -141,15 +141,6 @@ pub enum EventArray {
 }
 
 impl EventArray {
-    /// Sets the `source_type` in the metadata for all metric events in this array.
-    pub fn set_source_type(&mut self, source_type: &'static str) {
-        if let EventArray::Metrics(metrics) = self {
-            for metric in metrics {
-                metric.metadata_mut().set_source_type(source_type);
-            }
-        }
-    }
-
     /// Iterate over references to this array's events.
     pub fn iter_events(&self) -> impl Iterator<Item = EventRef<'_>> {
         match self {

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -24,7 +24,10 @@ const SPLUNK_HEC_TOKEN: &str = "splunk_hec_token";
 /// The event metadata structure is a `Arc` wrapper around the actual metadata to avoid cloning the
 /// underlying data until it becomes necessary to provide a `mut` copy.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct EventMetadata(pub(super) Arc<Inner>);
+pub struct EventMetadata {
+    #[serde(flatten)]
+    pub(super) inner: Arc<Inner>,
+}
 
 /// The actual metadata structure contained by both `struct Metric`
 /// and `struct LogEvent` types.
@@ -129,23 +132,25 @@ fn default_metadata_value() -> Value {
 impl EventMetadata {
     /// Creates `EventMetadata` with the given `Value`, and the rest of the fields with default values
     pub fn default_with_value(value: Value) -> Self {
-        Self(Arc::new(Inner {
-            value,
-            ..Default::default()
-        }))
+        Self {
+            inner: Arc::new(Inner {
+                value,
+                ..Default::default()
+            }),
+        }
     }
 
     fn get_mut(&mut self) -> &mut Inner {
-        Arc::make_mut(&mut self.0)
+        Arc::make_mut(&mut self.inner)
     }
 
     pub(super) fn into_owned(self) -> Inner {
-        Arc::unwrap_or_clone(self.0)
+        Arc::unwrap_or_clone(self.inner)
     }
 
     /// Returns a reference to the metadata value
     pub fn value(&self) -> &Value {
-        &self.0.value
+        &self.inner.value
     }
 
     /// Returns a mutable reference to the metadata value
@@ -155,7 +160,7 @@ impl EventMetadata {
 
     /// Returns a reference to the secrets
     pub fn secrets(&self) -> &Secrets {
-        &self.0.secrets
+        &self.inner.secrets
     }
 
     /// Returns a mutable reference to the secrets
@@ -166,20 +171,20 @@ impl EventMetadata {
     /// Returns a reference to the metadata source id.
     #[must_use]
     pub fn source_id(&self) -> Option<&Arc<ComponentKey>> {
-        self.0.source_id.as_ref()
+        self.inner.source_id.as_ref()
     }
 
     /// Returns a reference to the metadata source type.
     #[must_use]
     pub fn source_type(&self) -> Option<&str> {
-        self.0.source_type.as_deref()
+        self.inner.source_type.as_deref()
     }
 
     /// Returns a reference to the metadata parent id. This is the `OutputId`
     /// of the previous component the event was sent through (if any).
     #[must_use]
     pub fn upstream_id(&self) -> Option<&OutputId> {
-        self.0.upstream_id.as_deref()
+        self.inner.upstream_id.as_deref()
     }
 
     /// Sets the `source_id` in the metadata to the provided value.
@@ -199,7 +204,7 @@ impl EventMetadata {
 
     /// Return the datadog API key, if it exists
     pub fn datadog_api_key(&self) -> Option<Arc<str>> {
-        self.0.secrets.get(DATADOG_API_KEY).cloned()
+        self.inner.secrets.get(DATADOG_API_KEY).cloned()
     }
 
     /// Set the datadog API key to passed value
@@ -209,7 +214,7 @@ impl EventMetadata {
 
     /// Return the splunk hec token, if it exists
     pub fn splunk_hec_token(&self) -> Option<Arc<str>> {
-        self.0.secrets.get(SPLUNK_HEC_TOKEN).cloned()
+        self.inner.secrets.get(SPLUNK_HEC_TOKEN).cloned()
     }
 
     /// Set the splunk hec token to passed value
@@ -227,17 +232,17 @@ impl EventMetadata {
 
     /// Fetches the dropped field by meaning.
     pub fn dropped_field(&self, meaning: impl AsRef<str>) -> Option<&Value> {
-        self.0.dropped_fields.get(meaning.as_ref())
+        self.inner.dropped_fields.get(meaning.as_ref())
     }
 
     /// Returns a reference to the `DatadogMetricOriginMetadata`.
     pub fn datadog_origin_metadata(&self) -> Option<&DatadogMetricOriginMetadata> {
-        self.0.datadog_origin_metadata.as_ref()
+        self.inner.datadog_origin_metadata.as_ref()
     }
 
     /// Returns a reference to the event id.
     pub fn source_event_id(&self) -> Option<Uuid> {
-        self.0.source_event_id
+        self.inner.source_event_id
     }
 }
 
@@ -260,7 +265,9 @@ impl Default for Inner {
 
 impl Default for EventMetadata {
     fn default() -> Self {
-        Self(Arc::new(Inner::default()))
+        Self {
+            inner: Arc::new(Inner::default()),
+        }
     }
 }
 
@@ -276,7 +283,7 @@ impl ByteSizeOf for EventMetadata {
         // NOTE we don't count the `str` here because it's allocated somewhere
         // else. We're just moving around the pointer, which is already captured
         // by `ByteSizeOf::size_of`.
-        self.0.finalizers.allocated_bytes()
+        self.inner.finalizers.allocated_bytes()
     }
 }
 
@@ -355,7 +362,7 @@ impl EventMetadata {
 
     /// Update the finalizer(s) status.
     pub fn update_status(&self, status: EventStatus) {
-        self.0.finalizers.update_status(status);
+        self.inner.finalizers.update_status(status);
     }
 
     /// Update the finalizers' sources.
@@ -365,7 +372,7 @@ impl EventMetadata {
 
     /// Gets a reference to the event finalizers.
     pub fn finalizers(&self) -> &EventFinalizers {
-        &self.0.finalizers
+        &self.inner.finalizers
     }
 
     /// Add a new event finalizer to the existing list of event finalizers.
@@ -385,7 +392,7 @@ impl EventMetadata {
 
     /// Get the schema definition.
     pub fn schema_definition(&self) -> &Arc<schema::Definition> {
-        &self.0.schema_definition
+        &self.inner.schema_definition
     }
 
     /// Set the schema definition.

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -677,18 +677,21 @@ impl From<Metadata> for EventMetadata {
             }
         };
 
-        EventMetadata(Arc::new(Inner {
-            value: metadata_value.unwrap_or_else(|| vrl::value::Value::Object(ObjectMap::new())),
-            secrets: secrets.unwrap_or_default(),
-            finalizers: EventFinalizers::default(),
-            source_id,
-            source_type: source_type.map(Into::into),
-            upstream_id,
-            schema_definition: default_schema_definition(),
-            dropped_fields: ObjectMap::new(),
-            datadog_origin_metadata,
-            source_event_id,
-        }))
+        EventMetadata {
+            inner: Arc::new(Inner {
+                value: metadata_value
+                    .unwrap_or_else(|| vrl::value::Value::Object(ObjectMap::new())),
+                secrets: secrets.unwrap_or_default(),
+                finalizers: EventFinalizers::default(),
+                source_id,
+                source_type: source_type.map(Into::into),
+                upstream_id,
+                schema_definition: default_schema_definition(),
+                dropped_fields: ObjectMap::new(),
+                datadog_origin_metadata,
+                source_event_id,
+            }),
+        }
     }
 }
 

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -691,6 +691,7 @@ impl From<Metadata> for EventMetadata {
                 datadog_origin_metadata,
                 source_event_id,
             }),
+            last_transform_timestamp: None,
         }
     }
 }

--- a/lib/vector-core/src/latency.rs
+++ b/lib/vector-core/src/latency.rs
@@ -1,0 +1,60 @@
+use std::time::Instant;
+
+use metrics::{Histogram, gauge, histogram};
+use vector_common::stats::EwmaGauge;
+
+use crate::event::EventArray;
+
+const COMPONENT_LATENCY: &str = "component_latency_seconds";
+const COMPONENT_LATENCY_MEAN: &str = "component_latency_mean_seconds";
+const DEFAULT_LATENCY_EWMA_ALPHA: f64 = 0.9;
+
+#[derive(Debug)]
+pub struct LatencyRecorder {
+    histogram: Histogram,
+    gauge: EwmaGauge,
+}
+
+impl LatencyRecorder {
+    pub fn new(ewma_alpha: Option<f64>) -> Self {
+        Self {
+            histogram: histogram!(COMPONENT_LATENCY),
+            gauge: EwmaGauge::new(
+                gauge!(COMPONENT_LATENCY_MEAN),
+                ewma_alpha.or(Some(DEFAULT_LATENCY_EWMA_ALPHA)),
+            ),
+        }
+    }
+
+    pub fn on_send(&self, events: &mut EventArray) {
+        let now = Instant::now();
+        let mut sum = 0.0;
+        let mut count = 0usize;
+
+        // Since all of the events in the array will most likely have entered and exited the
+        // component at close to the same time, we average all the latencies over the entire array
+        // and record it just once in the EWMA-backed gauge. If we were to record each latency
+        // individually, the gauge would effectively just reflect the latest array's latency,
+        // eliminating the utility of the EWMA averaging. However, we record the individual
+        // latencies in the histogram to get a more granular view of the latency distribution.
+        for mut event in events.iter_events_mut() {
+            let metadata = event.metadata_mut();
+            if let Some(previous) = metadata.last_transform_timestamp() {
+                let latency = now.saturating_duration_since(previous).as_secs_f64();
+                sum += latency;
+                count += 1;
+                self.histogram.record(latency);
+            }
+
+            metadata.set_last_transform_timestamp(now);
+        }
+        if count > 0 {
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "losing precision is acceptable here"
+            )]
+            let mean = sum / count as f64;
+            self.gauge.record(mean);
+        }
+    }
+}

--- a/lib/vector-core/src/latency.rs
+++ b/lib/vector-core/src/latency.rs
@@ -26,8 +26,7 @@ impl LatencyRecorder {
         }
     }
 
-    pub fn on_send(&self, events: &mut EventArray) {
-        let now = Instant::now();
+    pub fn on_send(&self, events: &mut EventArray, now: Instant) {
         let mut sum = 0.0;
         let mut count = 0usize;
 

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod config;
 pub mod event;
 pub mod fanout;
 pub mod ipallowlist;
+pub mod latency;
 pub mod metrics;
 pub mod partition;
 pub mod schema;

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -21,8 +21,8 @@ pub use vector_config::impl_generate_config_from_default;
 pub use vector_core::compile_vrl;
 pub use vector_core::{
     EstimatedJsonEncodedSizeOf, buckets, default_data_dir, emit, event, fanout, ipallowlist,
-    metric_tags, metrics, partition, quantiles, register, samples, schema, serde, sink, source,
-    source_sender, tcp, tls, transform,
+    latency, metric_tags, metrics, partition, quantiles, register, samples, schema, serde, sink,
+    source, source_sender, tcp, tls, transform,
 };
 pub use vector_lookup as lookup;
 pub use vector_stream as stream;

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -36,7 +36,7 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
         errors.extend(output_errors);
     }
 
-    if let Err(alpha_errors) = validation::check_buffer_utilization_ewma_alpha(&builder) {
+    if let Err(alpha_errors) = validation::check_values(&builder) {
         errors.extend(alpha_errors);
     }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -11,13 +11,27 @@ use super::{
 };
 use crate::config::schema;
 
-/// Minimum value (exclusive) for `utilization_ewma_alpha`.
+/// Minimum value (exclusive) for EWMA alpha options.
 /// The alpha value must be strictly greater than this value.
 const EWMA_ALPHA_MIN: f64 = 0.0;
 
-/// Maximum value (exclusive) for `utilization_ewma_alpha`.
+/// Maximum value (exclusive) for EWMA alpha options.
 /// The alpha value must be strictly less than this value.
 const EWMA_ALPHA_MAX: f64 = 1.0;
+
+/// Validates an optional EWMA alpha value and returns an error message if invalid.
+/// Returns `None` if the value is `None` or valid, otherwise returns an error message.
+fn validate_ewma_alpha(alpha: Option<f64>, field_name: &str) -> Option<String> {
+    if let Some(alpha) = alpha
+        && !(alpha > EWMA_ALPHA_MIN && alpha < EWMA_ALPHA_MAX)
+    {
+        Some(format!(
+            "Global `{field_name}` must be between 0 and 1 exclusive (0 < alpha < 1), got {alpha}"
+        ))
+    } else {
+        None
+    }
+}
 
 /// Check that provide + topology config aren't present in the same builder, which is an error.
 pub fn check_provider(config: &ConfigBuilder) -> Result<(), Vec<String>> {
@@ -155,17 +169,25 @@ pub fn check_resources(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     }
 }
 
-/// Validates that `buffer_utilization_ewma_alpha` value is within the valid range (0 < alpha < 1)
-/// for the global configuration.
-pub fn check_buffer_utilization_ewma_alpha(config: &ConfigBuilder) -> Result<(), Vec<String>> {
-    if let Some(alpha) = config.global.buffer_utilization_ewma_alpha
-        && (alpha <= EWMA_ALPHA_MIN || alpha >= EWMA_ALPHA_MAX)
+/// Validates that `*_ewma_alpha` values are within the valid range (0 < alpha < 1).
+pub fn check_values(config: &ConfigBuilder) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+
+    if let Some(error) = validate_ewma_alpha(
+        config.global.buffer_utilization_ewma_alpha,
+        "buffer_utilization_ewma_alpha",
+    ) {
+        errors.push(error);
+    }
+    if let Some(error) = validate_ewma_alpha(config.global.latency_ewma_alpha, "latency_ewma_alpha")
     {
-        Err(vec![format!(
-            "Global `buffer_utilization_ewma_alpha` must be between 0 and 1 exclusive (0 < alpha < 1), got {alpha}"
-        )])
-    } else {
+        errors.push(error);
+    }
+
+    if errors.is_empty() {
         Ok(())
+    } else {
+        Err(errors)
     }
 }
 

--- a/src/test_util/mock/sinks/completion.rs
+++ b/src/test_util/mock/sinks/completion.rs
@@ -1,0 +1,95 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use futures_util::{FutureExt, StreamExt, future, stream::BoxStream};
+use tokio::sync::oneshot::Sender;
+use vector_lib::{
+    config::{AcknowledgementsConfig, Input},
+    configurable::configurable_component,
+    event::Event,
+    sink::{StreamSink, VectorSink},
+};
+
+use crate::{
+    config::{SinkConfig, SinkContext},
+    sinks::Healthcheck,
+};
+
+/// Configuration for the `test_completion` sink.
+#[configurable_component(sink("test_completion", "Test (completion)."))]
+#[derive(Clone, Debug, Default)]
+pub struct CompletionSinkConfig {
+    #[serde(skip)]
+    expected: usize,
+
+    #[serde(skip)]
+    completion_tx: Arc<Mutex<Option<Sender<bool>>>>,
+}
+
+impl_generate_config_from_default!(CompletionSinkConfig);
+
+impl CompletionSinkConfig {
+    pub fn new(expected: usize, completion_tx: Sender<bool>) -> Self {
+        Self {
+            expected,
+            completion_tx: Arc::new(Mutex::new(Some(completion_tx))),
+        }
+    }
+}
+
+#[async_trait]
+#[typetag::serde(name = "test_completion")]
+impl SinkConfig for CompletionSinkConfig {
+    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let completion_tx = self
+            .completion_tx
+            .lock()
+            .expect("completion sink mutex poisoned")
+            .take();
+
+        let sink = CompletionSink {
+            remaining: self.expected,
+            completion_tx,
+        };
+        let healthcheck = future::ready(Ok(())).boxed();
+
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &AcknowledgementsConfig::DEFAULT
+    }
+}
+
+struct CompletionSink {
+    remaining: usize,
+    completion_tx: Option<Sender<bool>>,
+}
+
+#[async_trait]
+impl StreamSink<Event> for CompletionSink {
+    async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+        while let Some(event) = input.next().await {
+            drop(event);
+
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                if self.remaining == 0
+                    && let Some(tx) = self.completion_tx.take()
+                {
+                    let _ = tx.send(true);
+                }
+            }
+        }
+
+        if let Some(tx) = self.completion_tx.take() {
+            let _ = tx.send(self.remaining == 0);
+        }
+
+        Ok(())
+    }
+}

--- a/src/test_util/mock/sinks/mod.rs
+++ b/src/test_util/mock/sinks/mod.rs
@@ -4,6 +4,9 @@ pub use self::backpressure::BackpressureSinkConfig;
 mod basic;
 pub use self::basic::BasicSinkConfig;
 
+mod completion;
+pub use self::completion::CompletionSinkConfig;
+
 mod error;
 pub use self::error::ErrorSinkConfig;
 

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -1,7 +1,7 @@
-use std::pin::Pin;
+use std::{pin::Pin, time::Duration};
 
 use async_trait::async_trait;
-use futures_util::Stream;
+use futures_util::{Stream, StreamExt as _};
 use vector_lib::{
     config::{DataType, Input, TransformOutput},
     configurable::configurable_component,
@@ -19,14 +19,28 @@ use crate::config::{GenerateConfig, OutputId, TransformConfig, TransformContext}
 pub struct NoopTransformConfig {
     #[configurable(derived)]
     transform_type: TransformType,
+
+    /// Optional per-event/array delay, in milliseconds.
+    ///
+    /// This is intended for tests that need deterministic, non-zero component latency.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    delay_ms: Option<u64>,
 }
 
 impl GenerateConfig for NoopTransformConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(&Self {
             transform_type: TransformType::Function,
+            delay_ms: None,
         })
         .unwrap()
+    }
+}
+
+impl NoopTransformConfig {
+    pub fn with_delay_ms(mut self, delay_ms: u64) -> Self {
+        self.delay_ms = Some(delay_ms);
+        self
     }
 }
 
@@ -52,37 +66,55 @@ impl TransformConfig for NoopTransformConfig {
     }
 
     async fn build(&self, _: &TransformContext) -> crate::Result<Transform> {
+        let delay = self.delay_ms.map(Duration::from_millis);
         match self.transform_type {
-            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform))),
-            TransformType::Synchronous => Ok(Transform::Synchronous(Box::new(NoopTransform))),
-            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform))),
+            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform { delay }))),
+            TransformType::Synchronous => {
+                Ok(Transform::Synchronous(Box::new(NoopTransform { delay })))
+            }
+            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform { delay }))),
         }
     }
 }
 
 impl From<TransformType> for NoopTransformConfig {
     fn from(transform_type: TransformType) -> Self {
-        Self { transform_type }
+        Self {
+            transform_type,
+            delay_ms: None,
+        }
     }
 }
 
 #[derive(Clone)]
-struct NoopTransform;
+struct NoopTransform {
+    delay: Option<Duration>,
+}
 
 impl FunctionTransform for NoopTransform {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
+        if let Some(delay) = self.delay {
+            std::thread::sleep(delay);
+        }
         output.push(event);
     }
 }
 
 impl<T> TaskTransform<T> for NoopTransform
 where
-    T: EventContainer + 'static,
+    T: EventContainer + Send + 'static,
 {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn futures_util::Stream<Item = T> + Send>>,
     ) -> Pin<Box<dyn Stream<Item = T> + Send>> {
-        Box::pin(task)
+        if let Some(delay) = self.delay {
+            Box::pin(task.then(move |item| async move {
+                tokio::time::sleep(delay).await;
+                item
+            }))
+        } else {
+            Box::pin(task)
+        }
     }
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -881,6 +881,7 @@ async fn run_source_output_pump(
         array.for_each_metadata_mut(|metadata| {
             metadata.set_source_id(Arc::clone(&source));
             metadata.set_source_type(source_type);
+            metadata.set_last_transform_timestamp(Instant::now());
         });
         fanout
             .send(array, Some(send_reference))

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -881,16 +881,15 @@ async fn run_source_output_pump(
         send_reference,
     }) = rx.next().await
     {
-        // Even though we have a `send_reference` timestamp here, that reference
-        // time is when the events were enqueued in the `SourceSender`, not when
-        // they were pulled out of the `rx` stream on this end. Since those times
-        // can be quite different (due to blocking inherent to the fanout send
-        // operation), we set the `last_transform_timestamp` to the current time
-        // instead to get an accurate reference for when the events started waiting
-        // for the first transform.
         array.for_each_metadata_mut(|metadata| {
             metadata.set_source_id(Arc::clone(&source));
             metadata.set_source_type(source_type);
+            // Even though we have a `send_reference` timestamp here, that reference time is when
+            // the events were enqueued in the `SourceSender`, not when they were pulled out of the
+            // `rx` stream on this end. Since those times can be quite different (due to blocking
+            // inherent to the fanout send operation), we set the `last_transform_timestamp` to the
+            // current time instead to get an accurate reference for when the events started waiting
+            // for the first transform.
             metadata.set_last_transform_timestamp(Instant::now());
         });
         fanout

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -22,7 +22,7 @@ use vector_lib::{
         BufferType, WhenFull,
         topology::{
             builder::TopologyBuilder,
-            channel::{BufferReceiver, BufferSender, ChannelMetricMetadata},
+            channel::{BufferReceiver, BufferSender, ChannelMetricMetadata, LimitedReceiver},
         },
     },
     internal_event::{self, CountByteSize, EventsSent, InternalEventHandle as _, Registered},
@@ -272,34 +272,13 @@ impl<'a> Builder<'a> {
             let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
 
             for output in source_outputs.into_iter() {
-                let mut rx = builder.add_source_output(output.clone(), key.clone());
+                let rx = builder.add_source_output(output.clone(), key.clone());
 
-                let (mut fanout, control) = Fanout::new();
+                let (fanout, control) = Fanout::new();
                 let source_type = source.inner.get_component_name();
                 let source = Arc::new(key.clone());
 
-                let pump = async move {
-                    debug!("Source pump starting.");
-
-                    while let Some(SourceSenderItem {
-                        events: mut array,
-                        send_reference,
-                    }) = rx.next().await
-                    {
-                        array.set_output_id(&source);
-                        array.set_source_type(source_type);
-                        fanout
-                            .send(array, Some(send_reference))
-                            .await
-                            .map_err(|e| {
-                                debug!("Source pump finished with an error.");
-                                TaskError::wrapped(e)
-                            })?;
-                    }
-
-                    debug!("Source pump finished normally.");
-                    Ok(TaskOutput::Source)
-                };
+                let pump = run_source_output_pump(rx, fanout, source, source_type);
 
                 pumps.push(pump.instrument(span.clone()));
                 controls.insert(
@@ -877,6 +856,43 @@ impl<'a> Builder<'a> {
 
         (task, outputs)
     }
+}
+
+async fn run_source_output_pump(
+    mut rx: LimitedReceiver<SourceSenderItem>,
+    mut fanout: Fanout,
+    source: Arc<ComponentKey>,
+    source_type: &'static str,
+) -> TaskResult {
+    debug!("Source pump starting.");
+
+    while let Some(SourceSenderItem {
+        events: mut array,
+        send_reference,
+    }) = rx.next().await
+    {
+        // Even though we have a `send_reference` timestamp here, that reference
+        // time is when the events were enqueued in the `SourceSender`, not when
+        // they were pulled out of the `rx` stream on this end. Since those times
+        // can be quite different (due to blocking inherent to the fanout send
+        // operation), we set the `last_transform_timestamp` to the current time
+        // instead to get an accurate reference for when the events started waiting
+        // for the first transform.
+        array.for_each_metadata_mut(|metadata| {
+            metadata.set_source_id(Arc::clone(&source));
+            metadata.set_source_type(source_type);
+        });
+        fanout
+            .send(array, Some(send_reference))
+            .await
+            .map_err(|e| {
+                debug!("Source pump finished with an error.");
+                TaskError::wrapped(e)
+            })?;
+    }
+
+    debug!("Source pump finished normally.");
+    Ok(TaskOutput::Source)
 }
 
 pub async fn reload_enrichment_tables(config: &Config) {

--- a/src/topology/test/compliance.rs
+++ b/src/topology/test/compliance.rs
@@ -19,6 +19,19 @@ use crate::{
     topology::RunningTopology,
 };
 
+const TEST_SOURCE_COMPONENT_ID: &str = "in";
+const TEST_UPSTREAM_COMPONENT_ID: &str = "transform";
+const TEST_SOURCE_TYPE: &str = "unit_test";
+
+fn set_expected_source_metadata(event: &mut Event) {
+    event.set_source_id(Arc::new(ComponentKey::from(TEST_SOURCE_COMPONENT_ID)));
+    event.set_upstream_id(Arc::new(OutputId::from(TEST_UPSTREAM_COMPONENT_ID)));
+    event.set_source_type(TEST_SOURCE_TYPE);
+    event
+        .metadata_mut()
+        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+}
+
 async fn create_topology(
     event: Event,
     transform_type: TransformType,
@@ -58,11 +71,7 @@ async fn test_function_transform_single_event() {
         let mut events = events.into_events().collect::<Vec<_>>();
         assert_eq!(events.len(), 1);
 
-        original_event.set_source_id(Arc::new(ComponentKey::from("in")));
-        original_event.set_upstream_id(Arc::new(OutputId::from("transform")));
-        original_event
-            .metadata_mut()
-            .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+        set_expected_source_metadata(&mut original_event);
 
         let event = events.remove(0);
         assert_eq!(original_event, event);
@@ -83,11 +92,7 @@ async fn test_sync_transform_single_event() {
         let mut events = events.into_events().collect::<Vec<_>>();
         assert_eq!(events.len(), 1);
 
-        original_event.set_source_id(Arc::new(ComponentKey::from("in")));
-        original_event.set_upstream_id(Arc::new(OutputId::from("transform")));
-        original_event
-            .metadata_mut()
-            .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+        set_expected_source_metadata(&mut original_event);
 
         let event = events.remove(0);
         assert_eq!(original_event, event);
@@ -107,11 +112,7 @@ async fn test_task_transform_single_event() {
         let mut events = events.into_events().collect::<Vec<_>>();
         assert_eq!(events.len(), 1);
 
-        original_event.set_source_id(Arc::new(ComponentKey::from("in")));
-        original_event.set_upstream_id(Arc::new(OutputId::from("transform")));
-        original_event
-            .metadata_mut()
-            .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+        set_expected_source_metadata(&mut original_event);
 
         let event = events.remove(0);
         assert_eq!(original_event, event);

--- a/src/topology/test/latency_metrics.rs
+++ b/src/topology/test/latency_metrics.rs
@@ -1,0 +1,147 @@
+use std::time::Instant;
+use tokio::{
+    sync::oneshot,
+    time::{Duration, timeout},
+};
+use vector_lib::metrics::Controller;
+
+use crate::{
+    config::Config,
+    event::{Event, LogEvent, Metric, MetricValue},
+    test_util::{
+        mock::{
+            basic_source,
+            sinks::CompletionSinkConfig,
+            transforms::{NoopTransformConfig, TransformType},
+        },
+        start_topology, trace_init,
+    },
+};
+
+const EVENT_COUNT: usize = 100;
+const TRANSFORM_DELAY_MS: u64 = 10;
+const SOURCE_ID: &str = "latency_source";
+const TRANSFORM_ID: &str = "latency_delay";
+const TRANSFORM_TYPE: &str = "test_noop";
+const TRANSFORM_KIND: &str = "transform";
+const SINK_ID: &str = "latency_sink";
+
+struct LatencyTestRun {
+    metrics: Vec<Metric>,
+    elapsed_time: f64,
+}
+
+#[tokio::test]
+async fn component_latency_metrics_emitted() {
+    let run = run_latency_topology().await;
+
+    assert_histogram_count(
+        &run.metrics,
+        "component_latency_seconds",
+        has_component_tags,
+    );
+    assert_gauge_range(
+        &run.metrics,
+        "component_latency_mean_seconds",
+        has_component_tags,
+        TRANSFORM_DELAY_MS as f64 / 1000.0,
+        run.elapsed_time,
+    );
+}
+
+async fn run_latency_topology() -> LatencyTestRun {
+    trace_init();
+
+    let controller = Controller::get().expect("metrics controller");
+    controller.reset();
+
+    let (mut source_tx, source_config) = basic_source();
+    let transform_config =
+        NoopTransformConfig::from(TransformType::Task).with_delay_ms(TRANSFORM_DELAY_MS);
+    let (sink_done_tx, sink_done_rx) = oneshot::channel();
+    let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
+
+    let mut config = Config::builder();
+    config.add_source(SOURCE_ID, source_config);
+    config.add_transform(TRANSFORM_ID, &[SOURCE_ID], transform_config);
+    config.add_sink(SINK_ID, &[TRANSFORM_ID], sink_config);
+
+    let start_time = Instant::now();
+    let (topology, _) = start_topology(config.build().unwrap(), false).await;
+
+    for idx in 0..EVENT_COUNT {
+        let event = Event::Log(LogEvent::from(format!("payload-{idx}")));
+        source_tx.send_event(event).await.unwrap();
+    }
+
+    drop(source_tx);
+
+    let completed = timeout(Duration::from_secs(5), sink_done_rx)
+        .await
+        .expect("timed out waiting for completion sink to finish")
+        .expect("completion sink sender dropped");
+    assert!(
+        completed,
+        "completion sink finished before receiving all events"
+    );
+
+    topology.stop().await;
+    let elapsed_time = start_time.elapsed().as_secs_f64();
+
+    LatencyTestRun {
+        metrics: controller.capture_metrics(),
+        elapsed_time,
+    }
+}
+
+fn assert_histogram_count(metrics: &[Metric], metric_name: &str, tags_match: fn(&Metric) -> bool) {
+    let histogram = metrics
+        .iter()
+        .find(|metric| metric.name() == metric_name && tags_match(metric))
+        .unwrap_or_else(|| panic!("{metric_name} histogram missing"));
+
+    match histogram.value() {
+        MetricValue::AggregatedHistogram { count, .. } => {
+            assert_eq!(
+                *count, EVENT_COUNT as u64,
+                "histogram count should match number of events"
+            );
+        }
+        other => panic!("expected aggregated histogram, got {other:?}"),
+    }
+}
+
+fn assert_gauge_range(
+    metrics: &[Metric],
+    metric_name: &str,
+    tags_match: fn(&Metric) -> bool,
+    expected_min: f64,
+    elapsed_time: f64,
+) {
+    let gauge = metrics
+        .iter()
+        .find(|metric| metric.name() == metric_name && tags_match(metric))
+        .unwrap_or_else(|| panic!("{metric_name} gauge missing"));
+
+    match gauge.value() {
+        MetricValue::Gauge { value } => {
+            assert!(
+                *value >= expected_min,
+                "expected mean latency to be >= {expected_min}, got {value}"
+            );
+            assert!(
+                *value < elapsed_time,
+                "expected mean latency ({value}) to be less than elapsed time ({elapsed_time})"
+            );
+        }
+        other => panic!("expected gauge metric, got {other:?}"),
+    }
+}
+
+fn has_component_tags(metric: &Metric) -> bool {
+    metric.tags().is_some_and(|tags| {
+        tags.get("component_id") == Some(TRANSFORM_ID)
+            && tags.get("component_type") == Some(TRANSFORM_TYPE)
+            && tags.get("component_kind") == Some(TRANSFORM_KIND)
+    })
+}

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -39,6 +39,7 @@ mod crash;
 mod doesnt_reload;
 #[cfg(all(feature = "sources-http_server", feature = "sinks-http"))]
 mod end_to_end;
+mod latency_metrics;
 #[cfg(all(
     feature = "sources-prometheus",
     feature = "sinks-prometheus",

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -85,6 +85,18 @@ fn into_message_stream(array: SourceSenderItem) -> impl futures::Stream<Item = S
     stream::iter(array.events.into_events().map(into_message))
 }
 
+const TEST_UPSTREAM_COMPONENT_ID: &str = "test";
+const TEST_BASIC_SOURCE_TYPE: &str = "test_basic";
+
+fn set_expected_source_metadata(event: &mut Event, source_component_id: &str) {
+    event.set_source_id(Arc::new(ComponentKey::from(source_component_id)));
+    event.set_upstream_id(Arc::new(OutputId::from(TEST_UPSTREAM_COMPONENT_ID)));
+    event.set_source_type(TEST_BASIC_SOURCE_TYPE);
+    event
+        .metadata_mut()
+        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+}
+
 #[tokio::test]
 async fn topology_shutdown_while_active() {
     trace_init();
@@ -159,11 +171,7 @@ async fn topology_source_and_sink() {
 
     let res = out1.flat_map(into_event_stream).collect::<Vec<_>>().await;
 
-    event.set_source_id(Arc::new(ComponentKey::from("in1")));
-    event.set_upstream_id(Arc::new(OutputId::from("test")));
-    event
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event, "in1");
 
     assert_eq!(vec![event], res);
 }
@@ -196,18 +204,8 @@ async fn topology_multiple_sources() {
 
     topology.stop().await;
 
-    event1.set_source_id(Arc::new(ComponentKey::from("in1")));
-    event2.set_source_id(Arc::new(ComponentKey::from("in2")));
-
-    event1.set_upstream_id(Arc::new(OutputId::from("test")));
-    event1
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
-
-    event2.set_upstream_id(Arc::new(OutputId::from("test")));
-    event2
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event1, "in1");
+    set_expected_source_metadata(&mut event2, "in2");
 
     assert_eq!(out_event1, Some(event1.into()));
     assert_eq!(out_event2, Some(event2.into()));
@@ -242,12 +240,7 @@ async fn topology_multiple_sinks() {
     let res2 = out2.flat_map(into_event_stream).collect::<Vec<_>>().await;
 
     // We should see that both sinks got the exact same event:
-    event.set_source_id(Arc::new(ComponentKey::from("in1")));
-
-    event.set_upstream_id(Arc::new(OutputId::from("test")));
-    event
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event, "in1");
 
     let expected = vec![event];
     assert_eq!(expected, res1);
@@ -322,12 +315,7 @@ async fn topology_remove_one_source() {
     drop(in2);
     topology.stop().await;
 
-    event1.set_source_id(Arc::new(ComponentKey::from("in1")));
-
-    event1.set_upstream_id(Arc::new(OutputId::from("test")));
-    event1
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event1, "in1");
 
     let res = h_out1.await.unwrap();
     assert_eq!(vec![event1], res);
@@ -366,12 +354,7 @@ async fn topology_remove_one_sink() {
     let res1 = out1.flat_map(into_event_stream).collect::<Vec<_>>().await;
     let res2 = out2.flat_map(into_event_stream).collect::<Vec<_>>().await;
 
-    event.set_source_id(Arc::new(ComponentKey::from("in1")));
-
-    event.set_upstream_id(Arc::new(OutputId::from("test")));
-    event
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event, "in1");
 
     assert_eq!(vec![event], res1);
     assert_eq!(Vec::<Event>::new(), res2);
@@ -482,11 +465,7 @@ async fn topology_swap_source() {
     // as we've removed it from the topology prior to the sends.
     assert_eq!(Vec::<Event>::new(), res1);
 
-    event2.set_source_id(Arc::new(ComponentKey::from("in2")));
-    event2.set_upstream_id(Arc::new(OutputId::from("test")));
-    event2
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event2, "in2");
 
     assert_eq!(vec![event2], res2);
 }
@@ -599,11 +578,7 @@ async fn topology_swap_sink() {
     // the new sink, which _was_ rebuilt:
     assert_eq!(Vec::<Event>::new(), res1);
 
-    event1.set_source_id(Arc::new(ComponentKey::from("in1")));
-    event1.set_upstream_id(Arc::new(OutputId::from("test")));
-    event1
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event1, "in1");
     assert_eq!(vec![event1], res2);
 }
 
@@ -711,17 +686,8 @@ async fn topology_rebuild_connected() {
 
     let res = h_out1.await.unwrap();
 
-    event1.set_source_id(Arc::new(ComponentKey::from("in1")));
-    event2.set_source_id(Arc::new(ComponentKey::from("in1")));
-
-    event1.set_upstream_id(Arc::new(OutputId::from("test")));
-    event2.set_upstream_id(Arc::new(OutputId::from("test")));
-    event1
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
-    event2
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event1, "in1");
+    set_expected_source_metadata(&mut event2, "in1");
 
     assert_eq!(vec![event1, event2], res);
 }
@@ -774,11 +740,7 @@ async fn topology_rebuild_connected_transform() {
     let res2 = h_out2.await.unwrap();
     assert_eq!(Vec::<Event>::new(), res1);
 
-    event.set_source_id(Arc::new(ComponentKey::from("in1")));
-    event.set_upstream_id(Arc::new(OutputId::from("test")));
-    event
-        .metadata_mut()
-        .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    set_expected_source_metadata(&mut event, "in1");
 
     assert_eq!(vec![event], res2);
 }

--- a/src/transforms/dedupe/config.rs
+++ b/src/transforms/dedupe/config.rs
@@ -104,6 +104,20 @@ mod tests {
         },
     };
 
+    const TEST_SOURCE_COMPONENT_ID: &str = "in";
+    const TEST_UPSTREAM_COMPONENT_ID: &str = "transform";
+    const TEST_SOURCE_TYPE: &str = "unit_test_stream";
+
+    fn set_expected_metadata(event: &mut Event) {
+        event.set_source_id(Arc::new(ComponentKey::from(TEST_SOURCE_COMPONENT_ID)));
+        event.set_upstream_id(Arc::new(OutputId::from(TEST_UPSTREAM_COMPONENT_ID)));
+        event.set_source_type(TEST_SOURCE_TYPE);
+        // The schema definition is copied from the source for dedupe.
+        event
+            .metadata_mut()
+            .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    }
+
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<DedupeConfig>();
@@ -181,12 +195,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event differs in matched field so should be output even though it
@@ -194,12 +203,7 @@ mod tests {
             tx.send(event2.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event2.set_source_id(Arc::new(ComponentKey::from("in")));
-            event2.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event2
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event2);
             assert_eq!(new_event, event2);
 
             // Third event has the same value for "matched" as first event, so it should be dropped.
@@ -241,12 +245,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event has a different matched field name with the same value,
@@ -254,12 +253,7 @@ mod tests {
             tx.send(event2.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event2.set_source_id(Arc::new(ComponentKey::from("in")));
-            event2.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event2
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event2);
             assert_eq!(new_event, event2);
 
             drop(tx);
@@ -304,12 +298,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event is the same just with different field order, so it
@@ -354,13 +343,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event gets output because it's not a dupe. This causes the first
@@ -368,12 +351,7 @@ mod tests {
             tx.send(event2.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event2.set_source_id(Arc::new(ComponentKey::from("in")));
-            event2.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event2
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event2);
 
             assert_eq!(new_event, event2);
 
@@ -382,7 +360,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             drop(tx);
@@ -432,13 +410,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second time the event gets dropped because it's a dupe.
@@ -450,7 +422,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             drop(tx);
@@ -491,12 +463,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event should also get passed through even though the string
@@ -504,12 +471,7 @@ mod tests {
             tx.send(event2.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event2.set_source_id(Arc::new(ComponentKey::from("in")));
-            event2.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event2
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event2);
             assert_eq!(new_event, event2);
 
             drop(tx);
@@ -554,12 +516,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event should also get passed through even though the string
@@ -567,12 +524,7 @@ mod tests {
             tx.send(event2.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event2.set_source_id(Arc::new(ComponentKey::from("in")));
-            event2.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event2
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event2);
             assert_eq!(new_event, event2);
 
             drop(tx);
@@ -610,12 +562,7 @@ mod tests {
             tx.send(event1.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event1.set_source_id(Arc::new(ComponentKey::from("in")));
-            event1.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event1
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event1);
             assert_eq!(new_event, event1);
 
             // Second event should also get passed through as null is different than
@@ -623,12 +570,7 @@ mod tests {
             tx.send(event2.clone()).await.unwrap();
             let new_event = out.recv().await.unwrap();
 
-            event2.set_source_id(Arc::new(ComponentKey::from("in")));
-            event2.set_upstream_id(Arc::new(OutputId::from("transform")));
-            // the schema definition is copied from the source for dedupe
-            event2
-                .metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut event2);
             assert_eq!(new_event, event2);
 
             drop(tx);

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -116,6 +116,19 @@ mod test {
         transforms::test::create_topology,
     };
 
+    const TEST_SOURCE_COMPONENT_ID: &str = "in";
+    const TEST_UPSTREAM_COMPONENT_ID: &str = "transform";
+    const TEST_SOURCE_TYPE: &str = "unit_test_stream";
+
+    fn set_expected_metadata(event: &mut Event) {
+        event.set_source_id(Arc::new(ComponentKey::from(TEST_SOURCE_COMPONENT_ID)));
+        event.set_upstream_id(Arc::new(OutputId::from(TEST_UPSTREAM_COMPONENT_ID)));
+        event.set_source_type(TEST_SOURCE_TYPE);
+        event
+            .metadata_mut()
+            .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+    }
+
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<super::FilterConfig>();
@@ -133,10 +146,7 @@ mod test {
             let mut log = Event::from(LogEvent::from("message"));
             tx.send(log.clone()).await.unwrap();
 
-            log.set_source_id(Arc::new(ComponentKey::from("in")));
-            log.set_upstream_id(Arc::new(OutputId::from("transform")));
-            log.metadata_mut()
-                .set_schema_definition(&Arc::new(Definition::default_legacy_namespace()));
+            set_expected_metadata(&mut log);
 
             assert_eq!(out.recv().await.unwrap(), log);
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -959,6 +959,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use chrono::{DateTime, Timelike, Utc, offset::TimeZone};
+    use similar_asserts::assert_eq;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
     use vector_lib::{
@@ -977,6 +978,11 @@ mod tests {
         test_util::components::assert_transform_compliance,
         transforms::test::create_topology,
     };
+
+    const TEST_SOURCE_COMPONENT_ID: &str = "in";
+    const TEST_UPSTREAM_COMPONENT_ID: &str = "transform";
+    const TEST_SOURCE_TYPE: &str = "unit_test_stream";
+    const TEST_NAMESPACE: &str = "test_namespace";
 
     #[test]
     fn generate_config() {
@@ -1004,6 +1010,12 @@ mod tests {
         log.as_mut_log()
             .insert(log_schema().timestamp_key_target_path().unwrap(), ts());
         log
+    }
+
+    fn set_test_source_metadata(metadata: &mut EventMetadata) {
+        metadata.set_upstream_id(Arc::new(OutputId::from(TEST_UPSTREAM_COMPONENT_ID)));
+        metadata.set_source_id(Arc::new(ComponentKey::from(TEST_SOURCE_COMPONENT_ID)));
+        metadata.set_source_type(TEST_SOURCE_TYPE);
     }
 
     async fn do_transform(config: LogToMetricConfig, event: Event) -> Option<Event> {
@@ -1072,8 +1084,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
         let metric = do_transform(config, event).await.unwrap();
 
         assert_eq!(
@@ -1115,8 +1126,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1170,8 +1180,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1226,8 +1235,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap().into_metric();
         let tags = metric.tags().expect("Metric should have tags");
@@ -1351,8 +1359,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1407,8 +1414,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
         let metric = do_transform(config, event).await.unwrap();
 
         assert_eq!(
@@ -1448,8 +1454,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1490,8 +1495,7 @@ mod tests {
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
 
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1586,8 +1590,7 @@ mod tests {
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let output = do_transform_multiple_events(config, event, 2).await;
 
@@ -1652,8 +1655,7 @@ mod tests {
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let output = do_transform_multiple_events(config, event, 2).await;
 
@@ -1706,8 +1708,7 @@ mod tests {
                 ));
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1748,8 +1749,7 @@ mod tests {
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1791,8 +1791,7 @@ mod tests {
 
         // definitions aren't valid for metrics yet, it's just set to the default (anything).
         metadata.set_schema_definition(&Arc::new(Definition::any()));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
+        set_test_source_metadata(&mut metadata);
 
         let metric = do_transform(config, event).await.unwrap();
 
@@ -1814,7 +1813,7 @@ mod tests {
     //  Metric Metadata Tests
     //
     fn create_log_event(json_str: &str) -> Event {
-        create_log_event_with_namespace(json_str, Some("test_namespace"))
+        create_log_event_with_namespace(json_str, Some(TEST_NAMESPACE))
     }
 
     fn create_log_event_with_namespace(json_str: &str, namespace: Option<&str>) -> Event {
@@ -1827,8 +1826,7 @@ mod tests {
         }
 
         let mut metadata = EventMetadata::default();
-        metadata.set_source_id(Arc::new(ComponentKey::from("in")));
-        metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
+        set_test_source_metadata(&mut metadata);
 
         Event::Log(LogEvent::from_parts(log_value, metadata.clone()))
     }
@@ -1861,7 +1859,7 @@ mod tests {
                 MetricValue::Gauge { value: 990.0 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",
@@ -1938,7 +1936,7 @@ mod tests {
                 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",
@@ -1997,7 +1995,7 @@ mod tests {
                 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",
@@ -2056,7 +2054,7 @@ mod tests {
                 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",
@@ -2117,7 +2115,7 @@ mod tests {
                 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",
@@ -2154,7 +2152,7 @@ mod tests {
                 MetricValue::Counter { value: 10.0 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",
@@ -2193,7 +2191,7 @@ mod tests {
                 },
                 metric.metadata().clone(),
             )
-            .with_namespace(Some("test_namespace"))
+            .with_namespace(Some(TEST_NAMESPACE))
             .with_tags(Some(metric_tags!(
                 "env" => "test_env",
                 "host" => "localhost",

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -273,6 +273,28 @@ components: sources: internal_metrics: {
 				reason: _reason
 			}
 		}
+		component_latency_seconds: {
+			description: """
+				The elapsed time, in fractional seconds, that an event spends in a single transform.
+
+				This includes both the time spent queued in the transform’s input buffer and the time spent executing the transform itself.
+				"""
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
+		component_latency_mean_seconds: {
+			description: """
+				The mean elapsed time, in fractional seconds, that an event spends in a single transform.
+
+				This includes both the time spent queued in the transform’s input buffer and the time spent executing the transform itself.
+
+				This value is smoothed over time using an exponentially weighted moving average (EWMA).
+				"""
+			type:              "gauge"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
 		buffer_byte_size: {
 			description:        "The number of bytes currently in the buffer."
 			type:               "gauge"

--- a/website/cue/reference/components/transforms.cue
+++ b/website/cue/reference/components/transforms.cue
@@ -15,11 +15,13 @@ components: transforms: [Name=string]: {
 	telemetry: metrics: {
 		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
 		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
+		component_latency_mean_seconds:       components.sources.internal_metrics.output.metrics.component_latency_mean_seconds
+		component_latency_seconds:            components.sources.internal_metrics.output.metrics.component_latency_seconds
+		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
 		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count
 		component_received_events_total:      components.sources.internal_metrics.output.metrics.component_received_events_total
-		component_received_event_bytes_total: components.sources.internal_metrics.output.metrics.component_received_event_bytes_total
-		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		component_sent_event_bytes_total:     components.sources.internal_metrics.output.metrics.component_sent_event_bytes_total
+		component_sent_events_total:          components.sources.internal_metrics.output.metrics.component_sent_events_total
 		transform_buffer_max_byte_size:       components.sources.internal_metrics.output.metrics.transform_buffer_max_byte_size
 		transform_buffer_max_event_size:      components.sources.internal_metrics.output.metrics.transform_buffer_max_event_size
 		transform_buffer_max_size_bytes:      components.sources.internal_metrics.output.metrics.transform_buffer_max_size_bytes

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -706,11 +706,11 @@ generated: configuration: configuration: {
 			The alpha value for the exponential weighted moving average (EWMA) of source and transform
 			buffer utilization metrics.
 
-			This value specifies how much of the existing value is retained when each update is made.
-			Values closer to 1.0 result in the value adjusting slower to changes. The default value of
-			0.9 is equivalent to a "half life" of 6-7 measurements.
+			This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
+			observations. Values closer to 1.0 retain more of the previous value, leading to slower
+			adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
 
-			Must be between 0 and 1 exclusive (0 < alpha < 1).
+			Must be between 0 and 1 exclusively (0 < alpha < 1).
 			"""
 		required: false
 		type: float: {}
@@ -828,6 +828,20 @@ generated: configuration: configuration: {
 
 			Set this to a value larger than your `internal_metrics` scrape interval (default 5 minutes)
 			so metrics live long enough to be emitted and captured.
+			"""
+		required: false
+		type: float: {}
+	}
+	latency_ewma_alpha: {
+		description: """
+			The alpha value for the exponential weighted moving average (EWMA) of transform latency
+			metrics.
+
+			This controls how quickly the `component_latency_mean_seconds` gauge responds to new
+			observations. Values closer to 1.0 retain more of the previous value, leading to slower
+			adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+
+			Must be between 0 and 1 exclusively (0 < alpha < 1).
 			"""
 		required: false
 		type: float: {}


### PR DESCRIPTION
## Summary

This adds the `component_latency_seconds` histogram and `component_latency_mean_seconds` gauge internal metrics, exposing the time an event spends in a single transform including the transform buffer.

Replaces #24612 

If you'd like me to break out any of the individual commits into separate PRs to make this easier to review, please LMK.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

Tested with a unit test plus a simple `internal_metrics` => transforms => `console` pipeline. We will be doing some more interesting load validation before merging.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
