### PR TITLE
enhancement(prometheus_scrape source): Add scraping of Prometheus metrics over Unix sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ dependencies = [
  "hyper-named-pipe",
  "hyper-rustls 0.27.5",
  "hyper-util",
- "hyperlocal",
+ "hyperlocal 0.9.1",
  "log",
  "pin-project-lite",
  "rustls 0.23.37",
@@ -5234,6 +5234,19 @@ dependencies = [
  "tower-service",
  "tracing 0.1.44",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper 0.14.32",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -12321,6 +12334,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper-openssl 0.9.2",
  "hyper-proxy",
+ "hyperlocal 0.8.0",
  "indexmap 2.12.0",
  "indoc",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,6 +388,7 @@ humantime.workspace = true
 hyper = { version = "0.14.32", default-features = false, features = ["client", "runtime", "http1", "http2", "server", "stream", "backports", "deprecated"] }
 hyper-openssl = { version = "0.9.2", default-features = false }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["openssl-tls"] }
+hyperlocal = "0.8.0" # newer versions require hyper 1.x
 indexmap.workspace = true
 inventory = { version = "0.3.20", default-features = false }
 ipnet = { version = "2", default-features = false, optional = true, features = ["serde", "std"] }

--- a/changelog.d/25095_prometheus_scrape_unix_sockets.enhancement.md
+++ b/changelog.d/25095_prometheus_scrape_unix_sockets.enhancement.md
@@ -1,0 +1,3 @@
+The `prometheus_scrape` source can now scrape metrics from Unix sockets. To use this feature, you must provide the path to the Unix socket, and you can also provide the path in the URI (i.e., `/metrics`).
+
+authors: weriomat

--- a/src/http.rs
+++ b/src/http.rs
@@ -211,7 +211,7 @@ pub fn build_tls_connector(
     Ok(https)
 }
 
-fn default_request_headers<B>(request: &mut Request<B>, user_agent: &HeaderValue) {
+pub fn default_request_headers<B>(request: &mut Request<B>, user_agent: &HeaderValue) {
     if !request.headers().contains_key("User-Agent") {
         request
             .headers_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ pub mod trace;
 pub mod transforms;
 pub mod types;
 pub mod unit_test;
+#[cfg(unix)]
+pub mod unix_http;
 pub(crate) mod utilization;
 pub mod validate;
 #[cfg(windows)]

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -427,6 +427,60 @@ mod test {
         assert!(!events.is_empty());
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prometheus_unix_socket() {
+        use tempfile::tempdir;
+        use tokio::net::UnixListener;
+        use tokio_stream::wrappers::UnixListenerStream;
+
+        use crate::test_util::wait_for_unix_socket;
+
+        // Cleanup once dropped
+        let dir = tempdir().unwrap();
+        let addr = dir.path().join("prometheus_unix.sock");
+
+        let dummy_endpoint = warp::path!("metrics").and(warp::header::exact("Accept", "text/plain")).map(|| {
+            r#"
+                    promhttp_metric_handler_requests_total{endpoint="http://example.com", instance="localhost:9999", code="200"} 100 1612411516789
+                    "#
+        });
+
+        let listener = UnixListener::bind(&addr).unwrap();
+        let incoming = UnixListenerStream::new(listener);
+
+        tokio::spawn(warp::serve(dummy_endpoint).run_incoming(incoming));
+        wait_for_unix_socket(addr.clone()).await;
+
+        let config = PrometheusScrapeConfig {
+            endpoints: vec![sources::prometheus::scrape::PrometheusEndpoint::Unix(
+                UnixEndpoint {
+                    path: addr.clone().into_os_string().into_string().unwrap(),
+                    endpoint: "/metrics".to_string(),
+                },
+            )],
+            interval: Duration::from_secs(1),
+            timeout: default_timeout(),
+            instance_tag: Some("instance".to_string()),
+            endpoint_tag: Some("endpoint".to_string()),
+            honor_labels: true,
+            query: HashMap::new(),
+            auth: None,
+            tls: None,
+        };
+
+        let events = run_and_assert_source_compliance(
+            config,
+            Duration::from_secs(3),
+            &HTTP_PULL_SOURCE_TAGS,
+        )
+        .await;
+        assert!(!events.is_empty());
+
+        // cleanup unix socket
+        tokio::fs::remove_file(addr).await.unwrap();
+    }
+
     #[tokio::test]
     async fn test_prometheus_honor_labels() {
         let (_guard, in_addr) = next_addr();

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, time::Duration};
 use bytes::Bytes;
 use futures_util::FutureExt;
 use http::{Uri, response::Parts};
+#[cfg(unix)]
+use hyperlocal::Uri as UnixUri;
 use serde_with::serde_as;
 use snafu::ResultExt;
 use vector_lib::{config::LogNamespace, configurable::configurable_component, event::Event};
@@ -34,6 +36,47 @@ static NOT_FOUND_NO_PATH: &str = "No path is set on the endpoint and we got a 40
                                   did you mean to use /metrics?\
                                   This behavior changed in version 0.11.";
 
+/// Unix socket configuration to scrape metrics from
+#[cfg(unix)]
+#[serde_as]
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub struct UnixEndpoint {
+    /// The Path to the unix socket
+    #[configurable(metadata(docs::examples = "/var/run/forgejo/forgejo.sock"))]
+    path: String,
+    /// The Path in the Uri
+    #[serde(default = "default_prometheus_path")]
+    #[configurable(metadata(docs::examples = "/metrics"))]
+    #[configurable(metadata(docs::examples = "/api/v1/metrics"))]
+    endpoint: String,
+}
+
+/// Uri Configuration to scrape metrics from
+#[serde_as]
+#[configurable_component]
+#[serde(untagged)]
+#[derive(Clone, Debug)]
+pub enum PrometheusEndpoint {
+    /// The Url to scrape metrics from
+    #[configurable(metadata(docs::examples = "http://localhost:9090/metrics"))]
+    Url(String),
+    /// The URI to scrape metrics from a unix socket
+    #[cfg(unix)]
+    Unix(UnixEndpoint),
+}
+
+impl From<std::string::String> for PrometheusEndpoint {
+    fn from(str: std::string::String) -> Self {
+        Self::Url(str)
+    }
+}
+
+/// The default path in the Uri for Unix Endpoint
+pub(crate) fn default_prometheus_path() -> String {
+    String::from("/metrics")
+}
+
 /// Configuration for the `prometheus_scrape` source.
 #[serde_as]
 #[configurable_component(source(
@@ -43,9 +86,8 @@ static NOT_FOUND_NO_PATH: &str = "No path is set on the endpoint and we got a 40
 #[derive(Clone, Debug)]
 pub struct PrometheusScrapeConfig {
     /// Endpoints to scrape metrics from.
-    #[configurable(metadata(docs::examples = "http://localhost:9090/metrics"))]
     #[serde(alias = "hosts")]
-    endpoints: Vec<String>,
+    endpoints: Vec<PrometheusEndpoint>,
 
     /// The interval between scrapes. Requests are run concurrently so if a scrape takes longer
     /// than the interval a new scrape will be started. This can take extra resources, set the timeout
@@ -115,7 +157,9 @@ fn query_example() -> serde_json::Value {
 impl GenerateConfig for PrometheusScrapeConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
-            endpoints: vec!["http://localhost:9090/metrics".to_string()],
+            endpoints: vec![sources::prometheus::scrape::PrometheusEndpoint::Url(
+                "http://localhost:9090/metrics".to_string(),
+            )],
             interval: default_interval(),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -136,9 +180,14 @@ impl SourceConfig for PrometheusScrapeConfig {
         let urls = self
             .endpoints
             .iter()
-            .map(|s| s.parse::<Uri>().context(sources::UriParseSnafu))
+            .map(|t| match t {
+                PrometheusEndpoint::Url(s) => s.parse::<Uri>().context(sources::UriParseSnafu),
+                #[cfg(unix)]
+                PrometheusEndpoint::Unix(u) => Ok(UnixUri::new(&u.path, &u.endpoint).into()).into(),
+            })
             .map(|r| r.map(|uri| build_url(&uri, &self.query)))
             .collect::<std::result::Result<Vec<Uri>, sources::BuildError>>()?;
+
         let tls = TlsSettings::from_options(self.tls.as_ref())?;
 
         let builder = PrometheusScrapeBuilder {
@@ -358,7 +407,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{}/metrics", in_addr).into()],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -392,7 +441,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{}/metrics", in_addr).into()],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -444,7 +493,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{}/metrics", in_addr).into()],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -510,7 +559,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{}/metrics", in_addr).into()],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -565,7 +614,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics?key1=val1", in_addr)],
+            endpoints: vec![format!("http://{}/metrics?key1=val1", in_addr).into()],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -681,7 +730,7 @@ mod test {
         config.add_source(
             "in",
             PrometheusScrapeConfig {
-                endpoints: vec![format!("http://{}", in_addr)],
+                endpoints: vec![format!("http://{}", in_addr).into()],
                 instance_tag: None,
                 endpoint_tag: None,
                 honor_labels: false,

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -23,6 +23,8 @@ use vector_lib::{
     shutdown::ShutdownSignal,
 };
 
+#[cfg(unix)]
+use crate::unix_http::UnixHttpClient;
 use crate::{
     SourceSender,
     http::{Auth, HttpClient, QueryParameterValue, QueryParameters},
@@ -160,12 +162,17 @@ pub(crate) async fn call<
     // proxy and tls settings.
     let client =
         HttpClient::new(inputs.tls.clone(), &inputs.proxy).expect("Building HTTP client failed");
+
+    #[cfg(unix)]
+    let unix_client = UnixHttpClient::new(inputs.tls.clone(), &inputs.proxy)
+        .expect("Building UNIX HTTP client failed");
+
     let mut stream = IntervalStream::new(tokio::time::interval(inputs.interval))
         .take_until(inputs.shutdown)
         .map(move |_| stream::iter(inputs.urls.clone()))
         .flatten()
         .map(move |base_url| {
-            let client = client.clone();
+            let scheme = base_url.scheme_str().map(String::from);
             let endpoint = base_url.to_string();
 
             let context_builder = context_builder.clone();
@@ -218,79 +225,86 @@ pub(crate) async fn call<
                 auth.apply(&mut request);
             }
 
-            tokio::time::timeout(inputs.timeout, client.send(request))
-                .then(move |result| async move {
-                    match result {
-                        Ok(Ok(response)) => Ok(response),
-                        Ok(Err(error)) => Err(error.into()),
-                        Err(_) => Err(format!(
-                            "Timeout error: request exceeded {}s",
-                            inputs.timeout.as_secs_f64()
-                        )
-                        .into()),
-                    }
-                })
-                .and_then(|response| async move {
-                    let (header, body) = response.into_parts();
-                    let body = http_body::Body::collect(body).await?.to_bytes();
-                    emit!(EndpointBytesReceived {
-                        byte_size: body.len(),
-                        protocol: "http",
-                        endpoint: endpoint.as_str(),
-                    });
-                    Ok((header, body))
-                })
-                .into_stream()
-                .filter_map(move |response| {
-                    ready(match response {
-                        Ok((header, body)) if header.status == hyper::StatusCode::OK => {
-                            context.on_response(&url, &header, &body).map(|mut events| {
-                                let byte_size = if events.is_empty() {
-                                    // We need to explicitly set the byte size
-                                    // to 0 since
-                                    // `estimated_json_encoded_size_of` returns
-                                    // at least 1 for an empty collection. For
-                                    // the purposes of the
-                                    // HttpClientEventsReceived event, we should
-                                    // emit 0 when there aren't any usable
-                                    // metrics.
-                                    JsonSize::zero()
-                                } else {
-                                    events.estimated_json_encoded_size_of()
-                                };
+            tokio::time::timeout(
+                inputs.timeout,
+                match scheme == Some(String::from("unix")) {
+                    #[cfg(unix)]
+                    true => unix_client.clone().send(request),
+                    _ => client.clone().send(request),
+                },
+            )
+            .then(move |result| async move {
+                match result {
+                    Ok(Ok(response)) => Ok(response),
+                    Ok(Err(error)) => Err(error.into()),
+                    Err(_) => Err(format!(
+                        "Timeout error: request exceeded {}s",
+                        inputs.timeout.as_secs_f64()
+                    )
+                    .into()),
+                }
+            })
+            .and_then(|response| async move {
+                let (header, body) = response.into_parts();
+                let body = http_body::Body::collect(body).await?.to_bytes();
+                emit!(EndpointBytesReceived {
+                    byte_size: body.len(),
+                    protocol: "http",
+                    endpoint: endpoint.as_str(),
+                });
+                Ok((header, body))
+            })
+            .into_stream()
+            .filter_map(move |response| {
+                ready(match response {
+                    Ok((header, body)) if header.status == hyper::StatusCode::OK => {
+                        context.on_response(&url, &header, &body).map(|mut events| {
+                            let byte_size = if events.is_empty() {
+                                // We need to explicitly set the byte size
+                                // to 0 since
+                                // `estimated_json_encoded_size_of` returns
+                                // at least 1 for an empty collection. For
+                                // the purposes of the
+                                // HttpClientEventsReceived event, we should
+                                // emit 0 when there aren't any usable
+                                // metrics.
+                                JsonSize::zero()
+                            } else {
+                                events.estimated_json_encoded_size_of()
+                            };
 
-                                emit!(HttpClientEventsReceived {
-                                    byte_size,
-                                    count: events.len(),
-                                    url: url.to_string()
-                                });
-
-                                // We'll enrich after receiving the events so
-                                // that the byte sizes are accurate.
-                                context.enrich_events(&mut events);
-
-                                stream::iter(events)
-                            })
-                        }
-                        Ok((header, _)) => {
-                            context.on_http_response_error(&url, &header);
-                            emit!(HttpClientHttpResponseError {
-                                code: header.status,
-                                url: url.to_string(),
-                            });
-                            None
-                        }
-                        Err(error) => {
-                            emit!(HttpClientHttpError {
-                                error,
+                            emit!(HttpClientEventsReceived {
+                                byte_size,
+                                count: events.len(),
                                 url: url.to_string()
                             });
-                            None
-                        }
-                    })
+
+                            // We'll enrich after receiving the events so
+                            // that the byte sizes are accurate.
+                            context.enrich_events(&mut events);
+
+                            stream::iter(events)
+                        })
+                    }
+                    Ok((header, _)) => {
+                        context.on_http_response_error(&url, &header);
+                        emit!(HttpClientHttpResponseError {
+                            code: header.status,
+                            url: url.to_string(),
+                        });
+                        None
+                    }
+                    Err(error) => {
+                        emit!(HttpClientHttpError {
+                            error,
+                            url: url.to_string()
+                        });
+                        None
+                    }
                 })
-                .flatten()
-                .boxed()
+            })
+            .flatten()
+            .boxed()
         })
         .flatten_unordered(None)
         .boxed();

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -23,6 +23,8 @@ use futures::{FutureExt, SinkExt, Stream, StreamExt, TryStreamExt, stream, task:
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 use rand::{Rng, rng};
 use rand_distr::Alphanumeric;
+#[cfg(unix)]
+use tokio::net::UnixStream;
 use tokio::{
     io::{AsyncRead, AsyncWrite, AsyncWriteExt, Result as IoResult},
     net::{TcpListener, TcpStream, ToSocketAddrs},
@@ -532,6 +534,19 @@ where
     wait_for(move || {
         let addr = addr.clone();
         async move { TcpStream::connect(addr).await.is_ok() }
+    })
+    .await
+}
+
+#[cfg(unix)]
+// Wait (for 5 secs) for a Unix socket to be reachable
+pub async fn wait_for_unix_socket<A>(addr: A)
+where
+    A: AsRef<Path> + Clone + Send + 'static,
+{
+    wait_for(move || {
+        let addr = addr.clone();
+        async move { UnixStream::connect(addr).await.is_ok() }
     })
     .await
 }

--- a/src/unix_http.rs
+++ b/src/unix_http.rs
@@ -1,0 +1,207 @@
+#![allow(missing_docs)]
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+
+use futures::future::BoxFuture;
+use http::{Request, header::HeaderValue};
+use hyper::{
+    body::{Body, HttpBody},
+    client,
+    client::Client,
+};
+use hyper_openssl::HttpsConnector;
+use hyper_proxy::ProxyConnector;
+use hyperlocal::UnixConnector;
+use snafu::ResultExt;
+use tower::Service;
+use tracing::Instrument;
+use vector_lib::{
+    config::proxy::ProxyConfig,
+    tls::{MaybeTlsSettings, tls_connector_builder},
+};
+
+use crate::{
+    http::{
+        BuildTlsConnectorSnafu, CallRequestSnafu, HttpError, MakeHttpsConnectorSnafu,
+        MakeProxyConnectorSnafu, default_request_headers,
+    },
+    internal_events::http_client,
+};
+
+type UnixHttpProxyConnector = ProxyConnector<HttpsConnector<UnixConnector>>;
+
+pub struct UnixHttpClient<B = Body> {
+    client: Client<UnixHttpProxyConnector, B>,
+    user_agent: HeaderValue,
+    proxy_connector: UnixHttpProxyConnector,
+}
+
+pub fn build_unix_tls_connector(
+    tls_settings: MaybeTlsSettings,
+) -> Result<HttpsConnector<UnixConnector>, HttpError> {
+    let tls = tls_connector_builder(&tls_settings).context(BuildTlsConnectorSnafu)?;
+    let mut https =
+        HttpsConnector::with_connector(UnixConnector, tls).context(MakeHttpsConnectorSnafu)?;
+
+    let settings = tls_settings.tls().cloned();
+    https.set_callback(move |c, _uri| {
+        if let Some(settings) = &settings {
+            settings.apply_connect_configuration(c)
+        } else {
+            Ok(())
+        }
+    });
+    Ok(https)
+}
+
+pub fn build_unix_proxy_connector(
+    tls_settings: MaybeTlsSettings,
+    proxy_config: &ProxyConfig,
+) -> Result<ProxyConnector<HttpsConnector<UnixConnector>>, HttpError> {
+    // Create dedicated unix TLS connector for the proxied connection with user TLS settings.
+    let tls = tls_connector_builder(&tls_settings)
+        .context(BuildTlsConnectorSnafu)?
+        .build();
+
+    let https = build_unix_tls_connector(tls_settings)?;
+    let mut proxy = ProxyConnector::new(https).unwrap();
+    // Make proxy connector aware of user TLS settings by setting the TLS connector:
+    // https://github.com/vectordotdev/vector/issues/13683
+    proxy.set_tls(Some(tls));
+    proxy_config
+        .configure(&mut proxy)
+        .context(MakeProxyConnectorSnafu)?;
+    Ok(proxy)
+}
+
+impl<B> UnixHttpClient<B>
+where
+    B: fmt::Debug + HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<crate::Error>,
+{
+    pub fn new(
+        tls_settings: impl Into<MaybeTlsSettings>,
+        proxy_config: &ProxyConfig,
+    ) -> Result<UnixHttpClient<B>, HttpError> {
+        UnixHttpClient::new_with_custom_client(tls_settings, proxy_config, &mut Client::builder())
+    }
+
+    pub fn new_with_custom_client(
+        tls_settings: impl Into<MaybeTlsSettings>,
+        proxy_config: &ProxyConfig,
+        client_builder: &mut client::Builder,
+    ) -> Result<UnixHttpClient<B>, HttpError> {
+        let proxy_connector = build_unix_proxy_connector(tls_settings.into(), proxy_config)?;
+        let client = client_builder.build(proxy_connector.clone());
+
+        let app_name = crate::get_app_name();
+        let version = crate::get_version();
+        let user_agent = HeaderValue::from_str(&format!("{app_name}/{version}"))
+            .expect("Invalid header value for user-agent!");
+
+        Ok(UnixHttpClient {
+            client,
+            user_agent,
+            proxy_connector,
+        })
+    }
+
+    // TODO: check this with uri?
+    pub fn send(
+        &self,
+        mut request: Request<B>,
+    ) -> BoxFuture<'static, Result<http::Response<Body>, HttpError>> {
+        let span = tracing::info_span!("http");
+        let _enter = span.enter();
+
+        default_request_headers(&mut request, &self.user_agent);
+        self.maybe_add_proxy_headers(&mut request);
+
+        emit!(http_client::AboutToSendHttpRequest { request: &request });
+
+        let response = self.client.request(request);
+
+        let fut = async move {
+            // Capture the time right before we issue the request.
+            // Request doesn't start the processing until we start polling it.
+            let before = std::time::Instant::now();
+
+            // Send request and wait for the result.
+            let response_result = response.await;
+
+            // Compute the roundtrip time it took to send the request and get
+            // the response or error.
+            let roundtrip = before.elapsed();
+
+            // Handle the errors and extract the response.
+            let response = response_result
+                .inspect_err(|error| {
+                    // Emit the error into the internal events system.
+                    emit!(http_client::GotHttpWarning { error, roundtrip });
+                })
+                .context(CallRequestSnafu)?;
+
+            // Emit the response into the internal events system.
+            emit!(http_client::GotHttpResponse {
+                response: &response,
+                roundtrip
+            });
+            Ok(response)
+        }
+        .instrument(span.clone().or_current());
+
+        Box::pin(fut)
+    }
+
+    fn maybe_add_proxy_headers(&self, request: &mut Request<B>) {
+        if let Some(proxy_headers) = self.proxy_connector.http_headers(request.uri()) {
+            for (k, v) in proxy_headers {
+                let request_headers = request.headers_mut();
+                if !request_headers.contains_key(k) {
+                    request_headers.insert(k, v.into());
+                }
+            }
+        }
+    }
+}
+
+impl<B> Service<Request<B>> for UnixHttpClient<B>
+where
+    B: fmt::Debug + HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<crate::Error> + Send,
+{
+    type Response = http::Response<Body>;
+    type Error = HttpError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request<B>) -> Self::Future {
+        self.send(request)
+    }
+}
+
+impl<B> Clone for UnixHttpClient<B> {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            user_agent: self.user_agent.clone(),
+            proxy_connector: self.proxy_connector.clone(),
+        }
+    }
+}
+
+impl<B> fmt::Debug for UnixHttpClient<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnixHttpClient")
+            .field("client", &self.client)
+            .field("user_agent", &self.user_agent)
+            .finish()
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
In this PR I plan to introduce the ability to scrape Prometheus metrics over Unix sockets. For this I have added a `UnixHttpClient` compatible with the `HttpClient` in its interface. Furthermore, I have adjusted the handling of endpoint URI's. Lastly the http_client is adjusted to handle URI's with the `unix` scheme via the new `UnixHttpClient`.
For further information, check the descriptions of the commits themselves.

There is some debate on how the URI should be handled. The current solution is an untagged union with special case for the Unix socket. This is not in line with #19012 and should be refactored further in the future. Another solution for the meantime could be that the path to the socket is passed as a query parameter (like Postgres does it [see 31.1.1.2. Connection URIs](https://www.postgresql.org/docs/9.5/libpq-connect.html). See the overview I made [here](https://github.com/vectordotdev/vector/issues/17050#issuecomment-4173050032).

Furthermore, the `UnixHttpClient` could be used by other sources wanting to scrape Unix sockets as well.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
```toml
[sources.unix]
endpoints = [{ path = "./test.sock" }] # this is a full path but irrelevant here
instance_tag = "instance_endpoint"
type = "prometheus_scrape"

[sources.tcp]
endpoints = ["http://127.0.0.1:9898"]
instance_tag = "instance_endpoint"
type = "prometheus_scrape"

[api]
enabled = true

[sinks.file]
type = "file"
inputs = ["unix", "tcp"]
path = "./out.log"
encoding.codec = "json"
```
## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

I have manually created dummy Prometheus metrics server running over a Unix socket and successfully scraped metrics. There were then written to a log file.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
Closes: #5794
<!--
- Related: #<issue/PR number or link>
-->
Related: #19012 
Related: #17050 
Related: #4554 

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
