### PR TITLE
fix(ci): use helm-charts develop branch for K8s E2E tests

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -197,6 +197,13 @@ jobs:
           MINIKUBE_VERSION: ${{ matrix.minikube_version }}
           CONTAINER_RUNTIME: ${{ matrix.container_runtime }}
 
+      - name: Checkout helm-charts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: vectordotdev/helm-charts
+          ref: develop
+          path: helm-charts
+
       # TODO: This job has been quite flakey. Need to investigate further and then remove the retries.
       - name: Run tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
@@ -204,6 +211,7 @@ jobs:
           USE_MINIKUBE_CACHE: "true"
           SKIP_PACKAGE_DEB: "true"
           CARGO_INCREMENTAL: 0
+          HELM_CHART_REPO: ${{ github.workspace }}/helm-charts/charts/vector
         with:
           timeout_minutes: 45
           max_attempts: 3

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -20,6 +20,12 @@ pub mod metrics;
 
 pub const BUSYBOX_IMAGE: &str = "busybox:1.28";
 
+/// Returns the Helm chart repo to use for E2E tests.
+/// Set `HELM_CHART_REPO` to override the default (e.g., a local chart path).
+pub fn helm_chart_repo() -> String {
+    env::var("HELM_CHART_REPO").unwrap_or_else(|_| "https://helm.vector.dev".to_string())
+}
+
 pub fn init() {
     _ = env_logger::builder().is_test(true).try_init();
 }

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -74,7 +74,7 @@ async fn default_agent() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -199,7 +199,7 @@ async fn partial_merge() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -351,7 +351,7 @@ async fn preexisting() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -453,7 +453,7 @@ async fn multiple_lines() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -580,7 +580,7 @@ async fn metadata_annotation() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -769,7 +769,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -1012,7 +1012,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&config_override_name(&override_name, true), CONFIG],
                 ..Default::default()
@@ -1207,7 +1207,7 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -1416,7 +1416,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&config_override_name(&override_name, true), CONFIG],
                 ..Default::default()
@@ -1576,7 +1576,7 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -1738,7 +1738,7 @@ async fn existing_config_file() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -1839,7 +1839,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -1994,7 +1994,7 @@ async fn host_metrics() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![
                     &config_override_name(&override_name, true),
@@ -2060,7 +2060,7 @@ async fn simple_checkpoint() -> Result<(), Box<dyn std::error::Error>> {
             "test-vector",
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![HELM_VALUES_AGENT],
                 ..Default::default()

--- a/lib/k8s-e2e-tests/tests/vector-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-aggregator.rs
@@ -19,7 +19,7 @@ async fn dummy_topology() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&config_override_name(&override_name, false)],
                 ..Default::default()
@@ -54,7 +54,7 @@ async fn metrics_pipeline() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&config_override_name(&override_name, false)],
                 ..Default::default()

--- a/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
+++ b/lib/k8s-e2e-tests/tests/vector-dd-agent-aggregator.rs
@@ -58,7 +58,7 @@ async fn datadog_to_vector() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "vector",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&config_override_name(&override_name, false)],
                 ..Default::default()

--- a/lib/k8s-e2e-tests/tests/vector.rs
+++ b/lib/k8s-e2e-tests/tests/vector.rs
@@ -77,7 +77,7 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "aggregator",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 ..Default::default()
             },
@@ -97,7 +97,7 @@ async fn logs() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "agent",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&helm_values_stdout_sink(&agent_override_name)],
                 ..Default::default()
@@ -198,7 +198,7 @@ async fn haproxy() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "aggregator",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![CONFIG],
                 ..Default::default()
@@ -227,7 +227,7 @@ async fn haproxy() -> Result<(), Box<dyn std::error::Error>> {
             &namespace,
             "vector",
             "agent",
-            "https://helm.vector.dev",
+            &helm_chart_repo(),
             VectorConfig {
                 custom_helm_values: vec![&helm_values_haproxy(&agent_override_name)],
                 ..Default::default()

--- a/scripts/deploy-chart-test.sh
+++ b/scripts/deploy-chart-test.sh
@@ -61,8 +61,14 @@ up() {
   # A Vector container image to use.
   CONTAINER_IMAGE="${CONTAINER_IMAGE:?"You must assign CONTAINER_IMAGE variable with the Vector container image name"}"
 
-  $VECTOR_TEST_HELM repo add "$CUSTOM_HELM_REPO_LOCAL_NAME" "$CHART_REPO" --force-update || true
-  $VECTOR_TEST_HELM repo update
+  # Support both remote repos (https://...) and local chart paths
+  if [[ "$CHART_REPO" == http* ]]; then
+    $VECTOR_TEST_HELM repo add "$CUSTOM_HELM_REPO_LOCAL_NAME" "$CHART_REPO" --force-update || true
+    $VECTOR_TEST_HELM repo update
+    HELM_INSTALL_TARGET="$CUSTOM_HELM_REPO_LOCAL_NAME/$HELM_CHART"
+  else
+    HELM_INSTALL_TARGET="$CHART_REPO"
+  fi
 
   $VECTOR_TEST_KUBECTL create namespace "$NAMESPACE" --dry-run -o yaml | $VECTOR_TEST_KUBECTL apply -f -
 
@@ -95,7 +101,7 @@ up() {
     --namespace "$NAMESPACE" \
     "${HELM_VALUES[@]}" \
     "$RELEASE_NAME" \
-    "$CUSTOM_HELM_REPO_LOCAL_NAME/$HELM_CHART"
+    "$HELM_INSTALL_TARGET"
   { set +x; } &>/dev/null
 }
 


### PR DESCRIPTION
## Summary

Instead of pulling the published chart from `helm.vector.dev`, clone the helm-charts repo (`develop` branch) and use the local chart path. This breaks the circular dependency between Vector and helm-charts releases and catches chart incompatibilities before release.

- Add `helm_chart_repo()` helper with `HELM_CHART_REPO` env var override, defaulting to `https://helm.vector.dev`
- Update `deploy-chart-test.sh` to support local chart paths (skip `helm repo add` for non-URL paths)
- Clone `vectordotdev/helm-charts` in CI and set `HELM_CHART_REPO`

## How did you test this PR?

- `cargo check --features e2e-tests` passes
- `make check-clippy` passes
- Validated YAML syntax

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes.
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Fixes: #25111

🤖 Generated with [Claude Code](https://claude.com/claude-code)