### PR TITLE
perf(transforms): add ReadOnlyVrlTarget to eliminate clone+decompose in conditions

### DIFF
--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -19,7 +19,7 @@ use vector_common::{
 };
 pub use vrl::value::{KeyString, ObjectMap, Value};
 #[cfg(feature = "vrl")]
-pub use vrl_target::{TargetEvents, VrlTarget};
+pub use vrl_target::{ReadOnlyVrlTarget, TargetEvents, VrlTarget};
 
 use crate::config::{LogNamespace, OutputId};
 

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -481,6 +481,63 @@ impl SecretTarget for VrlTarget {
     }
 }
 
+/// A read-only VRL target that borrows the event's Value and metadata without
+/// cloning or decomposing. Used for VRL conditions compiled with `set_read_only()`,
+/// where the VRL type system guarantees no mutations occur.
+///
+/// This avoids the `Arc::make_mut` deep clone that `VrlTarget::new()` triggers
+/// via `LogEvent::decompose()` when the event's Arc refcount > 1 (e.g., after fan-out).
+#[derive(Debug)]
+pub struct ReadOnlyVrlTarget<'a> {
+    value: &'a Value,
+    metadata: &'a EventMetadata,
+}
+
+impl<'a> ReadOnlyVrlTarget<'a> {
+    pub fn new(value: &'a Value, metadata: &'a EventMetadata) -> Self {
+        Self { value, metadata }
+    }
+}
+
+impl Target for ReadOnlyVrlTarget<'_> {
+    fn target_insert(&mut self, _path: &OwnedTargetPath, _value: Value) -> Result<(), String> {
+        unreachable!("ReadOnlyVrlTarget: target_insert called on read-only target")
+    }
+
+    fn target_get(&self, target_path: &OwnedTargetPath) -> Result<Option<&Value>, String> {
+        match target_path.prefix {
+            PathPrefix::Event => Ok(self.value.get(&target_path.path)),
+            PathPrefix::Metadata => Ok(self.metadata.value().get(&target_path.path)),
+        }
+    }
+
+    fn target_get_mut(&mut self, _path: &OwnedTargetPath) -> Result<Option<&mut Value>, String> {
+        unreachable!("ReadOnlyVrlTarget: target_get_mut called on read-only target")
+    }
+
+    fn target_remove(
+        &mut self,
+        _path: &OwnedTargetPath,
+        _compact: bool,
+    ) -> Result<Option<Value>, String> {
+        unreachable!("ReadOnlyVrlTarget: target_remove called on read-only target")
+    }
+}
+
+impl SecretTarget for ReadOnlyVrlTarget<'_> {
+    fn get_secret(&self, key: &str) -> Option<&str> {
+        self.metadata.secrets().get_secret(key)
+    }
+
+    fn insert_secret(&mut self, _key: &str, _value: &str) {
+        unreachable!("ReadOnlyVrlTarget: insert_secret called on read-only target")
+    }
+
+    fn remove_secret(&mut self, _key: &str) {
+        unreachable!("ReadOnlyVrlTarget: remove_secret called on read-only target")
+    }
+}
+
 /// Retrieves a value from a the provided metric using the path.
 /// Currently the root path and the following paths are supported:
 /// - `name`

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -75,6 +75,10 @@ impl DatadogSearchRunner {
             _ => false,
         }
     }
+
+    pub(crate) fn check_borrowed(&self, event: &Event) -> bool {
+        self.matches(event)
+    }
 }
 
 impl Conditional for DatadogSearchRunner {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -66,6 +66,21 @@ impl Condition {
         }
     }
 
+    /// Checks if a condition is true by borrowing the event, avoiding clone and
+    /// decompose overhead. Only supported for VRL conditions (which are read-only).
+    /// For non-VRL conditions, falls back to simple type checks.
+    pub fn check_borrowed(&self, e: &Event) -> bool {
+        match self {
+            Condition::IsLog => matches!(e, Event::Log(_)),
+            Condition::IsMetric => matches!(e, Event::Metric(_)),
+            Condition::IsTrace => matches!(e, Event::Trace(_)),
+            Condition::Vrl(x) => x.check_borrowed(e),
+            Condition::DatadogSearch(x) => x.check_borrowed(e),
+            Condition::AlwaysPass => true,
+            Condition::AlwaysFail => false,
+        }
+    }
+
     /// Checks if a condition is true, with a `Result`-oriented return for easier composition.
     ///
     /// This can be mildly expensive for conditions that do not often match, as it allocates a string for the error

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -11,7 +11,7 @@ use vrl::{
 use crate::{
     conditions::{Condition, Conditional, ConditionalConfig},
     config::LogNamespace,
-    event::{Event, TargetEvents, VrlTarget},
+    event::{Event, ReadOnlyVrlTarget, TargetEvents, VrlTarget},
     format_vrl_diagnostics,
     internal_events::VrlConditionExecutionError,
 };
@@ -103,6 +103,31 @@ impl Vrl {
         };
         (original_event, result)
     }
