### PR TITLE
fix(unit tests): test_udp_syslog can overflow default size receive buffer

### DIFF
--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1208,7 +1208,7 @@ mod test {
             // Create and spawn the source.
             let config = SyslogConfig::from_mode(Mode::Udp {
                 address: in_addr.into(),
-                receive_buffer_bytes: None,
+                receive_buffer_bytes: Some(4 * 1024 * 1024),
             });
 
             let key = ComponentKey::from("in");


### PR DESCRIPTION
## Summary
`test_udp_syslog` sends out 1000 UDP datagrams with no delay, which can saturate the kernel UDP receive buffer, depending on the environment. Specifically in Alpine Linux CI, this test was causing consistent failures. The test failure looks like this:
```
  TRY 4 FAIL [   2.192s] (2650/2654) vector sources::syslog::test::test_udp_syslog
  stdout ───
    running 1 test
    test sources::syslog::test::test_udp_syslog ... FAILED
    failures:
    failures:
        sources::syslog::test::test_udp_syslog
    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1834 filtered out; finished in 2.18s
  stderr ───
    thread 'sources::syslog::test::test_udp_syslog' (46526) panicked at src/sources/syslog.rs:1253:13:
    assertion `left == right` failed
      left: 917
     right: 1000
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR specifies `receive_buffer_bytes` of 4MB which should be sufficient for the amount of data sent in the test, which I estimate to be around 500KB. This is typically doubled for overhead/padding, and then I added more headroom just to make sure, since this buffer sizing only applies during this specific test.

## Vector configuration
Build from source, then:
```
	cargo nextest run \
		--fail-fast \
		--frozen \
		--no-default-features \
		--features default-musl,component-validation-runner \
		--offline \
		--release \
		--workspace \
		--test-threads num-cpus
```

## How did you test this PR?
In Alpine Linux CI, test passes on x86_64, aarch64, ppc64le and riscv64

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: https://github.com/vectordotdev/vector/issues/2886#issuecomment-4024710232
- Related: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/92645

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
