### PR TITLE
fix(dev): hardcode DOCKER_API_VERSION=1.44 in amazon-ecs-local-container-endpoints

### DIFF
--- a/tests/integration/aws/config/compose.yaml
+++ b/tests/integration/aws/config/compose.yaml
@@ -9,6 +9,8 @@ services:
     - SERVICES=kinesis,s3,cloudwatch,es,firehose,kms,sqs,sns,logs
   mock-ecs:
     image: docker.io/amazon/amazon-ecs-local-container-endpoints:latest
+    environment:
+    - DOCKER_API_VERSION=1.44
     volumes:
     - $DOCKER_SOCKET:/var/run/docker.sock
     - $HOME/.aws/:/home/.aws/


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Docker v29 broke compatibility with api version < 1.44

This hacks in compatibility for the abandoned image `docker.io/amazon/amazon-ecs-local-container-endpoints`.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
`./scripts/run-integration-test.sh int aws`

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- CI run: https://github.com/vectordotdev/vector/actions/runs/22159376293/job/64072120202?pr=24684
- https://www.docker.com/blog/docker-engine-version-29/#minimum-api-version-update
- https://github.com/actions/runner-images/issues/13474

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->
