### PR TITLE
feat(sinks): add dlq logic on sink and support for elasticsearch 

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -564,3 +564,4 @@ sighup
 CLAUDE
 linting
 lexers
+dlq

--- a/changelog.d/1772_add_dlq.feature.md
+++ b/changelog.d/1772_add_dlq.feature.md
@@ -1,0 +1,73 @@
+Add support for Dead Letter Queue (dlq) on sink and enabling it in Elasticsearch sink.
+
+## Simple use case
+Create two indexes, one with mapped filed `value` equal to long and one without mappings like this:
+
+```bash
+curl -X PUT "localhost:9200/test-index" -H 'Content-Type: application/json' -d '
+{
+  "mappings": {
+    "properties": {
+      "value": {
+        "type": "long"
+      }
+    }
+  }
+}' -v
+
+curl -X PUT "localhost:9200/test-index-no-mapping" -H 'Content-Type: application/json' -d '{}' -v
+```
+
+Then, configure vector like this:
+
+```yaml
+api:
+  enabled: true
+sources:
+  my_source:
+    type: demo_logs
+    format: shuffle
+    lines:
+      - '{"value":1,"tag":"ok"}'
+      - '{"value":2,"tag":"ok"}'
+      - '{"value":"bad","tag":"bad"}'
+      - '{"value":"bad2","tag":"bad"}'
+      - '{"value":3,"tag":"bad"}'
+
+transforms:
+  my_transform:
+    type: remap
+    inputs:
+      - my_source
+    source: |
+      . = parse_json!(.message)
+  my_dlq_transform:
+    type: remap
+    inputs:
+      - "es_out.dlq"
+    source: |
+      .enter_dlq = true
+sinks:
+  es_out:
+    type: elasticsearch
+    inputs:
+      - my_transform
+    endpoints:
+      - "http://localhost:9200"
+    bulk:
+      index: "test-index"
+  es_dlq_out:
+    type: elasticsearch
+    inputs:
+      - "my_dlq_transform"
+    endpoints:
+      - "http://localhost:9200"
+    bulk:
+      index: "test-index-no-mapping"
+
+```
+
+You should see that the events with `value` field as string will be sent to `test-index-no-mapping` index and the ones with `value` field as long will be sent to `test-index` index.
+As per example above, `es_out.dlq` is used as input for `transform` or can be used directly into another `sink`, like filesystem line.
+
+authors: tanganellilore

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -191,6 +191,72 @@ impl SourceOutput {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SinkOutput {
+    pub port: Option<String>,
+    pub ty: DataType,
+
+    // NOTE: schema definitions are only implemented/supported for log-type events. There is no
+    // inherent blocker to support other types as well, but it'll require additional work to add
+    // the relevant schemas, and store them separately in this type.
+    pub schema_definition: Option<Arc<schema::Definition>>,
+}
+
+impl SinkOutput {
+    #[must_use]
+    pub fn new_maybe_logs(ty: DataType, schema_definition: schema::Definition) -> Self {
+        let schema_definition = ty
+            .contains(DataType::Log)
+            .then(|| Arc::new(schema_definition));
+
+        Self {
+            port: None,
+            ty,
+            schema_definition,
+        }
+    }
+
+    #[must_use]
+    pub fn new_metrics() -> Self {
+        Self {
+            port: None,
+            ty: DataType::Metric,
+            schema_definition: None,
+        }
+    }
+
+    #[must_use]
+    pub fn new_traces() -> Self {
+        Self {
+            port: None,
+            ty: DataType::Trace,
+            schema_definition: None,
+        }
+    }
+
+    #[must_use]
+    pub fn schema_definition(&self, schema_enabled: bool) -> Option<schema::Definition> {
+        use std::ops::Deref;
+
+        self.schema_definition.as_ref().map(|definition| {
+            if schema_enabled {
+                definition.deref().clone()
+            } else {
+                let mut new_definition =
+                    schema::Definition::default_for_namespace(definition.log_namespaces());
+                new_definition.add_meanings(definition.meanings());
+                new_definition
+            }
+        })
+    }
+
+    #[must_use]
+    pub fn with_port(mut self, name: impl Into<String>) -> Self {
+        self.port = Some(name.into());
+        self
+    }
+}
+
 fn fmt_helper(
     f: &mut fmt::Formatter<'_>,
     maybe_port: Option<&String>,
@@ -204,6 +270,12 @@ fn fmt_helper(
 }
 
 impl fmt::Display for SourceOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_helper(f, self.port.as_ref(), self.ty)
+    }
+}
+
+impl fmt::Display for SinkOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_helper(f, self.port.as_ref(), self.ty)
     }

--- a/lib/vector-core/src/source_sender/builder.rs
+++ b/lib/vector-core/src/source_sender/builder.rs
@@ -5,7 +5,7 @@ use vector_buffers::topology::channel::LimitedReceiver;
 use vector_common::internal_event::DEFAULT_OUTPUT;
 
 use super::{CHUNK_SIZE, LAG_TIME_NAME, Output, SourceSender, SourceSenderItem};
