### PR TITLE
chore(dev): replace derivative macro with standard Default derives on enums

### DIFF
--- a/lib/codecs/src/decoding/format/vrl.rs
+++ b/lib/codecs/src/decoding/format/vrl.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use derivative::Derivative;
 use smallvec::{SmallVec, smallvec};
 use vector_config_macros::configurable_component;
 use vector_core::{
@@ -26,8 +25,7 @@ pub struct VrlDeserializerConfig {
 
 /// VRL-specific decoding options.
 #[configurable_component]
-#[derive(Debug, Clone, PartialEq, Eq, Derivative)]
-#[derivative(Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct VrlDeserializerOptions {
     /// The [Vector Remap Language][vrl] (VRL) program to execute for each event.
     /// Note that the final contents of the `.` target will be used as the decoding result.

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -85,11 +85,10 @@ pub struct ChunkedGelfDecoderOptions {
 
 /// Decompression options for ChunkedGelfDecoder.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ChunkedGelfDecompressionConfig {
     /// Automatically detect the decompression method based on the magic bytes of the message.
-    #[derivative(Default)]
+    #[default]
     Auto,
     /// Use Gzip decompression.
     Gzip,

--- a/lib/codecs/src/decoding/framing/length_delimited.rs
+++ b/lib/codecs/src/decoding/framing/length_delimited.rs
@@ -1,5 +1,4 @@
 use bytes::{Bytes, BytesMut};
-use derivative::Derivative;
 use tokio_util::codec::Decoder;
 use vector_config::configurable_component;
 
@@ -8,8 +7,7 @@ use crate::common::length_delimited::LengthDelimitedCoderOptions;
 
 /// Config used to build a `LengthDelimitedDecoder`.
 #[configurable_component]
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct LengthDelimitedDecoderConfig {
     /// Options for the length delimited decoder.
     #[serde(skip_serializing_if = "vector_core::serde::is_default")]

--- a/lib/codecs/src/decoding/framing/newline_delimited.rs
+++ b/lib/codecs/src/decoding/framing/newline_delimited.rs
@@ -1,5 +1,4 @@
 use bytes::{Bytes, BytesMut};
-use derivative::Derivative;
 use tokio_util::codec::Decoder;
 use vector_config::configurable_component;
 
@@ -16,8 +15,7 @@ pub struct NewlineDelimitedDecoderConfig {
 
 /// Options for building a `NewlineDelimitedDecoder`.
 #[configurable_component]
-#[derive(Clone, Debug, Derivative, PartialEq, Eq)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NewlineDelimitedDecoderOptions {
     /// The maximum length of the byte buffer.
     ///

--- a/lib/codecs/src/decoding/framing/octet_counting.rs
+++ b/lib/codecs/src/decoding/framing/octet_counting.rs
@@ -1,7 +1,6 @@
 use std::io;
 
 use bytes::{Buf, Bytes, BytesMut};
-use derivative::Derivative;
 use tokio_util::codec::{LinesCodec, LinesCodecError};
 use tracing::trace;
 use vector_config::configurable_component;
@@ -30,8 +29,7 @@ impl OctetCountingDecoderConfig {
 
 /// Options for building a `OctetCountingDecoder`.
 #[configurable_component]
-#[derive(Clone, Debug, Derivative, PartialEq, Eq)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct OctetCountingDecoderOptions {
     /// The maximum length of the byte buffer.
     #[serde(skip_serializing_if = "vector_core::serde::is_default")]

--- a/lib/codecs/src/decoding/framing/varint_length_delimited.rs
+++ b/lib/codecs/src/decoding/framing/varint_length_delimited.rs
@@ -1,5 +1,4 @@
 use bytes::{Buf, Bytes, BytesMut};
-use derivative::Derivative;
 use snafu::Snafu;
 use tokio_util::codec::Decoder;
 use vector_config::configurable_component;
@@ -38,8 +37,7 @@ impl FramingError for VarintFramingError {
 
 /// Config used to build a `VarintLengthDelimitedDecoder`.
 #[configurable_component]
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct VarintLengthDelimitedDecoderConfig {
     /// Maximum frame length
     #[serde(default = "default_max_frame_length")]

--- a/lib/codecs/src/encoding/framing/length_delimited.rs
+++ b/lib/codecs/src/encoding/framing/length_delimited.rs
@@ -1,5 +1,4 @@
 use bytes::BytesMut;
-use derivative::Derivative;
 use tokio_util::codec::{Encoder, LengthDelimitedCodec};
 use vector_config::configurable_component;
 
@@ -8,8 +7,7 @@ use crate::common::length_delimited::LengthDelimitedCoderOptions;
 
 /// Config used to build a `LengthDelimitedEncoder`.
 #[configurable_component]
-#[derive(Debug, Clone, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct LengthDelimitedEncoderConfig {
     /// Options for the length delimited decoder.
     #[serde(skip_serializing_if = "vector_core::serde::is_default")]

--- a/lib/codecs/src/encoding/framing/varint_length_delimited.rs
+++ b/lib/codecs/src/encoding/framing/varint_length_delimited.rs
@@ -1,5 +1,4 @@
 use bytes::{BufMut, BytesMut};
-use derivative::Derivative;
 use snafu::Snafu;
 use tokio_util::codec::Encoder;
 use vector_config::configurable_component;
@@ -17,8 +16,7 @@ impl FramingError for VarintFramingError {}
 
 /// Config used to build a `VarintLengthDelimitedEncoder`.
 #[configurable_component]
-#[derive(Debug, Clone, PartialEq, Eq, Derivative)]
-#[derivative(Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct VarintLengthDelimitedEncoderConfig {
     /// Maximum frame length
     #[serde(default = "default_max_frame_length")]

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -19,12 +19,11 @@ enum KafkaError {
 
 /// Supported compression types for Kafka.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum KafkaCompression {
     /// No compression.
-    #[derivative(Default)]
+    #[default]
     None,
 
     /// Gzip.

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -26,12 +26,11 @@ use crate::{
 ///
 /// [formats]: https://clickhouse.com/docs/en/interfaces/formats
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
 #[serde(rename_all = "snake_case")]
-#[derivative(Default)]
 #[allow(clippy::enum_variant_names)]
 pub enum Format {
-    #[derivative(Default)]
+    #[default]
     /// JSONEachRow.
     JsonEachRow,
 

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -18,14 +18,13 @@ use crate::{
 ///
 /// [standard_streams]: https://en.wikipedia.org/wiki/Standard_streams
 #[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Target {
     /// Write output to [STDOUT][stdout].
     ///
     /// [stdout]: https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)
-    #[derivative(Default)]
+    #[default]
     Stdout,
 
     /// Write output to [STDERR][stderr].

--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -80,7 +80,7 @@ pub enum ElasticsearchMode {
 
 /// Bulk API actions.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum BulkAction {
     /// The `index` action.
@@ -127,7 +127,7 @@ impl TryFrom<&str> for BulkAction {
 
 /// Elasticsearch version types.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum VersionType {
     /// The `internal` type.

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -162,8 +162,7 @@ pub(super) enum StackdriverLogName {
 
 /// Label Configuration.
 #[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default)]
 pub(super) struct StackdriverLabelConfig {
     /// The value of this field is used to retrieve the associated labels from the `jsonPayload`
     /// and extract their values to set as LogEntry labels.

--- a/src/sinks/gcp_chronicle/compression.rs
+++ b/src/sinks/gcp_chronicle/compression.rs
@@ -20,11 +20,10 @@ use crate::sinks::util::{
 };
 
 /// Compression configuration.
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum ChronicleCompression {
     /// No compression.
-    #[derivative(Default)]
+    #[default]
     None,
 
     /// [Gzip][gzip] compression.

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -26,8 +26,7 @@ pub fn default_endpoint() -> String {
 ///
 /// [predefined_acls]: https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum GcsPredefinedAcl {
     /// Bucket/object can be read by authenticated users.
@@ -65,7 +64,7 @@ pub enum GcsPredefinedAcl {
     /// part of the project team is granted the `READER` permission.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     ProjectPrivate,
 
     /// Bucket/object can be read publicly.
@@ -81,14 +80,13 @@ pub enum GcsPredefinedAcl {
 ///
 /// [storage_classes]: https://cloud.google.com/storage/docs/storage-classes
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, PartialEq, Eq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum GcsStorageClass {
     /// Standard storage.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     Standard,
 
     /// Nearline storage.

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -18,7 +18,7 @@ use crate::sinks::{
 #[configurable(metadata(
     deprecated = "The `greptimedb` sink has been renamed. Please use `greptimedb_metrics` instead."
 ))]
-#[derive(Clone, Debug, Derivative)]
+#[derive(Clone, Debug, Default)]
 pub struct GreptimeDBConfig(GreptimeDBMetricsConfig);
 
 impl GenerateConfig for GreptimeDBConfig {

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -115,9 +115,8 @@ pub struct HttpSinkConfig {
 ///
 /// [rfc9110]: https://datatracker.ietf.org/doc/html/rfc9110#section-9.1
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
-#[derivative(Default)]
 pub enum HttpMethod {
     /// GET.
     Get,
@@ -126,7 +125,7 @@ pub enum HttpMethod {
     Head,
 
     /// POST.
-    #[derivative(Default)]
+    #[default]
     Post,
 
     /// PUT.

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -171,8 +171,7 @@ impl SinkBatchSettings for LokiDefaultBatchSettings {
 /// any necessary sorting/reordering. If you're using an earlier version, then you must use `Drop`
 /// or `RewriteTimestamp` depending on which option makes the most sense for your use case.
 #[configurable_component]
-#[derive(Copy, Clone, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Copy, Clone, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum OutOfOrderAction {
     /// Accept the event.
@@ -180,7 +179,7 @@ pub enum OutOfOrderAction {
     /// The event is not dropped and is sent without modification.
     ///
     /// Requires Loki 2.4.0 or newer.
-    #[derivative(Default)]
+    #[default]
     Accept,
 
     /// Rewrite the timestamp of the event to the timestamp of the latest event seen by the sink.

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -53,13 +53,12 @@ pub struct MqttSinkConfig {
 
 /// Supported Quality of Service types for MQTT.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 #[allow(clippy::enum_variant_names)]
 pub enum MqttQoS {
     /// AtLeastOnce.
-    #[derivative(Default)]
+    #[default]
     AtLeastOnce,
 
     /// AtMostOnce.

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -12,12 +12,11 @@ use crate::{http::HttpClient, sinks::prelude::*};
 
 /// New Relic region.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
-#[derivative(Default)]
 pub enum NewRelicRegion {
     /// US region.
-    #[derivative(Default)]
+    #[default]
     Us,
 
     /// EU region.
@@ -26,12 +25,11 @@ pub enum NewRelicRegion {
 
 /// New Relic API endpoint.
 #[configurable_component]
-#[derive(Clone, Copy, Derivative, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
-#[derivative(Default)]
 pub enum NewRelicApi {
     /// Events API.
-    #[derivative(Default)]
+    #[default]
     Events,
 
     /// Metrics API.

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -162,12 +162,11 @@ pub struct OAuth2Config {
 
 /// Supported compression types for Pulsar.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum PulsarCompression {
     /// No compression.
-    #[derivative(Default)]
+    #[default]
     None,
 
     /// LZ4.

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -22,8 +22,7 @@ impl TowerRequestConfigDefaults for RedisTowerRequestConfigDefaults {
 
 /// Redis data type to store messages in.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DataTypeConfig {
     /// The Redis `list` type.
@@ -31,7 +30,7 @@ pub enum DataTypeConfig {
     /// This resembles a deque, where messages can be popped and pushed from either end.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     List,
 
     /// The Redis `sorted set` type.
@@ -48,7 +47,7 @@ pub enum DataTypeConfig {
 
 /// List-specific options.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub struct ListOption {
     /// The method to use for pushing messages into a `list`.
@@ -57,8 +56,7 @@ pub struct ListOption {
 
 /// Method for pushing messages into a `list`.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ListMethod {
     /// Use the `rpush` method.
@@ -66,7 +64,7 @@ pub enum ListMethod {
     /// This pushes messages onto the tail of the list.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     RPush,
 
     /// Use the `lpush` method.
@@ -77,7 +75,7 @@ pub enum ListMethod {
 
 /// Sorted Set-specific options
 #[configurable_component]
-#[derive(Clone, Debug, Derivative, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub struct SortedSetOption {
     /// The method to use for pushing messages into a `sorted set`.
@@ -96,8 +94,7 @@ pub struct SortedSetOption {
 
 /// Method for pushing messages into a `sorted set`.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum SortedSetMethod {
     /// Use the `zadd` method.
@@ -105,7 +102,7 @@ pub enum SortedSetMethod {
     /// This adds messages onto a queue with a score.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     ZAdd,
 }
 
@@ -281,14 +278,13 @@ impl From<SentinelConnectionSettings> for SentinelNodeConnectionInfo {
 
 /// How/if TLS should be established.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum MaybeTlsMode {
     /// Don't use TLS.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     None,
 
     /// Enable TLS with certificate verification.
@@ -311,8 +307,7 @@ impl From<MaybeTlsMode> for Option<TlsMode> {
 /// Connection independent information used to establish a connection
 /// to a redis instance sentinel owns.
 #[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RedisConnectionSettings {
     /// The database number to use. Usually `0`.
     pub db: i64,
@@ -340,13 +335,12 @@ impl From<RedisConnectionSettings> for RedisConnectionInfo {
 
 /// The communication protocol to use with the redis server.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum RedisProtocolVersion {
     /// Use RESP2.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     RESP2,
 
     /// Use RESP3.

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -141,12 +141,11 @@ fn example_tags() -> HashMap<String, String> {
 ///
 /// [aws_docs]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, PartialEq, Eq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum S3StorageClass {
     /// Standard Redundancy.
-    #[derivative(Default)]
+    #[default]
     Standard,
 
     /// Reduced Redundancy.
@@ -228,8 +227,7 @@ impl From<S3ServerSideEncryption> for ServerSideEncryption {
 ///
 /// [canned_acl]: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum S3CannedAcl {
     /// Bucket/object are private.
@@ -238,7 +236,7 @@ pub enum S3CannedAcl {
     /// access.
     ///
     /// This is the default.
-    #[derivative(Default)]
+    #[default]
     Private,
 
     /// Bucket/object can be read publicly.

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -50,11 +50,10 @@ use crate::{
 
 /// Request handling action when the request limit has been exceeded.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 enum Action {
-    #[derivative(Default)]
+    #[default]
     /// Additional requests will return with an error.
     Defer,
 

--- a/src/sinks/util/buffer/compression.rs
+++ b/src/sinks/util/buffer/compression.rs
@@ -16,11 +16,10 @@ use vector_lib::configurable::{
 use crate::sinks::util::zstd::ZstdCompressionLevel;
 
 /// Compression configuration.
-#[derive(Copy, Clone, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum Compression {
     /// No compression.
-    #[derivative(Default)]
+    #[default]
     None,
 
     /// [Gzip][gzip] compression.

--- a/src/sinks/util/service/concurrency.rs
+++ b/src/sinks/util/service/concurrency.rs
@@ -18,7 +18,7 @@ use vector_lib::configurable::{
 ///
 /// This can be set either to one of the below enum values or to a positive integer, which denotes
 /// a fixed concurrency limit.
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 pub enum Concurrency {
     /// A fixed concurrency of 1.
     ///

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -113,9 +113,8 @@ const fn access_keys_example() -> [&'static str; 2] {
 /// Compression scheme for records in a Firehose message.
 #[configurable_component]
 #[configurable(metadata(docs::advanced))]
-#[derive(Clone, Copy, Debug, Derivative, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[derivative(Default)]
 pub enum Compression {
     /// Automatically attempt to determine the compression scheme.
     ///
@@ -127,7 +126,7 @@ pub enum Compression {
     /// set `gzip` in this field so that any records that are not-gzipped are rejected.
     ///
     /// [magic_bytes]: https://en.wikipedia.org/wiki/List_of_file_signatures
-    #[derivative(Default)]
+    #[default]
     Auto,
 
     /// Uncompressed.

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -34,9 +34,8 @@ pub mod sqs;
 /// Compression scheme for objects retrieved from S3.
 #[configurable_component]
 #[configurable(metadata(docs::advanced))]
-#[derive(Clone, Copy, Debug, Derivative, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[derivative(Default)]
 pub enum Compression {
     /// Automatically attempt to determine the compression scheme.
     ///
@@ -44,7 +43,7 @@ pub enum Compression {
     /// `Content-Type` metadata, as well as the key suffix (for example, `.gz`).
     ///
     /// It is set to `none` if the compression scheme cannot be determined.
-    #[derivative(Default)]
+    #[default]
     Auto,
 
     /// Uncompressed.
@@ -59,14 +58,13 @@ pub enum Compression {
 
 /// Strategies for consuming objects from AWS S3.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative)]
+#[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
-#[derivative(Default)]
 enum Strategy {
     /// Consumes objects by processing bucket notification events sent to an [AWS SQS queue][aws_sqs].
     ///
     /// [aws_sqs]: https://aws.amazon.com/sqs/
-    #[derivative(Default)]
+    #[default]
     Sqs,
 }
 

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -94,8 +94,7 @@ pub enum DemoLogsConfigError {
 
 /// Output format configuration.
 #[configurable_component]
-#[derive(Clone, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Default)]
 #[serde(tag = "format", rename_all = "snake_case")]
 #[configurable(metadata(
     docs::enum_tag_description = "The format of the randomly generated output."
@@ -136,7 +135,7 @@ pub enum OutputFormat {
     /// Randomly generated HTTP server logs in [JSON][json] format.
     ///
     /// [json]: https://en.wikipedia.org/wiki/JSON
-    #[derivative(Default)]
+    #[default]
     Json,
 }
 

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -35,12 +35,11 @@ enum BuildError {
 
 /// Data type to use for reading messages from Redis.
 #[configurable_component]
-#[derive(Copy, Clone, Debug, Derivative)]
-#[derivative(Default)]
+#[derive(Copy, Clone, Debug, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DataTypeConfig {
     /// The `list` data type.
-    #[derivative(Default)]
+    #[default]
     List,
 
     /// The `channel` data type.
@@ -51,7 +50,7 @@ pub enum DataTypeConfig {
 
 /// Options for the Redis `list` data type.
 #[configurable_component]
-#[derive(Copy, Clone, Debug, Default, Derivative, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub struct ListOption {
     #[configurable(derived)]
@@ -60,12 +59,11 @@ pub struct ListOption {
 
 /// Method for getting events from the `list` data type.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
-#[derivative(Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Method {
     /// Pop messages from the head of the list.
-    #[derivative(Default)]
+    #[default]
     Lpop,
 
     /// Pop messages from the tail of the list.

--- a/src/sources/util/body_decoding.rs
+++ b/src/sources/util/body_decoding.rs
@@ -2,12 +2,11 @@ use vector_lib::configurable::configurable_component;
 
 /// Content encoding.
 #[configurable_component]
-#[derive(Clone, Copy, Debug, Derivative, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
-#[derivative(Default)]
 pub enum Encoding {
     /// Plaintext.
-    #[derivative(Default)]
+    #[default]
     Text,
 
     /// Newline-delimited JSON.


### PR DESCRIPTION
## Summary

Replaces uses of the `derivative` crate's `#[derivative(Default)]` attribute on enums with the standard Rust `#[default]` attribute on enum variants, and removes `Derivative` from the corresponding `#[derive(...)]` lists.

## Vector configuration

NA

## How did you test this PR?

`make check-clippy`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA