### PR TITLE
enhancement(transforms): dynamic rate for sample

### DIFF
--- a/changelog.d/sample_dynamic_ratio_field.feature.md
+++ b/changelog.d/sample_dynamic_ratio_field.feature.md
@@ -1,0 +1,3 @@
+Added `ratio_field` and `rate_field` options to the `sample` transform to support dynamic per-event sampling, while requiring static `rate` or `ratio` fallback configuration and disallowing `ratio_field` and `rate_field` together.
+
+authors: jhammer

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -6,7 +6,7 @@ use vector_lib::{
 };
 use vrl::value::Kind;
 
-use super::transform::{Sample, SampleMode};
+use super::transform::{DynamicSampleFields, Sample, SampleMode};
 use crate::{
     conditions::AnyCondition,
     config::{
@@ -29,10 +29,18 @@ pub enum SampleError {
     #[snafu(display("Only non-zero numbers are allowed values for `rate`"))]
     InvalidRate,
 
+    #[snafu(display("Only one value can be provided for either 'rate' or 'ratio', but not both"))]
+    InvalidStaticConfiguration,
+
     #[snafu(display(
-        "Exactly one value must be provided for either 'rate' or 'ratio', but not both"
+        "Only one value can be provided for either 'ratio_field' or 'rate_field', but not both"
     ))]
-    InvalidConfiguration,
+    InvalidDynamicConfiguration,
+
+    #[snafu(display(
+        "Exactly one value must be provided for either 'rate' or 'ratio' to configure static sampling"
+    ))]
+    MissingStaticConfiguration,
 }
 
 /// Configuration for the `sample` transform.
