### PR TITLE
fix(ci): verify choco package install after 5xx from feed

### DIFF
--- a/scripts/environment/bootstrap-windows-2025.ps1
+++ b/scripts/environment/bootstrap-windows-2025.ps1
@@ -11,9 +11,10 @@ function Install-ChocoPackage {
 
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
         choco install $Package --execution-timeout=7200 -y
-        # choco can return exit code 0 even on 5xx errors from the feed,
-        # so verify the package is actually installed
-        if ($LASTEXITCODE -eq 0 -and (choco list --local-only --exact $Package | Select-String $Package)) {
+        # Both `choco install` and `choco list` can exit 0 even on 5xx errors
+        # from the feed, so verify install by matching a "name|version" line
+        # in the list output. --limit-output strips headers/warnings.
+        if ((choco list --limit-output -e $Package) -match "^$([regex]::Escape($Package))\|") {
             return
         }
 

--- a/scripts/environment/bootstrap-windows-2025.ps1
+++ b/scripts/environment/bootstrap-windows-2025.ps1
@@ -11,7 +11,9 @@ function Install-ChocoPackage {
 
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
         choco install $Package --execution-timeout=7200 -y
-        if ($LASTEXITCODE -eq 0) {
+        # choco can return exit code 0 even on 5xx errors from the feed,
+        # so verify the package is actually installed
+        if ($LASTEXITCODE -eq 0 -and (choco list --local-only --exact $Package | Select-String $Package)) {
             return
         }
 


### PR DESCRIPTION
## Summary

`choco install` returns exit code 0 even when the chocolatey feed returns a 503, causing the Windows bootstrap to silently skip installing `make` and `protoc`. The build then fails ~30 minutes later when these tools are needed.

Adds a post-install verification via `choco list --local-only` so the retry logic actually triggers on transient feed errors.

Ref: https://github.com/vectordotdev/vector/actions/runs/23935387636/job/69810717854

## Vector configuration

NA

## How did you test this PR?

Verified the 503 behavior in the linked CI run logs where both `make` and `protoc` installs silently failed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/23935387636/job/69810717854