### PR TITLE
chore(dev): consolidate advisory ignores with issue links

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -40,16 +40,8 @@ license-files = [
 
 [advisories]
 ignore = [
-  # Vulnerability in `rsa` crate: https://rustsec.org/advisories/RUSTSEC-2023-0071.html
-  # There is not fix available yet.
-  # https://github.com/vectordotdev/vector/issues/19262
-  "RUSTSEC-2023-0071",
-  { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained" },
-  { id = "RUSTSEC-2024-0384", reason = "instant is unmaintained" },
-  { id = "RUSTSEC-2025-0012", reason = "backoff is unmaintained" },
-  # rustls-pemfile is unmaintained. Blocked by both async-nats and http 1.0.0 upgrade.
-  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained" },
-  # rustls-webpki 0.101.7 vulnerability. Fix requires upgrading rustls from 0.21 to 0.23+,
-  # which is a significant chain upgrade through aws-smithy-http-client, hyper-rustls, tokio-rustls, etc.
-  { id = "RUSTSEC-2026-0049", reason = "Fix requires major rustls upgrade (0.21 -> 0.23+); tracked for future upgrade" },
+  { id = "RUSTSEC-2023-0071", reason = "rsa marvin attack - unpatched upstream (https://github.com/vectordotdev/vector/issues/19262)" },
+  { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained (https://github.com/vectordotdev/vector/issues/24940)" },
+  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained - unpatched crate (https://github.com/bytebeamio/rumqtt/issues/1010) & tonic/reqwest upgrade (https://github.com/vectordotdev/vector/issues/19179)" },
+  { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.102 is vulnerable - tonic upgrade (https://github.com/vectordotdev/vector/issues/19179)" },
 ]


### PR DESCRIPTION
## Summary

Consolidates `deny.toml` advisory ignores into a consistent inline format with tracking issue links. Also removes two entries that are no longer needed (`RUSTSEC-2024-0384`, `RUSTSEC-2025-0012`).

## Vector configuration

NA

## How did you test this PR?

`make check-deny`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA