### PR TITLE
docs(dnstap source): regenerate VRL docs with message size fields

### DIFF
--- a/docs/generated/parse_dnstap.json
+++ b/docs/generated/parse_dnstap.json
@@ -41,6 +41,8 @@
         "extraInfo": "",
         "messageType": "ResolverQuery",
         "messageTypeId": 3,
+        "requestMessageSize": 54,
+        "responseMessageSize": 100,
         "queryZone": "com.",
         "requestData": {
           "fullRcode": 0,


### PR DESCRIPTION
## Summary

Regenerates `docs/generated/parse_dnstap.json` to include the `requestMessageSize` and `responseMessageSize` fields added in #24552. The `check-generated-vrl-docs` CI check caught this but was not a required status check, so the PR merged anyway. It has since been added as a required check.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #24552