### PR TITLE
enhancement(transforms): dynamic rate for sample

### DIFF
--- a/changelog.d/sample_dynamic_ratio_field.feature.md
+++ b/changelog.d/sample_dynamic_ratio_field.feature.md
@@ -1,0 +1,3 @@
+Added `ratio_field` and `rate_field` options to the `sample` transform to support dynamic per-event sampling, while requiring static `rate` or `ratio` fallback configuration and disallowing `ratio_field` and `rate_field` together.
+
+authors: jhammer

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -6,7 +6,7 @@ use vector_lib::{
 };
 use vrl::value::Kind;
 
-use super::transform::{Sample, SampleMode};
+use super::transform::{DynamicSampleFields, Sample, SampleMode};
 use crate::{
     conditions::AnyCondition,
     config::{
@@ -29,10 +29,23 @@ pub enum SampleError {
     #[snafu(display("Only non-zero numbers are allowed values for `rate`"))]
     InvalidRate,
 
+    #[snafu(display("Only one value can be provided for either 'rate' or 'ratio', but not both"))]
+    InvalidStaticConfiguration,
+
     #[snafu(display(
-        "Exactly one value must be provided for either 'rate' or 'ratio', but not both"
+        "Only one value can be provided for either 'ratio_field' or 'rate_field', but not both"
     ))]
-    InvalidConfiguration,
+    InvalidDynamicConfiguration,
+
+    #[snafu(display(
+        "Exactly one value must be provided for either 'rate' or 'ratio' to configure static sampling"
+    ))]
+    MissingStaticConfiguration,
+
+    #[snafu(display(
+        "'key_field' cannot be combined with 'ratio_field' or 'rate_field' because dynamic values can vary per event and break key-based coherence"
+    ))]
+    InvalidKeyFieldDynamicCombination,
 }
 
 /// Configuration for the `sample` transform.
