### PR TITLE
chore(ci): add missing Windows source files to integration_windows filter

### DIFF
--- a/.github/workflows/integration_windows.yml
+++ b/.github/workflows/integration_windows.yml
@@ -23,6 +23,9 @@ jobs:
             windows:
               - "src/sources/windows_event_log/**"
               - "src/internal_events/windows_event_log.rs"
+              - "src/internal_events/windows.rs"
+              - "src/vector_windows.rs"
+              - "src/service.rs"
               - "tests/integration/windows-event-log/**"
               - ".github/workflows/integration_windows.yml"
 


### PR DESCRIPTION
## Summary

The `integration_windows.yml` path filter was missing three Windows-related source files, meaning changes to those files would not trigger the Windows integration tests.

Added:
- `src/vector_windows.rs` -- Windows service dispatcher/entry point
- `src/internal_events/windows.rs` -- Windows service start/stop internal events
- `src/service.rs` -- Windows service control logic (`#[cfg(windows)]`)

## Vector configuration

N/A -- CI-only change.

## How did you test this PR?

Verified the missing files exist and contain Windows-specific code. No functional code changes.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)