### PR TITLE
perf(log_event): reuse Arc allocation in VrlTarget and eagerly cache sizes

### DIFF
--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -160,6 +160,12 @@ pub struct LogEvent {
     metadata: EventMetadata,
 }
 
+/// Opaque handle holding the Arc allocation from a decomposed `LogEvent`.
+/// Used with [`LogEvent::decompose`] and [`LogEvent::recompose`] to avoid
+/// re-allocating the Arc when round-tripping through VRL execution.
+#[derive(Clone, Debug)]
+pub struct LogEventResidual(Arc<Inner>);
+
 impl LogEvent {
     /// This used to be the implementation for `LogEvent::from(&'str)`, but this is now only
     /// valid for `LogNamespace::Legacy`
@@ -282,6 +288,52 @@ impl LogEvent {
             .fields;
         let metadata = self.metadata;
         (value, metadata)
+    }
+
+    /// Decompose a `LogEvent` into its `Value`, `EventMetadata`, and an opaque handle
+    /// that allows the `LogEvent` to be reconstructed without a new Arc allocation.
+    ///
+    /// This is an optimization for VRL execution: the Value is extracted for in-place
+    /// mutation, then put back via [`LogEvent::recompose`] reusing the same heap allocation.
+    pub fn decompose(mut self) -> (Value, EventMetadata, LogEventResidual) {
+        // Ensure we have unique ownership of the Arc contents.
+        // When refcount == 1, this is just an atomic load (no clone).
+        let inner = Arc::make_mut(&mut self.inner);
+        // Extract the Value, leaving a placeholder behind.
+        let value = std::mem::replace(&mut inner.fields, Value::Null);
+        (value, self.metadata, LogEventResidual(self.inner))
+    }
+
+    /// Reconstruct a `LogEvent` from a `Value`, `EventMetadata`, and the residual handle
+    /// from a prior [`LogEvent::decompose`] call. Reuses the original Arc allocation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `LogEventResidual` Arc is not uniquely owned (i.e., if it was cloned
+    /// after calling [`LogEvent::decompose`]).
+    pub fn recompose(
+        value: Value,
+        metadata: EventMetadata,
+        mut residual: LogEventResidual,
+    ) -> Self {
+        // The residual Arc should be uniquely owned since we took it via decompose.
+        let inner =
+            Arc::get_mut(&mut residual.0).expect("LogEventResidual Arc must be uniquely owned");
+        inner.fields = value;
+        // Eagerly compute and cache sizes rather than invalidating.
+        // This moves the cost of size computation into the spawned transform task
+        // (concurrent path), so the main thread's send_single_buffer only reads
+        // cached values instead of recomputing from a full BTreeMap walk.
+        let json_size = inner.fields.estimated_json_encoded_size_of();
+        inner.json_encoded_size_cache.store(
+            NonZeroJsonSize::new(json_size),
+        );
+        let byte_size = size_of::<Inner>() + inner.fields.allocated_bytes();
+        inner.size_cache.store(NonZeroUsize::new(byte_size));
+        Self {
+            inner: residual.0,
+            metadata,
+        }
     }
 
     #[must_use]

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -6,7 +6,7 @@ pub use finalization::{
     BatchNotifier, BatchStatus, BatchStatusReceiver, EventFinalizer, EventFinalizers, EventStatus,
     Finalizable,
 };
-pub use log_event::LogEvent;
+pub use log_event::{LogEvent, LogEventResidual};
 pub use metadata::{DatadogMetricOriginMetadata, EventMetadata, WithMetadata};
 pub use metric::{Metric, MetricKind, MetricTags, MetricValue, StatisticKind};
 pub use r#ref::{EventMutRef, EventRef};

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -14,7 +14,10 @@ use vrl::{
     value::{Kind, ObjectMap, Value},
 };
 
-use super::{Event, EventMetadata, LogEvent, Metric, MetricKind, TraceEvent, metric::TagValue};
+use super::{
+    Event, EventMetadata, LogEvent, LogEventResidual, Metric, MetricKind, TraceEvent,
+    metric::TagValue,
+};
 use crate::{
     config::{LogNamespace, log_schema},
     schema::Definition,
@@ -38,7 +41,11 @@ const MAX_METRIC_PATH_DEPTH: usize = 3;
 pub enum VrlTarget {
     // `LogEvent` is essentially just a destructured `event::LogEvent`, but without the semantics
     // that `fields` must always be a `Map` variant.
-    LogEvent(Value, EventMetadata),
+    //
+    // The optional `LogEventResidual` holds the original Arc allocation so that
+    // `into_events` can reconstruct the `LogEvent` without a new heap allocation
+    // when the Value is still an Object (the common case).
+    LogEvent(Value, EventMetadata, Option<LogEventResidual>),
     Metric {
         metric: Metric,
         value: Value,
@@ -103,8 +110,8 @@ impl VrlTarget {
     pub fn new(event: Event, info: &ProgramInfo, multi_value_metric_tags: bool) -> Self {
         match event {
             Event::Log(event) => {
-                let (value, metadata) = event.into_parts();
-                VrlTarget::LogEvent(value, metadata)
+                let (value, metadata, residual) = event.decompose();
+                VrlTarget::LogEvent(value, metadata, Some(residual))
             }
             Event::Metric(metric) => {
                 // We pre-generate [`Value`] types for the metric fields accessed in
@@ -144,9 +151,14 @@ impl VrlTarget {
     /// array to `.` in VRL.
     pub fn into_events(self, log_namespace: LogNamespace) -> TargetEvents {
         match self {
-            VrlTarget::LogEvent(value, metadata) => match value {
+            VrlTarget::LogEvent(value, metadata, residual) => match value {
                 value @ Value::Object(_) => {
-                    TargetEvents::One(LogEvent::from_parts(value, metadata).into())
+                    // Reuse the original Arc allocation when possible to avoid a new heap alloc.
+                    let log = match residual {
+                        Some(residual) => LogEvent::recompose(value, metadata, residual),
+                        None => LogEvent::from_parts(value, metadata),
+                    };
+                    TargetEvents::One(log.into())
                 }
 
                 Value::Array(values) => TargetEvents::Logs(TargetIter {
@@ -184,14 +196,14 @@ impl VrlTarget {
 
     fn metadata(&self) -> &EventMetadata {
         match self {
-            VrlTarget::LogEvent(_, metadata) | VrlTarget::Trace(_, metadata) => metadata,
+            VrlTarget::LogEvent(_, metadata, _) | VrlTarget::Trace(_, metadata) => metadata,
             VrlTarget::Metric { metric, .. } => metric.metadata(),
         }
     }
 
     fn metadata_mut(&mut self) -> &mut EventMetadata {
         match self {
-            VrlTarget::LogEvent(_, metadata) | VrlTarget::Trace(_, metadata) => metadata,
+            VrlTarget::LogEvent(_, metadata, _) | VrlTarget::Trace(_, metadata) => metadata,
             VrlTarget::Metric { metric, .. } => metric.metadata_mut(),
         }
     }
@@ -281,7 +293,7 @@ impl Target for VrlTarget {
         let path = &target_path.path;
         match target_path.prefix {
             PathPrefix::Event => match self {
-                VrlTarget::LogEvent(log, _) | VrlTarget::Trace(log, _) => {
+                VrlTarget::LogEvent(log, _, _) | VrlTarget::Trace(log, _) => {
                     log.insert(path, value);
                     Ok(())
                 }
@@ -379,7 +391,7 @@ impl Target for VrlTarget {
     fn target_get(&self, target_path: &OwnedTargetPath) -> Result<Option<&Value>, String> {
         match target_path.prefix {
             PathPrefix::Event => match self {
-                VrlTarget::LogEvent(log, _) | VrlTarget::Trace(log, _) => {
+                VrlTarget::LogEvent(log, _, _) | VrlTarget::Trace(log, _) => {
                     Ok(log.get(&target_path.path))
                 }
                 VrlTarget::Metric { value, .. } => target_get_metric(&target_path.path, value),
@@ -394,7 +406,7 @@ impl Target for VrlTarget {
     ) -> Result<Option<&mut Value>, String> {
         match target_path.prefix {
             PathPrefix::Event => match self {
-                VrlTarget::LogEvent(log, _) | VrlTarget::Trace(log, _) => {
+                VrlTarget::LogEvent(log, _, _) | VrlTarget::Trace(log, _) => {
                     Ok(log.get_mut(&target_path.path))
                 }
                 VrlTarget::Metric { value, .. } => target_get_mut_metric(&target_path.path, value),
@@ -410,7 +422,7 @@ impl Target for VrlTarget {
     ) -> Result<Option<vrl::value::Value>, String> {
         match target_path.prefix {
             PathPrefix::Event => match self {
-                VrlTarget::LogEvent(log, _) | VrlTarget::Trace(log, _) => {
+                VrlTarget::LogEvent(log, _, _) | VrlTarget::Trace(log, _) => {
                     Ok(log.remove(&target_path.path, compact))
                 }
                 VrlTarget::Metric {


### PR DESCRIPTION
## Summary

Two related optimizations for the VRL transform hot path:

1. **`LogEvent::decompose`/`recompose`**: extracts the `Value` for in-place VRL mutation, then puts it back reusing the same `Arc<Inner>` heap allocation. Previously, `VrlTarget` would clone the entire `LogEvent` and rebuild it from parts, triggering a new Arc allocation on every event.

2. **Eager size cache population in `recompose`**: after VRL mutation, eagerly computes and caches `json_encoded_size` and `allocated_bytes`. This moves the cost into the concurrent transform task, so the main thread's `send_single_buffer` reads cached values instead of recomputing from a full BTreeMap walk.

## Vector configuration

Standard pipeline: `file` source → `remap` + `filter` transforms → `blackhole` sink.

## How did you test this PR?

**E2E Docker benchmark** (1 GB log file, `--profiler none`, 4-core pinning, 3 trials):

| Configuration | Run 1 | Run 2 | Run 3 | Median | σ | Δ (median) |
|---|---|---|---|---|---|---|
| Master baseline | 195.14 | 185.73 | 205.66 | 195.14 | 9.97 | — |
| This PR (isolated) | 205.62 | 205.65 | 200.27 | 205.62 | 3.10 | +5.4% |
| All perf PRs stacked | 208.02 | 208.02 | 208.05 | 208.02 | 0.02 | +6.6% |

`cargo check` passes with the E2E feature set.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.