### PR TITLE
chore(aws_s3 source): add custom endpoint for sqs

### DIFF
--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -242,12 +242,12 @@ impl AwsS3Config {
         let region = self.region.region();
         let endpoint = self.region.endpoint();
 
-        let s3_client = create_client::<S3ClientBuilder>(
+        let (s3_client, region) = create_client_and_region::<S3ClientBuilder>(
             &S3ClientBuilder {
                 force_path_style: Some(self.force_path_style),
             },
             &self.auth,
-            region.clone(),
+            region,
             endpoint.clone(),
             proxy,
             self.tls_options.as_ref(),
@@ -261,11 +261,22 @@ impl AwsS3Config {
 
         match self.sqs {
             Some(ref sqs) => {
-                let (sqs_client, region) = create_client_and_region::<SqsClientBuilder>(
+                let sqs_region = sqs
+                    .region
+                    .as_ref()
+                    .and_then(|r| r.region())
+                    .or_else(|| Some(region.clone()));
+                let sqs_endpoint = sqs
+                    .region
+                    .as_ref()
+                    .and_then(|r| r.endpoint())
+                    .or_else(|| endpoint.clone());
+
+                let sqs_client = create_client::<SqsClientBuilder>(
                     &SqsClientBuilder {},
                     &self.auth,
-                    region.clone(),
-                    endpoint,
+                    sqs_region,
+                    sqs_endpoint,
                     proxy,
                     sqs.tls_options.as_ref(),
                     sqs.timeout.as_ref(),

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -43,7 +43,7 @@ use vector_lib::{
 
 use crate::{
     SourceSender,
-    aws::AwsTimeout,
+    aws::{AwsTimeout, RegionOrEndpoint},
     codecs::Decoder,
     common::backoff::ExponentialBackoff,
     config::{SourceAcknowledgementsConfig, SourceContext},
@@ -183,6 +183,15 @@ pub(super) struct Config {
     /// Configuration for deferring events to another queue based on their age.
     #[configurable(derived)]
     pub(super) deferred: Option<DeferredConfig>,
+
+    /// Override the region/endpoint used for the SQS client.
+    ///
+    /// When set, this takes precedence over the top-level `region`/`endpoint` fields,
+    /// allowing S3 and SQS to connect to different hosts (e.g. MinIO for S3 and
+    /// ElasticMQ for SQS).
+    #[configurable(derived)]
+    #[serde(flatten, default)]
+    pub(super) region: Option<RegionOrEndpoint>,
 }
 
 const fn default_poll_secs() -> u32 {


### PR DESCRIPTION
## Summary
Add ability to separate SQS endpoint from s3 configuration. It's useful for working with local environments like MinIO and ElasticMQ or non-AWS clouds.

## Vector configuration

```
[sources.my_s3]
  type = "aws_s3"
  endpoint = "http://minio.cluster.local:9000/" 
  region = "us-east-1"

  [sources.my_s3.sqs]
  queue_url = "http://elasticmq.cluster.local:9324/queue/my-queue"
  endpoint = "http://elasticmq.cluster.local:9324/"
```

## How did you test this PR?
- cargo check
- make check-clippy
- local setup with own S3 and SQS endpoints

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.