### PR TITLE
feat(splunk_hec source): Support custom extractors

### DIFF
--- a/changelog.d/23990_splunk_hec_custom_extractors.feature.md
+++ b/changelog.d/23990_splunk_hec_custom_extractors.feature.md
@@ -1,0 +1,4 @@
+Modifies the internal Splunk HEC source so that it can be extended with a custom set of extractors.
+It does not change the config or the behavior of the default implementation of the source.
+
+authors: 20agbekodo

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -48,10 +48,7 @@ use warp::{
 };
 
 use self::{
-    acknowledgements::{
-        HecAckStatusRequest, HecAckStatusResponse, HecAcknowledgementsConfig,
-        IndexerAcknowledgement,
-    },
+    acknowledgements::{HecAckStatusRequest, HecAckStatusResponse, IndexerAcknowledgement},
     splunk_response::{HecResponse, HecResponseMetadata, HecStatusCode},
 };
 use crate::{
@@ -67,6 +64,7 @@ use crate::{
 };
 
 mod acknowledgements;
+pub use acknowledgements::HecAcknowledgementsConfig;
 use std::marker::PhantomData;
 
 // Event fields unique to splunk_hec source
@@ -156,7 +154,7 @@ impl SourceConfig for SplunkConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), true)?;
 
-        let source: SplunkSource = SplunkSource::new(self, tls.http_protocol_name(), cx);
+        let source: SplunkSource = SplunkSource::new(self, (), tls.http_protocol_name(), cx);
 
         let listener = tls.bind(&self.address).await?;
 
