### PR TITLE
fix(gcp_pubsub source): treat expected stream closures as non-errors

### DIFF
--- a/changelog.d/25151_gcp_pubsub_expected_closure.fix.md
+++ b/changelog.d/25151_gcp_pubsub_expected_closure.fix.md
@@ -1,0 +1,6 @@
+The `gcp_pubsub` source no longer logs an ERROR or increments `component_errors_total`
+when the server closes a StreamingPull stream for an expected reason. These routine
+closures are now logged at debug level and trigger an immediate reconnect instead of
+waiting for `retry_delay_secs`.
+
+authors: andylibrian

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -722,6 +722,9 @@ fn translate_error(error: tonic::Status) -> State {
     if is_reset(&error) {
         debug!("Stream reset by server.");
         State::RetryNow
+    } else if is_expected_closure(&error) {
+        debug!("Stream closed for an expected reason by the server.");
+        State::RetryNow
     } else {
         emit!(GcpPubsubReceiveError { error });
         State::RetryDelay
@@ -735,6 +738,13 @@ fn is_reset(error: &Status) -> bool {
         .and_then(|error| error.source())
         .and_then(|source| source.downcast_ref::<h2::Error>())
         .is_some_and(|error| error.is_remote() && error.is_reset())
+}
+
+fn is_expected_closure(error: &Status) -> bool {
+    error.code() == Code::Unavailable
+        && error
+            .message()
+            .starts_with("The StreamingPull stream closed for an expected reason")
 }
 
 #[pin_project::pin_project]
@@ -838,6 +848,36 @@ mod tests {
         .with_event_field(&owned_value_path!("message_id"), Kind::bytes(), None);
 
         assert_eq!(definitions, Some(expected_definition));
+    }
+
+    #[test]
+    fn expected_closure_matches_unavailable_with_known_message() {
+        let error = Status::unavailable(
+            "The StreamingPull stream closed for an expected reason. Reconnecting.",
+        );
+        assert!(is_expected_closure(&error));
+    }
+
+    #[test]
+    fn expected_closure_does_not_match_different_message() {
+        let error = Status::unavailable("Server shutting down");
+        assert!(!is_expected_closure(&error));
+    }
+
+    #[test]
+    fn expected_closure_does_not_match_different_code() {
+        let error = Status::internal(
+            "The StreamingPull stream closed for an expected reason. Reconnecting.",
+        );
+        assert!(!is_expected_closure(&error));
+    }
+
+    #[test]
+    fn translate_error_retries_now_on_expected_closure() {
+        let error = Status::unavailable(
+            "The StreamingPull stream closed for an expected reason. Reconnecting.",
+        );
+        assert!(matches!(translate_error(error), State::RetryNow));
     }
 }
 


### PR DESCRIPTION
## Summary

The `gcp_pubsub` source emits ERROR-level logs and increments `component_errors_total` when Google's Pub/Sub server closes a StreamingPull connection for an expected reason. Google's documentation describes these periodic closures as routine behavior:

> "The Pub/Sub servers recurrently close the connection after a time period to avoid a long-running sticky connection. The client library automatically reopens a StreamingPull connection."

https://cloud.google.com/pubsub/docs/pull#streamingpull 

The observed error:

```
ERROR vector::internal_events::gcp_pubsub: Failed to fetch events.
  error=status: Unavailable,
  message: "The StreamingPull stream closed for an expected reason and should be recreated..."
```

This causes false alerts, inflates `component_errors_total`, and introduces an unnecessary `retry_delay_secs` (default 1s) pause before reconnecting.

**Root cause:** `translate_error()` only special-cases HTTP/2-level resets via `is_reset()`, which inspects the `hyper::Error` → `h2::Error` source chain. The expected closure arrives as a gRPC-level `tonic::Status` with `Code::Unavailable`, which `is_reset()` cannot detect. It falls through to the else branch, emitting `GcpPubsubReceiveError` (ERROR + metric) and returning `State::RetryDelay`.

**Fix:** Add an `is_expected_closure()` predicate that checks for `Code::Unavailable` with a message starting with `"The StreamingPull stream closed for an expected reason"`. When matched, log at `debug!` level and return `State::RetryNow` for immediate reconnection — following the same pattern as the existing `is_reset()` handler.

If Google ever changes the message text, detection stops and behavior safely regresses to the current ERROR + delay — not a new failure mode.

## Vector configuration

```yaml
sources:
  gcp_pubsub_source:
    type: gcp_pubsub
    project: *redacted*
    subscription: vector

transforms:
  parse_logs:
    type: remap
    inputs:
      - gcp_pubsub_source
    source: |
      . = parse_json!(.message)

sinks:
  vmlogs:
    type: elasticsearch
    inputs:
      - parse_logs
    endpoints:
      - http://vlinsert:9481/insert/elasticsearch/
    api_version: v8
```

## How did you test this PR?

**Unit tests** — 4 new tests in `src/sources/gcp_pubsub.rs`:

- `expected_closure_matches_unavailable_with_known_message` — predicate matches expected closure
- `expected_closure_does_not_match_different_message` — predicate rejects other Unavailable messages
- `expected_closure_does_not_match_different_code` — predicate rejects non-Unavailable codes
- `translate_error_retries_now_on_expected_closure` — translate_error returns `State::RetryNow`

**Real GKE test** — two-phase test on a GKE cluster consuming from GCP Pub/Sub:

1. **Phase 1 (baseline):** Deployed unmodified `master` (v0.55.0).
  Confirmed ERROR logs and `component_errors_total` increments continued at the expected rate. Also observed a genuine Unavailable error (`"The service was unable to fulfill your request"`) which is correctly NOT matched by this fix.
3. **Phase 2 (fix):** Deployed this branch. After 1+ hour of monitoring: zero `Failed to fetch events` ERROR logs from the fix pod, while streams continued scaling up normally (concurrency 1→3), confirming expected closures are handled silently with immediate reconnect.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Closes #25151 

## Files to create/modify

- `changelog.d/22304_gcp_pubsub_expected_closure.fix.md`
- `src/sources/gcp_pubsub.rs`

## Verification

```
make fmt
make check-fmt
make check-clippy
./scripts/check_changelog_fragments.sh
cargo test -p vector --lib sources::gcp_pubsub --no-default-features --features sources-gcp_pubsub
```

