### PR TITLE
fix(ci): modernize cross ubuntu bootstrap script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,13 +267,27 @@ cross-enable: cargo-install-cross
 CARGO_HANDLES_FRESHNESS:
 	${EMPTY}
 
+# Pinned digests for ghcr.io/cross-rs/<target>:edge.
+# Source: cross-rs/cross @ f86fd03bb70b4c6802847c18087e21391498b0b4, built 2026-04-10 (Ubuntu 20.04 focal).
+# Refresh with: crane digest ghcr.io/cross-rs/<target>:edge
+CROSS_DIGEST_x86_64-unknown-linux-gnu       := sha256:13f7a68e55cb05a19e840bce65834fc785dc069e0c2218d12b8fdb8f8a1519d5
+CROSS_DIGEST_aarch64-unknown-linux-gnu      := sha256:3bf094d22fc4f73c9bdce45ddd7a8bbae349efdbd51b4d4b5ee1bedd8454466b
+CROSS_DIGEST_x86_64-unknown-linux-musl      := sha256:c59deede3efcd7cb6f6a57641241ba1c63cfe35b7965be09a851242b4209639d
+CROSS_DIGEST_aarch64-unknown-linux-musl     := sha256:dad492e0f040c6e712d4be9b970c9de5f3b8ef9cde6b9a2b437d56d1dabeb808
+CROSS_DIGEST_armv7-unknown-linux-gnueabihf  := sha256:73294ebb06e077e49bbbecfe8f17507e9e0b733a2a1ba23056abcd9c0ba617c9
+CROSS_DIGEST_armv7-unknown-linux-musleabihf := sha256:49bdc9a4cf2f1bcb385389c85be8f43c4399fa6d6fe22883702ef13eb921e443
+CROSS_DIGEST_arm-unknown-linux-gnueabi      := sha256:0c70b0e54724bd599dff00a2888f8ea176a5b6c85af47aad9ad25296f63e2967
+CROSS_DIGEST_arm-unknown-linux-musleabi     := sha256:0ca8f4afcc29fb5964aa63e482452e8869311a610c5868f22ded400c4e483328
+
 # GNU Make < 3.82 pattern matching priority depends on the definition order
 # so cross-image-% must be defined before cross-%
 .PHONY: cross-image-%
 cross-image-%: export TRIPLE =$($(strip @):cross-image-%=%)
 cross-image-%:
+	$(if $(CROSS_DIGEST_$*),,$(error No CROSS_DIGEST pinned for $*. Add it to the digest table in Makefile.))
 	$(CONTAINER_TOOL) build \
 		--build-arg TARGET=${TRIPLE} \
+		--build-arg CROSS_DIGEST=$(CROSS_DIGEST_$*) \
 		--file scripts/cross/Dockerfile \
 		--tag vector-cross-env:${TRIPLE} \
 		.

--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -1,7 +1,7 @@
-ARG CROSS_VERSION=0.2.5
 ARG TARGET=x86_64-unknown-linux-musl
+ARG CROSS_DIGEST
 
-FROM ghcr.io/cross-rs/${TARGET}:${CROSS_VERSION}
+FROM ghcr.io/cross-rs/${TARGET}@${CROSS_DIGEST}
 
 # Common steps for all targets
 COPY scripts/cross/bootstrap-ubuntu.sh /

--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -8,6 +8,16 @@ COPY scripts/cross/bootstrap-ubuntu.sh /
 COPY scripts/environment/install-protoc.sh /
 RUN /bootstrap-ubuntu.sh && bash /install-protoc.sh
 
+# Allow cmake to find pre-built dependencies (e.g. curl from curl-sys) that
+# land in CMAKE_PREFIX_PATH rather than the cross sysroot.  The cross-rs
+# toolchain.cmake sets CMAKE_FIND_ROOT_PATH_MODE_{LIBRARY,INCLUDE} to ONLY,
+# which makes cmake ignore CMAKE_PREFIX_PATH entries outside the sysroot.
+# Switching to BOTH lets FindCURL (and similar modules) locate libraries that
+# Cargo crates like curl-sys build from source and expose via CMAKE_PREFIX_PATH.
+RUN if [ -f /opt/toolchain.cmake ]; then \
+      printf '\n# Allow finding pre-built cargo dependencies via CMAKE_PREFIX_PATH\nset(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)\nset(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)\n' >> /opt/toolchain.cmake; \
+    fi
+
 # Relocate libstdc++ for musl targets that need it (TODO: investigate if still required)
 RUN if [ "$TARGET" = "arm-unknown-linux-musleabi" ]; then \
       LIBSTDC=/usr/local/arm-linux-musleabi/lib/libstdc++.a; \

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -22,6 +22,5 @@ apt-get install -y \
   llvm \
   clang \
   unzip \
-  libsasl2-dev \
-  libcurl4-openssl-dev
+  libsasl2-dev
 

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -1,31 +1,26 @@
 #!/bin/sh
 set -o errexit
 
-echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+export DEBIAN_FRONTEND=noninteractive
+export ACCEPT_EULA=Y
+
+# Configure apt for speed and efficiency
+cat > /etc/apt/apt.conf.d/90-vector-optimizations <<EOF
+Acquire::Retries "5";
+Acquire::Queue-Mode "host";
+Acquire::Languages "none";
+APT::Install-Recommends "false";
+EOF
+
 
 apt-get update
 apt-get install -y \
   apt-transport-https \
   gnupg \
-  wget
-
-# we need LLVM >= 3.9 for onig_sys/bindgen
-
-cat <<-EOF > /etc/apt/sources.list.d/llvm.list
-deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
-deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main
-EOF
-
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
-
-apt-get update
-
-# unzip is needed for protoc
-# clang/llvm is needed due to bindgen (zstd-sys/onig_sys)
-apt-get install -y \
-      libclang1-9 \
-      llvm-9 \
-      clang \
-      unzip \
-      libsasl2-dev
+  wget \
+  libclang1 \
+  llvm \
+  clang \
+  unzip \
+  libsasl2-dev
 

--- a/scripts/cross/bootstrap-ubuntu.sh
+++ b/scripts/cross/bootstrap-ubuntu.sh
@@ -22,5 +22,6 @@ apt-get install -y \
   llvm \
   clang \
   unzip \
-  libsasl2-dev
+  libsasl2-dev \
+  libcurl4-openssl-dev
 


### PR DESCRIPTION
## Summary

Upgrade the cross-compilation base images from `ghcr.io/cross-rs/<target>:0.2.5` (Ubuntu 16.04 xenial, EOL) to pinned digests of the `:edge` tag (Ubuntu 20.04 focal, cross-rs commit `f86fd03b`, built 2026-04-10). The `apt.llvm.org/xenial` repo the old script relied on is gone, and nightly cross builds were failing as a result.

- Pinning is by SHA256 digest rather than a moving `edge` tag for reproducibility. Digests live in the Makefile alongside the `cross-image-%` recipe.
- `scripts/cross/bootstrap-ubuntu.sh` now installs `llvm`/`clang` from the base image's own repos instead of the defunct LLVM 9 apt source.

## Vector configuration

NA

## How did you test this PR?

CI trigger: See [run](https://github.com/vectordotdev/vector/actions/runs/24529364574?pr=25215).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/24494354219