### PR TITLE
feat(ci): add Datadog static analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,26 @@
+name: Static Analysis
+
+on:
+  push:
+    branches:
+      - master
+      - "**"  # Run on all branches (includes PR branches)
+  workflow_dispatch:  # Allow manual trigger from GitHub UI
+
+permissions:
+  contents: read
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Datadog Static Analyzer
+        if: ${{ secrets.DD_API_KEY != '' }}
+        uses: DataDog/datadog-static-analyzer-github-action@8340f18875fcefca86844b5f947ce2431387e552 # v3.0.0
+        with:
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_site: datadoghq.com
+          secrets_enabled: true


### PR DESCRIPTION
## Summary

Adds a Datadog Static Analysis CI workflow to Vector, mirroring what was done in the VRL repo. Runs the Datadog Static Analyzer on all branches on push.

## Vector configuration

N/A

## How did you test this PR?

CI-only change. Verified workflow syntax.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Related: #
-->