### PR TITLE
chore(external docs): fix typos in rustdoc comments

### DIFF
--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -69,7 +69,7 @@ pub struct DatadogLogsConfig {
 
     /// When enabled this sink will normalize events to conform to the Datadog Agent standard. This
     /// also sends requests to the logs backend with the `DD-PROTOCOL: agent-json` header. This bool
-    /// will be overidden as `true` if this header has already been set in the request.headers
+    /// will be overridden as `true` if this header has already been set in the request.headers
     /// configuration setting.
     #[serde(default)]
     pub conforms_as_agent: bool,

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -68,7 +68,7 @@ pub enum GcsPredefinedAcl {
     #[derivative(Default)]
     ProjectPrivate,
 
-    /// Bucket/object can be read publically.
+    /// Bucket/object can be read publicly.
     ///
     /// The bucket/object owner is granted the `OWNER` permission, and all other users, whether
     /// authenticated or anonymous, are granted the `READER` permission.

--- a/website/cue/reference/components/sinks/generated/datadog_logs.cue
+++ b/website/cue/reference/components/sinks/generated/datadog_logs.cue
@@ -100,7 +100,7 @@ generated: components: sinks: datadog_logs: configuration: {
 		description: """
 			When enabled this sink will normalize events to conform to the Datadog Agent standard. This
 			also sends requests to the logs backend with the `DD-PROTOCOL: agent-json` header. This bool
-			will be overidden as `true` if this header has already been set in the request.headers
+			will be overridden as `true` if this header has already been set in the request.headers
 			configuration setting.
 			"""
 		required: false

--- a/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
@@ -75,7 +75,7 @@ generated: components: sinks: gcp_cloud_storage: configuration: {
 				This is the default.
 				"""
 			"public-read": """
-				Bucket/object can be read publically.
+				Bucket/object can be read publicly.
 
 				The bucket/object owner is granted the `OWNER` permission, and all other users, whether
 				authenticated or anonymous, are granted the `READER` permission.


### PR DESCRIPTION
## Summary
- Fix `overidden` → `overridden` in `src/sinks/datadog/logs/config.rs` and generated CUE file
- Fix `publically` → `publicly` in `src/sinks/gcs_common/config.rs` and generated CUE file

Ref https://github.com/SchemaStore/schemastore/pull/5464

## Test plan
- [x] No functional changes, doc-only fixes
