### PR TITLE
enhancement(core): Do not terminate when accept fails

### DIFF
--- a/changelog.d/24722_accept_retry_on_error.fix.md
+++ b/changelog.d/24722_accept_retry_on_error.fix.md
@@ -1,0 +1,3 @@
+The OpenTelemetry source HTTP listener no longer terminates when `accept` fails with a transient error (e.g., too many open file descriptors). It now retries after one second and logs the error, preventing silent listener death under resource pressure.
+
+authors: fbs

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -5,6 +5,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::{FutureExt, Stream, future::BoxFuture, stream};
@@ -54,6 +55,7 @@ impl MaybeTlsSettings {
             listener,
             acceptor,
             origin_filter: None,
+            retry_accept: false,
         })
     }
 
@@ -73,6 +75,7 @@ impl MaybeTlsSettings {
             listener,
             acceptor,
             origin_filter: Some(allow_origin),
+            retry_accept: false,
         })
     }
 }
@@ -81,13 +84,34 @@ pub struct MaybeTlsListener {
     listener: TcpListener,
     acceptor: Option<SslAcceptor>,
     origin_filter: Option<Vec<IpNet>>,
+    retry_accept: bool,
 }
 
 impl MaybeTlsListener {
+    pub fn set_retry_accept(&mut self, retry: bool) {
+        self.retry_accept = retry;
+    }
+
+    async fn retrying_accept(&mut self) -> tokio::io::Result<(TcpStream, SocketAddr)> {
+        if !self.retry_accept {
+            return self.listener.accept().await;
+        }
+        loop {
+            // Accept can error on too many open FDs or the other end closing
+            // This doesn't have to be fatal, we can retry
+            match self.listener.accept().await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    error!("accept error: {e}");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            }
+        }
+    }
     pub async fn accept(&mut self) -> crate::tls::Result<MaybeTlsIncomingStream<TcpStream>> {
         let listener = self
-            .listener
-            .accept()
+            .retrying_accept()
             .await
             .map(|(stream, peer_addr)| {
                 MaybeTlsIncomingStream::new(stream, peer_addr, self.acceptor.clone())
@@ -183,6 +207,7 @@ impl From<TcpListener> for MaybeTlsListener {
             listener,
             acceptor: None,
             origin_filter: None,
+            retry_accept: false,
         }
     }
 }

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -104,7 +104,6 @@ impl MaybeTlsListener {
                 Err(e) => {
                     error!("accept error: {e}");
                     tokio::time::sleep(Duration::from_secs(1)).await;
-                    continue;
                 }
             }
         }

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -109,6 +109,7 @@ impl MaybeTlsListener {
             }
         }
     }
+
     pub async fn accept(&mut self) -> crate::tls::Result<MaybeTlsIncomingStream<TcpStream>> {
         let listener = self
             .retrying_accept()

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -61,7 +61,8 @@ pub(crate) async fn run_http_server(
     shutdown: ShutdownSignal,
     keepalive_settings: KeepaliveConfig,
 ) -> crate::Result<()> {
-    let listener = tls_settings.bind(&address).await?;
+    let mut listener = tls_settings.bind(&address).await?;
+    listener.set_retry_accept(true);
     let routes = filters.recover(handle_rejection);
 
     info!(message = "Building HTTP server.", address = %address);


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Errors from the `accept` syscall are currently treated as fatal and terminate the listener, instead of retrying when possible. There is no indication that this happens, the source just stop. This is especially bad when vector acts as a 'central' aggregator.

This first changes the core `MaybeTlsListener` to support retries:

``` 
The `accept` syscall can fail[0], e.g. when hitting the open FD limit. This
doesn't have to be a fatal error and the accept can be retried.
Currently it is not retried. Instead the listener is terminated and all
subsequent requests are rejected.

The implementation is simple: if accept fails its retried 1 second
later and an error is logged. This can probably be improved, but its
already an improvement over the current behaviour of terminating the
listener.

The retry behaviour is opt in. In some cases it might be reasonable to
not retry and instead terminate.

The whole thing is a bit ugly and it looks hard to test in a unit test
setup, as fault injection is hard to do there.

[0]: the docs for tokio's TcpListener say:

> Note that accepting a connection can lead to various errors and not
> all of them are necessarily fatal ‒ for example having too many open
> file descriptors or the other side closing the connection while it
> waits in an accept queue. These would terminate the stream if not
> handled in any way
```

The 2nd one enables it for the opentelemetry source only. If it works well there it can be used in other places

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

### before:

```
$ bash -c "ulimit -n 12; vector --config vector-otel.yaml"
2026-02-24T15:28:23.770354Z  INFO source{component_kind="source" component_id=otel component_type=opentelemetry}: vector::sources::util::grpc: Building gRPC server. address=127.0.0.1:4317
2026-02-24T15:28:23.770808Z  INFO source{component_kind="source" component_id=otel component_type=opentelemetry}: vector::sources::opentelemetry::http: Building HTTP server. address=127.0.0.1:4318
```

vector stops listening after getting an EMFILE:
```
$ nc -v localhost 4318
Connection to localhost port 4318 [tcp/*] succeeded!

$ nc -v localhost 4318
nc: connectx to localhost port 4318 (tcp) failed: Connection refused
nc: connectx to localhost port 4318 (tcp) failed: Connection refused

$ lsof -a -p $(pgrep vector) -iTCP -nn -P | grep LIST
vector  58184 bsmit   10u  IPv4 0xdc9280a9a8422fc1      0t0  TCP 127.0.0.1:4317 (LISTEN)
```

### new

```
$ bash -c "ulimit -n 12; target/debug/vector --config vector-otel.yaml"
2026-02-24T15:27:40.457658Z  INFO source{component_kind="source" component_id=otel component_type=opentelemetry}: vector::sources::util::grpc: Building gRPC server. address=127.0.0.1:4317
2026-02-24T15:27:40.459152Z  INFO source{component_kind="source" component_id=otel component_type=opentelemetry}: vector::sources::opentelemetry::http: Building HTTP server. address=127.0.0.1:4318
2026-02-24T15:27:43.001975Z ERROR source{component_kind="source" component_id=otel component_type=opentelemetry}: vector_core::tls::incoming: accept error: Too many open files (os error 24)
2026-02-24T15:27:46.107262Z ERROR source{component_kind="source" component_id=otel component_type=opentelemetry}: vector_core::tls::incoming: Internal log [accept error: Too many open files (os error 24)] is being suppressed to avoid flooding.
```

Keeps working:

```
$ nc -v localhost 4318
Connection to localhost port 4318 [tcp/*] succeeded!
$ nc -v localhost 4318
Connection to localhost port 4318 [tcp/*] succeeded!
```

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

Not sure if this qualifies as user facing. 

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

Related: #24705 

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
