### PR TITLE
fix(ci): install vdev via setup action in ci-integration-review workflow

### DIFF
--- a/.github/workflows/ci-integration-review.yml
+++ b/.github/workflows/ci-integration-review.yml
@@ -117,13 +117,16 @@ jobs:
           submodules: "recursive"
           ref: ${{ github.event.review.commit_id }}
 
+      - uses: ./.github/actions/setup
+        with:
+          vdev: true
+          datadog-ci: true
+
       - name: Pull test runner image
         uses: ./.github/actions/pull-test-runner
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ github.event.review.commit_id }}
-
-      - run: bash scripts/environment/prepare.sh --modules=datadog-ci
 
       - name: Integration Tests - ${{ matrix.service }}
         if: ${{ startsWith(github.event.review.body, '/ci-run-integration-all')
@@ -156,13 +159,16 @@ jobs:
           submodules: "recursive"
           ref: ${{ github.event.review.commit_id }}
 
+      - uses: ./.github/actions/setup
+        with:
+          vdev: true
+          datadog-ci: true
+
       - name: Pull test runner image
         uses: ./.github/actions/pull-test-runner
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ github.event.review.commit_id }}
-
-      - run: bash scripts/environment/prepare.sh --modules=datadog-ci
 
       - name: E2E Tests - ${{ matrix.service }}
         if: ${{ startsWith(github.event.review.body, '/ci-run-e2e-all')


### PR DESCRIPTION
## Summary

The `ci-integration-review` workflow was missing vdev installation, causing `run-integration-test.sh` to fall back to `cargo vdev`. This triggers a full compilation of vdev from source, which fails because `protoc` is not available on the runner.

Replace the `prepare.sh --modules=datadog-ci` step in both `integration-tests` and `e2e-tests` jobs with the `setup` action (`vdev: true`, `datadog-ci: true`). The `build-test-runner` job (which runs first) already populates the vdev cache via `setup`, so the later jobs restore from cache without needing to compile.

Observed failure in #25066 where `vdev int show -e aws` panicked with a protoc error, producing `ERROR: no environments found for int test 'aws'`.

## Vector configuration

NA

## How did you test this PR?

`/ci-run-integration-aws`

[Run](https://github.com/vectordotdev/vector/actions/runs/23767616621?pr=25077)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25066