@@ -61,6 +74,24 @@ pub struct SampleConfig {
     #[configurable(validation(range(min = 0.0, max = 1.0)))]
     pub ratio: Option<f64>,
 
+    /// The event field whose numeric value is used as the sampling ratio on a per-event basis.
+    ///
+    /// Accepts integer, floating point, or string values that parse as a number. The value must be
+    /// in `(0, 1]` to be considered valid (for example, `0.25` keeps 25%). If the field is missing
+    /// or invalid, static sampling settings (`rate` or `ratio`) are used as a fallback.
+    /// This option cannot be used together with `rate_field`.
+    #[configurable(metadata(docs::examples = "sample_rate"))]
+    pub ratio_field: Option<String>,
+
+    /// The event field whose integer value is used as the sampling rate on a per-event basis, expressed as `1/N`.
+    ///
+    /// Accepts an integer, or a string that parses as a positive integer; floating point values
+    /// are rejected. The value must be a positive integer to be considered valid. If the field is
+    /// missing or invalid, static sampling settings (`rate` or `ratio`) are used as a fallback.
+    /// This option cannot be used together with `ratio_field`.
+    #[configurable(metadata(docs::examples = "sample_rate_n"))]
+    pub rate_field: Option<String>,
+
     /// The name of the field whose value is hashed to determine if the event should be
     /// sampled.
     ///
@@ -72,6 +103,8 @@ pub struct SampleConfig {
     ///
     /// This can be useful to, for example, ensure that all logs for a given transaction are
     /// sampled together, but that overall `1/N` transactions are sampled.
+    ///
+    /// This option cannot be combined with `ratio_field` or `rate_field`.
     #[configurable(metadata(docs::examples = "message"))]
     pub key_field: Option<String>,
 
@@ -84,6 +117,9 @@ pub struct SampleConfig {
     ///
     /// If left unspecified, or if the event doesn't have `group_by`, then the event is not
     /// sampled separately.
+    ///
+    /// This can also be used with `ratio_field` or `rate_field` to apply dynamic sampling
+    /// independently per rendered group value.
     #[configurable(metadata(
         docs::examples = "{{ service }}",
         docs::examples = "{{ hostname }}-{{ service }}"
@@ -96,6 +132,18 @@ pub struct SampleConfig {
 
 impl SampleConfig {
     fn sample_rate(&self) -> Result<SampleMode, SampleError> {
+        if self.ratio_field.is_some() && self.rate_field.is_some() {
+            return Err(SampleError::InvalidDynamicConfiguration);
+        }
+
+        if self.key_field.is_some() && (self.ratio_field.is_some() || self.rate_field.is_some()) {
+            return Err(SampleError::InvalidKeyFieldDynamicCombination);
+        }
+
+        if self.rate.is_some() && self.ratio.is_some() {
+            return Err(SampleError::InvalidStaticConfiguration);
+        }
+
         match (self.rate, self.ratio) {
             (None, Some(ratio)) => {
                 if ratio <= 0.0 {
@@ -111,7 +159,8 @@ impl SampleConfig {
                     Ok(SampleMode::new_rate(rate))
                 }
             }
-            _ => Err(SampleError::InvalidConfiguration),
+            (None, None) => Err(SampleError::MissingStaticConfiguration),
+            _ => Err(SampleError::InvalidStaticConfiguration),
         }
     }
 }
@@ -121,6 +170,8 @@ impl GenerateConfig for SampleConfig {
         toml::Value::try_from(Self {
             rate: None,
             ratio: Some(0.1),
+            ratio_field: None,
+            rate_field: None,
             key_field: None,
             group_by: None,
             exclude: None::<AnyCondition>,
@@ -134,19 +185,37 @@ impl GenerateConfig for SampleConfig {
 #[typetag::serde(name = "sample")]
 impl TransformConfig for SampleConfig {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        Ok(Transform::function(Sample::new(
-            Self::NAME.to_string(),
-            self.sample_rate()?,
-            self.key_field.clone(),
-            self.group_by.clone(),
-            self.exclude
-                .as_ref()
-                .map(|condition| {
-                    condition.build(&context.enrichment_tables, &context.metrics_storage)
-                })
-                .transpose()?,
-            self.sample_rate_key.clone(),
-        )))
+        let sample_mode = self.sample_rate()?;
+        let exclude = self
+            .exclude
+            .as_ref()
+            .map(|condition| condition.build(&context.enrichment_tables, &context.metrics_storage))
+            .transpose()?;
+
+        let sample = if self.ratio_field.is_some() || self.rate_field.is_some() {
+            Sample::new_with_dynamic(
+                Self::NAME.to_string(),
+                sample_mode,
+                DynamicSampleFields {
+                    ratio_field: self.ratio_field.clone(),
+                    rate_field: self.rate_field.clone(),
+                },
+                self.group_by.clone(),
+                exclude,
+                self.sample_rate_key.clone(),
+            )
+        } else {
+            Sample::new(
+                Self::NAME.to_string(),
+                sample_mode,
+                self.key_field.clone(),
+                self.group_by.clone(),
+                exclude,
+                self.sample_rate_key.clone(),
+            )
+        };
+
+        Ok(Transform::function(sample))
     }
 
     fn input(&self) -> Input {
@@ -191,10 +260,100 @@ pub fn default_sample_rate_key() -> OptionalValuePath {
 
 #[cfg(test)]
 mod tests {
-    use crate::transforms::sample::config::SampleConfig;
+    use crate::{
+        config::TransformConfig,
+        transforms::sample::config::{SampleConfig, SampleError},
+    };
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<SampleConfig>();
+    }
+
+    #[test]
+    fn rejects_dynamic_ratio_only_configuration() {
+        let config = SampleConfig {
+            rate: None,
+            ratio: None,
+            ratio_field: Some("sample_rate".to_string()),
+            rate_field: None,
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        let err = config.sample_rate().unwrap_err();
+        assert!(matches!(err, SampleError::MissingStaticConfiguration));
+    }
+
+    #[test]
+    fn rejects_dynamic_rate_only_configuration() {
+        let config = SampleConfig {
+            rate: None,
+            ratio: None,
+            ratio_field: None,
+            rate_field: Some("sample_rate_n".to_string()),
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        let err = config.sample_rate().unwrap_err();
+        assert!(matches!(err, SampleError::MissingStaticConfiguration));
+    }
+
+    #[test]
+    fn validates_static_with_dynamic_configuration() {
+        let config = SampleConfig {
+            rate: Some(10),
+            ratio: None,
+            ratio_field: None,
+            rate_field: Some("sample_rate_n".to_string()),
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        assert!(config.validate(&crate::schema::Definition::any()).is_ok());
+    }
+
+    #[test]
+    fn rejects_both_dynamic_fields_configuration() {
+        let config = SampleConfig {
+            rate: Some(10),
+            ratio: None,
+            ratio_field: Some("sample_rate".to_string()),
+            rate_field: Some("sample_rate_n".to_string()),
+            key_field: None,
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        let err = config.sample_rate().unwrap_err();
+        assert!(matches!(err, SampleError::InvalidDynamicConfiguration));
+    }
+
+    #[test]
+    fn rejects_key_field_with_dynamic_configuration() {
+        let config = SampleConfig {
+            rate: Some(10),
+            ratio: None,
+            ratio_field: Some("sample_ratio".to_string()),
+            rate_field: None,
+            key_field: Some("trace_id".to_string()),
+            sample_rate_key: super::default_sample_rate_key(),
+            group_by: None,
+            exclude: None,
+        };
+
+        let err = config.sample_rate().unwrap_err();
+        assert!(matches!(
+            err,
+            SampleError::InvalidKeyFieldDynamicCombination
+        ));
     }
 }

--- a/src/transforms/sample/tests.rs
+++ b/src/transforms/sample/tests.rs
@@ -1,4 +1,5 @@
 use approx::assert_relative_eq;
+use indoc::indoc;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use vector_lib::lookup::lookup_v2::OptionalValuePath;
@@ -14,7 +15,7 @@ use crate::{
         FunctionTransform, OutputBuffer,
         sample::{
             config::{SampleConfig, default_sample_rate_key},
-            transform::{Sample, SampleMode},
+            transform::{DynamicSampleFields, Sample, SampleMode},
         },
         test::{create_topology, transform_one},
     },
@@ -26,6 +27,8 @@ async fn emits_internal_events() {
         let config = SampleConfig {
             rate: None,
             ratio: Some(1.0),
+            ratio_field: None,
+            rate_field: None,
             key_field: None,
             group_by: None,
             exclude: None,
@@ -322,6 +325,330 @@ fn sample_at_rates_higher_then_half() {
             .count();
         assert_eq!(total_observed as f64, 10000.0 * sampler.ratio());
     }
+}
+
+#[test]
+fn dynamic_ratio_field_overrides_static_ratio() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.1),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut event = Event::Log(LogEvent::from("hello"));
+    let log = event.as_mut_log();
+    log.insert("dynamic_ratio", 1.0);
+
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_ratio_field_falls_back_to_static_ratio_when_missing() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(1.0),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let event = Event::Log(LogEvent::from("hello"));
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_rate_field_overrides_static_ratio() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut event = Event::Log(LogEvent::from("hello"));
+    let log = event.as_mut_log();
+    log.insert("dynamic_rate", 1);
+
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_rate_field_falls_back_to_static_ratio_when_missing() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(1.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let event = Event::Log(LogEvent::from("hello"));
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_rate_field_rejects_float_and_falls_back_to_static_ratio() {
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(1.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        None,
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut event = Event::Log(LogEvent::from("hello"));
+    let log = event.as_mut_log();
+    log.insert("dynamic_rate", 2.0);
+
+    let output = transform_one(&mut sampler, event).expect("event should be sampled");
+    assert_eq!(output.as_log()["sample_rate"], "1".into());
+}
+
+#[test]
+fn dynamic_ratio_honors_group_by_key() {
+    let ratio = 0.5_f64;
+    let events_per_service = 200;
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.0),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        Some(Template::try_from("{{ service }}").unwrap()),
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut sampled_service_a = 0;
+    let mut sampled_service_b = 0;
+    for _ in 0..events_per_service {
+        for service in ["service-a", "service-b"] {
+            let mut event = Event::Log(LogEvent::from("hello"));
+            let log = event.as_mut_log();
+            log.insert("service", service);
+            log.insert("dynamic_ratio", ratio);
+            if let Some(output) = transform_one(&mut sampler, event) {
+                assert_eq!(output.as_log()["sample_rate"], "0.5".into());
+                if service == "service-a" {
+                    sampled_service_a += 1;
+                } else {
+                    sampled_service_b += 1;
+                }
+            }
+        }
+    }
+
+    assert!(
+        (60..140).contains(&sampled_service_a),
+        "service-a sampled {} out of {events_per_service}",
+        sampled_service_a
+    );
+    assert!(
+        (60..140).contains(&sampled_service_b),
+        "service-b sampled {} out of {events_per_service}",
+        sampled_service_b
+    );
+}
+
+#[test]
+fn dynamic_rate_honors_group_by_key() {
+    let rate = 2_i64;
+    let events_per_service = 200;
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        Some(Template::try_from("{{ service }}").unwrap()),
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut sampled_service_a = 0;
+    let mut sampled_service_b = 0;
+    for _ in 0..events_per_service {
+        for service in ["service-a", "service-b"] {
+            let mut event = Event::Log(LogEvent::from("hello"));
+            let log = event.as_mut_log();
+            log.insert("service", service);
+            log.insert("dynamic_rate", rate);
+            if let Some(output) = transform_one(&mut sampler, event) {
+                assert_eq!(output.as_log()["sample_rate"], "2".into());
+                if service == "service-a" {
+                    sampled_service_a += 1;
+                } else {
+                    sampled_service_b += 1;
+                }
+            }
+        }
+    }
+
+    assert!(
+        (60..140).contains(&sampled_service_a),
+        "service-a sampled {} out of {events_per_service}",
+        sampled_service_a
+    );
+    assert!(
+        (60..140).contains(&sampled_service_b),
+        "service-b sampled {} out of {events_per_service}",
+        sampled_service_b
+    );
+}
+
+#[test]
+fn dynamic_ratio_group_by_samples_mixed_ratios_at_expected_rates() {
+    let events_per_ratio = 500;
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.0),
+        DynamicSampleFields {
+            ratio_field: Some("dynamic_ratio".to_string()),
+            rate_field: None,
+        },
+        Some(Template::try_from("{{ service }}").unwrap()),
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut sampled_low_ratio = 0;
+    let mut sampled_high_ratio = 0;
+    for _ in 0..events_per_ratio {
+        for (ratio, is_low_ratio) in [(0.25_f64, true), (0.75_f64, false)] {
+            let mut event = Event::Log(LogEvent::from("hello"));
+            let log = event.as_mut_log();
+            log.insert("service", "service-a");
+            log.insert("dynamic_ratio", ratio);
+            if let Some(output) = transform_one(&mut sampler, event) {
+                assert_eq!(output.as_log()["sample_rate"], ratio.to_string().into());
+                if is_low_ratio {
+                    sampled_low_ratio += 1;
+                } else {
+                    sampled_high_ratio += 1;
+                }
+            }
+        }
+    }
+
+    assert!(
+        (80..220).contains(&sampled_low_ratio),
+        "ratio=0.25 sampled {} out of {events_per_ratio}",
+        sampled_low_ratio
+    );
+    assert!(
+        (300..450).contains(&sampled_high_ratio),
+        "ratio=0.75 sampled {} out of {events_per_ratio}",
+        sampled_high_ratio
+    );
+    assert!(
+        sampled_high_ratio > sampled_low_ratio,
+        "ratio=0.75 sampled {sampled_high_ratio}, ratio=0.25 sampled {sampled_low_ratio}"
+    );
+}
+
+#[test]
+fn dynamic_rate_group_by_samples_mixed_rates_at_expected_rates() {
+    let events_per_rate = 600;
+    let mut sampler = Sample::new_with_dynamic(
+        "sample".to_string(),
+        SampleMode::new_ratio(0.0),
+        DynamicSampleFields {
+            ratio_field: None,
+            rate_field: Some("dynamic_rate".to_string()),
+        },
+        Some(Template::try_from("{{ service }}").unwrap()),
+        None,
+        default_sample_rate_key(),
+    );
+
+    let mut sampled_rate_2 = 0;
+    let mut sampled_rate_3 = 0;
+    for _ in 0..events_per_rate {
+        for rate in [2_i64, 3_i64] {
+            let mut event = Event::Log(LogEvent::from("hello"));
+            let log = event.as_mut_log();
+            log.insert("service", "service-a");
+            log.insert("dynamic_rate", rate);
+            if let Some(output) = transform_one(&mut sampler, event) {
+                assert_eq!(output.as_log()["sample_rate"], rate.to_string().into());
+                if rate == 2 {
+                    sampled_rate_2 += 1;
+                } else {
+                    sampled_rate_3 += 1;
+                }
+            }
+        }
+    }
+
+    assert!(
+        (220..380).contains(&sampled_rate_2),
+        "rate=2 sampled {} out of {events_per_rate}",
+        sampled_rate_2
+    );
+    assert!(
+        (120..280).contains(&sampled_rate_3),
+        "rate=3 sampled {} out of {events_per_rate}",
+        sampled_rate_3
+    );
+    assert!(
+        sampled_rate_2 > sampled_rate_3,
+        "rate=2 sampled {sampled_rate_2}, rate=3 sampled {sampled_rate_3}"
+    );
+}
+
+#[tokio::test]
+async fn dynamic_field_config_drives_dynamic_sampling() {
+    assert_transform_compliance(async move {
+        let config: SampleConfig = serde_yaml::from_str(indoc! {r#"
+            ratio_field: dynamic_ratio
+            ratio: 1.0
+        "#})
+        .expect("config should deserialize");
+
+        let (tx, rx) = mpsc::channel(1);
+        let (topology, mut out) = create_topology(ReceiverStream::new(rx), config).await;
+
+        let mut log = LogEvent::from("hello");
+        log.insert("dynamic_ratio", 1.0);
+        tx.send(log.into()).await.unwrap();
+
+        let event = out.recv().await.expect("event should be sampled");
+        assert_eq!(event.as_log()["sample_rate"], "1".into());
+
+        drop(tx);
+        topology.stop().await;
+        assert_eq!(out.recv().await, None);
+    })
+    .await
 }
 
 fn condition_contains(key: &str, needle: &str) -> Condition {

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::HashMap,
+    fmt,
+    hash::{Hash, Hasher},
+    num::NonZeroU64,
+};
 
 use vector_lib::{
     config::LegacyKey,
@@ -91,6 +96,26 @@ impl SampleMode {
     }
 }
 
+enum EventSampleMode {
+    Ratio(f64),
+    Rate(NonZeroU64),
+}
+
+impl EventSampleMode {
+    fn sample_rate_label(&self) -> String {
+        match self {
+            Self::Ratio(ratio) => ratio.to_string(),
+            Self::Rate(rate) => rate.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DynamicSampleFields {
+    pub ratio_field: Option<String>,
+    pub rate_field: Option<String>,
+}
+
 impl fmt::Display for SampleMode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Avoids the print of an additional '.0' which was not performed in the previous
@@ -103,11 +128,23 @@ impl fmt::Display for SampleMode {
 }
 
 #[derive(Clone)]
+pub enum SampleKeySource {
+    Static {
+        key_field: Option<String>,
+        group_by: Option<Template>,
+    },
+    Dynamic {
+        fields: DynamicSampleFields,
+        group_by: Option<Template>,
+    },
+}
+
+#[derive(Clone)]
 pub struct Sample {
     name: String,
-    rate: SampleMode,
-    key_field: Option<String>,
-    group_by: Option<Template>,
+    static_mode: SampleMode,
+    key_source: SampleKeySource,
+    dynamic_event_counters: HashMap<Option<String>, u64>,
     exclude: Option<Condition>,
     sample_rate_key: OptionalValuePath,
 }
@@ -116,19 +153,55 @@ impl Sample {
     // This function is dead code when the feature flag `transforms-impl-sample` is specified but not
     // `transforms-sample`.
     #![allow(dead_code)]
-    pub const fn new(
+    pub fn new(
         name: String,
-        rate: SampleMode,
+        static_mode: SampleMode,
         key_field: Option<String>,
         group_by: Option<Template>,
         exclude: Option<Condition>,
         sample_rate_key: OptionalValuePath,
     ) -> Self {
+        Self::new_with_source(
+            name,
+            static_mode,
+            SampleKeySource::Static {
+                key_field,
+                group_by,
+            },
+            exclude,
+            sample_rate_key,
+        )
+    }
+
+    pub fn new_with_dynamic(
+        name: String,
+        static_mode: SampleMode,
+        fields: DynamicSampleFields,
+        group_by: Option<Template>,
+        exclude: Option<Condition>,
+        sample_rate_key: OptionalValuePath,
+    ) -> Self {
+        Self::new_with_source(
+            name,
+            static_mode,
+            SampleKeySource::Dynamic { fields, group_by },
+            exclude,
+            sample_rate_key,
+        )
+    }
+
+    fn new_with_source(
+        name: String,
+        static_mode: SampleMode,
+        key_source: SampleKeySource,
+        exclude: Option<Condition>,
+        sample_rate_key: OptionalValuePath,
+    ) -> Self {
         Self {
             name,
-            rate,
-            key_field,
-            group_by,
+            static_mode,
+            key_source,
+            dynamic_event_counters: HashMap::default(),
             exclude,
             sample_rate_key,
         }
@@ -136,10 +209,119 @@ impl Sample {
 
     #[cfg(test)]
     pub fn ratio(&self) -> f64 {
-        match self.rate {
-            SampleMode::Rate { rate, .. } => 1.0f64 / rate as f64,
-            SampleMode::Ratio { ratio, .. } => ratio,
+        match &self.static_mode {
+            SampleMode::Rate { rate, .. } => 1.0f64 / *rate as f64,
+            SampleMode::Ratio { ratio, .. } => *ratio,
         }
+    }
+
+    fn dynamic_sample_hash(group_by_key: Option<&str>, counter: u64) -> u64 {
+        let mut hasher = seahash::SeaHasher::new();
+        group_by_key.hash(&mut hasher);
+        counter.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn sample_with_dynamic_ratio(&mut self, ratio: f64, group_by_key: Option<String>) -> bool {
+        let counter_value = self
+            .dynamic_event_counters
+            .entry(group_by_key.clone())
+            .or_default();
+        let old_counter_value = *counter_value;
+        *counter_value += 1;
+
+        let hash = Self::dynamic_sample_hash(group_by_key.as_deref(), old_counter_value);
+        let hash_ratio_threshold = (ratio * (u64::MAX as u128) as f64) as u64;
+        hash <= hash_ratio_threshold
+    }
+
+    fn event_ratio(&self, event: &Event) -> Option<f64> {
+        let ratio_field = match &self.key_source {
+            SampleKeySource::Dynamic { fields, .. } => fields.ratio_field.as_ref()?,
+            SampleKeySource::Static { .. } => return None,
+        };
+
+        let value = self.get_event_value(event, ratio_field.as_str())?;
+
+        let ratio = match value {
+            Value::Integer(value) => *value as f64,
+            Value::Float(value) => value.into_inner(),
+            Value::Bytes(bytes) => std::str::from_utf8(bytes).ok()?.parse::<f64>().ok()?,
+            _ => return None,
+        };
+
+        (ratio > 0.0 && ratio <= 1.0).then_some(ratio)
+    }
+
+    fn event_rate(&self, event: &Event) -> Option<NonZeroU64> {
+        let rate_field = match &self.key_source {
+            SampleKeySource::Dynamic { fields, .. } => fields.rate_field.as_ref()?,
+            SampleKeySource::Static { .. } => return None,
+        };
+
+        let value = self.get_event_value(event, rate_field.as_str())?;
+
+        match value {
+            Value::Integer(value) => u64::try_from(*value).ok().and_then(NonZeroU64::new),
+            Value::Bytes(bytes) => std::str::from_utf8(bytes).ok()?.parse::<NonZeroU64>().ok(),
+            _ => None,
+        }
+    }
+
+    fn get_event_value<'a>(&self, event: &'a Event, path: &str) -> Option<&'a Value> {
+        match event {
+            Event::Log(event) => event.parse_path_and_get_value(path).ok().flatten(),
+            Event::Trace(event) => event.parse_path_and_get_value(path).ok().flatten(),
+            Event::Metric(_) => panic!("component can never receive metric events"),
+        }
+    }
+
+    fn event_sample_mode(&self, event: &Event) -> Option<EventSampleMode> {
+        self.event_ratio(event)
+            .map(EventSampleMode::Ratio)
+            .or_else(|| self.event_rate(event).map(EventSampleMode::Rate))
+    }
+
+    fn sample_with_dynamic_rate(&mut self, rate: NonZeroU64, group_by_key: Option<String>) -> bool {
+        let counter_value = self
+            .dynamic_event_counters
+            .entry(group_by_key.clone())
+            .or_default();
+        let old_counter_value = *counter_value;
+        *counter_value += 1;
+        let hash = Self::dynamic_sample_hash(group_by_key.as_deref(), old_counter_value);
+
+        hash.is_multiple_of(rate.get())
+    }
+
+    fn group_by_key(&self, event: &Event) -> Option<String> {
+        let group_by = match &self.key_source {
+            SampleKeySource::Static { group_by, .. } => group_by.as_ref()?,
+            SampleKeySource::Dynamic { group_by, .. } => group_by.as_ref()?,
+        };
+
+        match event {
+            Event::Log(event) => group_by.render_string(event),
+            Event::Trace(event) => group_by.render_string(event),
+            Event::Metric(_) => panic!("component can never receive metric events"),
+        }
+        .map_err(|error| {
+            emit!(TemplateRenderingError {
+                error,
+                field: Some("group_by"),
+                drop_event: false,
+            })
+        })
+        .ok()
+    }
+
+    fn static_key_value<'a>(&self, event: &'a Event) -> Option<&'a Value> {
+        let key_field = match &self.key_source {
+            SampleKeySource::Static { key_field, .. } => key_field.as_ref()?,
+            SampleKeySource::Dynamic { .. } => return None,
+        };
+
+        self.get_event_value(event, key_field)
     }
 }
 
@@ -159,36 +341,24 @@ impl FunctionTransform for Sample {
             }
         };
 
-        let value = self.key_field.as_ref().and_then(|key_field| match &event {
-            Event::Log(event) => event
-                .parse_path_and_get_value(key_field.as_str())
-                .ok()
-                .flatten(),
-            Event::Trace(event) => event
-                .parse_path_and_get_value(key_field.as_str())
-                .ok()
-                .flatten(),
-            Event::Metric(_) => panic!("component can never receive metric events"),
-        });
+        let group_by_key = self.group_by_key(&event);
+        let value = self.static_key_value(&event);
 
-        // Fetch actual field value if group_by option is set.
-        let group_by_key = self.group_by.as_ref().and_then(|group_by| {
-            match &event {
-                Event::Log(event) => group_by.render_string(event),
-                Event::Trace(event) => group_by.render_string(event),
-                Event::Metric(_) => panic!("component can never receive metric events"),
+        let event_sample_mode = self.event_sample_mode(&event);
+        let sample_rate = event_sample_mode
+            .as_ref()
+            .map(EventSampleMode::sample_rate_label)
+            .unwrap_or_else(|| self.static_mode.to_string());
+
+        let should_sample = match event_sample_mode {
+            Some(EventSampleMode::Ratio(ratio)) => {
+                self.sample_with_dynamic_ratio(ratio, group_by_key)
             }
-            .map_err(|error| {
-                emit!(TemplateRenderingError {
-                    error,
-                    field: Some("group_by"),
-                    drop_event: false,
-                })
-            })
-            .ok()
-        });
+            Some(EventSampleMode::Rate(rate)) => self.sample_with_dynamic_rate(rate, group_by_key),
+            None => self.static_mode.increment(group_by_key, value),
+        };
 
-        if self.rate.increment(group_by_key, value) {
+        if should_sample {
             if let Some(path) = &self.sample_rate_key.path {
                 match event {
                     Event::Log(ref mut event) => {
@@ -197,11 +367,11 @@ impl FunctionTransform for Sample {
                             event,
                             Some(LegacyKey::Overwrite(path)),
                             path,
-                            self.rate.to_string(),
+                            sample_rate.clone(),
                         );
                     }
                     Event::Trace(ref mut event) => {
-                        event.insert(&OwnedTargetPath::event(path.clone()), self.rate.to_string());
+                        event.insert(&OwnedTargetPath::event(path.clone()), sample_rate);
                     }
                     Event::Metric(_) => panic!("component can never receive metric events"),
                 };

--- a/website/cue/reference/components/transforms/generated/sample.cue
+++ b/website/cue/reference/components/transforms/generated/sample.cue
@@ -12,6 +12,9 @@ generated: components: transforms: sample: configuration: {
 
 			If left unspecified, or if the event doesn't have `group_by`, then the event is not
 			sampled separately.
+
+			This can also be used with `ratio_field` or `rate_field` to apply dynamic sampling
+			independently per rendered group value.
 			"""
 		required: false
 		type: string: {
@@ -32,6 +35,8 @@ generated: components: transforms: sample: configuration: {
 
 			This can be useful to, for example, ensure that all logs for a given transaction are
 			sampled together, but that overall `1/N` transactions are sampled.
+
+			This option cannot be combined with `ratio_field` or `rate_field`.
 			"""
 		required: false
 		type: string: examples: ["message"]
@@ -49,6 +54,18 @@ generated: components: transforms: sample: configuration: {
 			1500,
 		]
 	}
+	rate_field: {
+		description: """
+			The event field whose integer value is used as the sampling rate on a per-event basis, expressed as `1/N`.
+
+			Accepts an integer, or a string that parses as a positive integer; floating point values
+			are rejected. The value must be a positive integer to be considered valid. If the field is
+			missing or invalid, static sampling settings (`rate` or `ratio`) are used as a fallback.
+			This option cannot be used together with `ratio_field`.
+			"""
+		required: false
+		type: string: examples: ["sample_rate_n"]
+	}
 	ratio: {
 		description: """
 			The rate at which events are forwarded, expressed as a percentage
@@ -62,6 +79,18 @@ generated: components: transforms: sample: configuration: {
 		type: float: examples: [
 			0.13,
 		]
+	}
+	ratio_field: {
+		description: """
+			The event field whose numeric value is used as the sampling ratio on a per-event basis.
+
+			Accepts integer, floating point, or string values that parse as a number. The value must be
+			in `(0, 1]` to be considered valid (for example, `0.25` keeps 25%). If the field is missing
+			or invalid, static sampling settings (`rate` or `ratio`) are used as a fallback.
+			This option cannot be used together with `rate_field`.
+			"""
+		required: false
+		type: string: examples: ["sample_rate"]
 	}
 	sample_rate_key: {
 		description: "The event key in which the sample rate is stored. If set to an empty string, the sample rate will not be added to the event."


### PR DESCRIPTION
## Summary
This PR adds dynamic per-event sampling to the `sample` transform

Changes included:
- Add `ratio_field` support for per-event ratio sampling `(0, 1]`
- Add `rate_field` support for per-event `1/N` sampling (positive integer only)
- Require static sampling configuration (`rate` or `ratio`) as a fallback value (dynamic-only mode is not allowed).
- Disallow configuring `ratio_field` and `rate_field` together.
- Disallow configuring dynamic fields together with `key_field`.
- Ensure dynamic sampling honors `group_by` when provided.

## Vector configuration

Dynamic per-event ratio sampling with static fallback:
```toml
[transforms.sample_dynamic]
type = "sample"
inputs = ["in"]

# This PR adds this optional dynamic field to drive sampling
# (choose one)
ratio_field = "sample_ratio"
# rate_field = "sample_rate_n"

# Normal ratio/rate field remains required, as the static fallback 
# (exactly one of these)
ratio = 0.01
# rate = 100

# (optional) deterministic grouping still works with dynamic sampling
group_by = "{{ service }}"
```

The `key_field` concept is not compatible. For example
```toml
key_field = "trace_id"
```
means “sample decisions are coherent per key” (same key should be treated together).
The new dynamic mode (ratio_field / rate_field) reads sampling values per event, so two events with the same key could ask for different rates/ratios. That combination breaks key-based coherence, so config validation rejects it explicitly

## How did you test this PR?
Ran locally:
- `vector-ci-env "make fmt"`
- `vector-ci-env "make check-fmt"`
- `vector-ci-env "make check-clippy"`
- `vector-ci-env "make check-generated-docs"`
- `vector-ci-env "make check-markdown"`
- `vector-ci-env "./scripts/check_changelog_fragments.sh"`
- `vector-ci-env "cargo test -p vector --no-default-features --features transforms-sample sample:: --lib"`

Test coverage added/updated includes:
- reject dynamic ratio-only config
- reject dynamic rate-only config
- reject config that sets both dynamic fields
- reject config that sets dynamic field + key_field
- accept static + dynamic config
- dynamic ratio overrides static
- dynamic rate overrides static
- dynamic ratio fallback to static ratio/rate when missing
- dynamic rate fallback to static ratio when missing
- dynamic rate rejects floating point values and falls back to static ratio
- dynamic ratio honors `group_by`
- dynamic rate honors `group_by`

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
