### PR TITLE
docs(website): convert TOML config examples to YAML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,10 @@ make cue-build
 
 **Note:** Website changes use Hugo, CUE, Tailwind CSS, and TypeScript. See [website/README.md](website/README.md) for details.
 
+## Configuration Format
+
+Always generate Vector configuration examples in **YAML** unless the user explicitly asks for TOML or JSON. YAML is Vector's recommended and default configuration format since v0.34.
+
 ## Common Patterns
 
 ### Development Tools

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ make cue-build
 
 ## Configuration Format
 
-Always generate Vector configuration examples in **YAML** unless the user explicitly asks for TOML or JSON. YAML is Vector's recommended and default configuration format since v0.34.
+Always generate Vector configuration examples in **YAML** unless the user explicitly asks for TOML or JSON. YAML is Vector's recommended and default configuration format.
 
 ## Common Patterns
 

--- a/website/content/en/blog/adaptive-request-concurrency.md
+++ b/website/content/en/blog/adaptive-request-concurrency.md
@@ -94,13 +94,15 @@ This decision tree is always active and Vector always "knows" what to do, even i
 
 Vector never stops quietly making the linear up vs. exponential down decision in the background, and it works out of the box with zero configuration beyond enabling the feature, which is currently on an opt-in basis in version 0.11. You can enable ARC in an HTTP sink by setting the [`request.concurrency`][request_concurrency] parameter to `adaptive`. Here's an example for a Clickhouse sink:
 
-```toml
-[sinks.clickhouse_internal]
-type = "clickhouse"
-inputs = ["log_stream_1", "log_stream_2"]
-host = "http://clickhouse-prod:8123"
-table = "prod-log-data"
-request.concurrency = "adaptive"
+```yaml
+sinks:
+  clickhouse_internal:
+    type: "clickhouse"
+    inputs: ["log_stream_1", "log_stream_2"]
+    host: "http://clickhouse-prod:8123"
+    table: "prod-log-data"
+    request:
+      concurrency: "adaptive"
 ```
 
 There's also room for fine-tuning if you find yourself needing additional knobs:

--- a/website/content/en/blog/graphql-api.md
+++ b/website/content/en/blog/graphql-api.md
@@ -193,7 +193,7 @@ query {
 
 The API is an opt-in feature that spawns an HTTP server to accept queries.
 
-To enable, open your `vector.toml`, and add the following:
+To enable, open your `vector.yaml`, and add the following:
 
 ```yaml
 api:

--- a/website/content/en/blog/graphql-api.md
+++ b/website/content/en/blog/graphql-api.md
@@ -36,19 +36,22 @@ tuned!
 
 Start up Vector locally with the following config:
 
-```toml
-[api]
-enabled = true
+```yaml
+api:
+  enabled: true
 
-[sources.demo]
-type = "demo_logs"
-format = "json"
-interval = 1.0
+sources:
+  demo:
+    type: "demo_logs"
+    format: "json"
+    interval: 1.0
 
-[sinks.console]
-type = "console"
-inputs = ["demo"]
-encoding.codec = "text"
+sinks:
+  console:
+    type: "console"
+    inputs: ["demo"]
+    encoding:
+      codec: "text"
 ```
 
 You can then access
@@ -192,10 +195,10 @@ The API is an opt-in feature that spawns an HTTP server to accept queries.
 
 To enable, open your `vector.toml`, and add the following:
 
-```toml
-[api]
-  enabled = true
-  address = "127.0.0.1:8686" # optional. Change IP/port if required
+```yaml
+api:
+  enabled: true
+  address: "127.0.0.1:8686" # optional. Change IP/port if required
 ```
 
 After restarting Vector, you can access an API playground at

--- a/website/content/en/blog/kubernetes-integration.md
+++ b/website/content/en/blog/kubernetes-integration.md
@@ -27,15 +27,17 @@ The crux of our Kubernetes integration for Vector is the new [`kubernetes_logs`]
 
 This simple Vector configuration, for example, would suffice to send logs from *all* of your Nodes/Pods to [Elasticsearch]:
 
-```toml title="vector.toml"
-[sources.k8s_all]
-type = "kubernetes_logs"
+```yaml title="vector.yaml"
+sources:
+  k8s_all:
+    type: "kubernetes_logs"
 
-[sinks.es_out]
-type = "elasticsearch"
-inputs = ["k8s_all"]
-host = "http://your-elasticsearch-cluster:9200"
-index = "vector-k8s-%F"
+sinks:
+  es_out:
+    type: "elasticsearch"
+    inputs: ["k8s_all"]
+    host: "http://your-elasticsearch-cluster:9200"
+    index: "vector-k8s-%F"
 ```
 
 Using this simple topology as a starting point, you can [transform][transforms] your log data in a wide variety of ways, ship it to [other sinks][sinks], and much more.

--- a/website/content/en/blog/log-namespacing.md
+++ b/website/content/en/blog/log-namespacing.md
@@ -39,27 +39,30 @@ so you can try out Log Namespacing on individual sources.
 The following example enables the `log_namespace` feature globally, then disables it for a single
 source.
 
-```toml
-schema.log_namespace = true
+```yaml
+schema:
+  log_namespace: true
 
-[sources.input_with_log_namespace]
-type = "demo_logs"
-format = "shuffle"
-lines = ["input_with_log_namespace"]
-interval = 1
+sources:
+  input_with_log_namespace:
+    type: "demo_logs"
+    format: "shuffle"
+    lines: ["input_with_log_namespace"]
+    interval: 1
 
-[sources.input_without_log_namespace]
-type = "demo_logs"
-format = "shuffle"
-lines = ["input_without_log_namespace"]
-interval = 1
-log_namespace = false
+  input_without_log_namespace:
+    type: "demo_logs"
+    format: "shuffle"
+    lines: ["input_without_log_namespace"]
+    interval: 1
+    log_namespace: false
 
-[sinks.console]
-type = "console"
-inputs = ["input_with_log_namespace", "input_without_log_namespace"]
-encoding.codec = "json"
-
+sinks:
+  console:
+    type: "console"
+    inputs: ["input_with_log_namespace", "input_without_log_namespace"]
+    encoding:
+      codec: "json"
 ```
 
 ## How It Works

--- a/website/content/en/docs/administration/management.md
+++ b/website/content/en/docs/administration/management.md
@@ -176,7 +176,7 @@ docker restart -f $(docker ps -aqf "name=vector")
 {{< /tab >}}
 {{< /tabs >}}
 
-The commands above involve configuring Vector using TOML, but you can also use JSON or YAML. You can also use one of
+The commands above involve configuring Vector using YAML, but you can also use TOML or JSON. You can also use one of
 three image variants (the commands assume `alpine`):
 
 | Variant | Image basis |

