### PR TITLE
chore(ci): update check-spelling

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
+        uses: check-spelling/check-spelling@a35147f799f30f8739c33f92222c847214e82e67 # v0.0.26 (see check-spelling/check-spelling/issues/103)
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does. -->

As per https://github.com/check-spelling/check-spelling/issues/103 GitHub recently changed the API that check-spelling was using to determine if it was running with unsafe permissions.

This is causing PRs to fail with an Unsafe Permissions error; e.g., https://github.com/vectordotdev/vector/actions/runs/23985475380

## Vector configuration
N/A

## How did you test this PR?
N/A

## Change Type

- [X] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the `no-changelog` label to this PR.
