### PR TITLE
chore(external docs): instruct agents to use PR template when creating PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ make build-licenses
 
 ## Creating Pull Requests
 
-Before opening a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and use it as the body structure.
+Before opening a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and use it as the reference for the PR body structure and title.
 
 ## Reference Documentation
 


### PR DESCRIPTION
## Summary

Adds a "Creating Pull Requests" section to `AGENTS.md` instructing AI agents to read and follow `.github/PULL_REQUEST_TEMPLATE.md` when opening PRs. This ensures agents produce properly structured PRs that match the project's expectations.

## Vector configuration

N/A

## How did you test this PR?

Documentation-only change.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Related: #
-->