### PR TITLE
fix(internal_logs source): prevent silent drops and improve throughput

### DIFF
--- a/changelog.d/24220_internal_logs_drops.fix.md
+++ b/changelog.d/24220_internal_logs_drops.fix.md
@@ -1,0 +1,3 @@
+Fixed the `internal_logs` source silently dropping events under high load. The internal broadcast channel buffer used to fan out tracing events to subscribers was raised from 99 to 10000, and any events that are still dropped due to lag now increment the standard `component_discarded_events_total{intentional="false"}` metric so the loss is observable.
+
+authors: thomasqueirozb

--- a/changelog.d/24220_internal_logs_drops.fix.md
+++ b/changelog.d/24220_internal_logs_drops.fix.md
@@ -1,3 +1,3 @@
-Fixed the `internal_logs` source silently dropping events under high load. The internal broadcast channel buffer used to fan out tracing events to subscribers was raised from 99 to 10000, and any events that are still dropped due to lag now increment the standard `component_discarded_events_total{intentional="false"}` metric so the loss is observable.
+Fixed the `internal_logs` source silently dropping events under high load. Events that are still dropped when the underlying broadcast receiver lags now increment the standard `component_discarded_events_total{intentional="false"}` metric so the loss is observable.
 
 authors: thomasqueirozb

--- a/changelog.d/24220_internal_logs_throughput.enhancement.md
+++ b/changelog.d/24220_internal_logs_throughput.enhancement.md
@@ -1,3 +1,3 @@
-Improved the throughput of the `internal_logs` source under high log volume. Broadcast consumption is now decoupled from downstream sending via a dedicated drain task plus a bounded intermediate queue, and events are forwarded downstream in batches. Under a `VECTOR_LOG=trace` firehose this reduces dropped internal log events by roughly 60%.
+Improved the throughput of the `internal_logs` source under high log volume. When using `VECTOR_LOG=trace`, which produces a very high amount of logs, this reduces dropped internal log events by roughly 60%.
 
 authors: thomasqueirozb

--- a/changelog.d/24220_internal_logs_throughput.enhancement.md
+++ b/changelog.d/24220_internal_logs_throughput.enhancement.md
@@ -1,0 +1,3 @@
+Improved the throughput of the `internal_logs` source under high log volume. Broadcast consumption is now decoupled from downstream sending via a dedicated drain task plus a bounded intermediate queue, and events are forwarded downstream in batches. Under a `VECTOR_LOG=trace` firehose this reduces dropped internal log events by roughly 60%.
+
+authors: thomasqueirozb

--- a/src/internal_events/internal_logs.rs
+++ b/src/internal_events/internal_logs.rs
@@ -30,21 +30,3 @@ impl InternalEvent for InternalLogsEventsReceived {
         counter!("component_received_event_bytes_total").increment(self.byte_size.get() as u64);
     }
 }
-
-#[derive(Debug, NamedInternalEvent)]
-pub struct InternalLogsLagged {
-    pub count: u64,
-}
-
-impl InternalEvent for InternalLogsLagged {
-    fn emit(self) {
-        // MUST NOT emit logs here to avoid an infinite log loop. We mirror the
-        // standard `ComponentEventsDropped` metric so the loss surfaces in the
-        // usual dropped-events dashboards.
-        counter!(
-            "component_discarded_events_total",
-            "intentional" => "false",
-        )
-        .increment(self.count);
-    }
-}

--- a/src/internal_events/internal_logs.rs
+++ b/src/internal_events/internal_logs.rs
@@ -30,3 +30,21 @@ impl InternalEvent for InternalLogsEventsReceived {
         counter!("component_received_event_bytes_total").increment(self.byte_size.get() as u64);
     }
 }
+
+#[derive(Debug, NamedInternalEvent)]
+pub struct InternalLogsLagged {
+    pub count: u64,
+}
+
+impl InternalEvent for InternalLogsLagged {
+    fn emit(self) {
+        // MUST NOT emit logs here to avoid an infinite log loop. We mirror the
+        // standard `ComponentEventsDropped` metric so the loss surfaces in the
+        // usual dropped-events dashboards.
+        counter!(
+            "component_discarded_events_total",
+            "intentional" => "false",
+        )
+        .increment(self.count);
+    }
+}

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -4,6 +4,7 @@ use vector_lib::{
     codecs::BytesDeserializerConfig,
     config::{LegacyKey, LogNamespace, log_schema},
     configurable::configurable_component,
+    internal_event::{ComponentEventsDropped, UNINTENTIONAL},
     lookup::{OwnedValuePath, lookup_v2::OptionalValuePath, owned_value_path, path},
     schema::Definition,
 };
@@ -13,10 +14,7 @@ use crate::{
     SourceSender,
     config::{DataType, SourceConfig, SourceContext, SourceOutput},
     event::{EstimatedJsonEncodedSizeOf, Event},
-    internal_events::{
-        InternalLogsBytesReceived, InternalLogsEventsReceived, InternalLogsLagged,
-        StreamClosedError,
-    },
+    internal_events::{InternalLogsBytesReceived, InternalLogsEventsReceived, StreamClosedError},
     shutdown::ShutdownSignal,
     trace::TraceSubscription,
 };
