### PR TITLE
chore(ci): update GHCR cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-ghcr-images.yml
+++ b/.github/workflows/cleanup-ghcr-images.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           package-name: vector
           package-type: container
-          min-versions-to-keep: 8
+          min-versions-to-keep: 30
           ignore-versions: '^(nightly$|\d+\.\d+)'
 
   cleanup-test-runner:


### PR DESCRIPTION
## Summary

Improves the weekly GHCR cleanup workflow with two changes:
- Add a new job to delete dated nightly tags (e.g. `nightly-2025-01-15-alpine`) keeping only the 8 most recent, with an explicit guard to never touch semver/release tags or the `nightly` floating tag
- Split cleanup steps into separate jobs so a failure in one does not affect the other

### Note on Untagged images 

We used to delete untagged images but that included attestations. Since Vector doesn't currently publish attestations this is a non-issue today, but we might change that soon.

In GHCR, container image attestations (provenance, SBOM) are stored as untagged package versions linked to their parent tagged image via the OCI referrers API. They have no human-readable tag, so they look identical to orphaned build artifacts.

## Vector configuration

N/A

## How did you test this PR?

Reviewed the action configuration manually. The dated nightly deletion job has two guards via `ignore-versions`:
1. Never deletes versions tagged as a semver release (e.g. `0.42.0`)
2. Never deletes the `nightly` floating tag

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A