### PR TITLE
fix(releasing): add libsasl2-2 runtime dep to Debian-based images

### DIFF
--- a/distribution/docker/debian/Dockerfile
+++ b/distribution/docker/debian/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.opencontainers.image.documentation="https://vector.dev/docs"
 
 # we want the latest versions of these
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata systemd && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates tzdata systemd libsasl2-2 && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/bin/vector /usr/bin/vector
 COPY --from=builder /usr/share/vector /usr/share/vector

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # TARGET
 #
 FROM docker.io/debian:trixie-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
-RUN apt-get update && apt-get dist-upgrade -y && apt-get -y --no-install-recommends install zlib1g ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get dist-upgrade -y && apt-get -y --no-install-recommends install zlib1g ca-certificates libsasl2-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /vector/vector /usr/bin/vector
 RUN mkdir --parents --mode=0777 /var/lib/vector
 


### PR DESCRIPTION
## Summary

- Adds `libsasl2-2` to the apt-get install in `distribution/docker/debian/Dockerfile`
- Adds `libsasl2-2` to the apt-get install in `regression/Dockerfile`

## Root cause

Commit fd766a073 changed the `default` Cargo feature from `rdkafka?/gssapi-vendored` (static linking) to `rdkafka?/gssapi` (dynamic linking). After this change, the vector binary requires `libsasl2.so.2` at runtime, but neither Debian-based Docker final stage installed it, causing the smoke-test to fail:

```
/usr/bin/vector: error while loading shared libraries: libsasl2.so.2: cannot open shared object file: No such file or directory
ERROR: process "/usr/bin/vector --version" did not complete successfully: exit code: 127
```

This broke both the distribution image build and the regression detection suite.

## Test plan

- [x] Docker build of `distribution/docker/debian/Dockerfile` succeeds with smoke test passing
- [x] Docker build of `regression/Dockerfile` succeeds with smoke test passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)