### PR TITLE
feat(honeycomb sink): add samplerate_field config option

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -457,6 +457,7 @@ rstest
 rsyslog
 rsyslogd
 rumqttc
+samplerate
 Salesforce
 Samsung
 SBT

--- a/changelog.d/18098_honeycomb_samplerate.enhancement.md
+++ b/changelog.d/18098_honeycomb_samplerate.enhancement.md
@@ -1,0 +1,6 @@
+Added a `samplerate_field` configuration option to the `honeycomb` sink, allowing users to
+specify a field in their events to be used as the `samplerate` value in the Honeycomb Batch API.
+
+Issue: https://github.com/vectordotdev/vector/issues/18098
+
+authors: fru1tworld

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -3,7 +3,10 @@
 use bytes::Bytes;
 use futures::FutureExt;
 use http::{Request, StatusCode, Uri};
-use vector_lib::{configurable::configurable_component, sensitive_string::SensitiveString};
+use vector_lib::{
+    configurable::configurable_component, lookup::lookup_v2::OptionalTargetPath,
+    sensitive_string::SensitiveString,
+};
 use vrl::value::Kind;
 
 use super::{
@@ -64,6 +67,16 @@ pub struct HoneycombConfig {
     #[serde(default = "Compression::zstd_default")]
     compression: Compression,
 
+    /// An optional field name that contains the sample rate for the event.
+    ///
+    /// If set, the value of this field is extracted from the event and sent as the
+    /// `samplerate` field in the Honeycomb batch API. The field is removed from the
+    /// event data. If the field is missing or its value is not an integer, the
+    /// `samplerate` field is omitted from the API request.
+    #[configurable(metadata(docs::examples = "sample_rate"))]
+    #[serde(default)]
+    samplerate_field: Option<OptionalTargetPath>,
+
     #[configurable(derived)]
     #[serde(
         default,
@@ -105,6 +118,7 @@ impl SinkConfig for HoneycombConfig {
         let request_builder = HoneycombRequestBuilder {
             encoder: HoneycombEncoder {
                 transformer: self.encoding.clone(),
+                samplerate_field: self.samplerate_field.clone(),
             },
             compression: self.compression,
         };

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -69,10 +69,10 @@ pub struct HoneycombConfig {
 
     /// An optional field name that contains the sample rate for the event.
     ///
-    /// If set, the value of this field is extracted from the event and sent as the
-    /// `samplerate` field in the Honeycomb batch API. The field is removed from the
-    /// event data. If the field is missing or its value is not an integer, the
-    /// `samplerate` field is omitted from the API request.
+    /// If set, the field is removed from the event data. When the value is a positive
+    /// integer, it is sent as the `samplerate` field in the Honeycomb batch API.
+    /// If the field is missing or its value is not a positive integer, the `samplerate`
+    /// field is omitted from the API request.
     #[configurable(metadata(docs::examples = "sample_rate"))]
     #[serde(default)]
     samplerate_field: Option<OptionalTargetPath>,

--- a/src/sinks/honeycomb/encoder.rs
+++ b/src/sinks/honeycomb/encoder.rs
@@ -6,6 +6,8 @@ use bytes::Bytes;
 use chrono::{SecondsFormat, Utc};
 use serde_json::{json, to_vec};
 
+use vector_lib::lookup::lookup_v2::OptionalTargetPath;
+
 use crate::sinks::{
     prelude::*,
     util::encoding::{Encoder as SinkEncoder, write_all},
@@ -13,6 +15,7 @@ use crate::sinks::{
 
 pub(super) struct HoneycombEncoder {
     pub(super) transformer: Transformer,
+    pub(super) samplerate_field: Option<OptionalTargetPath>,
 }
 
 impl SinkEncoder<Vec<Event>> for HoneycombEncoder {
@@ -37,10 +40,30 @@ impl SinkEncoder<Vec<Event>> for HoneycombEncoder {
                 _ => Utc::now(),
             };
 
-            let data = json!({
+            let samplerate = self.samplerate_field.as_ref().and_then(|field| {
+                field.path.as_ref().and_then(|path| {
+                    log.remove(path).and_then(|value| match value {
+                        Value::Integer(rate) => Some(rate),
+                        other => {
+                            warn!(
+                                message = "Samplerate field value was not an integer, ignoring.",
+                                field = %path,
+                                value_type = other.kind_str(),
+                            );
+                            None
+                        }
+                    })
+                })
+            });
+
+            let mut data = json!({
                 "time": timestamp.to_rfc3339_opts(SecondsFormat::Nanos, true),
                 "data": log.convert_to_fields(),
             });
+
+            if let Some(rate) = samplerate {
+                data["samplerate"] = json!(rate);
+            }
 
             json_events.push(data);
         }

--- a/src/sinks/honeycomb/encoder.rs
+++ b/src/sinks/honeycomb/encoder.rs
@@ -43,7 +43,15 @@ impl SinkEncoder<Vec<Event>> for HoneycombEncoder {
             let samplerate = self.samplerate_field.as_ref().and_then(|field| {
                 field.path.as_ref().and_then(|path| {
                     log.remove(path).and_then(|value| match value {
-                        Value::Integer(rate) => Some(rate),
+                        Value::Integer(rate) if rate > 0 => Some(rate),
+                        Value::Integer(rate) => {
+                            warn!(
+                                message = "Samplerate field value must be a positive integer, ignoring.",
+                                field = %path,
+                                value = %rate,
+                            );
+                            None
+                        }
                         other => {
                             warn!(
                                 message = "Samplerate field value was not an integer, ignoring.",

--- a/src/sinks/honeycomb/tests.rs
+++ b/src/sinks/honeycomb/tests.rs
@@ -142,14 +142,15 @@ mod samplerate {
 
         // samplerate should be omitted for non-integer values
         assert!(event.get("samplerate").is_none());
-        // "rate" should still be removed from data (it was extracted)
+        // Configured field is always removed from data
         assert!(event["data"].get("rate").is_none());
     }
 
     #[test]
-    fn encode_event_samplerate_field_value_zero() {
+    fn encode_event_samplerate_field_value_zero_or_negative() {
         let encoder = make_encoder(Some("rate"));
 
+        // Zero is invalid (samplerate means "1 in N", N must be > 0)
         let mut log = LogEvent::default();
         log.insert("rate", 0);
         log.insert("message", "hello");
@@ -162,8 +163,24 @@ mod samplerate {
         let output = decode_output(buf.get_ref());
         let event = &output[0];
 
-        // 0 is a valid samplerate
-        assert_eq!(event["samplerate"], serde_json::json!(0));
+        assert!(event.get("samplerate").is_none());
+        // Invalid integer values are still removed from data
+        assert!(event["data"].get("rate").is_none());
+
+        // Negative is also invalid
+        let mut log = LogEvent::default();
+        log.insert("rate", -5);
+        log.insert("message", "hello");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(vec![Event::Log(log)], &mut buf)
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        let event = &output[0];
+
+        assert!(event.get("samplerate").is_none());
         assert!(event["data"].get("rate").is_none());
     }
 
@@ -200,7 +217,7 @@ mod samplerate {
         // Second event: no samplerate field at all
         assert!(output[1].get("samplerate").is_none());
 
-        // Third event: non-integer, so no samplerate
+        // Third event: non-integer, so no samplerate; field still removed from data
         assert!(output[2].get("samplerate").is_none());
         assert!(output[2]["data"].get("rate").is_none());
     }

--- a/src/sinks/honeycomb/tests.rs
+++ b/src/sinks/honeycomb/tests.rs
@@ -34,3 +34,174 @@ async fn component_spec_compliance() {
     let event = Event::Log(LogEvent::from("simple message"));
     run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 }
+
+mod samplerate {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::sinks::{
+        honeycomb::encoder::HoneycombEncoder, util::encoding::Encoder as SinkEncoder,
+    };
+    use vector_lib::lookup::lookup_v2::OptionalTargetPath;
+
+    fn make_encoder(samplerate_field: Option<&str>) -> HoneycombEncoder {
+        HoneycombEncoder {
+            transformer: Transformer::default(),
+            samplerate_field: samplerate_field.map(|f| {
+                OptionalTargetPath::try_from(f.to_string())
+                    .expect("unable to parse OptionalTargetPath")
+            }),
+        }
+    }
+
+    fn decode_output(buf: &[u8]) -> Vec<serde_json::Value> {
+        serde_json::from_slice(buf).expect("should be valid JSON array")
+    }
+
+    #[test]
+    fn encode_event_with_samplerate_field() {
+        let encoder = make_encoder(Some("rate"));
+
+        let mut log = LogEvent::default();
+        log.insert("rate", 5);
+        log.insert("message", "hello");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(vec![Event::Log(log)], &mut buf)
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        assert_eq!(output.len(), 1);
+
+        let event = &output[0];
+        assert_eq!(event["samplerate"], serde_json::json!(5));
+
+        // "rate" should be removed from data
+        assert!(event["data"].get("rate").is_none());
+        // "message" should still be in data
+        assert!(event["data"].get("message").is_some());
+    }
+
+    #[test]
+    fn encode_event_without_samplerate_field_configured() {
+        let encoder = make_encoder(None);
+
+        let mut log = LogEvent::default();
+        log.insert("rate", 5);
+        log.insert("message", "hello");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(vec![Event::Log(log)], &mut buf)
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        let event = &output[0];
+
+        // No samplerate key at top level
+        assert!(event.get("samplerate").is_none());
+        // "rate" should still be in data
+        assert!(event["data"].get("rate").is_some());
+    }
+
+    #[test]
+    fn encode_event_samplerate_field_missing_from_event() {
+        let encoder = make_encoder(Some("rate"));
+
+        let mut log = LogEvent::default();
+        log.insert("message", "hello");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(vec![Event::Log(log)], &mut buf)
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        let event = &output[0];
+
+        // No samplerate key since the field doesn't exist
+        assert!(event.get("samplerate").is_none());
+    }
+
+    #[test]
+    fn encode_event_samplerate_field_not_integer() {
+        let encoder = make_encoder(Some("rate"));
+
+        let mut log = LogEvent::default();
+        log.insert("rate", "not-a-number");
+        log.insert("message", "hello");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(vec![Event::Log(log)], &mut buf)
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        let event = &output[0];
+
+        // samplerate should be omitted for non-integer values
+        assert!(event.get("samplerate").is_none());
+        // "rate" should still be removed from data (it was extracted)
+        assert!(event["data"].get("rate").is_none());
+    }
+
+    #[test]
+    fn encode_event_samplerate_field_value_zero() {
+        let encoder = make_encoder(Some("rate"));
+
+        let mut log = LogEvent::default();
+        log.insert("rate", 0);
+        log.insert("message", "hello");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(vec![Event::Log(log)], &mut buf)
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        let event = &output[0];
+
+        // 0 is a valid samplerate
+        assert_eq!(event["samplerate"], serde_json::json!(0));
+        assert!(event["data"].get("rate").is_none());
+    }
+
+    #[test]
+    fn encode_multiple_events_mixed_samplerate() {
+        let encoder = make_encoder(Some("rate"));
+
+        let mut log1 = LogEvent::default();
+        log1.insert("rate", 10);
+        log1.insert("message", "with rate");
+
+        let mut log2 = LogEvent::default();
+        log2.insert("message", "no rate");
+
+        let mut log3 = LogEvent::default();
+        log3.insert("rate", "invalid");
+        log3.insert("message", "invalid rate");
+
+        let mut buf = Cursor::new(Vec::new());
+        encoder
+            .encode_input(
+                vec![Event::Log(log1), Event::Log(log2), Event::Log(log3)],
+                &mut buf,
+            )
+            .unwrap();
+
+        let output = decode_output(buf.get_ref());
+        assert_eq!(output.len(), 3);
+
+        // First event: has integer samplerate
+        assert_eq!(output[0]["samplerate"], serde_json::json!(10));
+        assert!(output[0]["data"].get("rate").is_none());
+
+        // Second event: no samplerate field at all
+        assert!(output[1].get("samplerate").is_none());
+
+        // Third event: non-integer, so no samplerate
+        assert!(output[2].get("samplerate").is_none());
+        assert!(output[2]["data"].get("rate").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Add a `samplerate_field` configuration option to the Honeycomb sink. When set, the specified field is extracted from each event and sent as the `samplerate` value in the Honeycomb Batch API. The field is removed from the event data. If the field is missing or not an integer, `samplerate` is omitted.

Closes #18098

## Vector configuration

```toml
[sinks.honeycomb]
type = "honeycomb"
api_key = "${HONEYCOMB_API_KEY}"
dataset = "my-dataset"
samplerate_field = "sample_rate"
```

## How did you test this PR?

- Added 6 unit tests covering: valid integer, no config, missing field, non-integer type, zero value, and mixed batch
- `cargo test -p vector --lib -- sinks::honeycomb::tests::samplerate` (6/6 pass)
- `make check-clippy` pass
- `make check-fmt` pass

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #18098