@@ -163,12 +161,18 @@ async fn run(
 
     // Note: This loop, or anything called within it, MUST NOT generate
     // any logs that don't break the loop, as that could cause an
-    // infinite loop since it receives all such logs.
+    // infinite loop since it receives all such logs. The one exception is
+    // `ComponentEventsDropped` below, which is only emitted in response to
+    // an already-observed lag and therefore produces at most one extra log
+    // per lag incident (bounded amplification, not recursion).
     while let Some(item) = rx.next().await {
         let mut log = match item {
             Ok(log) => log,
             Err(skipped) => {
-                emit!(InternalLogsLagged { count: skipped });
+                emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                    count: skipped as usize,
+                    reason: "Internal logs broadcast receiver lagged.",
+                });
                 continue;
             }
         };

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -173,7 +173,14 @@ async fn run(
     // and then continue with the normal stream of internal log events. Buffered events are
     // wrapped in `Ok` to match the `Result<LogEvent, u64>` items produced by the live
     // subscription, where `Err(n)` indicates that `n` events were dropped due to broadcast lag.
+    //
+    // `shutdown` is cloned so the drain task can terminate its stream via `take_until`, while
+    // the main task still holds a live handle. The `ShutdownSignalToken` must outlive the
+    // entire `run()` scope — the source is only considered complete once every clone is
+    // dropped — so giving the drain task sole ownership would let topology teardown race with
+    // in-flight batches still being processed by the main task.
     let buffered_events = subscription.buffered_events().await;
+    let _shutdown_guard = shutdown.clone();
     let rx = stream::iter(buffered_events.into_iter().flatten().map(Ok))
         .chain(subscription.into_stream())
         .take_until(shutdown);

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -1,9 +1,11 @@
 use chrono::Utc;
 use futures::{StreamExt, stream};
+use tokio::sync::mpsc;
 use vector_lib::{
     codecs::BytesDeserializerConfig,
     config::{LegacyKey, LogNamespace, log_schema},
     configurable::configurable_component,
+    event::LogEvent,
     internal_event::{ComponentEventsDropped, UNINTENTIONAL},
     lookup::{OwnedValuePath, lookup_v2::OptionalValuePath, owned_value_path, path},
     schema::Definition,
@@ -18,6 +20,23 @@ use crate::{
     shutdown::ShutdownSignal,
     trace::TraceSubscription,
 };
+
+/// Capacity of the intermediate queue that decouples broadcast consumption from downstream
+/// sending. The drain task pushes into this queue as fast as it can receive from the broadcast
+/// channel; the main task pulls in batches to `send_batch`. Sized to absorb short bursts while
+/// downstream is backpressured without further growing memory.
+const INTERMEDIATE_QUEUE_CAPACITY: usize = 10_000;
+
+/// Maximum number of events the main task will gather into a single batch before calling
+/// `send_batch`. Amortizes per-call overhead (timestamp capture, metrics, chunking).
+const MAX_BATCH_SIZE: usize = 1024;
+
+/// Item flowing from the drain task to the main task.
+enum DrainItem {
+    Log(LogEvent),
+    /// `n` events were dropped at the broadcast layer (receiver lagged) before the next event.
+    Lagged(u64),
+}
 
 /// Configuration for the `internal_logs` source.
 #[configurable_component(source(
@@ -155,9 +174,18 @@ async fn run(
     // wrapped in `Ok` to match the `Result<LogEvent, u64>` items produced by the live
     // subscription, where `Err(n)` indicates that `n` events were dropped due to broadcast lag.
     let buffered_events = subscription.buffered_events().await;
-    let mut rx = stream::iter(buffered_events.into_iter().flatten().map(Ok))
+    let rx = stream::iter(buffered_events.into_iter().flatten().map(Ok))
         .chain(subscription.into_stream())
         .take_until(shutdown);
+
+    // Decouple broadcast consumption from downstream sending. The drain task consumes the
+    // broadcast as fast as possible and hands events to the main task through a bounded queue;
+    // the main task enriches and `send_batch`es them downstream. When the main task is blocked
+    // on sink backpressure, the drain task can still empty short bursts into the queue, which
+    // keeps the broadcast receiver from lagging. Under sustained overload the queue fills, the
+    // drain task backpressures, and broadcast lag is eventually surfaced via `Lagged(n)` items.
+    let (queue_tx, mut queue_rx) = mpsc::channel::<DrainItem>(INTERMEDIATE_QUEUE_CAPACITY);
+    let drain_task = tokio::spawn(drain_broadcast(rx, queue_tx));
 
     // Note: This loop, or anything called within it, MUST NOT generate
     // any logs that don't break the loop, as that could cause an
@@ -165,61 +193,101 @@ async fn run(
     // `ComponentEventsDropped` below, which is only emitted in response to
     // an already-observed lag and therefore produces at most one extra log
     // per lag incident (bounded amplification, not recursion).
-    while let Some(item) = rx.next().await {
-        let mut log = match item {
-            Ok(log) => log,
-            Err(skipped) => {
-                emit!(ComponentEventsDropped::<UNINTENTIONAL> {
-                    count: skipped as usize,
-                    reason: "Internal logs broadcast receiver lagged.",
-                });
-                continue;
-            }
-        };
-        // TODO: Should this actually be in memory size?
-        let byte_size = log.estimated_json_encoded_size_of().get();
-        let json_byte_size = log.estimated_json_encoded_size_of();
-        // This event doesn't emit any log
-        emit!(InternalLogsBytesReceived { byte_size });
-        emit!(InternalLogsEventsReceived {
-            count: 1,
-            byte_size: json_byte_size,
-        });
+    let mut batch: Vec<DrainItem> = Vec::with_capacity(MAX_BATCH_SIZE);
+    while queue_rx.recv_many(&mut batch, MAX_BATCH_SIZE).await > 0 {
+        let mut events: Vec<Event> = Vec::with_capacity(batch.len());
+        let mut byte_size_total: usize = 0;
+        let mut json_byte_size_total = vector_lib::json_size::JsonSize::zero();
+        let mut lagged_total: u64 = 0;
 
-        if let Ok(hostname) = &hostname {
-            let legacy_host_key = host_key.as_ref().map(LegacyKey::Overwrite);
-            log_namespace.insert_source_metadata(
-                InternalLogsConfig::NAME,
-                &mut log,
-                legacy_host_key,
-                path!("host"),
-                hostname.to_owned(),
-            );
+        let now = Utc::now();
+        for item in batch.drain(..) {
+            match item {
+                DrainItem::Lagged(n) => lagged_total += n,
+                DrainItem::Log(mut log) => {
+                    let byte_size = log.estimated_json_encoded_size_of().get();
+                    let json_byte_size = log.estimated_json_encoded_size_of();
+                    byte_size_total += byte_size;
+                    json_byte_size_total += json_byte_size;
+
+                    if let Ok(hostname) = &hostname {
+                        let legacy_host_key = host_key.as_ref().map(LegacyKey::Overwrite);
+                        log_namespace.insert_source_metadata(
+                            InternalLogsConfig::NAME,
+                            &mut log,
+                            legacy_host_key,
+                            path!("host"),
+                            hostname.to_owned(),
+                        );
+                    }
+
+                    let legacy_pid_key = pid_key.as_ref().map(LegacyKey::Overwrite);
+                    log_namespace.insert_source_metadata(
+                        InternalLogsConfig::NAME,
+                        &mut log,
+                        legacy_pid_key,
+                        path!("pid"),
+                        pid,
+                    );
+
+                    log_namespace.insert_standard_vector_source_metadata(
+                        &mut log,
+                        InternalLogsConfig::NAME,
+                        now,
+                    );
+
+                    events.push(Event::from(log));
+                }
+            }
         }
 
-        let legacy_pid_key = pid_key.as_ref().map(LegacyKey::Overwrite);
-        log_namespace.insert_source_metadata(
-            InternalLogsConfig::NAME,
-            &mut log,
-            legacy_pid_key,
-            path!("pid"),
-            pid,
-        );
+        if lagged_total > 0 {
+            emit!(ComponentEventsDropped::<UNINTENTIONAL> {
+                count: lagged_total as usize,
+                reason: "Internal logs broadcast receiver lagged.",
+            });
+        }
 
-        log_namespace.insert_standard_vector_source_metadata(
-            &mut log,
-            InternalLogsConfig::NAME,
-            Utc::now(),
-        );
+        if events.is_empty() {
+            continue;
+        }
 
-        if (out.send_event(Event::from(log)).await).is_err() {
+        emit!(InternalLogsBytesReceived {
+            byte_size: byte_size_total,
+        });
+        emit!(InternalLogsEventsReceived {
+            count: events.len(),
+            byte_size: json_byte_size_total,
+        });
+
+        let event_count = events.len();
+        if out.send_batch(events).await.is_err() {
             // this wont trigger any infinite loop considering it stops the component
-            emit!(StreamClosedError { count: 1 });
+            emit!(StreamClosedError { count: event_count });
             return Err(());
         }
     }
 
+    // Wait for the drain task to exit cleanly after shutdown.
+    let _ = drain_task.await;
     Ok(())
+}
+
+/// Drains `rx` into `queue_tx` as fast as possible. Runs in a spawned task so broadcast
+/// consumption is decoupled from the main task's downstream send latency.
+async fn drain_broadcast<S>(mut rx: S, queue_tx: mpsc::Sender<DrainItem>)
+where
+    S: futures::Stream<Item = Result<LogEvent, u64>> + Unpin,
+{
+    while let Some(item) = rx.next().await {
+        let drain_item = match item {
+            Ok(log) => DrainItem::Log(log),
+            Err(n) => DrainItem::Lagged(n),
+        };
+        if queue_tx.send(drain_item).await.is_err() {
+            break;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -13,7 +13,10 @@ use crate::{
     SourceSender,
     config::{DataType, SourceConfig, SourceContext, SourceOutput},
     event::{EstimatedJsonEncodedSizeOf, Event},
-    internal_events::{InternalLogsBytesReceived, InternalLogsEventsReceived, StreamClosedError},
+    internal_events::{
+        InternalLogsBytesReceived, InternalLogsEventsReceived, InternalLogsLagged,
+        StreamClosedError,
+    },
     shutdown::ShutdownSignal,
     trace::TraceSubscription,
 };
@@ -150,16 +153,25 @@ async fn run(
     let pid = std::process::id();
 
     // Chain any log events that were captured during early buffering to the front,
-    // and then continue with the normal stream of internal log events.
+    // and then continue with the normal stream of internal log events. Buffered events are
+    // wrapped in `Ok` to match the `Result<LogEvent, u64>` items produced by the live
+    // subscription, where `Err(n)` indicates that `n` events were dropped due to broadcast lag.
     let buffered_events = subscription.buffered_events().await;
-    let mut rx = stream::iter(buffered_events.into_iter().flatten())
+    let mut rx = stream::iter(buffered_events.into_iter().flatten().map(Ok))
         .chain(subscription.into_stream())
         .take_until(shutdown);
 
     // Note: This loop, or anything called within it, MUST NOT generate
     // any logs that don't break the loop, as that could cause an
     // infinite loop since it receives all such logs.
-    while let Some(mut log) = rx.next().await {
+    while let Some(item) = rx.next().await {
+        let mut log = match item {
+            Ok(log) => log,
+            Err(skipped) => {
+                emit!(InternalLogsLagged { count: skipped });
+                continue;
+            }
+        };
         // TODO: Should this actually be in memory size?
         let byte_size = log.estimated_json_encoded_size_of().get();
         let json_byte_size = log.estimated_json_encoded_size_of();

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -541,4 +541,65 @@ mod tests {
 
         assert_eq!(definitions, Some(expected_definition))
     }
+
+    // Verify that broadcast lag is surfaced via `component_discarded_events_total` rather
+    // than being silently swallowed.
+    //
+    // Strategy: run inside a single-threaded tokio runtime (the default for `#[tokio::test]`).
+    // While the current task holds the CPU without yielding, no other tokio tasks are scheduled.
+    // We flood the broadcast channel (capacity 99) with more events than it can hold. The drain
+    // task hasn't polled yet, so the broadcast overflows and records a lag count. After we yield,
+    // the drain task observes `Lagged(n)` and the main task emits `ComponentEventsDropped`.
+    // We use a non-consuming downstream receiver to ensure `send_batch` eventually blocks,
+    // preventing any events from being silently drained before we check the metric.
+    #[tokio::test]
+    #[serial]
+    async fn broadcast_lag_increments_discarded_metric() {
+        trace::init(false, false, "error", 10);
+        vector_lib::metrics::init_test();
+        trace::reset_early_buffer();
+
+        // The downstream receiver is intentionally not polled; this means the source's
+        // send_batch will block once the output channel fills, creating backpressure that
+        // ensures the intermediate queue and broadcast stay full during the flood.
+        let (tx, _rx) = SourceSender::new_test();
+        let source = InternalLogsConfig::default()
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(source);
+
+        // Yield twice: once for the drain task to start polling the broadcast, once for the
+        // main task to start polling the queue. Both will block immediately (nothing to read).
+        tokio::task::yield_now().await;
+        trace::stop_early_buffering();
+        tokio::task::yield_now().await;
+
+        let controller = vector_lib::metrics::Controller::get()
+            .expect("metrics controller must be initialized");
+        controller.reset();
+
+        // Emit more events than the broadcast capacity (99) without yielding. In a
+        // single-threaded runtime this guarantees the drain task cannot poll between emits,
+        // so the broadcast overflows and accumulates a lag count.
+        for i in 0usize..200 {
+            error!(message = "broadcast lag test", i);
+        }
+
+        // Yield enough times for the drain task to observe the Lagged error and the main
+        // task to emit ComponentEventsDropped.
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+
+        let discarded_any = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_discarded_events_total");
+
+        assert!(
+            discarded_any,
+            "expected component_discarded_events_total to be emitted when broadcast lags"
+        );
+    }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -9,13 +9,13 @@ use std::{
     },
 };
 
-use futures_util::{Stream, StreamExt, future::ready};
+use futures_util::{Stream, StreamExt};
 use metrics_tracing_context::MetricsLayer;
 use tokio::sync::{
     broadcast::{self, Receiver, Sender},
     oneshot,
 };
-use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use tracing::{Event, Subscriber};
 use tracing_limit::RateLimitedLayer;
 use tracing_subscriber::{
@@ -169,9 +169,14 @@ fn consume_early_buffer() -> Vec<LogEvent> {
         .expect("early buffer was already consumed")
 }
 
+/// Capacity of the broadcast channel used to fan out internal log events to subscribers
+/// (e.g. the `internal_logs` source). Sized to absorb bursts without dropping events at
+/// elevated log levels while keeping worst-case memory bounded.
+const TRACE_BROADCAST_CAPACITY: usize = 10_000;
+
 /// Gets or creates a trace sender for sending internal log events.
 fn get_trace_sender() -> &'static broadcast::Sender<LogEvent> {
-    SENDER.get_or_init(|| broadcast::channel(99).0)
+    SENDER.get_or_init(|| broadcast::channel(TRACE_BROADCAST_CAPACITY).0)
 }
 
 /// Attempts to get the trace sender for sending internal log events.
@@ -279,10 +284,14 @@ impl TraceSubscription {
     }
 
     /// Converts this subscription into a raw stream of log events.
-    pub fn into_stream(self) -> impl Stream<Item = LogEvent> + Unpin {
-        // We ignore errors because the only error we get is when the broadcast receiver lags, and there's nothing we
-        // can actually do about that so there's no reason to force callers to even deal with it.
-        BroadcastStream::new(self.trace_rx).filter_map(|event| ready(event.ok()))
+    ///
+    /// `Err(n)` items signal that the underlying broadcast receiver lagged and `n` events were
+    /// dropped before the next successful receive. Callers are expected to surface this via a
+    /// metric — they MUST NOT log it through `tracing`, since that would feed back into this
+    /// broadcast and can amplify the lag.
+    pub fn into_stream(self) -> impl Stream<Item = Result<LogEvent, u64>> + Unpin {
+        BroadcastStream::new(self.trace_rx)
+            .map(|event| event.map_err(|BroadcastStreamRecvError::Lagged(n)| n))
     }
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -169,14 +169,9 @@ fn consume_early_buffer() -> Vec<LogEvent> {
         .expect("early buffer was already consumed")
 }
 
-/// Capacity of the broadcast channel used to fan out internal log events to subscribers
-/// (e.g. the `internal_logs` source). Sized to absorb bursts without dropping events at
-/// elevated log levels while keeping worst-case memory bounded.
-const TRACE_BROADCAST_CAPACITY: usize = 10_000;
-
 /// Gets or creates a trace sender for sending internal log events.
 fn get_trace_sender() -> &'static broadcast::Sender<LogEvent> {
-    SENDER.get_or_init(|| broadcast::channel(TRACE_BROADCAST_CAPACITY).0)
+    SENDER.get_or_init(|| broadcast::channel(99).0)
 }
 
 /// Attempts to get the trace sender for sending internal log events.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -287,7 +287,7 @@ impl TraceSubscription {
     ///
     /// `Err(n)` items signal that the underlying broadcast receiver lagged and `n` events were
     /// dropped before the next successful receive. Callers are expected to surface this via a
-    /// metric — they MUST NOT log it through `tracing`, since that would feed back into this
+    /// metric. They MUST NOT log it through `tracing`, since that would feed back into this
     /// broadcast and can amplify the lag.
     pub fn into_stream(self) -> impl Stream<Item = Result<LogEvent, u64>> + Unpin {
         BroadcastStream::new(self.trace_rx)


### PR DESCRIPTION
## Summary

Fixes issue #24220: the `internal_logs` source silently dropped events under high load.

- Decouples broadcast consumption from downstream sending. A dedicated drain task pulls from the trace broadcast into a bounded intermediate queue; the main task batches from the queue and calls `send_batch`. This keeps the broadcast receiver drained while the sink is backpressured, and amortizes per-event overhead downstream.
- Surfaces any remaining drops via the standard `ComponentEventsDropped` / `component_discarded_events_total{intentional="false"}` metric, replacing the previous silent `BroadcastStreamRecvError::Lagged` swallow.

## Benchmark

Both `internal_logs` and `internal_metrics` sources feed into their own sinks. The prometheus_exporter is scraped at the end of each 20s run to read `component_received_events_total` and `component_discarded_events_total{intentional="false"}` for the `internal_logs` source.

On master the drops are silently filtered. For the "master" rows below, master's `into_stream()` was temporarily patched to increment the same drop metric (without any tracing call, to avoid a feedback loop) so the numbers are comparable. That patch is **not** part of this PR.

### Minimal config (from the issue: console sink)

```yaml
api:
  enabled: true

sources:
  internal_logs:
    type: internal_logs
  internal_metrics:
    type: internal_metrics
    scrape_interval_secs: 1

sinks:
  show_internal_logs:
    type: console
    inputs:
      - internal_logs
    encoding:
      codec: json
  prom:
    type: prometheus_exporter
    inputs:
      - internal_metrics
    address: 127.0.0.1:9598
```

### Blackhole sink (isolates the source path from stdout/JSON costs)

```yaml
api:
  enabled: true

sources:
  internal_logs:
    type: internal_logs
  internal_metrics:
    type: internal_metrics
    scrape_interval_secs: 1

sinks:
  null_sink:
    type: blackhole
    inputs:
      - internal_logs
  prom:
    type: prometheus_exporter
    inputs:
      - internal_metrics
    address: 127.0.0.1:9598
```

### Design comparison, console sink, `VECTOR_LOG=trace`, 20s

Isolates the source-path change. Buffer size is the broadcast capacity in `src/trace.rs`.

| Design                     | Broadcast buffer | Drops   |
| -------------------------- | ---------------- | ------: |
| Single-task loop (master)  | 99               | 876,567 |
| Single-task loop           | 10,000           | 848,510 |
| Drain + batching           | 99               | 353,217 |
| Drain + batching           | 10,000           | 333,105 |

Buffer size made almost no difference (~6%) once the drain + batching path was in place, so the original 99 is retained.

### Sink comparison, `VECTOR_LOG=trace`, 20s

Compares master (pathed) vs this branch across the console sink (from the issue) and a blackhole sink (isolates the source).

Keep in mind that the dropped events in master without a patch show up as 0, and logs are silently dropped.

| Version          | Sink      |      Received |       Dropped |         Total |  Drop % |
| ---------------- | --------- | ------------: | ------------: | ------------: | ------: |
| master (patched) | console   |       129,468 |       776,664 |       906,132 |   85.7% |
| master (patched) | blackhole |       147,279 |       883,563 |     1,030,842 |   85.7% |
| this branch      | console   |       395,443 |       353,870 |       749,313 |   47.2% |
| this branch      | blackhole | **1,524,445** |         **0** | **1,524,445** |  **0%** |

Interpretation:

- On master the source itself is the bottleneck: single-event `send_event` and broadcast consumption being coupled cap throughput at ~5k events/sec delivered and drop ~86% of events even when the sink is free (blackhole). The `BroadcastStreamRecvError::Lagged` path is silently filtered on stock master, so those drops aren't visible anywhere.
- With the drain + batching design, the source can deliver ~76k events/sec (~10x higher delivered throughput, ~1.5x higher combined throughput) when the sink doesn't backpressure. On the console sink it still drops under `trace` because stdout + JSON encoding caps at ~20k events/sec, but those drops are now surfaced in metrics.

Under `VECTOR_LOG=debug` (normal load), both configs show zero drops.

## How did you test this PR?

- `cargo nextest run --no-default-features --features sources-internal_logs --lib sources::internal_logs::` (all existing tests pass)
- `cargo vdev check events`
- `make check-clippy`
- `make check-fmt`
- Ran both configs at `VECTOR_LOG=debug` and `VECTOR_LOG=trace`, comparing `component_received_events_total` and `component_discarded_events_total` between master and this branch.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #24220