### PR TITLE
enhancement(host_metrics source): replace heim with sysinfo in network collector

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -244,6 +244,7 @@ gzip'ed
 hashring
 hbb
 hec
+heim
 heka
 hfs
 highlighters
@@ -559,6 +560,7 @@ sustainability
 Swich
 syscalls
 sysfs
+sysinfo
 sysinit
 syslogng
 sysv

--- a/changelog.d/23646_host_metrics_network_sysinfo.enhancement.md
+++ b/changelog.d/23646_host_metrics_network_sysinfo.enhancement.md
@@ -1,0 +1,6 @@
+The `host_metrics` source network collector now uses `sysinfo` instead of the
+unmaintained `heim` crate. `network_transmit_packets_total` is now emitted on
+all platforms (previously linux/windows only). Windows `network_transmit_packets_drop_total`
+is temporarily unavailable pending upstream sysinfo support.
+
+authors: mushrowan

--- a/src/sources/host_metrics/network.rs
+++ b/src/sources/host_metrics/network.rs
@@ -1,13 +1,7 @@
-use futures::StreamExt;
-#[cfg(target_os = "linux")]
-use heim::net::os::linux::IoCountersExt;
-#[cfg(windows)]
-use heim::net::os::windows::IoCountersExt;
-use heim::units::information::byte;
+use sysinfo::Networks;
 use vector_lib::{configurable::configurable_component, metric_tags};
 
-use super::{FilterList, HostMetrics, default_all_devices, example_devices, filter_result};
-use crate::internal_events::HostMetricsScrapeDetailError;
+use super::{FilterList, HostMetrics, default_all_devices, example_devices};
 
 /// Options for the network metrics collector.
 #[configurable_component]
@@ -23,75 +17,69 @@ pub struct NetworkConfig {
 impl HostMetrics {
     pub async fn network_metrics(&self, output: &mut super::MetricsBuffer) {
         output.name = "network";
-        match heim::net::io_counters().await {
-            Ok(counters) => {
-                for counter in counters
-                    .filter_map(|result| {
-                        filter_result(result, "Failed to load/parse network data.")
-                    })
-                    // The following pair should be possible to do in one
-                    // .filter_map, but it results in a strange "one type is
-                    // more general than the other" error.
-                    .map(|counter| {
-                        self.config
-                            .network
-                            .devices
-                            .contains_str(Some(counter.interface()))
-                            .then_some(counter)
-                    })
-                    .filter_map(|counter| async { counter })
-                    .collect::<Vec<_>>()
-                    .await
-                {
-                    let interface = counter.interface();
-                    let tags = metric_tags!("device" => interface);
-                    output.counter(
-                        "network_receive_bytes_total",
-                        counter.bytes_recv().get::<byte>() as f64,
-                        tags.clone(),
-                    );
-                    output.counter(
-                        "network_receive_errs_total",
-                        counter.errors_recv() as f64,
-                        tags.clone(),
-                    );
-                    output.counter(
-                        "network_receive_packets_total",
-                        counter.packets_recv() as f64,
-                        tags.clone(),
-                    );
-                    output.counter(
-                        "network_transmit_bytes_total",
-                        counter.bytes_sent().get::<byte>() as f64,
-                        tags.clone(),
-                    );
-                    #[cfg(any(target_os = "linux", windows))]
-                    output.counter(
-                        "network_transmit_packets_drop_total",
-                        counter.drop_sent() as f64,
-                        tags.clone(),
-                    );
-                    #[cfg(any(target_os = "linux", windows))]
-                    output.counter(
-                        "network_transmit_packets_total",
-                        counter.packets_sent() as f64,
-                        tags.clone(),
-                    );
-                    output.counter(
-                        "network_transmit_errs_total",
-                        counter.errors_sent() as f64,
-                        tags,
-                    );
-                }
+        let networks = Networks::new_with_refreshed_list();
+        for (interface, data) in &networks {
+            if !self
+                .config
+                .network
+                .devices
+                .contains_str(Some(interface.as_str()))
+            {
+                continue;
             }
-            Err(error) => {
-                emit!(HostMetricsScrapeDetailError {
-                    message: "Failed to load network I/O counters.",
-                    error,
-                });
+
+            let tags = metric_tags!("device" => interface.as_str());
+            output.counter(
+                "network_receive_bytes_total",
+                data.total_received() as f64,
+                tags.clone(),
+            );
+            output.counter(
+                "network_receive_errs_total",
+                data.total_errors_on_received() as f64,
+                tags.clone(),
+            );
+            output.counter(
+                "network_receive_packets_total",
+                data.total_packets_received() as f64,
+                tags.clone(),
+            );
+            output.counter(
+                "network_transmit_bytes_total",
+                data.total_transmitted() as f64,
+                tags.clone(),
+            );
+            output.counter(
+                "network_transmit_packets_total",
+                data.total_packets_transmitted() as f64,
+                tags.clone(),
+            );
+            // sysinfo doesn't expose drop counters, read from sysfs on linux
+            #[cfg(target_os = "linux")]
+            if let Some(drops) = read_sysfs_tx_dropped(interface) {
+                output.counter(
+                    "network_transmit_packets_drop_total",
+                    drops as f64,
+                    tags.clone(),
+                );
             }
+
+            output.counter(
+                "network_transmit_errs_total",
+                data.total_errors_on_transmitted() as f64,
+                tags,
+            );
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn read_sysfs_tx_dropped(interface: &str) -> Option<u64> {
+    std::fs::read_to_string(format!(
+        "/sys/class/net/{interface}/statistics/tx_dropped"
+    ))
+    .ok()
+    .and_then(|s| s.trim().parse().ok())
 }
 
 // The Windows CI environment produces zero network metrics, causing


### PR DESCRIPTION
## Summary

replace `heim::net::io_counters()` with `sysinfo::Networks` in the host_metrics
network collector. first step in removing the unmaintained heim dependency
(#23646). sysinfo is already a dep (used by `process.rs`)

`network_transmit_packets_total` now emitted on all platforms (was linux/windows
only). windows tx drops temporarily unavailable since sysinfo doesn't expose
drop counters yet, linux drops preserved via inline sysfs read

## Vector configuration

```toml
[sources.host_metrics]
type = "host_metrics"
collectors = ["network"]
```

## How did you test this PR?

```bash
cargo test -p vector --no-default-features --features sources-host_metrics sources::host_metrics::network
```

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our
      [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #23646
- Related: #20414

## Notes