@@ -60,6 +68,22 @@ pub struct SampleConfig {
     #[configurable(metadata(docs::examples = 0.13))]
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
     pub ratio: Option<f64>,
+
+    /// The event field whose numeric value is used as the sampling ratio on a per-event basis.
+    ///
+    /// The value must be in `(0, 1]` to be considered valid. If the field is missing or invalid,
+    /// static sampling settings (`rate` or `ratio`) are used as a fallback.
+    /// This option cannot be used together with `rate_field`.
+    #[configurable(metadata(docs::examples = "sample_rate"))]
+    pub ratio_field: Option<String>,
+
+    /// The event field whose integer value is used as the sampling rate on a per-event basis, expressed as `1/N`.
+    ///
+    /// The value must be a positive integer to be considered valid. If the field is missing or invalid,
+    /// static sampling settings (`rate` or `ratio`) are used as a fallback.
+    /// This option cannot be used together with `ratio_field`.
+    #[configurable(metadata(docs::examples = "sample_rate_n"))]
+    pub rate_field: Option<String>,
 
     /// The name of the field whose value is hashed to determine if the event should be
     /// sampled.
@@ -96,6 +120,14 @@ pub struct SampleConfig {
 
 impl SampleConfig {
     fn sample_rate(&self) -> Result<SampleMode, SampleError> {
+        if self.ratio_field.is_some() && self.rate_field.is_some() {
+            return Err(SampleError::InvalidDynamicConfiguration);
+        }
+
+        if self.rate.is_some() && self.ratio.is_some() {
+            return Err(SampleError::InvalidStaticConfiguration);
+        }
+
         match (self.rate, self.ratio) {
             (None, Some(ratio)) => {
                 if ratio <= 0.0 {
@@ -111,7 +143,8 @@ impl SampleConfig {
                     Ok(SampleMode::new_rate(rate))
                 }
             }
-            _ => Err(SampleError::InvalidConfiguration),
+            (None, None) => Err(SampleError::MissingStaticConfiguration),
+            _ => Err(SampleError::InvalidStaticConfiguration),
         }
     }
 }
@@ -121,6 +154,8 @@ impl GenerateConfig for SampleConfig {
         toml::Value::try_from(Self {
             rate: None,
             ratio: Some(0.1),
+            ratio_field: None,
+            rate_field: None,
             key_field: None,
             group_by: None,
             exclude: None::<AnyCondition>,
@@ -134,9 +169,13 @@ impl GenerateConfig for SampleConfig {
 #[typetag::serde(name = "sample")]
 impl TransformConfig for SampleConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::function(Sample::new(
+        Ok(Transform::function(Sample::new_with_dynamic(
             Self::NAME.to_string(),
             self.sample_rate()?,
+            DynamicSampleFields {
+                ratio_field: self.ratio_field.clone(),
+                rate_field: self.rate_field.clone(),
+            },
             self.key_field.clone(),
             self.group_by.clone(),
             self.exclude
@@ -191,10 +230,74 @@ pub fn default_sample_rate_key() -> OptionalValuePath {
 
 #[cfg(test)]
 mod tests {
-    use crate::transforms::sample::config::SampleConfig;
+    use crate::{config::TransformConfig, transforms::sample::config::SampleConfig};
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<SampleConfig>();
+    }
+
+    #[test]
+    fn rejects_dynamic_ratio_only_configuration() {
+        let config = SampleConfig {
+            rate: None,
+            ratio: None,
+            ratio_field: Some("sample_rate".to_string()),
+            rate_field: None,
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        assert!(config.validate(&crate::schema::Definition::any()).is_err());
+    }
+
+    #[test]
+    fn rejects_dynamic_rate_only_configuration() {
+        let config = SampleConfig {
+            rate: None,
+            ratio: None,
+            ratio_field: None,
+            rate_field: Some("sample_rate_n".to_string()),
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        assert!(config.validate(&crate::schema::Definition::any()).is_err());
+    }
+
+    #[test]
+    fn validates_static_with_dynamic_configuration() {
+        let config = SampleConfig {
+            rate: Some(10),
+            ratio: None,
+            ratio_field: None,
+            rate_field: Some("sample_rate_n".to_string()),
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        assert!(config.validate(&crate::schema::Definition::any()).is_ok());
+    }
+
+    #[test]
+    fn rejects_both_dynamic_fields_configuration() {
+        let config = SampleConfig {
+            rate: Some(10),
+            ratio: None,
+            ratio_field: Some("sample_rate".to_string()),
+            rate_field: Some("sample_rate_n".to_string()),
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        assert!(config.validate(&crate::schema::Definition::any()).is_err());
     }
 }

--- a/src/transforms/sample/tests.rs
+++ b/src/transforms/sample/tests.rs
@@ -14,7 +14,7 @@ use crate::{
         FunctionTransform, OutputBuffer,
         sample::{
             config::{SampleConfig, default_sample_rate_key},
-            transform::{Sample, SampleMode},
+            transform::{DynamicSampleFields, Sample, SampleMode},
         },
         test::{create_topology, transform_one},
     },
@@ -26,6 +26,8 @@ async fn emits_internal_events() {
         let config = SampleConfig {
             rate: None,
             ratio: Some(1.0),
+            ratio_field: None,
+            rate_field: None,
             key_field: None,
             group_by: None,
             exclude: None,
@@ -322,6 +324,113 @@ fn sample_at_rates_higher_then_half() {
             .count();
         assert_eq!(total_observed as f64, 10000.0 * sampler.ratio());
     }
+}
+
+#[test]
+fn dynamic_ratio_field_overrides_static_ratio() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.1),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        Some("other_field".into()),
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut event = Event::Log(LogEvent::from("hello"));
+    let log = event.as_mut_log();
+    log.insert("other_field", "foo");
+    log.insert("dynamic_ratio", 1.0);
+
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_ratio_field_falls_back_to_static_ratio_when_missing() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(1.0),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        None,
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let event = Event::Log(LogEvent::from("hello"));
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_ratio_field_falls_back_to_static_rate_when_missing() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_rate(2),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        None,
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let event = Event::Log(LogEvent::from("hello"));
+    assert!(transform_one(&mut sampler, event).is_some());
+}
+
+#[test]
+fn dynamic_rate_field_overrides_static_ratio() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        Some("other_field".into()),
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut event = Event::Log(LogEvent::from("hello"));
+    let log = event.as_mut_log();
+    log.insert("other_field", "foo");
+    log.insert("dynamic_rate", 1);
+
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_rate_field_falls_back_to_static_ratio_when_missing() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(1.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        None,
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let event = Event::Log(LogEvent::from("hello"));
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
 }
 
 fn condition_contains(key: &str, needle: &str) -> Condition {

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -89,6 +89,32 @@ impl SampleMode {
             } => hash <= *hash_ratio_threshold,
         }
     }
+
+    fn hash_with_ratio(value: &[u8], ratio: f64) -> bool {
+        let hash = seahash::hash(value);
+        let hash_ratio_threshold = (ratio * (u64::MAX as u128) as f64) as u64;
+        hash <= hash_ratio_threshold
+    }
+}
+
+enum EventSampleMode {
+    Ratio(f64),
+    Rate(u64),
+}
+
+#[derive(Clone, Default)]
+pub struct DynamicSampleFields {
+    pub ratio_field: Option<String>,
+    pub rate_field: Option<String>,
+}
+
+impl fmt::Display for EventSampleMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Ratio(ratio) => write!(f, "{ratio}"),
+            Self::Rate(rate) => write!(f, "{rate}"),
+        }
+    }
 }
 
 impl fmt::Display for SampleMode {
@@ -105,7 +131,11 @@ impl fmt::Display for SampleMode {
 #[derive(Clone)]
 pub struct Sample {
     name: String,
-    rate: SampleMode,
+    static_mode: SampleMode,
+    ratio_field: Option<String>,
+    rate_field: Option<String>,
+    dynamic_values: HashMap<Option<String>, f64>,
+    dynamic_counters: HashMap<Option<String>, u64>,
     key_field: Option<String>,
     group_by: Option<Template>,
     exclude: Option<Condition>,
@@ -116,7 +146,7 @@ impl Sample {
     // This function is dead code when the feature flag `transforms-impl-sample` is specified but not
     // `transforms-sample`.
     #![allow(dead_code)]
-    pub const fn new(
+    pub fn new(
         name: String,
         rate: SampleMode,
         key_field: Option<String>,
@@ -124,9 +154,33 @@ impl Sample {
         exclude: Option<Condition>,
         sample_rate_key: OptionalValuePath,
     ) -> Self {
-        Self {
+        Self::new_with_dynamic(
             name,
             rate,
+            DynamicSampleFields::default(),
+            key_field,
+            group_by,
+            exclude,
+            sample_rate_key,
+        )
+    }
+
+    pub fn new_with_dynamic(
+        name: String,
+        static_mode: SampleMode,
+        dynamic_fields: DynamicSampleFields,
+        key_field: Option<String>,
+        group_by: Option<Template>,
+        exclude: Option<Condition>,
+        sample_rate_key: OptionalValuePath,
+    ) -> Self {
+        Self {
+            name,
+            static_mode,
+            ratio_field: dynamic_fields.ratio_field,
+            rate_field: dynamic_fields.rate_field,
+            dynamic_values: HashMap::default(),
+            dynamic_counters: HashMap::default(),
             key_field,
             group_by,
             exclude,
@@ -136,9 +190,107 @@ impl Sample {
 
     #[cfg(test)]
     pub fn ratio(&self) -> f64 {
-        match self.rate {
-            SampleMode::Rate { rate, .. } => 1.0f64 / rate as f64,
-            SampleMode::Ratio { ratio, .. } => ratio,
+        match &self.static_mode {
+            SampleMode::Rate { rate, .. } => 1.0f64 / *rate as f64,
+            SampleMode::Ratio { ratio, .. } => *ratio,
+        }
+    }
+
+    fn increment_dynamic_ratio(
+        &mut self,
+        ratio: f64,
+        group_by_key: Option<String>,
+        value: Option<&Value>,
+    ) -> bool {
+        let threshold_exceeded = {
+            let current_value = self
+                .dynamic_values
+                .entry(group_by_key)
+                .or_insert(1.0 - ratio);
+            let incremented_value = *current_value + ratio;
+            *current_value = if incremented_value >= 1.0 {
+                incremented_value - 1.0
+            } else {
+                incremented_value
+            };
+            incremented_value >= 1.0
+        };
+
+        if let Some(value) = value {
+            SampleMode::hash_with_ratio(value.to_string_lossy().as_bytes(), ratio)
+        } else {
+            threshold_exceeded
+        }
+    }
+
+    fn event_ratio(&self, event: &Event) -> Option<f64> {
+        let ratio_field = self.ratio_field.as_ref()?;
+        let value = self.get_event_value(event, ratio_field.as_str())?;
+
+        let ratio = match value {
+            Value::Integer(value) => *value as f64,
+            Value::Float(value) => value.into_inner(),
+            Value::Bytes(bytes) => std::str::from_utf8(bytes).ok()?.parse::<f64>().ok()?,
+            _ => return None,
+        };
+
+        (ratio > 0.0 && ratio <= 1.0).then_some(ratio)
+    }
+
+    fn event_rate(&self, event: &Event) -> Option<u64> {
+        let rate_field = self.rate_field.as_ref()?;
+        let value = self.get_event_value(event, rate_field.as_str())?;
+
+        match value {
+            Value::Integer(value) => (*value > 0).then_some(*value as u64),
+            Value::Float(value) => {
+                let value = value.into_inner();
+                (value.is_finite()
+                    && value > 0.0
+                    && value.fract() == 0.0
+                    && value <= u64::MAX as f64)
+                    .then_some(value as u64)
+            }
+            Value::Bytes(bytes) => std::str::from_utf8(bytes)
+                .ok()?
+                .parse::<u64>()
+                .ok()
+                .filter(|value| *value > 0),
+            _ => None,
+        }
+    }
+
+    fn get_event_value<'a>(&self, event: &'a Event, path: &str) -> Option<&'a Value> {
+        match event {
+            Event::Log(event) => event.parse_path_and_get_value(path).ok().flatten(),
+            Event::Trace(event) => event.parse_path_and_get_value(path).ok().flatten(),
+            Event::Metric(_) => panic!("component can never receive metric events"),
+        }
+    }
+
+    fn event_sample_mode(&self, event: &Event) -> Option<EventSampleMode> {
+        self.event_ratio(event)
+            .map(EventSampleMode::Ratio)
+            .or_else(|| self.event_rate(event).map(EventSampleMode::Rate))
+    }
+
+    fn increment_dynamic_rate(
+        &mut self,
+        rate: u64,
+        group_by_key: Option<String>,
+        value: Option<&Value>,
+    ) -> bool {
+        let threshold_exceeded = {
+            let counter_value = self.dynamic_counters.entry(group_by_key).or_default();
+            let old_counter_value = *counter_value;
+            *counter_value += 1;
+            old_counter_value.is_multiple_of(rate)
+        };
+
+        if let Some(value) = value {
+            seahash::hash(value.to_string_lossy().as_bytes()).is_multiple_of(rate)
+        } else {
+            threshold_exceeded
         }
     }
 }
@@ -188,7 +340,23 @@ impl FunctionTransform for Sample {
             .ok()
         });
 
-        if self.rate.increment(group_by_key, value) {
+        let event_sample_mode = self.event_sample_mode(&event);
+        let sample_rate = event_sample_mode
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| self.static_mode.to_string());
+
+        let should_sample = match event_sample_mode {
+            Some(EventSampleMode::Ratio(ratio)) => {
+                self.increment_dynamic_ratio(ratio, group_by_key, value)
+            }
+            Some(EventSampleMode::Rate(rate)) => {
+                self.increment_dynamic_rate(rate, group_by_key, value)
+            }
+            None => self.static_mode.increment(group_by_key, value),
+        };
+
+        if should_sample {
             if let Some(path) = &self.sample_rate_key.path {
                 match event {
                     Event::Log(ref mut event) => {
@@ -197,11 +365,11 @@ impl FunctionTransform for Sample {
                             event,
                             Some(LegacyKey::Overwrite(path)),
                             path,
-                            self.rate.to_string(),
+                            sample_rate.clone(),
                         );
                     }
                     Event::Trace(ref mut event) => {
-                        event.insert(&OwnedTargetPath::event(path.clone()), self.rate.to_string());
+                        event.insert(&OwnedTargetPath::event(path.clone()), sample_rate);
                     }
                     Event::Metric(_) => panic!("component can never receive metric events"),
                 };

--- a/website/cue/reference/components/transforms/generated/sample.cue
+++ b/website/cue/reference/components/transforms/generated/sample.cue
@@ -63,6 +63,28 @@ generated: components: transforms: sample: configuration: {
 			0.13,
 		]
 	}
+	ratio_field: {
+		description: """
+			The event field whose numeric value is used as the sampling ratio on a per-event basis.
+
+			The value must be in `(0, 1]` to be considered valid. If the field is missing or invalid,
+			static sampling settings (`rate` or `ratio`) are used as a fallback.
+			This option cannot be used together with `rate_field`.
+			"""
+		required: false
+		type: string: examples: ["sample_rate"]
+	}
+	rate_field: {
+		description: """
+			The event field whose integer value is used as the sampling rate on a per-event basis, expressed as `1/N`.
+
+			The value must be a positive integer to be considered valid. If the field is missing or invalid,
+			static sampling settings (`rate` or `ratio`) are used as a fallback.
+			This option cannot be used together with `ratio_field`.
+			"""
+		required: false
+		type: string: examples: ["sample_rate_n"]
+	}
 	sample_rate_key: {
 		description: "The event key in which the sample rate is stored. If set to an empty string, the sample rate will not be added to the event."
 		required:    false


### PR DESCRIPTION
## Summary
This PR improves the `sample` transform for per-event sampling use cases by adding dynamic field-driven sampling while preserving safe fallback behavior.

Changes included:
- Add `ratio_field` support for per-event ratio sampling (`(0, 1]`).
- Add `rate_field` support for per-event `1/N` sampling (positive integer).
- Requires static sampling configuration (`rate` or `ratio`), as a default value. i.e. dynamic-only mode is not allowed.
- Disallow configuring `ratio_field` and `rate_field` together (mirrors the existing `rate` vs `ratio` exclusivity pattern).
- Keeps `sample_rate_key` populated with the effective sampling value used for each sampled event.
- Add validation and transform tests for fallback behavior and invalid configs.
- Update generated transform reference metadata and changelog fragment.

## Vector configuration
```toml
[transforms.sample_dynamic]
type = "sample"
inputs = ["in"]

# required static fallback (exactly one of these)
ratio = 0.01
# rate = 100

# optional dynamic field (choose one)
ratio_field = "sample_ratio"
# rate_field = "sample_rate_n"

# optional deterministic/keyed sampling controls
key_field = "trace_id"
group_by = "{{ service }}"
```

## How did you test this PR?
Ran locally:
- `cargo fmt --all`
- `cargo test --no-default-features --features transforms-sample sample:: --lib`
- `cargo clippy --no-default-features --features transforms-sample --lib --tests -- -D warnings`
- `./scripts/check_changelog_fragments.sh`

Test coverage added/updated includes:
- reject dynamic ratio-only config
- reject dynamic rate-only config
- reject config that sets both dynamic fields
- accept static + dynamic config
- dynamic ratio overrides static
- dynamic rate overrides static
- dynamic ratio fallback to static ratio/rate when missing
- dynamic rate fallback to static ratio when missing

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Related: dynamic per-event sampling use case for `sample` transform

