### PR TITLE
fix(ci): use cargo nextest in coverage workflow to prevent test pollution

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
           datadog-ci: true
 
       - name: "Generate code coverage"
-        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
 
       - name: "Upload coverage to Datadog"
         env:


### PR DESCRIPTION
## Summary

Switch the code coverage workflow from `cargo llvm-cov` to `cargo llvm-cov nextest`. The standard `cargo test` runner executes tests in the same process, allowing global state mutations (e.g. log schema changes) from one test to bleed into others. `cargo nextest` runs each test in an isolated process, matching the behavior of regular CI and preventing spurious failures.

## Vector configuration

NA

## How did you test this PR?

The failing tests (`test_rfc3164_sanitization`, `test_rfc5424_empty_message_and_sd`) reproduce with `cargo llvm-cov` and pass with `cargo llvm-cov nextest`.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- [CI run](https://github.com/vectordotdev/vector/actions/runs/23363740057)