--- a/website/content/en/docs/architecture/guarantees.md
+++ b/website/content/en/docs/architecture/guarantees.md
@@ -61,12 +61,13 @@ delivery?](#faq-at-least-once) FAQ below).
 In order to achieve at-least-once delivery between restarts,
 your sink must be configured to use disk-based buffers:
 
-```toml title="vector.toml"
-[sinks.my_sink_id]
-  [sinks.my_sink_id.buffer]
-    type = "disk"
-    when_full = "block"
-    max_size = 104900000 # 100MiB
+```yaml title="vector.yaml"
+sinks:
+  my_sink_id:
+    buffer:
+      type: "disk"
+      when_full: "block"
+      max_size: 104900000 # 100MiB
 ```
 
 Refer to each [sink's][sinks] documentation for further guidance on its buffer options.

--- a/website/content/en/docs/architecture/pipeline-model.md
+++ b/website/content/en/docs/architecture/pipeline-model.md
@@ -10,7 +10,7 @@ Vector's pipeline model is based on a [directed acyclic graph][dag] of [componen
 
 ## Defining pipelines
 
-A Vector pipeline is defined through a YAML, TOML, or JSON [configuration] file. For maintainability, many Vector users use configuration and data templating languages like [Jsonnet] or [CUE].
+A Vector pipeline is defined through a YAML, TOML, or JSON [configuration] file. We recommend using YAML as the default format. For maintainability, many Vector users use configuration and data templating languages like [Jsonnet] or [CUE].
 
 Configuration is checked at pipeline compile time (when Vector boots). This prevents simple mistakes and enforces DAG properties.
 

--- a/website/content/en/docs/reference/configuration/_index.md
+++ b/website/content/en/docs/reference/configuration/_index.md
@@ -250,8 +250,9 @@ Refer to the [Environment Variables](docs/reference/environment_variables/) page
 ### Formats
 
 Vector supports [YAML], [TOML], and [JSON] to ensure that Vector fits into your
-workflow. A side benefit of supporting YAML and JSON is that they enable you to use
-data templating languages such as [ytt], [Jsonnet] and [Cue].
+workflow. We recommend using YAML as the default configuration format. A side
+benefit of supporting YAML and JSON is that they enable you to use data templating
+languages such as [ytt], [Jsonnet] and [Cue].
 
 #### Location
 

--- a/website/content/en/docs/reference/configuration/template-syntax.md
+++ b/website/content/en/docs/reference/configuration/template-syntax.md
@@ -12,11 +12,12 @@ data. Any option that supports this syntax will be clearly documented as such in
 Let's partition data on AWS S3 by "application_id" and "date". We can accomplish this with the `key_prefix` option in
 the `aws_s3` sink:
 
-```toml
-[sinks.backup]
-  type = "aws_s3"
-  bucket = "all_application_logs"
-  key_prefix = "application_id={{ application_id }}/date=%F/"
+```yaml
+sinks:
+  backup:
+    type: "aws_s3"
+    bucket: "all_application_logs"
+    key_prefix: "application_id={{ application_id }}/date=%F/"
 ```
 
 Notice that Vector allows direct field references as well as "strftime" specifiers. If we were to run the following log
@@ -45,16 +46,16 @@ enables dynamic partitioning, something fundamental to storing log data in files
 
 Individual [log event][log] fields can be accessed using `{{ ... }}` to wrap a VRL [path expression][path_expression]:
 
-```toml
-option = "{{ .parent.child }}"
+```yaml
+option: "{{ .parent.child }}"
 ```
 
 ### Strftime specifiers
 
 In addition to directly accessing fields, Vector offers a shortcut for injecting [strftime specifiers][strftime]:
 
-```toml
-option = "year=%Y/month=%m/day=%d/"
+```yaml
+option: "year=%Y/month=%m/day=%d/"
 ```
 
 {{< info >}}
@@ -67,14 +68,14 @@ and the name of this field can be changed via the [global `timestamp_key` option
 You can escape this syntax by prefixing the character with a `\`. For example, you can escape the event field syntax
 like this:
 
-```toml
-option = "\{{ field_name }}"
+```yaml
+option: "\{{ field_name }}"
 ```
 
 And [strftime] specified like so:
 
-```toml
-option = "year=\%Y/month=\%m/day=\%d/"
+```yaml
+option: "year=\\%Y/month=\\%m/day=\\%d/"
 ```
 
 Each of the values above would be treated literally.
@@ -91,15 +92,16 @@ You can find additional examples for accessing fields in the
 Vector doesn't currently support fallback values, [issue 1692][1692] is open to add this functionality. In the interim,
 you can use the [`remap` transform][remap] to set a default value:
 
-```toml
-[transforms.set_defaults]
-  type = "remap"
-  inputs = ["my-source-id"]
-  source = '''
-    if !exists(.my_field) {
-      .my_field = "default"
-    }
-  '''
+```yaml
+transforms:
+  set_defaults:
+    type: "remap"
+    inputs:
+      - "my-source-id"
+    source: |
+      if !exists(.my_field) {
+        .my_field = "default"
+      }
 ```
 
 ### Missing fields

--- a/website/content/en/docs/reference/configuration/template-syntax.md
+++ b/website/content/en/docs/reference/configuration/template-syntax.md
@@ -69,7 +69,7 @@ You can escape this syntax by prefixing the character with a `\`. For example, y
 like this:
 
 ```yaml
-option: "\{{ field_name }}"
+option: '\{{ field_name }}'
 ```
 
 And [strftime] specified like so:

--- a/website/content/en/docs/reference/configuration/template-syntax.md
+++ b/website/content/en/docs/reference/configuration/template-syntax.md
@@ -12,6 +12,9 @@ data. Any option that supports this syntax will be clearly documented as such in
 Let's partition data on AWS S3 by "application_id" and "date". We can accomplish this with the `key_prefix` option in
 the `aws_s3` sink:
 
+{{< tabs default="YAML" >}}
+{{< tab title="YAML" >}}
+
 ```yaml
 sinks:
   backup:
@@ -19,6 +22,19 @@ sinks:
     bucket: "all_application_logs"
     key_prefix: "application_id={{ application_id }}/date=%F/"
 ```
+
+{{< /tab >}}
+{{< tab title="TOML" >}}
+
+```toml
+[sinks.backup]
+  type = "aws_s3"
+  bucket = "all_application_logs"
+  key_prefix = "application_id={{ application_id }}/date=%F/"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 Notice that Vector allows direct field references as well as "strftime" specifiers. If we were to run the following log
 event through Vector:
@@ -46,17 +62,43 @@ enables dynamic partitioning, something fundamental to storing log data in files
 
 Individual [log event][log] fields can be accessed using `{{ ... }}` to wrap a VRL [path expression][path_expression]:
 
+{{< tabs default="YAML" >}}
+{{< tab title="YAML" >}}
+
 ```yaml
 option: "{{ .parent.child }}"
 ```
+
+{{< /tab >}}
+{{< tab title="TOML" >}}
+
+```toml
+option = "{{ .parent.child }}"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Strftime specifiers
 
 In addition to directly accessing fields, Vector offers a shortcut for injecting [strftime specifiers][strftime]:
 
+{{< tabs default="YAML" >}}
+{{< tab title="YAML" >}}
+
 ```yaml
 option: "year=%Y/month=%m/day=%d/"
 ```
+
+{{< /tab >}}
+{{< tab title="TOML" >}}
+
+```toml
+option = "year=%Y/month=%m/day=%d/"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 {{< info >}}
 The value is derived from the [`timestamp` field](/docs/architecture/data-model/log/#timestamps)
@@ -68,15 +110,41 @@ and the name of this field can be changed via the [global `timestamp_key` option
 You can escape this syntax by prefixing the character with a `\`. For example, you can escape the event field syntax
 like this:
 
+{{< tabs default="YAML" >}}
+{{< tab title="YAML" >}}
+
 ```yaml
 option: '\{{ field_name }}'
 ```
 
+{{< /tab >}}
+{{< tab title="TOML" >}}
+
+```toml
+option = "\{{ field_name }}"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
 And [strftime] specified like so:
+
+{{< tabs default="YAML" >}}
+{{< tab title="YAML" >}}
 
 ```yaml
 option: "year=\\%Y/month=\\%m/day=\\%d/"
 ```
+
+{{< /tab >}}
+{{< tab title="TOML" >}}
+
+```toml
+option = "year=\%Y/month=\%m/day=\%d/"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 Each of the values above would be treated literally.
 
@@ -92,6 +160,9 @@ You can find additional examples for accessing fields in the
 Vector doesn't currently support fallback values, [issue 1692][1692] is open to add this functionality. In the interim,
 you can use the [`remap` transform][remap] to set a default value:
 
+{{< tabs default="YAML" >}}
+{{< tab title="YAML" >}}
+
 ```yaml
 transforms:
   set_defaults:
@@ -103,6 +174,23 @@ transforms:
         .my_field = "default"
       }
 ```
+
+{{< /tab >}}
+{{< tab title="TOML" >}}
+
+```toml
+[transforms.set_defaults]
+  type = "remap"
+  inputs = ["my-source-id"]
+  source = '''
+    if !exists(.my_field) {
+      .my_field = "default"
+    }
+  '''
+```
+
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Missing fields
 

--- a/website/content/en/docs/reference/configuration/unit-tests.md
+++ b/website/content/en/docs/reference/configuration/unit-tests.md
@@ -77,12 +77,11 @@ functions][type], functions like [`exists`][exists], [`includes`][includes],
 [`is_nullish`][is_nullish] and [`contains`][contains], and VRL [comparisons]. Here's an example
 usage of a Boolean expression passed to an `assert` function:
 
-```toml
-[[tests.outputs.conditions]]
-type = "vrl"
-source = '''
-assert!(is_string(.message) && is_timestamp(.timestamp) && !exists(.other))
-'''
+```yaml
+conditions:
+  - type: "vrl"
+    source: |
+      assert!(is_string(.message) && is_timestamp(.timestamp) && !exists(.other))
 ```
 
 In this case, the VRL program (under `source`) evaluates to a single Boolean that expresses the
@@ -94,29 +93,27 @@ following:
 
 It's also possible to break a test up into multiple `assert` or `assert_eq` statements:
 
-```toml
-source = '''
-assert!(exists(.message), "no message field provided")
-assert!(!is_nullish(.message), "message field is an empty string")
-assert!(is_string(.message), "message field has as unexpected type")
-assert_eq!(.message, "success", "message field had an unexpected value")
-assert!(exists(.timestamp), "no timestamp provided")
-assert!(is_timestamp(.timestamp), "timestamp is invalid")
-assert!(!exists(.other), "extraneous other field present")
-'''
+```yaml
+source: |
+  assert!(exists(.message), "no message field provided")
+  assert!(!is_nullish(.message), "message field is an empty string")
+  assert!(is_string(.message), "message field has as unexpected type")
+  assert_eq!(.message, "success", "message field had an unexpected value")
+  assert!(exists(.timestamp), "no timestamp provided")
+  assert!(is_timestamp(.timestamp), "timestamp is invalid")
+  assert!(!exists(.other), "extraneous other field present")
 ```
 
 You can also store the Boolean expressions in variables rather than passing the entire statement to
 the `assert` function:
 
-```toml
-source = '''
-message_field_valid = exists(.message) &&
-  !is_nullish(.message) &&
-  .message == "success"
+```yaml
+source: |
+  message_field_valid = exists(.message) &&
+    !is_nullish(.message) &&
+    .message == "success"
 
-assert!(message_field_valid)
-'''
+  assert!(message_field_valid)
 ```
 
 ## Example unit test configuration {#example}
@@ -124,48 +121,48 @@ assert!(message_field_valid)
 Below is an annotated example of a unit test suite for a transform called `add_metadata`, which
 adds a unique ID and a timestamp to log events:
 
-```toml
-[sources.all_container_services]
-type = "docker_logs"
-docker_host = "http://localhost:2375"
-include_images = ["web_frontend", "web_backend", "auth_service"]
+```yaml
+sources:
+  all_container_services:
+    type: "docker_logs"
+    docker_host: "http://localhost:2375"
+    include_images: ["web_frontend", "web_backend", "auth_service"]
 
 # The transform being tested is a Vector Remap Language (VRL) transform that
 # adds two fields to each incoming log event: a timestamp and a unique ID
-[transforms.add_metadata]
-type = "remap"
-inputs = ["all_container_services"]
-source = '''
-.timestamp = now()
-.id = uuid_v4()
-'''
+transforms:
+  add_metadata:
+    type: "remap"
+    inputs: ["all_container_services"]
+    source: |
+      .timestamp = now()
+      .id = uuid_v4()
 
 # Here we begin configuring our test suite
-[[tests]]
-name = "Test for the add_metadata transform"
+tests:
+  - name: "Test for the add_metadata transform"
 
-# The inputs for the test
-[[tests.inputs]]
-insert_at = "add_metadata" # The transform into which the testing event is inserted
-type = "log"               # The event type (either log or metric)
+    # The inputs for the test
+    inputs:
+      - insert_at: "add_metadata" # The transform into which the testing event is inserted
+        type: "log"               # The event type (either log or metric)
 
-# The test log event that is passed to the `add_metadata` transform
-[tests.inputs.log_fields]
-message = "successful transaction"
-code = 200
+        # The test log event that is passed to the `add_metadata` transform
+        log_fields:
+          message: "successful transaction"
+          code: 200
 
-# The expected outputs of the test
-[[tests.outputs]]
-extract_from = "add_metadata" # The transform from which the resulting event is extracted
+    # The expected outputs of the test
+    outputs:
+      - extract_from: "add_metadata" # The transform from which the resulting event is extracted
 
-# The declaration of what we expect
-[[tests.outputs.conditions]]
-type = "vrl"
-source = '''
-assert!(is_timestamp(.timestamp))
-assert!(is_string(.id))
-assert_eq!(.message, "successful transaction")
-'''
+        # The declaration of what we expect
+        conditions:
+          - type: "vrl"
+            source: |
+              assert!(is_timestamp(.timestamp))
+              assert!(is_string(.id))
+              assert_eq!(.message, "successful transaction")
 ```
 
 This example represents a complete test of the `add_metadata` transform, include test `inputs`
@@ -187,7 +184,7 @@ unit tests as a way of **mocking observability data sources** and ensuring that 
 respond to those mock sources the way that you would expect.
 
 {{< success title="Multiple config formats available" >}}
-The unit testing example above is in TOML but Vector also supports YAML and JSON as configuration
+The unit testing example above is in YAML but Vector also supports TOML and JSON as configuration
 formats.
 {{< /success >}}
 
@@ -198,16 +195,15 @@ same config file alongside your transform definitions or split them out into a s
 
 Unit tests need are specified inside of a `tests` array. Each test requires a `name`:
 
-```toml
-[[tests]]
-name = "test 1"
-# Other test config
+```yaml
+tests:
+  - name: "test 1"
+    # Other test config
 
-[[tests]]
-name = "test_2"
-# Other test config
+  - name: "test_2"
+    # Other test config
 
-# etc.
+  # etc.
 ```
 
 Inside each test definition, you need to specify two things:
@@ -230,18 +226,19 @@ In the `inputs` array for the test, you have these options:
 
 Here's an example `inputs` declaration:
 
-```toml
-[transforms.add_metadata]
-# transform config
+```yaml
+transforms:
+  add_metadata:
+    # transform config
 
-[[tests]]
-name = "Test add_metadata transform"
+tests:
+  - name: "Test add_metadata transform"
 
-[[tests.inputs]]
-insert_at = "add_metadata"
+    inputs:
+      - insert_at: "add_metadata"
 
-[tests.inputs.log_fields]
-message = "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
+        log_fields:
+          message: "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
 ```
 
 ### Outputs
@@ -262,16 +259,15 @@ Each condition in the `conditions` array has two fields:
 
 Here's an example `outputs` declaration:
 
-```toml
-[[tests.outputs]]
-extract_from = "add_metadata"
+```yaml
+outputs:
+  - extract_from: "add_metadata"
 
-[[tests.outputs.conditions]]
-type = "vrl"
-source = '''
-assert!(is_string(.id))
-assert!(exists(.tags))
-'''
+    conditions:
+      - type: "vrl"
+        source: |
+          assert!(is_string(.id))
+          assert!(exists(.tags))
 ```
 
 #### Asserting no output
@@ -280,10 +276,10 @@ In some cases, you may need to assert that _no_ event is output by a transform. 
 this at the root level of a specific test's configuration using the `no_outputs_from` parameter,
 which takes a list of transform names. Here's an example:
 
-```toml
-[[tests]]
-name = "Ensure no output"
-no_outputs_from = ["log_filter", "metric_filter"]
+```yaml
+tests:
+  - name: "Ensure no output"
+    no_outputs_from: ["log_filter", "metric_filter"]
 ```
 
 In this test configuration, Vector would expect that the `log_filter` and `metric_filter` transforms
@@ -298,26 +294,27 @@ Some examples of use cases for `no_outputs_from`:
 
 Below is a full example of using `no_outputs_from` in a Vector unit test:
 
-```toml
-[transforms.log_filter]
-type = "filter"
-inputs = ["log_source"]
-condition = '.env == "production"'
+```yaml
+transforms:
+  log_filter:
+    type: "filter"
+    inputs: ["log_source"]
+    condition: '.env == "production"'
 
-[[tests]]
-name = "Filter out non-production events"
-no_outputs_from = ["log_filter"]
+tests:
+  - name: "Filter out non-production events"
+    no_outputs_from: ["log_filter"]
 
-[[tests.inputs]]
-type = "log"
-insert_at = "log_filter"
+    inputs:
+      - type: "log"
+        insert_at: "log_filter"
 
-[tests.inputs.log_fields]
-message = "success"
-code = 202
-endpoint = "/transactions"
-method = "POST"
-env = "staging"
+        log_fields:
+          message: "success"
+          code: 202
+          endpoint: "/transactions"
+          method: "POST"
+          env: "staging"
 ```
 
 This unit test passes because the `env` field of the input event has a value of `staging`, which
@@ -340,11 +337,11 @@ either a structured event [object](#object) or a raw [string](#raw-string-value)
 
 To specify a structured log event as your test input, use `log_fields`:
 
-```toml
-[tests.inputs.log_fields]
-message = "successful transaction"
-code = 200
-id = "38c5b0d0-5e7e-42aa-ae86-2b642ad2d1b8"
+```yaml
+log_fields:
+  message: "successful transaction"
+  code: 200
+  id: "38c5b0d0-5e7e-42aa-ae86-2b642ad2d1b8"
 ```
 
 If there are hyphens in the field name, you will need to quote this part (at least in YAML):
@@ -362,38 +359,38 @@ If there are hyphens in the field name, you will need to quote this part (at lea
 
 To specify a raw string value for a log event, use `value`:
 
-```toml
-[[tests.inputs]]
-insert_at = "add_metadata"
-value = "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
+```yaml
+inputs:
+  - insert_at: "add_metadata"
+    value: "<102>1 2020-12-22T15:22:31.111Z vector-user.biz su 2666 ID389 - Something went wrong"
 ```
 
 ##### VRL program
 
 To specify a program to construct the log event, use `source`:
 
-```toml
-[[tests.inputs]]
-  insert_at = "canary"
-  type = "vrl"
-  source = """
-    . = {"a": {"b": "c"}, "d": now()}
-  """
+```yaml
+inputs:
+  - insert_at: "canary"
+    type: "vrl"
+    source: |
+      . = {"a": {"b": "c"}, "d": now()}
 ```
 
 #### Metrics
 
 You can specify the fields in a metric event to be unit tested using a `metric` object:
 
-```toml
-[[tests.inputs]]
-insert_at = "my_metric_transform"
-type = "metric"
+```yaml
+inputs:
+  - insert_at: "my_metric_transform"
+    type: "metric"
 
-[tests.inputs.metric]
-name = "count"
-kind = "absolute"
-counter = { value = 1 }
+    metric:
+      name: "count"
+      kind: "absolute"
+      counter:
+        value: 1
 ```
 
 Aggregated metrics are a little different:
@@ -414,40 +411,40 @@ tests:
 
 Here's a full end-to-end example of unit testing a metric through a transform:
 
-```toml
-[transforms.add_env_to_metric]
-type = "remap"
-inputs = []
-source = '''
-env, err = get_env_var("ENV")
-if err != null {
-  log(err, level: "error")
-}
-tags.environment = env
-'''
+```yaml
+transforms:
+  add_env_to_metric:
+    type: "remap"
+    inputs: []
+    source: |
+      env, err = get_env_var("ENV")
+      if err != null {
+        log(err, level: "error")
+      }
+      tags.environment = env
 
-[[tests]]
-name = "add_unique_id_test"
+tests:
+  - name: "add_unique_id_test"
 
-[[tests.inputs]]
-insert_at = "add_env_to_metric"
-type = "metric"
+    inputs:
+      - insert_at: "add_env_to_metric"
+        type: "metric"
 
-[tests.inputs.metric]
-name = "website_hits"
-kind = "absolute"
-counter = { value = 1 }
+        metric:
+          name: "website_hits"
+          kind: "absolute"
+          counter:
+            value: 1
 
-[[tests.outputs]]
-extract_from = "add_env_to_metric"
+    outputs:
+      - extract_from: "add_env_to_metric"
 
-[[tests.outputs.conditions]]
-type = "vrl"
-source = '''
-assert_eq!(.name, "website_hits")
-assert_eq!(.kind, "absolute")
-assert_eq!(.tags.environment, "production")
-'''
+        conditions:
+          - type: "vrl"
+            source: |
+              assert_eq!(.name, "website_hits")
+              assert_eq!(.kind, "absolute")
+              assert_eq!(.tags.environment, "production")
 ```
 
 ## Multiple transforms {#multiple}
@@ -464,73 +461,71 @@ You may notice that the three transforms in this example could be combined into 
 transform. Their separation into multiple transforms here is purely for demonstration purposes.
 {{< /warning >}}
 
-```toml
+```yaml
 # This source, like all sources, is ignored in the unit test itself
-[sources.web_backend]
-type = "docker_logs"
-docker_host = "http://localhost:2375"
-include_images = ["web_backend"]
+sources:
+  web_backend:
+    type: "docker_logs"
+    docker_host: "http://localhost:2375"
+    include_images: ["web_backend"]
 
 # The first transform in the chain
-[transforms.add_env_metadata]
-type = "remap"
-inputs = ["web_backend"]
-source = '''
-.tags.environment = "production"
-'''
+transforms:
+  add_env_metadata:
+    type: "remap"
+    inputs: ["web_backend"]
+    source: |
+      .tags.environment = "production"
 
-# The second transform in the chain
-[transforms.sanitize]
-type = "remap"
-inputs = ["add_env_metadata"]
-source = '''
-del(.username)
-del(.email)
-'''
+  # The second transform in the chain
+  sanitize:
+    type: "remap"
+    inputs: ["add_env_metadata"]
+    source: |
+      del(.username)
+      del(.email)
 
-# The final transform in the chain
-[transforms.add_host_metadata]
-type = "remap"
-inputs = ["sanitize"]
-source = '''
-.tags.host = "web-backend1.vector-user.biz"
-'''
+  # The final transform in the chain
+  add_host_metadata:
+    type: "remap"
+    inputs: ["sanitize"]
+    source: |
+      .tags.host = "web-backend1.vector-user.biz"
 
-[[tests]]
-name = "Multiple chained remap transforms"
+tests:
+  - name: "Multiple chained remap transforms"
 
-[[tests.inputs]]
-type = "log"
-# Insert test input events into the first transform
-insert_at = "add_env_metadata"
+    inputs:
+      - type: "log"
+        # Insert test input events into the first transform
+        insert_at: "add_env_metadata"
 
-# The input event to insert into the first transform in the chain
-[tests.inputs.log_fields]
-message = "image successfully uploaded"
-code = 202
-username = "tonydanza1337"
-email = "tony@whostheboss.com"
-transaction_id = "bcef6a6a-2b72-4a9a-99a0-97ae89d82815"
+        # The input event to insert into the first transform in the chain
+        log_fields:
+          message: "image successfully uploaded"
+          code: 202
+          username: "tonydanza1337"
+          email: "tony@whostheboss.com"
+          transaction_id: "bcef6a6a-2b72-4a9a-99a0-97ae89d82815"
 
-[[tests.outputs]]
-# Extract test outputs from the last transform
-extract_from = "add_host_metadata"
+    outputs:
+      - # Extract test outputs from the last transform
+        extract_from: "add_host_metadata"
 
-[[tests.outputs.conditions]]
-type = "vrl"
-# Our VRL assertions for the test output
-source = '''
-assert_eq!(.tags.environment, "production", "incorrect environment tag")
-assert_eq!(.tags.host, "web-backend1.vector-user.biz", "incorrect host tag")
-assert!(!exists(.username))
-assert!(!exists(.email))
+        conditions:
+          - type: "vrl"
+            # Our VRL assertions for the test output
+            source: |
+              assert_eq!(.tags.environment, "production", "incorrect environment tag")
+              assert_eq!(.tags.host, "web-backend1.vector-user.biz", "incorrect host tag")
+              assert!(!exists(.username))
+              assert!(!exists(.email))
 
-valid_transaction_id = exists(.transaction_id) &&
-  is_string(.transaction_id) &&
-  length!(.transaction_id) == 36
+              valid_transaction_id = exists(.transaction_id) &&
+                is_string(.transaction_id) &&
+                length!(.transaction_id) == 36
 
-assert!(valid_transaction_id, "transaction ID invalid")
-'''
+              assert!(valid_transaction_id, "transaction ID invalid")
 ```
 
 From a testing standpoint, all three transforms here can be thought of as a single unit. One example
@@ -541,41 +536,40 @@ extracted from the end of the chain (`add_host_metadata`), and one set of VRL
 You could also test a subset of this transform chain. This configuration, for example, would test
 only the first two transforms (`add_env_metadata` and `sanitize`):
 
-```toml
-[[tests]]
-name = "First two transforms"
+```yaml
+tests:
+  - name: "First two transforms"
 
-[[tests.inputs]]
-type = "log"
-# Insert test input into the first transform
-insert_at = "add_env_metadata"
+    inputs:
+      - type: "log"
+        # Insert test input into the first transform
+        insert_at: "add_env_metadata"
 
-# For comparison, we can use the same input event as above
-[tests.inputs.log_fields]
-message = "image successfully uploaded"
-code = 202
-username = "tonydanza1337"
-email = "tony@whostheboss.com"
-transaction_id = "bcef6a6a-2b72-4a9a-99a0-97ae89d82815"
+        # For comparison, we can use the same input event as above
+        log_fields:
+          message: "image successfully uploaded"
+          code: 202
+          username: "tonydanza1337"
+          email: "tony@whostheboss.com"
+          transaction_id: "bcef6a6a-2b72-4a9a-99a0-97ae89d82815"
 
-[[tests.outputs]]
-# Extract test output from the second transform rather than the last
-extract_from = "sanitize"
+    outputs:
+      - # Extract test output from the second transform rather than the last
+        extract_from: "sanitize"
 
-[[tests.outputs.conditions]]
-type = "vrl"
-source = '''
-assert_eq!(.tags.environment, "production", "incorrect environment tag")
-assert!(!exists(.tags.host), "host tag included")
-assert!(!exists(.username))
-assert!(!exists(.email))
+        conditions:
+          - type: "vrl"
+            source: |
+              assert_eq!(.tags.environment, "production", "incorrect environment tag")
+              assert!(!exists(.tags.host), "host tag included")
+              assert!(!exists(.username))
+              assert!(!exists(.email))
 
-valid_transaction_id = exists(.transaction_id) &&
-  is_string(.transaction_id) &&
-  length!(.transaction_id) == 36
+              valid_transaction_id = exists(.transaction_id) &&
+                is_string(.transaction_id) &&
+                length!(.transaction_id) == 36
 
-assert!(valid_transaction_id, "transaction ID invalid")
-'''
+              assert!(valid_transaction_id, "transaction ID invalid")
 ```
 
 In the VRL conditions for this two-transform test, notice that the assertion regarding the `host`

--- a/website/content/en/docs/setup/going-to-prod/high-availability.md
+++ b/website/content/en/docs/setup/going-to-prod/high-availability.md
@@ -53,23 +53,26 @@ We recommend routing dropped events immediately to a backup destination to prior
 
 The following is an example configuration that routes failed events from a `remap` transform to a `aws_s3` sink:
 
-```toml
-[sources.input]
-    type = "datadog_agent"
+```yaml
+sources:
+  input:
+    type: "datadog_agent"
 
-[transforms.parsing]
-    inputs = ["input"]
-    type = "remap"
-    reroute_dropped = true
-    source = "..."
+transforms:
+  parsing:
+    inputs: ["input"]
+    type: "remap"
+    reroute_dropped: true
+    source: "..."
 
-[sinks.analysis]
-    inputs = ["parsing"]
-    type = "datadog_logs"
+sinks:
+  analysis:
+    inputs: ["parsing"]
+    type: "datadog_logs"
 
-[sinks.backup]
-    inputs = ["**parsing.dropped**"] # dropped events from the `parsing` transform
-    type = "aws_s3"
+  backup:
+    inputs: ["parsing.dropped"] # dropped events from the `parsing` transform
+    type: "aws_s3"
 ```
 
 {{< info >}}

--- a/website/content/en/guides/advanced/custom-aggregations-with-lua.md
+++ b/website/content/en/guides/advanced/custom-aggregations-with-lua.md
@@ -31,12 +31,12 @@ There are three types of hooks: `init`, `process`, and `shutdown`.
 
 The most important of them is `process`, which is called on each incoming events. It can be defined like this:
 
-```toml
-hooks.process = """
-function (event, emit)
-  -- do something
-end
-"""
+```yaml
+hooks:
+  process: |
+    function (event, emit)
+      -- do something
+    end
 ```
 
 It takes a single event and can output one or many of them using the `emit` function provided as the second argument.
@@ -76,54 +76,54 @@ variables.
 
 Using the knowledge from the previous section, it is possible to write down the following transform definition:
 
-```toml title="vector.toml"
-[transforms.aggregator]
-type = "lua"
-version = "2"
-inputs = [] # add IDs of the input components here
+```yaml title="vector.yaml"
+transforms:
+  aggregator:
+    type: "lua"
+    version: "2"
+    inputs: [] # add IDs of the input components here
 
-hooks.init = """
-  function (emit)
-    count = 0 -- initialize state by setting a global variable
-  end
-"""
+    hooks:
+      init: |
+        function (emit)
+          count = 0 -- initialize state by setting a global variable
+        end
 
-hooks.process = """
-  function (event, emit)
-    count = count + 1 -- increment the counter and exit
-  end
-"""
+      process: |
+        function (event, emit)
+          count = count + 1 -- increment the counter and exit
+        end
 
-timers = [{interval_seconds = 5, handler = """
-  function (emit)
-    emit {
-      metric = {
-        name = "event_counter",
-        kind = "incremental",
-        timestamp = os.date("!*t"),
-        counter = {
-          value = counter
-        }
-      }
-    }
-    counter = 0
-  end
-"""}]
+      shutdown: |
+        function (emit)
+          emit {
+            metric = {
+              name = "event_counter",
+              kind = "incremental",
+              timestamp = os.date("!*t"),
+              counter = {
+                value = counter
+              }
+            }
+          }
+        end
 
-hooks.shutdown = """
-  function (emit)
-    emit {
-      metric = {
-        name = "event_counter",
-        kind = "incremental",
-        timestamp = os.date("!*t"),
-        counter = {
-          value = counter
-        }
-      }
-    }
-  end
-"""
+    timers:
+      - interval_seconds: 5
+        handler: |
+          function (emit)
+            emit {
+              metric = {
+                name = "event_counter",
+                kind = "incremental",
+                timestamp = os.date("!*t"),
+                counter = {
+                  value = counter
+                }
+              }
+            }
+            counter = 0
+          end
 ```
 
 One could plug it into a [pipeline][docs.about.concepts#pipelines] and it would work!
@@ -137,8 +137,8 @@ identical. It is possible make the config more [DRY][urls.dry_code] by extractin
 a dedicated function. Such a function can be placed into the [source][docs.transforms.lua#source]
 section of the config:
 
-```toml
-source = """
+```yaml
+source: |
   function make_counter(value)
     return metric = {
       name = "event_counter",
@@ -149,28 +149,28 @@ source = """
       }
     }
   end
-"""
 ```
 
 and then adjusting the timer handler
 
-```toml
-timers = [{interval_seconds = 5, handler = """
-  function (emit)
-    emit(make_counter(counter))
-    counter = 0
-  end
-"""}]
+```yaml
+timers:
+  - interval_seconds: 5
+    handler: |
+      function (emit)
+        emit(make_counter(counter))
+        counter = 0
+      end
 ```
 
 and the `shutdown` hook:
 
-```toml
-hooks.shutdown = """
-  function (emit)
-    emit(make_counter(counter))
-  end
-"""
+```yaml
+hooks:
+  shutdown: |
+    function (emit)
+      emit(make_counter(counter))
+    end
 ```
 
 ## Keep All Code Together
@@ -178,45 +178,48 @@ hooks.shutdown = """
 The new config looks tidier, but in order to make it more readable, it is also possible to gather implementations of
 all functions into the `source` section, resulting in the following component declaration:
 
-```toml title="vector.toml"
-[transforms.aggregator]
-type = "lua"
-version = "2"
-inputs = [] # add IDs of the input components here
-hooks.init = "init"
-hooks.process = "process"
-hooks.shutdown = "shutdown"
-timers = [{interval_seconds = 5, handler = "timer_handler"}]
+```yaml title="vector.yaml"
+transforms:
+  aggregator:
+    type: "lua"
+    version: "2"
+    inputs: [] # add IDs of the input components here
+    hooks:
+      init: "init"
+      process: "process"
+      shutdown: "shutdown"
+    timers:
+      - interval_seconds: 5
+        handler: "timer_handler"
 
-source = """
-  function init()
-    count = 0
-  end
+    source: |
+      function init()
+        count = 0
+      end
 
-  function process()
-    count = count + 1
-  end
+      function process()
+        count = count + 1
+      end
 
-  function timer_handler(emit)
-    emit(make_counter(counter))
-    counter = 0
-  end
+      function timer_handler(emit)
+        emit(make_counter(counter))
+        counter = 0
+      end
 
-  function shutdown(emit)
-    emit(make_counter(counter))
-  end
+      function shutdown(emit)
+        emit(make_counter(counter))
+      end
 
-  function make_counter(value)
-    return metric = {
-      name = "event_counter",
-      kind = "incremental",
-      timestamp = os.date("!*t"),
-      counter = {
-        value = value
-      }
-    }
-  end
-"""
+      function make_counter(value)
+        return metric = {
+          name = "event_counter",
+          kind = "incremental",
+          timestamp = os.date("!*t"),
+          counter = {
+            value = value
+          }
+        }
+      end
 ```
 
 ## A Loadable Module
@@ -262,16 +265,20 @@ end
 
 and
 
-```toml title="vector.toml"
-[transforms.aggregator]
-type = "lua"
-version = "2"
-inputs = [] # add IDs of the input components here
-hooks.init = "init"
-hooks.process = "process"
-hooks.shutdown = "shutdown"
-timers = [{interval_seconds = 5, handler = "timer_handler"}]
-source = "require('aggregator')"
+```yaml title="vector.yaml"
+transforms:
+  aggregator:
+    type: "lua"
+    version: "2"
+    inputs: [] # add IDs of the input components here
+    hooks:
+      init: "init"
+      process: "process"
+      shutdown: "shutdown"
+    timers:
+      - interval_seconds: 5
+        handler: "timer_handler"
+    source: "require('aggregator')"
 ```
 
 There are also [other possibilities][urls.lua_modules_tutorial] to define Lua modules which do not require to use

--- a/website/content/en/guides/advanced/merge-multiline-logs-with-lua.md
+++ b/website/content/en/guides/advanced/merge-multiline-logs-with-lua.md
@@ -43,44 +43,44 @@ in the [guide on parsing CSV logs][guides.parsing-csv-logs-with-lua]. The underl
 
 Such an algorithm can be implemented, for example, with the following transform config:
 
-```toml title="vector.toml"
-[transforms.lua]
-  inputs = []
-  type = "lua"
-  version = "2"
-  source = """
-    csv = require("csv") -- load the `lua-csv` module
-    expected_columns = 23 -- expected number of columns in incoming CSV lines
-    line_separator = "\\r\\n" -- note the double escaping required by the TOML format
-  """
-  hooks.process = """
-    function (event, emit)
-      merged_event = merge(event)
-      if merged_event == nil then -- a global variable containing the merged event
-        merged_event = event -- if it is empty, set it to the current event
-      else -- otherwise, concatenate the line in the stored merged event
-           -- with the next line
-        merged_event.log.message = merged_event.log.message ..
-                                  line_separator .. event.log.message
-      end
+```yaml title="vector.yaml"
+transforms:
+  lua:
+    inputs: []
+    type: "lua"
+    version: "2"
+    source: |
+      csv = require("csv") -- load the `lua-csv` module
+      expected_columns = 23 -- expected number of columns in incoming CSV lines
+      line_separator = "\r\n"
+    hooks:
+      process: |
+        function (event, emit)
+          merged_event = merge(event)
+          if merged_event == nil then -- a global variable containing the merged event
+            merged_event = event -- if it is empty, set it to the current event
+          else -- otherwise, concatenate the line in the stored merged event
+               -- with the next line
+            merged_event.log.message = merged_event.log.message ..
+                                      line_separator .. event.log.message
+          end
 
-      fields = csv.openstring(event.log.message):lines()() -- parse CSV
-      if #fields < expected_columns then
-        return -- not all fields are present in the merged event yet
-      end
+          fields = csv.openstring(event.log.message):lines()() -- parse CSV
+          if #fields < expected_columns then
+            return -- not all fields are present in the merged event yet
+          end
 
-      -- do something with the array of the parsed fields
-      merged_event.log.csv_fields = fields -- for example, just store them in an
-                                           -- array field
+          -- do something with the array of the parsed fields
+          merged_event.log.csv_fields = fields -- for example, just store them in an
+                                               -- array field
 
-      emit(merged_event) -- emit the resulting event
-      merged_event = nil -- clear the merged event
-    end
-  """
+          emit(merged_event) -- emit the resulting event
+          merged_event = nil -- clear the merged event
+        end
 ```
 
-In this code sample, the `source` option defines code that's executed when the transform is created.
-while the `hooks.process` option defines a function that's called for each incoming event.
+In this code sample, the `source` option defines code that is executed when the transform is created,
+while the `hooks.process` option defines a function that is called for each incoming event.
 
 ## How It Works
 

--- a/website/content/en/guides/advanced/parsing-csv-logs-with-lua.md
+++ b/website/content/en/guides/advanced/parsing-csv-logs-with-lua.md
@@ -36,36 +36,40 @@ log file:
 
 Let us draft an initial version of the Vector's configuration file:
 
-```toml title="vector.toml"
-data_dir = "."
+```yaml title="vector.yaml"
+data_dir: "."
 
-[sources.file]
-  type = "file"
-  include = ["*.csv"]
-  ignore_checkpoints = true
+sources:
+  file:
+    type: "file"
+    include: ["*.csv"]
+    ignore_checkpoints: true
 
-[transforms.lua]
-  inputs = ["file"]
-  type = "lua"
-  version = "2"
-  hooks.process = """
-    function (event, emit)
-      -- to be expanded
-      emit(event)
-    end
-  """
+transforms:
+  lua:
+    inputs: ["file"]
+    type: "lua"
+    version: "2"
+    hooks:
+      process: |
+        function (event, emit)
+          -- to be expanded
+          emit(event)
+        end
 
-[sinks.console]
-  inputs = ["lua"]
-  type = "console"
-  encoding.codec = "json"
+sinks:
+  console:
+    inputs: ["lua"]
+    type: "console"
+    encoding:
+      codec: "json"
 ```
 
 This config sets up a [pipeline][docs.meta.glossary#pipeline] that reads log files, pipes them through the parsing
 transform (which currently is configured to just pass the events through), and displays the produced log events using
 [`console`][docs.sinks.console] sink.
 
-At this point, running `vector --config vector.toml` results in the following output:
+At this point, running `vector --config vector.yaml` results in the following output:
 
 ```json
 {"file":"log.csv","host":"localhost","message":"2020-04-09 12:48:49.661 UTC,,,1,,localhost.1,1,,2020-04-09 12:48:49 UTC,,0,LOG,00000,\"ending log output to stderr\",,\"Future log output will go to log destination \"\"csvlog\"\".\",,,,,,,\"\"","timestamp":"2020-04-09T14:33:28Z"}
@@ -77,7 +81,7 @@ At this point, running `vector --config vector.toml` results in the following ou
 
 In order to perform actual parsing, it is possible to leverage [`lua-csv`][urls.lua_csv_repo].
 Because it consists of a [single file][urls.lua_csv_view], it is possible to just download it to the same
-directory where `vector.toml` is stored:
+directory where `vector.yaml` is stored:
 
 ```bash
 curl -o csv.lua https://raw.githubusercontent.com/geoffleyland/lua-csv/d20cd42d61dc52e7f6bcb13b596ac7a7d4282fbf/lua/csv.lua
@@ -86,10 +90,9 @@ curl -o csv.lua https://raw.githubusercontent.com/geoffleyland/lua-csv/d20cd42d6
 Then it would be possible to load it by calling [`require`][urls.lua_require] Lua function in the
 [`source`][docs.transforms.lua#source] configuration section:
 
-```toml
-source = """
+```yaml
+source: |
   csv = require("csv")
-"""
 ```
 
 With this `source` the `csv` module is loaded when Vector is started up (or if the `lua` transform is added later and the
@@ -99,85 +102,85 @@ config is automatically reloaded) and can be used through the global variable `c
 
 With the `csv` module, the [`hooks.process`][docs.transforms.lua#process] can be changed to the following:
 
-```toml
-hooks.process = """
-  function (event, emit)
-    fields = csv.openstring(event.log.message):lines()() -- parse the `message` field
-    event.log.message = nil -- drop the `message` field
+```yaml
+hooks:
+  process: |
+    function (event, emit)
+      fields = csv.openstring(event.log.message):lines()() -- parse the `message` field
+      event.log.message = nil -- drop the `message` field
 
-    column_names = {  -- a sequence containing CSV column names
-      -- ...
-    }
+      column_names = {  -- a sequence containing CSV column names
+        -- ...
+      }
 
-    for column, value in ipairs(fields) do -- iterate over CSV columns
-      column_name = column_names[column] -- get column name
-      event.log[column_name] = value -- set the corresponding field in the event
+      for column, value in ipairs(fields) do -- iterate over CSV columns
+        column_name = column_names[column] -- get column name
+        event.log[column_name] = value -- set the corresponding field in the event
+      end
+
+      emit(event) -- emit the transformed event
     end
-
-    emit(event) -- emit the transformed event
-  end
-"""
 ```
 
 Note that the `column_names` can be created just once, in the `source` section instead to speed up processing.
 Putting it there and using the column names from the PostgreSQL documentation results in the following definition of
 the whole transform:
 
-```toml title="vector.toml"
+```yaml title="vector.yaml"
 # ...
-[transforms.lua]
-  inputs = ["file"]
-  type = "lua"
-  version = "2"
-  source = """
-    csv = require("csv") -- load external module for parsing CSV
-    column_names = {  -- a sequence containing CSV column names
-      "log_time",
-      "user_name",
-      "database_name",
-      "process_id",
-      "connection_from",
-      "session_id",
-      "session_line_num",
-      "command_tag",
-      "session_start_time",
-      "virtual_transaction_id",
-      "transaction_id",
-      "error_severity",
-      "sql_state_code",
-      "message",
-      "detail",
-      "hint",
-      "internal_query",
-      "internal_query_pos",
-      "context",
-      "query",
-      "query_pos",
-      "location",
-      "application_name",
-      -- available only in postgres > 13, to remove for postgres <= 13
-      "backend_type",
-      "leader_pid",
-      "query_id"
-    }
-  """
-  hooks.process = """
-    function (event, emit)
-      fields = csv.openstring(event.log.message):lines()() -- parse the `message` field
-      event.log.message = nil -- drop the `message` field
+transforms:
+  lua:
+    inputs: ["file"]
+    type: "lua"
+    version: "2"
+    source: |
+      csv = require("csv") -- load external module for parsing CSV
+      column_names = {  -- a sequence containing CSV column names
+        "log_time",
+        "user_name",
+        "database_name",
+        "process_id",
+        "connection_from",
+        "session_id",
+        "session_line_num",
+        "command_tag",
+        "session_start_time",
+        "virtual_transaction_id",
+        "transaction_id",
+        "error_severity",
+        "sql_state_code",
+        "message",
+        "detail",
+        "hint",
+        "internal_query",
+        "internal_query_pos",
+        "context",
+        "query",
+        "query_pos",
+        "location",
+        "application_name",
+        -- available only in postgres > 13, to remove for postgres <= 13
+        "backend_type",
+        "leader_pid",
+        "query_id"
+      }
+    hooks:
+      process: |
+        function (event, emit)
+          fields = csv.openstring(event.log.message):lines()() -- parse the `message` field
+          event.log.message = nil -- drop the `message` field
 
-      for column, column_name in ipairs(column_names) do -- iterate over column names
-        value = fields[column] -- get field value
-        event.log[column_name] = value -- set the corresponding field in the event
-      end
+          for column, column_name in ipairs(column_names) do -- iterate over column names
+            value = fields[column] -- get field value
+            event.log[column_name] = value -- set the corresponding field in the event
+          end
 
-      emit(event) -- emit the transformed event
-    end
-    """
-#...
+          emit(event) -- emit the transformed event
+        end
+# ...
 ```
 
-Trying to run `vector --config vector.toml` with the same input file results in structured events being output:
+Trying to run `vector --config vector.yaml` with the same input file results in structured events being output:
 
 ```json
 {"application_name":"","backend_type":"not initialized","command_tag":"","connection_from":"","context":"","database_name":"","detail":"","error_severity":"LOG","file":"log.csv","hint":"Future log output will go to log destination \"csvlog\".","host":"localhost","internal_query":"","internal_query_pos":"","leader_pid":"","location":"","log_time":"2020-04-09 12:48:49.661 UTC","message":"ending log output to stderr","process_id":"1","query":"","query_id":"0","query_pos":"","session_id":"localhost.1","session_line_num":"1","session_start_time":"2020-04-09 12:48:49 UTC","sql_state_code":"00000","timestamp":"2020-04-09T19:49:07Z","transaction_id":"0","user_name":"","virtual_transaction_id":""}

--- a/website/content/en/guides/aws/cloudwatch-logs-firehose.md
+++ b/website/content/en/guides/aws/cloudwatch-logs-firehose.md
@@ -79,33 +79,36 @@ export FIREHOSE_S3_BUCKET="firehose-${AWS_ACCOUNT_ID}" # a bucket to write event
 
 Let's take a look at the configuration we will be using:
 
-```toml title="vector.toml"
-[sources.firehose]
-  type = "aws_kinesis_firehose"
-  address = "0.0.0.0:8080" # the public URL will be set when configuring Firehose
-  access_key = "${FIREHOSE_ACCESS_KEY} # this will also be set when configuring Firehose
+```yaml title="vector.yaml"
+sources:
+  firehose:
+    type: "aws_kinesis_firehose"
+    address: "0.0.0.0:8080" # the public URL will be set when configuring Firehose
+    access_key: "${FIREHOSE_ACCESS_KEY}" # this will also be set when configuring Firehose
 
-[transforms.parse]
-  type = "remap"
-  inputs = ["firehose"]
-  drop_on_error = false
-  source = '''
-    parsed = parse_aws_cloudwatch_log_subscription_message!(.message)
-    . = unnest(parsed.log_events)
-    . = map_values(.) -> |value| {
-       event = del(value.log_events)
-       value |= event
-       message = del(.message)
-       . |= object!(parse_json!(message))
-    }
-  '''
+transforms:
+  parse:
+    type: "remap"
+    inputs: ["firehose"]
+    drop_on_error: false
+    source: |
+      parsed = parse_aws_cloudwatch_log_subscription_message!(.message)
+      . = unnest(parsed.log_events)
+      . = map_values(.) -> |value| {
+         event = del(value.log_events)
+         value |= event
+         message = del(.message)
+         . |= object!(parse_json!(message))
+      }
 
 # you may want to add more transforms here
 
-[sinks.console]
-  type = "console"
-  inputs = ["parse"]
-  encoding.codec = "json"
+sinks:
+  console:
+    type: "console"
+    inputs: ["parse"]
+    encoding:
+      codec: "json"
 ```
 
 This will configure `vector` to listen for Firehose messages on the configured
@@ -352,16 +355,19 @@ delivery stream.
 To make sure everything is wired up correctly, let's send some logs to the log
 group we've setup. We can use Vector for this too!
 
-```bash
-[sources.stdin]
-  type = "stdin"
-[sinks.cloudwatch]
-  type = "aws_cloudwatch_logs"
-  inputs = ["stdin"]
-  group_name = "${LOG_GROUP}"
-  stream_name = "test"
-  region = "us-east-1"
-  encoding.codec = "json"
+```yaml
+sources:
+  stdin:
+    type: "stdin"
+sinks:
+  cloudwatch:
+    type: "aws_cloudwatch_logs"
+    inputs: ["stdin"]
+    group_name: "${LOG_GROUP}"
+    stream_name: "test"
+    region: "us-east-1"
+    encoding:
+      codec: "json"
 ```
 
 This will read lines from `stdin` and write them to CloudWatch Logs. See the
@@ -377,7 +383,7 @@ Let's send some logs. For this, I'm using
 log data.
 
 ```bash
-flog -f json | vector --config config.toml
+flog -f json | vector --config config.yaml
 ```
 
 This will send some logs to your log group. Within 300 seconds (the default
@@ -450,11 +456,12 @@ send it as an HTTP request:
 
 The [`aws_kinesis_firehose`][aws_kinesis_firehose] source:
 
-```toml
-[sources.firehose]
-  type = "aws_kinesis_firehose"
-  address = "0.0.0.0:8080" # the public URL will be set in the Firehose config
-  access_key = "my secret key" # this will also be set in the Firehose config
+```yaml
+sources:
+  firehose:
+    type: "aws_kinesis_firehose"
+    address: "0.0.0.0:8080" # the public URL will be set in the Firehose config
+    access_key: "my secret key" # this will also be set in the Firehose config
 ```
 
 will accept this request, decode the record (which is gzip'ed and then base64 encoded), to produce an event that looks like:
@@ -479,21 +486,21 @@ can use a [`remap`][remap] transform and leverage the [`parse_aws_cloudwatch_log
 [`unnest`][unnest], [`map_values`][map_values], and [`parse_json`][parse_json]
 functions:
 
-```toml
-[transforms.parse]
-  type = "remap"
-  inputs = ["firehose"]
-  drop_on_error = false
-  source = '''
-    parsed = parse_aws_cloudwatch_log_subscription_message!(.message)
-    . = unnest(parsed.log_events)
-    . = map_values(.) -> |value| {
-       event = del(value.log_events)
-       value |= event
-       message = del(.message)
-       . |= object!(parse_json!(message))
-    }
-  '''
+```yaml
+transforms:
+  parse:
+    type: "remap"
+    inputs: ["firehose"]
+    drop_on_error: false
+    source: |
+      parsed = parse_aws_cloudwatch_log_subscription_message!(.message)
+      . = unnest(parsed.log_events)
+      . = map_values(.) -> |value| {
+         event = del(value.log_events)
+         value |= event
+         message = del(.message)
+         . |= object!(parse_json!(message))
+      }
 ```
 
 Let's step through this program one function at a time.

--- a/website/content/en/guides/level-up/managing-complex-configs.md
+++ b/website/content/en/guides/level-up/managing-complex-configs.md
@@ -40,28 +40,32 @@ For example, if we wished to create a chain of three transforms; `remap`, `filte
 and `reduce`, we can run:
 
 ```bash
-vector generate /remap,filter,reduce > vector.toml
+vector generate /remap,filter,reduce > vector.yaml
 # Find out more with `vector generate --help`
 ```
 
 And most of the boilerplate will be written for us, with each component printed
 with an `inputs` field that specifies the component before it:
 
-```toml title="vector.toml"
-[transforms.transform0]
-  inputs = [ "somewhere" ]
-  type = "remap"
-  # etc ...
+```yaml title="vector.yaml"
+transforms:
+  transform0:
+    inputs:
+      - "somewhere"
+    type: "remap"
+    # etc ...
 
-[transforms.transform1]
-  inputs = [ "transform0" ]
-  type = "filter"
-  # etc ...
+  transform1:
+    inputs:
+      - "transform0"
+    type: "filter"
+    # etc ...
 
-[transforms.transform2]
-  inputs = [ "transform1" ]
-  type = "reduce"
-  # etc ...
+  transform2:
+    inputs:
+      - "transform1"
+    type: "reduce"
+    # etc ...
 ```
 
 The IDs of the generated components are sequential (`transform0`,
@@ -79,18 +83,20 @@ Let's imagine we are in the process of building the config from the [unit test
 guide][guides.unit-testing], we might start off with our source and
 the grok parser:
 
-```toml title="vector.toml"
-[sources.over_tcp]
-  type = "socket"
-  mode = "tcp"
-  address = "0.0.0.0:9000"
+```yaml title="vector.yaml"
+sources:
+  over_tcp:
+    type: "socket"
+    mode: "tcp"
+    address: "0.0.0.0:9000"
 
-[transforms.foo]
-  inputs = ["over_tcp"]
-  type = "remap"
-  source = '''
-  . = parse_grok!(.message, s'%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}')
-'''
+transforms:
+  foo:
+    inputs:
+      - "over_tcp"
+    type: "remap"
+    source: |
+      . = parse_grok!(.message, s'%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}')
 ```
 
 A common way to test this transform might be to temporarily change the source
@@ -101,30 +107,28 @@ our config to run tests rather than focusing on features.
 Instead, we can leave our source as a `socket` type and add a unit test to the
 end of our config:
 
-```toml title="vector.toml"
-[[tests]]
-  name = "check_simple_log"
-
-  [[tests.inputs]]
-    insert_at = "foo"
-    type = "raw"
-    value = "2019-11-28T12:00:00+00:00 info Sorry, I'm busy this week Cecil"
-
-  [[tests.outputs]]
-    extract_from = "foo"
+```yaml title="vector.yaml"
+tests:
+  - name: "check_simple_log"
+    inputs:
+      - insert_at: "foo"
+        type: "raw"
+        value: "2019-11-28T12:00:00+00:00 info Sorry, I'm busy this week Cecil"
+    outputs:
+      - extract_from: "foo"
 ```
 
 When we add a unit test output without any conditions it will simply print the
 input and output events of a transform, allowing us to inspect its behavior:
 
 ```sh
-$ vector test ./vector.toml
-Running vector.toml tests
-test vector.toml: check_simple_log ... passed
+$ vector test ./vector.yaml
+Running vector.yaml tests
+test vector.yaml: check_simple_log ... passed
 
 inspections:
 
---- vector.toml ---
+--- vector.yaml ---
 
 test 'check_simple_log':
 
@@ -137,28 +141,23 @@ As we introduce new transforms to our config we can change the test output
 to check the latest transform. Or, occasionally, we can add conditions to an
 output in order to turn it into a regression test:
 
-```toml title="vector.toml"
-[[tests]]
-  name = "check_simple_log"
-
-  [[tests.inputs]]
-    insert_at = "foo"
-    type = "raw"
-    value = "2019-11-28T12:00:00+00:00 info Sorry, I'm busy this week Cecil"
-
-  # This is now a regression test
-  [[tests.outputs]]
-    extract_from = "foo"
-    [[tests.outputs.conditions]]
-      type = "vrl"
-      source = """
-        assert_eq!(.message, "Sorry, I'm busy this week Cecil")
-      """
-
-  # And we add a new output without conditions for inspecting
-  # a new transform
-  [[tests.outputs]]
-    extract_from = "bar"
+```yaml title="vector.yaml"
+tests:
+  - name: "check_simple_log"
+    inputs:
+      - insert_at: "foo"
+        type: "raw"
+        value: "2019-11-28T12:00:00+00:00 info Sorry, I'm busy this week Cecil"
+    outputs:
+      # This is now a regression test
+      - extract_from: "foo"
+        conditions:
+          - type: "vrl"
+            source: |
+              assert_eq!(.message, "Sorry, I'm busy this week Cecil")
+      # And we add a new output without conditions for inspecting
+      # a new transform
+      - extract_from: "bar"
 ```
 
 How many tests you add is at your discretion, but you probably don't need to
@@ -175,10 +174,10 @@ With Vector you can split a config down into as many files as you like and run
 them all as a larger topology:
 
 ```bash
-# These three examples run the same two configs together:
-vector -c ./configs/foo.toml -c ./configs/bar.toml
-vector -c ./configs/*.toml
-vector -c ./configs/foo.toml ./configs/bar.toml
+# These three examples run the same two configs together:
+vector -c ./configs/foo.yaml -c ./configs/bar.yaml
+vector -c ./configs/*.yaml
+vector -c ./configs/foo.yaml ./configs/bar.yaml
 ```
 
 If you have a large chain of components it's a good idea to break them out into
@@ -193,52 +192,58 @@ With Vector you can define a component configuration inside a component type fol
 
 Let's take an example with the following configuration file:
 
-```toml title="vector.toml"
-[sources.syslog]
-type = "syslog"
-address = "0.0.0.0:514"
-max_length = 42000
-mode = "tcp"
+```yaml title="vector.yaml"
+sources:
+  syslog:
+    type: "syslog"
+    address: "0.0.0.0:514"
+    max_length: 42000
+    mode: "tcp"
 
-[transforms.change_fields]
-type = "remap"
-inputs = ["syslog"]
-source = """
-.new_field = "some value"
-"""
+transforms:
+  change_fields:
+    type: "remap"
+    inputs:
+      - "syslog"
+    source: |
+      .new_field = "some value"
 
-[sinks.stdout]
-type = "console"
-inputs = ["change_fields"]
-target = "stdout"
-encoding.codec = "json"
+sinks:
+  stdout:
+    type: "console"
+    inputs:
+      - "change_fields"
+    target: "stdout"
+    encoding:
+      codec: "json"
 ```
 
-We can extract the `syslog` source in the file `/etc/vector/sources/syslog.toml`
+We can extract the `syslog` source in the file `/etc/vector/sources/syslog.yaml`
 
-```toml title="syslog.toml"
-type = "syslog"
-address = "0.0.0.0:514"
-max_length = 42000
-mode = "tcp"
+```yaml title="syslog.yaml"
+type: "syslog"
+address: "0.0.0.0:514"
+max_length: 42000
+mode: "tcp"
 ```
 
-The `change_fields` transform in the file `/etc/vector/transforms/change_fields.toml`
+The `change_fields` transform in the file `/etc/vector/transforms/change_fields.yaml`
 
-```toml title="change_fields.toml"
-type = "remap"
-inputs = ["syslog"]
-source = """
-.new_field = "some value"
-"""
+```yaml title="change_fields.yaml"
+type: "remap"
+inputs:
+  - "syslog"
+source: |
+  .new_field = "some value"
 ```
 
-And the `stdout` sink in the file `/etc/vector/sinks/stdout.toml`
+And the `stdout` sink in the file `/etc/vector/sinks/stdout.yaml`
 
-```toml title="stdout.toml"
-type = "console"
-inputs = ["change_fields"]
-target = "stdout"
+```yaml title="stdout.yaml"
+type: "console"
+inputs:
+  - "change_fields"
+target: "stdout"
 ```
 
 And for Vector to look for the configuration in the component type related folders,

--- a/website/content/en/guides/level-up/managing-schemas.md
+++ b/website/content/en/guides/level-up/managing-schemas.md
@@ -41,13 +41,13 @@ By default, Vector primarily operates on three fields: `host`, `message`, and `t
 
 Vector sets these fields on logs as it ingests data (from a [source][docs.sources]). It may be that your data does not
 follow this convention. In this case you can modify the global defaults for all incoming data in the `log_schema`
-section of your `vector.toml`.
+section of your `vector.yaml`.
 
-```toml title="vector.toml"
-[log_schema]
-host_key = "instance" # default "host"
-message_key = "info" # default "message"
-timestamp_key = "datetime" # default "timestamp"
+```yaml title="vector.yaml"
+log_schema:
+  host_key: "instance" # default "host"
+  message_key: "info" # default "message"
+  timestamp_key: "datetime" # default "timestamp"
 
 # Sources, transforms, and sinks...
 ```
@@ -65,15 +65,16 @@ and you'll likely need to configure this at a more fine-grained level.
 Some services will produce logs with the timestamp field mapped to `@timestamp` or some other value.
 
 If your vector pipeline is only working with data passing through these systems, you can add the following to your
-`vector.toml`:
+`vector.yaml`:
 
-```toml title="vector.toml"
-[log_schema]
-  timestamp_key = "@timestamp"  # Applies to all sources, sinks, and transforms!
+```yaml title="vector.yaml"
+log_schema:
+  timestamp_key: "@timestamp" # Applies to all sources, sinks, and transforms!
 
-[sources.my_naming_confused_source]
-  type = "logplex"
-  address = "0.0.0.0:8088"
+sources:
+  my_naming_confused_source:
+    type: "logplex"
+    address: "0.0.0.0:8088"
 ```
 
 
@@ -91,24 +92,24 @@ Commonly you'll want to do this near either the source or sink of your pipeline.
 
 A transform of this type looks like this:
 
-```toml title="vector.toml"
-[transforms.strip_personal_details]
-type = "remap"
-inputs = ["my-source-id"]
-source = '''
-  del(.email, .passport_number)
-'''
+```yaml title="vector.yaml"
+transforms:
+  strip_personal_details:
+    type: "remap"
+    inputs: ["my-source-id"]
+    source: |
+      del(.email, .passport_number)
 ```
 
 The `remap` transform has a wealth of mapping functions, and in cases where we wish to flip this concept and drop all fields except for a list of exceptions we can do that with the `only_fields` function:
 
-```toml title="vector.toml"
-[transforms.strip_personal_details]
-type = "remap"
-inputs = ["my-source-id"]
-source = '''
-  only_fields(.timestamp, .message, .host, .user_id)
-'''
+```yaml title="vector.yaml"
+transforms:
+  strip_personal_details:
+    type: "remap"
+    inputs: ["my-source-id"]
+    source: |
+      only_fields(.timestamp, .message, .host, .user_id)
 ```
 
 ### Example: Filtering data for GDPR compliance
@@ -127,51 +128,54 @@ config, just a little example!)
 
 We can build a config that will do the first part of this, but we'll just output to console for ease of this example.
 
-```toml title="vector.toml"
-data_dir = "./data"
-dns_servers = []
+```yaml title="vector.yaml"
+data_dir: "./data"
+dns_servers: []
 
-[sources.application]
-max_length = 102400
-type = "stdin"
+sources:
+  application:
+    max_length: 102400
+    type: "stdin"
 
-[transforms.parse]
-inputs = ["application"]
-type = "remap"
-source = '''
-. = parse_json!(.message)
-'''
+transforms:
+  parse:
+    inputs: ["application"]
+    type: "remap"
+    source: |
+      . = parse_json!(.message)
 
-[transforms.not_gdpr]
-type = "filter"
-inputs = ["parse"]
-condition = ".gdpr == false"
+  not_gdpr:
+    type: "filter"
+    inputs: ["parse"]
+    condition: ".gdpr == false"
 
-[transforms.gdpr_to_strip]
-type = "filter"
-inputs = ["parse"]
-condition = ".gdpr == true"
+  gdpr_to_strip:
+    type: "filter"
+    inputs: ["parse"]
+    condition: ".gdpr == true"
 
-[transforms.gdpr_stripped]
-type = "remap"
-inputs = ["gdpr_to_strip"]
-source = "del(.email)"
+  gdpr_stripped:
+    type: "remap"
+    inputs: ["gdpr_to_strip"]
+    source: "del(.email)"
 
-[sinks.console]
-healthcheck = true
-inputs = ["not_gdpr", "gdpr_stripped"]
-type = "console"
-encoding.codec = "json"
-[sinks.console.buffer]
-type = "memory"
-max_events = 500
-when_full = "block"
+sinks:
+  console:
+    healthcheck: true
+    inputs: ["not_gdpr", "gdpr_stripped"]
+    type: "console"
+    encoding:
+      codec: "json"
+    buffer:
+      type: "memory"
+      max_events: 500
+      when_full: "block"
 ```
 
 Let's have a look:
 
 ```bash
-$ cat <<-EOF | cargo run -- --config test.toml
+$ cat <<-EOF | cargo run -- --config test.yaml
 { "id": "user1", "gdpr": false, "email": "us-user1@datadoghq.com" }
 { "id": "user2", "gdpr": false, "email": "us-user2@datadoghq.com" }
 { "id": "user3", "gdpr": true, "email": "eu-user3@datadoghq.com" }
@@ -202,15 +206,17 @@ The applications for this include some of the reasons discussed in
 
 Lets take a look at what that might look like:
 
-```toml title="vector.toml"
-[sinks.output]
-  inputs = ["demo_logs"]
-  type = "kafka"
+```yaml title="vector.yaml"
+sinks:
+  output:
+    inputs: ["demo_logs"]
+    type: "kafka"
 
-  # Put events in the host specific topic.
-  topic = "{{service}}"
-  encoding.except_fields = ["service"] # Remove this field now and save some bytes
-  # ...
+    # Put events in the host specific topic.
+    topic: "{{service}}"
+    encoding:
+      except_fields: ["service"] # Remove this field now and save some bytes
+    # ...
 ```
 
 {{< warning >}}
@@ -222,14 +228,14 @@ a field which you want templatable open an issue and let us know.
 
 It's fairly common for one part of your pipeline to expect a field to be named differently than another part! The `remap` transform can also be used to slide data around for you.
 
-```toml title="vector.toml"
-[transforms.rename_timestamp]
-  type = "remap"
-  inputs = ["source0"]
-  source = '''
-    ."@timestamp" = .timestamp
-    del(.timestamp)
-  '''
+```yaml title="vector.yaml"
+transforms:
+  rename_timestamp:
+    type: "remap"
+    inputs: ["source0"]
+    source: |
+      ."@timestamp" = .timestamp
+      del(.timestamp)
 ```
 
 Other times you might need to concatenate fields together, or perform arithmetic on their numerical values, the [`remap`][docs.transforms.remap] transform can be used to do all of these things.
@@ -246,14 +252,14 @@ It's useful for when:
 Let's pretend one of your teammates falsely assumed folks always have first and last names, so we have a `first_name`
 and a `last_name` field coming from a source, and we'd like to output a `name` field to a sink.
 
-```toml title="vector.toml"
-[transforms.moosh_names]
-  type = "remap"
-  inputs = ["source0"]
-  source = '''
-    .name = .first_name + " " + .last_name
-    del(.first_name, .last_name)
-  '''
+```yaml title="vector.yaml"
+transforms:
+  moosh_names:
+    type: "remap"
+    inputs: ["source0"]
+    source: |
+      .name = .first_name + " " + .last_name
+      del(.first_name, .last_name)
 ```
 
 ## Coercing Data Types
@@ -263,14 +269,14 @@ should be a number, or vice versa.
 
 Gadzooks! The [`remap`][docs.transforms.remap] transform is also the correct tool for this job!
 
-```toml title="vector.toml"
-[transforms.correct_source_types]
-  type = "remap"
-  inputs = ["source0"]
-  source = '''
-    .count = int(.count)
-    .date = timestamp(.date, "%F")
-  '''
+```yaml title="vector.yaml"
+transforms:
+  correct_source_types:
+    type: "remap"
+    inputs: ["source0"]
+    source: |
+      .count = int(.count)
+      .date = timestamp(.date, "%F")
 ```
 
 Remember that you can follow the coercion mappings with `del` or `only_fields` functions, empowering it to drop
@@ -286,12 +292,12 @@ To do this we'll use the `timestamp` function with a format string argument. To 
 [`strftime`](https://docs.rs/chrono/0.4.10/chrono/format/strftime/index.html) documentation. Let's ship some Canadian
 friendly logs up to the great white north!
 
-```toml title="vector.toml"
-[transforms.format_timestamp]
-  type = "remap"
-  source = '''
-    .timestamp = timestamp(.timestamp, "%Y/%m/%d:%H:%M:%S %z")
-  '''
+```yaml title="vector.yaml"
+transforms:
+  format_timestamp:
+    type: "remap"
+    source: |
+      .timestamp = timestamp(.timestamp, "%Y/%m/%d:%H:%M:%S %z")
 ```
 
 ## Working with data formats
@@ -305,12 +311,14 @@ supported. In these cases, you can use the `encoding` option.
 The [`console`][docs.sinks.console] sink supports both `json` and `text` as its
 output format
 
-```toml title="vector.toml"
-[sinks.print]
-  type = "console"
-  inputs = ["source0"]
-  target = "stdout"
-  encoding.codec = "json"
+```yaml title="vector.yaml"
+sinks:
+  print:
+    type: "console"
+    inputs: ["source0"]
+    target: "stdout"
+    encoding:
+      codec: "json"
 ```
 
 You can also use a transform like [`remap`][docs.transforms.remap] or to parse out

--- a/website/content/en/guides/level-up/vector-tap-guide.md
+++ b/website/content/en/guides/level-up/vector-tap-guide.md
@@ -31,27 +31,26 @@ To start, we'll reference the following base configuration, but feel free to
 substitute your own. Just note that the [Vector API] must be enabled for `vector
 tap` to work. See [under the hood](#under-the-hood) for more details.
 
-```toml
-[api]
-enabled = true
+```yaml
+api:
+  enabled: true
 
-[sources.in]
-type = "demo_logs"
-format = "shuffle"
-lines = [
-  "test1",
-  "test2",
-]
+sources:
+  in:
+    type: "demo_logs"
+    format: "shuffle"
+    lines: ["test1", "test2"]
 
-[sinks.out]
-type = "blackhole"
-inputs = ["in*"]
+sinks:
+  out:
+    type: "blackhole"
+    inputs: ["in*"]
 ```
 
 Run Vector with this configuration and watch the configuration for changes.
 
 ```console
-vector --config path/to/config.toml -w
+vector --config path/to/config.yaml -w
 ```
 
 Now run `vector tap`! You should start seeing a stream of
@@ -125,14 +124,12 @@ accordingly by re-matching your provided patterns.
 With `vector tap` running, add the following `demo_logs` source to the base
 configuration.
 
-```toml
-[sources.in-2]
-type = "demo_logs"
-format = "shuffle"
-lines = [
-  "new test1",
-  "new test2",
-]
+```yaml
+sources:
+  in-2:
+    type: "demo_logs"
+    format: "shuffle"
+    lines: ["new test1", "new test2"]
 ```
 
 You'll now see events from component `in-2` appear in `tap` output.
@@ -155,43 +152,45 @@ troubleshoot a pipeline.
 
 We'll use the following Vector configuration.
 
-```toml
-[api]
-enabled = true
+```yaml
+api:
+  enabled: true
 
-[sources.in]
-type = "demo_logs"
-format = "shuffle"
-lines = [
-  '{ "type": "icecream", "flavor": "strawberry" }',
-  '{ "type": "icecream", "flavor": "chocolate" }',
-  '{ "type": "icecream", "flavor": "wasabi" }',
-]
+sources:
+  in:
+    type: "demo_logs"
+    format: "shuffle"
+    lines:
+      - '{ "type": "icecream", "flavor": "strawberry" }'
+      - '{ "type": "icecream", "flavor": "chocolate" }'
+      - '{ "type": "icecream", "flavor": "wasabi" }'
 
-[transforms.picky]
-type = "remap"
-inputs = ["in"]
-drop_on_abort = true
-reroute_dropped = true
-source = '''
-  if .flavor == "strawberry" {
-    .happiness = 10
-  } else if .flavor == "chocolate" {
-    .happiness = 5
-  } else {
-    abort
-  }
-'''
+transforms:
+  picky:
+    type: "remap"
+    inputs: ["in"]
+    drop_on_abort: true
+    reroute_dropped: true
+    source: |
+      if .flavor == "strawberry" {
+        .happiness = 10
+      } else if .flavor == "chocolate" {
+        .happiness = 5
+      } else {
+        abort
+      }
 
-[sinks.store]
-type = "console"
-inputs = ["picky"]
-target = "stdout"
-encoding.codec = "json"
+sinks:
+  store:
+    type: "console"
+    inputs: ["picky"]
+    target: "stdout"
+    encoding:
+      codec: "json"
 
-[sinks.trash]
-type = "blackhole"
-inputs = ["picky.dropped"]
+  trash:
+    type: "blackhole"
+    inputs: ["picky.dropped"]
 ```
 
 Running this configuration, we expect to see our favorite ice cream logs appear

--- a/website/content/en/highlights/2019-11-25-unit-testing-vector-config-files.md
+++ b/website/content/en/highlights/2019-11-25-unit-testing-vector-config-files.md
@@ -26,32 +26,31 @@ mission-critical production pipelines that are collaborated on.
 Let's look at a basic example that uses the [`regex_parser`
 transform][docs.transforms.regex_parser] to parse log lines:
 
-```toml title="vector.toml"
-[sources.my_logs]
-  type    = "file"
-  include = ["/var/log/my-app.log"]
+```yaml title="vector.yaml"
+sources:
+  my_logs:
+    type: "file"
+    include: ["/var/log/my-app.log"]
 
-[transforms.parser]
-  inputs = ["my_logs"]
-  type   = "regex_parser"
-  regex  = "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
+transforms:
+  parser:
+    inputs: ["my_logs"]
+    type: "regex_parser"
+    regex: "^(?P<timestamp>[\\w\\-:\\+]+) (?P<level>\\w+) (?P<message>.*)$"
 
-[[tests]]
-  name = "verify_regex"
-
-  [tests.input]
-    insert_at = "parser"
-    type = "raw"
-    value = "2019-11-28T12:00:00+00:00 info Hello world"
-
-  [[tests.outputs]]
-    extract_from = "parser"
-
-    [[tests.outputs.conditions]]
-      type = "check_fields"
-      "timestamp.equals" = "2019-11-28T12:00:00+00:00"
-      "level.equals" = "info"
-      "message.equals" = "Hello world"
+tests:
+  - name: "verify_regex"
+    input:
+      insert_at: "parser"
+      type: "raw"
+      value: "2019-11-28T12:00:00+00:00 info Hello world"
+    outputs:
+      - extract_from: "parser"
+        conditions:
+          - type: "check_fields"
+            "timestamp.equals": "2019-11-28T12:00:00+00:00"
+            "level.equals": "info"
+            "message.equals": "Hello world"
 ```
 
 And you can run the tests via the new `test` subcommand:

--- a/website/content/en/highlights/2019-11-25-unit-testing-vector-config-files.md
+++ b/website/content/en/highlights/2019-11-25-unit-testing-vector-config-files.md
@@ -56,9 +56,9 @@ tests:
 And you can run the tests via the new `test` subcommand:
 
 ```sh
-$ vector test ./vector.toml
-Running ./vector.toml tests
-Test ./vector.toml: verify_regex ... passed
+$ vector test ./vector.yaml
+Running ./vector.yaml tests
+Test ./vector.yaml: verify_regex ... passed
 ```
 
 ## Why?

--- a/website/content/en/highlights/2019-12-13-custom-dns.md
+++ b/website/content/en/highlights/2019-12-13-custom-dns.md
@@ -20,8 +20,8 @@ servers in your configs.
 
 The configuration isn't complicated, it's a global array field `dns_servers`:
 
-```toml
-dns_servers = ["0.0.0.0:53"]
+```yaml
+dns_servers: ["0.0.0.0:53"]
 ```
 
 When `dns_servers` is set Vector will ignore the system configuration and use

--- a/website/content/en/highlights/2019-12-16-ec2-metadata.md
+++ b/website/content/en/highlights/2019-12-16-ec2-metadata.md
@@ -21,19 +21,19 @@ our brand spanking new [`aws_ec2_metadata` transform][docs.transforms.aws_ec2_me
 Configuration isn't complicated, just add and hook up the transform. If you
 don't want all enrichments added then white-list them with the `fields` option:
 
-```toml
-[transforms.fill_me_up]
-  type = "aws_ec2_metadata"
-  inputs = ["my-source-id"]
-  fields = [
-    "instance-id",
-    "local-hostname",
-    "public-hostname",
-    "public-ipv4",
-    "ami-id",
-    "availability-zone",
-    "region",
-  ]
+```yaml
+transforms:
+  fill_me_up:
+    type: "aws_ec2_metadata"
+    inputs: ["my-source-id"]
+    fields:
+      - "instance-id"
+      - "local-hostname"
+      - "public-hostname"
+      - "public-ipv4"
+      - "ami-id"
+      - "availability-zone"
+      - "region"
 ```
 
 For more guidance get on the [reference page][docs.transforms.aws_ec2_metadata].

--- a/website/content/en/highlights/2020-01-07-prometheus-source.md
+++ b/website/content/en/highlights/2020-01-07-prometheus-source.md
@@ -25,11 +25,12 @@ metrics data model and tested our interoperability between metrics sources.
 To use it simply add the source config and point it towards the hosts you wish
 to scrape:
 
-```toml
-[sources.my_source_id]
-  type = "prometheus_scrape"
-  hosts = ["http://localhost:9090"]
-  scrape_interval_secs = 1
+```yaml
+sources:
+  my_source_id:
+    type: "prometheus_scrape"
+    hosts: ["http://localhost:9090"]
+    scrape_interval_secs: 1
 ```
 
 For more guidance get on the [reference page][docs.sources.prometheus].

--- a/website/content/en/highlights/2020-01-20-splunk-hec-specify-indexed-fields.md
+++ b/website/content/en/highlights/2020-01-20-splunk-hec-specify-indexed-fields.md
@@ -21,9 +21,10 @@ will _not_ index any fields by default.
 In order to mark desired fields as indexed you can use the optional
 configuration option `indexed_fields`:
 
-```toml title="vector.toml"
- [sinks.my_sink_id]
-   type = "splunk_hec"
-   inputs = ["my-source-id"]
-+  indexed_fields = ["foo", "bar"]
+```yaml title="vector.yaml"
+ sinks:
+   my_sink_id:
+     type: "splunk_hec"
+     inputs: ["my-source-id"]
++    indexed_fields: ["foo", "bar"]
 ```

--- a/website/content/en/highlights/2020-02-05-merge-partial-docker-events.md
+++ b/website/content/en/highlights/2020-02-05-merge-partial-docker-events.md
@@ -20,10 +20,11 @@ events. This can be a very difficult and frustrating problem to solve with
 other tools (we speak from experience). In this release, Vector solves this
 automatically with a new `auto_partial_merge` option in the `docker_logs` source.
 
-```toml title="vector.toml"
-[sources.my_source_id]
-  type = "docker_logs"
-  auto_partial_merge = true
+```yaml title="vector.yaml"
+sources:
+  my_source_id:
+    type: "docker_logs"
+    auto_partial_merge: true
 ```
 
 We love assimilation and look forward to a future where our individualistic

--- a/website/content/en/highlights/2020-02-14-global-log-schema.md
+++ b/website/content/en/highlights/2020-02-14-global-log-schema.md
@@ -24,11 +24,11 @@ the default names for the [`message_key`][docs.global-options#message_key],
 [`host_key`][docs.global-options#host_key],
 [`timestamp_key`][docs.global-options#host_key], and more:
 
-```toml title="vector.toml"
-[log_schema]
-  host_key = "host" # default
-  message_key = "message" # default
-  timestamp_key = "timestamp" # default
+```yaml title="vector.yaml"
+log_schema:
+  host_key: "host" # default
+  message_key: "message" # default
+  timestamp_key: "timestamp" # default
 ```
 
 Why is this useful?

--- a/website/content/en/highlights/2020-02-21-file-source-multiline-support.md
+++ b/website/content/en/highlights/2020-02-21-file-source-multiline-support.md
@@ -34,16 +34,16 @@ foobar.rb:6:in `/': divided by 0 (ZeroDivisionError)
 
 You can merge them with the following config:
 
-```toml title="vector.toml"
-[sources.my_file_source]
-  type = "file"
-  # ...
-
-  [sources.my_file_source.multiline]
-    start_pattern = "^[^\\s]"
-    mode = "continue_through"
-    condition_pattern = "^[\\s]+from"
-    timeout_ms = 1000
+```yaml title="vector.yaml"
+sources:
+  my_file_source:
+    type: "file"
+    # ...
+    multiline:
+      start_pattern: "^[^\\s]"
+      mode: "continue_through"
+      condition_pattern: "^[\\s]+from"
+      timeout_ms: 1000
 ```
 
 And if this doesn't do it, you can always fall back to the [`lua` transform][docs.transforms.lua].

--- a/website/content/en/highlights/2020-02-24-swimlanes-transform.md
+++ b/website/content/en/highlights/2020-02-24-swimlanes-transform.md
@@ -16,15 +16,16 @@ The new [`swimlanes` transform][docs.transforms.swimlanes] makes it much easier
 to configure conditional branches of transforms and sinks. For example, you can
 easily create [if/else pipelines][docs.transforms.swimlanes#examples].
 
-```toml title="vector.toml"
-[transforms.lanes]
-  types = "swimlanes"
-
-  [transforms.my_transform_id.lanes.errors]
-    "level.eq" = "error"
-
-  [transforms.my_transform_id.lanes.not_errors]
-    "level.neq" = "error"
+```yaml title="vector.yaml"
+transforms:
+  lanes:
+    types: "swimlanes"
+  my_transform_id:
+    lanes:
+      errors:
+        "level.eq": "error"
+      not_errors:
+        "level.neq": "error"
 ```
 
 Remember to occasionally let your branches mingle so that they don't completely

--- a/website/content/en/highlights/2020-03-04-encoding-only-fields-except-fields.md
+++ b/website/content/en/highlights/2020-03-04-encoding-only-fields-except-fields.md
@@ -23,11 +23,13 @@ Vector has deprecated the root-level `encoding` option in favor of new
 
 Upgrading is easy:
 
-```toml title="vector.toml"
- [sinks.my-sink]
-   type = "..."
--  encoding = "json"
-+  encoding.codec = "json"
-+  encoding.except_fields = ["_meta"] # optional
-+  encoding.timestamp_format = "rfc3339" # optional
+```yaml title="vector.yaml"
+ sinks:
+   my-sink:
+     type: "..."
+-    encoding: "json"
++    encoding:
++      codec: "json"
++      except_fields: ["_meta"] # optional
++      timestamp_format: "rfc3339" # optional
 ```

--- a/website/content/en/highlights/2020-03-10-dedupe-transform.md
+++ b/website/content/en/highlights/2020-03-10-dedupe-transform.md
@@ -22,14 +22,16 @@ mistakes that accidentally duplicate logs. This mistake can easily double
 
 Simply add the transform to your pipeline:
 
-```toml
-[transforms.my_transform_id]
-  # General
-  type = "dedupe" # required
-  inputs = ["my-source-id"] # required
+```yaml
+transforms:
+  my_transform_id:
+    # General
+    type: "dedupe" # required
+    inputs: ["my-source-id"] # required
 
-  # Fields
-  fields.match = ["timestamp", "host", "message"] # optional, default
+    # Fields
+    fields:
+      match: ["timestamp", "host", "message"] # optional, default
 ```
 
 {{< success >}}

--- a/website/content/en/highlights/2020-03-11-tag-cardinality-limit-transform.md
+++ b/website/content/en/highlights/2020-03-11-tag-cardinality-limit-transform.md
@@ -20,13 +20,14 @@ protect against this we built a new
 
 Getting started is easy. Simply add this component to your pipeline:
 
-```toml title="vector.toml"
-[transforms.tag_protection]
-  type = "tag_cardinality_limit"
-  inputs = ["my-source-id"]
-  limit_exceeded_action = "drop_tag"
-  mode = "exact"
-  value_limit = 500
+```yaml title="vector.yaml"
+transforms:
+  tag_protection:
+    type: "tag_cardinality_limit"
+    inputs: ["my-source-id"]
+    limit_exceeded_action: "drop_tag"
+    mode: "exact"
+    value_limit: 500
 ```
 
 {{< success >}}

--- a/website/content/en/highlights/2020-03-31-filter-transform.md
+++ b/website/content/en/highlights/2020-03-31-filter-transform.md
@@ -20,15 +20,17 @@ transform since it is much more expressive.
 
 ## Get Started
 
-```toml title="vector.toml"
-[transforms.haproxy_errors]
-  # General
-  type = "filter"
-  inputs = ["my-source-id"]
+```yaml title="vector.yaml"
+transforms:
+  haproxy_errors:
+    # General
+    type: "filter"
+    inputs: ["my-source-id"]
 
-  # Conditions
-  condition."level.eq" = "error"
-  condition."service.eq" = "haproxy"
+    # Conditions
+    condition:
+      "level.eq": "error"
+      "service.eq": "haproxy"
 ```
 
 Check out the [docs][docs.transforms.filter] for a fill list of available

--- a/website/content/en/highlights/2020-04-01-more-condition-predicates.md
+++ b/website/content/en/highlights/2020-04-01-more-condition-predicates.md
@@ -31,10 +31,12 @@ following predicates were added:
 For example, you can filter all messages that contain the `error` term with
 the new `contains` predicate:
 
-```toml
-[transforms.errors]
-  type = "filter"
-  condition."message.contain" = "error"
+```yaml
+transforms:
+  errors:
+    type: "filter"
+    condition:
+      "message.contain": "error"
 ```
 
 The world is your oyster.

--- a/website/content/en/highlights/2020-05-27-add-support-for-loading-multiple-cas.md
+++ b/website/content/en/highlights/2020-05-27-add-support-for-loading-multiple-cas.md
@@ -15,15 +15,17 @@ Working with `openssl` isn't very fun, and we don't want to inflict that on you.
 
 This is particularly useful if you have a socket source:
 
-```toml title="vector.toml"
-[sources.tls]
-  type = "socket"
-  address = "0.0.0.0:6514"
-  mode = "tcp"
-  tls.enabled = true
-  tls.crt_path = "cert.pfx"
-  tls.ca_path = "ca.pem" # Now supported: More complicated PEMS!
-  tls.verify_certificate = true
+```yaml title="vector.yaml"
+sources:
+  tls:
+    type: "socket"
+    address: "0.0.0.0:6514"
+    mode: "tcp"
+    tls:
+      enabled: true
+      crt_path: "cert.pfx"
+      ca_path: "ca.pem" # Now supported: More complicated PEMS!
+      verify_certificate: true
 ```
 
 If it doesn't, that's a bug. [**Report it.**][urls.new_bug_report] We squash bugs.

--- a/website/content/en/highlights/2020-07-10-add-reduce-transform.md
+++ b/website/content/en/highlights/2020-07-10-add-reduce-transform.md
@@ -54,42 +54,49 @@ Then output this (but not formatted so nicely!):
 
 We'll run this config:
 
-```toml title=vector.toml
-data_dir = "tmp"
+```yaml title=vector.yaml
+data_dir: "tmp"
 
-[sources.source0]
-  include = ["input.log"]
-  start_at_beginning = true
-  type = "file"
-  fingerprinting.strategy = "device_and_inode"
+sources:
+  source0:
+    include: ["input.log"]
+    start_at_beginning: true
+    type: "file"
+    fingerprinting:
+      strategy: "device_and_inode"
 
-[transforms.transform0]
-  inputs = ["source0"]
-  type = "json_parser"
-  field = "message"
+transforms:
+  transform0:
+    inputs: ["source0"]
+    type: "json_parser"
+    field: "message"
 
-[transforms.transform1]
-  inputs = ["transform0"]
-  type = "reduce"
-  identifier_fields = ["request_id"]
-  ends_when.type = "check_fields"
-  ends_when."response_status.exists" = true
-  merge_strategies.message = "discard"
-  merge_strategies.query = "discard"
-  merge_strategies.template = "discard"
-  merge_strategies.query_duration_ms = "sum"
-  merge_strategies.render_duration_ms = "sum"
-  merge_strategies.response_duration_ms = "sum"
+  transform1:
+    inputs: ["transform0"]
+    type: "reduce"
+    identifier_fields: ["request_id"]
+    ends_when:
+      type: "check_fields"
+      "response_status.exists": true
+    merge_strategies:
+      message: "discard"
+      query: "discard"
+      template: "discard"
+      query_duration_ms: "sum"
+      render_duration_ms: "sum"
+      response_duration_ms: "sum"
 
-[sinks.sink0]
-  healthcheck = true
-  inputs = ["transform1"]
-  type = "file"
-  path = "output.log"
-  encoding = "ndjson"
-  buffer.type = "memory"
-  buffer.max_events = 500
-  buffer.when_full = "block"s
+sinks:
+  sink0:
+    healthcheck: true
+    inputs: ["transform1"]
+    type: "file"
+    path: "output.log"
+    encoding: "ndjson"
+    buffer:
+      type: "memory"
+      max_events: 500
+      when_full: "block"
 ```
 
 We hope you find this useful!

--- a/website/content/en/highlights/2020-09-18-adaptive-concurrency.md
+++ b/website/content/en/highlights/2020-09-18-adaptive-concurrency.md
@@ -25,11 +25,13 @@ inspired by TCP congestion control algorithms.
 This feature, like all Vector features, will begin its life in public beta and
 be available on an opt-in basis. To get it, enable it for each sink:
 
-```toml
-[sinks.my-sink]
-type = "..." # any http-based sink
-request.concurrency = "adaptive"
-# and remove the request.rate_limit_* settings
+```yaml
+sinks:
+  my-sink:
+    type: "..." # any http-based sink
+    request:
+      concurrency: "adaptive"
+    # and remove the request.rate_limit_* settings
 ```
 
 [announcement]: /blog/adaptive-request-concurrency/

--- a/website/content/en/highlights/2020-10-27-metrics-integrations.md
+++ b/website/content/en/highlights/2020-10-27-metrics-integrations.md
@@ -39,14 +39,16 @@ the single agent for all of your logs, metrics, and traces.
 
 To get started with these sources, define them and go:
 
-```toml
-[sources.host_metrics]
-type = "host_metrics" # or apache_metrics, mongodb_metrics, or internal_metrics
+```yaml
+sources:
+  host_metrics:
+    type: "host_metrics" # or apache_metrics, mongodb_metrics, or internal_metrics
 
 # Then connect them to a sink:
-[sinks.prometheus]
-type = "prometheus"
-inputs = ["host_metrics"]
+sinks:
+  prometheus:
+    type: "prometheus"
+    inputs: ["host_metrics"]
 ```
 
 Tada! One agent for all of your data. Check out the [docs][docs] for more

--- a/website/content/en/highlights/2020-11-19-prometheus-remote-integrations.md
+++ b/website/content/en/highlights/2020-11-19-prometheus-remote-integrations.md
@@ -31,17 +31,20 @@ Prometheus operators can route a stream of Prometheus data to the archiving
 solution of their choice. For this use case we recommend object stores for their
 cheap and durable qualities:
 
-```toml title="vector.toml"
-[sources.prometheus]
-  type = "prometheus_remote_write"
+```yaml title="vector.yaml"
+sources:
+  prometheus:
+    type: "prometheus_remote_write"
 
-[transforms.convert]
-  type = "metric_to_log"
-  inputs = ["prometheus"]
+transforms:
+  convert:
+    type: "metric_to_log"
+    inputs: ["prometheus"]
 
-[sinks.backup]
-  type = "aws_s3"
-  inputs = ["convert"]
+sinks:
+  backup:
+    type: "aws_s3"
+    inputs: ["convert"]
 ```
 
 Swap `aws_s3` with `gcp_cloud_storage` or other object stores.
@@ -68,13 +71,15 @@ To get started, setup the new
 your metrics to [Datadog][datadog], [New Relic][new_relic], [Influx][influx],
 [Elasticsearch][elastic], and [many other sinks][sinks]:
 
-```toml title="vector.toml"
-[sources.prometheus]
-  type = "prometheus_remote_write"
+```yaml title="vector.yaml"
+sources:
+  prometheus:
+    type: "prometheus_remote_write"
 
-[sinks.datadog]
-  type = "datadog_metrics"
-  inputs = ["prometheus"]
+sinks:
+  datadog:
+    type: "datadog_metrics"
+    inputs: ["prometheus"]
 ```
 
 [chronosphere]: https://chronosphere.io/

--- a/website/content/en/highlights/2020-11-25-json-yaml-config-formats.md
+++ b/website/content/en/highlights/2020-11-25-json-yaml-config-formats.md
@@ -12,9 +12,9 @@ badges:
 ---
 
 To ensure Vector fits into existing workflows, like Kubernetes, we've added
-support for JSON and YAML config formats in addition to TOML. As of Vector
-0.34, YAML is the recommended and default configuration format, but users are
-welcome to use TOML and JSON as they see fit.
+support for JSON and YAML config formats in addition to TOML. YAML is now the
+recommended and default configuration format, but users are welcome to use
+TOML and JSON as they see fit.
 
 ## Use cases
 

--- a/website/content/en/highlights/2020-11-25-json-yaml-config-formats.md
+++ b/website/content/en/highlights/2020-11-25-json-yaml-config-formats.md
@@ -12,9 +12,9 @@ badges:
 ---
 
 To ensure Vector fits into existing workflows, like Kubernetes, we've added
-support for JSON and YAML config formats in addition to TOML. TOML will
-continue to be our default format, but users are welcome to use JSON and YAML
-as they see fit.
+support for JSON and YAML config formats in addition to TOML. As of Vector
+0.34, YAML is the recommended and default configuration format, but users are
+welcome to use TOML and JSON as they see fit.
 
 ## Use cases
 

--- a/website/content/en/highlights/2020-12-23-graphql-api.md
+++ b/website/content/en/highlights/2020-12-23-graphql-api.md
@@ -28,10 +28,10 @@ The GraphQL API for Vector is **disabled by default**. We want to keep Vector's
 behavior as predictable and secure as possible, so we chose to make the feature
 opt-in. To enable the API, add this to your Vector config:
 
-```toml
-[api]
-enabled = true
-address = "127.0.0.1:8686" # optional. Change IP/port if required
+```yaml
+api:
+  enabled: true
+  address: "127.0.0.1:8686" # optional. Change IP/port if required
 ```
 
 ## Read more

--- a/website/content/en/highlights/2020-12-23-internal-logs-source.md
+++ b/website/content/en/highlights/2020-12-23-internal-logs-source.md
@@ -38,24 +38,27 @@ metrics and modify and ship them however you wish.
 Here's an example Vector configuration that ships Vector's logs to Splunk and
 allows its internal metrics to be scraped by [Prometheus]:
 
-```toml
-[sources.vector_logs]
-type = "internal_logs"
+```yaml
+sources:
+  vector_logs:
+    type: "internal_logs"
 
-[sources.vector_metrics]
-type = "internal_metrics"
+  vector_metrics:
+    type: "internal_metrics"
 
-[sinks.splunk]
-type = "splunk_hec"
-inputs = ["vector_logs"]
-endpoint = "https://my-account.splunkcloud.com"
-token = "${SPLUNK_HEC_TOKEN}"
-encoding.codec = "json"
+sinks:
+  splunk:
+    type: "splunk_hec"
+    inputs: ["vector_logs"]
+    endpoint: "https://my-account.splunkcloud.com"
+    token: "${SPLUNK_HEC_TOKEN}"
+    encoding:
+      codec: "json"
 
-[sinks.prometheus]
-type = "prometheus"
-inputs = ["vector_metrics"]
-address = "0.0.0.0:9090"
+  prometheus:
+    type: "prometheus"
+    inputs: ["vector_metrics"]
+    address: "0.0.0.0:9090"
 ```
 
 [internal_logs]: /docs/reference/configuration/sources/internal_logs

--- a/website/content/en/highlights/2021-01-10-kafka-sink-metrics.md
+++ b/website/content/en/highlights/2021-01-10-kafka-sink-metrics.md
@@ -18,14 +18,17 @@ metric events through Kafka. Metrics events are encoded into a format that
 mimics our [internal metrics data model], ideal for custom consumers on the
 other end. Getting started is easy:
 
-```toml
-[sources.host_metrics]
-type = "host_metrics"
+```yaml
+sources:
+  host_metrics:
+    type: "host_metrics"
 
-[sinks.kafka]
-type = "kafka"
-inputs = ["host_metrics"]
-encoding.codec = "json"
+sinks:
+  kafka:
+    type: "kafka"
+    inputs: ["host_metrics"]
+    encoding:
+      codec: "json"
 ```
 
 ## Caveats

--- a/website/content/en/highlights/2021-01-20-wildcard-identifiers.md
+++ b/website/content/en/highlights/2021-01-20-wildcard-identifiers.md
@@ -15,26 +15,28 @@ badges:
 [PR 6170][pr_6170] introduced wildcards when referencing component names in the `inputs` option. This allows you to build
 dynamic topologies. This feature comes with one limitation: the wildcard must be at the end of the string.
 
-```toml
-[sources.app1_logs]
-type = "file"
-includes = ["/var/log/app1.log"]
+```yaml
+sources:
+  app1_logs:
+    type: "file"
+    includes: ["/var/log/app1.log"]
 
-[sources.app2_logs]
-type = "file"
-includes = ["/var/log/app.log"]
+  app2_logs:
+    type: "file"
+    includes: ["/var/log/app.log"]
 
-[sources.system_logs]
-type = "file"
-includes = ["/var/log/system.log"]
+  system_logs:
+    type: "file"
+    includes: ["/var/log/system.log"]
 
-[sinks.app_logs]
-type = "datadog_logs"
-inputs = ["app*"]
+sinks:
+  app_logs:
+    type: "datadog_logs"
+    inputs: ["app*"]
 
-[sinks.archive]
-type = "aws_s3"
-inputs = ["app*", "system_logs"]
+  archive:
+    type: "aws_s3"
+    inputs: ["app*", "system_logs"]
 ```
 
 [pr_6170]: https://github.com/vectordotdev/vector/pull/6170

--- a/website/content/en/highlights/2021-02-16-0-12-upgrade-guide.md
+++ b/website/content/en/highlights/2021-02-16-0-12-upgrade-guide.md
@@ -117,12 +117,12 @@ The following transforms have been deprecated in favor of the new [`remap` trans
 Deprecation notices have been placed on each of these transforms with example VRL programs that demonstrate how to
 migrate to the new `remap` transform. For example, migrating from the `json_parser` transform is as simple as:
 
-```toml
-[transforms.remap]
-type = "remap"
-source = '''
-. = merge(., parse_json!(.message))
-'''
+```yaml
+transforms:
+  remap:
+    type: "remap"
+    source: |
+      . = merge(., parse_json!(.message))
 ```
 
 **You do not need to upgrade immediately. These transforms will not be removed until Vector hits 1.0, a milestone that

--- a/website/content/en/highlights/2021-02-16-filter-remap-support.md
+++ b/website/content/en/highlights/2021-02-16-filter-remap-support.md
@@ -24,20 +24,26 @@ Previously, the `filter` transform required you to specify conditions using
 The example configuration below shows the same `filter` transform using the old
 system (`check_fields`) and the new system (`remap`):
 
-```toml
-[transforms.filter_out_non_critical]
-type = "filter"
-inputs = ["http-server-logs"]f
+```yaml
+transforms:
+  filter_out_non_critical:
+    type: "filter"
+    inputs: ["http-server-logs"]
 
-# Using check_fields
-condition.type = "check_fields"
-condition.message.status_code.ne = 200
-condition.message.severity.ne = "info"
-condition.message.severity.ne = "debug"
+    # Using check_fields
+    condition:
+      type: "check_fields"
+      message:
+        status_code:
+          ne: 200
+        severity:
+          ne: "info"
+          # ne: "debug"
 
-# Using remap
-condition.type = "remap"
-condition.source = '.status_code != 200 && !includes(["info", "debug"], .severity)'
+    # Using remap
+    condition:
+      type: "remap"
+      source: '.status_code != 200 && !includes(["info", "debug"], .severity)'
 ```
 
 [filter]: /docs/reference/configuration/transforms/filter

--- a/website/content/en/highlights/2021-04-21-vector-tap.md
+++ b/website/content/en/highlights/2021-04-21-vector-tap.md
@@ -27,19 +27,22 @@ of this component.
 
 For example, given the configuration:
 
-```toml
-[api]
-  enabled =  true
-[sources.in]
-  type = "generator"
-  format = "shuffle"
-  interval = 1.0
-  lines = ["Hello World"]
-  sequence = true
+```yaml
+api:
+  enabled: true
 
-[sinks.out]
-  type = "blackhole"
-  inputs = ["in"]
+sources:
+  in:
+    type: "generator"
+    format: "shuffle"
+    interval: 1.0
+    lines: ["Hello World"]
+    sequence: true
+
+sinks:
+  out:
+    type: "blackhole"
+    inputs: ["in"]
 ```
 
 If you were to run `vector` and then, in another terminal, run `vector tap in`,

--- a/website/content/en/highlights/2021-04-21-vrl-abort.md
+++ b/website/content/en/highlights/2021-04-21-vrl-abort.md
@@ -28,27 +28,32 @@ validation on the event before processing it, discarding any invalid events.
 
 Given a config of:
 
-```toml
-[sources.in]
-  type = "generator"
-  format = "shuffle"
-  interval = 1.0
-  lines = ['{ "message": "valid message", "type": "ok"}', '{ "message": "invalid message", "type": "unknown"}']
+```yaml
+sources:
+  in:
+    type: "generator"
+    format: "shuffle"
+    interval: 1.0
+    lines:
+      - '{ "message": "valid message", "type": "ok"}'
+      - '{ "message": "invalid message", "type": "unknown"}'
 
-[transforms.remap]
-  type = "remap"
-  inputs = ["in"]
-  source = """
-    . |= object!(parse_json!(string!(.message)))
-    if .type != "ok" {
-      abort # unknown type
-    }
-  """
+transforms:
+  remap:
+    type: "remap"
+    inputs: ["in"]
+    source: |
+      . |= object!(parse_json!(string!(.message)))
+      if .type != "ok" {
+        abort # unknown type
+      }
 
-[sinks.out]
-  type = "console"
-  inputs = ["remap"]
-  encoding.codec = "json"
+sinks:
+  out:
+    type: "console"
+    inputs: ["remap"]
+    encoding:
+      codec: "json"
 ```
 
 You would expect to see something like:

--- a/website/content/en/highlights/2021-07-14-0-15-upgrade-guide.md
+++ b/website/content/en/highlights/2021-07-14-0-15-upgrade-guide.md
@@ -42,38 +42,42 @@ This means, if you are presently using the deprecated `check_fields` syntax, you
 
 For example, if you previously had:
 
-```toml
-[transforms.sample]
-type = "sample"
-inputs = ["in"]
-rate = 10
-key_field = "message"
-exclude."message.contains" = "error"
+```yaml
+transforms:
+  sample:
+    type: "sample"
+    inputs: ["in"]
+    rate: 10
+    key_field: "message"
+    exclude:
+      "message.contains": "error"
 ```
 
 You will need to add `exclude.type = "check_fields"` like:
 
-```toml
-[transforms.sample]
-type = "sample"
-inputs = ["in"]
-rate = 10
-key_field = "message"
-exclude."type" = "check_fields"
-exclude."message.contains" = "error"
+```yaml
+transforms:
+  sample:
+    type: "sample"
+    inputs: ["in"]
+    rate: 10
+    key_field: "message"
+    exclude:
+      "type": "check_fields"
+      "message.contains": "error"
 ```
 
 To convert this to the new [VRL][VRL] conditions, you would write:
 
-```toml
-[transforms.sample]
-type = "sample"
-inputs = ["in"]
-rate = 10
-key_field = "message"
-exclude = """
-  contains!(.message, "error")
-"""
+```yaml
+transforms:
+  sample:
+    type: "sample"
+    inputs: ["in"]
+    rate: 10
+    key_field: "message"
+    exclude: |
+      contains!(.message, "error")
 ```
 
 We recommend upgrading to the [VRL][VRL] conditions as these are much more powerful than the legacy `check_fields`-style
@@ -85,40 +89,42 @@ The `remap` condition type has been renamed `vrl` in this release to better high
 a [VRL][VRL] program. Most examples of using this condition type have the short-hand condition config of just specifying
 the [VRL][VRL] program without specifying a `type`. For example:
 
-```toml
-[transforms.filter_a]
-  inputs = ["stdin"]
-  type = "filter"
-  condition = '''
+```yaml
+transforms:
+  filter_a:
+    inputs: ["stdin"]
+    type: "filter"
+    condition: |
       message = if exists(.tags) { .tags.message } else { .message }
       message == "test filter 1"
-    '''
 ```
 
 Which is automatically a [VRL][VRL] condition. However, if you were specifying the `type` like:
 
-```toml
-[transforms.filter_a]
-inputs = ["stdin"]
-type = "filter"
-condition.type = "remap"
-condition.source = '''
-    message = if exists(.tags) { .tags.message } else { .message }
-    message == "test filter 1"
-'''
+```yaml
+transforms:
+  filter_a:
+    inputs: ["stdin"]
+    type: "filter"
+    condition:
+      type: "remap"
+      source: |
+        message = if exists(.tags) { .tags.message } else { .message }
+        message == "test filter 1"
 ```
 
 Then you will need to update `type = "remap"` to `type = "vrl"` like:
 
-```toml
-[transforms.filter_a]
-inputs = ["stdin"]
-type = "filter"
-condition.type = "vrl"
-condition.source = '''
-    message = if exists(.tags) { .tags.message } else { .message }
-    message == "test filter 1"
-'''
+```yaml
+transforms:
+  filter_a:
+    inputs: ["stdin"]
+    type: "filter"
+    condition:
+      type: "vrl"
+      source: |
+        message = if exists(.tags) { .tags.message } else { .message }
+        message == "test filter 1"
 ```
 
 [vrl]: /docs/reference/vrl/

--- a/website/content/en/highlights/2021-07-14-vector-graph.md
+++ b/website/content/en/highlights/2021-07-14-vector-graph.md
@@ -16,69 +16,73 @@ a graph in [DOT][DOT] format. This output can then be visualized using [Graphviz
 
 For example, if you had a config, `vector.toml`, like:
 
-```toml
+```yaml
 ##
 ## Sources
 ##
 
-[sources.internal_metrics]
-type = "internal_metrics"
+sources:
+  internal_metrics:
+    type: "internal_metrics"
 
-[sources.dd_logs]
-type = "datadog_logs" # required
-acknowledgements = false # optional, default
-address = "0.0.0.0:8282" # required
+  dd_logs:
+    type: "datadog_logs" # required
+    acknowledgements: false # optional, default
+    address: "0.0.0.0:8282" # required
 
-[sources.file_gen]
-type = "file"
-include = ["/var/log/file_gen/**/*.log"]
-read_from = "beginning"
+  file_gen:
+    type: "file"
+    include: ["/var/log/file_gen/**/*.log"]
+    read_from: "beginning"
 
 ##
 ## Transforms
 ##
 
-[transforms.remap]
-type = "remap"
-inputs = ["file_gen"]
-source = '''
-.agent_name = "vector"
-parsed, err = parse_json(.message)
-if err == null {
-    .message = parsed
-    .format = "json"
-} else {
-    .format = "ascii"
-}
-matches = parse_regex!(.file, r'.*/(?P<num>\d+)-(?P<name>\w+).log')
-.origin, err = .host + "/" + matches.name + "/" + matches.num
-if err != null {
-    log("Failed to parse origin from file name", level: "error")
-}
-'''
+transforms:
+  remap:
+    type: "remap"
+    inputs: ["file_gen"]
+    source: |
+      .agent_name = "vector"
+      parsed, err = parse_json(.message)
+      if err == null {
+          .message = parsed
+          .format = "json"
+      } else {
+          .format = "ascii"
+      }
+      matches = parse_regex!(.file, r'.*/(?P<num>\d+)-(?P<name>\w+).log')
+      .origin, err = .host + "/" + matches.name + "/" + matches.num
+      if err != null {
+          log("Failed to parse origin from file name", level: "error")
+      }
 
 ##
 ## Sinks
 ##
 
-[sinks.prometheus]
-type = "prometheus_exporter"
-inputs = ["internal_metrics"]
-address = "0.0.0.0:9598"
+sinks:
+  prometheus:
+    type: "prometheus_exporter"
+    inputs: ["internal_metrics"]
+    address: "0.0.0.0:9598"
 
-[sinks.dd_logs_egress]
-type = "datadog_logs"
-inputs = ["dd_logs"]
-default_api_key = ""
-encoding.codec = "json"
-request.concurrency = "adaptive"
-batch.max_bytes = 5242880
-request.rate_limit_num = 1000
+  dd_logs_egress:
+    type: "datadog_logs"
+    inputs: ["dd_logs"]
+    default_api_key: ""
+    encoding:
+      codec: "json"
+    request:
+      concurrency: "adaptive"
+      rate_limit_num: 1000
+    batch:
+      max_bytes: 5242880
 
-
-[sinks.blackhole]
-type = "blackhole"
-inputs = ["remap"]
+  blackhole:
+    type: "blackhole"
+    inputs: ["remap"]
 ```
 
 And you ran the new `vector graph --config vector.toml` you would see:

--- a/website/content/en/highlights/2021-07-14-vector-graph.md
+++ b/website/content/en/highlights/2021-07-14-vector-graph.md
@@ -14,7 +14,7 @@ badges:
 This release adds a new subcommand `vector graph` to output the topology specified by you Vector configuration as
 a graph in [DOT][DOT] format. This output can then be visualized using [Graphviz] to produce an image.
 
-For example, if you had a config, `vector.toml`, like:
+For example, if you had a config, `vector.yaml`, like:
 
 ```yaml
 ##
@@ -85,7 +85,7 @@ sinks:
     inputs: ["remap"]
 ```
 
-And you ran the new `vector graph --config vector.toml` you would see:
+And you ran the new `vector graph --config vector.yaml` you would see:
 
 ```dot
 digraph {
@@ -106,7 +106,7 @@ digraph {
 To render this, if you have [Graphviz] installed, you could do:
 
 ```shell
-vector graph --config vector.toml | dot -Tpng > graph.png
+vector graph --config vector.yaml | dot -Tpng > graph.png
 ```
 
 To get an image that looks like:

--- a/website/content/en/highlights/2021-07-16-remap-multiple.md
+++ b/website/content/en/highlights/2021-07-16-remap-multiple.md
@@ -20,13 +20,13 @@ will create one log event for each event in the array.
 
 For example:
 
-```toml
-[transforms.remap]
-type = "remap"
-inputs = []
-source = """
-. = [{"message": "hello"}, {"message": "world"}]
-"""
+```yaml
+transforms:
+  remap:
+    type: "remap"
+    inputs: []
+    source: |
+      . = [{"message": "hello"}, {"message": "world"}]
 ```
 
 Would generate two output events:
@@ -45,15 +45,15 @@ Additionally, to make it easier to convert an incoming log event into an array, 
 function to VRL that transforms an incoming event where one of the fields is an array into an array of events, each with
 one of the elements from the array field. This is easiest to see with an example:
 
-```toml
-[transforms.remap]
-type = "remap"
-inputs = []
-source = """
-. = {"host": "localhost", "events": [{"message": "hello"}, {"message": "world"}]} # to represent the incoming event
+```yaml
+transforms:
+  remap:
+    type: "remap"
+    inputs: []
+    source: |
+      . = {"host": "localhost", "events": [{"message": "hello"}, {"message": "world"}]} # to represent the incoming event
 
-. = unnest(.events)
-"""
+      . = unnest(.events)
 ```
 
 Would output the following log events:
@@ -69,24 +69,23 @@ and another `remap` transform to receive each new event.
 
 An example of this:
 
-```toml
-[transforms.explode]
-type = "remap"
-inputs = []
-source = """
-. = {"host": "localhost", "events": [{"message": "hello"}, {"message": "world"}]} # to represent the incoming event
+```yaml
+transforms:
+  explode:
+    type: "remap"
+    inputs: []
+    source: |
+      . = {"host": "localhost", "events": [{"message": "hello"}, {"message": "world"}]} # to represent the incoming event
 
-. = unnest(.events)
-"""
+      . = unnest(.events)
 
-[transforms.map]
-type = "remap"
-inputs = ["explode"]
-source = """
-# example of pulling up the nested field to merge it into the top-level
-. |= .events
-del(.events)
-"""
+  map:
+    type: "remap"
+    inputs: ["explode"]
+    source: |
+      # example of pulling up the nested field to merge it into the top-level
+      . |= .events
+      del(.events)
 ```
 
 Would output the following log events:

--- a/website/content/en/highlights/2021-08-20-rate-limits.md
+++ b/website/content/en/highlights/2021-08-20-rate-limits.md
@@ -23,9 +23,10 @@ have no rate limiting and a maximum number of concurrent requests of 1024.
 To configure a request rate limit or maximum concurrency on a HTTP-based sink,
 you can set the `request` parameters like:
 
-```toml
-request.concurrency = 5 # limit to 5 in-flight requests
-request.rate_limit_num = 10 # limit to 10 requests / second
+```yaml
+request:
+  concurrency: 5 # limit to 5 in-flight requests
+  rate_limit_num: 10 # limit to 10 requests / second
 ```
 
 If you haven't already, we recommend trying out our [adaptive concurrency

--- a/website/content/en/highlights/2021-08-25-0-16-upgrade-guide.md
+++ b/website/content/en/highlights/2021-08-25-0-16-upgrade-guide.md
@@ -30,11 +30,12 @@ components.
 
 For example, with the component config:
 
-```toml
-[transforms.parse_nginx]
-type = "remap"
-inputs = []
-source = ""
+```yaml
+transforms:
+  parse_nginx:
+    type: "remap"
+    inputs: []
+    source: ""
 ```
 
 The `parse_nginx` part of the config is now only referred to as `ID` in the documentation.
@@ -57,19 +58,22 @@ limitations and is only useful for backward compatibility with older clients.
 We no longer allow you to set the encoding of the payloads in the Datadog logs
 sink. For instance, if your configuration looks like so:
 
-```toml
-[sinks.dd_logs_egress]
-type = "datadog_logs"
-inputs = ["datadog_agent"]
-encoding.codec = "json"
+```yaml
+sinks:
+  dd_logs_egress:
+    type: "datadog_logs"
+    inputs: ["datadog_agent"]
+    encoding:
+      codec: "json"
 ```
 
 You should remove `encoding.codec` entirely, leaving you with:
 
-```toml
-[sinks.dd_logs_egress]
-type = "datadog_logs"
-inputs = ["datadog_agent"]
+```yaml
+sinks:
+  dd_logs_egress:
+    type: "datadog_logs"
+    inputs: ["datadog_agent"]
 ```
 
 Encoding fields other than `codec` are still valid.

--- a/website/content/en/highlights/2021-10-06-arc-default.md
+++ b/website/content/en/highlights/2021-10-06-arc-default.md
@@ -20,8 +20,9 @@ increased pressure downstream, to avoid overwhelming the sink destination.
 This feature was previously able to be opted into with the following
 configuration:
 
-```toml
-request.concurrency = "adaptive"
+```yaml
+request:
+  concurrency: "adaptive"
 ```
 
 This is the new default for HTTP-based sinks. As mentioned in the [announcement
@@ -35,8 +36,9 @@ If you would like to instead use a fixed concurrency as was previously the
 default, you can set a static value like:
 
 
-```toml
-request.concurrency = 5
+```yaml
+request:
+  concurrency: 5
 ```
 
 This will tell Vector to limit to 5 concurrent requests.

--- a/website/content/en/highlights/2021-10-06-source-codecs.md
+++ b/website/content/en/highlights/2021-10-06-source-codecs.md
@@ -17,12 +17,14 @@ added new `decoding` options to [most sources][9404].
 For example, if you have a `kafka` source that has JSON-encoded messages, now
 you can simply add `decoding.codec = "json"` to your source configuration like:
 
-```toml
-[sources.kafka]
-type = "kafka"
-bootstrap_servers = "localhost:9200"
-topics = ["my_topic"]
-decoding.codec = "json"
+```yaml
+sources:
+  kafka:
+    type: "kafka"
+    bootstrap_servers: "localhost:9200"
+    topics: ["my_topic"]
+    decoding:
+      codec: "json"
 ```
 
 This will decode your messages from JSON, thus saving you from an additional
@@ -35,12 +37,15 @@ separating messages).
 For example, if you have an `http` source where the messages are delimited by
 commas instead of newlines, you can configure this like:
 
-```toml
-[sources.http]
-type = "http"
-address = "0.0.0.0:8080"
-framing.method = "character_delimited"
-framing.character_delimited.delimiter = ","
+```yaml
+sources:
+  http:
+    type: "http"
+    address: "0.0.0.0:8080"
+    framing:
+      method: "character_delimited"
+      character_delimited:
+        delimiter: ","
 ```
 
 To have Vector parse each comma-delimited element as a new message. This can be

--- a/website/content/en/highlights/2021-11-12-event-throttle-transform.md
+++ b/website/content/en/highlights/2021-11-12-event-throttle-transform.md
@@ -48,12 +48,13 @@ Given these incoming log events:
 
 ...and this configuration...
 
-```toml
-[transforms.my_transform_id]
-type = "throttle"
-inputs = [ "my-source-or-transform-id" ]
-threshold = 1
-window_secs = 60
+```yaml
+transforms:
+  my_transform_id:
+    type: "throttle"
+    inputs: ["my-source-or-transform-id"]
+    threshold: 1
+    window_secs: 60
 ```
 
 ...only one event will be allowed through:

--- a/website/content/en/highlights/2021-12-15-splunk-hec-improvements.md
+++ b/website/content/en/highlights/2021-12-15-splunk-hec-improvements.md
@@ -31,8 +31,8 @@ would not work with Splunk senders that required them.
 
 Now, you can configure the `splunk_hec` source to use the indexer acknowledgements protocol by configuring:
 
-```toml
-acknowledgements = true
+```yaml
+acknowledgements: true
 ```
 
 When enabled, responses to incoming requests will include an ID that can be used to query for acknowledgement status at the newly exposed `/services/collector/ack` endpoint ([learn more here][indexer how it works]). The acknowledgement status is wired into Vector's
@@ -51,8 +51,9 @@ acknowledgements][indexer] part of the HEC protocol.
 This has defaulted to on to provide higher guarantees, but can be disabled to
 restore the previous behavior by configuring:
 
-```toml
-acknowledgements.indexer_acknowledgements_enabled = false
+```yaml
+acknowledgements:
+  indexer_acknowledgements_enabled: false
 ```
 
 ## Passthrough Token Routing

--- a/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
+++ b/website/content/en/highlights/2021-12-28-0-19-0-upgrade-guide.md
@@ -165,11 +165,11 @@ source, you will now see a `splunk_channel` field in events output from the
 included channel information from requests in their events. If you want to
 remove this field, you can simply drop it with a `remap` transform like follows:
 
-```toml
-[transforms.foo]
-type = "remap"
-inputs = ["bar"] # where bar is the splunk_hec source
-source = '''
-  del(.splunk_channel)
-'''
+```yaml
+transforms:
+  foo:
+    type: "remap"
+    inputs: ["bar"] # where bar is the splunk_hec source
+    source: |
+      del(.splunk_channel)
 ```

--- a/website/content/en/highlights/2022-01-12-vector-unit-test-improvements.md
+++ b/website/content/en/highlights/2022-01-12-vector-unit-test-improvements.md
@@ -13,30 +13,28 @@ full support for testing task-style transforms (previously there may have been
 issues when using multiple inputs with task transforms). For example, you can
 now test `remap` transform's `dropped` output like so,
 
-```toml
-[transforms.foo]
-  type = "remap"
-  inputs = []
-  drop_on_abort = true
-  reroute_dropped = true
-  source = "abort"
+```yaml
+transforms:
+  foo:
+    type: "remap"
+    inputs: []
+    drop_on_abort: true
+    reroute_dropped: true
+    source: "abort"
 
-[[tests]]
-  name = "remap_dropped_output"
-  no_outputs_from = [ "foo" ]
-
-  [[tests.inputs]]
-    insert_at = "foo"
-    type = "log"
-    [tests.inputs.log_fields]
-      message = "I will be dropped"
-
-  [[tests.outputs]]
-    extract_from = "foo.dropped"
-
-    [[tests.outputs.conditions]]
-      type = "vrl"
-      source = 'assert_eq!(.message, "I will be dropped", "incorrect message")'
+tests:
+  - name: "remap_dropped_output"
+    no_outputs_from: ["foo"]
+    inputs:
+      - insert_at: "foo"
+        type: "log"
+        log_fields:
+          message: "I will be dropped"
+    outputs:
+      - extract_from: "foo.dropped"
+        conditions:
+          - type: "vrl"
+            source: 'assert_eq!(.message, "I will be dropped", "incorrect message")'
 ```
 
 Under-the-hood, we've reworked the unit testing implementation to more closely

--- a/website/content/en/highlights/2022-02-08-disk-buffer-v2-beta.md
+++ b/website/content/en/highlights/2022-02-08-disk-buffer-v2-beta.md
@@ -33,10 +33,12 @@ persistence, regardless of issues with Vector and the host system.
 
 You may already be familiar with disk buffers if you have a sink configuration that looks like this:
 
-```toml
-[sinks.http]
-# ...
-buffer.type = "disk"
+```yaml
+sinks:
+  http:
+    # ...
+    buffer:
+      type: "disk"
 ```
 
 ## Current disk buffer implementation
@@ -74,16 +76,20 @@ for those who don't utilize a stateless deployment process as mentioned above.
 With all of that said, changing Vector to use the new disk buffer implementation is as simple as
 changing a single line:
 
-```toml
+```yaml
 # From this:
-[sinks.http]
-# ...
-buffer.type = "disk"
+sinks:
+  http:
+    # ...
+    buffer:
+      type: "disk"
 
 # To this:
-[sinks.http]
-# ...
-buffer.type = "disk_v2"
+sinks:
+  http:
+    # ...
+    buffer:
+      type: "disk_v2"
 ```
 
 ## Let us know what you think!

--- a/website/content/en/highlights/2022-03-15-vrl-vm-beta.md
+++ b/website/content/en/highlights/2022-03-15-vrl-vm-beta.md
@@ -20,14 +20,14 @@ the VRL program that is being run.
 
 You can give the VM a try by adding the `runtime` configuration option to your Remap transform:
 
-```toml
-[transforms.remap]
-type = "remap"
-inputs = [ "..." ]
-runtime = "vm"
-source = '''
-...
-'''
+```yaml
+transforms:
+  remap:
+    type: "remap"
+    inputs: ["..."]
+    runtime: "vm"
+    source: |
+      ...
 ```
 
 ## Let us know what you think!

--- a/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-03-22-0-21-0-upgrade-guide.md
@@ -64,24 +64,28 @@ Here are some examples that require migrating
 | foo\\"bar | "foo\\"bar" | Double quotes and backlashes must be escaped _inside_ quotes |
 
 
-### TOML transform example
+### YAML transform example
 
 Old syntax
 
-```toml
-[transforms.dedupe]
-type = "dedupe"
-inputs = ["input"]
-fields.match = ["message.user-identifier"]
+```yaml
+transforms:
+  dedupe:
+    type: "dedupe"
+    inputs: ["input"]
+    fields:
+      match: ["message.user-identifier"]
 ```
 
 New syntax (the dash requires the field name to be quoted)
 
-```toml
-[transforms.dedupe]
-type = "dedupe"
-inputs = ["input"]
-fields.match = ["message.\"user-identifier\""]
+```yaml
+transforms:
+  dedupe:
+    type: "dedupe"
+    inputs: ["input"]
+    fields:
+      match: ['message."user-identifier"']
 ```
 
 For more information on the new syntax, you can review the [VRL path expressions documentation](https://vector.dev/docs/reference/vrl/expressions/#path)

--- a/website/content/en/highlights/2022-03-31-native-event-codecs.md
+++ b/website/content/en/highlights/2022-03-31-native-event-codecs.md
@@ -23,12 +23,14 @@ transform.
 For example, an `exec` source can now be configured to receive events via the
 `native_json` codec:
 
-```toml
-[sources.in]
-type = "exec"
-mode = "scheduled"
-command = ["./scrape.sh"]
-decoding.codec = "native_json"
+```yaml
+sources:
+  in:
+    type: "exec"
+    mode: "scheduled"
+    command: ["./scrape.sh"]
+    decoding:
+      codec: "native_json"
 ```
 
 If `scrape.sh` contained:
@@ -82,24 +84,28 @@ deserialize directly to the same native representation within Vector.
 
 Example source configuration:
 
-```toml
-[sources.in]
-type = "kafka"
-bootstrap_servers = "localhost:9092"
-topics = ["vector"]
-decoding.codec = "native"
+```yaml
+sources:
+  in:
+    type: "kafka"
+    bootstrap_servers: "localhost:9092"
+    topics: ["vector"]
+    decoding:
+      codec: "native"
 ```
 
 This would allow an instance of Vector to receive events from another Vector
 instance that has a `kafka` sink configured like:
 
-```toml
-[sinks.out]
-type = "kafka"
-inputs = ["..."]
-bootstrap_servers = "localhost:9092"
-topic = "vector"
-encoding.codec = "native"
+```yaml
+sinks:
+  out:
+    type: "kafka"
+    inputs: ["..."]
+    bootstrap_servers: "localhost:9092"
+    topic: "vector"
+    encoding:
+      codec: "native"
 ```
 
 Note that the new `native` encoding option is not yet documented on sinks as we

--- a/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-05-03-0-22-0-upgrade-guide.md
@@ -32,40 +32,39 @@ The `gcp_stackdriver_metrics` sink now matches the `gcp_stackdriver_logs`
 configuration, and doesn't require an additional `labels` section to add
 labels to submitted metrics.
 
-##### TOML transform example
+##### YAML transform example
 
 Old configuration
 
-```toml
-[sinks.my_sink_id]
-type = "gcp_stackdriver_metrics"
-inputs = [ "my-source-or-transform-id" ]
-credentials_path = "/path/to/credentials.json"
-project_id = "vector-123456"
-
-  [sinks.my_sink_id.resource]
-  type = "global"
-
-    [sinks.my_sink_id.resource.labels]
-    projectId = "vector-123456"
-    instanceId = "Twilight"
-    zone = "us-central1-a"
+```yaml
+sinks:
+  my_sink_id:
+    type: "gcp_stackdriver_metrics"
+    inputs: ["my-source-or-transform-id"]
+    credentials_path: "/path/to/credentials.json"
+    project_id: "vector-123456"
+    resource:
+      type: "global"
+      labels:
+        projectId: "vector-123456"
+        instanceId: "Twilight"
+        zone: "us-central1-a"
 ```
 
 New configuration
 
-```toml
-[sinks.my_sink_id]
-type = "gcp_stackdriver_metrics"
-inputs = [ "my-source-or-transform-id" ]
-credentials_path = "/path/to/credentials.json"
-project_id = "vector-123456"
-
-  [sinks.my_sink_id.resource]
-  type = "global"
-  projectId = "vector-123456"
-  instanceId = "Twilight"
-  zone = "us-central1-a"
+```yaml
+sinks:
+  my_sink_id:
+    type: "gcp_stackdriver_metrics"
+    inputs: ["my-source-or-transform-id"]
+    credentials_path: "/path/to/credentials.json"
+    project_id: "vector-123456"
+    resource:
+      type: "global"
+      projectId: "vector-123456"
+      instanceId: "Twilight"
+      zone: "us-central1-a"
 ```
 
 For more information on the new syntax, you can review the [GCP Stackdriver Metrics sink documentation](https://vector.dev/docs/reference/configuration/sinks/gcp_stackdriver_metrics/)
@@ -179,413 +178,442 @@ transform.
 
 Before:
 
-```toml
-[transforms.add_fields]
-type = "add_fields"
-inputs = ["some_input"]
-fields.parent.child2 = "value2"
+```yaml
+transforms:
+  add_fields:
+    type: "add_fields"
+    inputs: ["some_input"]
+    fields:
+      parent:
+        child2: "value2"
 ```
 
 After:
 
-```toml
-[transforms.add_fields]
-type = "remap"
-inputs = ["some_input"]
-source = '''
-.parent.child2 = "value2"
-'''
+```yaml
+transforms:
+  add_fields:
+    type: "remap"
+    inputs: ["some_input"]
+    source: |
+      .parent.child2 = "value2"
 ```
 
 ##### `add_tags`
 
 Before:
 
-```toml
-[transforms.add_tags]
-type = "add_tags"
-inputs = ["some_input"]
-tags.some_tag = "some_value"
+```yaml
+transforms:
+  add_tags:
+    type: "add_tags"
+    inputs: ["some_input"]
+    tags:
+      some_tag: "some_value"
 ```
 
 After:
 
-```toml
-[transforms.add_tags]
-type = "remap"
-inputs = ["some_input"]
-source = '''
-.tags.some_tag = "some_value"
-'''
+```yaml
+transforms:
+  add_tags:
+    type: "remap"
+    inputs: ["some_input"]
+    source: |
+      .tags.some_tag = "some_value"
 ```
 
 ##### `ansi_stripper`
 
 Before:
 
-```toml
-[transforms.ansi_stripper]
-type = "ansi_stripper"
-inputs = ["some_input"]
+```yaml
+transforms:
+  ansi_stripper:
+    type: "ansi_stripper"
+    inputs: ["some_input"]
 ```
 
 After:
 
-```toml
-[transforms.ansi_stripper]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-.message = strip_ansi_escape_codes(string!(.message))
-'''
+```yaml
+transforms:
+  ansi_stripper:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      .message = strip_ansi_escape_codes(string!(.message))
 ```
 
 ##### `aws_cloudwatch_logs_subscription_parser`
 
 Before:
 
-```toml
-[transforms.aws_cloudwatch_logs_subscription_parser]
-type = "aws_cloudwatch_logs_subscription_parser"
-inputs = ["some_input"]
+```yaml
+transforms:
+  aws_cloudwatch_logs_subscription_parser:
+    type: "aws_cloudwatch_logs_subscription_parser"
+    inputs: ["some_input"]
 ```
 
 After:
 
-```toml
-[transforms.aws_cloudwatch_logs_subscription_parser]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-. |= parse_aws_cloudwatch_log_subscription_message!(.message)
-'''
+```yaml
+transforms:
+  aws_cloudwatch_logs_subscription_parser:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      . |= parse_aws_cloudwatch_log_subscription_message!(.message)
 ```
 
 ##### `coercer`
 
 Before:
 
-```toml
-[transforms.coercer]
-type = "coercer"
-inputs = ["some_input"]
-types.some_bool = "bool"
-types.some_float = "float"
-types.some_int = "int"
-types.some_string = "string"
-types.some_timestamp = "timestamp"
+```yaml
+transforms:
+  coercer:
+    type: "coercer"
+    inputs: ["some_input"]
+    types:
+      some_bool: "bool"
+      some_float: "float"
+      some_int: "int"
+      some_string: "string"
+      some_timestamp: "timestamp"
 ```
 
 After:
 
-```toml
-[transforms.coercer]
-type = "remap"
-inputs = ["some_input"]
-source = '''
-.some_bool = to_bool!(.some_bool)
-.some_float = to_float!(.some_float)
-.some_int = to_int!(.some_int)
-.some_string = to_string!(.some_string)
-.some_timestamp = to_timestamp!(.some_timestamp)
-'''
+```yaml
+transforms:
+  coercer:
+    type: "remap"
+    inputs: ["some_input"]
+    source: |
+      .some_bool = to_bool!(.some_bool)
+      .some_float = to_float!(.some_float)
+      .some_int = to_int!(.some_int)
+      .some_string = to_string!(.some_string)
+      .some_timestamp = to_timestamp!(.some_timestamp)
 ```
 
 ##### `concat`
 
 Before:
 
-```toml
-[transforms.concat]
-type = "concat"
-inputs = ["some_input"]
-items = ["month", "day", "year"]
-target = "date"
-joiner = "/"
+```yaml
+transforms:
+  concat:
+    type: "concat"
+    inputs: ["some_input"]
+    items: ["month", "day", "year"]
+    target: "date"
+    joiner: "/"
 ```
 
 After:
 
-```toml
-[transforms.concat]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-.date = join!([.month, .day, .year], "/")
-'''
+```yaml
+transforms:
+  concat:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      .date = join!([.month, .day, .year], "/")
 ```
 
 ##### `grok_parser`
 
 Before:
 
-```toml
-[transforms.grok_parser]
-type = "grok_parser"
-inputs = ["some_input"]
-pattern = "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
-types.timestamp = "timestamp|%+"
-types.level = "string"
-types.message = "string"
+```yaml
+transforms:
+  grok_parser:
+    type: "grok_parser"
+    inputs: ["some_input"]
+    pattern: "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}"
+    types:
+      timestamp: "timestamp|%+"
+      level: "string"
+      message: "string"
 ```
 
 After:
 
-```toml
-[transforms.grok_parser]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-. |= parse_grok!(.message, "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}")
-.timestamp = parse_timestamp!(.timestamp , format: "%+")
-'''
+```yaml
+transforms:
+  grok_parser:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      . |= parse_grok!(.message, "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:level} %{GREEDYDATA:message}")
+      .timestamp = parse_timestamp!(.timestamp , format: "%+")
 ```
 
 ##### `json_parser`
 
 Before:
 
-```toml
-[transforms.json_parser]
-type = "json_parser"
-inputs = ["some_input"]
+```yaml
+transforms:
+  json_parser:
+    type: "json_parser"
+    inputs: ["some_input"]
 ```
 
 After:
 
-```toml
-[transforms.json_parser]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-. |= object!(parse_json(.message))
-'''
+```yaml
+transforms:
+  json_parser:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      . |= object!(parse_json(.message))
 ```
 
 ##### `key_value_parser`
 
 Before:
 
-```toml
-[transforms.key_value_parser]
-type = "key_value_parser"
-inputs = ["some_input"]
+```yaml
+transforms:
+  key_value_parser:
+    type: "key_value_parser"
+    inputs: ["some_input"]
 ```
 
 After:
 
-```toml
-[transforms.key_value_parser]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-. |= parse_key_value!(.message)
-'''
+```yaml
+transforms:
+  key_value_parser:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      . |= parse_key_value!(.message)
 ```
 
 ##### `logfmt_parser`
 
 Before:
 
-```toml
-[transforms.logfmt_parser]
-type = "logfmt_parser"
-inputs = ["some_input"]
+```yaml
+transforms:
+  logfmt_parser:
+    type: "logfmt_parser"
+    inputs: ["some_input"]
 ```
 
 After:
 
-```toml
-[transforms.logfmt_parser]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-. |= parse_logfmt!(.message)
-'''
+```yaml
+transforms:
+  logfmt_parser:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      . |= parse_logfmt!(.message)
 ```
 
 ##### `merge`
 
 Before:
 
-```toml
-[transforms.merge]
-type = "merge"
-inputs = ["some_input"]
+```yaml
+transforms:
+  merge:
+    type: "merge"
+    inputs: ["some_input"]
 ```
 
 After:
 
-```toml
-[transforms.merge]
-type = "reduce"
-inputs = ["some_input"]
-starts_when = "._partial == true"
-merge_strategies.message = "concat"
+```yaml
+transforms:
+  merge:
+    type: "reduce"
+    inputs: ["some_input"]
+    starts_when: "._partial == true"
+    merge_strategies:
+      message: "concat"
 ```
 
 ##### `regex_parser`
 
 Before:
 
-```toml
-[transforms.regex_parser]
-type = "regex_parser"
-inputs = ["some_input"]
-patterns = ['^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$']
-types.bytes_in = "int"
-types.timestamp = "timestamp|%d/%m/%Y:%H:%M:%S %z"
-types.status = "int"
-types.bytes_out = "int"
+```yaml
+transforms:
+  regex_parser:
+    type: "regex_parser"
+    inputs: ["some_input"]
+    patterns:
+      - '^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$'
+    types:
+      bytes_in: "int"
+      timestamp: "timestamp|%d/%m/%Y:%H:%M:%S %z"
+      status: "int"
+      bytes_out: "int"
 ```
 
 After:
 
-```toml
-[transforms.regex_parser]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-. |= parse_regex!(.message, [#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#]
-.bytes_in = to_int!(.bytes_in)
-.some_timestamp = parse_timestamp!(.some_timestamp, "%d/%m/%Y:%H:%M:%S %z")
-.status = to_int!(.status)
-.bytes_out = to_int!(.bytes_out)
-'''
+```yaml
+transforms:
+  regex_parser:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      . |= parse_regex!(.message, [#"^(?P<host>[\w\.]+) - (?P<user>[\w]+) (?P<bytes_in>[\d]+) \[(?P<timestamp>.*)\] "(?P<method>[\w]+) (?P<path>.*)" (?P<status>[\d]+) (?P<bytes_out>[\d]+)$"#]
+      .bytes_in = to_int!(.bytes_in)
+      .some_timestamp = parse_timestamp!(.some_timestamp, "%d/%m/%Y:%H:%M:%S %z")
+      .status = to_int!(.status)
+      .bytes_out = to_int!(.bytes_out)
 ```
 
 ##### `remove_fields`
 
 Before:
 
-```toml
-[transforms.remove_fields]
-type = "remove_fields"
-inputs = ["some_input"]
-fields = ["parent.child"]
+```yaml
+transforms:
+  remove_fields:
+    type: "remove_fields"
+    inputs: ["some_input"]
+    fields: ["parent.child"]
 ```
 
 After:
 
-```toml
-[transforms.remove_fields]
-type = "remap"
-inputs = ["some_input"]
-source = '''
-del(.parent.child)
-'''
+```yaml
+transforms:
+  remove_fields:
+    type: "remap"
+    inputs: ["some_input"]
+    source: |
+      del(.parent.child)
 ```
 
 ##### `remove_tags`
 
 Before:
 
-```toml
-[transforms.remove_tags]
-type = "remove_tags"
-inputs = ["some_input"]
-tags = ["some_tag"]
+```yaml
+transforms:
+  remove_tags:
+    type: "remove_tags"
+    inputs: ["some_input"]
+    tags: ["some_tag"]
 ```
 
 After:
 
-```toml
-[transforms.remove_tags]
-type = "remap"
-inputs = ["some_input"]
-source = '''
-del(.tags.some_tag)
-'''
+```yaml
+transforms:
+  remove_tags:
+    type: "remap"
+    inputs: ["some_input"]
+    source: |
+      del(.tags.some_tag)
 ```
 
 ##### `rename_fields`
 
 Before:
 
-```toml
-[transforms.rename_fields]
-type = "rename_fields"
-inputs = ["some_input"]
-fields.new_name = ["old_name"]
+```yaml
+transforms:
+  rename_fields:
+    type: "rename_fields"
+    inputs: ["some_input"]
+    fields:
+      new_name: ["old_name"]
 ```
 
 After:
 
-```toml
-[transforms.rename_fields]
-type = "remap"
-inputs = ["some_input"]
-source = '''
-.new_name = del(.old_name)
-'''
+```yaml
+transforms:
+  rename_fields:
+    type: "remap"
+    inputs: ["some_input"]
+    source: |
+      .new_name = del(.old_name)
 ```
 
 ##### `split`
 
 Before:
 
-```toml
-[transforms.split]
-type = "split"
-inputs = ["some_input"]
-field_names = ["remote_addr", "user_id", "timestamp", "message", "status", "bytes"]
-types.status = "int"
-types.bytes = "int"
+```yaml
+transforms:
+  split:
+    type: "split"
+    inputs: ["some_input"]
+    field_names: ["remote_addr", "user_id", "timestamp", "message", "status", "bytes"]
+    types:
+      status: "int"
+      bytes: "int"
 ```
 
 After:
 
-```toml
-[transforms.split]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-values = split(.message)
-.remote_addr = values[0]
-.user_id = values[1]
-.timestamp = values[2]
-.message = values[3]
-.status = to_int!(values[4])
-.bytes = to_int!(values[5])
-'''
+```yaml
+transforms:
+  split:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      values = split(.message)
+      .remote_addr = values[0]
+      .user_id = values[1]
+      .timestamp = values[2]
+      .message = values[3]
+      .status = to_int!(values[4])
+      .bytes = to_int!(values[5])
 ```
 
 ##### `tokenizer`
 
 Before:
 
-```toml
-[transforms.tokenizer]
-type = "tokenizer"
-inputs = ["some_input"]
-field_names = ["remote_addr", "ident", "user_id", "timestamp", "message", "status", "bytes"]
-.types.status = "int"
-.types.bytes = "int"
+```yaml
+transforms:
+  tokenizer:
+    type: "tokenizer"
+    inputs: ["some_input"]
+    field_names: ["remote_addr", "ident", "user_id", "timestamp", "message", "status", "bytes"]
+    types:
+      status: "int"
+      bytes: "int"
 ```
 
 After:
 
-```toml
-[transforms.tokenizer]
-type = "remap"
-inputs = ["some_input"]
-drop_on_error = false
-source = '''
-values = parse_tokens!(.message)
-.remote_addr = values[0]
-.user_id = values[1]
-.timestamp = values[2]
-.message = values[3]
-.status = to_int!(values[4])
-.bytes = to_int!(values[5])
-'''
+```yaml
+transforms:
+  tokenizer:
+    type: "remap"
+    inputs: ["some_input"]
+    drop_on_error: false
+    source: |
+      values = parse_tokens!(.message)
+      .remote_addr = values[0]
+      .user_id = values[1]
+      .timestamp = values[2]
+      .message = values[3]
+      .status = to_int!(values[4])
+      .bytes = to_int!(values[5])
 ```

--- a/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md
@@ -135,15 +135,16 @@ will give a compile-time error if you try to mutate the event in a condition.
 
 Example filter transform config
 
-```toml
-[transforms.filter]
-type = "filter"
-inputs = [ "input" ]
-condition.type = "vrl"
-condition.source = """
-.foo = "bar"
-true
-"""
+```yaml
+transforms:
+  filter:
+    type: "filter"
+    inputs: ["input"]
+    condition:
+      type: "vrl"
+      source: |
+        .foo = "bar"
+        true
 ```
 
 New error
@@ -253,8 +254,9 @@ need to remove it to avoid Vector from erroring on startup.
 The `gcp_pubsub` sink now supports a variety of codecs. To encode your logs as JSON before
 publishing them to Cloud Pub/Sub, add the following encoding option
 
-```toml
-encoding.codec = "json"
+```yaml
+encoding:
+  codec: "json"
 ```
 
 to the config of your `gcp_pubsub` sink.
@@ -264,8 +266,9 @@ to the config of your `gcp_pubsub` sink.
 The `humio_metrics` sink configuration no longer expects an `encoding` option.
 If you previously used the encoding option
 
-```toml
-encoding.codec = "json"
+```yaml
+encoding:
+  codec: "json"
 ```
 
 you need to remove the line from your `humio_metrics` config. Metrics are now
@@ -277,8 +280,9 @@ We streamlined the encoding configuration for our sinks, enabling all applicable
 from a variety of codecs: `json`, `text`, `raw`, `logfmt`, `avro`, `native` or `native_json`, e.g.
 by setting
 
-```toml
-encoding.codec = "json"
+```yaml
+encoding:
+  codec: "json"
 ```
 
 in your sink configuration.
@@ -287,8 +291,9 @@ Additionally, some sinks now support configuring how encoded events should be se
 stream or batch: `bytes`, `character_delimited`, `length_delimited` or `newline_delimited`, e.g. by
 setting
 
-```toml
-framing.method = "newline_delimited"
+```yaml
+framing:
+  method: "newline_delimited"
 ```
 
 in your sink configuration.
@@ -353,10 +358,9 @@ This was introduced in order to better handle metrics sent from the `datadog_age
 
 The result is that configurations with VRL expressions that expect the namespace to be in the name will need to be adapted to either remove the namespace from the name, or join the namespace and the name, for example:
 
-```toml
-full_metric_name = """
-join([.namespace, .name], ".")
-"""
+```yaml
+full_metric_name: |
+  join([.namespace, .name], ".")
 ```
 
 ### Deprecations
@@ -365,14 +369,15 @@ join([.namespace, .name], ".")
 
 We are deprecating setting encoding options by a shorthand string. E.g. when your sink encoding used
 
-```toml
-encoding = "json"
+```yaml
+encoding: "json"
 ```
 
 it should now be replaced by explicitly setting the `codec`
 
-```toml
-encoding.codec = "json"
+```yaml
+encoding:
+  codec: "json"
 ```
 
 #### Sink encoding value `ndjson` is now `json` encoding + `newline_delimited` framing {#sink-encoding-ndjson-json}
@@ -382,20 +387,24 @@ can be set explicitly via a dedicated `framing` option.
 
 This affects all sink configurations that previously used
 
-```toml
-encoding.codec = "ndjson"
+```yaml
+encoding:
+  codec: "ndjson"
 ```
 
 The `http`, `aws_s3`, `gcp_cloud_storage` and `azure_blob` sinks should be configured to use a combination of `json`
 encoding and `newline_delimited` framing instead
 
-```toml
-framing.method = "newline_delimited"
-encoding.codec = "json"
+```yaml
+framing:
+  method: "newline_delimited"
+encoding:
+  codec: "json"
 ```
 
 For all other sinks, simply set the codec to `json` to maintain the current behavior
 
-```toml
-encoding.codec = "json"
+```yaml
+encoding:
+  codec: "json"
 ```

--- a/website/content/en/highlights/2022-07-07-secrets-management.md
+++ b/website/content/en/highlights/2022-07-07-secrets-management.md
@@ -19,21 +19,24 @@ these values can be read if a user on a host has access to read from the `/proc`
 
 A secret backend can be configured like this:
 
-```toml
-[secret.backend_1]
-type = "exec" # exec is the only supported backend as of writing
-command = ["/path/to/cmd1"]
+```yaml
+secret:
+  backend_1:
+    type: "exec" # exec is the only supported backend as of writing
+    command: ["/path/to/cmd1"]
 ```
 
 You can then specify where secrets should be read via `SECRET[<backend name>.<secret name>]` in the config like:
 
-```toml
-[sources.my_source_id]
-type = "aws_sqs"
-region = "us-east-1"
-queue_url = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
-auth.access_key_id = "SECRET[backend_1.aws_access_key_id]"
-auth.secret_access_key = "SECRET[backend_1.aws_secret_access_key]"
+```yaml
+sources:
+  my_source_id:
+    type: "aws_sqs"
+    region: "us-east-1"
+    queue_url: "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
+    auth:
+      access_key_id: "SECRET[backend_1.aws_access_key_id]"
+      secret_access_key: "SECRET[backend_1.aws_secret_access_key]"
 ```
 
 Here `auth.access_key_id` and `auth.secret_access_key` will use secrets provided by the `backend_1` secret backend.

--- a/website/content/en/highlights/2022-07-07-sink-codecs.md
+++ b/website/content/en/highlights/2022-07-07-sink-codecs.md
@@ -20,13 +20,16 @@ For example, if you have a `socket` sink that you want to send
 [length-delimited][length_delimited] JSON-encoded, messages, you can now do so
 with configuration like:
 
-```toml
-[sinks.socket]
-type = "socket"
-address = "92.12.333.224:5000"
-mode = "tcp"
-framing.method = "length_delimited"
-encoding.codec = "json"
+```yaml
+sinks:
+  socket:
+    type: "socket"
+    address: "92.12.333.224:5000"
+    mode: "tcp"
+    framing:
+      method: "length_delimited"
+    encoding:
+      codec: "json"
 ```
 
 This will encode messages flowing into this sink as JSON and frame them using

--- a/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
@@ -67,16 +67,17 @@ Additionally, the [account ID][nr_account_id] must also now be specified.
 All put together, here's an example of converting from a `new_relic_logs` sink configuration over to
 the `new_relic` sink configuration:
 
-```toml
-[sinks.new_relic_logs]
-type = "new_relic_logs"
-license_key = "xxxx"
+```yaml
+sinks:
+  new_relic_logs:
+    type: "new_relic_logs"
+    license_key: "xxxx"
 
-[sinks.new_relic]
-type = "new_relic"
-license_key = "xxxx"
-account_id = "yyyy"
-api = "logs"
+  new_relic:
+    type: "new_relic"
+    license_key: "xxxx"
+    account_id: "yyyy"
+    api: "logs"
 ```
 
 [0-24-0-upgrade-guide]: https://vector.dev/highlights/2022-08-16-0-24-0-upgrade-guide/#deprecated-components
@@ -143,27 +144,28 @@ The older version 1 API is now deprecated and will be removed in a future versio
 
 For example, the following partial configuration:
 
-```toml
-[transform.example]
-type = "lua"
-version = 1
-source = """
-  event["a"] = "some value"
-  event["b"] = nil
-"""
+```yaml
+transform:
+  example:
+    type: "lua"
+    version: 1
+    source: |
+      event["a"] = "some value"
+      event["b"] = nil
 ```
 
 would need to be converted to the following:
 
-```toml
-[transform.example]
-type = "lua"
-version = 2
-hooks.process = """
-  function (event, emit)
-    event.log.a = "some value"
-    event.log.b = nil
-    emit(event)
-  end
-"""
+```yaml
+transform:
+  example:
+    type: "lua"
+    version: 2
+    hooks:
+      process: |
+        function (event, emit)
+          event.log.a = "some value"
+          event.log.b = nil
+          emit(event)
+        end
 ```

--- a/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
+++ b/website/content/en/highlights/2022-10-04-0-25-0-upgrade-guide.md
@@ -145,7 +145,7 @@ The older version 1 API is now deprecated and will be removed in a future versio
 For example, the following partial configuration:
 
 ```yaml
-transform:
+transforms:
   example:
     type: "lua"
     version: 1
@@ -157,7 +157,7 @@ transform:
 would need to be converted to the following:
 
 ```yaml
-transform:
+transforms:
   example:
     type: "lua"
     version: 2

--- a/website/content/en/highlights/2024-07-29-0-40-0-upgrade-guide.md
+++ b/website/content/en/highlights/2024-07-29-0-40-0-upgrade-guide.md
@@ -73,10 +73,11 @@ The new behavior is to use the default strategy based on the element type.
 
 ###### Config
 
-```toml
-group_by = [ "id" ]
-merge_strategies.id = "discard"
-merge_strategies."a.b[0]" = "array"
+```yaml
+group_by: ["id"]
+merge_strategies:
+  id: "discard"
+  "a.b[0]": "array"
 ```
 
 ###### Event 1


### PR DESCRIPTION
## Summary

Convert all TOML-only configuration examples across the Vector website to YAML
and add explicit recommendations for YAML as the default configuration format.

**Motivation:**

- **Consistency**: YAML has been Vector's default format since v0.34, yet most
  website examples were still written in TOML. This creates a confusing
  experience for new users.
- **Encourage YAML adoption**: By presenting all examples in YAML and adding
  explicit recommendations, we guide users toward the format that aligns with
  the broader ecosystem (Kubernetes, Helm, etc.).
- **LLM tooling**: LLMs and AI-assisted development tools work better when
  documentation is consistent. Having a single canonical format across all
  examples reduces ambiguity and improves the quality of AI-generated Vector
  configurations.

**Changes:**

- Converted 63 files: core docs, guides, blog posts, and highlight pages
- Updated prose references from `.toml` to `.yaml`
- Added "we recommend YAML" language to pages that describe multi-format support
- Updated the outdated 2020 highlight that called TOML the default format
- Left intentional TOML in the tabbed config reference (`_index.md`) untouched

## Vector configuration

N/A (docs-only change)

## How did you test this PR?

Visual inspection of converted YAML blocks for correctness.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)