### PR TITLE
chore(dev): pin localstack image to SHA256 digest

### DIFF
--- a/tests/integration/aws/config/compose.yaml
+++ b/tests/integration/aws/config/compose.yaml
@@ -4,7 +4,7 @@ services:
   mock-ec2-metadata:
     image: public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.13.0
   mock-localstack:
-    image: docker.io/localstack/localstack:stable
+    image: docker.io/localstack/localstack@sha256:46302bcb91a7e8008e6394be8afafdbfa40fb77a54d4046a38be35992042d5de
     environment:
     - SERVICES=kinesis,s3,cloudwatch,es,firehose,kms,sqs,sns,logs
   mock-ecs:


### PR DESCRIPTION
## Summary

Pin the localstack Docker image to a specific SHA256 digest instead of the `stable` tag. This was blocking the MQ due to an unexpected image update.

## Vector configuration

NA

## How did you test this PR?

Ran the AWS integration tests locally.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- https://github.com/vectordotdev/vector/actions/runs/23439651808/job/68188196363