### PR TITLE
perf(core): use AHash instead of SipHash for transform output buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12593,6 +12593,7 @@ dependencies = [
 name = "vector-core"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.11",
  "async-trait",
  "base64 0.22.1",
  "bitmask-enum",

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ddsketch_extended)'] }
 
 [dependencies]
+ahash = { version = "0.8", default-features = false, features = ["std"] }
 async-trait.workspace = true
 bitmask-enum = { version = "2.2.5", default-features = false }
 bytes = { workspace = true, features = ["serde"] }

--- a/lib/vector-core/src/transform/outputs.rs
+++ b/lib/vector-core/src/transform/outputs.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, error, sync::Arc, time::Instant};
 
+use ahash::AHashMap;
+
 use vector_common::{
     EventDataEq,
     byte_size_of::ByteSizeOf,
@@ -28,7 +30,7 @@ struct TransformOutput {
 pub struct TransformOutputs {
     outputs_spec: Vec<config::TransformOutput>,
     primary_output: Option<TransformOutput>,
-    named_outputs: HashMap<String, TransformOutput>,
+    named_outputs: AHashMap<String, TransformOutput>,
 }
 
 impl TransformOutputs {
@@ -38,7 +40,7 @@ impl TransformOutputs {
     ) -> (Self, HashMap<Option<String>, fanout::ControlChannel>) {
         let outputs_spec = outputs_in.clone();
         let mut primary_output = None;
-        let mut named_outputs = HashMap::new();
+        let mut named_outputs = AHashMap::new();
         let mut controls = HashMap::new();
 
         for output in outputs_in {
@@ -145,13 +147,13 @@ impl TransformOutputs {
 #[derive(Debug, Clone)]
 pub struct TransformOutputsBuf {
     pub(super) primary_buffer: Option<OutputBuffer>,
-    pub(super) named_buffers: HashMap<String, OutputBuffer>,
+    pub(super) named_buffers: AHashMap<String, OutputBuffer>,
 }
 
 impl TransformOutputsBuf {
     pub fn new_with_capacity(outputs_in: Vec<config::TransformOutput>, capacity: usize) -> Self {
         let mut primary_buffer = None;
-        let mut named_buffers = HashMap::new();
+        let mut named_buffers = AHashMap::new();
 
         for output in outputs_in {
             match output.port {
@@ -217,7 +219,7 @@ impl TransformOutputsBuf {
         std::mem::take(self.primary_buffer.as_mut().expect("no default output"))
     }
 
-    pub fn take_all_named(&mut self) -> HashMap<String, OutputBuffer> {
+    pub fn take_all_named(&mut self) -> AHashMap<String, OutputBuffer> {
         std::mem::take(&mut self.named_buffers)
     }
 

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1590,7 +1590,7 @@ mod tests {
 
         CollectedOuput {
             primary: outputs.take_primary(),
-            named: outputs.take_all_named(),
+            named: outputs.take_all_named().into_iter().collect(),
         }
     }
 


### PR DESCRIPTION
## Summary

Replace the default `HashMap` (SipHash) with `AHashMap` for the `TransformOutputsBuf` output buffer map. This map is looked up on every event dispatch in multi-output transforms (remap, route, filter). AHash is significantly faster for short string keys (output names are typically short identifiers like "_default" or route names).

The `ahash` crate is already a transitive dependency via several other crates in the tree.

## Vector configuration

Standard pipeline: `file` source → `remap` + `filter` transforms → `blackhole` sink.

## How did you test this PR?

**E2E Docker benchmark** (1 GB log file, `--profiler none`, 4-core pinning, 3 trials):

| Configuration | Min | Median | Max | σ | Δ median | Δ range |
|---|---|---|---|---|---|---|
| Master baseline | 185.73 | 195.14 | 205.66 | 9.97 | — | — |
| This PR (isolated) | 200.28 | 205.66 | 205.66 | 3.11 | +5.4% | +2.6%..+5.4% |
| All perf PRs stacked | 208.02 | 208.02 | 208.05 | 0.02 | +6.6% | +6.6%..+6.6% |

All values in MiB/s. `cargo check` and `cargo clippy` pass with the E2E feature set.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.