### PR TITLE
enhancement: Vector enable apiserver cache by default to prevent overloading kube-apiserver

### DIFF
--- a/changelog.d/24646_kubernetes_logs_apiserver_cache_default.enhancement.md
+++ b/changelog.d/24646_kubernetes_logs_apiserver_cache_default.enhancement.md
@@ -1,0 +1,3 @@
+The `kubernetes_logs` source now defaults `use_apiserver_cache` to `true`. This allows the kube-apiserver to serve LIST requests from its watch cache instead of issuing quorum reads directly against etcd, which can overload etcd in large clusters. Users who require strongly consistent reads can restore the previous behavior by explicitly setting `use_apiserver_cache: false`.
+
+authors: NierYYDS

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -321,7 +321,7 @@ impl Default for Config {
             ingestion_timestamp_field: None,
             timezone: None,
             kube_config_file: None,
-            use_apiserver_cache: false,
+            use_apiserver_cache: true,
             delay_deletion_ms: default_delay_deletion_ms(),
             log_namespace: None,
             internal_metrics: Default::default(),

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -470,6 +470,6 @@ generated: components: sources: kubernetes_logs: configuration: {
 	use_apiserver_cache: {
 		description: "Determines if requests to the kube-apiserver can be served by a cache."
 		required:    false
-		type: bool: default: false
+		type: bool: default: true
 	}
 }


### PR DESCRIPTION
I deployed Vector in a production cluster with over 1,000 nodes, which immediately caused the cluster to crash.

Upon investigation, logs and metrics showed a sudden CPU spike in both etcd and kube-apiserver. The root cause was traced back to Vector issuing LIST requests without setting resourceVersion. This behavior forces Quorum reads effectively bypassing the kube-apiserver's watch cache and hitting etcd directly.

Although I resolved the incident by manually configuring `use_apiserver_cache: true`, the current default behavior poses a catastrophic risk for large-scale environments.

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
