### PR TITLE
docs(internal docs): consolidate reference documentation into detailed docs table in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,8 @@ Before opening a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQU
 PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec and are validated by `.github/workflows/semantic.yml`.
 
 Examples:
-```
+
+```text
 feat(kafka source): add consumer group lag metric
 fix(loki sink): handle empty label sets correctly
 docs(internal docs): update contributing guide


### PR DESCRIPTION
## Summary

Merges selected links from the `## Reference Documentation` section into the `## Detailed Documentation` table, then removes the now-redundant section. This consolidates navigation into a single place.

Links excluded from the merge (already referenced elsewhere or not documentation):
- `CONTRIBUTING.md` and `docs/DEVELOPING.md` — already linked in the top-level header
- `website/README.md` — already referenced in the Website/Docs section
- `src/internal_events` — source code directory, not a doc

## Vector configuration

N/A

## How did you test this PR?

Manual review of the resulting markdown.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A