### PR TITLE
chore(website): Add osv-scanner.toml and ignore MAL-2025-3174

### DIFF
--- a/website/osv-scanner.toml
+++ b/website/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "MAL-2025-3174"
+reason = "typesense-sync: package pulled in from s3 and not from npm"


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Ignore MAL-2025-3174 which incorrectly flags `typesense-sync` as malware. This package is being pulled in from s3 not npm.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
```sh
osv-scanner scan -L website/yarn.lock
```

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- [MAL-2025-3174](https://osv.dev/vulnerability/MAL-2025-3174)
<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->