-use crate::config::{ComponentKey, OutputId, SourceOutput};
+use crate::config::{ComponentKey, OutputId, SinkOutput, SourceOutput};
 
 pub struct Builder {
     buf_size: usize,
@@ -51,6 +51,47 @@ impl Builder {
     pub fn add_source_output(
         &mut self,
         output: SourceOutput,
+        component_key: ComponentKey,
+    ) -> LimitedReceiver<SourceSenderItem> {
+        let lag_time = self.lag_time.clone();
+        let log_definition = output.schema_definition.clone();
+        let output_id = OutputId {
+            component: component_key,
+            port: output.port.clone(),
+        };
+        match output.port {
+            None => {
+                let (output, rx) = Output::new_with_buffer(
+                    self.buf_size,
+                    DEFAULT_OUTPUT.to_owned(),
+                    lag_time,
+                    log_definition,
+                    output_id,
+                    self.timeout,
+                    self.ewma_half_life_seconds,
+                );
+                self.default_output = Some(output);
+                rx
+            }
+            Some(name) => {
+                let (output, rx) = Output::new_with_buffer(
+                    self.buf_size,
+                    name.clone(),
+                    lag_time,
+                    log_definition,
+                    output_id,
+                    self.timeout,
+                    self.ewma_half_life_seconds,
+                );
+                self.named_outputs.insert(name, output);
+                rx
+            }
+        }
+    }
+
+    pub fn add_sink_output(
+        &mut self,
+        output: SinkOutput,
         component_key: ComponentKey,
     ) -> LimitedReceiver<SourceSenderItem> {
         let lag_time = self.lag_time.clone();

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -36,8 +36,8 @@ pub mod config {
     pub use vector_common::config::ComponentKey;
     pub use vector_core::config::{
         AcknowledgementsConfig, DataType, GlobalOptions, Input, LegacyKey, LogNamespace, LogSchema,
-        MEMORY_BUFFER_DEFAULT_MAX_EVENTS, OutputId, SourceAcknowledgementsConfig, SourceOutput,
-        Tags, Telemetry, TransformOutput, WildcardMatching, clone_input_definitions,
+        MEMORY_BUFFER_DEFAULT_MAX_EVENTS, OutputId, SinkOutput, SourceAcknowledgementsConfig,
+        SourceOutput, Tags, Telemetry, TransformOutput, WildcardMatching, clone_input_definitions,
         init_log_schema, init_telemetry, log_schema, proxy, telemetry,
     };
 }

--- a/lib/vector-top/src/dashboard.rs
+++ b/lib/vector-top/src/dashboard.rs
@@ -373,7 +373,7 @@ impl<'a> Widgets<'a> {
                         .map(Cell::from)
                         .collect::<Vec<_>>();
                     data[1] = Cell::from(id.as_str());
-                    data[5] = Cell::from(sent_events_metric);
+                    data[6] = Cell::from(sent_events_metric);
                     items.push(Row::new(data).style(Style::default()));
                 }
             }

--- a/src/api/schema/metrics/filter.rs
+++ b/src/api/schema/metrics/filter.rs
@@ -41,6 +41,20 @@ fn sum_metrics_owned<I: IntoIterator<Item = Metric>>(metrics: I) -> Option<Metri
     Some(iter.fold(m, |mut m1, m2| if m1.update(&m2) { m1 } else { m2 }))
 }
 
+fn component_total_sent_events_metric(metrics: Vec<Metric>) -> Option<Metric> {
+    let output_agnostic: Vec<Metric> = metrics
+        .iter()
+        .filter(|m| m.tag_value("output").is_none())
+        .cloned()
+        .collect();
+
+    if output_agnostic.is_empty() {
+        sum_metrics_owned(metrics)
+    } else {
+        sum_metrics_owned(output_agnostic)
+    }
+}
+
 pub trait MetricsFilter<'a> {
     fn received_bytes_total(&self) -> Option<ReceivedBytesTotal>;
     fn received_events_total(&self) -> Option<ReceivedEventsTotal>;
@@ -310,7 +324,7 @@ pub fn component_sent_events_totals_metrics_with_outputs(
                         })
                         .collect();
 
-                    let sum = sum_metrics_owned(metrics)?;
+                    let sum = component_total_sent_events_metric(metrics)?;
                     match sum.value() {
                         MetricValue::Counter { value }
                             if cache.insert(id, *value).unwrap_or(0.00) < *value =>
@@ -350,7 +364,7 @@ pub fn component_sent_events_total_throughputs_with_outputs(
                         })
                         .collect::<Vec<_>>();
 
-                    let sum = sum_metrics_owned(metrics)?;
+                    let sum = component_total_sent_events_metric(metrics)?;
                     let total_throughput = throughput(&sum, id.clone(), &mut cache)?;
                     Some((
                         ComponentKey::from(id),

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -6,8 +6,8 @@ use std::{
 use indexmap::{IndexMap, set::IndexSet};
 
 use super::{
-    ComponentKey, DataType, OutputId, SinkOuter, SourceOuter, SourceOutput, TransformContext,
-    TransformOuter, TransformOutput, WildcardMatching, schema,
+    ComponentKey, DataType, OutputId, SinkOuter, SinkOutput, SourceOuter, SourceOutput,
+    TransformContext, TransformOuter, TransformOutput, WildcardMatching, schema,
 };
 
 #[derive(Debug, Clone)]
@@ -21,6 +21,7 @@ pub enum Node {
     },
     Sink {
         ty: DataType,
+        outputs: Vec<SinkOutput>,
     },
 }
 
@@ -44,8 +45,12 @@ impl fmt::Display for Node {
                 }
                 Ok(())
             }
-            Node::Sink { ty } => {
-                write!(f, "component_kind: sink\n  types: {ty}")
+            Node::Sink { ty, outputs } => {
+                write!(f, "component_kind: sink\n  types: {ty}\n  outputs:")?;
+                for output in outputs {
+                    write!(f, "\n    {output}")?;
+                }
+                Ok(())
             }
         }
     }
@@ -127,6 +132,7 @@ impl Graph {
                 id.clone(),
                 Node::Sink {
                     ty: config.inner.input().data_type(),
+                    outputs: config.inner.outputs(schema.log_namespace()),
                 },
             );
         }
@@ -215,7 +221,7 @@ impl Graph {
         match self.nodes[key] {
             Node::Source { .. } => panic!("no inputs on sources"),
             Node::Transform { in_ty, .. } => in_ty,
-            Node::Sink { ty } => ty,
+            Node::Sink { ty, .. } => ty,
         }
     }
 
@@ -237,7 +243,11 @@ impl Graph {
                 .find(|output| output.port == id.port)
                 .map(|output| output.ty)
                 .expect("output didn't exist"),
-            Node::Sink { .. } => panic!("no outputs on sinks"),
+            Node::Sink { outputs, .. } => outputs
+                .iter()
+                .find(|output| output.port == id.port)
+                .map(|output| output.ty)
+                .expect("output didn't exist"),
         }
     }
 
@@ -322,7 +332,13 @@ impl Graph {
         self.nodes
             .iter()
             .flat_map(|(key, node)| match node {
-                Node::Sink { .. } => vec![],
+                Node::Sink { outputs, .. } => outputs
+                    .iter()
+                    .map(|output| OutputId {
+                        component: key.clone(),
+                        port: output.port.clone(),
+                    })
+                    .collect::<Vec<_>>(),
                 Node::Source { outputs } => outputs
                     .iter()
                     .map(|output| OutputId {
@@ -414,7 +430,7 @@ impl Graph {
             .into_iter()
             .filter(|path| {
                 if let Some(key) = path.last() {
-                    matches!(self.nodes.get(key), Some(Node::Sink { ty: _ }))
+                    matches!(self.nodes.get(key), Some(Node::Sink { .. }))
                 } else {
                     false
                 }
@@ -488,7 +504,13 @@ mod test {
         fn add_sink(&mut self, id: &str, ty: DataType, inputs: Vec<&str>) {
             let id = ComponentKey::from(id);
             let inputs = clean_inputs(inputs);
-            self.nodes.insert(id.clone(), Node::Sink { ty });
+            self.nodes.insert(
+                id.clone(),
+                Node::Sink {
+                    ty,
+                    outputs: vec![],
+                },
+            );
             for from in inputs {
                 self.edges.push(Edge {
                     from,
@@ -505,6 +527,17 @@ mod test {
         ) -> Result<(), String> {
             let available_inputs = self.input_map().unwrap();
             self.add_input(input, &node.into(), &available_inputs, wildcard_matching)
+        }
+
+        fn add_sink_output(&mut self, id: &str, port: &str, ty: DataType) {
+            match self.nodes.get_mut(&ComponentKey::from(id)) {
+                Some(Node::Sink { outputs, .. }) => outputs.push(SinkOutput {
+                    port: Some(port.to_string()),
+                    ty,
+                    schema_definition: None,
+                }),
+                _ => panic!("output added to non-sink"),
+            }
         }
     }
 
@@ -701,6 +734,20 @@ mod test {
                 "log_to_log.not_errors",
                 WildcardMatching::Strict
             )
+        );
+    }
+
+    #[test]
+    fn allows_sink_outputs() {
+        let mut graph = Graph::default();
+        graph.add_source("log_source", DataType::Log);
+        graph.add_sink("elastic", DataType::Log, vec!["log_source"]);
+        graph.add_sink_output("elastic", "dlq", DataType::Log);
+        graph.add_sink("dlq_sink", DataType::Log, vec![]);
+
+        assert_eq!(
+            Ok(()),
+            graph.test_add_input("dlq_sink", "elastic.dlq", WildcardMatching::Strict)
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use vector_config::configurable_component;
 pub use vector_lib::{
     config::{
-        AcknowledgementsConfig, DataType, GlobalOptions, Input, LogNamespace,
+        AcknowledgementsConfig, DataType, GlobalOptions, Input, LogNamespace, SinkOutput,
         SourceAcknowledgementsConfig, SourceOutput, TransformOutput, WildcardMatching,
     },
     configurable::component::{GenerateConfig, SinkDescription, TransformDescription},

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use serde_with::serde_as;
 use vector_lib::{
     buffers::{BufferConfig, BufferType},
-    config::{AcknowledgementsConfig, GlobalOptions, Input},
+    config::{AcknowledgementsConfig, GlobalOptions, Input, LogNamespace, SinkOutput},
     configurable::{
         Configurable, GenerateError, Metadata, NamedComponent,
         attributes::CustomAttribute,
@@ -15,6 +15,7 @@ use vector_lib::{
     },
     id::Inputs,
     sink::VectorSink,
+    source_sender::SourceSender,
 };
 use vector_vrl_metrics::MetricsStorage;
 
@@ -250,6 +251,11 @@ pub trait SinkConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync
     /// Gets the input configuration for this sink.
     fn input(&self) -> Input;
 
+    /// Gets the list of outputs exposed by this sink.
+    fn outputs(&self, _global_log_namespace: LogNamespace) -> Vec<SinkOutput> {
+        Vec::new()
+    }
+
     /// Gets the files to watch to trigger reload
     fn files_to_watch(&self) -> Vec<&PathBuf> {
         Vec::new()
@@ -274,6 +280,7 @@ dyn_clone::clone_trait_object!(SinkConfig);
 
 #[derive(Clone, Debug)]
 pub struct SinkContext {
+    pub key: Option<ComponentKey>,
     pub healthcheck: SinkHealthcheckOptions,
     pub globals: GlobalOptions,
     pub enrichment_tables: vector_lib::enrichment::TableRegistry,
@@ -282,6 +289,7 @@ pub struct SinkContext {
     pub schema: schema::Options,
     pub app_name: String,
     pub app_name_slug: String,
+    pub outputs: Option<SourceSender>,
 
     /// Extra context data provided by the running app and shared across all components. This can be
     /// used to pass shared settings or other data from outside the components.
@@ -291,6 +299,7 @@ pub struct SinkContext {
 impl Default for SinkContext {
     fn default() -> Self {
         Self {
+            key: Default::default(),
             healthcheck: Default::default(),
             globals: Default::default(),
             enrichment_tables: Default::default(),
@@ -299,6 +308,7 @@ impl Default for SinkContext {
             schema: Default::default(),
             app_name: crate::get_app_name().to_string(),
             app_name_slug: crate::get_slugified_app_name(),
+            outputs: Default::default(),
             extra_context: Default::default(),
         }
     }
@@ -311,5 +321,9 @@ impl SinkContext {
 
     pub const fn proxy(&self) -> &ProxyConfig {
         &self.proxy
+    }
+
+    pub const fn outputs(&self) -> Option<&SourceSender> {
+        self.outputs.as_ref()
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -254,6 +254,20 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
         }
     }
 
+    for (key, sink) in config.sinks.iter() {
+        if sink
+            .inner
+            .outputs(config.schema.log_namespace())
+            .iter()
+            .map(|output| output.port.as_deref().unwrap_or(""))
+            .any(|name| name == DEFAULT_OUTPUT)
+        {
+            errors.push(format!(
+                "Sink {key} cannot have a named output with reserved name: `{DEFAULT_OUTPUT}`"
+            ));
+        }
+    }
+
     if errors.is_empty() {
         Ok(())
     } else {

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -13,7 +13,7 @@ use vrl::value::Kind;
 
 use crate::{
     codecs::Transformer,
-    config::{AcknowledgementsConfig, DataType, Input, SinkConfig, SinkContext},
+    config::{AcknowledgementsConfig, DataType, Input, SinkConfig, SinkContext, SinkOutput},
     event::{EventRef, LogEvent, Value},
     http::{HttpClient, QueryParameters},
     internal_events::TemplateRenderingError,
@@ -28,8 +28,8 @@ use crate::{
             sink::ElasticsearchSink,
         },
         util::{
-            BatchConfig, Compression, RealtimeSizeBasedDefaultBatchSettings, http::RequestConfig,
-            service::HealthConfig,
+            BatchConfig, Compression, RealtimeSizeBasedDefaultBatchSettings, SinkDlq,
+            http::RequestConfig, service::HealthConfig,
         },
     },
     template::Template,
@@ -550,13 +550,20 @@ impl SinkConfig for ElasticsearchConfig {
 
         let health_config = self.endpoint_health.clone().unwrap_or_default();
 
+        let dlq = SinkDlq::from_context(&cx, "elasticsearch");
+
         let services = commons
             .iter()
             .map(|common| {
                 let endpoint = common.base_url.clone();
 
                 let http_request_builder = HttpRequestBuilder::new(common, self);
-                let service = ElasticsearchService::new(client.clone(), http_request_builder);
+                let service = ElasticsearchService::new(
+                    client.clone(),
+                    http_request_builder,
+                    self.request_retry_partial,
+                    dlq.clone(),
+                );
 
                 (endpoint, service)
             })
@@ -590,6 +597,10 @@ impl SinkConfig for ElasticsearchConfig {
         let requirements = Requirement::empty().optional_meaning("timestamp", Kind::timestamp());
 
         Input::new(DataType::Metric | DataType::Log).with_schema_requirement(requirements)
+    }
+
+    fn outputs(&self, _global_log_namespace: vector_lib::config::LogNamespace) -> Vec<SinkOutput> {
+        vec![SinkDlq::log_output()]
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {

--- a/src/sinks/elasticsearch/request_builder.rs
+++ b/src/sinks/elasticsearch/request_builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bytes::Bytes;
 use vector_lib::{
     EstimatedJsonEncodedSizeOf, json_size::JsonSize, request_metadata::RequestMetadata,
@@ -27,7 +29,7 @@ pub struct Metadata {
     finalizers: EventFinalizers,
     batch_size: usize,
     events_byte_size: JsonSize,
-    original_events: Vec<ProcessedEvent>,
+    original_events: Arc<Vec<ProcessedEvent>>,
 }
 
 impl RequestBuilder<Vec<ProcessedEvent>> for ElasticsearchRequestBuilder {
@@ -62,7 +64,7 @@ impl RequestBuilder<Vec<ProcessedEvent>> for ElasticsearchRequestBuilder {
             finalizers: events.take_finalizers(),
             batch_size: events.len(),
             events_byte_size,
-            original_events: events.clone(),
+            original_events: Arc::new(events.clone()),
         };
         (es_metadata, metadata_builder, events)
     }

--- a/src/sinks/elasticsearch/retry.rs
+++ b/src/sinks/elasticsearch/retry.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use http::StatusCode;
 use serde::Deserialize;
 use vector_lib::{EstimatedJsonEncodedSizeOf, json_size::JsonSize};
@@ -19,19 +21,21 @@ use crate::{
 };
 
 #[derive(Deserialize, Debug)]
-struct EsResultResponse {
+pub(super) struct EsResultResponse {
     items: Vec<EsResultItem>,
 }
 
 impl EsResultResponse {
-    fn parse(body: &str) -> Result<Self, String> {
+    pub(super) fn parse(body: &str) -> Result<Self, String> {
         serde_json::from_str::<EsResultResponse>(body).map_err(|json_error| {
             format!("some messages failed, could not parse response, error: {json_error}")
         })
     }
 
     /// Returns iterator over status codes for items and optional error details.
-    fn iter_status(&self) -> impl Iterator<Item = (StatusCode, Option<&EsErrorDetails>)> {
+    pub(super) fn iter_status(
+        &self,
+    ) -> impl Iterator<Item = (StatusCode, Option<&EsErrorDetails>)> {
         self.items.iter().filter_map(|item| {
             item.result()
                 .status
@@ -51,7 +55,10 @@ impl EsResultResponse {
             .find_map(|item| item.result().error.as_ref())
         {
             Some(error) => format!("error type: {}, reason: {}", error.err_type, error.reason),
-            None => format!("error response: {body}"),
+            None => format!(
+                "error response without item details (body bytes: {})",
+                body.len()
+            ),
         }
     }
 }
@@ -83,11 +90,11 @@ struct EsIndexResult {
     error: Option<EsErrorDetails>,
 }
 
-#[derive(Deserialize, Debug)]
-struct EsErrorDetails {
-    reason: String,
+#[derive(Clone, Deserialize, Debug)]
+pub(super) struct EsErrorDetails {
+    pub(super) reason: String,
     #[serde(rename = "type")]
-    err_type: String,
+    pub(super) err_type: String,
 }
 
 #[derive(Clone)]
@@ -154,8 +161,8 @@ impl RetryLogic for ElasticsearchRetryLogic {
                                         move |req: ElasticsearchRequest| {
                                             let mut failed_events: Vec<ProcessedEvent> = req
                                                 .original_events
-                                                .clone()
-                                                .into_iter()
+                                                .iter()
+                                                .cloned()
                                                 .zip(status_codes.iter())
                                                 .filter(|&(_, &flag)| flag)
                                                 .map(|(item, _)| item)
@@ -182,7 +189,7 @@ impl RetryLogic for ElasticsearchRetryLogic {
                                                 batch_size,
                                                 events_byte_size,
                                                 metadata,
-                                                original_events: failed_events,
+                                                original_events: Arc::new(failed_events),
                                                 elasticsearch_request_builder: req
                                                     .elasticsearch_request_builder,
                                             }

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -10,19 +10,20 @@ use hyper::{Body, Request, service::Service};
 use tower::ServiceExt;
 use vector_lib::{
     ByteSizeOf,
+    internal_event::{ComponentEventsDropped, UNINTENTIONAL},
     json_size::JsonSize,
     request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata},
     stream::DriverResponse,
 };
 
-use super::{ElasticsearchCommon, ElasticsearchConfig};
+use super::{ElasticsearchCommon, ElasticsearchConfig, retry::EsResultResponse};
 use crate::{
-    event::{EventFinalizers, EventStatus, Finalizable},
+    event::{Event, EventFinalizers, EventStatus, Finalizable},
     http::HttpClient,
     sinks::{
         elasticsearch::{encoder::ProcessedEvent, request_builder::ElasticsearchRequestBuilder},
         util::{
-            Compression, ElementCount,
+            Compression, ElementCount, SinkDlq,
             auth::Auth,
             http::{HttpBatchService, RequestConfig},
         },
@@ -36,7 +37,7 @@ pub struct ElasticsearchRequest {
     pub batch_size: usize,
     pub events_byte_size: JsonSize,
     pub metadata: RequestMetadata,
-    pub original_events: Vec<ProcessedEvent>, //store original_events for reconstruct request when retrying
+    pub original_events: Arc<Vec<ProcessedEvent>>, // store original_events for reconstruct request when retrying
     pub elasticsearch_request_builder: ElasticsearchRequestBuilder,
 }
 
@@ -77,12 +78,16 @@ pub struct ElasticsearchService {
         BoxFuture<'static, Result<http::Request<Bytes>, crate::Error>>,
         ElasticsearchRequest,
     >,
+    dlq: Option<SinkDlq>,
+    request_retry_partial: bool,
 }
 
 impl ElasticsearchService {
     pub fn new(
         http_client: HttpClient<Body>,
         http_request_builder: HttpRequestBuilder,
+        request_retry_partial: bool,
+        dlq: Option<SinkDlq>,
     ) -> ElasticsearchService {
         let http_request_builder = Arc::new(http_request_builder);
         let batch_service = HttpBatchService::new(http_client, move |req| {
@@ -91,7 +96,11 @@ impl ElasticsearchService {
                 Box::pin(async move { request_builder.build_request(req).await });
             future
         });
-        ElasticsearchService { batch_service }
+        ElasticsearchService {
+            batch_service,
+            dlq,
+            request_retry_partial,
+        }
     }
 }
 
@@ -101,6 +110,58 @@ pub struct HttpRequestBuilder {
     pub service_type: crate::sinks::elasticsearch::OpenSearchServiceType,
     pub compression: Compression,
     pub http_request_config: RequestConfig,
+}
+
+#[derive(Clone, Copy)]
+struct BulkFailureSummary {
+    had_failed_items: bool,
+    has_unhandled_failures: bool,
+    dlq_eligible_failures: usize,
+}
+
+impl BulkFailureSummary {
+    const fn handled_all_failures(self) -> bool {
+        self.had_failed_items && !self.has_unhandled_failures
+    }
+}
+
+fn is_status_dlq_eligible(status: http::StatusCode, request_retry_partial: bool) -> (bool, bool) {
+    let is_failed = !status.is_success();
+    let is_retryable = status == http::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+    let should_dlq = if request_retry_partial {
+        is_failed && !is_retryable
+    } else {
+        is_failed
+    };
+
+    (is_failed, should_dlq)
+}
+
+fn summarize_bulk_failures(
+    statuses: &[(http::StatusCode, Option<&super::retry::EsErrorDetails>)],
+    request_retry_partial: bool,
+    original_events_len: usize,
+) -> BulkFailureSummary {
+    let mut summary = BulkFailureSummary {
+        had_failed_items: false,
+        has_unhandled_failures: statuses.len() != original_events_len,
+        dlq_eligible_failures: 0,
+    };
+
+    for (status, _error) in statuses.iter().copied() {
+        let (is_failed, should_dlq) = is_status_dlq_eligible(status, request_retry_partial);
+        summary.had_failed_items |= is_failed;
+
+        if is_failed && !should_dlq {
+            summary.has_unhandled_failures = true;
+        }
+
+        if should_dlq {
+            summary.dlq_eligible_failures += 1;
+        }
+    }
+
+    summary
 }
 
 impl HttpRequestBuilder {
@@ -163,6 +224,82 @@ impl HttpRequestBuilder {
     }
 }
 
+/// Processes a successful bulk response with partial failures, routing DLQ-eligible events to
+/// the sink's DLQ output port and returning whether all failures were accounted for.
+///
+/// Returns `true` if every failure was either sent to the DLQ or is a retryable error that
+/// will be handled by the retry logic (e.g. 429 when `request_retry_partial` is enabled).
+async fn maybe_emit_dlq(
+    dlq: &mut Option<SinkDlq>,
+    original_events: &[ProcessedEvent],
+    parsed: &EsResultResponse,
+    request_retry_partial: bool,
+) -> Result<bool, crate::Error> {
+    let statuses: Vec<_> = parsed.iter_status().collect();
+    let orphan_count = original_events.len().saturating_sub(statuses.len());
+    let summary = summarize_bulk_failures(&statuses, request_retry_partial, original_events.len());
+
+    // No DLQ connected: emit a dropped-events metric for any events we can't route elsewhere.
+    if dlq.is_none() {
+        let dropped = summary.dlq_eligible_failures + orphan_count;
+        if dropped > 0 {
+            let reason = "elasticsearch partial failures had no connected dlq output";
+            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                count: dropped,
+                reason,
+            });
+            // Return false so get_event_status yields EventStatus::Rejected, making these
+            // failures visible as errors in vector top / topology metrics.
+            return Ok(false);
+        }
+        return Ok(summary.handled_all_failures());
+    }
+
+    if summary.dlq_eligible_failures == 0 && orphan_count == 0 {
+        return Ok(summary.handled_all_failures());
+    }
+
+    let d = dlq.as_mut().expect("dlq is Some, checked above");
+    let mut dlq_events = Vec::new();
+
+    // Collect events whose ES response status is non-retryable.
+    for (event, (status, error)) in original_events.iter().zip(statuses.iter().copied()) {
+        let (_, should_dlq) = is_status_dlq_eligible(status, request_retry_partial);
+        if should_dlq {
+            let mut event = event.clone();
+            let mut details = serde_json::Map::new();
+            details.insert("status".to_string(), status.as_u16().into());
+            details.insert("retry_partial".to_string(), request_retry_partial.into());
+            if let Some(error) = error {
+                details.insert("error_type".to_string(), error.err_type.clone().into());
+                details.insert("error_reason".to_string(), error.reason.clone().into());
+            }
+            d.annotate_log(&mut event.log, "elasticsearch_bulk_rejected", details);
+            dlq_events.push(Event::from(event.log));
+        }
+    }
+
+    // Collect orphaned events: ES returned fewer items than events sent (malformed response).
+    for event in &original_events[statuses.len()..] {
+        let mut event = event.clone();
+        d.annotate_log(
+            &mut event.log,
+            "elasticsearch_missing_response_item",
+            serde_json::Map::new(),
+        );
+        dlq_events.push(Event::from(event.log));
+    }
+
+    if !dlq_events.is_empty() {
+        d.send_events(dlq_events).await?;
+    }
+
+    // Return true if the DLQ actually handled something (DLQ-eligible failures or orphans).
+    // Retryable failures (429, 5xx when retry_partial=true) are handled independently by the
+    // tower retry layer
+    Ok(summary.dlq_eligible_failures > 0 || orphan_count > 0)
+}
+
 pub struct ElasticsearchResponse {
     pub http_response: Response<Bytes>,
     pub event_status: EventStatus,
@@ -192,13 +329,38 @@ impl Service<ElasticsearchRequest> for ElasticsearchService {
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, mut req: ElasticsearchRequest) -> Self::Future {
         let mut http_service = self.batch_service.clone();
+        let mut dlq = self.dlq.clone();
+        let request_retry_partial = self.request_retry_partial;
         Box::pin(async move {
             http_service.ready().await?;
             let events_byte_size =
                 std::mem::take(req.metadata_mut()).into_events_estimated_json_encoded_byte_size();
+            let original_events = Arc::clone(&req.original_events);
             let http_response = http_service.call(req).await?;
+            let parsed_bulk_response = if http_response.status().is_success() {
+                let body = String::from_utf8_lossy(http_response.body());
+                if body.contains("\"errors\":true") {
+                    EsResultResponse::parse(&body).ok()
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
 
-            let event_status = get_event_status(&http_response);
+            let dlq_handled_all_failures = match &parsed_bulk_response {
+                Some(parsed) => {
+                    maybe_emit_dlq(&mut dlq, &original_events, parsed, request_retry_partial)
+                        .await?
+                }
+                None => false,
+            };
+
+            let event_status = get_event_status(
+                &http_response,
+                dlq_handled_all_failures,
+                parsed_bulk_response.as_ref(),
+            );
             Ok(ElasticsearchResponse {
                 event_status,
                 http_response,
@@ -211,31 +373,265 @@ impl Service<ElasticsearchRequest> for ElasticsearchService {
 // This event is not part of the event framework but is kept because some users were depending on it
 // to identify the number of errors returned by Elasticsearch. It can be dropped when we have better
 // telemetry. Ref: #15886
-fn emit_bad_response_error(response: &Response<Bytes>) {
+fn emit_bad_response_error(response: &Response<Bytes>, parsed: Option<&EsResultResponse>) {
     let error_code = format!("http_response_{}", response.status().as_u16());
+    let mut item_status = None;
+    let mut error_type = None;
+    let mut error_reason = None;
+
+    if let Some(parsed) = parsed
+        && let Some((status, details)) = parsed
+            .iter_status()
+            .find(|(status, _)| !status.is_success())
+    {
+        item_status = Some(status.as_u16());
+        if let Some(details) = details {
+            error_type = Some(details.err_type.clone());
+            error_reason = Some(details.reason.clone());
+        }
+    }
 
     error!(
-        message =  "Response contained errors.",
+        message = "Response contained errors.",
         error_code = error_code,
-        response = ?response,
+        http_status = response.status().as_u16(),
+        body_bytes = response.body().len(),
+        item_status,
+        error_type,
+        error_reason,
     );
 }
 
-fn get_event_status(response: &Response<Bytes>) -> EventStatus {
+fn get_event_status(
+    response: &Response<Bytes>,
+    dlq_handled_all_failures: bool,
+    parsed_body: Option<&EsResultResponse>,
+) -> EventStatus {
     let status = response.status();
     if status.is_success() {
-        let body = String::from_utf8_lossy(response.body());
-        if body.contains("\"errors\":true") {
-            emit_bad_response_error(response);
-            EventStatus::Rejected
+        if parsed_body.is_some() {
+            // `"errors":true` was found and parsed; log error details from the pre-parsed body.
+            emit_bad_response_error(response, parsed_body);
+            if dlq_handled_all_failures {
+                EventStatus::Delivered
+            } else {
+                EventStatus::Rejected
+            }
         } else {
             EventStatus::Delivered
         }
     } else if status.is_server_error() {
-        emit_bad_response_error(response);
+        emit_bad_response_error(response, None);
         EventStatus::Errored
     } else {
-        emit_bad_response_error(response);
+        emit_bad_response_error(response, None);
         EventStatus::Rejected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use http::StatusCode;
+    use vector_lib::{
+        event::into_event_stream, request_metadata::RequestMetadata, source_sender::SourceSender,
+    };
+    use vrl::event_path;
+
+    use super::*;
+    use crate::{
+        config::{ComponentKey, SinkContext},
+        sinks::elasticsearch::{
+            BulkAction,
+            encoder::{DocumentMetadata, ElasticsearchEncoder},
+        },
+    };
+
+    fn processed_event(message: &str) -> ProcessedEvent {
+        ProcessedEvent {
+            index: "vector".to_string(),
+            bulk_action: BulkAction::Index,
+            log: crate::event::LogEvent::from(message),
+            document_metadata: DocumentMetadata::WithoutId,
+        }
+    }
+
+    fn request(events: Vec<ProcessedEvent>) -> ElasticsearchRequest {
+        ElasticsearchRequest {
+            payload: Bytes::new(),
+            finalizers: EventFinalizers::default(),
+            batch_size: events.len(),
+            events_byte_size: JsonSize::zero(),
+            metadata: RequestMetadata::default(),
+            original_events: Arc::new(events),
+            elasticsearch_request_builder: ElasticsearchRequestBuilder {
+                compression: Compression::None,
+                encoder: ElasticsearchEncoder::default(),
+            },
+        }
+    }
+
+    fn make_dlq(output: SourceSender) -> Option<SinkDlq> {
+        SinkDlq::from_context(
+            &SinkContext {
+                key: Some(ComponentKey::from("elastic")),
+                outputs: Some(output),
+                ..Default::default()
+            },
+            "elasticsearch",
+        )
+    }
+
+    fn dlq_sender() -> (SourceSender, impl futures::Stream<Item = Event> + Unpin) {
+        let mut builder = SourceSender::builder().with_buffer(10);
+        let rx = builder.add_sink_output(SinkDlq::log_output(), "elastic".into());
+        let sender = builder.build();
+        let stream = rx.into_stream().flat_map(into_event_stream);
+        (sender, stream)
+    }
+
+    fn parse_response_body(response: &http::Response<Bytes>) -> EsResultResponse {
+        let body = String::from_utf8_lossy(response.body());
+        EsResultResponse::parse(&body).expect("test response body must be valid ES response JSON")
+    }
+
+    #[tokio::test]
+    async fn emits_only_non_retryable_partial_failures_to_dlq() {
+        let (output, mut stream) = dlq_sender();
+        let mut dlq = make_dlq(output);
+        let req = request(vec![processed_event("first"), processed_event("second")]);
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .body(Bytes::from(
+                r#"{"errors":true,"items":[{"index":{"status":400,"error":{"type":"mapper_parsing_exception","reason":"bad mapping"}}},{"index":{"status":429}}]}"#,
+            ))
+            .unwrap();
+
+        let parsed = parse_response_body(&response);
+        assert!(
+            maybe_emit_dlq(&mut dlq, &req.original_events, &parsed, true)
+                .await
+                .unwrap()
+        );
+        drop(dlq);
+
+        let event = stream.next().await.unwrap().into_log();
+        assert_eq!(event.get_message().unwrap().to_string_lossy(), "first");
+        assert_eq!(
+            event.get(event_path!("metadata", "dlq", "reason")).unwrap(),
+            &"elasticsearch_bulk_rejected".into()
+        );
+        assert_eq!(
+            event.get(event_path!("metadata", "dlq", "status")).unwrap(),
+            &400.into()
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn emits_all_failed_items_to_dlq_when_partial_retry_disabled() {
+        let (output, mut stream) = dlq_sender();
+        let mut dlq = make_dlq(output);
+        let req = request(vec![processed_event("first"), processed_event("second")]);
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .body(Bytes::from(
+                r#"{"errors":true,"items":[{"index":{"status":400,"error":{"type":"mapper_parsing_exception","reason":"bad mapping"}}},{"index":{"status":429}}]}"#,
+            ))
+            .unwrap();
+
+        let parsed = parse_response_body(&response);
+        assert!(
+            maybe_emit_dlq(&mut dlq, &req.original_events, &parsed, false)
+                .await
+                .unwrap()
+        );
+        drop(dlq);
+
+        assert_eq!(
+            stream
+                .next()
+                .await
+                .unwrap()
+                .into_log()
+                .get_message()
+                .unwrap()
+                .to_string_lossy(),
+            "first"
+        );
+        assert_eq!(
+            stream
+                .next()
+                .await
+                .unwrap()
+                .into_log()
+                .get_message()
+                .unwrap()
+                .to_string_lossy(),
+            "second"
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn does_not_mark_retryable_partial_failures_as_fully_handled() {
+        let (output, mut stream) = dlq_sender();
+        let mut dlq = make_dlq(output);
+        let req = request(vec![processed_event("first")]);
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .body(Bytes::from(
+                r#"{"errors":true,"items":[{"index":{"status":429}}]}"#,
+            ))
+            .unwrap();
+
+        let parsed = parse_response_body(&response);
+        assert!(
+            !maybe_emit_dlq(&mut dlq, &req.original_events, &parsed, true)
+                .await
+                .unwrap()
+        );
+        drop(dlq);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn routes_orphaned_events_to_dlq_on_truncated_response() {
+        let (output, mut stream) = dlq_sender();
+        let mut dlq = make_dlq(output);
+        // 2 events sent, ES responds with only 1 item (truncated/malformed response).
+        let req = request(vec![processed_event("first"), processed_event("orphan")]);
+        let response = http::Response::builder()
+            .status(StatusCode::OK)
+            .body(Bytes::from(
+                r#"{"errors":true,"items":[{"index":{"status":400,"error":{"type":"mapper_parsing_exception","reason":"bad mapping"}}}]}"#,
+            ))
+            .unwrap();
+
+        let parsed = parse_response_body(&response);
+        assert!(
+            maybe_emit_dlq(&mut dlq, &req.original_events, &parsed, true)
+                .await
+                .unwrap()
+        );
+        drop(dlq);
+
+        // First event: DLQ'd due to 400 status
+        let event = stream.next().await.unwrap().into_log();
+        assert_eq!(event.get_message().unwrap().to_string_lossy(), "first");
+        assert_eq!(
+            event.get(event_path!("metadata", "dlq", "reason")).unwrap(),
+            &"elasticsearch_bulk_rejected".into()
+        );
+
+        // Second event: DLQ'd as orphan (no corresponding status in response)
+        let event = stream.next().await.unwrap().into_log();
+        assert_eq!(event.get_message().unwrap().to_string_lossy(), "orphan");
+        assert_eq!(
+            event.get(event_path!("metadata", "dlq", "reason")).unwrap(),
+            &"elasticsearch_missing_response_item".into()
+        );
+
+        assert!(stream.next().await.is_none());
     }
 }

--- a/src/sinks/util/dlq.rs
+++ b/src/sinks/util/dlq.rs
@@ -1,0 +1,86 @@
+use vector_lib::{
+    config::{DataType, SinkOutput},
+    source_sender::SourceSender,
+};
+use vrl::path::ValuePath;
+use vrl::{metadata_path, path};
+
+use crate::{
+    config::{ComponentKey, SinkContext, log_schema},
+    event::{Event, LogEvent},
+    schema::Definition,
+};
+
+/// Conventional sink output port name used for dead-letter routing.
+pub const DLQ_OUTPUT: &str = "dlq";
+
+#[derive(Clone)]
+pub struct SinkDlq {
+    component_id: ComponentKey,
+    component_type: &'static str,
+    output: SourceSender,
+}
+
+impl SinkDlq {
+    pub fn from_context(cx: &SinkContext, component_type: &'static str) -> Option<Self> {
+        let output = cx.outputs().cloned()?;
+        let component_id = cx
+            .key
+            .clone()
+            .unwrap_or_else(|| ComponentKey::from("unknown"));
+
+        Some(Self {
+            component_id,
+            component_type,
+            output,
+        })
+    }
+
+    pub fn log_output() -> SinkOutput {
+        SinkOutput::new_maybe_logs(DataType::Log, Definition::any()).with_port(DLQ_OUTPUT)
+    }
+
+    pub fn annotate_log(
+        &self,
+        log: &mut LogEvent,
+        reason: &str,
+        mut details: serde_json::Map<String, serde_json::Value>,
+    ) {
+        details.insert("reason".to_string(), reason.into());
+        details.insert(
+            "component_id".to_string(),
+            self.component_id.to_string().into(),
+        );
+        details.insert(
+            "component_type".to_string(),
+            self.component_type.to_string().into(),
+        );
+        details.insert("component_kind".to_string(), "sink".into());
+
+        let data = serde_json::Value::Object(details);
+
+        match log.namespace() {
+            vector_lib::config::LogNamespace::Legacy => {
+                if let Some(metadata_key) = log_schema().metadata_key() {
+                    use vrl::path::PathPrefix;
+                    log.insert((PathPrefix::Event, metadata_key.concat(path!("dlq"))), data);
+                }
+            }
+            vector_lib::config::LogNamespace::Vector => {
+                log.insert(metadata_path!("vector", "dlq"), data);
+            }
+        }
+    }
+
+    pub async fn send_events(&mut self, events: Vec<Event>) -> Result<(), crate::Error> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        // `send_batch_named` emits standard output metrics/events for the `dlq` port.
+        self.output
+            .send_batch_named(DLQ_OUTPUT, events)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -7,6 +7,7 @@ pub mod buffer;
 pub mod builder;
 pub mod compressor;
 pub mod datagram;
+pub mod dlq;
 pub mod encoding;
 pub mod http;
 pub mod metadata;
@@ -45,6 +46,7 @@ pub use buffer::{
 pub use builder::SinkBuilderExt;
 use chrono::{FixedOffset, Offset, Utc};
 pub use compressor::Compressor;
+pub use dlq::{DLQ_OUTPUT, SinkDlq};
 pub use normalizer::Normalizer;
 pub use request_builder::{IncrementalRequestBuilder, RequestBuilder};
 pub use service::{

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -168,6 +168,25 @@ impl<'a> Builder<'a> {
         finalized_outputs
     }
 
+    fn is_sink_output_connected(&self, sink_key: &ComponentKey, port: Option<&str>) -> bool {
+        let output_id = OutputId {
+            component: sink_key.clone(),
+            port: port.map(str::to_owned),
+        };
+
+        self.config
+            .transforms()
+            .any(|(_, transform)| transform.inputs.contains(&output_id))
+            || self
+                .config
+                .sinks()
+                .any(|(_, sink)| sink.inputs.contains(&output_id))
+            || self
+                .config
+                .enrichment_tables()
+                .any(|(_, table)| table.inputs.contains(&output_id))
+    }
+
     /// Loads, or reloads the enrichment tables.
     /// The tables are stored in the `ENRICHMENT_TABLES` global variable.
     async fn load_enrichment_tables(&mut self) -> &'static vector_lib::enrichment::TableRegistry {
@@ -546,6 +565,12 @@ impl<'a> Builder<'a> {
             debug!(component_id = %key, "Building new sink.");
 
             let sink_inputs = &sink.inputs;
+            let sink_outputs = sink
+                .inner
+                .outputs(self.config.schema.log_namespace())
+                .into_iter()
+                .filter(|output| self.is_sink_output_connected(key, output.port.as_deref()))
+                .collect::<Vec<_>>();
             let healthcheck = sink.healthcheck();
             let enable_healthcheck = healthcheck.enabled && self.config.healthchecks.enabled;
             let healthcheck_timeout = healthcheck.timeout;
@@ -560,6 +585,33 @@ impl<'a> Builder<'a> {
                 component_type = %sink.inner.get_component_name(),
             );
             let _entered_span = span.enter();
+
+            let mut sink_output_pumps = Vec::new();
+            let sink_output = if sink_outputs.is_empty() {
+                None
+            } else {
+                let mut builder = SourceSender::builder()
+                    .with_buffer(*SOURCE_SENDER_BUFFER_SIZE)
+                    .with_ewma_half_life_seconds(
+                        self.config.global.buffer_utilization_ewma_half_life_seconds,
+                    );
+
+                for output in sink_outputs.into_iter() {
+                    let rx = builder.add_sink_output(output.clone(), key.clone());
+                    let (fanout, control) = Fanout::new();
+                    let pump = run_sink_output_pump(rx, fanout);
+                    sink_output_pumps.push(pump.boxed());
+                    self.outputs.insert(
+                        OutputId {
+                            component: key.clone(),
+                            port: output.port.clone(),
+                        },
+                        control,
+                    );
+                }
+
+                Some(builder.build())
+            };
 
             // At this point, we've validated that all transforms are valid, including any
             // transform that mutates the schema provided by their sources. We can now validate the
@@ -601,6 +653,7 @@ impl<'a> Builder<'a> {
             };
 
             let cx = SinkContext {
+                key: Some(key.clone()),
                 healthcheck,
                 globals: self.config.global.clone(),
                 enrichment_tables: enrichment_tables.clone(),
@@ -609,6 +662,7 @@ impl<'a> Builder<'a> {
                 schema: self.config.schema,
                 app_name: crate::get_app_name().to_string(),
                 app_name_slug: crate::get_slugified_app_name(),
+                outputs: sink_output,
                 extra_context: self.extra_context.clone(),
             };
 
@@ -626,8 +680,15 @@ impl<'a> Builder<'a> {
                 .utilization_registry
                 .add_component(key.clone(), gauge!("utilization"));
             let component_key = key.clone();
+            let sink_output_pumps = sink_output_pumps;
             let sink = async move {
                 debug!("Sink starting.");
+
+                for pump in sink_output_pumps {
+                    let task_name =
+                        format!(">> {} ({}, output pump) >>", typetag, component_key.id());
+                    _ = spawn_named(pump, task_name.as_ref());
+                }
 
                 // Why is this Arc<Mutex<Option<_>>> needed you ask.
                 // In case when this function build_pieces errors
@@ -906,6 +967,30 @@ async fn run_source_output_pump(
     }
 
     debug!("Source pump finished normally.");
+    Ok(TaskOutput::Source)
+}
+
+async fn run_sink_output_pump(
+    mut rx: LimitedReceiver<SourceSenderItem>,
+    mut fanout: Fanout,
+) -> TaskResult {
+    debug!("Sink output pump starting.");
+
+    while let Some(SourceSenderItem {
+        events: array,
+        send_reference,
+    }) = rx.next().await
+    {
+        fanout
+            .send(array, Some(send_reference))
+            .await
+            .map_err(|e| {
+                debug!("Sink output pump finished with an error.");
+                TaskError::wrapped(e)
+            })?;
+    }
+
+    debug!("Sink output pump finished normally.");
     Ok(TaskOutput::Source)
 }
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -609,6 +609,7 @@ impl RunningTopology {
         for key in &removed_sinks {
             debug!(component_id = %key, "Removing sink.");
             self.remove_inputs(key, diff, new_config).await;
+            self.remove_outputs(key);
 
             if let Some(registry) = self.utilization_registry.as_ref() {
                 registry.remove_component(key);
@@ -633,6 +634,7 @@ impl RunningTopology {
 
         for key in &sinks_to_change {
             debug!(component_id = %key, "Changing sink.");
+            self.remove_outputs(key);
             if reuse_buffers.contains(key) {
                 self.detach_triggers
                     .remove(key)
@@ -722,7 +724,8 @@ impl RunningTopology {
             }
 
             for key in &diff.sinks.to_remove {
-                // Sinks only have inputs
+                // Sinks can have both inputs and outputs.
+                self.outputs_tap_metadata.remove(key);
                 self.inputs_tap_metadata.remove(key);
             }
 
@@ -776,6 +779,15 @@ impl RunningTopology {
                 }
             }
 
+            for key in diff.sinks.changed_and_added() {
+                if let Some(task) = new_pieces.tasks.get(key)
+                    && new_pieces.outputs.contains_key(key)
+                {
+                    self.outputs_tap_metadata
+                        .insert(key.clone(), ("sink", task.typetag().to_string()));
+                }
+            }
+
             for (key, input) in &new_pieces.inputs {
                 self.inputs_tap_metadata
                     .insert(key.clone(), input.1.clone());
@@ -803,6 +815,18 @@ impl RunningTopology {
         // need them to be available to any transforms and sinks that come afterwards.
         for key in diff.transforms.changed_and_added() {
             debug!(component_id = %key, "Configuring outputs for transform.");
+            self.setup_outputs(key, new_pieces).await;
+        }
+
+        let sink_keys_with_outputs = diff
+            .sinks
+            .changed_and_added()
+            .filter(|key| new_pieces.outputs.contains_key(*key))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for key in &sink_keys_with_outputs {
+            debug!(component_id = %key, "Configuring outputs for sink.");
             self.setup_outputs(key, new_pieces).await;
         }
 
@@ -885,8 +909,7 @@ impl RunningTopology {
                         .map(|key| key.to_string())
                         .chain(added_changed_tables.iter().map(|key| key.to_string()))
                         .collect(),
-                    // Note, only sources and transforms are relevant. Sinks do
-                    // not have outputs to tap.
+                    // Sources, transforms, and some sinks can expose outputs to tap.
                     removals,
                 })
                 .expect("Couldn't broadcast config changes.");


### PR DESCRIPTION
## Summary

This PR introduces a **Dead Letter Queue (DLQ)** output port for sinks, allowing failed/rejected events to be routed to other components instead of being silently dropped.

The implementation includes:
- A generic `SinkDlq` utility (`src/sinks/util/dlq.rs`) that can be adopted by any sink
- Full integration with the **Elasticsearch** sink, which routes non-retryable bulk failures (4xx) and orphaned events to the `<sink_id>.dlq` output port
- Each DLQ event is annotated with metadata explaining the failure (reason, status code, error type/reason from Elasticsearch)

The `request_retry_partial` flag controls behavior: retryable failures (429, 5xx) are retried normally; only truly non-retryable failures are sent to DLQ.

## Vector configuration

```yaml
api:
  enabled: true
sources:
  my_source:
    type: demo_logs
    format: shuffle
    lines:
      - '{"value":1,"tag":"ok"}'
      - '{"value":2,"tag":"ok"}'
      - '{"value":"bad","tag":"bad"}'
      - '{"value":"bad2","tag":"bad"}'
      - '{"value":3,"tag":"bad"}'

transforms:
  my_transform:
    type: remap
    inputs:
      - my_source
    source: |
      . = parse_json!(.message)
  my_dlq_transform:
    type: remap
    inputs:
      - "es_out.dlq"
    source: |
      .enter_dlq = true
sinks:
  es_out:
    type: elasticsearch
    inputs:
      - my_transform
    endpoints:
      - "http://localhost:9200"
    bulk:
      index: "test-index"
  es_dlq_out:
    type: elasticsearch
    inputs:
      - "my_dlq_transform"
    endpoints:
      - "http://localhost:9200"
    bulk:
      index: "test-index-no-mapping"
```


## How did you test this PR?
Unit tests in src/sinks/elasticsearch/service.rs covering:

- Non-retryable failures (4xx) routed to DLQ
- Retryable failures (429, 5xx) handled by retry logic
- Orphaned events (missing from Elasticsearch bulk response) routed to DLQ
- DLQ behavior with request_retry_partial enabled/disabled

I have tested in two way:
- Manual end-to-end testing with a local Elasticsearch instance using the configuration above
- Dev&Test env with vector that process normally 5k e/s and at peak 20k e/s.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #1772
- RFC used as a guide: #14708 


## Notes
N/A
