### PR TITLE
fix(ci): pin Pulsar integration test image to 4.1.3

### DIFF
--- a/tests/integration/pulsar/config/test.yaml
+++ b/tests/integration/pulsar/config/test.yaml
@@ -7,7 +7,9 @@ env:
   PULSAR_HOST: pulsar
 
 matrix:
-  version: [latest]
+  # TODO: re-enable `latest` once TLS tests pass with newer Pulsar images.
+  # See https://github.com/vectordotdev/vector/issues/25096
+  version: ["4.1.3"]
 
 # changes to these files/paths will invoke the integration test in CI
 # expressions are evaluated using https://github.com/micromatch/picomatch


### PR DESCRIPTION
## Summary

The `apachepulsar/pulsar:latest` Docker image recently moved to a newer version that breaks TLS connectivity in CI. This causes two Pulsar TLS integration tests to fail:

- `sinks::pulsar::integration_tests::pulsar_happy_tls`
- `sources::pulsar::integration_tests::consumes_event_with_tls`

This PR pins the Pulsar test image to `4.1.3` to unblock the merge queue. Re-enabling `latest` is tracked in #25096.

## Vector configuration

N/A

## How did you test this PR?

Tests will run in the MQ and validate if this fix works.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25096
- Failed run: https://github.com/vectordotdev/vector/actions/runs/23863175519/job/69576435462