### PR TITLE
fix(dev): add toml to codecs dev-dependencies

### DIFF
--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -61,6 +61,7 @@ toml = { version = "0.9.8", optional = true }
 futures.workspace = true
 indoc.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+toml.workspace = true
 similar-asserts = "1.7.0"
 vector-core = { path = "../vector-core", default-features = false, features = ["vrl", "test"] }
 rstest = "0.26.1"


### PR DESCRIPTION
## Summary

`cargo test -p codecs` fails to compile because tests in `transformer.rs` use the `toml` crate which was only available behind the `syslog` feature flag. Add `toml` as a workspace dev-dependency to fix this.

## Vector configuration

NA

## How did you test this PR?

`cargo test -p codecs --no-run` compiles successfully.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References