### PR TITLE
chore(deps): upgrade mold linker from 1.2.1/2.0.0 to 2.40.4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -182,7 +182,7 @@ runs:
         # We explicitly put `mold-wrapper.so` right beside `mold` itself because it's hard-coded to look in the same directory
         # first when trying to load the shared object, so we can dodge having to care about the "right" lib folder to put it in.
         TEMP=$(mktemp -d)
-        MOLD_VERSION=1.2.1
+        MOLD_VERSION=2.40.4
         MOLD_TARGET=mold-${MOLD_VERSION}-$(uname -m)-linux
         curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${MOLD_TARGET}.tar.gz" \
         --output "$TEMP/${MOLD_TARGET}.tar.gz"

--- a/scripts/environment/bootstrap-ubuntu-24.04.sh
+++ b/scripts/environment/bootstrap-ubuntu-24.04.sh
@@ -145,7 +145,7 @@ if [ -z "${DISABLE_MOLD:-""}" ] ; then
     # We explicitly put `mold-wrapper.so` right beside `mold` itself because it's hard-coded to look in the same directory
     # first when trying to load the shared object, so we can dodge having to care about the "right" lib folder to put it in.
     TEMP=$(mktemp -d)
-    MOLD_VERSION=1.2.1
+    MOLD_VERSION=2.40.4
     MOLD_TARGET=mold-${MOLD_VERSION}-$(uname -m)-linux
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/${MOLD_TARGET}.tar.gz" \
         --output "$TEMP/${MOLD_TARGET}.tar.gz"

--- a/tilt/Dockerfile
+++ b/tilt/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install build-essential
 RUN git clone https://github.com/rui314/mold.git \
     && mkdir mold/build \
     && cd mold/build \
-    && git checkout v2.0.0 \
+    && git checkout v2.40.4 \
     && ../install-build-deps.sh \
     && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ .. \
     && cmake --build . -j $(nproc) \


### PR DESCRIPTION
## Summary

Upgrades mold linker to v2.40.4 (latest) across all three locations where it is installed or built.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA