### PR TITLE
chore(deps): ignore RUSTSEC-2026-0049 (rustls-webpki) until rustls can be upgraded

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,4 @@ ignore = [
   # rustls-webpki 0.101.7 vulnerability. Fix requires upgrading rustls from 0.21 to 0.23+,
   # which is a significant chain upgrade through aws-smithy-http-client, hyper-rustls, tokio-rustls, etc.
   { id = "RUSTSEC-2026-0049", reason = "Fix requires major rustls upgrade (0.21 -> 0.23+); tracked for future upgrade" },
-  # tokio-io 0.1.13 is unmaintained; no safe upgrade available (superseded by tokio crate itself).
-  { id = "RUSTSEC-2026-0058", reason = "tokio-io is unmaintained with no safe upgrade available" },
 ]


### PR DESCRIPTION
## Summary

`make check-deny` fails due to **RUSTSEC-2026-0049** (`rustls-webpki 0.101.7`): a vulnerability where certificates with multiple CRL distribution points only have the first one checked, so subsequent CRLs can be silently skipped for revocation. The fix requires `rustls-webpki >= 0.103.10`, which means upgrading `rustls` from `0.21` to `0.23+` — a significant chain that touches `aws-smithy-http-client`, `hyper-rustls`, `tokio-rustls`, and `tokio-tungstenite`.

Some crates have not yet updated to `rustls-webpki >= 0.103.10`, such as async-nats. Others are permanently stuck on older versions of rustls since we're using very outdated versions, like tonic/reqwest/bollard/etc. These depend on the http 1.0 upgrade

## Vector configuration

N/A

## How did you test this PR?

```
make check-deny
```

Output: `advisories ok, bans ok, licenses ok, sources ok`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #19179
- Related: #24975