### PR TITLE
feat(prometheus_scrape source): add configurable headers, gzip compression, and redirect following

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -409,6 +409,7 @@ OKD
 oneof
 ONEZONE
 opcounters
+openmetrics
 openstring
 opinsights
 oplog

--- a/changelog.d/19656_prometheus_scrape_headers.feature.md
+++ b/changelog.d/19656_prometheus_scrape_headers.feature.md
@@ -1,0 +1,3 @@
+Added configurable `headers` option to the `prometheus_scrape` source, allowing custom HTTP request headers on scrape requests. This is useful for scraping endpoints that require specific headers, such as HashiCorp Vault's `Accept: application/openmetrics-text`.
+
+authors: mushrowan

--- a/changelog.d/20127_prometheus_scrape_compression.feature.md
+++ b/changelog.d/20127_prometheus_scrape_compression.feature.md
@@ -1,0 +1,3 @@
+The `prometheus_scrape` source now sends `Accept-Encoding: gzip` by default and automatically decompresses gzip responses, matching the behaviour of Prometheus and VictoriaMetrics scrapers. This can be overridden via the new `headers` config option.
+
+authors: mushrowan

--- a/changelog.d/24416_prometheus_scrape_redirects.fix.md
+++ b/changelog.d/24416_prometheus_scrape_redirects.fix.md
@@ -1,0 +1,3 @@
+The `prometheus_scrape` source (and other HTTP client sources) now follows HTTP redirects (301, 302, 307, 308) instead of treating them as errors.
+
+authors: mushrowan


### PR DESCRIPTION
## Summary

improves the `prometheus_scrape` source HTTP client with three changes:

- **configurable request headers** via a new `headers` config option
- **gzip compression** - sends `Accept-Encoding: gzip` by default and
  automatically decompresses responses, matching prometheus and victoriametrics
  scraper behaviour. can be overridden via `headers`
- **HTTP redirect following** for 301, 302, 307, and 308 responses instead of
  treating them as errors. method is changed to GET for 301/302 (RFC 7231),
  preserved for 307/308

the redirect and decompression logic is in `http_client.rs` so other HTTP client
sources benefit too

## Vector configuration

```toml
[sources.prometheus_scrape]
type = "prometheus_scrape"
endpoints = ["http://localhost:9090/metrics"]
headers.Accept = ["application/openmetrics-text"]
```

## How did you test this PR?

```bash
cargo test -p vector --no-default-features --features sources-prometheus prometheus
```

tests added for custom headers, redirect following, and gzip response handling

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our
      [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #19656
- Closes: #20127
- Closes: #24416
- Closes: #19962 (already fixed by #20065 but still open)