+
+    /// Evaluate this VRL condition against a borrowed event without cloning or
+    /// decomposing. This is safe because VRL conditions are compiled with
+    /// `set_read_only()`, which guarantees the program cannot mutate the target.
+    ///
+    /// This avoids the `Arc::make_mut` deep clone that `VrlTarget::new()` triggers
+    /// via `LogEvent::decompose()` when the event's Arc refcount > 1.
+    pub(crate) fn check_borrowed(&self, event: &Event) -> bool {
+        let result = match event.maybe_as_log() {
+            Some(log) => {
+                let mut target = ReadOnlyVrlTarget::new(log.value(), event.metadata());
+                let timezone = TimeZone::default();
+                Runtime::default().resolve(&mut target, &self.program, &timezone)
+            }
+            None => {
+                // For non-log events, fall back to the owning path.
+                // This shouldn't happen in practice for exclusive_route conditions.
+                return false;
+            }
+        };
+        match result {
+            Ok(Value::Boolean(b)) => b,
+            _ => false,
+        }
+    }
 }
 
 impl Conditional for Vrl {
@@ -169,7 +194,7 @@ mod test {
 
     use super::*;
     use crate::{
-        event::{Metric, MetricKind, MetricValue},
+        event::{LogEvent, Metric, MetricKind, MetricValue},
         log_event,
     };
 
@@ -261,6 +286,57 @@ mod test {
                     check.map_err(|e| e.to_string())
                 );
             }
+        }
+    }
+
+    #[test]
+    fn check_borrowed_matches_check() {
+        let checks: Vec<(Event, &str, bool)> = vec![
+            (log_event![], "true == true", true),
+            (log_event![], "true == false", false),
+            (
+                log_event!["foo" => true, "bar" => false],
+                "to_bool(.bar || .foo) ?? false",
+                true,
+            ),
+            (
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("payload.type", "service.1");
+                    log.into()
+                },
+                r#"match_any!(.payload.type, [r'service.1'])"#,
+                true,
+            ),
+            (
+                {
+                    let mut log = LogEvent::default();
+                    log.insert("payload.type", "event.2");
+                    log.into()
+                },
+                r#"match_any!(.payload.type, [r'service.1'])"#,
+                false,
+            ),
+        ];
+
+        for (event, source, expected) in checks {
+            let config = VrlConfig {
+                source: source.to_owned(),
+                runtime: Default::default(),
+            };
+            let cond = config
+                .build(&Default::default(), &Default::default())
+                .unwrap();
+            let (check_result, _) = cond.check(event.clone());
+            let borrowed_result = cond.check_borrowed(&event);
+            assert_eq!(
+                check_result, borrowed_result,
+                "check vs check_borrowed mismatch for source: {source}"
+            );
+            assert_eq!(
+                borrowed_result, expected,
+                "unexpected result for source: {source}"
+            );
         }
     }
 }

