### PR TITLE
chore(ci): consolidate protoc setup under prepare.sh

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,7 +24,7 @@ inputs:
   protoc:
     required: false
     default: false
-    description: "Install protoc (uses scripts/environment/install-protoc.sh)."
+    description: "Install protoc (uses prepare.sh protoc module)."
   cue:
     required: false
     default: false
@@ -186,17 +186,6 @@ runs:
         rustc-wrapper = "$RUSTC_WRAPPER"
         EOF
 
-    - name: Install protoc
-      if: ${{ inputs.protoc == 'true' }}
-      shell: bash
-      run: |
-        echo "Installing protoc"
-        if [[ "${{ runner.os }}" == "macOS" ]]; then
-          sudo bash ./scripts/environment/install-protoc.sh /usr/local/bin
-        else
-          sudo bash ./scripts/environment/install-protoc.sh
-        fi
-
     - name: Install cue
       if: ${{ inputs.cue == 'true' }}
       shell: bash
@@ -250,6 +239,7 @@ runs:
       run: |
         mods=()
         [[ "${{ inputs.rust == 'true' || env.NEEDS_RUST == 'true' }}" == "true" ]] && mods+=("rustup")
+        [[ "${{ inputs.protoc }}" == "true" ]] && mods+=("protoc")
         [[ "${{ inputs.cargo-deb }}" == "true" ]] && mods+=("cargo-deb")
         [[ "${{ inputs.cross }}" == "true" ]] && mods+=("cross")
         [[ "${{ inputs.cargo-nextest }}" == "true" ]] && mods+=("cargo-nextest")

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,7 +24,7 @@ inputs:
   protoc:
     required: false
     default: false
-    description: "Install protoc (uses prepare.sh protoc module)."
+    description: "Install protoc."
   cue:
     required: false
     default: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust: true
+          protoc: true
           cargo-cache: true
       - run: cd rust-doc && make ci-docs-build
 

--- a/rust-doc/Makefile
+++ b/rust-doc/Makefile
@@ -1,9 +1,8 @@
 # Full docs build with all dependencies for local development
 docs:
-	../scripts/environment/install-protoc.sh ${HOME}/protoc
-	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs" --workspace
+	../scripts/environment/prepare.sh --modules=protoc
+	PATH=${PATH}:${HOME}/.local/bin cargo doc --no-default-features --features="docs" --workspace
 # rust-doc.vector.dev specific build without the extra dependencies
 ci-docs-build:
-	../scripts/environment/install-protoc.sh ${HOME}/protoc
-	PATH=${PATH}:${HOME}/protoc/ cargo doc --no-default-features --features="docs" --no-deps --workspace
+	cargo doc --no-default-features --features="docs" --no-deps --workspace
 	cargo doc --no-deps -p vrl

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -42,6 +42,7 @@ WASM_PACK_VERSION="0.15.0"
 
 ALL_MODULES=(
   rustup
+  protoc
   cargo-deb
   cross
   cargo-nextest
@@ -82,6 +83,7 @@ Usage: $0 [--modules=mod1,mod2,...]
 
 Modules:
   rustup
+  protoc
   cargo-deb
   cross
   cargo-nextest
@@ -311,6 +313,21 @@ if contains_module rustup; then
   fi
 fi
 set -e -o verbose
+
+if contains_module protoc; then
+  if [[ -n "${CI:-}" ]]; then
+    protoc_dir="${RUNNER_TEMP:?RUNNER_TEMP must be set when CI is enabled}/protoc-bin"
+  else
+    protoc_dir="${HOME}/.local/bin"
+  fi
+
+  bash "${SCRIPT_DIR}/install-protoc.sh" "${protoc_dir}"
+  export PATH="${protoc_dir}:${PATH}"
+
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "${protoc_dir}" >> "${GITHUB_PATH}"
+  fi
+fi
 
 maybe_install_cargo_tool cargo-deb "${CARGO_DEB_VERSION}" "${CARGO_DEB_VERSION}"
 maybe_install_cargo_tool cross "${CROSS_VERSION}"


### PR DESCRIPTION
## Summary

Add a `protoc` module to `prepare.sh` and route the composite GitHub setup action plus the Rust-docs workflow through it.

The module keeps `install-protoc.sh` as the pinned cross-platform implementation. In CI, it installs into `$RUNNER_TEMP/protoc-bin`, makes that path available to the current shell, and adds it to `GITHUB_PATH` for later workflow steps—removing the privileged system-path install.

The Rust-docs CI job now requests `protoc` through the shared setup action, and the local Rust-docs target uses the same module rather than its own `$HOME/protoc` installation.

## Vector configuration

N/A

## How did you test this PR?

- `bash -n scripts/environment/prepare.sh scripts/environment/install-protoc.sh`
- `make check-scripts`
- `make -C rust-doc -n docs ci-docs-build`
- `make check-markdown`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A
