### PR TITLE
chore(feature flags): consolidate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -530,14 +530,15 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
 target-base = ["enable-api-client", "rdkafka?/cmake_build", "sources-dnstap"]
-target-aarch64-unknown-linux-gnu =      ["target-base", "unix"]
-target-aarch64-unknown-linux-musl =     ["target-base", "unix"]
-target-armv7-unknown-linux-gnueabihf =  ["target-base", "unix"]
+target-unix = ["target-base", "unix"]
+target-aarch64-unknown-linux-gnu =      ["target-unix"]
+target-aarch64-unknown-linux-musl =     ["target-unix"]
+target-armv7-unknown-linux-gnueabihf =  ["target-unix"]
 target-armv7-unknown-linux-musleabihf = ["target-base"]
-target-arm-unknown-linux-gnueabi =      ["target-base", "unix"]
+target-arm-unknown-linux-gnueabi =      ["target-unix"]
 target-arm-unknown-linux-musleabi =     ["target-base"]
-target-x86_64-unknown-linux-gnu =       ["target-base", "unix", "rdkafka?/gssapi-vendored"]
-target-x86_64-unknown-linux-musl =      ["target-base", "unix"]
+target-x86_64-unknown-linux-gnu =       ["target-unix", "rdkafka?/gssapi-vendored"]
+target-x86_64-unknown-linux-musl =      ["target-unix"]
 
 # Enables features that work only on systems providing `cfg(unix)`
 unix = ["tikv-jemallocator", "allocation-tracing"]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Consolidate Cargo.toml features.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
`make test`. The number of tests ran now and in `master` is the same (2636)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

---

LLM generated script to test out flags with `master`:

```py
#!/usr/bin/env python3

# Master flags
master_flags = {
    "default": ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "secrets"],
    "docs": ["api", "api-client", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"],
    "default-cmake": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "secrets"],
    "default-msvc": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "transforms", "secrets"],
    "default-musl": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "secrets"],
    "default-no-api-client": ["api", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "secrets"],
    "target-aarch64-unknown-linux-gnu": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"],
    "target-aarch64-unknown-linux-musl": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"],
    "target-armv7-unknown-linux-gnueabihf": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"],
    "target-armv7-unknown-linux-musleabihf": ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "secrets"],
    "target-arm-unknown-linux-gnueabi": ["api", "api-client", "enrichment-tables", "rdkafka?/cmake_build", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"],
    "target-arm-unknown-linux-musleabi": ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "secrets"],
    "target-x86_64-unknown-linux-gnu": ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "rdkafka?/gssapi-vendored", "secrets"],
    "target-x86_64-unknown-linux-musl": ["api", "api-client", "rdkafka?/cmake_build", "enrichment-tables", "sinks", "sources", "sources-dnstap", "transforms", "unix", "secrets"],
}

# Branch flags (with helper expansions)
_default_base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets"]
_default_api_client = _default_base + ["api-client"]
_default_unix = _default_api_client + ["sources-dnstap", "unix"]
_target_default = _default_api_client + ["rdkafka?/cmake_build", "sources-dnstap"]

branch_flags = {
    "default": _default_unix + ["rdkafka?/gssapi-vendored"],
    "docs": _default_unix,
    "default-cmake": _default_unix + ["rdkafka?/gssapi-vendored", "rdkafka?/cmake_build"],
    "default-msvc": _default_api_client + ["rdkafka?/cmake_build"],
    "default-musl": _default_unix + ["rdkafka?/gssapi-vendored", "rdkafka?/cmake_build"],
    "default-no-api-client": _default_base + ["sources-dnstap", "unix", "rdkafka?/gssapi-vendored"],
    "target-aarch64-unknown-linux-gnu": _target_default + ["unix"],
    "target-aarch64-unknown-linux-musl": _target_default + ["unix"],
    "target-armv7-unknown-linux-gnueabihf": _target_default + ["unix"],
    "target-armv7-unknown-linux-musleabihf": _target_default,
    "target-arm-unknown-linux-gnueabi": _target_default + ["unix"],
    "target-arm-unknown-linux-musleabi": _target_default,
    "target-x86_64-unknown-linux-gnu": _target_default + ["unix", "rdkafka?/gssapi-vendored"],
    "target-x86_64-unknown-linux-musl": _target_default + ["unix"],
}

print("=" * 80)
print("FEATURE FLAG VERIFICATION: Master vs Branch")
print("=" * 80)
print()

all_match = True
matches = []
mismatches = []

for flag_name in sorted(master_flags.keys()):
    if flag_name not in branch_flags:
        print(f"❌ {flag_name}: MISSING in branch")
        mismatches.append(flag_name)
        all_match = False
        continue

    master_set = set(master_flags[flag_name])
    branch_set = set(branch_flags[flag_name])

    if master_set == branch_set:
        matches.append(flag_name)
    else:
        mismatches.append(flag_name)
        all_match = False

# Print results
print("✅ MATCHING FLAGS:")
print("-" * 80)
for flag_name in matches:
    print(f"  • {flag_name}")
print()

if mismatches:
    print("❌ MISMATCHED FLAGS:")
    print("-" * 80)
    for flag_name in mismatches:
        if flag_name not in branch_flags:
            print(f"  • {flag_name}: MISSING in branch")
        else:
            master_set = set(master_flags[flag_name])
            branch_set = set(branch_flags[flag_name])
            print(f"  • {flag_name}:")
            if master_set - branch_set:
                print(f"      Missing: {sorted(master_set - branch_set)}")
            if branch_set - master_set:
                print(f"      Extra: {sorted(branch_set - master_set)}")
    print()

print("=" * 80)
print(f"RESULT: {'✅ ALL FLAGS MATCH!' if all_match else '❌ SOME FLAGS DIFFER!'}")
print("=" * 80)
print(f"\nTotal flags checked: {len(master_flags)}")
print(f"Matching: {len(matches)}")
print(f"Mismatched: {len(mismatches)}")

# Exit with appropriate code
exit(0 if all_match else 1)
```