### PR TITLE
chore(website deps): remove unused fs package

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,6 @@
     "domhandler": "^4.2.0",
     "dotenv-defaults": "^2.0.2",
     "downshift": "^6.1.3",
-    "fs": "^0.0.1-security",
     "glob-promise": "^4.2.0",
     "lodash.chunk": "^4.2.0",
     "path": "^0.12.7",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2432,11 +2432,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
-
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"


### PR DESCRIPTION
## Summary

Removes the unused `fs` npm package ([npmjs.com/package/fs](https://www.npmjs.com/package/fs)) from website dependencies. The `fs` package has been flagged as malicious ([MAL-2025-21003](https://osv.dev/vulnerability/MAL-2025-21003)). The version we were using (0.0.1-security) is not itself malicious but is completely useless — it's a placeholder that does nothing.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA