### PR TITLE
fix(ci): add changes job to integration-test-suite needs to catch cancellations

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -211,6 +211,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: always()
     needs:
+      - changes
       - build-test-runner
       - integration-tests
       - e2e-tests


### PR DESCRIPTION
## Summary

When the `changes` job in `integration.yml` is cancelled (e.g. via `cancel-in-progress`), its downstream jobs (`build-test-runner`, `integration-tests`, `e2e-tests`) are skipped rather than cancelled. The `integration-test-suite` gate only checked those downstream jobs, so it saw all-skipped and exited successfully — allowing a merge even though the required checks never actually ran.

Fix: add `changes` to `integration-test-suite`'s `needs` so a cancelled `changes` job is captured by the `contains(needs.*.result, 'cancelled')` check.

For `pull_request` events, `changes` is naturally `skipped` (its `if` condition gates on `merge_group`), so the gate continues to pass correctly on PRs.

Reproducer: https://github.com/vectordotdev/vector/actions/runs/22864963792/job/66329116605

## Vector configuration

NA

## How did you test this PR?

Reviewed the GitHub Actions run linked above and traced the job result propagation logic.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA