### PR TITLE
feat(unit tests): add `expected_event_count` field to test outputs

### DIFF
--- a/changelog.d/20278_expected_event_count.feature.md
+++ b/changelog.d/20278_expected_event_count.feature.md
@@ -1,0 +1,1 @@
+Unit tests now support an optional `expected_event_count` field on test outputs, allowing assertions on the number of events emitted by a transform.

--- a/changelog.d/20278_expected_event_count.feature.md
+++ b/changelog.d/20278_expected_event_count.feature.md
@@ -1,1 +1,3 @@
 Unit tests now support an optional `expected_event_count` field on test outputs, allowing assertions on the number of events emitted by a transform.
+
+authors: prontidis

--- a/changelog.d/20278_expected_event_count.feature.md
+++ b/changelog.d/20278_expected_event_count.feature.md
@@ -1,3 +1,3 @@
 Unit tests now support an optional `expected_event_count` field on test outputs, allowing assertions on the number of events emitted by a transform.
 
-authors: prontidis
+authors: pront

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -446,11 +446,12 @@ impl TestDefinition<String> {
                 let TestOutput {
                     extract_from,
                     conditions,
+                    expected_event_count,
                 } = old;
 
-                (extract_from.to_vec(), conditions)
+                (extract_from.to_vec(), conditions, expected_event_count)
             })
