### PR TITLE
enhancement(observability)!: Time-weight buffer utilization means

### DIFF
--- a/changelog.d/time-weighted-buffer-utilization-mean.breaking.md
+++ b/changelog.d/time-weighted-buffer-utilization-mean.breaking.md
@@ -1,0 +1,5 @@
+The `*buffer_utilization_mean` metrics have been enhanced to use time-weighted
+averaging which make them more representative of the actual buffer utilization
+over time.
+
+authors: bruceg

--- a/changelog.d/time-weighted-buffer-utilization-mean.breaking.md
+++ b/changelog.d/time-weighted-buffer-utilization-mean.breaking.md
@@ -2,4 +2,8 @@ The `*buffer_utilization_mean` metrics have been enhanced to use time-weighted
 averaging which make them more representative of the actual buffer utilization
 over time.
 
+This change is breaking due to the replacement of the existing
+`buffer_utilization_ewma_alpha` config option with
+`buffer_utilization_ewma_half_life_seconds`.
+
 authors: bruceg

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -191,13 +191,13 @@ impl<T: Bufferable> TopologyBuilder<T> {
         when_full: WhenFull,
         receiver_span: &Span,
         metadata: Option<ChannelMetricMetadata>,
-        ewma_alpha: Option<f64>,
+        ewma_half_life_seconds: Option<f64>,
     ) -> (BufferSender<T>, BufferReceiver<T>) {
         let usage_handle = BufferUsageHandle::noop();
         usage_handle.set_buffer_limits(None, Some(max_events.get()));
 
         let limit = MemoryBufferSize::MaxEvents(max_events);
-        let (sender, receiver) = limited(limit, metadata, ewma_alpha);
+        let (sender, receiver) = limited(limit, metadata, ewma_half_life_seconds);
 
         let mode = match when_full {
             WhenFull::Overflow => WhenFull::Block,

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -7,6 +7,7 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    time::Instant,
 };
 
 #[cfg(test)]
@@ -17,9 +18,11 @@ use crossbeam_queue::{ArrayQueue, SegQueue};
 use futures::Stream;
 use metrics::{Gauge, Histogram, gauge, histogram};
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
-use vector_common::stats::EwmaGauge;
+use vector_common::stats::TimeEwmaGauge;
 
 use crate::{InMemoryBufferable, config::MemoryBufferSize};
+
+pub const DEFAULT_EWMA_HALF_LIFE_SECONDS: f64 = 5.0;
 
 /// Error returned by `LimitedSender::send` when the receiver has disconnected.
 #[derive(Debug, PartialEq, Eq)]
@@ -110,7 +113,7 @@ impl ChannelMetricMetadata {
 struct Metrics {
     histogram: Histogram,
     gauge: Gauge,
-    mean_gauge: EwmaGauge,
+    mean_gauge: TimeEwmaGauge,
     // We hold a handle to the max gauge to avoid it being dropped by the metrics collector, but
     // since the value is static, we never need to update it. The compiler detects this as an unused
     // field, so we need to suppress the warning here.
@@ -127,8 +130,10 @@ impl Metrics {
     fn new(
         limit: MemoryBufferSize,
         metadata: ChannelMetricMetadata,
-        ewma_alpha: Option<f64>,
+        ewma_half_life_seconds: Option<f64>,
     ) -> Self {
+        let ewma_half_life_seconds =
+            ewma_half_life_seconds.unwrap_or(DEFAULT_EWMA_HALF_LIFE_SECONDS);
         let ChannelMetricMetadata { prefix, output } = metadata;
         let (legacy_suffix, gauge_suffix, max_value) = match limit {
             MemoryBufferSize::MaxEvents(max_events) => (
@@ -157,7 +162,7 @@ impl Metrics {
             Self {
                 histogram: histogram!(histogram_name, "output" => label_value.clone()),
                 gauge: gauge!(gauge_name, "output" => label_value.clone()),
-                mean_gauge: EwmaGauge::new(mean_gauge_handle, ewma_alpha),
+                mean_gauge: TimeEwmaGauge::new(mean_gauge_handle, ewma_half_life_seconds),
                 max_gauge,
                 legacy_max_gauge,
                 #[cfg(test)]
@@ -173,7 +178,7 @@ impl Metrics {
             Self {
                 histogram: histogram!(histogram_name),
                 gauge: gauge!(gauge_name),
-                mean_gauge: EwmaGauge::new(mean_gauge_handle, ewma_alpha),
+                mean_gauge: TimeEwmaGauge::new(mean_gauge_handle, ewma_half_life_seconds),
                 max_gauge,
                 legacy_max_gauge,
                 #[cfg(test)]
@@ -183,10 +188,10 @@ impl Metrics {
     }
 
     #[expect(clippy::cast_precision_loss)]
-    fn record(&self, value: usize) {
+    fn record(&self, value: usize, reference: Instant) {
         self.histogram.record(value as f64);
         self.gauge.set(value as f64);
-        self.mean_gauge.record(value as f64);
+        self.mean_gauge.record(value as f64, reference);
         #[cfg(test)]
         if let Ok(mut recorded) = self.recorded_values.lock() {
             recorded.push(value);
@@ -221,10 +226,11 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
     fn new(
         limit: MemoryBufferSize,
         metric_metadata: Option<ChannelMetricMetadata>,
-        ewma_alpha: Option<f64>,
+        ewma_half_life_seconds: Option<f64>,
     ) -> Self {
         let read_waker = Arc::new(Notify::new());
-        let metrics = metric_metadata.map(|metadata| Metrics::new(limit, metadata, ewma_alpha));
+        let metrics =
+            metric_metadata.map(|metadata| Metrics::new(limit, metadata, ewma_half_life_seconds));
         match limit {
             MemoryBufferSize::MaxEvents(max_events) => Inner {
                 data: Arc::new(ArrayQueue::new(max_events.get())),
@@ -256,7 +262,7 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
             // acquired fewer permits than their true size, `size` is the correct utilization since
             // the queue must have been empty for the oversized acquire to succeed.
             let utilization = size.max(self.used_capacity());
-            metrics.record(utilization);
+            metrics.record(utilization, Instant::now());
         }
         self.data.push((permits, item));
         self.read_waker.notify_one();
@@ -275,7 +281,7 @@ impl<T> Inner<T> {
                 // been released yet, used_capacity is stable against racing senders acquiring those
                 // permits.
                 let utilization = self.used_capacity().saturating_sub(permit.num_permits());
-                metrics.record(utilization);
+                metrics.record(utilization, Instant::now());
             }
             // Release permits after recording so a waiting sender cannot enqueue a new item
             // before this pop's utilization measurement is taken.
@@ -440,9 +446,9 @@ impl<T> Drop for LimitedReceiver<T> {
 pub fn limited<T: InMemoryBufferable + fmt::Debug>(
     limit: MemoryBufferSize,
     metric_metadata: Option<ChannelMetricMetadata>,
-    ewma_alpha: Option<f64>,
+    ewma_half_life_seconds: Option<f64>,
 ) -> (LimitedSender<T>, LimitedReceiver<T>) {
-    let inner = Inner::new(limit, metric_metadata, ewma_alpha);
+    let inner = Inner::new(limit, metric_metadata, ewma_half_life_seconds);
 
     let sender = LimitedSender {
         inner: inner.clone(),

--- a/lib/vector-buffers/src/topology/channel/mod.rs
+++ b/lib/vector-buffers/src/topology/channel/mod.rs
@@ -3,11 +3,11 @@ mod receiver;
 mod sender;
 
 pub use limited_queue::{
-    ChannelMetricMetadata, LimitedReceiver, LimitedSender, SendError, limited,
+    ChannelMetricMetadata, DEFAULT_EWMA_HALF_LIFE_SECONDS, LimitedReceiver, LimitedSender,
+    SendError, limited,
 };
 pub use receiver::*;
 pub use sender::*;
-pub use vector_common::stats::DEFAULT_EWMA_ALPHA;
 
 #[cfg(test)]
 mod tests;

--- a/lib/vector-common/src/stats/mod.rs
+++ b/lib/vector-common/src/stats/mod.rs
@@ -1,12 +1,17 @@
 #![allow(missing_docs)]
 
-pub mod ewma_gauge;
+mod ewma_gauge;
+mod time_ewma;
 
-pub use ewma_gauge::{DEFAULT_EWMA_ALPHA, EwmaGauge};
+pub use ewma_gauge::{EwmaGauge, TimeEwmaGauge};
+pub use time_ewma::TimeEwma;
 
 use std::sync::atomic::Ordering;
 
 use crate::atomic::AtomicF64;
+
+/// The default alpha parameter used when constructing EWMA-backed gauges.
+pub const DEFAULT_EWMA_ALPHA: f64 = 0.9;
 
 /// Exponentially Weighted Moving Average
 #[derive(Clone, Copy, Debug)]

--- a/lib/vector-common/src/stats/time_ewma.rs
+++ b/lib/vector-common/src/stats/time_ewma.rs
@@ -1,0 +1,84 @@
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug)]
+struct State {
+    average: f64,
+    point: f64,
+    reference: Instant,
+}
+
+/// Continuous-Time Exponentially Weighted Moving Average.
+///
+/// This is used to average values that are observed at irregular intervals but have a fixed value
+/// between the observations, AKA a piecewise-constant signal sampled at change points. Instead of
+/// an "alpha" parameter, this uses a "half-life" parameter which is the time it takes for the
+/// average to decay to half of its value, measured in seconds.
+#[derive(Clone, Copy, Debug)]
+pub struct TimeEwma {
+    state: Option<State>,
+    half_life_seconds: f64,
+}
+
+impl TimeEwma {
+    #[must_use]
+    pub const fn new(half_life_seconds: f64) -> Self {
+        Self {
+            state: None,
+            half_life_seconds,
+        }
+    }
+
+    #[must_use]
+    pub fn average(&self) -> Option<f64> {
+        self.state.map(|state| state.average)
+    }
+
+    /// Update the current average and return it for convenience. Note that this average will "lag"
+    /// the current observation because the new average is based on the previous point and the
+    /// duration during which it was held constant. If the reference time is before the previous
+    /// update, the update is ignored and the previous average is returned.
+    pub fn update(&mut self, point: f64, reference: Instant) -> f64 {
+        let average = match self.state {
+            None => point,
+            Some(state) => {
+                if let Some(duration) = reference.checked_duration_since(state.reference) {
+                    let k = (-duration.as_secs_f64() / self.half_life_seconds).exp2();
+                    // The elapsed duration applies to the previously observed point, since that value
+                    // was held constant between observations.
+                    k * state.average + (1.0 - k) * state.point
+                } else {
+                    state.average
+                }
+            }
+        };
+        self.state = Some(State {
+            average,
+            point,
+            reference,
+        });
+        average
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TimeEwma;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    #[expect(clippy::float_cmp, reason = "exact values for this test")]
+    fn time_ewma_uses_previous_point_duration() {
+        let mut ewma = TimeEwma::new(1.0);
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_secs(1);
+        let t2 = t1 + Duration::from_secs(1);
+
+        assert_eq!(ewma.average(), None);
+        assert_eq!(ewma.update(0.0, t0), 0.0);
+        assert_eq!(ewma.average(), Some(0.0));
+        assert_eq!(ewma.update(10.0, t1), 0.0);
+        assert_eq!(ewma.average(), Some(0.0));
+        assert_eq!(ewma.update(10.0, t2), 5.0);
+        assert_eq!(ewma.average(), Some(5.0));
+    }
+}

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -10,6 +10,16 @@ use super::{
 };
 use crate::serde::bool_or_struct;
 
+#[expect(
+    clippy::ref_option,
+    reason = "we have to follow the serde calling convention"
+)]
+fn is_default_buffer_utilization_ewma_half_life_seconds(value: &Option<f64>) -> bool {
+    value.is_none_or(|seconds| {
+        seconds == vector_buffers::topology::channel::DEFAULT_EWMA_HALF_LIFE_SECONDS
+    })
+}
+
 #[derive(Debug, Snafu)]
 pub(crate) enum DataDirError {
     #[snafu(display("data_dir option required, but not given here or globally"))]
@@ -140,18 +150,18 @@ pub struct GlobalOptions {
     #[serde(skip_serializing_if = "crate::serde::is_default")]
     pub expire_metrics_per_metric_set: Option<Vec<PerMetricSetExpiration>>,
 
-    /// The alpha value for the exponential weighted moving average (EWMA) of source and transform
-    /// buffer utilization metrics.
+    /// The half-life, in seconds, for the exponential weighted moving average (EWMA) of source
+    /// and transform buffer utilization metrics.
     ///
     /// This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
-    /// observations. Values closer to 1.0 retain more of the previous value, leading to slower
-    /// adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+    /// observations. Longer half-lives retain more of the previous value, leading to slower
+    /// adjustments. The default is 5 seconds.
     ///
-    /// Must be between 0 and 1 exclusively (0 < alpha < 1).
-    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
-    #[configurable(validation(range(min = 0.0, max = 1.0)))]
+    /// Must be greater than 0.
+    #[serde(skip_serializing_if = "is_default_buffer_utilization_ewma_half_life_seconds")]
+    #[configurable(validation(range(min = 0.0)))]
     #[configurable(metadata(docs::advanced))]
-    pub buffer_utilization_ewma_alpha: Option<f64>,
+    pub buffer_utilization_ewma_half_life_seconds: Option<f64>,
 
     /// The alpha value for the exponential weighted moving average (EWMA) of transform latency
     /// metrics.
@@ -321,9 +331,9 @@ impl GlobalOptions {
                 expire_metrics: self.expire_metrics.or(with.expire_metrics),
                 expire_metrics_secs: self.expire_metrics_secs.or(with.expire_metrics_secs),
                 expire_metrics_per_metric_set: merged_expire_metrics_per_metric_set,
-                buffer_utilization_ewma_alpha: self
-                    .buffer_utilization_ewma_alpha
-                    .or(with.buffer_utilization_ewma_alpha),
+                buffer_utilization_ewma_half_life_seconds: self
+                    .buffer_utilization_ewma_half_life_seconds
+                    .or(with.buffer_utilization_ewma_half_life_seconds),
                 latency_ewma_alpha: self.latency_ewma_alpha.or(with.latency_ewma_alpha),
                 metrics_storage_refresh_period: self
                     .metrics_storage_refresh_period

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -155,7 +155,14 @@ pub struct GlobalOptions {
     ///
     /// This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
     /// observations. Longer half-lives retain more of the previous value, leading to slower
-    /// adjustments. The default is 5 seconds.
+    /// adjustments.
+    ///
+    /// - Lower values (< 1): Metrics update quickly but may be volatile
+    /// - Default (5): Balanced between responsiveness and stability
+    /// - Higher values (> 5): Smooth, stable metrics that update slowly
+    ///
+    /// Adjust based on whether you need fast detection of buffer issues (lower)
+    /// or want to see sustained trends without noise (higher).
     ///
     /// Must be greater than 0.
     #[serde(skip_serializing_if = "is_default_buffer_utilization_ewma_half_life_seconds")]

--- a/lib/vector-core/src/source_sender/builder.rs
+++ b/lib/vector-core/src/source_sender/builder.rs
@@ -13,7 +13,7 @@ pub struct Builder {
     named_outputs: HashMap<String, Output>,
     lag_time: Option<Histogram>,
     timeout: Option<Duration>,
-    ewma_alpha: Option<f64>,
+    ewma_half_life_seconds: Option<f64>,
 }
 
 impl Default for Builder {
@@ -24,7 +24,7 @@ impl Default for Builder {
             named_outputs: Default::default(),
             lag_time: Some(histogram!(LAG_TIME_NAME)),
             timeout: None,
-            ewma_alpha: None,
+            ewma_half_life_seconds: None,
         }
     }
 }
@@ -43,8 +43,8 @@ impl Builder {
     }
 
     #[must_use]
-    pub fn with_ewma_alpha(mut self, alpha: Option<f64>) -> Self {
-        self.ewma_alpha = alpha;
+    pub fn with_ewma_half_life_seconds(mut self, half_life_seconds: Option<f64>) -> Self {
+        self.ewma_half_life_seconds = half_life_seconds;
         self
     }
 
@@ -68,7 +68,7 @@ impl Builder {
                     log_definition,
                     output_id,
                     self.timeout,
-                    self.ewma_alpha,
+                    self.ewma_half_life_seconds,
                 );
                 self.default_output = Some(output);
                 rx
@@ -81,7 +81,7 @@ impl Builder {
                     log_definition,
                     output_id,
                     self.timeout,
-                    self.ewma_alpha,
+                    self.ewma_half_life_seconds,
                 );
                 self.named_outputs.insert(name, output);
                 rx

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -115,11 +115,11 @@ impl Output {
         log_definition: Option<Arc<Definition>>,
         output_id: OutputId,
         timeout: Option<Duration>,
-        ewma_alpha: Option<f64>,
+        ewma_half_life_seconds: Option<f64>,
     ) -> (Self, LimitedReceiver<SourceSenderItem>) {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(n).unwrap());
         let metrics = ChannelMetricMetadata::new(UTILIZATION_METRIC_PREFIX, Some(output.clone()));
-        let (tx, rx) = channel::limited(limit, Some(metrics), ewma_alpha);
+        let (tx, rx) = channel::limited(limit, Some(metrics), ewma_half_life_seconds);
         (
             Self {
                 sender: tx,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -267,7 +267,9 @@ impl<'a> Builder<'a> {
             let mut builder = SourceSender::builder()
                 .with_buffer(*SOURCE_SENDER_BUFFER_SIZE)
                 .with_timeout(source.inner.send_timeout())
-                .with_ewma_alpha(self.config.global.buffer_utilization_ewma_alpha);
+                .with_ewma_half_life_seconds(
+                    self.config.global.buffer_utilization_ewma_half_life_seconds,
+                );
             let mut pumps = Vec::new();
             let mut controls = HashMap::new();
             let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
@@ -509,7 +511,7 @@ impl<'a> Builder<'a> {
                 WhenFull::Block,
                 &span,
                 Some(metrics),
-                self.config.global.buffer_utilization_ewma_alpha,
+                self.config.global.buffer_utilization_ewma_half_life_seconds,
             );
 
             self.inputs

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -708,7 +708,14 @@ generated: configuration: configuration: {
 
 			This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
 			observations. Longer half-lives retain more of the previous value, leading to slower
-			adjustments. The default is 5 seconds.
+			adjustments.
+
+			- Lower values (< 1): Metrics update quickly but may be volatile
+			- Default (5): Balanced between responsiveness and stability
+			- Higher values (> 5): Smooth, stable metrics that update slowly
+
+			Adjust based on whether you need fast detection of buffer issues (lower)
+			or want to see sustained trends without noise (higher).
 
 			Must be greater than 0.
 			"""

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -701,16 +701,16 @@ generated: configuration: configuration: {
 			type: bool: {}
 		}
 	}
-	buffer_utilization_ewma_alpha: {
+	buffer_utilization_ewma_half_life_seconds: {
 		description: """
-			The alpha value for the exponential weighted moving average (EWMA) of source and transform
-			buffer utilization metrics.
+			The half-life, in seconds, for the exponential weighted moving average (EWMA) of source
+			and transform buffer utilization metrics.
 
 			This controls how quickly the `*_buffer_utilization_mean` gauges respond to new
-			observations. Values closer to 1.0 retain more of the previous value, leading to slower
-			adjustments. The default value of 0.9 is equivalent to a "half life" of 6-7 measurements.
+			observations. Longer half-lives retain more of the previous value, leading to slower
+			adjustments. The default is 5 seconds.
 
-			Must be between 0 and 1 exclusively (0 < alpha < 1).
+			Must be greater than 0.
 			"""
 		required: false
 		type: float: {}


### PR DESCRIPTION
## Summary

Under a fully loaded pipeline, the typical source will batch its received events into arrays, the size of which is currently capped at 1,000 events. The channel buffers for transforms, however, have a capacity limit of 100 events. This means their actual utilization under non-trivial load will bounce between 0 and 1,000 events, and the weighted mean value will just hover around 500. This is true both when infrequent batches are sent and when the pipeline is at capacity, making that mean value useless.

This change adds a duration-weighting calculation to the mean that weights values held for longer times more than those held for shorter times. This will cause the above two situations to reflect much different values in the mean.

This change is breaking due to the replacement of the existing `buffer_utilization_ewma_alpha` config option with `buffer_utilization_ewma_half_life_seconds`.

## Vector configuration

<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

Validated through running a number of pipelines confirming the smoothing behavior.

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [X] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
