### PR TITLE
chore(deps): add dependabot config for scripts/environment/npm-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -176,3 +176,18 @@ updates:
       npm_and_yarn:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/scripts/environment/npm-tools"
+    schedule:
+      interval: "monthly"
+      time: "05:00" # UTC
+    labels:
+      - "domain: deps"
+      - "no-changelog"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 50
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -186,7 +186,8 @@ updates:
       - "no-changelog"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 50
+    # Disable version updates; security updates bypass this limit
+    open-pull-requests-limit: 0
     groups:
       npm_and_yarn:
         patterns:


### PR DESCRIPTION
## Summary

Dependabot has no npm ecosystem entry for `scripts/environment/npm-tools`, so it receives no version or security updates.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References