### PR TITLE
fix(ci): add missing `contents: read` permission to integration review jobs

### DIFF
--- a/.github/workflows/ci-integration-review.yml
+++ b/.github/workflows/ci-integration-review.yml
@@ -85,6 +85,7 @@ jobs:
   build-test-runner:
     needs: prep-pr
     permissions:
+      contents: read
       packages: write   # Required to push test runner image to GHCR
     uses: ./.github/workflows/build-test-runner.yml
     with:
@@ -98,6 +99,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     permissions:
+      contents: read
       packages: read    # Required to pull test runner image from GHCR
     strategy:
       fail-fast: false
@@ -140,6 +142,7 @@ jobs:
     runs-on: ubuntu-24.04-8core
     timeout-minutes: 30
     permissions:
+      contents: read
       packages: read    # Required to pull test runner image from GHCR
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds the missing `contents: read` permission to the `build-test-runner` and integration test runner jobs in the CI integration review workflow.

## Vector configuration

NA

## How did you test this PR?

`/ci-run-integration-mqtt`

[Run](https://github.com/vectordotdev/vector/actions/runs/23751745461?pr=25067)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #24835