### PR TITLE
docs(aws_sns sink): correct documentation to use SNS topic terminology

### DIFF
--- a/src/sinks/aws_s_s/config.rs
+++ b/src/sinks/aws_s_s/config.rs
@@ -14,9 +14,9 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub(super) enum BuildError {
-    #[snafu(display("`message_group_id` should be defined for FIFO queue."))]
+    #[snafu(display("`message_group_id` should be defined for FIFO queue or topic."))]
     MessageGroupIdMissing,
-    #[snafu(display("`message_group_id` is not allowed with non-FIFO queue."))]
+    #[snafu(display("`message_group_id` is not allowed with non-FIFO queue or topic."))]
     MessageGroupIdNotAllowed,
     #[snafu(display("invalid topic template: {}", source))]
     TopicTemplate { source: TemplateParseError },
@@ -32,17 +32,19 @@ pub(super) struct BaseSSSinkConfig {
 
     /// The tag that specifies that a message belongs to a specific message group.
     ///
-    /// Can be applied only to FIFO queues.
+    /// Can be applied only to FIFO queues or FIFO topics.
     #[configurable(metadata(docs::examples = "vector"))]
     #[configurable(metadata(docs::examples = "vector-%Y-%m-%d"))]
     pub(super) message_group_id: Option<String>,
 
     /// The message deduplication ID value to allow AWS to identify duplicate messages.
     ///
-    /// This value is a template which should result in a unique string for each event. See the [AWS
-    /// documentation][deduplication_id_docs] for more about how AWS does message deduplication.
+    /// This value is a template which should result in a unique string for each event. See the [SQS
+    /// documentation][sqs_deduplication_id_docs] or [SNS documentation][sns_deduplication_id_docs]
+    /// for more about how AWS does message deduplication.
     ///
-    /// [deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+    /// [sqs_deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+    /// [sns_deduplication_id_docs]: https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
     #[configurable(metadata(docs::examples = "{{ transaction_id }}"))]
     pub(super) message_deduplication_id: Option<String>,
 

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -17,7 +17,7 @@ use crate::{
 /// Configuration for the `aws_sqs` sink.
 #[configurable_component(sink(
     "aws_sqs",
-    "Publish observability events to AWS Simple Queue Service topics."
+    "Publish observability events to AWS Simple Queue Service queues."
 ))]
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]

--- a/website/cue/reference/components/sinks/aws_sns.cue
+++ b/website/cue/reference/components/sinks/aws_sns.cue
@@ -43,7 +43,7 @@ components: sinks: aws_sns: components._aws & {
 				enabled_by_scheme:      true
 			}
 			to: {
-				service: services.aws_sqs
+				service: services.aws_sns
 
 				interface: {
 					socket: {
@@ -66,7 +66,7 @@ components: sinks: aws_sns: components._aws & {
 		notices: []
 	}
 
-	configuration: generated.components.sinks.aws_sqs.configuration & {
+	configuration: generated.components.sinks.aws_sns.configuration & {
 		_aws_include: false
 	}
 
@@ -79,7 +79,7 @@ components: sinks: aws_sns: components._aws & {
 	permissions: iam: [
 		{
 			platform:  "aws"
-			_service:  "sqs"
+			_service:  "sns"
 			_docs_tag: "AWSSimpleNotificationService"
 
 			policies: [

--- a/website/cue/reference/components/sinks/generated/aws_sns.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sns.cue
@@ -593,10 +593,12 @@ generated: components: sinks: aws_sns: configuration: {
 		description: """
 			The message deduplication ID value to allow AWS to identify duplicate messages.
 
-			This value is a template which should result in a unique string for each event. See the [AWS
-			documentation][deduplication_id_docs] for more about how AWS does message deduplication.
+			This value is a template which should result in a unique string for each event. See the [SQS
+			documentation][sqs_deduplication_id_docs] or [SNS documentation][sns_deduplication_id_docs]
+			for more about how AWS does message deduplication.
 
-			[deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+			[sqs_deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+			[sns_deduplication_id_docs]: https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
 			"""
 		required: false
 		type: string: examples: ["{{ transaction_id }}"]
@@ -605,7 +607,7 @@ generated: components: sinks: aws_sns: configuration: {
 		description: """
 			The tag that specifies that a message belongs to a specific message group.
 
-			Can be applied only to FIFO queues.
+			Can be applied only to FIFO queues or FIFO topics.
 			"""
 		required: false
 		type: string: examples: ["vector", "vector-%Y-%m-%d"]

--- a/website/cue/reference/components/sinks/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sqs.cue
@@ -593,10 +593,12 @@ generated: components: sinks: aws_sqs: configuration: {
 		description: """
 			The message deduplication ID value to allow AWS to identify duplicate messages.
 
-			This value is a template which should result in a unique string for each event. See the [AWS
-			documentation][deduplication_id_docs] for more about how AWS does message deduplication.
+			This value is a template which should result in a unique string for each event. See the [SQS
+			documentation][sqs_deduplication_id_docs] or [SNS documentation][sns_deduplication_id_docs]
+			for more about how AWS does message deduplication.
 
-			[deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+			[sqs_deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
+			[sns_deduplication_id_docs]: https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html
 			"""
 		required: false
 		type: string: examples: ["{{ transaction_id }}"]
@@ -605,7 +607,7 @@ generated: components: sinks: aws_sqs: configuration: {
 		description: """
 			The tag that specifies that a message belongs to a specific message group.
 
-			Can be applied only to FIFO queues.
+			Can be applied only to FIFO queues or FIFO topics.
 			"""
 		required: false
 		type: string: examples: ["vector", "vector-%Y-%m-%d"]

--- a/website/cue/reference/services/aws_sns.cue
+++ b/website/cue/reference/services/aws_sns.cue
@@ -1,0 +1,10 @@
+package metadata
+
+services: aws_sns: {
+	name:     "AWS Simple Notification Service"
+	thing:    "an \(name) topic"
+	url:      urls.aws_sns
+	versions: null
+
+	description: "[Amazon Simple Notification Service (SNS)](\(urls.aws_sns)) is a fully managed pub/sub messaging service that enables you to decouple microservices, distributed systems, and serverless applications."
+}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -83,6 +83,7 @@ urls: {
 	aws_s3_sse:                                 "\(aws_docs)/AmazonS3/latest/dev/UsingServerSideEncryption.html"
 	aws_s3_storage_classes:                     "https://aws.amazon.com/s3/storage-classes/"
 	aws_s3_tags:                                "\(aws_docs)/AmazonS3/latest/user-guide/add-object-tags.html"
+	aws_sns:                                    "https://aws.amazon.com/sns/"
 	aws_sns_api:                                "\(aws_docs)/AWSSimpleNotificationService/latest/APIReference/Welcome.html"
 	aws_sqs:                                    "https://aws.amazon.com/sqs/"
 	aws_sqs_api:                                "\(aws_docs)/AWSSimpleQueueService/latest/APIReference/Welcome.html"


### PR DESCRIPTION
## Summary

The `aws_sns` sink documentation was incorrectly referencing SQS configuration and terminology throughout. The `topic_arn` field was not appearing in the live docs at all because the CUE configuration pointed to the `aws_sqs` generated config instead of `aws_sns`.

## Vector configuration

NA

## How did you test this PR?

Ran `make generate-component-docs` to regenerate the component docs and verified `topic_arn` now appears correctly in the generated `aws_sns.cue`.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #24934