@@ -258,12 +256,17 @@ pub struct SplunkSource<E: Extractor = DefaultExtractor> {
     events_received: Registered<EventsReceived>,
     shutdown: vector_lib::shutdown::ShutdownSignal,
     out: SourceSender,
-
+    extractor_config: E::Config,
     _extractor: PhantomData<E>,
 }
 
 impl<E: Extractor> SplunkSource<E> {
-    fn new(config: &SplunkConfig, protocol: &'static str, cx: SourceContext) -> Self {
+    fn new(
+        config: &SplunkConfig,
+        extractor_config: E::Config,
+        protocol: &'static str,
+        cx: SourceContext,
+    ) -> Self {
         let log_namespace = cx.log_namespace(config.log_namespace);
         let acknowledgements = cx.do_acknowledgements(config.acknowledgements.enabled.into());
         let shutdown = cx.shutdown.clone();
@@ -289,13 +292,48 @@ impl<E: Extractor> SplunkSource<E> {
             store_hec_token: config.store_hec_token,
             log_namespace,
             events_received: register!(EventsReceived),
+            extractor_config,
             _extractor: PhantomData,
             shutdown: cx.shutdown,
             out: cx.out,
         }
     }
 
-    fn listen(
+    /// Construct a `SplunkSource` from individual parameters, without requiring a `SplunkConfig`.
+    /// Intended for use by wrapper source implementations (e.g. OPW's `splunk_hec_opw`).
+    pub fn new_from_parts(
+        valid_tokens: impl Iterator<Item = impl AsRef<str>>,
+        store_hec_token: bool,
+        acknowledgements: HecAcknowledgementsConfig,
+        log_namespace_override: Option<bool>,
+        extractor_config: E::Config,
+        protocol: &'static str,
+        cx: SourceContext,
+    ) -> Self {
+        let log_namespace = cx.log_namespace(log_namespace_override);
+        let acknowledgements_enabled = cx.do_acknowledgements(acknowledgements.enabled.into());
+        let shutdown = cx.shutdown.clone();
+
+        let idx_ack = acknowledgements_enabled
+            .then(|| Arc::new(IndexerAcknowledgement::new(acknowledgements, shutdown)));
+
+        SplunkSource::<E> {
+            valid_credentials: valid_tokens
+                .map(|token| format!("Splunk {}", token.as_ref()))
+                .collect(),
+            protocol,
+            idx_ack,
+            store_hec_token,
+            log_namespace,
+            events_received: register!(EventsReceived),
+            extractor_config,
+            _extractor: PhantomData,
+            shutdown: cx.shutdown,
+            out: cx.out,
+        }
+    }
+
+    pub fn listen(
         self,
         listener: vector_lib::tls::MaybeTlsListener,
         keepalive_settings: KeepaliveConfig,
@@ -363,6 +401,7 @@ impl<E: Extractor> SplunkSource<E> {
         let store_hec_token = self.store_hec_token;
         let log_namespace = self.log_namespace;
         let events_received = self.events_received.clone();
+        let extractor_config = self.extractor_config.clone();
         warp::post()
             .and(
                 path!("event")
@@ -388,6 +427,7 @@ impl<E: Extractor> SplunkSource<E> {
                     let mut out = out.clone();
                     let idx_ack = idx_ack.clone();
                     let events_received = events_received.clone();
+                    let extractor_config = extractor_config.clone();
 
                     async move {
                         if idx_ack.is_some() && channel.is_none() {
@@ -436,7 +476,12 @@ impl<E: Extractor> SplunkSource<E> {
                             batch,
                             log_namespace,
                             events_received,
-                            extractor: E::new(meta, log_namespace, store_hec_token),
+                            extractor: E::new(
+                                &extractor_config,
+                                meta,
+                                log_namespace,
+                                store_hec_token,
+                            ),
                         }
                         .into();
 
@@ -1047,8 +1092,16 @@ impl FieldExtractor {
 ///
 /// This DefaultExtractor can be wrapped in a custom implementation to extract additional properties.
 pub trait Extractor {
+    /// Config data passed at source construction time; available to `new` for each request.
+    type Config: Send + Sync + Clone + 'static;
+
     /// create a new instance of the extractor
-    fn new(meta: RequestMeta, log_namespace: LogNamespace, store_hec_token: bool) -> Self;
+    fn new(
+        config: &Self::Config,
+        meta: RequestMeta,
+        log_namespace: LogNamespace,
+        store_hec_token: bool,
+    ) -> Self;
 
     /// extract will be called for each value in the request and the associated log.
     fn extract(&mut self, log: &mut LogEvent, value: &mut JsonValue);
@@ -1061,7 +1114,14 @@ pub struct DefaultExtractor {
 }
 
 impl Extractor for DefaultExtractor {
-    fn new(meta: RequestMeta, log_namespace: LogNamespace, store_hec_token: bool) -> Self {
+    type Config = ();
+
+    fn new(
+        _config: &(),
+        meta: RequestMeta,
+        log_namespace: LogNamespace,
+        store_hec_token: bool,
+    ) -> Self {
         DefaultExtractor {
             extractors: [
                 // Extract the host field with the given priority:

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -424,18 +424,21 @@ impl<E: Extractor> SplunkSource<E> {
                         let mut error = None;
                         let mut events = Vec::new();
 
+                        let meta = RequestMeta {
+                            token: token.clone(),
+                            remote,
+                            remote_addr,
+                        };
+
                         let iter: EventIterator<'_, StrRead<'_>, E> = EventIteratorGenerator {
                             deserializer: Deserializer::from_str(&body).into_iter::<JsonValue>(),
                             channel,
                             batch,
                             log_namespace,
                             events_received,
+                            token,
                             store_hec_token,
-                            meta: RequestMeta {
-                                token,
-                                remote,
-                                remote_addr,
-                            },
+                            extractor: E::new(meta, log_namespace),
                         }
                         .into();
 
@@ -716,27 +719,28 @@ pub struct RequestMeta {
 }
 
 /// Intermediate struct to generate an `EventIterator`
-struct EventIteratorGenerator<'de, R: JsonRead<'de>> {
+struct EventIteratorGenerator<'de, R: JsonRead<'de>, E: Extractor> {
     deserializer: serde_json::StreamDeserializer<'de, R, JsonValue>,
     channel: Option<String>,
     batch: Option<BatchNotifier>,
     log_namespace: LogNamespace,
     events_received: Registered<EventsReceived>,
-    meta: RequestMeta,
+    token: Option<String>,
     store_hec_token: bool,
+    extractor: E,
 }
 
-impl<'de, R: JsonRead<'de>, E: Extractor> From<EventIteratorGenerator<'de, R>>
+impl<'de, R: JsonRead<'de>, E: Extractor> From<EventIteratorGenerator<'de, R, E>>
     for EventIterator<'de, R, E>
 {
-    fn from(f: EventIteratorGenerator<'de, R>) -> Self {
+    fn from(f: EventIteratorGenerator<'de, R, E>) -> Self {
         Self {
             deserializer: f.deserializer,
             events: 0,
             channel: f.channel.map(Value::from),
             time: Time::Now(Utc::now()),
-            token: f.meta.token.clone().map(Into::into),
-            extractor: E::new(f.meta, f.log_namespace),
+            token: f.token.map(Into::into),
+            extractor: f.extractor,
             batch: f.batch,
             log_namespace: f.log_namespace,
             events_received: f.events_received,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -696,7 +696,7 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
     /// Default time
     time: Time,
     /// Remaining extracted default values
-    extractors: E,
+    extractor: E,
     /// Event finalization
     batch: Option<BatchNotifier>,
     /// Splunk HEC Token for passthrough
@@ -736,7 +736,7 @@ impl<'de, R: JsonRead<'de>, E: Extractor> From<EventIteratorGenerator<'de, R>>
             channel: f.channel.map(Value::from),
             time: Time::Now(Utc::now()),
             token: f.meta.token.clone().map(Into::into),
-            extractors: E::new(f.meta, f.log_namespace),
+            extractor: E::new(f.meta, f.log_namespace),
             batch: f.batch,
             log_namespace: f.log_namespace,
             events_received: f.events_received,
@@ -840,7 +840,7 @@ impl<'de, R: JsonRead<'de>, E: Extractor> EventIterator<'de, R, E> {
         );
 
         // Extract default extracted fields
-        self.extractors.extract(&mut log, &mut json);
+        self.extractor.extract(&mut log, &mut json);
 
         // Add passthrough token if present
         if let Some(token) = &self.token

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -67,6 +67,7 @@ use crate::{
 };
 
 mod acknowledgements;
+use std::marker::PhantomData;
 
 // Event fields unique to splunk_hec source
 pub const CHANNEL: &str = "splunk_channel";
@@ -154,59 +155,12 @@ fn default_socket_address() -> SocketAddr {
 impl SourceConfig for SplunkConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), true)?;
-        let shutdown = cx.shutdown.clone();
-        let out = cx.out.clone();
-        let source = SplunkSource::new(self, tls.http_protocol_name(), cx);
 
-        let event_service = source.event_service(out.clone());
-        let raw_service = source.raw_service(out);
-        let health_service = source.health_service();
-        let ack_service = source.ack_service();
-        let options = SplunkSource::options();
-
-        let services = path!("services" / "collector" / ..)
-            .and(
-                event_service
-                    .or(raw_service)
-                    .unify()
-                    .or(health_service)
-                    .unify()
-                    .or(ack_service)
-                    .unify()
-                    .or(options)
-                    .unify(),
-            )
-            .or_else(finish_err);
+        let source: SplunkSource = SplunkSource::new(self, tls.http_protocol_name(), cx);
 
         let listener = tls.bind(&self.address).await?;
 
-        let keepalive_settings = self.keepalive.clone();
-        Ok(Box::pin(async move {
-            let span = Span::current();
-            let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
-                let svc = ServiceBuilder::new()
-                    .layer(build_http_trace_layer(span.clone()))
-                    .option_layer(keepalive_settings.max_connection_age_secs.map(|secs| {
-                        MaxConnectionAgeLayer::new(
-                            Duration::from_secs(secs),
-                            keepalive_settings.max_connection_age_jitter_factor,
-                            conn.peer_addr(),
-                        )
-                    }))
-                    .service(warp::service(services.clone()));
-                futures_util::future::ok::<_, Infallible>(svc)
-            });
-
-            Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
-                .serve(make_svc)
-                .with_graceful_shutdown(shutdown.map(|_| ()))
-                .await
-                .map_err(|err| {
-                    error!("An error occurred: {:?}.", err);
-                })?;
-
-            Ok(())
-        }))
+        Ok(source.listen(listener, self.keepalive.clone()))
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
@@ -295,21 +249,24 @@ impl SourceConfig for SplunkConfig {
     }
 }
 
-/// Shared data for responding to requests.
-struct SplunkSource {
+pub struct SplunkSource<E: Extractor = DefaultExtractor> {
     valid_credentials: Vec<String>,
     protocol: &'static str,
     idx_ack: Option<Arc<IndexerAcknowledgement>>,
     store_hec_token: bool,
     log_namespace: LogNamespace,
     events_received: Registered<EventsReceived>,
+    shutdown: vector_lib::shutdown::ShutdownSignal,
+    out: SourceSender,
+
+    _extractor: PhantomData<E>,
 }
 
-impl SplunkSource {
+impl<E: Extractor> SplunkSource<E> {
     fn new(config: &SplunkConfig, protocol: &'static str, cx: SourceContext) -> Self {
         let log_namespace = cx.log_namespace(config.log_namespace);
         let acknowledgements = cx.do_acknowledgements(config.acknowledgements.enabled.into());
-        let shutdown = cx.shutdown;
+        let shutdown = cx.shutdown.clone();
         let valid_tokens = config
             .valid_tokens
             .iter()
@@ -323,7 +280,7 @@ impl SplunkSource {
             ))
         });
 
-        SplunkSource {
+        SplunkSource::<E> {
             valid_credentials: valid_tokens
                 .map(|token| format!("Splunk {}", token.inner()))
                 .collect(),
@@ -332,7 +289,66 @@ impl SplunkSource {
             store_hec_token: config.store_hec_token,
             log_namespace,
             events_received: register!(EventsReceived),
+            _extractor: PhantomData,
+            shutdown: cx.shutdown.clone(),
+            out: cx.out.clone(),
         }
+    }
+
+    fn listen(
+        &self,
+        listener: vector_lib::tls::MaybeTlsListener,
+        keepalive_settings: KeepaliveConfig,
+    ) -> super::Source {
+        let event_service = self.event_service(self.out.clone());
+        let raw_service = self.raw_service(self.out.clone());
+        let health_service = self.health_service();
+        let ack_service = self.ack_service();
+
+        let options = options();
+
+        let services = path!("services" / "collector" / ..)
+            .and(
+                event_service
+                    .or(raw_service)
+                    .unify()
+                    .or(health_service)
+                    .unify()
+                    .or(ack_service)
+                    .unify()
+                    .or(options)
+                    .unify(),
+            )
+            .or_else(finish_err);
+
+        let shutdown = self.shutdown.clone();
+
+        Box::pin(async move {
+            let span = Span::current();
+            let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
+                let svc = ServiceBuilder::new()
+                    .layer(build_http_trace_layer(span.clone()))
+                    .option_layer(keepalive_settings.max_connection_age_secs.map(|secs| {
+                        MaxConnectionAgeLayer::new(
+                            Duration::from_secs(secs),
+                            keepalive_settings.max_connection_age_jitter_factor,
+                            conn.peer_addr(),
+                        )
+                    }))
+                    .service(warp::service(services.clone()));
+                futures_util::future::ok::<_, Infallible>(svc)
+            });
+
+            Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
+                .serve(make_svc)
+                .with_graceful_shutdown(shutdown.map(|_| ()))
+                .await
+                .map_err(|err| {
+                    error!("An error occurred: {:?}.", err);
+                })?;
+
+            Ok(())
+        })
     }
 
     fn event_service(&self, out: SourceSender) -> BoxedFilter<(Response,)> {
@@ -349,7 +365,6 @@ impl SplunkSource {
         let store_hec_token = self.store_hec_token;
         let log_namespace = self.log_namespace;
         let events_received = self.events_received.clone();
-
         warp::post()
             .and(
                 path!("event")
@@ -411,15 +426,18 @@ impl SplunkSource {
                         let mut error = None;
                         let mut events = Vec::new();
 
-                        let iter: EventIterator<'_, StrRead<'_>> = EventIteratorGenerator {
+                        let iter: EventIterator<'_, StrRead<'_>, E> = EventIteratorGenerator {
                             deserializer: Deserializer::from_str(&body).into_iter::<JsonValue>(),
                             channel,
-                            remote,
-                            remote_addr,
                             batch,
-                            token: token.filter(|_| store_hec_token).map(Into::into),
                             log_namespace,
                             events_received,
+                            store_hec_token,
+                            meta: RequestMeta {
+                                token,
+                                remote,
+                                remote_addr,
+                            },
                         }
                         .into();
 
@@ -467,7 +485,7 @@ impl SplunkSource {
         warp::post()
             .and(path!("raw" / "1.0").or(path!("raw")))
             .and(self.authorization())
-            .and(SplunkSource::required_channel())
+            .and(required_channel())
             .and(warp::addr::remote())
             .and(warp::header::optional::<String>("X-Forwarded-For"))
             .and(self.gzip())
@@ -544,40 +562,14 @@ impl SplunkSource {
             .boxed()
     }
 
-    fn lenient_json_content_type_check<T>() -> impl Filter<Extract = (T,), Error = Rejection> + Clone
-    where
-        T: Send + DeserializeOwned + 'static,
-    {
-        warp::header::optional::<HeaderValue>(CONTENT_TYPE.as_str())
-            .and(warp::body::bytes())
-            .and_then(
-                |ctype: Option<HeaderValue>, body: bytes::Bytes| async move {
-                    let ok = ctype
-                        .as_ref()
-                        .and_then(|v| v.to_str().ok())
-                        .map(|h| h.to_ascii_lowercase().contains("application/json"))
-                        .unwrap_or(true);
-
-                    if !ok {
-                        return Err(warp::reject::custom(ApiError::UnsupportedContentType));
-                    }
-
-                    let value = serde_json::from_slice::<T>(&body)
-                        .map_err(|_| warp::reject::custom(ApiError::BadRequest))?;
-
-                    Ok(value)
-                },
-            )
-    }
-
     fn ack_service(&self) -> BoxedFilter<(Response,)> {
         let idx_ack = self.idx_ack.clone();
 
         warp::post()
             .and(warp::path!("ack"))
             .and(self.authorization())
-            .and(SplunkSource::required_channel())
-            .and(Self::lenient_json_content_type_check::<HecAckStatusRequest>())
+            .and(required_channel())
+            .and(lenient_json_content_type_check::<HecAckStatusRequest>())
             .and_then(move |_, channel: String, req: HecAckStatusRequest| {
                 let idx_ack = idx_ack.clone();
                 async move {
@@ -592,23 +584,6 @@ impl SplunkSource {
                 }
             })
             .boxed()
-    }
-
-    fn options() -> BoxedFilter<(Response,)> {
-        let post = warp::options()
-            .and(
-                path!("event")
-                    .or(path!("event" / "1.0"))
-                    .or(path!("raw" / "1.0"))
-                    .or(path!("raw")),
-            )
-            .map(|_| warp::reply::with_header(warp::reply(), "Allow", "POST").into_response());
-
-        let get = warp::options()
-            .and(path!("health").or(path!("health" / "1.0")))
-            .map(|_| warp::reply::with_header(warp::reply(), "Allow", "GET").into_response());
-
-        post.or(get).unify().boxed()
     }
 
     /// Authorize request
@@ -651,25 +626,69 @@ impl SplunkSource {
             })
             .boxed()
     }
-
-    fn required_channel() -> BoxedFilter<(String,)> {
-        let splunk_channel_query_param = warp::query::<HashMap<String, String>>()
-            .map(|qs: HashMap<String, String>| qs.get("channel").map(|v| v.to_owned()));
-        let splunk_channel_header = warp::header::optional::<String>(X_SPLUNK_REQUEST_CHANNEL);
-
-        splunk_channel_header
-            .and(splunk_channel_query_param)
-            .and_then(|header: Option<String>, query_param| async move {
-                header
-                    .or(query_param)
-                    .ok_or_else(|| Rejection::from(ApiError::MissingChannel))
-            })
-            .boxed()
-    }
 }
+
+fn options() -> BoxedFilter<(Response,)> {
+    let post = warp::options()
+        .and(
+            path!("event")
+                .or(path!("event" / "1.0"))
+                .or(path!("raw" / "1.0"))
+                .or(path!("raw")),
+        )
+        .map(|_| warp::reply::with_header(warp::reply(), "Allow", "POST").into_response());
+
+    let get = warp::options()
+        .and(path!("health").or(path!("health" / "1.0")))
+        .map(|_| warp::reply::with_header(warp::reply(), "Allow", "GET").into_response());
+
+    post.or(get).unify().boxed()
+}
+
+fn required_channel() -> BoxedFilter<(String,)> {
+    let splunk_channel_query_param = warp::query::<HashMap<String, String>>()
+        .map(|qs: HashMap<String, String>| qs.get("channel").map(|v| v.to_owned()));
+    let splunk_channel_header = warp::header::optional::<String>(X_SPLUNK_REQUEST_CHANNEL);
+
+    splunk_channel_header
+        .and(splunk_channel_query_param)
+        .and_then(|header: Option<String>, query_param| async move {
+            header
+                .or(query_param)
+                .ok_or_else(|| Rejection::from(ApiError::MissingChannel))
+        })
+        .boxed()
+}
+
+fn lenient_json_content_type_check<T>() -> impl Filter<Extract = (T,), Error = Rejection> + Clone
+where
+    T: Send + DeserializeOwned + 'static,
+{
+    warp::header::optional::<HeaderValue>(CONTENT_TYPE.as_str())
+        .and(warp::body::bytes())
+        .and_then(
+            |ctype: Option<HeaderValue>, body: bytes::Bytes| async move {
+                let ok = ctype
+                    .as_ref()
+                    .and_then(|v| v.to_str().ok())
+                    .map(|h| h.to_ascii_lowercase().contains("application/json"))
+                    .unwrap_or(true);
+
+                if !ok {
+                    return Err(warp::reject::custom(ApiError::UnsupportedContentType));
+                }
+
+                let value = serde_json::from_slice::<T>(&body)
+                    .map_err(|_| warp::reject::custom(ApiError::BadRequest))?;
+
+                Ok(value)
+            },
+        )
+}
+
 /// Constructs one or more events from json-s coming from reader.
 /// If errors, it's done with input.
-struct EventIterator<'de, R: JsonRead<'de>> {
+struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
     /// Remaining request with JSON events
     deserializer: serde_json::StreamDeserializer<'de, R, JsonValue>,
     /// Count of sent events
@@ -679,7 +698,7 @@ struct EventIterator<'de, R: JsonRead<'de>> {
     /// Default time
     time: Time,
     /// Remaining extracted default values
-    extractors: [DefaultExtractor; 4],
+    extractors: E,
     /// Event finalization
     batch: Option<BatchNotifier>,
     /// Splunk HEC Token for passthrough
@@ -688,6 +707,14 @@ struct EventIterator<'de, R: JsonRead<'de>> {
     log_namespace: LogNamespace,
     /// handle to EventsReceived registry
     events_received: Registered<EventsReceived>,
+    /// Whether to store the HEC token in the log event metadata
+    store_hec_token: bool,
+}
+
+pub struct RequestMeta {
+    token: Option<String>,
+    remote: Option<SocketAddr>,
+    remote_addr: Option<String>,
 }
 
 /// Intermediate struct to generate an `EventIterator`
@@ -695,50 +722,32 @@ struct EventIteratorGenerator<'de, R: JsonRead<'de>> {
     deserializer: serde_json::StreamDeserializer<'de, R, JsonValue>,
     channel: Option<String>,
     batch: Option<BatchNotifier>,
-    token: Option<Arc<str>>,
     log_namespace: LogNamespace,
     events_received: Registered<EventsReceived>,
-    remote: Option<SocketAddr>,
-    remote_addr: Option<String>,
+    meta: RequestMeta,
+    store_hec_token: bool,
 }
 
-impl<'de, R: JsonRead<'de>> From<EventIteratorGenerator<'de, R>> for EventIterator<'de, R> {
+impl<'de, R: JsonRead<'de>, E: Extractor> From<EventIteratorGenerator<'de, R>>
+    for EventIterator<'de, R, E>
+{
     fn from(f: EventIteratorGenerator<'de, R>) -> Self {
         Self {
             deserializer: f.deserializer,
             events: 0,
             channel: f.channel.map(Value::from),
             time: Time::Now(Utc::now()),
-            extractors: [
-                // Extract the host field with the given priority:
-                // 1. The host field is present in the event payload
-                // 2. The x-forwarded-for header is present in the incoming request
-                // 3. Use the `remote`: SocketAddr value provided by warp
-                DefaultExtractor::new_with(
-                    "host",
-                    log_schema().host_key().cloned().into(),
-                    f.remote_addr
-                        .or_else(|| f.remote.map(|addr| addr.to_string()))
-                        .map(Value::from),
-                    f.log_namespace,
-                ),
-                DefaultExtractor::new("index", OptionalValuePath::new(INDEX), f.log_namespace),
-                DefaultExtractor::new("source", OptionalValuePath::new(SOURCE), f.log_namespace),
-                DefaultExtractor::new(
-                    "sourcetype",
-                    OptionalValuePath::new(SOURCETYPE),
-                    f.log_namespace,
-                ),
-            ],
+            token: f.meta.token.clone().map(Into::into),
+            extractors: E::new(f.meta, f.log_namespace),
             batch: f.batch,
-            token: f.token,
             log_namespace: f.log_namespace,
             events_received: f.events_received,
+            store_hec_token: f.store_hec_token,
         }
     }
 }
 
-impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
+impl<'de, R: JsonRead<'de>, E: Extractor> EventIterator<'de, R, E> {
     fn build_event(&mut self, mut json: JsonValue) -> Result<Event, Rejection> {
         // Construct Event from parsed json event
         let mut log = match self.log_namespace {
@@ -833,12 +842,12 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
         );
 
         // Extract default extracted fields
-        for de in self.extractors.iter_mut() {
-            de.extract(&mut log, &mut json);
-        }
+        self.extractors.extract(&mut log, &mut json);
 
         // Add passthrough token if present
-        if let Some(token) = &self.token {
+        if let Some(token) = &self.token
+            && self.store_hec_token
+        {
             log.metadata_mut().set_splunk_hec_token(Arc::clone(token));
         }
 
@@ -927,7 +936,7 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
     }
 }
 
-impl<'de, R: JsonRead<'de>> Iterator for EventIterator<'de, R> {
+impl<'de, R: JsonRead<'de>, E: Extractor> Iterator for EventIterator<'de, R, E> {
     type Item = Result<Event, Rejection>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -986,21 +995,22 @@ fn parse_timestamp(t: i64) -> Option<DateTime<Utc>> {
     Some(ts)
 }
 
-/// Maintains last known extracted value of field and uses it in the absence of field.
-struct DefaultExtractor {
+/// MetaExtractor is a helper struct that extracts a field from the request and adds it to the log event metadata.
+/// It maintains last known extracted value of field and uses it in the absence of field.
+struct MetaExtractor {
     field: &'static str,
     to_field: OptionalValuePath,
     value: Option<Value>,
     log_namespace: LogNamespace,
 }
 
-impl DefaultExtractor {
+impl MetaExtractor {
     const fn new(
         field: &'static str,
         to_field: OptionalValuePath,
         log_namespace: LogNamespace,
     ) -> Self {
-        DefaultExtractor {
+        MetaExtractor {
             field,
             to_field,
             value: None,
@@ -1014,7 +1024,7 @@ impl DefaultExtractor {
         value: impl Into<Option<Value>>,
         log_namespace: LogNamespace,
     ) -> Self {
-        DefaultExtractor {
+        MetaExtractor {
             field,
             to_field,
             value: value.into(),
@@ -1039,6 +1049,59 @@ impl DefaultExtractor {
                 &self.to_field.path.clone().unwrap_or(owned_value_path!("")),
                 index.clone(),
             )
+        }
+    }
+}
+
+/// Extractor describes a hook that can be attached to the splunk source to extract custom properties
+/// from the request and received values and add them to the log event.
+///
+/// The default implementation of the trait is DefaultExtractor which extracts the host field, index,
+/// source and sourcetype fields and stores them in the log metadata.
+///
+/// This DefaultExtractor can be wrapped in a custom implementation to extract additional properties.
+pub trait Extractor {
+    /// create a new instance of the extractor
+    fn new(meta: RequestMeta, log_namespace: LogNamespace) -> Self;
+
+    /// extract will be called for each value in the request and the associated log.
+    fn extract(&mut self, log: &mut LogEvent, value: &mut JsonValue);
+}
+
+pub struct DefaultExtractor {
+    extractors: [MetaExtractor; 4],
+}
+
+impl Extractor for DefaultExtractor {
+    fn new(meta: RequestMeta, log_namespace: LogNamespace) -> Self {
+        DefaultExtractor {
+            extractors: [
+                // Extract the host field with the given priority:
+                // 1. The host field is present in the event payload
+                // 2. The x-forwarded-for header is present in the incoming request
+                // 3. Use the `remote`: SocketAddr value provided by warp
+                MetaExtractor::new_with(
+                    "host",
+                    log_schema().host_key().cloned().into(),
+                    meta.remote_addr
+                        .or_else(|| meta.remote.map(|addr| addr.to_string()))
+                        .map(Value::from),
+                    log_namespace,
+                ),
+                MetaExtractor::new("index", OptionalValuePath::new(INDEX), log_namespace),
+                MetaExtractor::new("source", OptionalValuePath::new(SOURCE), log_namespace),
+                MetaExtractor::new(
+                    "sourcetype",
+                    OptionalValuePath::new(SOURCETYPE),
+                    log_namespace,
+                ),
+            ],
+        }
+    }
+
+    fn extract(&mut self, log: &mut LogEvent, value: &mut JsonValue) {
+        for de in self.extractors.iter_mut() {
+            de.extract(log, value);
         }
     }
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -995,20 +995,20 @@ fn parse_timestamp(t: i64) -> Option<DateTime<Utc>> {
 
 /// MetaExtractor is a helper struct that extracts a field from the request and adds it to the log event metadata.
 /// It maintains last known extracted value of field and uses it in the absence of field.
-struct MetaExtractor {
+struct FieldExtractor {
     field: &'static str,
     to_field: OptionalValuePath,
     value: Option<Value>,
     log_namespace: LogNamespace,
 }
 
-impl MetaExtractor {
+impl FieldExtractor {
     const fn new(
         field: &'static str,
         to_field: OptionalValuePath,
         log_namespace: LogNamespace,
     ) -> Self {
-        MetaExtractor {
+        Self {
             field,
             to_field,
             value: None,
@@ -1022,7 +1022,7 @@ impl MetaExtractor {
         value: impl Into<Option<Value>>,
         log_namespace: LogNamespace,
     ) -> Self {
-        MetaExtractor {
+        Self {
             field,
             to_field,
             value: value.into(),
@@ -1067,7 +1067,7 @@ pub trait Extractor {
 }
 
 pub struct DefaultExtractor {
-    extractors: [MetaExtractor; 4],
+    extractors: [FieldExtractor; 4],
 }
 
 impl Extractor for DefaultExtractor {
@@ -1078,7 +1078,7 @@ impl Extractor for DefaultExtractor {
                 // 1. The host field is present in the event payload
                 // 2. The x-forwarded-for header is present in the incoming request
                 // 3. Use the `remote`: SocketAddr value provided by warp
-                MetaExtractor::new_with(
+                FieldExtractor::new_with(
                     "host",
                     log_schema().host_key().cloned().into(),
                     meta.remote_addr
@@ -1086,9 +1086,9 @@ impl Extractor for DefaultExtractor {
                         .map(Value::from),
                     log_namespace,
                 ),
-                MetaExtractor::new("index", OptionalValuePath::new(INDEX), log_namespace),
-                MetaExtractor::new("source", OptionalValuePath::new(SOURCE), log_namespace),
-                MetaExtractor::new(
+                FieldExtractor::new("index", OptionalValuePath::new(INDEX), log_namespace),
+                FieldExtractor::new("source", OptionalValuePath::new(SOURCE), log_namespace),
+                FieldExtractor::new(
                     "sourcetype",
                     OptionalValuePath::new(SOURCETYPE),
                     log_namespace,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -712,6 +712,7 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
     store_hec_token: bool,
 }
 
+#[derive(Debug, Clone)]
 pub struct RequestMeta {
     pub token: Option<String>,
     pub remote: Option<SocketAddr>,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -436,9 +436,7 @@ impl<E: Extractor> SplunkSource<E> {
                             batch,
                             log_namespace,
                             events_received,
-                            token,
-                            store_hec_token,
-                            extractor: E::new(meta, log_namespace),
+                            extractor: E::new(meta, log_namespace, store_hec_token),
                         }
                         .into();
 
@@ -702,14 +700,10 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
     extractor: E,
     /// Event finalization
     batch: Option<BatchNotifier>,
-    /// Splunk HEC Token for passthrough
-    token: Option<Arc<str>>,
     /// Lognamespace to put the events in
     log_namespace: LogNamespace,
     /// handle to EventsReceived registry
     events_received: Registered<EventsReceived>,
-    /// Whether to store the HEC token in the log event metadata
-    store_hec_token: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -726,8 +720,6 @@ struct EventIteratorGenerator<'de, R: JsonRead<'de>, E: Extractor> {
     batch: Option<BatchNotifier>,
     log_namespace: LogNamespace,
     events_received: Registered<EventsReceived>,
-    token: Option<String>,
-    store_hec_token: bool,
     extractor: E,
 }
 
@@ -740,12 +732,10 @@ impl<'de, R: JsonRead<'de>, E: Extractor> From<EventIteratorGenerator<'de, R, E>
             events: 0,
             channel: f.channel.map(Value::from),
             time: Time::Now(Utc::now()),
-            token: f.token.map(Into::into),
             extractor: f.extractor,
             batch: f.batch,
             log_namespace: f.log_namespace,
             events_received: f.events_received,
-            store_hec_token: f.store_hec_token,
         }
     }
 }
@@ -846,13 +836,6 @@ impl<'de, R: JsonRead<'de>, E: Extractor> EventIterator<'de, R, E> {
 
         // Extract default extracted fields
         self.extractor.extract(&mut log, &mut json);
-
-        // Add passthrough token if present
-        if let Some(token) = &self.token
-            && self.store_hec_token
-        {
-            log.metadata_mut().set_splunk_hec_token(Arc::clone(token));
-        }
 
         if let Some(batch) = self.batch.clone() {
             log = log.with_batch_notifier(&batch);
@@ -1065,7 +1048,7 @@ impl FieldExtractor {
 /// This DefaultExtractor can be wrapped in a custom implementation to extract additional properties.
 pub trait Extractor {
     /// create a new instance of the extractor
-    fn new(meta: RequestMeta, log_namespace: LogNamespace) -> Self;
+    fn new(meta: RequestMeta, log_namespace: LogNamespace, store_hec_token: bool) -> Self;
 
     /// extract will be called for each value in the request and the associated log.
     fn extract(&mut self, log: &mut LogEvent, value: &mut JsonValue);
@@ -1073,10 +1056,12 @@ pub trait Extractor {
 
 pub struct DefaultExtractor {
     extractors: [FieldExtractor; 4],
+    store_hec_token: bool,
+    token: Option<String>,
 }
 
 impl Extractor for DefaultExtractor {
-    fn new(meta: RequestMeta, log_namespace: LogNamespace) -> Self {
+    fn new(meta: RequestMeta, log_namespace: LogNamespace, store_hec_token: bool) -> Self {
         DefaultExtractor {
             extractors: [
                 // Extract the host field with the given priority:
@@ -1099,12 +1084,22 @@ impl Extractor for DefaultExtractor {
                     log_namespace,
                 ),
             ],
+            store_hec_token,
+            token: meta.token,
         }
     }
 
     fn extract(&mut self, log: &mut LogEvent, value: &mut JsonValue) {
         for de in self.extractors.iter_mut() {
             de.extract(log, value);
+        }
+
+        // Add passthrough token if present
+        if let Some(token) = &self.token
+            && self.store_hec_token
+        {
+            log.metadata_mut()
+                .set_splunk_hec_token(token.clone().into());
         }
     }
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -710,9 +710,9 @@ struct EventIterator<'de, R: JsonRead<'de>, E: Extractor> {
 }
 
 pub struct RequestMeta {
-    token: Option<String>,
-    remote: Option<SocketAddr>,
-    remote_addr: Option<String>,
+    pub token: Option<String>,
+    pub remote: Option<SocketAddr>,
+    pub remote_addr: Option<String>,
 }
 
 /// Intermediate struct to generate an `EventIterator`


### PR DESCRIPTION
This PR is the complete version of [this one](https://github.com/vectordotdev/vector/pull/23803) which implements custom extractors for the SplunkHEC source. 

## Explanation

### From the first PR
- a trait `Extractor` was created and added as a generic parameter to `SplunkSource`
- the array of `DefaultExtractor`s used in the `EventIterator` were grouped under a single `DefaultExtractor` type implementing `Extractor` and provided as the default type for the splunk source generic (the original `DefaultExtractor` type was renamed `MetaExtractor`)
- this `Extractor` trait provides a constructor which is called when instantiating the `EventIterator`, passing a `RequestMeta` object containing information about the request being processed (splunk token, remote address)
- the splunk source initialization logic was put out of the `SplunkConfig` into a `listen` method so that the SplunkSource can be easily initialized in a different context
- some methods declared in the `SplunkSource` impl which did not depend on the SplunkSource struct (`options`, `required_channel`, `lenient_json_content_type_check`) were moved to plain functions to avoid the need for calling them with `SplunkSource::<DefaultExtractor>::options()`

### Added on top of that
Add `type Config: Send + Sync + Clone` to the `Extractor` trait so that implementations can receive per-source config data (such as a token-to-attribute mapping) at extractor construction time without relying on global state.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
