### PR TITLE
fix(deps): override smol-toml to 1.6.1 for markdownlint-cli2

### DIFF
--- a/scripts/environment/npm-tools/package-lock.json
+++ b/scripts/environment/npm-tools/package-lock.json
@@ -1232,9 +1232,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/scripts/environment/npm-tools/package.json
+++ b/scripts/environment/npm-tools/package.json
@@ -1,6 +1,11 @@
 {
   "private": true,
   "description": "Pinned npm tools for CI. Run 'npm ci' to install with exact versions from package-lock.json.",
+  "overrides": {
+    "markdownlint-cli2": {
+      "smol-toml": "1.6.1"
+    }
+  },
   "dependencies": {
     "@datadog/datadog-ci": "5.13.0",
     "markdownlint-cli2": "0.22.0",


### PR DESCRIPTION
## Summary

Override smol-toml from 1.6.0 to 1.6.1 in markdownlint-cli2 to address [GHSA-v3rj-xjv7-4jmq](https://github.com/advisories/GHSA-v3rj-xjv7-4jmq).

## Vector configuration

NA

## How did you test this PR?

`npm ls smol-toml` confirms the override is applied.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/advisories/GHSA-v3rj-xjv7-4jmq