-            .filter_map(|(extract_from, conditions)| {
+            .filter_map(|(extract_from, conditions, expected_event_count)| {
                 let mut outputs = Vec::new();
                 for from in extract_from {
                     if no_outputs_from.contains(&from) {
@@ -471,6 +472,7 @@ impl TestDefinition<String> {
                     Some(TestOutput {
                         extract_from: outputs.into(),
                         conditions,
+                        expected_event_count,
                     })
                 }
             })
@@ -525,6 +527,7 @@ impl TestDefinition<OutputId> {
                     .collect::<Vec<_>>()
                     .into(),
                 conditions: old.conditions,
+                expected_event_count: old.expected_event_count,
             })
             .collect();
 
@@ -596,6 +599,15 @@ pub struct TestOutput<T: 'static = OutputId> {
 
     /// The conditions to run against the output to validate that they were transformed as expected.
     pub conditions: Option<Vec<conditions::AnyCondition>>,
+
+    /// The expected number of events to be produced by the transform.
+    ///
+    /// If specified, the test will fail if the number of events emitted by the
+    /// transform does not match this value. This check is independent of
+    /// `conditions` -- the count is verified first, then each condition is
+    /// evaluated against the output events separately. This is useful for
+    /// transforms that may emit multiple events.
+    pub expected_event_count: Option<usize>,
 }
 
 #[cfg(all(test, feature = "sources-file", feature = "sinks-console"))]

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -293,14 +293,17 @@ impl UnitTestBuildMetadata {
         let mut template_sinks = IndexMap::new();
         let mut test_result_rxs = Vec::new();
         // Add sinks with checks
-        for (ids, checks) in outputs {
+        for (ids, (expected_event_count, checks)) in outputs {
             let (tx, rx) = oneshot::channel();
             let sink_ids = ids.clone();
             let sink_config = UnitTestSinkConfig {
                 test_name: test_name.to_string(),
                 transform_ids: ids.iter().map(|id| id.to_string()).collect(),
                 result_tx: Arc::new(Mutex::new(Some(tx))),
-                check: UnitTestSinkCheck::Checks(checks),
+                check: UnitTestSinkCheck::Checks {
+                    conditions: checks,
+                    expected_event_count,
+                },
             };
 
             test_result_rxs.push(rx);
@@ -569,8 +572,9 @@ fn build_and_validate_inputs(
 
 fn build_outputs(
     test_outputs: &[TestOutput],
-) -> Result<IndexMap<Vec<OutputId>, Vec<Vec<Condition>>>, Vec<String>> {
-    let mut outputs: IndexMap<Vec<OutputId>, Vec<Vec<Condition>>> = IndexMap::new();
+) -> Result<IndexMap<Vec<OutputId>, (Option<usize>, Vec<Vec<Condition>>)>, Vec<String>> {
+    let mut outputs: IndexMap<Vec<OutputId>, (Option<usize>, Vec<Vec<Condition>>)> =
+        IndexMap::new();
     let mut errors = Vec::new();
 
     for output in test_outputs {
@@ -590,10 +594,30 @@ fn build_outputs(
             }
         }
 
+        let expected_event_count = output.expected_event_count;
+        if expected_event_count == Some(0) && !conditions.is_empty() {
+            errors.push(format!(
+                "output for {:?} has expected_event_count of 0 but also defines conditions; \
+                 conditions cannot be evaluated when no events are expected",
+                output.extract_from
+            ));
+        }
         outputs
             .entry(output.extract_from.clone().to_vec())
-            .and_modify(|existing_conditions| existing_conditions.push(conditions.clone()))
-            .or_insert(vec![conditions.clone()]);
+            .and_modify(|(existing_count, existing_conditions)| {
+                if let (Some(existing), Some(new)) = (*existing_count, expected_event_count) {
+                    if existing != new {
+                        errors.push(format!(
+                            "conflicting expected_event_count for extract_from {:?}: {} vs {}",
+                            output.extract_from, existing, new
+                        ));
+                    }
+                } else if existing_count.is_none() {
+                    *existing_count = expected_event_count;
+                }
+                existing_conditions.push(conditions.clone());
+            })
+            .or_insert((expected_event_count, vec![conditions.clone()]));
     }
 
     if errors.is_empty() {

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -293,7 +293,7 @@ impl UnitTestBuildMetadata {
         let mut template_sinks = IndexMap::new();
         let mut test_result_rxs = Vec::new();
         // Add sinks with checks
-        for (ids, (expected_event_count, checks)) in outputs {
+        for (ids, built) in outputs {
             let (tx, rx) = oneshot::channel();
             let sink_ids = ids.clone();
             let sink_config = UnitTestSinkConfig {
@@ -301,8 +301,8 @@ impl UnitTestBuildMetadata {
                 transform_ids: ids.iter().map(|id| id.to_string()).collect(),
                 result_tx: Arc::new(Mutex::new(Some(tx))),
                 check: UnitTestSinkCheck::Checks {
-                    conditions: checks,
-                    expected_event_count,
+                    conditions: built.conditions,
+                    expected_event_count: built.expected_event_count,
                 },
             };
 
@@ -570,11 +570,16 @@ fn build_and_validate_inputs(
     }
 }
 
+#[derive(Default)]
+pub(super) struct BuiltOutput {
+    pub(super) expected_event_count: Option<usize>,
+    pub(super) conditions: Vec<Vec<Condition>>,
+}
+
 fn build_outputs(
     test_outputs: &[TestOutput],
-) -> Result<IndexMap<Vec<OutputId>, (Option<usize>, Vec<Vec<Condition>>)>, Vec<String>> {
-    let mut outputs: IndexMap<Vec<OutputId>, (Option<usize>, Vec<Vec<Condition>>)> =
-        IndexMap::new();
+) -> Result<IndexMap<Vec<OutputId>, BuiltOutput>, Vec<String>> {
+    let mut outputs: IndexMap<Vec<OutputId>, BuiltOutput> = IndexMap::new();
     let mut errors = Vec::new();
 
     for output in test_outputs {
@@ -604,27 +609,32 @@ fn build_outputs(
         }
         outputs
             .entry(output.extract_from.clone().to_vec())
-            .and_modify(|(existing_count, existing_conditions)| {
-                if let (Some(existing), Some(new)) = (*existing_count, expected_event_count) {
-                    if existing != new {
+            .and_modify(|existing| {
+                if let (Some(prev), Some(new)) =
+                    (existing.expected_event_count, expected_event_count)
+                {
+                    if prev != new {
                         errors.push(format!(
                             "conflicting expected_event_count for extract_from {:?}: {} vs {}",
-                            output.extract_from, existing, new
+                            output.extract_from, prev, new
                         ));
                     }
-                } else if existing_count.is_none() {
-                    *existing_count = expected_event_count;
+                } else if existing.expected_event_count.is_none() {
+                    existing.expected_event_count = expected_event_count;
                 }
-                existing_conditions.push(conditions.clone());
+                existing.conditions.push(conditions.clone());
             })
-            .or_insert((expected_event_count, vec![conditions.clone()]));
+            .or_insert_with(|| BuiltOutput {
+                expected_event_count,
+                conditions: vec![conditions.clone()],
+            });
     }
 
     // Post-merge validation: after merging entries that share the same
     // extract_from, reject any that ended up with expected_event_count of 0 and
     // non-empty conditions (which would pass vacuously against zero events).
-    for (extract_from, (count, conditions)) in &outputs {
-        if count == &Some(0) && conditions.iter().any(|c| !c.is_empty()) {
+    for (extract_from, built) in &outputs {
+        if built.expected_event_count == Some(0) && built.conditions.iter().any(|c| !c.is_empty()) {
             errors.push(format!(
                 "output for {extract_from:?} has expected_event_count of 0 but also defines conditions; \
                  conditions cannot be evaluated when no events are expected",

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -620,6 +620,18 @@ fn build_outputs(
             .or_insert((expected_event_count, vec![conditions.clone()]));
     }
 
+    // Post-merge validation: after merging entries that share the same
+    // extract_from, reject any that ended up with expected_event_count of 0 and
+    // non-empty conditions (which would pass vacuously against zero events).
+    for (extract_from, (count, conditions)) in &outputs {
+        if count == &Some(0) && conditions.iter().any(|c| !c.is_empty()) {
+            errors.push(format!(
+                "output for {extract_from:?} has expected_event_count of 0 but also defines conditions; \
+                 conditions cannot be evaluated when no events are expected",
+            ));
+        }
+    }
+
     if errors.is_empty() {
         Ok(outputs)
     } else {

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -1298,3 +1298,194 @@ async fn test_glob_input() {
     let mut tests = build_unit_tests(config).await.unwrap();
     assert!(tests.remove(0).run().await.errors.is_empty());
 }
+
+#[tokio::test]
+async fn expected_event_count_correct() {
+    crate::test_util::trace_init();
+
+    let config: ConfigBuilder = crate::config::format::deserialize(
+        indoc! {r#"
+                transforms:
+                  foo:
+                    inputs:
+                      - ignored
+                    type: remap
+                    source: |
+                      . = [{"message": "one"}, {"message": "two"}, {"message": "three"}]
+                tests:
+                  - name: event count check
+                    inputs:
+                      - insert_at: foo
+                        value: doesnt matter
+                    outputs:
+                      - extract_from: foo
+                        expected_event_count: 3
+                        conditions:
+                          - type: vrl
+                            source: |
+                              assert!(exists(.message), "message field must exist")
+            "#},
+        crate::config::Format::Yaml,
+    )
+    .unwrap();
+
+    let mut tests = build_unit_tests(config).await.unwrap();
+    assert!(tests.remove(0).run().await.errors.is_empty());
+}
+
+#[tokio::test]
+async fn expected_event_count_wrong() {
+    crate::test_util::trace_init();
+
+    let config: ConfigBuilder = crate::config::format::deserialize(
+        indoc! {r#"
+                transforms:
+                  foo:
+                    inputs:
+                      - ignored
+                    type: remap
+                    source: |
+                      . = [{"message": "one"}, {"message": "two"}, {"message": "three"}]
+                tests:
+                  - name: wrong event count
+                    inputs:
+                      - insert_at: foo
+                        value: doesnt matter
+                    outputs:
+                      - extract_from: foo
+                        expected_event_count: 2
+                        conditions:
+                          - type: vrl
+                            source: |
+                              assert!(exists(.message), "message field must exist")
+            "#},
+        crate::config::Format::Yaml,
+    )
+    .unwrap();
+
+    let mut tests = build_unit_tests(config).await.unwrap();
+    let errors = tests.remove(0).run().await.errors;
+    assert!(!errors.is_empty());
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.contains("expected 2 events") && e.contains("but received 3")),
+        "expected event count error, got: {errors:?}"
+    );
+}
+
+#[tokio::test]
+async fn expected_event_count_zero_no_conditions() {
+    crate::test_util::trace_init();
+
+    let config: ConfigBuilder = crate::config::format::deserialize(
+        indoc! {r#"
+            transforms:
+              foo:
+                inputs:
+                  - ignored
+                type: remap
+                source: |
+                  if .message == "drop me" {
+                    abort
+                  }
+            tests:
+              - name: zero events expected
+                inputs:
+                  - insert_at: foo
+                    value: "drop me"
+                outputs:
+                  - extract_from: foo
+                    expected_event_count: 0
+        "#},
+        crate::config::Format::Yaml,
+    )
+    .unwrap();
+
+    let mut tests = build_unit_tests(config).await.unwrap();
+    assert!(tests.remove(0).run().await.errors.is_empty());
+}
+
+#[tokio::test]
+async fn expected_event_count_zero_with_conditions_rejected() {
+    crate::test_util::trace_init();
+
+    let config: ConfigBuilder = crate::config::format::deserialize(
+        indoc! {r#"
+            transforms:
+              foo:
+                inputs:
+                  - ignored
+                type: remap
+                source: |
+                  if .message == "drop me" {
+                    abort
+                  }
+            tests:
+              - name: zero with conditions
+                inputs:
+                  - insert_at: foo
+                    value: "drop me"
+                outputs:
+                  - extract_from: foo
+                    expected_event_count: 0
+                    conditions:
+                      - type: vrl
+                        source: |
+                          assert!(exists(.message), "unreachable")
+        "#},
+        crate::config::Format::Yaml,
+    )
+    .unwrap();
+
+    let errs = build_unit_tests(config).await.err().unwrap();
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("expected_event_count of 0") && e.contains("conditions")),
+        "expected config error about zero count with conditions, got: {errs:?}"
+    );
+}
+
+#[tokio::test]
+async fn expected_event_count_conflicting_values() {
+    crate::test_util::trace_init();
+
+    let config: ConfigBuilder = crate::config::format::deserialize(
+        indoc! {r#"
+            transforms:
+              foo:
+                inputs:
+                  - ignored
+                type: remap
+                source: |
+                  . = [{"message": "one"}, {"message": "two"}]
+            tests:
+              - name: conflicting counts
+                inputs:
+                  - insert_at: foo
+                    value: doesnt matter
+                outputs:
+                  - extract_from: foo
+                    expected_event_count: 2
+                    conditions:
+                      - type: vrl
+                        source: |
+                          assert!(exists(.message), "ok")
+                  - extract_from: foo
+                    expected_event_count: 5
+                    conditions:
+                      - type: vrl
+                        source: |
+                          assert!(exists(.message), "ok")
+        "#},
+        crate::config::Format::Yaml,
+    )
+    .unwrap();
+
+    let errs = build_unit_tests(config).await.err().unwrap();
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("conflicting expected_event_count")),
+        "expected conflicting count error, got: {errs:?}"
+    );
+}

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -1305,26 +1305,26 @@ async fn expected_event_count_correct() {
 
     let config: ConfigBuilder = crate::config::format::deserialize(
         indoc! {r#"
-                transforms:
-                  foo:
-                    inputs:
-                      - ignored
-                    type: remap
-                    source: |
-                      . = [{"message": "one"}, {"message": "two"}, {"message": "three"}]
-                tests:
-                  - name: event count check
-                    inputs:
-                      - insert_at: foo
-                        value: doesnt matter
-                    outputs:
-                      - extract_from: foo
-                        expected_event_count: 3
-                        conditions:
-                          - type: vrl
-                            source: |
-                              assert!(exists(.message), "message field must exist")
-            "#},
+            transforms:
+              foo:
+                inputs:
+                  - ignored
+                type: remap
+                source: |
+                  . = [{"message": "one"}, {"message": "two"}, {"message": "three"}]
+            tests:
+              - name: event count check
+                inputs:
+                  - insert_at: foo
+                    value: doesnt matter
+                outputs:
+                  - extract_from: foo
+                    expected_event_count: 3
+                    conditions:
+                      - type: vrl
+                        source: |
+                          assert!(exists(.message), "message field must exist")
+        "#},
         crate::config::Format::Yaml,
     )
     .unwrap();
@@ -1339,26 +1339,26 @@ async fn expected_event_count_wrong() {
 
     let config: ConfigBuilder = crate::config::format::deserialize(
         indoc! {r#"
-                transforms:
-                  foo:
-                    inputs:
-                      - ignored
-                    type: remap
-                    source: |
-                      . = [{"message": "one"}, {"message": "two"}, {"message": "three"}]
-                tests:
-                  - name: wrong event count
-                    inputs:
-                      - insert_at: foo
-                        value: doesnt matter
-                    outputs:
-                      - extract_from: foo
-                        expected_event_count: 2
-                        conditions:
-                          - type: vrl
-                            source: |
-                              assert!(exists(.message), "message field must exist")
-            "#},
+            transforms:
+              foo:
+                inputs:
+                  - ignored
+                type: remap
+                source: |
+                  . = [{"message": "one"}, {"message": "two"}, {"message": "three"}]
+            tests:
+              - name: wrong event count
+                inputs:
+                  - insert_at: foo
+                    value: doesnt matter
+                outputs:
+                  - extract_from: foo
+                    expected_event_count: 2
+                    conditions:
+                      - type: vrl
+                        source: |
+                          assert!(exists(.message), "message field must exist")
+        "#},
         crate::config::Format::Yaml,
     )
     .unwrap();

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -1489,3 +1489,47 @@ async fn expected_event_count_conflicting_values() {
         "expected conflicting count error, got: {errs:?}"
     );
 }
+
+#[tokio::test]
+async fn expected_event_count_zero_split_with_conditions_rejected() {
+    crate::test_util::trace_init();
+
+    // Splitting expected_event_count: 0 and conditions across two output
+    // entries that share the same extract_from must still be rejected after
+    // merge, otherwise the conditions would pass vacuously against zero events.
+    let config: ConfigBuilder = crate::config::format::deserialize(
+        indoc! {r#"
+            transforms:
+              foo:
+                inputs:
+                  - ignored
+                type: remap
+                source: |
+                  if .message == "drop me" {
+                    abort
+                  }
+            tests:
+              - name: split zero with conditions
+                inputs:
+                  - insert_at: foo
+                    value: "drop me"
+                outputs:
+                  - extract_from: foo
+                    expected_event_count: 0
+                  - extract_from: foo
+                    conditions:
+                      - type: vrl
+                        source: |
+                          assert!(false, "should never be evaluated")
+        "#},
+        crate::config::Format::Yaml,
+    )
+    .unwrap();
+
+    let errs = build_unit_tests(config).await.err().unwrap();
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("expected_event_count of 0") && e.contains("conditions")),
+        "expected config error about zero count with conditions after merge, got: {errs:?}"
+    );
+}

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -117,7 +117,10 @@ impl SourceConfig for UnitTestStreamSourceConfig {
 #[derive(Clone, Default)]
 pub enum UnitTestSinkCheck {
     /// Check all events that are received against the list of conditions.
-    Checks(Vec<Vec<Condition>>),
+    Checks {
+        conditions: Vec<Vec<Condition>>,
+        expected_event_count: Option<usize>,
+    },
 
     /// Check that no events were received.
     NoOutputs,
@@ -203,8 +206,21 @@ impl StreamSink<Event> for UnitTestSink {
         }
 
         match self.check {
-            UnitTestSinkCheck::Checks(checks) => {
-                if output_events.is_empty() {
+            UnitTestSinkCheck::Checks {
+                conditions: checks,
+                expected_event_count,
+            } => {
+                if let Some(expected) = expected_event_count {
+                    let actual = output_events.len();
+                    if actual != expected {
+                        result.test_errors.push(format!(
+                            "expected {} events from transforms {:?}, but received {}",
+                            expected, self.transform_ids, actual
+                        ));
+                    }
+                }
+
+                if output_events.is_empty() && expected_event_count != Some(0) {
                     result
                         .test_errors
                         .push(format!("checks for transforms {:?} failed: no events received. Topology may be disconnected or transform is missing inputs.", self.transform_ids));


### PR DESCRIPTION
## Summary

- Adds an optional `expected_event_count` field to the `TestOutput` config struct, allowing users to assert on the number of events emitted by a transform in unit tests.
- Useful for transforms that emit multiple events (e.g., `remap`), where previously there was no way to verify the event count.
- Fully backwards-compatible: omitting the field skips the check entirely.

This is a low hanging since it was requested multiple times across various channels and it's easy to implement.

## Vector configuration

```yaml
tests:
  - name: split produces three events
    inputs:
      - insert_at: my_transform
        value: "one,two,three"
    outputs:
      - extract_from: my_transform
        expected_event_count: 3
        conditions:
          - type: vrl
            source: |
              assert!(exists(.message), "message field must exist")
```

## How did you test this PR?

Added two unit tests in `src/config/unit_test/tests.rs`:
1. `expected_event_count_correct` - verifies a matching count passes
2. `expected_event_count_wrong` - verifies a mismatched count produces a clear error message

Also ran `make check-clippy`, `make check-fmt`, and `make check-generated-docs` locally.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #20278

🤖 Generated with [Claude Code](https://claude.com/claude-code)