### PR TITLE
enhancement(host_metrics source): replace heim with sysinfo for load/host metrics

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -244,6 +244,7 @@ gzip'ed
 hashring
 hbb
 hec
+heim
 heka
 hfs
 highlighters
@@ -559,6 +560,7 @@ sustainability
 Swich
 syscalls
 sysfs
+sysinfo
 sysinit
 syslogng
 sysv

--- a/changelog.d/23646_host_metrics_loadhost_sysinfo.enhancement.md
+++ b/changelog.d/23646_host_metrics_loadhost_sysinfo.enhancement.md
@@ -1,0 +1,3 @@
+Replace heim with sysinfo for load average, uptime, and boot time metrics in the `host_metrics` source
+
+authors: mushrowan

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -6,9 +6,7 @@ use std::{
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use glob::{Pattern, PatternError};
-#[cfg(not(windows))]
-use heim::units::ratio::ratio;
-use heim::units::time::second;
+
 use serde_with::serde_as;
 use sysinfo::System;
 use tokio::time;
@@ -432,54 +430,22 @@ impl HostMetrics {
     pub async fn loadavg_metrics(&self, output: &mut MetricsBuffer) {
         output.name = "load";
         #[cfg(unix)]
-        match heim::cpu::os::unix::loadavg().await {
-            Ok(loadavg) => {
-                output.gauge(
-                    "load1",
-                    loadavg.0.get::<ratio>() as f64,
-                    MetricTags::default(),
-                );
-                output.gauge(
-                    "load5",
-                    loadavg.1.get::<ratio>() as f64,
-                    MetricTags::default(),
-                );
-                output.gauge(
-                    "load15",
-                    loadavg.2.get::<ratio>() as f64,
-                    MetricTags::default(),
-                );
-            }
-            Err(error) => {
-                emit!(HostMetricsScrapeDetailError {
-                    message: "Failed to load average info",
-                    error,
-                });
-            }
+        {
+            let loadavg = System::load_average();
+            output.gauge("load1", loadavg.one, MetricTags::default());
+            output.gauge("load5", loadavg.five, MetricTags::default());
+            output.gauge("load15", loadavg.fifteen, MetricTags::default());
         }
     }
 
     pub async fn host_metrics(&self, output: &mut MetricsBuffer) {
         output.name = "host";
-        match heim::host::uptime().await {
-            Ok(time) => output.gauge("uptime", time.get::<second>(), MetricTags::default()),
-            Err(error) => {
-                emit!(HostMetricsScrapeDetailError {
-                    message: "Failed to load host uptime info",
-                    error,
-                });
-            }
-        }
-
-        match heim::host::boot_time().await {
-            Ok(time) => output.gauge("boot_time", time.get::<second>(), MetricTags::default()),
-            Err(error) => {
-                emit!(HostMetricsScrapeDetailError {
-                    message: "Failed to load host boot time info",
-                    error,
-                });
-            }
-        }
+        output.gauge("uptime", System::uptime() as f64, MetricTags::default());
+        output.gauge(
+            "boot_time",
+            System::boot_time() as f64,
+            MetricTags::default(),
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

replace heim with sysinfo for load average, uptime, and boot time in the
host_metrics source. part of removing the unmaintained heim dependency (#23646)

- `heim::cpu::os::unix::loadavg()` -> `System::load_average()`
- `heim::host::uptime()` -> `System::uptime()`
- `heim::host::boot_time()` -> `System::boot_time()`

all three sysinfo methods are static, sync, and infallible so the error handling
arms are removed

## Vector configuration

```toml
[sources.host_metrics]
type = "host_metrics"
collectors = ["load", "host"]
```

## How did you test this PR?

```bash
cargo test -p vector --no-default-features --features sources-host_metrics \
  -- sources::host_metrics::tests::generates_loadavg_metrics \
     sources::host_metrics::tests::generates_host_metrics
```

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our
      [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #23646
- Related: #24818

## Notes