### PR TITLE
chore(deps): bump VRL and add feature for enable_crypto_functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -533,6 +533,7 @@ tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 vrl-functions-env = ["vrl/enable_env_functions"]
 vrl-functions-system = ["vrl/enable_system_functions"]
 vrl-functions-network = ["vrl/enable_network_functions"]
+vrl-functions-crypto = ["vrl/enable_crypto_functions"]
 
 # Enables the binary secret-backend-example
 secret-backend-example = ["transforms"]

--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ test-behavior-config: ## Runs configuration related behavioral tests
 
 .PHONY: test-behavior-%
 test-behavior-%: ## Runs behavioral test for a given category
-	${MAYBE_ENVIRONMENT_EXEC} cargo run --no-default-features --features transforms,vrl-functions-env,vrl-functions-system,vrl-functions-network -- test tests/behavior/$*/*
+	${MAYBE_ENVIRONMENT_EXEC} cargo run --no-default-features --features transforms,vrl-functions-env,vrl-functions-system,vrl-functions-network,vrl-functions-crypto -- test tests/behavior/$*/*
 
 .PHONY: test-behavior
 test-behavior: ## Runs all behavioral tests


### PR DESCRIPTION
## Summary

Bumps VRL and adds the `vrl-functions-crypto` feature to expose VRL's `enable_crypto_functions` in Vector, matching the existing env/system/network features.

## Vector configuration

NA

## How did you test this PR?

MQ: noticed failures when VRL was bumped in #24971 which caused `sha` functions to be undefined in `make test-behavior`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vrl/pull/1680