### PR TITLE
chore(ci): update SMP CLI to 0.26.1

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set SMP version
         id: experimental-meta
         run: |
-          export SMP_CRATE_VERSION="0.25.1"
+          export SMP_CRATE_VERSION="0.26.1"
           echo "smp crate version: ${SMP_CRATE_VERSION}"
           echo "SMP_CRATE_VERSION=${SMP_CRATE_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- Bumps SMP CLI version from 0.25.1 to 0.26.1 in the regression workflow

## Test plan
- [ ] Regression workflow runs successfully with the new SMP version