### PR TITLE
chore(ci): install datadog-ci from standalone binary instead of npm

### DIFF
--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -191,9 +191,11 @@ maybe_install_standalone_binary() {
     *) echo "Unsupported architecture: ${arch}"; return 1 ;;
   esac
 
-  local url="https://github.com/DataDog/datadog-ci/releases/download/v${version}/datadog-ci_${os}-${arch}"
-  sudo curl -fsSL "${url}" -o /usr/local/bin/datadog-ci
-  sudo chmod +x /usr/local/bin/datadog-ci
+  local dest="/usr/local/bin/${tool}"
+  local url="https://github.com/DataDog/datadog-ci/releases/download/v${version}/${tool}_${os}-${arch}"
+  local run=(); [[ -w "$(dirname "${dest}")" ]] || run=(sudo)
+  "${run[@]}" curl -fsSL "${url}" -o "${dest}"
+  "${run[@]}" chmod +x "${dest}"
 }
 
 # Always ensure git safe.directory is set


### PR DESCRIPTION
## Summary

Switches `datadog-ci` installation from `npm install -g` to the standalone binary from [GitHub Releases](https://github.com/DataDog/datadog-ci/releases).

### Why

On 2026-03-30/31, the owner of the `axios` npm package was compromised and malicious versions (1.14.1 and 0.30.4) were published containing a backdoor. See https://securitylabs.datadoghq.com/articles/axios-npm-supply-chain-compromise/

Our CI installs `datadog-ci` via `sudo npm install -g @datadog/datadog-ci@5.9.0`. While the package version is pinned, `npm install -g` does **not** use a lockfile, so transitive dependencies (including `axios`) are resolved from the npm registry at install time. Any CI runner that executed this during the ~3.5 hour compromise window (2026-03-30 23:59 - 2026-03-31 03:25 UTC) could have pulled the malicious axios 1.14.1.

## Vector configuration

N/A - CI infrastructure change only.

## How did you test this PR?

- Verified the standalone binary exists for all required platforms (`linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`) on the [v5.9.0 release](https://github.com/DataDog/datadog-ci/releases/tag/v5.9.0).
- The new helper follows the same version-check pattern as the existing `maybe_install_npm_package` to skip re-download when the correct version is already cached.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- [Datadog Security Advisory (Zendesk, 2026-03-31)](https://securitylabs.datadoghq.com/articles/malicious-axios-npm-campaign/)
- Affected CI run: https://github.com/vectordotdev/vector/actions/runs/23778138533

🤖 Generated with [Claude Code](https://claude.com/claude-code)