### PR TITLE
fix(buffers): add nesting depth limit to prevent protobuf decode corruption

### DIFF
--- a/changelog.d/protobuf_nesting_depth_limit.fix.md
+++ b/changelog.d/protobuf_nesting_depth_limit.fix.md
@@ -1,0 +1,3 @@
+Fixed disk buffer corruption caused by deeply nested events exceeding prost's protobuf recursion limit during decode. Events with nesting depth greater than 33 are now rejected at encode time across disk buffers, the native codec, and the `vector` sink's gRPC path, preventing unrecoverable buffer corruption.
+
+authors: connoryy

--- a/lib/codecs/src/encoding/format/native.rs
+++ b/lib/codecs/src/encoding/format/native.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tokio_util::codec::Encoder;
 use vector_core::{
     config::DataType,
-    event::{Event, EventArray, proto},
+    event::{Event, EventArray, MAX_NESTING_DEPTH, event_exceeds_max_nesting_depth, proto},
     schema,
 };
 
@@ -37,6 +37,12 @@ impl Encoder<Event> for NativeSerializer {
     type Error = vector_common::Error;
 
     fn encode(&mut self, event: Event, buffer: &mut BytesMut) -> Result<(), Self::Error> {
+        if event_exceeds_max_nesting_depth(&event) {
+            return Err(format!(
+                "event nesting depth exceeds maximum of {MAX_NESTING_DEPTH} for protobuf encoding"
+            )
+            .into());
+        }
         let array = EventArray::from(event);
         let proto = proto::EventArray::from(array);
         proto.encode(buffer)?;

--- a/lib/codecs/tests/native.rs
+++ b/lib/codecs/tests/native.rs
@@ -322,3 +322,62 @@ fn rebuild_fixtures(proto: &str, deserializer: &dyn Deserializer, serializer: &m
         out.flush().expect("Could not write rebuilt data");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Nesting depth guard integration tests for the native codec
+// ---------------------------------------------------------------------------
+
+use tokio_util::codec::Encoder;
+use vector_core::event::{LogEvent, ObjectMap, Value};
+
+fn create_nested_log_event(wrapping_levels: usize) -> LogEvent {
+    let mut value = Value::from("innermost");
+    for _ in 0..wrapping_levels {
+        let mut map = ObjectMap::new();
+        map.insert("nested".into(), value);
+        value = Value::Object(map);
+    }
+    let mut event = LogEvent::default();
+    event.insert("data", value);
+    event
+}
+
+#[test]
+fn native_codec_rejects_overly_nested_event() {
+    // 33 wrapping levels + "data" key = depth 34 > MAX_NESTING_DEPTH (33)
+    let event = create_nested_log_event(33);
+    let event = Event::Log(event);
+
+    let mut serializer = NativeSerializerConfig.build();
+    let mut buffer = BytesMut::with_capacity(8192);
+
+    let result = serializer.encode(event, &mut buffer);
+    assert!(
+        result.is_err(),
+        "native codec should reject events exceeding MAX_NESTING_DEPTH"
+    );
+}
+
+#[test]
+fn native_codec_roundtrip_max_depth_event() {
+    // 32 wrapping levels + "data" key = depth 33 = MAX_NESTING_DEPTH
+    let event = create_nested_log_event(32);
+    let original_data = event.value().get("data").cloned();
+    let event = Event::Log(event);
+
+    let mut serializer = NativeSerializerConfig.build();
+    let mut buffer = BytesMut::with_capacity(8192);
+
+    serializer
+        .encode(event, &mut buffer)
+        .expect("native codec should accept events at MAX_NESTING_DEPTH");
+
+    let deserializer = NativeDeserializerConfig.build();
+    let decoded_events = deserializer
+        .parse(buffer.freeze(), LogNamespace::Legacy)
+        .expect("native codec should decode events at MAX_NESTING_DEPTH");
+
+    assert_eq!(decoded_events.len(), 1);
+    let decoded_log = decoded_events.into_iter().next().unwrap().into_log();
+    assert_eq!(original_data.as_ref(), decoded_log.value().get("data"),);
+}

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -35,6 +35,7 @@ pub mod metric;
 pub mod proto;
 mod r#ref;
 mod ser;
+pub use ser::{MAX_NESTING_DEPTH, check_value_depth, event_exceeds_max_nesting_depth};
 #[cfg(test)]
 mod test;
 mod trace;

--- a/lib/vector-core/src/event/ser.rs
+++ b/lib/vector-core/src/event/ser.rs
@@ -3,13 +3,93 @@ use enumflags2::{BitFlags, FromBitsError, bitflags};
 use prost::Message;
 use snafu::Snafu;
 use vector_buffers::encoding::{AsMetadata, Encodable};
+use vrl::value::Value;
 
-use super::{Event, EventArray, proto};
+use super::{Event, EventArray, LogEvent, TraceEvent, proto};
+
+/// Maximum nesting depth allowed for events before protobuf encoding.
+///
+/// Prost enforces a recursion limit of 100 during protobuf decoding. In Vector's proto schema,
+/// each level of map nesting costs ~3 prost recursion levels (map entry -> key/value -> nested
+/// message). Empirically, prost decode fails at Value tree depth 34 and succeeds at depth 33.
+///
+/// We set the limit to 33 — the highest safe depth — to prevent corruption across all protobuf
+/// encoding paths (disk buffers, gRPC, native codec) while preserving backward compatibility
+/// with JSON payloads up to 32 levels deep (which become depth 33 after `parse_json` places them
+/// inside a `LogEvent` field).
+pub const MAX_NESTING_DEPTH: usize = 33;
+
+/// Check the nesting depth of a `Value`, returning `Err(actual_depth)` if it exceeds `max_depth`.
+///
+/// This performs an early-exit traversal: it returns as soon as any branch exceeds the limit,
+/// avoiding unnecessary work on well-formed events.
+///
+/// # Errors
+///
+/// Returns `Err(actual_depth)` if any branch of the value tree exceeds `max_depth`.
+pub fn check_value_depth(
+    value: &Value,
+    current_depth: usize,
+    max_depth: usize,
+) -> Result<(), usize> {
+    if current_depth > max_depth {
+        return Err(current_depth);
+    }
+    match value {
+        Value::Object(map) => {
+            for v in map.values() {
+                check_value_depth(v, current_depth + 1, max_depth)?;
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                check_value_depth(v, current_depth + 1, max_depth)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Returns `true` if the event's nesting depth exceeds `MAX_NESTING_DEPTH`.
+///
+/// Metrics have a fixed structure and cannot be deeply nested, so they always return `false`.
+pub fn event_exceeds_max_nesting_depth(event: &Event) -> bool {
+    let value = match event {
+        Event::Log(log) => log.value(),
+        Event::Trace(trace) => trace.value(),
+        Event::Metric(_) => return false,
+    };
+    check_value_depth(value, 0, MAX_NESTING_DEPTH).is_err()
+}
+
+/// Checks all events in an `EventArray` for nesting depth violations.
+///
+/// Returns `Err(EncodeError::NestingTooDeep)` if any log or trace event exceeds
+/// `MAX_NESTING_DEPTH`. Metrics are skipped (fixed structure, no deep nesting possible).
+fn check_event_array_nesting_depth(events: &EventArray) -> Result<(), EncodeError> {
+    let values: Box<dyn Iterator<Item = &Value> + '_> = match events {
+        EventArray::Logs(logs) => Box::new(logs.iter().map(LogEvent::value)),
+        EventArray::Traces(traces) => Box::new(traces.iter().map(TraceEvent::value)),
+        EventArray::Metrics(_) => return Ok(()),
+    };
+    for value in values {
+        if let Err(depth) = check_value_depth(value, 0, MAX_NESTING_DEPTH) {
+            return Err(EncodeError::NestingTooDeep {
+                depth,
+                max_depth: MAX_NESTING_DEPTH,
+            });
+        }
+    }
+    Ok(())
+}
 
 #[derive(Debug, Snafu)]
 pub enum EncodeError {
     #[snafu(display("the provided buffer was too small to fully encode this item"))]
     BufferTooSmall,
+    #[snafu(display("event nesting depth {depth} exceeds maximum of {max_depth}"))]
+    NestingTooDeep { depth: usize, max_depth: usize },
 }
 
 #[derive(Debug, Snafu)]
@@ -95,6 +175,11 @@ impl Encodable for EventArray {
     where
         B: BufMut,
     {
+        // Check nesting depth before encoding. Deeply nested events encode
+        // successfully but fail to decode due to prost's recursion limit,
+        // which would corrupt the disk buffer.
+        check_event_array_nesting_depth(&self)?;
+
         proto::EventArray::from(self)
             .encode(buffer)
             .map_err(|_| EncodeError::BufferTooSmall)

--- a/lib/vector-core/src/event/test/serialization.rs
+++ b/lib/vector-core/src/event/test/serialization.rs
@@ -1,4 +1,5 @@
 use bytes::{Buf, BufMut, BytesMut};
+use prost::Message;
 use quickcheck::{QuickCheck, TestResult};
 use regex::Regex;
 use similar_asserts::assert_eq;
@@ -6,6 +7,7 @@ use vector_buffers::encoding::Encodable;
 
 use super::*;
 use crate::config::log_schema;
+use crate::event::ser::check_value_depth;
 
 fn encode_value<T: Encodable, B: BufMut>(value: T, buffer: &mut B) {
     value.encode(buffer).expect("encoding should not fail");
@@ -95,4 +97,190 @@ fn type_serialization() {
     assert_eq!(map["int"], json!(4));
     assert_eq!(map["bool"], json!(true));
     assert_eq!(map["string"], json!("thisisastring"));
+}
+
+// ---------------------------------------------------------------------------
+// Nesting depth validation tests
+// ---------------------------------------------------------------------------
+
+/// Create a `LogEvent` with the specified nesting depth of maps.
+///
+/// The resulting `LogEvent` has a root Object (depth 0) containing a "data" key
+/// whose value is `wrapping_levels` levels of nested maps with a string leaf.
+/// The leaf string is at effective depth `wrapping_levels + 1` from the root.
+fn create_nested_log_event(wrapping_levels: usize) -> LogEvent {
+    let mut value = Value::from("innermost");
+    for _ in 0..wrapping_levels {
+        let mut map = ObjectMap::new();
+        map.insert("nested".into(), value);
+        value = Value::Object(map);
+    }
+    let mut event = LogEvent::default();
+    event.insert("data", value);
+    event
+}
+
+/// Demonstrates the root cause: prost encodes deeply nested events successfully,
+/// but fails to decode them due to its internal recursion limit of 100.
+#[test]
+fn deeply_nested_event_encodes_but_fails_prost_decode() {
+    // 33 wrapping levels + root "data" key = effective depth 34
+    let event = create_nested_log_event(33);
+    let array = EventArray::Logs(LogArray::from(vec![event]));
+
+    // Bypass our nesting check: convert directly to proto and encode raw
+    let proto_array = proto::EventArray::from(array);
+    let mut buffer = BytesMut::with_capacity(16384);
+    proto_array
+        .encode(&mut buffer)
+        .expect("prost encode should succeed even for deeply nested data");
+
+    // Decode fails: prost hits its recursion limit
+    let result = proto::EventArray::decode(buffer.freeze());
+    assert!(
+        result.is_err(),
+        "prost decode should fail at effective depth 34"
+    );
+}
+
+/// Confirms that events at exactly the max allowed depth encode AND decode via raw prost.
+#[test]
+fn event_at_max_depth_roundtrips_via_prost() {
+    // 32 wrapping levels + "data" key = leaf at depth 33 = MAX_NESTING_DEPTH
+    let event = create_nested_log_event(32);
+    let original = event.clone();
+    let array = EventArray::Logs(LogArray::from(vec![event]));
+
+    let proto_array = proto::EventArray::from(array);
+    let mut buffer = BytesMut::with_capacity(8192);
+    proto_array
+        .encode(&mut buffer)
+        .expect("prost encode should succeed at depth 33");
+
+    let decoded_proto = proto::EventArray::decode(buffer.freeze())
+        .expect("prost decode should succeed at depth 33");
+    let decoded_array = EventArray::from(decoded_proto);
+
+    let decoded_event = decoded_array.into_events().next().unwrap().into_log();
+    assert_eq!(
+        decoded_event.value().get("data"),
+        original.value().get("data"),
+    );
+}
+
+#[test]
+fn nesting_gate_accepts_flat_event() {
+    let mut event = LogEvent::from("hello world");
+    event.insert("foo", "bar");
+    event.insert("count", 42);
+
+    let events = EventArray::Logs(LogArray::from(vec![event]));
+    let mut buffer = BytesMut::with_capacity(1024);
+    assert!(events.encode(&mut buffer).is_ok());
+}
+
+#[test]
+fn nesting_gate_accepts_event_at_max_depth() {
+    // 32 wrapping levels + "data" key = leaf at depth 33 = MAX_NESTING_DEPTH
+    let event = create_nested_log_event(32);
+    let original = event.clone();
+    let events = EventArray::Logs(LogArray::from(vec![event]));
+    let mut buffer = BytesMut::with_capacity(8192);
+
+    events
+        .encode(&mut buffer)
+        .expect("encode should succeed at exactly MAX_NESTING_DEPTH");
+
+    let decoded = EventArray::decode(EventArray::get_metadata(), buffer)
+        .expect("decode should succeed at exactly MAX_NESTING_DEPTH");
+
+    let decoded_event = decoded.into_events().next().unwrap().into_log();
+    assert_eq!(
+        decoded_event.value().get("data"),
+        original.value().get("data"),
+    );
+}
+
+#[test]
+fn nesting_gate_rejects_event_exceeding_max_depth() {
+    // 33 wrapping levels + "data" key = leaf at depth 34, exceeds MAX_NESTING_DEPTH (33)
+    let event = create_nested_log_event(33);
+    let events = EventArray::Logs(LogArray::from(vec![event]));
+    let mut buffer = BytesMut::with_capacity(8192);
+
+    let result = events.encode(&mut buffer);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            super::super::ser::EncodeError::NestingTooDeep {
+                depth: 34,
+                max_depth: 33
+            }
+        ),
+        "expected NestingTooDeep error, got: {err:?}"
+    );
+}
+
+#[test]
+fn nesting_gate_rejects_trace_event_exceeding_max_depth() {
+    let mut value = Value::from("innermost");
+    for _ in 0..33 {
+        let mut map = ObjectMap::new();
+        map.insert("nested".into(), value);
+        value = Value::Object(map);
+    }
+    let mut trace = TraceEvent::default();
+    trace.insert("data", value);
+
+    let events = EventArray::Traces(TraceArray::from(vec![trace]));
+    let mut buffer = BytesMut::with_capacity(8192);
+
+    let result = events.encode(&mut buffer);
+    assert!(matches!(
+        result,
+        Err(super::super::ser::EncodeError::NestingTooDeep { .. })
+    ));
+}
+
+#[test]
+fn nesting_gate_accepts_metric_events() {
+    let metric = Metric::new(
+        "test_counter",
+        MetricKind::Incremental,
+        MetricValue::Counter { value: 1.0 },
+    );
+    let events = EventArray::Metrics(MetricArray::from(vec![metric]));
+    let mut buffer = BytesMut::with_capacity(1024);
+    assert!(events.encode(&mut buffer).is_ok());
+}
+
+#[test]
+fn check_value_depth_with_configurable_limit() {
+    let mut value = Value::from("leaf");
+    for _ in 0..5 {
+        let mut map = ObjectMap::new();
+        map.insert("n".into(), value);
+        value = Value::Object(map);
+    }
+
+    assert!(check_value_depth(&value, 0, 5).is_ok());
+    assert!(check_value_depth(&value, 0, 4).is_err());
+    assert!(check_value_depth(&value, 0, 10).is_ok());
+
+    let flat = Value::from("hello");
+    assert!(check_value_depth(&flat, 0, 0).is_ok());
+}
+
+#[test]
+fn check_value_depth_with_arrays() {
+    // Array containing an object containing an array containing a value = depth 3
+    let inner = Value::Array(vec![Value::from("leaf")]);
+    let mut map = ObjectMap::new();
+    map.insert("arr".into(), inner);
+    let value = Value::Array(vec![Value::Object(map)]);
+
+    assert!(check_value_depth(&value, 0, 3).is_ok());
+    assert!(check_value_depth(&value, 0, 2).is_err());
 }

--- a/src/sinks/vector/sink.rs
+++ b/src/sinks/vector/sink.rs
@@ -7,6 +7,8 @@ use tower::Service;
 use vector_lib::{
     ByteSizeOf, EstimatedJsonEncodedSizeOf,
     config::telemetry,
+    event::event_exceeds_max_nesting_depth,
+    internal_event::{ComponentEventsDropped, INTENTIONAL},
     request_metadata::GroupedCountByteSize,
     stream::{BatcherSettings, DriverResponse, batcher::data::BatchReduce},
 };
@@ -60,6 +62,17 @@ where
 {
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         input
+            .filter_map(|event| {
+                std::future::ready(if event_exceeds_max_nesting_depth(&event) {
+                    emit!(ComponentEventsDropped::<INTENTIONAL> {
+                        count: 1,
+                        reason: "Event nesting depth exceeds maximum for protobuf encoding.",
+                    });
+                    None
+                } else {
+                    Some(event)
+                })
+            })
             .map(|mut event| {
                 let mut byte_size = telemetry().create_request_count_byte_size();
                 byte_size.add_event(&event, event.estimated_json_encoded_size_of());


### PR DESCRIPTION
## Summary

Deeply nested log events (>33 levels) encode successfully via prost but fail to decode due to prost's internal recursion limit of 100. In Vector's proto schema, each level of map nesting costs ~3 prost recursion levels, causing decode failures at Value tree depth 34.

This is a data-corruption bug: once a deeply nested event is written to a disk buffer, subsequent reads — and even startup buffer validation — fail with `InvalidProtobufPayload`. The buffer becomes permanently unusable without manual deletion. The same failure occurs over the gRPC vector-to-vector path (infinite retries until shutdown timeout) and the native codec.

This PR adds a `MAX_NESTING_DEPTH` (33) check at the three protobuf encoding boundaries:

- **`EventArray::encode`** — guards disk buffer writes
- **`NativeSerializer::encode`** — guards the native codec (TCP/file sinks)
- **`VectorSink` stream filter** — guards the gRPC vector-to-vector path, emitting `ComponentEventsDropped` (intentional) so operators can monitor via `component_discarded_events_total`

The limit of 33 is the empirically determined maximum safe depth — events at depth 33 roundtrip correctly through prost, while depth 34 triggers the recursion limit.

## Vector configuration

Reproduction using disk buffer:
```yaml
sources:
  stdin:
    type: stdin
sinks:
  blackhole:
    type: blackhole
    inputs: ["stdin"]
    buffer:
      type: disk
      max_size: 268435488
```

```bash
# depth 33 JSON payload triggers corruption
echo '{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":"deep"}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}' | vector --config test.yaml
```

## How did you test this PR?

- Unit tests proving the root cause: prost encodes deeply nested events but fails to decode them
- Unit tests proving the fix: the nesting gate rejects events exceeding the limit while accepting events at exactly the maximum depth
- Roundtrip tests for both the `EventArray` (disk buffer) and native codec paths
- Tests covering logs, traces (both gated), and metrics (always pass — fixed structure)
- Tests for the `check_value_depth` utility with configurable limits, arrays, and objects

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Prost recursion limit: https://docs.rs/prost/latest/prost/struct.DecodeContext.html
- Related: deeply nested JSON payloads from upstream log sources (e.g., Kubernetes audit logs, application telemetry) can naturally exceed 32 levels of nesting