### PR TITLE
feat(vrl): add native parse_ddtags function

### DIFF
--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -12,6 +12,59 @@ use vector::{
 };
 use vrl::{event_path, prelude::*};
 
+// ~50 realistic Datadog tags with long values and duplicate keys.
+const DDTAGS_BENCH_INPUT: &str = "\
+env:production,\
+service:payment-gateway-service,\
+version:4.12.7-rc3,\
+host:ip-10-42-137-29.us-east-1.compute.internal,\
+instance-type:m5.2xlarge,\
+availability-zone:us-east-1c,\
+region:us-east-1,\
+cluster:eks-prod-main-useast1-2024,\
+namespace:payments,\
+pod_name:payment-gateway-service-7f8b9c6d4f-x2k9m,\
+container_name:payment-gateway,\
+image_tag:registry.internal.example.com/payments/gateway:4.12.7-rc3-sha-a1b2c3d4,\
+team:platform-payments,\
+cost_center:cc-payments-12345,\
+owner:payments-oncall@example.com,\
+pagerduty:payments-p1,\
+slo:payments-availability-99.99,\
+tier:tier-0-critical,\
+compliance:pci-dss-v4,\
+compliance:soc2-type2,\
+compliance:gdpr,\
+datacenter:us-east-1-primary,\
+network:vpc-0a1b2c3d4e5f67890,\
+subnet:subnet-private-us-east-1c-payments,\
+security_group:sg-payment-gateway-prod,\
+load_balancer:arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/payment-gw-prod/50dc6c495c0c9188,\
+target_group:arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/payment-gw-tg/73e2d6bc24d8a067,\
+dns:payment-gateway.internal.prod.example.com,\
+port:8443,\
+protocol:https,\
+framework:spring-boot-3.2.1,\
+runtime:openjdk-21.0.2+13,\
+orchestrator:kubernetes-1.29,\
+deploy_pipeline:argo-cd,\
+deploy_sha:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0,\
+deploy_timestamp:2024-11-15T14:32:07Z,\
+canary:false,\
+feature_flag:new-checkout-flow-v2,\
+feature_flag:payment-retry-logic-v3,\
+feature_flag:fraud-detection-ml-model-2024q4,\
+circuit_breaker:downstream-bank-api,\
+rate_limit_tier:premium,\
+db_pool:payments-primary-rds-cluster.cluster-abc123def456.us-east-1.rds.amazonaws.com,\
+cache_cluster:payments-redis-prod-001.abc123.0001.use1.cache.amazonaws.com,\
+message_queue:arn:aws:sqs:us-east-1:123456789012:payment-events-prod,\
+trace_sample_rate:0.15,\
+log_level:info,\
+custom_metric_prefix:payments.gateway,\
+git_repository:github.com/example-org/payment-gateway-service,\
+oncall_schedule:payments-primary-rotation-2024";
+
 criterion_group!(
     name = benches;
     // encapsulates CI noise we saw in
@@ -202,6 +255,109 @@ fn benchmark_remap(c: &mut Criterion) {
         b.iter_batched(
             || event.clone(),
             |event| coerce_runner(&mut tform, event, timestamp),
+            BatchSize::SmallInput,
+        );
+    });
+
+    let parse_ddtags_runner = |tform: &mut Box<dyn SyncTransform>, event: Event| {
+        let mut outputs = TransformOutputsBuf::new_with_capacity(
+            vec![TransformOutput::new(DataType::all_bits(), HashMap::new())],
+            1,
+        );
+        tform.transform(event, &mut outputs);
+        let result = outputs.take_primary();
+        let output_1 = result.first().unwrap().as_log();
+
+        debug_assert!(output_1.get(event_path!("parsed")).is_some());
+
+        result
+    };
+
+    group.bench_function("parse_ddtags/native", |b| {
+        let mut tform: Box<dyn SyncTransform> = Box::new(
+            Remap::new_ast(
+                RemapConfig {
+                    source: Some(
+                        r#".parsed = parse_ddtags!(string!(.ddtags))"#.to_string(),
+                    ),
+                    file: None,
+                    timezone: None,
+                    drop_on_error: true,
+                    drop_on_abort: true,
+                    ..Default::default()
+                },
+                &Default::default(),
+            )
+            .unwrap()
+            .0,
+        );
+
+        let event = {
+            let mut event = Event::Log(LogEvent::from("parse ddtags"));
+            event
+                .as_mut_log()
+                .insert(event_path!("ddtags"), DDTAGS_BENCH_INPUT.to_owned());
+            event
+        };
+
+        b.iter_batched(
+            || event.clone(),
+            |event| parse_ddtags_runner(&mut tform, event),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("parse_ddtags/pure_vrl", |b| {
+        let mut tform: Box<dyn SyncTransform> = Box::new(
+            Remap::new_ast(
+                RemapConfig {
+                    source: Some(
+                        indoc! {r#"
+                            tags = split!(string!(.ddtags), ",")
+                            result = {}
+                            for_each(tags) -> |_i, tag| {
+                                parts = split(tag, ":", limit: 2)
+                                key = strip_whitespace!(to_string!(get!(parts, [0])))
+                                val_raw = get(parts, [1]) ?? null
+                                val = if val_raw != null {
+                                    strip_whitespace!(to_string!(val_raw))
+                                } else {
+                                    true
+                                }
+                                existing = get(result, [key]) ?? null
+                                if existing == null {
+                                    result = set!(result, [key], [val])
+                                } else {
+                                    result = set!(result, [key], push!(array!(existing), val))
+                                }
+                            }
+                            .parsed = result
+                        "#}
+                        .to_string(),
+                    ),
+                    file: None,
+                    timezone: None,
+                    drop_on_error: true,
+                    drop_on_abort: true,
+                    ..Default::default()
+                },
+                &Default::default(),
+            )
+            .unwrap()
+            .0,
+        );
+
+        let event = {
+            let mut event = Event::Log(LogEvent::from("parse ddtags"));
+            event
+                .as_mut_log()
+                .insert(event_path!("ddtags"), DDTAGS_BENCH_INPUT.to_owned());
+            event
+        };
+
+        b.iter_batched(
+            || event.clone(),
+            |event| parse_ddtags_runner(&mut tform, event),
             BatchSize::SmallInput,
         );
     });

--- a/changelog.d/parse_ddtags_vrl_function.feature.md
+++ b/changelog.d/parse_ddtags_vrl_function.feature.md
@@ -1,0 +1,1 @@
+Added a `parse_ddtags` VRL function that parses Datadog tag strings (comma-separated `key:value` pairs) into objects. The `multivalue` parameter controls duplicate key handling.

--- a/lib/vector-vrl/functions/src/lib.rs
+++ b/lib/vector-vrl/functions/src/lib.rs
@@ -12,6 +12,7 @@
 use vrl::{compiler::Function, path::OwnedTargetPath};
 
 pub mod get_secret;
+pub mod parse_ddtags;
 pub mod remove_secret;
 pub mod set_secret;
 pub mod set_semantic_meaning;
@@ -30,6 +31,7 @@ pub fn secret_functions() -> Vec<Box<dyn Function>> {
     vec![
         Box::new(set_semantic_meaning::SetSemanticMeaning) as _,
         Box::new(get_secret::GetSecret) as _,
+        Box::new(parse_ddtags::ParseDdtags) as _,
         Box::new(remove_secret::RemoveSecret) as _,
         Box::new(set_secret::SetSecret) as _,
     ]

--- a/lib/vector-vrl/functions/src/parse_ddtags.rs
+++ b/lib/vector-vrl/functions/src/parse_ddtags.rs
@@ -1,0 +1,293 @@
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use vrl::prelude::*;
+
+static DEFAULT_MULTIVALUE: LazyLock<Value> = LazyLock::new(|| Value::Boolean(true));
+
+static PARAMETERS: LazyLock<Vec<Parameter>> = LazyLock::new(|| {
+    vec![
+        Parameter::required(
+            "value",
+            kind::BYTES,
+            "The Datadog tag string to parse (comma-separated key:value pairs).",
+        ),
+        Parameter::optional(
+            "multivalue",
+            kind::BOOLEAN,
+            "If true (default), all values are wrapped in arrays to support duplicate keys. If false, the first value for each key wins.",
+        )
+        .default(&DEFAULT_MULTIVALUE),
+    ]
+});
+
+/// Iterate over the tags in a ddtag string, yielding `(key, value)` pairs.
+/// Skips empty segments and empty keys. Splits on the first colon only.
+fn iter_tags(input: &str) -> impl Iterator<Item = (&str, Value)> {
+    input.split(',').filter_map(|segment| {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            return None;
+        }
+        let (key, val) = match segment.find(':') {
+            Some(pos) => (segment[..pos].trim(), Value::from(segment[pos + 1..].trim())),
+            None => (segment, Value::Boolean(true)),
+        };
+        if key.is_empty() { None } else { Some((key, val)) }
+    })
+}
+
+fn collect_multivalue(input: &str) -> Value {
+    let mut map: BTreeMap<KeyString, Vec<Value>> = BTreeMap::new();
+    for (key, val) in iter_tags(input) {
+        map.entry(KeyString::from(key)).or_default().push(val);
+    }
+    Value::Object(map.into_iter().map(|(k, v)| (k, Value::Array(v))).collect())
+}
+
+fn collect_single_value(input: &str) -> Value {
+    let mut map = ObjectMap::new();
+    for (key, val) in iter_tags(input) {
+        map.entry(KeyString::from(key)).or_insert(val);
+    }
+    Value::Object(map)
+}
+
+fn parse_ddtags_impl(value: Value, multivalue: Value) -> Resolved {
+    let input = value.try_bytes_utf8_lossy()?;
+    let multivalue = multivalue.try_boolean()?;
+
+    Ok(if multivalue {
+        collect_multivalue(&input)
+    } else {
+        collect_single_value(&input)
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ParseDdtags;
+
+impl Function for ParseDdtags {
+    fn identifier(&self) -> &'static str {
+        "parse_ddtags"
+    }
+
+    fn summary(&self) -> &'static str {
+        "Parses a Datadog tag string into an object."
+    }
+
+    fn usage(&self) -> &'static str {
+        indoc! {r#"
+            Parses the `value` as a Datadog tag string — comma-separated `key:value` pairs
+            such as `"env:prod,host:server1,host:server2"`.
+
+            When `multivalue` is `true` (the default), every value is wrapped in an array so
+            that duplicate keys are preserved:
+
+                parse_ddtags!("host:a,host:b")  =>  {"host": ["a", "b"]}
+
+            When `multivalue` is `false`, the first encountered value for each key wins and
+            values are stored as plain strings:
+
+                parse_ddtags!("host:a,host:b", multivalue: false)  =>  {"host": "a"}
+
+            * Tags without a colon become standalone keys with a boolean `true` value.
+            * Values containing colons (e.g. URLs, ARNs) are handled correctly — only the
+              first colon is used as the key/value separator.
+            * Whitespace around keys and values is trimmed.
+            * Empty segments from leading, trailing, or consecutive commas are ignored.
+        "#}
+    }
+
+    fn category(&self) -> &'static str {
+        Category::Parse.as_ref()
+    }
+
+    fn internal_failure_reasons(&self) -> &'static [&'static str] {
+        &["`value` is not a string."]
+    }
+
+    fn return_kind(&self) -> u16 {
+        kind::OBJECT
+    }
+
+    fn return_rules(&self) -> &'static [&'static str] {
+        &[
+            "The function is fallible — it raises an error if `value` is not a string.",
+            "When `multivalue` is `true`, returns an object mapping each key to an array of strings (or booleans for standalone keys).",
+            "When `multivalue` is `false`, returns an object mapping each key to a single string (or boolean). Duplicate keys are resolved in favor of the first occurrence.",
+        ]
+    }
+
+    fn parameters(&self) -> &'static [Parameter] {
+        PARAMETERS.as_slice()
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        &[
+            example! {
+                title: "Parse Datadog tags (multivalue, default)",
+                source: r#"parse_ddtags!("env:prod,host:server1")"#,
+                result: Ok(r#"{"env": ["prod"], "host": ["server1"]}"#),
+            },
+            example! {
+                title: "Parse Datadog tags with duplicate keys",
+                source: r#"parse_ddtags!("env:prod,host:a,host:b")"#,
+                result: Ok(r#"{"env": ["prod"], "host": ["a", "b"]}"#),
+            },
+            example! {
+                title: "Parse Datadog tags (single-value mode)",
+                source: r#"parse_ddtags!("env:prod,host:a,host:b", multivalue: false)"#,
+                result: Ok(r#"{"env": "prod", "host": "a"}"#),
+            },
+            example! {
+                title: "Standalone keys and colons in values",
+                source: r#"parse_ddtags!("novalue,url:https://example.com:8080/path", multivalue: false)"#,
+                result: Ok(r#"{"novalue": true, "url": "https://example.com:8080/path"}"#),
+            },
+        ]
+    }
+
+    fn compile(
+        &self,
+        _state: &TypeState,
+        _ctx: &mut FunctionCompileContext,
+        arguments: ArgumentList,
+    ) -> Compiled {
+        let value = arguments.required("value");
+        let multivalue = arguments.optional("multivalue");
+
+        Ok(ParseDdtagsFn { value, multivalue }.as_expr())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParseDdtagsFn {
+    value: Box<dyn Expression>,
+    multivalue: Option<Box<dyn Expression>>,
+}
+
+impl FunctionExpression for ParseDdtagsFn {
+    fn resolve(&self, ctx: &mut Context) -> Resolved {
+        let value = self.value.resolve(ctx)?;
+        let multivalue = self
+            .multivalue
+            .map_resolve_with_default(ctx, || DEFAULT_MULTIVALUE.clone())?;
+        parse_ddtags_impl(value, multivalue)
+    }
+
+    fn type_def(&self, _: &TypeState) -> TypeDef {
+        // Values can be strings (from key:value) or booleans (standalone keys),
+        // and in multivalue mode they are wrapped in arrays.
+        TypeDef::object(Collection::from_unknown(
+            Kind::bytes()
+                | Kind::boolean()
+                | Kind::array(Collection::from_unknown(Kind::bytes() | Kind::boolean())),
+        ))
+        .fallible()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vrl::value;
+
+    #[test]
+    fn basic_multivalue() {
+        let result =
+            parse_ddtags_impl(Value::from("env:prod,host:server1"), Value::Boolean(true)).unwrap();
+        assert_eq!(result, value!({"env": ["prod"], "host": ["server1"]}));
+    }
+
+    #[test]
+    fn duplicate_keys_multivalue() {
+        let result =
+            parse_ddtags_impl(Value::from("env:prod,host:a,host:b"), Value::Boolean(true)).unwrap();
+        assert_eq!(result, value!({"env": ["prod"], "host": ["a", "b"]}));
+    }
+
+    #[test]
+    fn duplicate_keys_single_value_first_wins() {
+        let result =
+            parse_ddtags_impl(Value::from("env:prod,host:a,host:b"), Value::Boolean(false))
+                .unwrap();
+        assert_eq!(result, value!({"env": "prod", "host": "a"}));
+    }
+
+    #[test]
+    fn standalone_key_multivalue() {
+        let result =
+            parse_ddtags_impl(Value::from("env:prod,standalone"), Value::Boolean(true)).unwrap();
+        assert_eq!(result, value!({"env": ["prod"], "standalone": [true]}));
+    }
+
+    #[test]
+    fn standalone_key_single_value() {
+        let result =
+            parse_ddtags_impl(Value::from("env:prod,standalone"), Value::Boolean(false)).unwrap();
+        assert_eq!(result, value!({"env": "prod", "standalone": true}));
+    }
+
+    #[test]
+    fn empty_input() {
+        let result = parse_ddtags_impl(Value::from(""), Value::Boolean(true)).unwrap();
+        assert_eq!(result, value!({}));
+    }
+
+    #[test]
+    fn whitespace_trimming() {
+        let result = parse_ddtags_impl(
+            Value::from(" env : prod , host : server1 "),
+            Value::Boolean(false),
+        )
+        .unwrap();
+        assert_eq!(result, value!({"env": "prod", "host": "server1"}));
+    }
+
+    #[test]
+    fn multiple_colons_in_value() {
+        let result = parse_ddtags_impl(
+            Value::from("url:http://example.com:8080/path"),
+            Value::Boolean(false),
+        )
+        .unwrap();
+        assert_eq!(result, value!({"url": "http://example.com:8080/path"}));
+    }
+
+    #[test]
+    fn trailing_and_leading_commas() {
+        let result =
+            parse_ddtags_impl(Value::from(",env:prod,,host:a,"), Value::Boolean(false)).unwrap();
+        assert_eq!(result, value!({"env": "prod", "host": "a"}));
+    }
+
+    #[test]
+    fn empty_key_skipped() {
+        let result =
+            parse_ddtags_impl(Value::from(":value,env:prod"), Value::Boolean(false)).unwrap();
+        assert_eq!(result, value!({"env": "prod"}));
+    }
+
+    #[test]
+    fn realistic_ddtags() {
+        let result = parse_ddtags_impl(
+            Value::from(
+                "env:prod,host:server1,region:us-east-1,service:web,version:1.2.3,host:server2,team:platform",
+            ),
+            Value::Boolean(true),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            value!({
+                "env": ["prod"],
+                "host": ["server1", "server2"],
+                "region": ["us-east-1"],
+                "service": ["web"],
+                "team": ["platform"],
+                "version": ["1.2.3"],
+            })
+        );
+    }
+}


### PR DESCRIPTION
Add a VRL function `parse_ddtags(value, multivalue: true)` that parses Datadog tag strings (comma-separated key:value pairs) into objects.

In multivalue mode (default), values are arrays so duplicate keys are preserved. In single-value mode, the first occurrence wins.

Handles standalone keys (no colon), colons embedded in values (splits on first only), whitespace trimming, and empty segments.

Benchmarked against the equivalent pure-VRL implementation (for_each + split + get/set/push) on a realistic 50-tag input:

  native:   10.1 µs/iter
  pure VRL: 320.8 µs/iter  (~32x slower)

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

None

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
