### PR TITLE
fix(buffers): Improve buffer utilization metric tracking

### DIFF
--- a/changelog.d/24911-buffer-utilization-metric-tracking.fix.md
+++ b/changelog.d/24911-buffer-utilization-metric-tracking.fix.md
@@ -1,0 +1,3 @@
+Fixed regression in buffer utilization metric tracking around underflow.
+
+authors: bruceg

--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -19,34 +19,6 @@ use crate::{
 /// always used a "relaxed" ordering when updating them.
 const ORDERING: Ordering = Ordering::Relaxed;
 
-fn increment_counter(counter: &AtomicU64, delta: u64) {
-    counter
-        .fetch_update(ORDERING, ORDERING, |current| {
-            Some(current.checked_add(delta).unwrap_or_else(|| {
-                warn!(
-                    current,
-                    delta, "Buffer counter overflowed. Clamping value to `u64::MAX`."
-                );
-                u64::MAX
-            }))
-        })
-        .ok();
-}
-
-fn decrement_counter(counter: &AtomicU64, delta: u64) {
-    counter
-        .fetch_update(ORDERING, ORDERING, |current| {
-            Some(current.checked_sub(delta).unwrap_or_else(|| {
-                warn!(
-                    current,
-                    delta, "Buffer counter underflowed. Clamping value to `0`."
-                );
-                0
-            }))
-        })
-        .ok();
-}
-
 /// Snapshot of category metrics.
 struct CategorySnapshot {
     event_count: u64,
@@ -62,10 +34,15 @@ impl CategorySnapshot {
 
 /// Per-category metrics.
 ///
-/// This tracks the number of events, and their size in the buffer, that a given category has interacted with. A
-/// category in this case could be something like the receive or send categories i.e. being written into the buffer, and
-/// then read out of the buffer. Overall, it's a simple grouping mechanism because we often want to track the change in
-/// both number of events, and their size as measured by the buffer.
+/// This tracks the number of events, and their size in the buffer, that a given category has
+/// interacted with. A category in this case could be something like the receive or send categories
+/// i.e. being written into the buffer, and then read out of the buffer. Overall, it's a simple
+/// grouping mechanism because we often want to track the change in both number of events, and their
+/// size as measured by the buffer.
+///
+///  At a sustained 1 GiB/sec, which is still faster than Vector can currently achieve, a `u64` byte
+///  counter would take over 500 years to overflow. As such, we don't handle failures due to
+///  overflow as it is effectively impossible.
 #[derive(Debug, Default)]
 struct CategoryMetrics {
     event_count: AtomicU64,
@@ -75,14 +52,8 @@ struct CategoryMetrics {
 impl CategoryMetrics {
     /// Increments the event count and byte size by the given amounts.
     fn increment(&self, event_count: u64, event_byte_size: u64) {
-        increment_counter(&self.event_count, event_count);
-        increment_counter(&self.event_byte_size, event_byte_size);
-    }
-
-    /// Decrements the event count and byte size by the given amounts.
-    fn decrement(&self, event_count: u64, event_byte_size: u64) {
-        decrement_counter(&self.event_count, event_count);
-        decrement_counter(&self.event_byte_size, event_byte_size);
+        self.event_count.fetch_add(event_count, ORDERING);
+        self.event_byte_size.fetch_add(event_byte_size, ORDERING);
     }
 
     /// Sets the event count and event byte size to the given amount.
@@ -111,6 +82,41 @@ impl CategoryMetrics {
         CategorySnapshot {
             event_count: self.event_count.swap(0, ORDERING),
             event_byte_size: self.event_byte_size.swap(0, ORDERING),
+        }
+    }
+}
+
+/// `CurrentMetrics` is a wrapper around a pair of `CategoryMetrics` that are used to track a
+/// "current" value that may increment or decrement. The challenge this solves is that the
+/// increments and decrements may race and result in underflows that are hard to handle using only
+/// efficient atomic operations. By tracking the increments and decrements separately, we can ensure
+/// that the current value is always accurate even if the increments and decrements race.
+#[derive(Debug, Default)]
+struct CurrentMetrics {
+    increments: CategoryMetrics,
+    decrements: CategoryMetrics,
+}
+
+impl CurrentMetrics {
+    fn increment(&self, event_count: u64, event_byte_size: u64) {
+        self.increments.increment(event_count, event_byte_size);
+    }
+
+    fn decrement(&self, event_count: u64, event_byte_size: u64) {
+        self.decrements.increment(event_count, event_byte_size);
+    }
+
+    fn get(&self) -> CategorySnapshot {
+        let entered_total = self.increments.get();
+        let left_total = self.decrements.get();
+
+        CategorySnapshot {
+            event_count: entered_total
+                .event_count
+                .saturating_sub(left_total.event_count),
+            event_byte_size: entered_total
+                .event_byte_size
+                .saturating_sub(left_total.event_byte_size),
         }
     }
 }
@@ -195,7 +201,7 @@ struct BufferUsageData {
     dropped: CategoryMetrics,
     dropped_intentional: CategoryMetrics,
     max_size: CategoryMetrics,
-    current: CategoryMetrics,
+    current: CurrentMetrics,
 }
 
 impl BufferUsageData {
@@ -372,68 +378,30 @@ impl BufferUsage {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-
     use super::*;
 
     #[test]
-    fn test_multithreaded_updates_are_correct() {
-        const NUM_THREADS: u64 = 16;
-        const INCREMENTS_PER_THREAD: u64 = 10_000;
+    fn current_usage_is_derived_from_entered_and_left_totals() {
+        let handle = BufferUsageHandle {
+            state: Arc::new(BufferUsageData::new(0)),
+        };
 
-        let counter = Arc::new(AtomicU64::new(0));
+        handle.increment_received_event_count_and_byte_size(10, 1000);
+        handle.increment_sent_event_count_and_byte_size(3, 300);
+        handle.increment_dropped_event_count_and_byte_size(2, 200, false);
 
-        let mut handles = vec![];
-
-        for _ in 0..NUM_THREADS {
-            let counter = Arc::clone(&counter);
-            let handle = thread::spawn(move || {
-                for _ in 0..INCREMENTS_PER_THREAD {
-                    increment_counter(&counter, 1);
-                    decrement_counter(&counter, 1);
-                }
-            });
-            handles.push(handle);
-        }
-
-        for handle in handles {
-            handle.join().unwrap();
-        }
-
-        assert_eq!(counter.load(ORDERING), 0);
+        let current = handle.state.current.get();
+        assert_eq!(current.event_count, 5);
+        assert_eq!(current.event_byte_size, 500);
     }
 
     #[test]
-    fn test_decrement_counter_prevents_negatives() {
-        let counter = AtomicU64::new(100);
+    fn current_usage_saturates_at_zero() {
+        let data = BufferUsageData::new(0);
+        data.current.decrement(10, 1000);
 
-        decrement_counter(&counter, 50);
-        assert_eq!(counter.load(ORDERING), 50);
-
-        decrement_counter(&counter, 100);
-        assert_eq!(counter.load(ORDERING), 0);
-
-        decrement_counter(&counter, 50);
-        assert_eq!(counter.load(ORDERING), 0);
-
-        decrement_counter(&counter, u64::MAX);
-        assert_eq!(counter.load(ORDERING), 0);
-    }
-
-    #[test]
-    fn test_increment_counter_prevents_overflow() {
-        let counter = AtomicU64::new(u64::MAX - 2);
-
-        increment_counter(&counter, 1);
-        assert_eq!(counter.load(ORDERING), u64::MAX - 1);
-
-        increment_counter(&counter, 1);
-        assert_eq!(counter.load(ORDERING), u64::MAX);
-
-        increment_counter(&counter, 1);
-        assert_eq!(counter.load(ORDERING), u64::MAX);
-
-        increment_counter(&counter, u64::MAX);
-        assert_eq!(counter.load(ORDERING), u64::MAX);
+        let current = data.current.get();
+        assert_eq!(current.event_count, 0);
+        assert_eq!(current.event_byte_size, 0);
     }
 }


### PR DESCRIPTION
## Summary

The buffer usage metrics, in particular the value of the current utilization levels, were tracked using an atomic `u64` which was updated using a `fetch_update` mechanism in order to protect against underflowing. This same mechanism was extended to all of the atomics as well for consistency. The problem with that is that `fetch_udpate` internally uses a loop around a `compare-and-exchange` operation which is very expensive, particularly when contended. In comparison, the base `fetch_add` is typically a single locked instruction which completes in many fewer cycles.

This change returns these atomics to only ever use `fetch_add` and then calculate the current level by subtracting the count of increments from the count of decrements.

## Vector configuration

N/A

## How did you test this PR?

Unit tests

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

https://github.com/vectordotdev/vector/issues/24058

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
