### PR TITLE
chore(dev): reference issue #24687 above DOCKER_API_VERSION hack

### DIFF
--- a/tests/integration/aws/config/compose.yaml
+++ b/tests/integration/aws/config/compose.yaml
@@ -10,6 +10,7 @@ services:
   mock-ecs:
     image: docker.io/amazon/amazon-ecs-local-container-endpoints:latest
     environment:
+    # https://github.com/vectordotdev/vector/issues/24687
     - DOCKER_API_VERSION=1.44
     volumes:
     - $DOCKER_SOCKET:/var/run/docker.sock


### PR DESCRIPTION
## Summary

Adds a reference to #24687 above the `DOCKER_API_VERSION=1.44` workaround in the AWS integration test compose file.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #24684
- Related: #24687