### PR TITLE
fix(dnstap source): close TCP connection after sending FINISH to prevent CLOSE_WAIT socket leak

### DIFF
--- a/changelog.d/24838_dnstap_tcp_socket_leak.fix.md
+++ b/changelog.d/24838_dnstap_tcp_socket_leak.fix.md
@@ -1,0 +1,7 @@
+Fix TCP socket leak in `dnstap` source where sockets would accumulate in `CLOSE_WAIT` state
+indefinitely. After sending a FrameStream `FINISH` frame in response to a client `STOP`, Vector
+now explicitly closes the write side of the TCP connection as required by the FrameStream protocol,
+preventing `CLOSE_WAIT` accumulation that previously exhausted the connection limit after extended
+operation.
+
+authors: jpds

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -248,6 +248,11 @@ impl FrameStreamReader {
                             self.send_control_frame(Self::make_frame(ControlHeader::Finish, None));
                         }
                         self.state.control_state = ControlState::Stopped; //stream is now done
+                        // Close the write side of the connection after STOP/FINISH.
+                        // Per the FrameStream protocol, the server should initiate TCP close
+                        // after sending FINISH. Without this, sockets accumulate in CLOSE_WAIT
+                        // because the client may wait for the server to close first.
+                        self.close_sink();
                     }
                     _ => error!("Got wrong control frame, expected STOP."),
                 }
@@ -364,6 +369,15 @@ impl FrameStreamReader {
 
         if let Err(e) = block_on(self.response_sink.lock().unwrap().send_all(&mut stream)) {
             error!("Encountered error '{:#?}' while sending control frame.", e);
+        }
+    }
+
+    fn close_sink(&mut self) {
+        if let Err(e) = block_on(self.response_sink.lock().unwrap().close()) {
+            error!(
+                "Encountered error '{:#?}' while closing connection after FINISH.",
+                e
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

After sending a FrameStream FINISH frame in response to a client STOP, explicitly shut down the write side of the TCP connection. Per the FrameStream protocol, the server should initiate TCP close after FINISH. Without this, sockets accumulate in CLOSE_WAIT indefinitely because the client may wait for the server to close first, creating a protocol-level deadlock.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

Simple change to TCP behaviour.

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Fixes #24838

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
