### PR TITLE
chore(deps): explicitly enable preserve_order feature for serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ reqwest = { version = "0.11", features = ["json"] }
 rust_decimal = { version = "1.37.0", default-features = false, features = ["std"] }
 semver = { version = "1.0.27", default-features = false, features = ["serde", "std"] }
 serde = { version = "1.0.219", default-features = false, features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.143", default-features = false, features = ["raw_value", "std"] }
+serde_json = { version = "1.0.143", default-features = false, features = ["preserve_order", "raw_value", "std"] }
 serde_yaml = { version = "0.9.34", default-features = false }
 snafu = { version = "0.8.9", default-features = false, features = ["futures", "std"] }
 socket2 = { version = "0.5.10", default-features = false }


### PR DESCRIPTION
## Summary

The `preserve_order` feature was already implicitly enabled via the `bson` crate dependency. This explicitly enables it in the workspace `serde_json` dependency declaration.

See motivation [here](https://github.com/vectordotdev/vector/pull/24719#discussion_r2886015563).

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #24719