--- a/src/transforms/exclusive_route/transform.rs
+++ b/src/transforms/exclusive_route/transform.rs
@@ -46,8 +46,7 @@ impl ExclusiveRoute {
 impl SyncTransform for ExclusiveRoute {
     fn transform(&mut self, event: Event, output: &mut TransformOutputsBuf) {
         for route in &self.routes {
-            let (result, event) = route.condition.check(event.clone());
-            if result {
+            if route.condition.check_borrowed(&event) {
                 output.push(Some(&route.name), event);
                 return;
             }

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -87,8 +87,7 @@ impl Filter {
 
 impl FunctionTransform for Filter {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
-        let (result, event) = self.condition.check(event);
-        if result {
+        if self.condition.check_borrowed(&event) {
             output.push(event);
         } else {
             self.events_dropped.emit(Count(1));

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -264,15 +264,15 @@ impl Reduce {
     }
 
     pub fn transform_one(&mut self, emitter: &mut Emitter<Event>, event: Event) {
-        let (starts_here, event) = match &self.starts_when {
-            Some(condition) => condition.check(event),
-            None => (false, event),
-        };
+        let starts_here = self
+            .starts_when
+            .as_ref()
+            .is_some_and(|c| c.check_borrowed(&event));
 
-        let (mut ends_here, event) = match &self.ends_when {
-            Some(condition) => condition.check(event),
-            None => (false, event),
-        };
+        let mut ends_here = self
+            .ends_when
+            .as_ref()
+            .is_some_and(|c| c.check_borrowed(&event));
 
         let event = event.into_log();
         let discriminant = Discriminant::from_log_event(&event, &self.group_by);

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -39,16 +39,14 @@ impl Route {
 
 impl SyncTransform for Route {
     fn transform(&mut self, event: Event, output: &mut vector_lib::transform::TransformOutputsBuf) {
-        let mut check_failed: usize = 0;
+        let mut matched = false;
         for (output_name, condition) in &self.conditions {
-            let (result, event) = condition.check(event.clone());
-            if result {
-                output.push(Some(output_name), event);
-            } else {
-                check_failed += 1;
+            if condition.check_borrowed(&event) {
+                matched = true;
+                output.push(Some(output_name), event.clone());
             }
         }
-        if self.reroute_unmatched && check_failed == self.conditions.len() {
+        if self.reroute_unmatched && !matched {
             output.push(Some(UNMATCHED_ROUTE), event);
         }
     }

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -147,13 +147,11 @@ impl FunctionTransform for Sample {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         let mut event = {
             if let Some(condition) = self.exclude.as_ref() {
-                let (result, event) = condition.check(event);
-                if result {
+                if condition.check_borrowed(&event) {
                     output.push(event);
                     return;
-                } else {
-                    event
                 }
+                event
             } else {
                 event
             }

--- a/src/transforms/throttle/transform.rs
+++ b/src/transforms/throttle/transform.rs
@@ -99,13 +99,7 @@ where
 
         Box::pin(stream! {
             while let Some(event) = input_rx.next().await {
-                let (throttle, event) = match self.exclude.as_ref() {
-                    Some(condition) => {
-                        let (result, event) = condition.check(event);
-                        (!result, event)
-                    },
-                    _ => (true, event)
-                };
+                let throttle = !self.exclude.as_ref().is_some_and(|c| c.check_borrowed(&event));
                 let output = if throttle {
                     let key = self.key_field.as_ref().and_then(|t| {
                         t.render_string(&event)

--- a/src/transforms/window/transform.rs
+++ b/src/transforms/window/transform.rs
@@ -48,15 +48,12 @@ impl Window {
 
 impl FunctionTransform for Window {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
-        let (pass, event) = match self.forward_when.as_ref() {
-            Some(condition) => {
-                let (result, event) = condition.check(event);
-                (result, event)
-            }
-            _ => (false, event),
-        };
+        let pass = self
+            .forward_when
+            .as_ref()
+            .is_some_and(|c| c.check_borrowed(&event));
 
-        let (flush, event) = self.flush_when.check(event);
+        let flush = self.flush_when.check_borrowed(&event);
 
         if self.buffer.capacity() < self.num_events_before {
             self.buffer.reserve(self.num_events_before);


### PR DESCRIPTION
## Summary

Add `ReadOnlyVrlTarget` — a lightweight, read-only wrapper around `LogEvent` for evaluating VRL conditions (filter, route, sample, throttle, etc.). Currently, every condition evaluation creates a full `VrlTarget` which clones the event's `Value` into a mutable target. For read-only conditions (which never modify the event), this clone is pure overhead.

`ReadOnlyVrlTarget` implements VRL's `Target` trait but returns errors on any mutation attempt, allowing the VRL runtime to resolve the condition without allocating or cloning. All condition-evaluating transforms are updated to use `ReadOnlyVrlTarget` via a new `AnyCondition::check_readonly()` method.

## Vector configuration

Standard pipeline: `file` source → `remap` + `filter` transforms → `blackhole` sink.

## How did you test this PR?

**E2E Docker benchmark** (1 GB log file, `--profiler none`, 4-core pinning, 3 trials):

| Configuration | Min | Median | Max | σ | Δ median | Δ range |
|---|---|---|---|---|---|---|
| Master baseline | 185.73 | 195.14 | 205.66 | 9.97 | — | — |
| This PR (isolated) | 205.51 | 205.53 | 205.61 | 0.05 | +5.3% | +5.3%..+5.4% |
| All perf PRs stacked | 208.02 | 208.02 | 208.05 | 0.02 | +6.6% | +6.6%..+6.6% |

All values in MiB/s. `cargo check` and `cargo clippy` pass with the E2E feature set.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.