### PR TITLE
fix(ci): fix secrets in static analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,14 +13,17 @@ permissions:
 jobs:
   static-analysis:
     runs-on: ubuntu-latest
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Datadog Static Analyzer
-        if: ${{ secrets.DD_API_KEY != '' }}
+        if: ${{ env.DD_API_KEY != '' }}
         uses: DataDog/datadog-static-analyzer-github-action@8340f18875fcefca86844b5f947ce2431387e552 # v3.0.0
         with:
-          dd_api_key: ${{ secrets.DD_API_KEY }}
-          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_api_key: ${{ env.DD_API_KEY }}
+          dd_app_key: ${{ env.DD_APP_KEY }}
           dd_site: datadoghq.com
           secrets_enabled: true


### PR DESCRIPTION
## Summary

The `secrets` context is not a recognized named-value in workflow expression evaluation for merge queue pushes, causing the static-analysis workflow to fail at parse time with 0 jobs. Secrets are now passed through job-level `env` vars instead.

## Vector configuration

NA

## How did you test this PR?

Validated the workflow YAML syntax. The fix follows the documented GitHub Actions pattern for referencing secrets in step `if` conditions.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/24480483836