### PR TITLE
fix(ci): replace npm installs with binary/isolated installs for datadog-ci and markdownlint-cli2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -83,7 +83,7 @@ inputs:
   datadog-ci:
     required: false
     default: false
-    description: "Install @datadog/datadog-ci (npm)."
+    description: "Install datadog-ci standalone binary."
 
 runs:
   using: "composite"
@@ -267,6 +267,7 @@ runs:
           ~/.cargo/bin/cargo-llvm-cov
           ~/.cargo/bin/dd-rust-license-tool
           ~/.cargo/bin/wasm-pack
+          /opt/markdownlint-cli2
           /usr/local/bin/markdownlint-cli2
           /usr/local/bin/datadog-ci
         key: ${{ runner.os }}-prepare-binaries-${{ hashFiles('scripts/environment/*') }}

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -148,23 +148,6 @@ maybe_install_cargo_tool() {
   fi
 }
 
-# Helper for NPM packages
-# Usage: maybe_install_npm_package <tool-name> <package-name> <version> <version-check-pattern> <version-command>
-maybe_install_npm_package() {
-  local tool="$1"
-  local package="$2"
-  local version="$3"
-  local version_pattern="${4:-$version}"
-  local version_cmd="${5:---version}"  # Default to --version, can override with "version" etc.
-
-  if ! contains_module "$tool"; then
-    return 0
-  fi
-
-  if [[ "$("$tool" "$version_cmd" 2>/dev/null)" != "$version_pattern" ]]; then
-    sudo npm install -g "${package}@${version}"
-  fi
-}
 
 # Always ensure git safe.directory is set
 git config --global --add safe.directory "$(pwd)"
@@ -218,5 +201,50 @@ maybe_install_cargo_tool dd-rust-license-tool "${DD_RUST_LICENSE_TOOL_VERSION}"
 maybe_install_cargo_tool wasm-pack "${WASM_PACK_VERSION}"
 maybe_install_cargo_tool vdev "${VDEV_VERSION}"
 
-maybe_install_npm_package markdownlint-cli2 markdownlint-cli2 "${MARKDOWNLINT_CLI2_VERSION}"
-maybe_install_npm_package datadog-ci "@datadog/datadog-ci" "${DATADOG_CI_VERSION}" "v${DATADOG_CI_VERSION}" "version"
+maybe_install_markdownlint_cli2() {
+  if ! contains_module "markdownlint-cli2"; then
+    return 0
+  fi
+
+  if markdownlint-cli2 --version 2>/dev/null | grep -q "^${MARKDOWNLINT_CLI2_VERSION}$"; then
+    return 0
+  fi
+
+  if [[ "${CI:-}" == "true" ]]; then
+    local install_dir="/opt/markdownlint-cli2"
+    sudo mkdir -p "$install_dir"
+    # Install into an isolated directory so all deps are co-located and cacheable
+    sudo npm install --prefix "$install_dir" "markdownlint-cli2@${MARKDOWNLINT_CLI2_VERSION}"
+    sudo ln -sf "$install_dir/node_modules/.bin/markdownlint-cli2" /usr/local/bin/markdownlint-cli2
+  else
+    sudo npm install -g "markdownlint-cli2@${MARKDOWNLINT_CLI2_VERSION}"
+  fi
+}
+maybe_install_markdownlint_cli2
+
+maybe_install_datadog_ci() {
+  if ! contains_module "datadog-ci"; then
+    return 0
+  fi
+
+  if datadog-ci version 2>/dev/null | grep -q "^v${DATADOG_CI_VERSION}$"; then
+    return 0
+  fi
+
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "$arch" in
+    x86_64)        arch="x64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) echo "Unsupported arch for datadog-ci: $arch"; exit 1 ;;
+  esac
+
+  local binary_name="datadog-ci_${os}-${arch}"
+  curl -fsSL "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/${binary_name}" \
+    -o /tmp/datadog-ci
+  sudo install -m 755 /tmp/datadog-ci /usr/local/bin/datadog-ci
+  rm -f /tmp/datadog-ci
+}
+maybe_install_datadog_ci


### PR DESCRIPTION
## Summary

`datadog-ci` and `markdownlint-cli2` were installed via npm, which put a Node.js wrapper script at `/usr/local/bin/<tool>` but left the actual package in `/usr/local/lib/node_modules/`. The CI cache only covered the wrapper scripts, so npm re-downloaded both packages on every run even on a cache hit.

- `datadog-ci`: replaced with a direct binary download from GitHub Releases (standalone executable, no Node required)
- `markdownlint-cli2`: no standalone binary exists, so install via `npm install --prefix /opt/markdownlint-cli2` (CI only) to co-locate the package and all transitive deps in one cacheable directory, then symlink the binary; falls back to `npm install -g` locally

## Vector configuration

NA

## How did you test this PR?

CI will run tests and upload them

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA