### PR TITLE
feat(prometheus_remote_write source, prometheus_remote_write sink): add support for Prometheus native histograms

### DIFF
--- a/changelog.d/prometheus_native_histograms.feature.md
+++ b/changelog.d/prometheus_native_histograms.feature.md
@@ -11,4 +11,4 @@ For sinks that do not natively support this format (such as the
 native histograms are automatically converted to classic aggregated histograms.
 This conversion is lossy but allows existing pipelines to continue operating.
 
-authors: l1n
+authors: l1n sanjams2

--- a/changelog.d/prometheus_native_histograms.feature.md
+++ b/changelog.d/prometheus_native_histograms.feature.md
@@ -1,0 +1,14 @@
+Added support for Prometheus native histograms (sparse/exponential histograms).
+
+The `prometheus_remote_write` source now accepts native histograms sent via the
+Prometheus remote write protocol, preserving their full resolution and sparse
+bucket representation. The `prometheus_remote_write` sink emits native histograms
+directly, enabling lossless pass-through of native histogram data between
+Prometheus-compatible systems.
+
+For sinks that do not natively support this format (such as the
+`prometheus_exporter` text exposition format, InfluxDB, GreptimeDB, and Datadog),
+native histograms are automatically converted to classic aggregated histograms.
+This conversion is lossy but allows existing pipelines to continue operating.
+
+authors: l1n

--- a/lib/prometheus-parser/proto/prometheus-types.proto
+++ b/lib/prometheus-parser/proto/prometheus-types.proto
@@ -114,7 +114,9 @@ message Histogram {
 message TimeSeries {
   repeated Label labels        = 1 [(nullable) = false];
   repeated Sample samples      = 2 [(nullable) = false];
-  repeated Histogram histograms = 3 [(nullable) = false];
+  // field 3 is `exemplars` upstream; reserved here for wire compatibility.
+  reserved 3;
+  repeated Histogram histograms = 4 [(nullable) = false];
 }
 
 message Label {

--- a/lib/prometheus-parser/proto/prometheus-types.proto
+++ b/lib/prometheus-parser/proto/prometheus-types.proto
@@ -50,10 +50,71 @@ message Sample {
   int64 timestamp = 2;
 }
 
+// A BucketSpan defines a number of consecutive buckets with their
+// offset. Logically, it would be more straightforward to include
+// the bucket counts in the Span. However, the protobuf representation
+// is more compact if the bucket counts are in a separate array.
+message BucketSpan {
+  sint32 offset = 1; // Gap to previous span, or starting point for 1st span (which can be negative).
+  uint32 length = 2; // Length of consecutive buckets.
+}
+
+// A native histogram, also known as a sparse histogram.
+// Source: https://github.com/prometheus/prometheus/blob/main/prompb/types.proto
+message Histogram {
+  enum ResetHint {
+    UNKNOWN = 0; // Need to test for a counter reset explicitly.
+    YES     = 1; // This is the 1st histogram after a counter reset.
+    NO      = 2; // There was no counter reset between this and the previous Histogram.
+    GAUGE   = 3; // This is a gauge histogram where counter resets don't happen.
+  }
+
+  oneof count { // Count of observations in the histogram.
+    uint64 count_int   = 1;
+    double count_float = 2;
+  }
+  double sum = 3; // Sum of observations in the histogram.
+
+  // The schema defines the bucket schema. Currently, valid numbers
+  // are -4 <= n <= 8. They are all for base-2 bucket schemas, where 1
+  // is a bucket boundary in each case, and then each power of two is
+  // divided into 2^n logarithmic buckets. Or in other words, each
+  // bucket boundary is the previous boundary times 2^(2^-n).
+  sint32 schema         = 4;
+  double zero_threshold = 5; // Breadth of the zero bucket.
+
+  oneof zero_count { // Count in zero bucket.
+    uint64 zero_count_int   = 6;
+    double zero_count_float = 7;
+  }
+
+  // Negative Buckets.
+  repeated BucketSpan negative_spans = 8 [(nullable) = false];
+  // Use either "negative_deltas" or "negative_counts", the former for
+  // regular histograms with integer counts, the latter for float
+  // histograms.
+  repeated sint64 negative_deltas = 9; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+  repeated double negative_counts = 10; // Absolute count of each bucket.
+
+  // Positive Buckets.
+  repeated BucketSpan positive_spans = 11 [(nullable) = false];
+  // Use either "positive_deltas" or "positive_counts", the former for
+  // regular histograms with integer counts, the latter for float
+  // histograms.
+  repeated sint64 positive_deltas = 12; // Count delta of each bucket compared to previous one (or to zero for 1st bucket).
+  repeated double positive_counts = 13; // Absolute count of each bucket.
+
+  ResetHint reset_hint = 14;
+
+  // timestamp is in ms format.
+  int64 timestamp = 15;
+}
+
 // TimeSeries represents samples and labels for a single time series.
 message TimeSeries {
-  repeated Label labels   = 1 [(nullable) = false];
-  repeated Sample samples = 2 [(nullable) = false];
+  repeated Label labels        = 1 [(nullable) = false];
+  repeated Sample samples      = 2 [(nullable) = false];
+  repeated Histogram histograms = 3 [(nullable) = false];
 }
 
 message Label {

--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -111,12 +111,22 @@ pub struct SimpleMetric {
     pub value: f64,
 }
 
+/// A Prometheus native (exponential) histogram received via remote write.
+///
+/// The raw proto representation is preserved so that downstream code can convert it into Vector's internal
+/// `NativeHistogram` metric type without loss of information.
+#[derive(Debug, PartialEq)]
+pub struct NativeHistogramMetric {
+    pub histogram: proto::Histogram,
+}
+
 type MetricMap<T> = IndexMap<GroupKey, T>;
 
 #[derive(Debug)]
 pub enum GroupKind {
     Summary(MetricMap<SummaryMetric>),
     Histogram(MetricMap<HistogramMetric>),
+    NativeHistogram(MetricMap<NativeHistogramMetric>),
     Gauge(MetricMap<SimpleMetric>),
     Counter(MetricMap<SimpleMetric>),
     Untyped(MetricMap<SimpleMetric>),
@@ -143,7 +153,7 @@ impl GroupKind {
         match self {
             Self::Counter { .. } => kind == MetricKind::Counter,
             Self::Gauge { .. } => kind == MetricKind::Gauge,
-            Self::Histogram { .. } => kind == MetricKind::Histogram,
+            Self::Histogram { .. } | Self::NativeHistogram { .. } => kind == MetricKind::Histogram,
             Self::Summary { .. } => kind == MetricKind::Summary,
             Self::Untyped { .. } => true,
         }
@@ -204,6 +214,17 @@ impl GroupKind {
                     }));
                 }
             },
+            // Native histograms only receive data via proto Histogram messages, not float samples.
+            // If a float sample is pushed to a native histogram group, bounce it back to be
+            // reprocessed as a separate group.
+            Self::NativeHistogram(_) => {
+                return Ok(Some(Metric {
+                    name: metric.name,
+                    timestamp: key.timestamp,
+                    labels: key.labels,
+                    value,
+                }));
+            }
             Self::Summary(metrics) => match suffix {
                 "" => {
                     let quantile = key
@@ -393,6 +414,39 @@ impl MetricGroupSet {
         Ok(())
     }
 
+    fn insert_native_histogram(
+        &mut self,
+        name: &str,
+        labels: &BTreeMap<String, String>,
+        histogram: proto::Histogram,
+    ) {
+        let key = GroupKey {
+            timestamp: Some(histogram.timestamp),
+            labels: labels.clone(),
+        };
+
+        // Look up an existing group for this name. If it's already a native histogram group, push
+        // into it. If it's a classic histogram group with no data yet (created from metadata),
+        // upgrade it to a native histogram group. Otherwise, create a new group.
+        match self.0.get_mut(name) {
+            Some(GroupKind::NativeHistogram(metrics)) => {
+                metrics.insert(key, NativeHistogramMetric { histogram });
+            }
+            Some(GroupKind::Histogram(metrics)) if metrics.is_empty() => {
+                let mut new_metrics = IndexMap::default();
+                new_metrics.insert(key, NativeHistogramMetric { histogram });
+                self.0
+                    .insert(name.into(), GroupKind::NativeHistogram(new_metrics));
+            }
+            _ => {
+                let mut metrics = IndexMap::default();
+                metrics.insert(key, NativeHistogramMetric { histogram });
+                self.0
+                    .insert(name.into(), GroupKind::NativeHistogram(metrics));
+            }
+        }
+    }
+
     fn finish(self) -> Vec<MetricGroup> {
         self.0
             .into_iter()
@@ -430,6 +484,10 @@ pub fn parse_request(
 
         for sample in timeseries.samples {
             groups.insert_sample(&name, &labels, sample)?;
+        }
+
+        for histogram in timeseries.histograms {
+            groups.insert_native_histogram(&name, &labels, histogram);
         }
     }
 
@@ -756,6 +814,7 @@ mod test {
                     samples: vec![
                         $( proto::Sample { value: $sample as f64, timestamp: $timestamp as i64 }, )*
                     ],
+                    histograms: vec![],
                 }, )* ],
             }
         };
@@ -947,6 +1006,7 @@ mod test {
                     value: 12345.0,
                     timestamp: 1395066367500,
                 }],
+                histograms: vec![],
             }],
         };
 
@@ -967,5 +1027,57 @@ mod test {
             err,
             ParserError::MultipleMetricKinds { name } if name == "go_memstats_alloc_bytes"
         ));
+    }
+
+    #[test]
+    fn parse_request_native_histogram() {
+        use proto::histogram::{Count, ResetHint, ZeroCount};
+
+        let histogram = proto::Histogram {
+            count: Some(Count::CountInt(6)),
+            sum: 18.5,
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: Some(ZeroCount::ZeroCountInt(0)),
+            negative_spans: vec![],
+            negative_deltas: vec![],
+            negative_counts: vec![],
+            positive_spans: vec![proto::BucketSpan {
+                offset: 1,
+                length: 3,
+            }],
+            positive_deltas: vec![2, 1, -2],
+            positive_counts: vec![],
+            reset_hint: ResetHint::No as i32,
+            timestamp: 1_612_325_106_789,
+        };
+
+        let request = proto::WriteRequest {
+            metadata: vec![proto::MetricMetadata {
+                r#type: proto::MetricType::Histogram as i32,
+                metric_family_name: "request_latency".into(),
+                help: String::default(),
+                unit: String::default(),
+            }],
+            timeseries: vec![proto::TimeSeries {
+                labels: vec![proto::Label {
+                    name: "__name__".into(),
+                    value: "request_latency".into(),
+                }],
+                samples: vec![],
+                histograms: vec![histogram],
+            }],
+        };
+
+        let parsed = parse_request(request, MetadataConflictStrategy::Reject).unwrap();
+        assert_eq!(parsed.len(), 1);
+        match_group!(parsed[0], "request_latency", NativeHistogram => |metrics: &MetricMap<NativeHistogramMetric>| {
+            assert_eq!(metrics.len(), 1);
+            let (key, metric) = metrics.get_index(0).unwrap();
+            assert_eq!(key.timestamp, Some(1_612_325_106_789));
+            assert_eq!(metric.histogram.sum, 18.5);
+            assert_eq!(metric.histogram.schema, 0);
+            assert_eq!(metric.histogram.positive_deltas, vec![2, 1, -2]);
+        });
     }
 }

--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -119,6 +119,7 @@ message Metric {
     Sketch sketch = 15;
     AggregatedHistogram3 aggregated_histogram3 = 16;
     AggregatedSummary3 aggregated_summary3 = 17;
+    NativeHistogram native_histogram = 22;
   }
   string namespace = 11;
   uint32 interval_ms = 18;
@@ -238,4 +239,53 @@ message Sketch {
   oneof sketch {
     AgentDDSketch agent_dd_sketch = 1;
   }
+}
+
+message NativeHistogram {
+  // Span of consecutive populated buckets.
+  message BucketSpan {
+    sint32 offset = 1;
+    uint32 length = 2;
+  }
+
+  // Reset hint for the histogram.
+  enum ResetHint {
+    UNKNOWN = 0;
+    YES = 1;
+    NO = 2;
+    GAUGE = 3;
+  }
+
+  // Total observation count: either integer (counter) or float (gauge).
+  oneof count {
+    uint64 count_int = 1;
+    double count_float = 2;
+  }
+
+  double sum = 3;
+
+  // Resolution schema: higher = finer resolution.
+  sint32 schema = 4;
+
+  double zero_threshold = 5;
+
+  // Zero bucket count: either integer (counter) or float (gauge).
+  oneof zero_count {
+    uint64 zero_count_int = 6;
+    double zero_count_float = 7;
+  }
+
+  repeated BucketSpan negative_spans = 8;
+  // For integer histograms, delta-encoded. Mutually exclusive with negative_counts.
+  repeated sint64 negative_deltas = 9;
+  // For float histograms, absolute values. Mutually exclusive with negative_deltas.
+  repeated double negative_counts = 10;
+
+  repeated BucketSpan positive_spans = 11;
+  // For integer histograms, delta-encoded. Mutually exclusive with positive_counts.
+  repeated sint64 positive_deltas = 12;
+  // For float histograms, absolute values. Mutually exclusive with positive_deltas.
+  repeated double positive_counts = 13;
+
+  ResetHint reset_hint = 14;
 }

--- a/lib/vector-core/src/event/arbitrary_impl.rs
+++ b/lib/vector-core/src/event/arbitrary_impl.rs
@@ -8,7 +8,8 @@ use super::{
     Event, EventMetadata, LogEvent, Metric, MetricKind, MetricValue, StatisticKind, TraceEvent,
     metric::{
         Bucket, MetricData, MetricName, MetricSeries, MetricSketch, MetricTags, MetricTime,
-        Quantile, Sample,
+        NativeHistogramBuckets, NativeHistogramCount, NativeHistogramResetHint,
+        NativeHistogramSpan, Quantile, Sample,
     },
 };
 use crate::metrics::AgentDDSketch;
@@ -194,14 +195,74 @@ impl Arbitrary for MetricKind {
     }
 }
 
+fn arbitrary_native_histogram(g: &mut Gen) -> MetricValue {
+    // Prometheus native histograms are either integer-typed (counter histograms) or
+    // float-typed (gauge histograms); count and bucket storage must agree on type
+    // for proto roundtrips to be lossless.
+    let is_float = bool::arbitrary(g);
+    let make_count = |g: &mut Gen| {
+        if is_float {
+            NativeHistogramCount::Float((f64::arbitrary(g) % MAX_F64_SIZE).abs())
+        } else {
+            NativeHistogramCount::Integer(u64::arbitrary(g) % 10_000)
+        }
+    };
+    // Generate 0..=2 spans and the matching number of bucket values.
+    let make_spans_buckets = |g: &mut Gen| {
+        let span_count = u8::arbitrary(g) % 3;
+        let mut spans = Vec::with_capacity(span_count as usize);
+        let mut total_len = 0usize;
+        for _ in 0..span_count {
+            let length = 1 + u32::arbitrary(g) % 4;
+            spans.push(NativeHistogramSpan {
+                offset: i32::arbitrary(g) % 8,
+                length,
+            });
+            total_len += length as usize;
+        }
+        let buckets = if is_float {
+            NativeHistogramBuckets::FloatCounts(
+                iter::repeat_with(|| (f64::arbitrary(g) % MAX_F64_SIZE).abs())
+                    .take(total_len)
+                    .collect(),
+            )
+        } else {
+            NativeHistogramBuckets::IntegerDeltas(
+                iter::repeat_with(|| i64::arbitrary(g) % 100)
+                    .take(total_len)
+                    .collect(),
+            )
+        };
+        (spans, buckets)
+    };
+    let (positive_spans, positive_buckets) = make_spans_buckets(g);
+    let (negative_spans, negative_buckets) = make_spans_buckets(g);
+    let reset_hint = match u8::arbitrary(g) % 4 {
+        0 => NativeHistogramResetHint::Unknown,
+        1 => NativeHistogramResetHint::Yes,
+        2 => NativeHistogramResetHint::No,
+        _ => NativeHistogramResetHint::Gauge,
+    };
+    MetricValue::NativeHistogram {
+        count: make_count(g),
+        sum: f64::arbitrary(g) % MAX_F64_SIZE,
+        schema: (i32::arbitrary(g) % 13) - 4,
+        zero_threshold: (f64::arbitrary(g) % 1.0).abs(),
+        zero_count: make_count(g),
+        positive_spans,
+        positive_buckets,
+        negative_spans,
+        negative_buckets,
+        reset_hint,
+    }
+}
+
 impl Arbitrary for MetricValue {
     fn arbitrary(g: &mut Gen) -> Self {
         // Quickcheck can't derive Arbitrary for enums, see
         // https://github.com/BurntSushi/quickcheck/issues/98.  The magical
-        // constant here are the number of fields in `MetricValue`. Because the
-        // field total is not a power of two we introduce a bias into choice
-        // here toward `MetricValue::Counter` and `MetricValue::Gauge`.
-        match u8::arbitrary(g) % 7 {
+        // constant here are the number of fields in `MetricValue`.
+        match u8::arbitrary(g) % 8 {
             0 => MetricValue::Counter {
                 value: f64_for_arbitrary(g),
             },
@@ -249,6 +310,7 @@ impl Arbitrary for MetricValue {
                     sketch: MetricSketch::AgentDDSketch(sketch),
                 }
             }
+            7 => arbitrary_native_histogram(g),
 
             _ => unreachable!(),
         }

--- a/lib/vector-core/src/event/arbitrary_impl.rs
+++ b/lib/vector-core/src/event/arbitrary_impl.rs
@@ -386,6 +386,10 @@ impl Arbitrary for MetricValue {
             MetricValue::Sketch { sketch } => Box::new(iter::once(MetricValue::Sketch {
                 sketch: sketch.clone(),
             })),
+            // Similar to sketches, native histograms have tightly coupled internal invariants
+            // (spans must match bucket counts, deltas encode running totals) that don't lend
+            // themselves to naive shrinking.
+            native @ MetricValue::NativeHistogram { .. } => Box::new(iter::once(native.clone())),
         }
     }
 }

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -126,6 +126,7 @@ impl IntoLua for LuaMetricTags {
 
 impl IntoLua for LuaMetric {
     #![allow(clippy::wrong_self_convention)] // this trait is defined by mlua
+    #[allow(clippy::too_many_lines)]
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         let tbl = lua.create_table()?;
 
@@ -222,6 +223,25 @@ impl IntoLua for LuaMetric {
                 };
 
                 tbl.raw_set("sketch", sketch_tbl)?;
+            }
+            native @ MetricValue::NativeHistogram { .. } => {
+                // Lua scripts operate on classic histograms; expose native histograms via lossy
+                // conversion so existing scripts continue to work.
+                if let Some(MetricValue::AggregatedHistogram {
+                    buckets,
+                    count,
+                    sum,
+                }) = native.native_histogram_to_agg_histogram()
+                {
+                    let aggregated_histogram = lua.create_table()?;
+                    let counts: Vec<_> = buckets.iter().map(|b| b.count).collect();
+                    let limits: Vec<_> = buckets.iter().map(|b| b.upper_limit).collect();
+                    aggregated_histogram.raw_set("buckets", limits)?;
+                    aggregated_histogram.raw_set("counts", counts)?;
+                    aggregated_histogram.raw_set("count", count)?;
+                    aggregated_histogram.raw_set("sum", sum)?;
+                    tbl.raw_set("aggregated_histogram", aggregated_histogram)?;
+                }
             }
         }
 

--- a/lib/vector-core/src/event/metric/arbitrary.rs
+++ b/lib/vector-core/src/event/metric/arbitrary.rs
@@ -5,7 +5,8 @@ use proptest::{
 };
 
 use super::{
-    Bucket, MetricSketch, MetricTags, MetricValue, Quantile, Sample, StatisticKind, TagValue,
+    Bucket, MetricSketch, MetricTags, MetricValue, NativeHistogramBuckets, NativeHistogramCount,
+    NativeHistogramResetHint, NativeHistogramSpan, Quantile, Sample, StatisticKind, TagValue,
     TagValueSet, samples_to_buckets,
 };
 use crate::metrics::AgentDDSketch;
@@ -60,9 +61,90 @@ impl Arbitrary for MetricValue {
                 }
             }),
             any::<MetricSketch>().prop_map(|sketch| MetricValue::Sketch { sketch }),
+            native_histogram_strategy(),
         ];
         strategy.boxed()
     }
+}
+
+// Generates spans and a bucket count vector whose lengths are consistent (sum of
+// span lengths == number of bucket values). The `is_float` flag decides which
+// bucket encoding is used.
+fn native_spans_and_buckets(
+    is_float: bool,
+) -> impl Strategy<Value = (Vec<NativeHistogramSpan>, NativeHistogramBuckets)> {
+    use proptest::collection::vec as arb_vec;
+    arb_vec((-8i32..8, 1u32..5), 0..3).prop_flat_map(move |raw_spans| {
+        let spans: Vec<_> = raw_spans
+            .iter()
+            .map(|&(offset, length)| NativeHistogramSpan { offset, length })
+            .collect();
+        let total: usize = raw_spans.iter().map(|&(_, l)| l as usize).sum();
+        if is_float {
+            arb_vec(realistic_float().prop_map(f64::abs), total..=total)
+                .prop_map(move |v| (spans.clone(), NativeHistogramBuckets::FloatCounts(v)))
+                .boxed()
+        } else {
+            arb_vec(-100i64..100, total..=total)
+                .prop_map(move |v| (spans.clone(), NativeHistogramBuckets::IntegerDeltas(v)))
+                .boxed()
+        }
+    })
+}
+
+fn native_histogram_strategy() -> impl Strategy<Value = MetricValue> {
+    let reset_hint = prop_oneof![
+        Just(NativeHistogramResetHint::Unknown),
+        Just(NativeHistogramResetHint::Yes),
+        Just(NativeHistogramResetHint::No),
+        Just(NativeHistogramResetHint::Gauge),
+    ];
+    (
+        any::<bool>(),
+        -4i32..=8,
+        0.0f64..1.0,
+        realistic_float(),
+        reset_hint,
+    )
+        .prop_flat_map(|(is_float, schema, zero_threshold, sum, reset_hint)| {
+            let count = if is_float {
+                realistic_float()
+                    .prop_map(|v| NativeHistogramCount::Float(v.abs()))
+                    .boxed()
+            } else {
+                (0u64..10_000)
+                    .prop_map(NativeHistogramCount::Integer)
+                    .boxed()
+            };
+            let zero_count = count.clone();
+            (
+                count,
+                zero_count,
+                native_spans_and_buckets(is_float),
+                native_spans_and_buckets(is_float),
+            )
+                .prop_map(
+                    move |(
+                        count,
+                        zero_count,
+                        (positive_spans, positive_buckets),
+                        (negative_spans, negative_buckets),
+                    )| {
+                        MetricValue::NativeHistogram {
+                            count,
+                            sum,
+                            schema,
+                            zero_threshold,
+                            zero_count,
+                            positive_spans,
+                            positive_buckets,
+                            negative_spans,
+                            negative_buckets,
+                            reset_hint,
+                        }
+                    },
+                )
+        })
 }
 
 impl Arbitrary for MetricSketch {

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -84,6 +84,59 @@ pub enum MetricValue {
         #[configurable(derived)]
         sketch: MetricSketch,
     },
+
+    /// A Prometheus-style native (exponential) histogram.
+    ///
+    /// Native histograms use exponential bucket boundaries determined by a `schema` parameter, allowing for high
+    /// resolution at low cost. Unlike `AggregatedHistogram` which uses fixed bucket boundaries, native histograms use
+    /// sparse buckets indexed by integer keys, where adjacent buckets grow by a factor of `2^(2^-schema)`.
+    ///
+    /// See <https://prometheus.io/docs/specs/native_histograms/> for details.
+    NativeHistogram {
+        /// The total number of observations.
+        ///
+        /// May be a float to support gauge histograms where resets can cause fractional counts.
+        count: NativeHistogramCount,
+
+        /// The sum of all observations.
+        sum: f64,
+
+        /// The resolution parameter.
+        ///
+        /// Valid values are from -4 to 8 for standard exponential schemas. Higher values give finer resolution.
+        /// Bucket boundaries are at `(2^(2^-schema))^n` for positive buckets.
+        schema: i32,
+
+        /// The width of the "zero bucket".
+        ///
+        /// Observations in `[-zero_threshold, zero_threshold]` are counted in the zero bucket rather than in positive
+        /// or negative exponential buckets.
+        zero_threshold: f64,
+
+        /// Count of observations in the zero bucket.
+        zero_count: NativeHistogramCount,
+
+        /// Spans of populated positive buckets.
+        positive_spans: Vec<NativeHistogramSpan>,
+
+        /// Bucket values for positive buckets.
+        ///
+        /// For integer counts, these are deltas from the previous bucket (first is absolute). For float counts, these
+        /// are absolute values. The interpretation depends on the `count` type.
+        positive_buckets: NativeHistogramBuckets,
+
+        /// Spans of populated negative buckets.
+        negative_spans: Vec<NativeHistogramSpan>,
+
+        /// Bucket values for negative buckets.
+        ///
+        /// For integer counts, these are deltas from the previous bucket (first is absolute). For float counts, these
+        /// are absolute values. The interpretation depends on the `count` type.
+        negative_buckets: NativeHistogramBuckets,
+
+        /// Hint about whether this represents a counter reset.
+        reset_hint: NativeHistogramResetHint,
+    },
 }
 
 impl MetricValue {
@@ -99,6 +152,7 @@ impl MetricValue {
             MetricValue::AggregatedSummary { count, .. }
             | MetricValue::AggregatedHistogram { count, .. } => *count == 0,
             MetricValue::Sketch { sketch } => sketch.is_empty(),
+            MetricValue::NativeHistogram { count, .. } => count.as_f64() == 0.0,
         }
     }
 
@@ -114,6 +168,89 @@ impl MetricValue {
             Self::AggregatedHistogram { .. } => "aggregated histogram",
             Self::AggregatedSummary { .. } => "aggregated summary",
             Self::Sketch { sketch } => sketch.as_name(),
+            Self::NativeHistogram { .. } => "native histogram",
+        }
+    }
+
+    /// Converts a native histogram to an aggregated histogram.
+    ///
+    /// This is a **lossy** conversion: native histograms use exponential bucket boundaries determined by the schema,
+    /// while aggregated histograms use fixed explicit boundaries. The resulting aggregated histogram will have one
+    /// bucket per populated native histogram bucket, with upper limits computed from the schema.
+    ///
+    /// Negative buckets are merged together as observations below zero, and the zero bucket is placed at
+    /// `zero_threshold`.
+    ///
+    /// If this value is not a native histogram, returns `None`.
+    #[must_use]
+    pub fn native_histogram_to_agg_histogram(&self) -> Option<MetricValue> {
+        match self {
+            MetricValue::NativeHistogram {
+                count,
+                sum,
+                schema,
+                zero_threshold,
+                zero_count,
+                positive_spans,
+                positive_buckets,
+                negative_spans,
+                negative_buckets,
+                ..
+            } => {
+                let mut buckets = Vec::new();
+
+                // All negative observations collapse into one bucket at upper_limit = -zero_threshold (or 0 if
+                // zero_threshold is 0). This is lossy but aggregated histograms don't naturally represent negative
+                // exponential buckets.
+                let neg_total: f64 = iter_span_counts(negative_spans, negative_buckets)
+                    .map(|(_, c)| c)
+                    .sum();
+                if neg_total > 0.0 {
+                    let limit = if *zero_threshold > 0.0 {
+                        -*zero_threshold
+                    } else {
+                        0.0
+                    };
+                    buckets.push(Bucket {
+                        upper_limit: limit,
+                        // Truncation: fractional counts from float histograms are floored.
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        count: neg_total.max(0.0) as u64,
+                    });
+                }
+
+                // Zero bucket.
+                let zc = zero_count.as_f64();
+                if zc > 0.0 {
+                    buckets.push(Bucket {
+                        upper_limit: *zero_threshold,
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        count: zc.max(0.0) as u64,
+                    });
+                }
+
+                // Positive buckets: compute upper bound for each populated bucket.
+                for (index, c) in iter_span_counts(positive_spans, positive_buckets) {
+                    if c > 0.0 {
+                        buckets.push(Bucket {
+                            upper_limit: native_histogram_bucket_upper_bound(*schema, index),
+                            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                            count: c.max(0.0) as u64,
+                        });
+                    }
+                }
+
+                // Truncation: fractional counts from float histograms are floored.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let count_u64 = count.as_f64().max(0.0) as u64;
+
+                Some(MetricValue::AggregatedHistogram {
+                    buckets,
+                    count: count_u64,
+                    sum: *sum,
+                })
+            }
+            _ => None,
         }
     }
 
@@ -199,6 +336,24 @@ impl MetricValue {
                     ddsketch.clear();
                 }
             },
+            Self::NativeHistogram {
+                count,
+                sum,
+                zero_count,
+                positive_spans,
+                positive_buckets,
+                negative_spans,
+                negative_buckets,
+                ..
+            } => {
+                *count = NativeHistogramCount::default();
+                *sum = 0.0;
+                *zero_count = NativeHistogramCount::default();
+                positive_spans.clear();
+                *positive_buckets = NativeHistogramBuckets::default();
+                negative_spans.clear();
+                *negative_buckets = NativeHistogramBuckets::default();
+            }
         }
     }
 
@@ -371,6 +526,18 @@ impl ByteSizeOf for MetricValue {
             Self::AggregatedHistogram { buckets, .. } => buckets.allocated_bytes(),
             Self::AggregatedSummary { quantiles, .. } => quantiles.allocated_bytes(),
             Self::Sketch { sketch } => sketch.allocated_bytes(),
+            Self::NativeHistogram {
+                positive_spans,
+                positive_buckets,
+                negative_spans,
+                negative_buckets,
+                ..
+            } => {
+                positive_spans.allocated_bytes()
+                    + positive_buckets.allocated_bytes()
+                    + negative_spans.allocated_bytes()
+                    + negative_buckets.allocated_bytes()
+            }
         }
     }
 }
@@ -421,6 +588,43 @@ impl PartialEq for MetricValue {
             ) => l_quantiles == r_quantiles && l_count == r_count && float_eq(*l_sum, *r_sum),
             (Self::Sketch { sketch: l_sketch }, Self::Sketch { sketch: r_sketch }) => {
                 l_sketch == r_sketch
+            }
+            (
+                Self::NativeHistogram {
+                    count: left_count,
+                    sum: left_sum,
+                    schema: left_schema,
+                    zero_threshold: left_zero_threshold,
+                    zero_count: left_zero_count,
+                    positive_spans: left_positive_spans,
+                    positive_buckets: left_positive_buckets,
+                    negative_spans: left_negative_spans,
+                    negative_buckets: left_negative_buckets,
+                    reset_hint: left_reset_hint,
+                },
+                Self::NativeHistogram {
+                    count: right_count,
+                    sum: right_sum,
+                    schema: right_schema,
+                    zero_threshold: right_zero_threshold,
+                    zero_count: right_zero_count,
+                    positive_spans: right_positive_spans,
+                    positive_buckets: right_positive_buckets,
+                    negative_spans: right_negative_spans,
+                    negative_buckets: right_negative_buckets,
+                    reset_hint: right_reset_hint,
+                },
+            ) => {
+                left_count == right_count
+                    && float_eq(*left_sum, *right_sum)
+                    && left_schema == right_schema
+                    && float_eq(*left_zero_threshold, *right_zero_threshold)
+                    && left_zero_count == right_zero_count
+                    && left_positive_spans == right_positive_spans
+                    && left_positive_buckets == right_positive_buckets
+                    && left_negative_spans == right_negative_spans
+                    && left_negative_buckets == right_negative_buckets
+                    && left_reset_hint == right_reset_hint
             }
             _ => false,
         }
@@ -499,6 +703,28 @@ impl fmt::Display for MetricValue {
                         })
                     }
                 }
+            }
+            MetricValue::NativeHistogram {
+                count,
+                sum,
+                schema,
+                zero_threshold,
+                zero_count,
+                positive_buckets,
+                negative_buckets,
+                ..
+            } => {
+                write!(
+                    fmt,
+                    "count={} sum={} schema={} zero_threshold={} zero_count={} pos_buckets={} neg_buckets={}",
+                    count.as_f64(),
+                    sum,
+                    schema,
+                    zero_threshold,
+                    zero_count.as_f64(),
+                    positive_buckets.len(),
+                    negative_buckets.len(),
+                )
             }
         }
     }
@@ -745,5 +971,402 @@ impl Quantile {
 impl ByteSizeOf for Quantile {
     fn allocated_bytes(&self) -> usize {
         0
+    }
+}
+
+/// Count type for native histograms.
+///
+/// Integer counts are used for traditional counter-style histograms. Float counts are used for gauge histograms where
+/// values may decrease, or when the source uses float counts.
+#[configurable_component]
+#[derive(Clone, Copy, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeHistogramCount {
+    /// Integer count value.
+    Integer(u64),
+
+    /// Floating-point count value.
+    Float(f64),
+}
+
+impl NativeHistogramCount {
+    /// Returns this count as a floating point value.
+    pub fn as_f64(&self) -> f64 {
+        match self {
+            // The loss of precision here is acceptable for display/summary purposes.
+            #[allow(clippy::cast_precision_loss)]
+            Self::Integer(v) => *v as f64,
+            Self::Float(v) => *v,
+        }
+    }
+
+    /// Returns `true` if the count represents a float-type histogram (gauge histogram).
+    pub const fn is_float(&self) -> bool {
+        matches!(self, Self::Float(_))
+    }
+}
+
+impl PartialEq for NativeHistogramCount {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Integer(a), Self::Integer(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => float_eq(*a, *b),
+            _ => false,
+        }
+    }
+}
+
+impl Default for NativeHistogramCount {
+    fn default() -> Self {
+        Self::Integer(0)
+    }
+}
+
+impl ByteSizeOf for NativeHistogramCount {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
+}
+
+/// A span of consecutive populated buckets in a native histogram.
+///
+/// Native histograms use a sparse representation: rather than storing every bucket, only non-empty ranges ("spans") are
+/// stored. A span indicates where a run of consecutive buckets begins and how long it is.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NativeHistogramSpan {
+    /// Gap in bucket indices from the previous span (or from zero for the first span).
+    pub offset: i32,
+
+    /// Number of consecutive buckets in this span.
+    pub length: u32,
+}
+
+impl ByteSizeOf for NativeHistogramSpan {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
+}
+
+/// Bucket counts for native histograms.
+///
+/// Integer histograms store bucket counts as deltas from the previous bucket (first value is absolute), enabling
+/// efficient encoding. Float histograms (gauge histograms) store absolute bucket counts directly.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeHistogramBuckets {
+    /// Delta-encoded integer bucket counts.
+    ///
+    /// The first value is the absolute count of the first bucket; subsequent values are the delta from the previous
+    /// bucket's count.
+    IntegerDeltas(Vec<i64>),
+
+    /// Absolute floating-point bucket counts.
+    FloatCounts(Vec<f64>),
+}
+
+impl NativeHistogramBuckets {
+    /// Returns the number of buckets represented.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::IntegerDeltas(v) => v.len(),
+            Self::FloatCounts(v) => v.len(),
+        }
+    }
+
+    /// Returns `true` if there are no buckets.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Iterates over absolute bucket counts as floating-point values.
+    ///
+    /// For integer-delta buckets, this decodes the deltas into absolute counts.
+    pub fn iter_absolute(&self) -> impl Iterator<Item = f64> + '_ {
+        let mut running: i64 = 0;
+        let mut idx: usize = 0;
+        std::iter::from_fn(move || match self {
+            Self::IntegerDeltas(deltas) => {
+                let d = *deltas.get(idx)?;
+                running = running.wrapping_add(d);
+                idx += 1;
+                // Allow precision loss for display/summary purposes.
+                #[allow(clippy::cast_precision_loss)]
+                Some(running as f64)
+            }
+            Self::FloatCounts(counts) => {
+                let v = *counts.get(idx)?;
+                idx += 1;
+                Some(v)
+            }
+        })
+    }
+}
+
+impl PartialEq for NativeHistogramBuckets {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::IntegerDeltas(a), Self::IntegerDeltas(b)) => a == b,
+            (Self::FloatCounts(a), Self::FloatCounts(b)) => {
+                a.len() == b.len() && a.iter().zip(b).all(|(x, y)| float_eq(*x, *y))
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Default for NativeHistogramBuckets {
+    fn default() -> Self {
+        Self::IntegerDeltas(Vec::new())
+    }
+}
+
+impl ByteSizeOf for NativeHistogramBuckets {
+    fn allocated_bytes(&self) -> usize {
+        match self {
+            Self::IntegerDeltas(v) => v.allocated_bytes(),
+            Self::FloatCounts(v) => v.allocated_bytes(),
+        }
+    }
+}
+
+/// Reset hint for native histograms, indicating whether the histogram was reset.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeHistogramResetHint {
+    /// No hint; receiver should detect resets from the data.
+    #[default]
+    Unknown,
+
+    /// This histogram is the first after a reset (or the very first observation).
+    Yes,
+
+    /// This histogram is known not to be the first after a reset.
+    No,
+
+    /// This histogram is a gauge histogram (no reset semantics).
+    Gauge,
+}
+
+impl ByteSizeOf for NativeHistogramResetHint {
+    fn allocated_bytes(&self) -> usize {
+        0
+    }
+}
+
+/// Compute the upper bound of a native histogram bucket given its index and schema.
+///
+/// For positive indices, the upper bound is `(2^(2^-schema))^index`. For index 0, the upper bound is 1.0.
+/// The lower bound of a bucket is the upper bound of the previous bucket (or `zero_threshold` for the first positive
+/// bucket).
+#[must_use]
+pub fn native_histogram_bucket_upper_bound(schema: i32, index: i32) -> f64 {
+    // Special case: schema -4 through 8, index can be negative or positive.
+    // upper_bound = 2^(index * 2^(-schema))
+    let exp = f64::from(index) * (-f64::from(schema)).exp2();
+    exp.exp2()
+}
+
+/// Iterate over `(bucket_index, absolute_count)` pairs for the given spans and bucket data.
+///
+/// Spans describe which bucket indices are populated; this function zips them with the absolute (decoded) counts from
+/// the bucket storage.
+fn iter_span_counts<'a>(
+    spans: &'a [NativeHistogramSpan],
+    buckets: &'a NativeHistogramBuckets,
+) -> impl Iterator<Item = (i32, f64)> + 'a {
+    // First, expand spans into a flat sequence of bucket indices.
+    let indices = spans.iter().scan(0i32, |index, span| {
+        *index += span.offset;
+        let start = *index;
+        #[allow(clippy::cast_possible_wrap)]
+        {
+            *index += span.length as i32;
+        }
+        Some((start, span.length))
+    });
+
+    indices
+        .flat_map(|(start, length)| {
+            #[allow(clippy::cast_possible_wrap)]
+            (0..length).map(move |i| start + i as i32)
+        })
+        .zip(buckets.iter_absolute())
+}
+
+#[cfg(test)]
+mod native_histogram_tests {
+    use super::*;
+
+    #[test]
+    fn bucket_upper_bound_schema_0() {
+        // Schema 0: bucket boundaries are powers of 2.
+        assert_eq!(native_histogram_bucket_upper_bound(0, 0), 1.0);
+        assert_eq!(native_histogram_bucket_upper_bound(0, 1), 2.0);
+        assert_eq!(native_histogram_bucket_upper_bound(0, 2), 4.0);
+        assert_eq!(native_histogram_bucket_upper_bound(0, 3), 8.0);
+        assert_eq!(native_histogram_bucket_upper_bound(0, -1), 0.5);
+    }
+
+    #[test]
+    fn bucket_upper_bound_schema_1() {
+        // Schema 1: bucket boundaries at 2^(n/2), so sqrt(2)^n.
+        assert_eq!(native_histogram_bucket_upper_bound(1, 0), 1.0);
+        assert!((native_histogram_bucket_upper_bound(1, 1) - 2.0_f64.sqrt()).abs() < 1e-10);
+        assert!((native_histogram_bucket_upper_bound(1, 2) - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn iter_absolute_decodes_integer_deltas() {
+        let buckets = NativeHistogramBuckets::IntegerDeltas(vec![2, 1, -2, 3]);
+        let absolute: Vec<f64> = buckets.iter_absolute().collect();
+        assert_eq!(absolute, vec![2.0, 3.0, 1.0, 4.0]);
+    }
+
+    #[test]
+    fn iter_absolute_passes_float_counts() {
+        let buckets = NativeHistogramBuckets::FloatCounts(vec![1.5, 2.5, 0.5]);
+        let absolute: Vec<f64> = buckets.iter_absolute().collect();
+        assert_eq!(absolute, vec![1.5, 2.5, 0.5]);
+    }
+
+    #[test]
+    fn iter_span_counts_single_span() {
+        let spans = vec![NativeHistogramSpan {
+            offset: 1,
+            length: 3,
+        }];
+        let buckets = NativeHistogramBuckets::IntegerDeltas(vec![2, 1, -2]);
+        let result: Vec<(i32, f64)> = iter_span_counts(&spans, &buckets).collect();
+        assert_eq!(result, vec![(1, 2.0), (2, 3.0), (3, 1.0)]);
+    }
+
+    #[test]
+    fn iter_span_counts_multiple_spans_with_gap() {
+        // Span 1: indices 0..2, Span 2: gap of 3, then indices 5..7
+        let spans = vec![
+            NativeHistogramSpan {
+                offset: 0,
+                length: 2,
+            },
+            NativeHistogramSpan {
+                offset: 3,
+                length: 2,
+            },
+        ];
+        let buckets = NativeHistogramBuckets::IntegerDeltas(vec![1, 1, 1, 1]);
+        let result: Vec<(i32, f64)> = iter_span_counts(&spans, &buckets).collect();
+        assert_eq!(result, vec![(0, 1.0), (1, 2.0), (5, 3.0), (6, 4.0)]);
+    }
+
+    #[test]
+    fn native_histogram_to_agg_histogram_basic() {
+        let native = MetricValue::NativeHistogram {
+            count: NativeHistogramCount::Integer(6),
+            sum: 18.5,
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: NativeHistogramCount::Integer(0),
+            positive_spans: vec![NativeHistogramSpan {
+                offset: 1,
+                length: 3,
+            }],
+            positive_buckets: NativeHistogramBuckets::IntegerDeltas(vec![2, 1, -2]),
+            negative_spans: vec![],
+            negative_buckets: NativeHistogramBuckets::IntegerDeltas(vec![]),
+            reset_hint: NativeHistogramResetHint::No,
+        };
+
+        let agg = native.native_histogram_to_agg_histogram().unwrap();
+        match agg {
+            MetricValue::AggregatedHistogram {
+                buckets,
+                count,
+                sum,
+            } => {
+                assert_eq!(count, 6);
+                assert_eq!(sum, 18.5);
+                // Buckets at indices 1, 2, 3 with schema 0 -> upper bounds 2.0, 4.0, 8.0
+                // Counts: 2, 3, 1
+                assert_eq!(buckets.len(), 3);
+                assert_eq!(buckets[0].upper_limit, 2.0);
+                assert_eq!(buckets[0].count, 2);
+                assert_eq!(buckets[1].upper_limit, 4.0);
+                assert_eq!(buckets[1].count, 3);
+                assert_eq!(buckets[2].upper_limit, 8.0);
+                assert_eq!(buckets[2].count, 1);
+            }
+            _ => panic!("expected AggregatedHistogram"),
+        }
+    }
+
+    #[test]
+    fn native_histogram_to_agg_histogram_with_zero_bucket() {
+        let native = MetricValue::NativeHistogram {
+            count: NativeHistogramCount::Integer(5),
+            sum: 3.0,
+            schema: 0,
+            zero_threshold: 0.001,
+            zero_count: NativeHistogramCount::Integer(2),
+            positive_spans: vec![NativeHistogramSpan {
+                offset: 1,
+                length: 1,
+            }],
+            positive_buckets: NativeHistogramBuckets::IntegerDeltas(vec![3]),
+            negative_spans: vec![],
+            negative_buckets: NativeHistogramBuckets::IntegerDeltas(vec![]),
+            reset_hint: NativeHistogramResetHint::Unknown,
+        };
+
+        let agg = native.native_histogram_to_agg_histogram().unwrap();
+        match agg {
+            MetricValue::AggregatedHistogram { buckets, count, .. } => {
+                assert_eq!(count, 5);
+                assert_eq!(buckets.len(), 2);
+                // Zero bucket at threshold 0.001
+                assert_eq!(buckets[0].upper_limit, 0.001);
+                assert_eq!(buckets[0].count, 2);
+                // Positive bucket at index 1, schema 0 -> 2.0
+                assert_eq!(buckets[1].upper_limit, 2.0);
+                assert_eq!(buckets[1].count, 3);
+            }
+            _ => panic!("expected AggregatedHistogram"),
+        }
+    }
+
+    #[test]
+    fn native_histogram_is_empty() {
+        let empty = MetricValue::NativeHistogram {
+            count: NativeHistogramCount::Integer(0),
+            sum: 0.0,
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: NativeHistogramCount::Integer(0),
+            positive_spans: vec![],
+            positive_buckets: NativeHistogramBuckets::IntegerDeltas(vec![]),
+            negative_spans: vec![],
+            negative_buckets: NativeHistogramBuckets::IntegerDeltas(vec![]),
+            reset_hint: NativeHistogramResetHint::Unknown,
+        };
+        assert!(empty.is_empty());
+
+        let non_empty = MetricValue::NativeHistogram {
+            count: NativeHistogramCount::Integer(1),
+            sum: 1.0,
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: NativeHistogramCount::Integer(0),
+            positive_spans: vec![NativeHistogramSpan {
+                offset: 0,
+                length: 1,
+            }],
+            positive_buckets: NativeHistogramBuckets::IntegerDeltas(vec![1]),
+            negative_spans: vec![],
+            negative_buckets: NativeHistogramBuckets::IntegerDeltas(vec![]),
+            reset_hint: NativeHistogramResetHint::Unknown,
+        };
+        assert!(!non_empty.is_empty());
     }
 }

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -1089,7 +1089,7 @@ impl NativeHistogramBuckets {
         std::iter::from_fn(move || match self {
             Self::IntegerDeltas(deltas) => {
                 let d = *deltas.get(idx)?;
-                running = running.wrapping_add(d);
+                running = running.saturating_add(d);
                 idx += 1;
                 // Allow precision loss for display/summary purposes.
                 #[allow(clippy::cast_precision_loss)]

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -199,33 +199,35 @@ impl MetricValue {
             } => {
                 let mut buckets = Vec::new();
 
-                // All negative observations collapse into one bucket at upper_limit = -zero_threshold (or 0 if
-                // zero_threshold is 0). This is lossy but aggregated histograms don't naturally represent negative
-                // exponential buckets.
+                // All negative observations collapse into one bucket at upper_limit = -zero_threshold. This is lossy
+                // but aggregated histograms don't naturally represent negative exponential buckets.
                 let neg_total: f64 = iter_span_counts(negative_spans, negative_buckets)
                     .map(|(_, c)| c)
                     .sum();
-                if neg_total > 0.0 {
-                    let limit = if *zero_threshold > 0.0 {
-                        -*zero_threshold
-                    } else {
-                        0.0
-                    };
-                    buckets.push(Bucket {
-                        upper_limit: limit,
-                        // Truncation: fractional counts from float histograms are floored.
-                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        count: neg_total.max(0.0) as u64,
-                    });
-                }
-
-                // Zero bucket.
                 let zc = zero_count.as_f64();
-                if zc > 0.0 {
+
+                if *zero_threshold > 0.0 {
+                    if neg_total > 0.0 {
+                        buckets.push(Bucket {
+                            upper_limit: -*zero_threshold,
+                            // Truncation: fractional counts from float histograms are floored.
+                            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                            count: neg_total.max(0.0) as u64,
+                        });
+                    }
+                    if zc > 0.0 {
+                        buckets.push(Bucket {
+                            upper_limit: *zero_threshold,
+                            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                            count: zc.max(0.0) as u64,
+                        });
+                    }
+                } else if neg_total > 0.0 || zc > 0.0 {
+                    // zero_threshold == 0: negative and zero buckets would both land at upper_limit 0.0, so merge them.
                     buckets.push(Bucket {
-                        upper_limit: *zero_threshold,
+                        upper_limit: 0.0,
                         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        count: zc.max(0.0) as u64,
+                        count: (neg_total.max(0.0) + zc.max(0.0)) as u64,
                     });
                 }
 
@@ -346,13 +348,13 @@ impl MetricValue {
                 negative_buckets,
                 ..
             } => {
-                *count = NativeHistogramCount::default();
+                count.zero();
                 *sum = 0.0;
-                *zero_count = NativeHistogramCount::default();
+                zero_count.zero();
                 positive_spans.clear();
-                *positive_buckets = NativeHistogramBuckets::default();
+                positive_buckets.clear();
                 negative_spans.clear();
-                *negative_buckets = NativeHistogramBuckets::default();
+                negative_buckets.clear();
             }
         }
     }
@@ -1004,6 +1006,14 @@ impl NativeHistogramCount {
     pub const fn is_float(&self) -> bool {
         matches!(self, Self::Float(_))
     }
+
+    /// Resets the count to zero while preserving the integer/float variant.
+    pub const fn zero(&mut self) {
+        *self = match self {
+            Self::Integer(_) => Self::Integer(0),
+            Self::Float(_) => Self::Float(0.0),
+        };
+    }
 }
 
 impl PartialEq for NativeHistogramCount {
@@ -1078,6 +1088,14 @@ impl NativeHistogramBuckets {
     /// Returns `true` if there are no buckets.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Clears all bucket counts while preserving the integer/float variant.
+    pub fn clear(&mut self) {
+        match self {
+            Self::IntegerDeltas(v) => v.clear(),
+            Self::FloatCounts(v) => v.clear(),
+        }
     }
 
     /// Iterates over absolute bucket counts as floating-point values.
@@ -1333,6 +1351,87 @@ mod native_histogram_tests {
                 assert_eq!(buckets[1].count, 3);
             }
             _ => panic!("expected AggregatedHistogram"),
+        }
+    }
+
+    #[test]
+    fn native_histogram_to_agg_histogram_merges_neg_and_zero_at_zero_threshold() {
+        // zero_threshold == 0 with both negative observations and a nonzero zero_count must yield
+        // a single bucket at upper_limit 0.0 (not two colliding buckets).
+        let native = MetricValue::NativeHistogram {
+            count: NativeHistogramCount::Integer(7),
+            sum: -1.5,
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: NativeHistogramCount::Integer(2),
+            positive_spans: vec![NativeHistogramSpan {
+                offset: 1,
+                length: 1,
+            }],
+            positive_buckets: NativeHistogramBuckets::IntegerDeltas(vec![1]),
+            negative_spans: vec![NativeHistogramSpan {
+                offset: 1,
+                length: 1,
+            }],
+            negative_buckets: NativeHistogramBuckets::IntegerDeltas(vec![4]),
+            reset_hint: NativeHistogramResetHint::Unknown,
+        };
+
+        let agg = native.native_histogram_to_agg_histogram().unwrap();
+        match agg {
+            MetricValue::AggregatedHistogram { buckets, .. } => {
+                assert_eq!(buckets.len(), 2);
+                assert_eq!(buckets[0].upper_limit, 0.0);
+                assert_eq!(buckets[0].count, 6); // 4 negative + 2 zero
+                assert_eq!(buckets[1].upper_limit, 2.0);
+                assert_eq!(buckets[1].count, 1);
+            }
+            _ => panic!("expected AggregatedHistogram"),
+        }
+    }
+
+    #[test]
+    fn zero_preserves_float_variant() {
+        let mut native = MetricValue::NativeHistogram {
+            count: NativeHistogramCount::Float(5.0),
+            sum: 3.0,
+            schema: 0,
+            zero_threshold: 0.0,
+            zero_count: NativeHistogramCount::Float(1.0),
+            positive_spans: vec![NativeHistogramSpan {
+                offset: 1,
+                length: 1,
+            }],
+            positive_buckets: NativeHistogramBuckets::FloatCounts(vec![5.0]),
+            negative_spans: vec![],
+            negative_buckets: NativeHistogramBuckets::FloatCounts(vec![]),
+            reset_hint: NativeHistogramResetHint::Gauge,
+        };
+
+        native.zero();
+
+        match native {
+            MetricValue::NativeHistogram {
+                count,
+                zero_count,
+                positive_buckets,
+                negative_buckets,
+                ..
+            } => {
+                assert!(count.is_float());
+                assert_eq!(count, NativeHistogramCount::Float(0.0));
+                assert!(zero_count.is_float());
+                assert!(matches!(
+                    positive_buckets,
+                    NativeHistogramBuckets::FloatCounts(_)
+                ));
+                assert!(positive_buckets.is_empty());
+                assert!(matches!(
+                    negative_buckets,
+                    NativeHistogramBuckets::FloatCounts(_)
+                ));
+            }
+            _ => panic!("expected NativeHistogram"),
         }
     }
 

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -145,6 +145,7 @@ impl From<Trace> for super::TraceEvent {
 }
 
 impl From<MetricValue> for super::MetricValue {
+    #[allow(clippy::too_many_lines)]
     fn from(value: MetricValue) -> Self {
         match value {
             MetricValue::Counter(counter) => Self::Counter {
@@ -200,6 +201,76 @@ impl From<MetricValue> for super::MetricValue {
                     sketch: ddsketch.into(),
                 },
             },
+            MetricValue::NativeHistogram(h) => {
+                use super::metric::{
+                    NativeHistogramBuckets, NativeHistogramCount, NativeHistogramResetHint,
+                    NativeHistogramSpan,
+                };
+                use native_histogram::{Count, ResetHint, ZeroCount};
+
+                let count = match h.count {
+                    Some(Count::CountInt(v)) => NativeHistogramCount::Integer(v),
+                    Some(Count::CountFloat(v)) => NativeHistogramCount::Float(v),
+                    None => NativeHistogramCount::Integer(0),
+                };
+                let zero_count = match h.zero_count {
+                    Some(ZeroCount::ZeroCountInt(v)) => NativeHistogramCount::Integer(v),
+                    Some(ZeroCount::ZeroCountFloat(v)) => NativeHistogramCount::Float(v),
+                    None => NativeHistogramCount::Integer(0),
+                };
+                let positive_buckets = if !h.positive_deltas.is_empty() {
+                    NativeHistogramBuckets::IntegerDeltas(h.positive_deltas)
+                } else if !h.positive_counts.is_empty() {
+                    NativeHistogramBuckets::FloatCounts(h.positive_counts)
+                } else if count.is_float() {
+                    NativeHistogramBuckets::FloatCounts(Vec::new())
+                } else {
+                    NativeHistogramBuckets::IntegerDeltas(Vec::new())
+                };
+                let negative_buckets = if !h.negative_deltas.is_empty() {
+                    NativeHistogramBuckets::IntegerDeltas(h.negative_deltas)
+                } else if !h.negative_counts.is_empty() {
+                    NativeHistogramBuckets::FloatCounts(h.negative_counts)
+                } else if count.is_float() {
+                    NativeHistogramBuckets::FloatCounts(Vec::new())
+                } else {
+                    NativeHistogramBuckets::IntegerDeltas(Vec::new())
+                };
+                let reset_hint =
+                    match ResetHint::try_from(h.reset_hint).unwrap_or(ResetHint::Unknown) {
+                        ResetHint::Unknown => NativeHistogramResetHint::Unknown,
+                        ResetHint::Yes => NativeHistogramResetHint::Yes,
+                        ResetHint::No => NativeHistogramResetHint::No,
+                        ResetHint::Gauge => NativeHistogramResetHint::Gauge,
+                    };
+
+                Self::NativeHistogram {
+                    count,
+                    sum: h.sum,
+                    schema: h.schema,
+                    zero_threshold: h.zero_threshold,
+                    zero_count,
+                    positive_spans: h
+                        .positive_spans
+                        .into_iter()
+                        .map(|s| NativeHistogramSpan {
+                            offset: s.offset,
+                            length: s.length,
+                        })
+                        .collect(),
+                    positive_buckets,
+                    negative_spans: h
+                        .negative_spans
+                        .into_iter()
+                        .map(|s| NativeHistogramSpan {
+                            offset: s.offset,
+                            length: s.length,
+                        })
+                        .collect(),
+                    negative_buckets,
+                    reset_hint,
+                }
+            }
         }
     }
 }
@@ -357,6 +428,7 @@ impl From<super::Metric> for Metric {
 }
 
 impl From<super::MetricValue> for MetricValue {
+    #[allow(clippy::too_many_lines)]
     fn from(value: super::MetricValue) -> Self {
         match value {
             super::MetricValue::Counter { value } => Self::Counter(Counter { value }),
@@ -412,6 +484,73 @@ impl From<super::MetricValue> for MetricValue {
                     })
                 }
             },
+            super::MetricValue::NativeHistogram {
+                count,
+                sum,
+                schema,
+                zero_threshold,
+                zero_count,
+                positive_spans,
+                positive_buckets,
+                negative_spans,
+                negative_buckets,
+                reset_hint,
+            } => {
+                use super::metric::{
+                    NativeHistogramBuckets, NativeHistogramCount, NativeHistogramResetHint,
+                };
+                use native_histogram::{Count, ResetHint, ZeroCount};
+
+                let proto_count = match count {
+                    NativeHistogramCount::Integer(v) => Count::CountInt(v),
+                    NativeHistogramCount::Float(v) => Count::CountFloat(v),
+                };
+                let proto_zero_count = match zero_count {
+                    NativeHistogramCount::Integer(v) => ZeroCount::ZeroCountInt(v),
+                    NativeHistogramCount::Float(v) => ZeroCount::ZeroCountFloat(v),
+                };
+                let proto_reset_hint = match reset_hint {
+                    NativeHistogramResetHint::Unknown => ResetHint::Unknown,
+                    NativeHistogramResetHint::Yes => ResetHint::Yes,
+                    NativeHistogramResetHint::No => ResetHint::No,
+                    NativeHistogramResetHint::Gauge => ResetHint::Gauge,
+                };
+                let (positive_deltas, positive_counts) = match positive_buckets {
+                    NativeHistogramBuckets::IntegerDeltas(d) => (d, Vec::new()),
+                    NativeHistogramBuckets::FloatCounts(c) => (Vec::new(), c),
+                };
+                let (negative_deltas, negative_counts) = match negative_buckets {
+                    NativeHistogramBuckets::IntegerDeltas(d) => (d, Vec::new()),
+                    NativeHistogramBuckets::FloatCounts(c) => (Vec::new(), c),
+                };
+
+                Self::NativeHistogram(NativeHistogram {
+                    count: Some(proto_count),
+                    sum,
+                    schema,
+                    zero_threshold,
+                    zero_count: Some(proto_zero_count),
+                    positive_spans: positive_spans
+                        .into_iter()
+                        .map(|s| native_histogram::BucketSpan {
+                            offset: s.offset,
+                            length: s.length,
+                        })
+                        .collect(),
+                    positive_deltas,
+                    positive_counts,
+                    negative_spans: negative_spans
+                        .into_iter()
+                        .map(|s| native_histogram::BucketSpan {
+                            offset: s.offset,
+                            length: s.length,
+                        })
+                        .collect(),
+                    negative_deltas,
+                    negative_counts,
+                    reset_hint: proto_reset_hint as i32,
+                })
+            }
         }
     }
 }

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -47,6 +47,7 @@ pub enum VrlTarget {
     Trace(Value, EventMetadata),
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum TargetEvents {
     One(Event),
     Logs(TargetIter<LogEvent>),

--- a/src/sinks/datadog/metrics/normalizer.rs
+++ b/src/sinks/datadog/metrics/normalizer.rs
@@ -27,6 +27,15 @@ impl MetricNormalize for DatadogMetricsNormalizer {
                 .make_incremental(metric)
                 .filter(|metric| !metric.value().is_empty())
                 .and_then(|metric| AgentDDSketch::transform_to_sketch(metric).ok()),
+            // Native histograms are converted to aggregated histograms first (lossy), then to
+            // sketches. Like sketches, they can't be meaningfully subtracted, so we treat them as
+            // implicitly incremental.
+            MetricValue::NativeHistogram { .. } => metric
+                .value()
+                .native_histogram_to_agg_histogram()
+                .map(|agg| metric.clone().into_incremental().with_value(agg))
+                .filter(|m| !m.value().is_empty())
+                .and_then(|m| AgentDDSketch::transform_to_sketch(m).ok()),
             // Sketches cannot be subtracted from one another, so we treat them as implicitly
             // incremental, and just update the metric type.
             MetricValue::Sketch { .. } => Some(metric.into_incremental()),

--- a/src/sinks/datadog/metrics/sink.rs
+++ b/src/sinks/datadog/metrics/sink.rs
@@ -54,6 +54,8 @@ impl Partitioner for DatadogMetricsTypePartitioner {
             // NOTE: AggregatedSummary will be split into counters and gauges during normalization
             MetricValue::AggregatedSummary { .. } => series,
             MetricValue::Sketch { .. } => DatadogMetricsEndpoint::Sketches,
+            // Native histograms are most similar to sketches (sparse, exponential bucketing).
+            MetricValue::NativeHistogram { .. } => DatadogMetricsEndpoint::Sketches,
         };
         (item.metadata().datadog_api_key(), endpoint)
     }

--- a/src/sinks/greptimedb/metrics/batch.rs
+++ b/src/sinks/greptimedb/metrics/batch.rs
@@ -38,6 +38,10 @@ impl GreptimeDBBatchSizer {
                 MetricValue::AggregatedHistogram { buckets, .. }  => F64_BYTE_SIZE * (buckets.len() + SUMMARY_STAT_FIELD_COUNT),
                 MetricValue::AggregatedSummary { quantiles, .. } => F64_BYTE_SIZE * (quantiles.len() + SUMMARY_STAT_FIELD_COUNT),
                 MetricValue::Sketch { .. } => F64_BYTE_SIZE * (DISTRIBUTION_QUANTILES.len() + DISTRIBUTION_STAT_FIELD_COUNT),
+                // Native histograms are converted to classic histograms before encoding, so estimate based on
+                // total populated bucket count.
+                MetricValue::NativeHistogram { positive_buckets, negative_buckets, .. } =>
+                    F64_BYTE_SIZE * (positive_buckets.len() + negative_buckets.len() + SUMMARY_STAT_FIELD_COUNT),
             }
     }
 }

--- a/src/sinks/greptimedb/metrics/request_builder.rs
+++ b/src/sinks/greptimedb/metrics/request_builder.rs
@@ -130,6 +130,19 @@ pub fn metric_to_insert_request(
             let MetricSketch::AgentDDSketch(sketch) = sketch;
             encode_sketch(sketch, &mut schema, &mut columns);
         }
+        value @ MetricValue::NativeHistogram { .. } => {
+            // GreptimeDB doesn't support native histograms natively; convert to classic histogram.
+            if let Some(MetricValue::AggregatedHistogram {
+                buckets,
+                count,
+                sum,
+            }) = value.native_histogram_to_agg_histogram()
+            {
+                encode_histogram(buckets.as_ref(), &mut schema, &mut columns);
+                encode_f64_value("count", count as f64, &mut schema, &mut columns);
+                encode_f64_value("sum", sum, &mut schema, &mut columns);
+            }
+        }
     }
 
     RowInsertRequest {

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -398,6 +398,33 @@ fn get_type_and_fields(
                 ("sketch", Some(fields))
             }
         },
+        native @ MetricValue::NativeHistogram { .. } => {
+            // InfluxDB doesn't support native histograms; convert to classic histogram buckets.
+            let fields = native.native_histogram_to_agg_histogram().and_then(|agg| {
+                if let MetricValue::AggregatedHistogram {
+                    buckets,
+                    count,
+                    sum,
+                } = agg
+                {
+                    let mut fields: HashMap<KeyString, Field> = buckets
+                        .iter()
+                        .map(|sample| {
+                            (
+                                format!("bucket_{}", sample.upper_limit).into(),
+                                Field::UnsignedInt(sample.count),
+                            )
+                        })
+                        .collect();
+                    fields.insert("count".into(), Field::UnsignedInt(count));
+                    fields.insert("sum".into(), Field::Float(sum));
+                    Some(fields)
+                } else {
+                    None
+                }
+            });
+            ("histogram", fields)
+        }
     }
 }
 

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -3,7 +3,10 @@ use std::{collections::BTreeMap, fmt::Write as _};
 use chrono::Utc;
 use indexmap::map::IndexMap;
 use vector_lib::{
-    event::metric::{MetricSketch, MetricTags, Quantile, samples_to_buckets},
+    event::metric::{
+        MetricSketch, MetricTags, NativeHistogramBuckets, NativeHistogramCount,
+        NativeHistogramResetHint, NativeHistogramSpan, Quantile, samples_to_buckets,
+    },
     prometheus::parser::{METRIC_NAME_LABEL, proto},
 };
 
@@ -28,6 +31,79 @@ pub(super) trait MetricCollector {
         tags: Option<&MetricTags>,
         extra: Option<(&str, String)>,
     );
+
+    /// Emit a native histogram.
+    ///
+    /// The default implementation converts the native histogram to a classic aggregated histogram
+    /// and emits it as multiple samples. Collectors that support native histograms (e.g.,
+    /// Prometheus remote write) should override this to emit a proper native histogram.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_native_histogram(
+        &mut self,
+        timestamp_millis: Option<i64>,
+        name: &str,
+        tags: Option<&MetricTags>,
+        count: &NativeHistogramCount,
+        sum: f64,
+        schema: i32,
+        zero_threshold: f64,
+        zero_count: &NativeHistogramCount,
+        positive_spans: &[NativeHistogramSpan],
+        positive_buckets: &NativeHistogramBuckets,
+        negative_spans: &[NativeHistogramSpan],
+        negative_buckets: &NativeHistogramBuckets,
+        reset_hint: NativeHistogramResetHint,
+    ) {
+        // Suppress "unused" warnings for parameters only needed by overriding implementations.
+        let _ = (schema, reset_hint);
+
+        // Fallback: build a classic histogram representation and emit it as float samples.
+        // This is lossy but allows the text exposition format to represent native histograms.
+        let native_value = MetricValue::NativeHistogram {
+            count: *count,
+            sum,
+            schema,
+            zero_threshold,
+            zero_count: *zero_count,
+            positive_spans: positive_spans.to_vec(),
+            positive_buckets: positive_buckets.clone(),
+            negative_spans: negative_spans.to_vec(),
+            negative_buckets: negative_buckets.clone(),
+            reset_hint,
+        };
+        if let Some(MetricValue::AggregatedHistogram {
+            buckets,
+            count,
+            sum,
+        }) = native_value.native_histogram_to_agg_histogram()
+        {
+            let mut bucket_count = 0.0;
+            for bucket in &buckets {
+                if bucket.upper_limit.is_infinite() {
+                    continue;
+                }
+                bucket_count += bucket.count as f64;
+                self.emit_value(
+                    timestamp_millis,
+                    name,
+                    "_bucket",
+                    bucket_count,
+                    tags,
+                    Some(("le", bucket.upper_limit.to_string())),
+                );
+            }
+            self.emit_value(
+                timestamp_millis,
+                name,
+                "_bucket",
+                count as f64,
+                tags,
+                Some(("le", "+Inf".to_string())),
+            );
+            self.emit_value(timestamp_millis, name, "_sum", sum, tags, None);
+            self.emit_value(timestamp_millis, name, "_count", count as f64, tags, None);
+        }
+    }
 
     fn finish(self) -> Self::Output;
 
@@ -215,6 +291,34 @@ pub(super) trait MetricCollector {
                         );
                     }
                 },
+                MetricValue::NativeHistogram {
+                    count,
+                    sum,
+                    schema,
+                    zero_threshold,
+                    zero_count,
+                    positive_spans,
+                    positive_buckets,
+                    negative_spans,
+                    negative_buckets,
+                    reset_hint,
+                } => {
+                    self.emit_native_histogram(
+                        timestamp,
+                        name,
+                        tags,
+                        count,
+                        *sum,
+                        *schema,
+                        *zero_threshold,
+                        zero_count,
+                        positive_spans,
+                        positive_buckets,
+                        negative_spans,
+                        negative_buckets,
+                        *reset_hint,
+                    );
+                }
             }
         }
     }
@@ -315,8 +419,14 @@ impl StringCollector {
 
 type Labels = Vec<proto::Label>;
 
+#[derive(Default)]
+struct SeriesEntry {
+    samples: Vec<proto::Sample>,
+    histograms: Vec<proto::Histogram>,
+}
+
 pub(super) struct TimeSeries {
-    buffer: IndexMap<Labels, Vec<proto::Sample>>,
+    buffer: IndexMap<Labels, SeriesEntry>,
     metadata: IndexMap<String, proto::MetricMetadata>,
     timestamp: Option<i64>,
 }
@@ -392,14 +502,102 @@ impl MetricCollector for TimeSeries {
         self.buffer
             .entry(Self::make_labels(tags, name, suffix, extra))
             .or_default()
+            .samples
             .push(proto::Sample { value, timestamp });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_native_histogram(
+        &mut self,
+        timestamp_millis: Option<i64>,
+        name: &str,
+        tags: Option<&MetricTags>,
+        count: &NativeHistogramCount,
+        sum: f64,
+        schema: i32,
+        zero_threshold: f64,
+        zero_count: &NativeHistogramCount,
+        positive_spans: &[NativeHistogramSpan],
+        positive_buckets: &NativeHistogramBuckets,
+        negative_spans: &[NativeHistogramSpan],
+        negative_buckets: &NativeHistogramBuckets,
+        reset_hint: NativeHistogramResetHint,
+    ) {
+        use proto::histogram::{Count, ResetHint, ZeroCount};
+
+        let timestamp = timestamp_millis.unwrap_or_else(|| self.default_timestamp());
+
+        let proto_count = match count {
+            NativeHistogramCount::Integer(v) => Count::CountInt(*v),
+            NativeHistogramCount::Float(v) => Count::CountFloat(*v),
+        };
+
+        let proto_zero_count = match zero_count {
+            NativeHistogramCount::Integer(v) => ZeroCount::ZeroCountInt(*v),
+            NativeHistogramCount::Float(v) => ZeroCount::ZeroCountFloat(*v),
+        };
+
+        let proto_reset_hint = match reset_hint {
+            NativeHistogramResetHint::Unknown => ResetHint::Unknown,
+            NativeHistogramResetHint::Yes => ResetHint::Yes,
+            NativeHistogramResetHint::No => ResetHint::No,
+            NativeHistogramResetHint::Gauge => ResetHint::Gauge,
+        };
+
+        let (positive_deltas, positive_counts) = match positive_buckets {
+            NativeHistogramBuckets::IntegerDeltas(d) => (d.clone(), Vec::new()),
+            NativeHistogramBuckets::FloatCounts(c) => (Vec::new(), c.clone()),
+        };
+
+        let (negative_deltas, negative_counts) = match negative_buckets {
+            NativeHistogramBuckets::IntegerDeltas(d) => (d.clone(), Vec::new()),
+            NativeHistogramBuckets::FloatCounts(c) => (Vec::new(), c.clone()),
+        };
+
+        let histogram = proto::Histogram {
+            count: Some(proto_count),
+            sum,
+            schema,
+            zero_threshold,
+            zero_count: Some(proto_zero_count),
+            negative_spans: negative_spans
+                .iter()
+                .map(|s| proto::BucketSpan {
+                    offset: s.offset,
+                    length: s.length,
+                })
+                .collect(),
+            negative_deltas,
+            negative_counts,
+            positive_spans: positive_spans
+                .iter()
+                .map(|s| proto::BucketSpan {
+                    offset: s.offset,
+                    length: s.length,
+                })
+                .collect(),
+            positive_deltas,
+            positive_counts,
+            reset_hint: proto_reset_hint as i32,
+            timestamp,
+        };
+
+        self.buffer
+            .entry(Self::make_labels(tags, name, "", None))
+            .or_default()
+            .histograms
+            .push(histogram);
     }
 
     fn finish(self) -> proto::WriteRequest {
         let timeseries = self
             .buffer
             .into_iter()
-            .map(|(labels, samples)| proto::TimeSeries { labels, samples })
+            .map(|(labels, entry)| proto::TimeSeries {
+                labels,
+                samples: entry.samples,
+                histograms: entry.histograms,
+            })
             .collect::<Vec<_>>();
         let metadata = self
             .metadata
@@ -429,6 +627,7 @@ const fn prometheus_metric_type(metric_value: &MetricValue) -> proto::MetricType
         MetricValue::AggregatedHistogram { .. } => MetricType::Histogram,
         MetricValue::AggregatedSummary { .. } => MetricType::Summary,
         MetricValue::Sketch { .. } => MetricType::Summary,
+        MetricValue::NativeHistogram { .. } => MetricType::Histogram,
     }
 }
 
@@ -489,6 +688,7 @@ mod tests {
                                 value: $svalue,
                                 timestamp: $timestamp,
                             }],
+                            histograms: vec![],
                         },
                     )*
                 ],
@@ -967,6 +1167,90 @@ mod tests {
                 # TYPE something counter
                 something{code="success"} 1
             "#}
+        );
+    }
+
+    fn native_histogram_metric() -> Metric {
+        use crate::event::metric::{
+            NativeHistogramBuckets, NativeHistogramCount, NativeHistogramResetHint,
+            NativeHistogramSpan,
+        };
+
+        // A simple native histogram with schema=0 (powers of 2), 3 populated positive buckets
+        // starting at index 1: buckets at indices 1, 2, 3 with counts 2, 3, 1.
+        // Delta encoding: [2, 1, -2] -> absolute counts [2, 3, 1]
+        // Upper bounds at schema=0: index 1 -> 2.0, index 2 -> 4.0, index 3 -> 8.0
+        Metric::new(
+            "request_latency".to_owned(),
+            MetricKind::Absolute,
+            MetricValue::NativeHistogram {
+                count: NativeHistogramCount::Integer(6),
+                sum: 18.5,
+                schema: 0,
+                zero_threshold: 0.0,
+                zero_count: NativeHistogramCount::Integer(0),
+                positive_spans: vec![NativeHistogramSpan {
+                    offset: 1,
+                    length: 3,
+                }],
+                positive_buckets: NativeHistogramBuckets::IntegerDeltas(vec![2, 1, -2]),
+                negative_spans: vec![],
+                negative_buckets: NativeHistogramBuckets::IntegerDeltas(vec![]),
+                reset_hint: NativeHistogramResetHint::No,
+            },
+        )
+        .with_tags(Some(tags()))
+        .with_timestamp(Some(timestamp()))
+    }
+
+    #[test]
+    fn encodes_native_histogram_as_text_fallback() {
+        // Text exposition format doesn't support native histograms, so we expect a lossy
+        // conversion to classic bucketed histogram.
+        let encoded = encode_one::<StringCollector>(None, &[], &[], &native_histogram_metric());
+        assert_eq!(
+            encoded,
+            indoc! {r#"
+                # HELP request_latency request_latency
+                # TYPE request_latency histogram
+                request_latency_bucket{code="200",le="2"} 2 1612325106789
+                request_latency_bucket{code="200",le="4"} 5 1612325106789
+                request_latency_bucket{code="200",le="8"} 6 1612325106789
+                request_latency_bucket{code="200",le="+Inf"} 6 1612325106789
+                request_latency_sum{code="200"} 18.5 1612325106789
+                request_latency_count{code="200"} 6 1612325106789
+            "#}
+        );
+    }
+
+    #[test]
+    fn encodes_native_histogram_as_remote_write() {
+        // Remote write supports native histograms directly - verify we emit a proper
+        // proto::Histogram rather than expanding to multiple samples.
+        let encoded = encode_one::<TimeSeries>(None, &[], &[], &native_histogram_metric());
+
+        assert_eq!(encoded.timeseries.len(), 1);
+        let ts = &encoded.timeseries[0];
+        assert!(ts.samples.is_empty(), "expected no float samples");
+        assert_eq!(ts.histograms.len(), 1);
+
+        let h = &ts.histograms[0];
+        assert_eq!(h.schema, 0);
+        assert_eq!(h.sum, 18.5);
+        assert_eq!(h.count, Some(proto::histogram::Count::CountInt(6)));
+        assert_eq!(h.positive_spans.len(), 1);
+        assert_eq!(h.positive_spans[0].offset, 1);
+        assert_eq!(h.positive_spans[0].length, 3);
+        assert_eq!(h.positive_deltas, vec![2, 1, -2]);
+        assert!(h.positive_counts.is_empty());
+        assert_eq!(h.reset_hint, proto::histogram::ResetHint::No as i32);
+        assert_eq!(h.timestamp, 1612325106789);
+
+        // Verify labels include __name__ without suffix.
+        assert!(
+            ts.labels
+                .iter()
+                .any(|l| { l.name == "__name__" && l.value == "request_latency" })
         );
     }
 }

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -54,9 +54,6 @@ pub(super) trait MetricCollector {
         negative_buckets: &NativeHistogramBuckets,
         reset_hint: NativeHistogramResetHint,
     ) {
-        // Suppress "unused" warnings for parameters only needed by overriding implementations.
-        let _ = (schema, reset_hint);
-
         // Fallback: build a classic histogram representation and emit it as float samples.
         // This is lossy but allows the text exposition format to represent native histograms.
         let native_value = MetricValue::NativeHistogram {

--- a/src/sinks/util/buffer/metrics/split.rs
+++ b/src/sinks/util/buffer/metrics/split.rs
@@ -119,7 +119,8 @@ impl MetricSplit for AggregatedSummarySplitter {
             | MetricValue::Set { .. }
             | MetricValue::Distribution { .. }
             | MetricValue::AggregatedHistogram { .. }
-            | MetricValue::Sketch { .. } => {
+            | MetricValue::Sketch { .. }
+            | MetricValue::NativeHistogram { .. } => {
                 SplitIterator::single(Metric::from_parts(series, data, metadata))
             }
             MetricValue::AggregatedSummary { .. } => {

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -9,7 +9,10 @@ use vector_lib::prometheus::parser::{
 
 use crate::event::{
     Event,
-    metric::{Bucket, Metric, MetricKind, MetricTags, MetricValue, Quantile},
+    metric::{
+        Bucket, Metric, MetricKind, MetricTags, MetricValue, NativeHistogramBuckets,
+        NativeHistogramCount, NativeHistogramResetHint, NativeHistogramSpan, Quantile,
+    },
 };
 
 fn utc_timestamp(timestamp: Option<i64>, default: DateTime<Utc>) -> DateTime<Utc> {
@@ -197,10 +200,100 @@ fn reparse_groups(
                     );
                 }
             }
+            GroupKind::NativeHistogram(metrics) => {
+                for (key, metric) in metrics {
+                    if skip_nan_values && metric.histogram.sum.is_nan() {
+                        continue;
+                    }
+
+                    let tags = combine_tags(key.labels, tag_overrides.clone());
+                    let value = proto_histogram_to_native(metric.histogram);
+
+                    result.push(
+                        Metric::new(group.name.clone(), metric_kind, value)
+                            .with_timestamp(Some(utc_timestamp(key.timestamp, start)))
+                            .with_tags(tags.as_option())
+                            .into(),
+                    );
+                }
+            }
         }
     }
 
     result
+}
+
+/// Convert a Prometheus proto `Histogram` into Vector's internal `NativeHistogram` representation.
+fn proto_histogram_to_native(h: vector_lib::prometheus::parser::proto::Histogram) -> MetricValue {
+    use vector_lib::prometheus::parser::proto::histogram::{Count, ResetHint, ZeroCount};
+
+    let count = match h.count {
+        Some(Count::CountInt(v)) => NativeHistogramCount::Integer(v),
+        Some(Count::CountFloat(v)) => NativeHistogramCount::Float(v),
+        None => NativeHistogramCount::Integer(0),
+    };
+
+    let zero_count = match h.zero_count {
+        Some(ZeroCount::ZeroCountInt(v)) => NativeHistogramCount::Integer(v),
+        Some(ZeroCount::ZeroCountFloat(v)) => NativeHistogramCount::Float(v),
+        None => NativeHistogramCount::Integer(0),
+    };
+
+    // Float histograms use absolute counts; integer histograms use delta encoding.
+    // Prefer integer deltas when present, else fall back to float counts.
+    let positive_buckets = if !h.positive_deltas.is_empty() {
+        NativeHistogramBuckets::IntegerDeltas(h.positive_deltas)
+    } else if !h.positive_counts.is_empty() {
+        NativeHistogramBuckets::FloatCounts(h.positive_counts)
+    } else if count.is_float() {
+        NativeHistogramBuckets::FloatCounts(Vec::new())
+    } else {
+        NativeHistogramBuckets::IntegerDeltas(Vec::new())
+    };
+
+    let negative_buckets = if !h.negative_deltas.is_empty() {
+        NativeHistogramBuckets::IntegerDeltas(h.negative_deltas)
+    } else if !h.negative_counts.is_empty() {
+        NativeHistogramBuckets::FloatCounts(h.negative_counts)
+    } else if count.is_float() {
+        NativeHistogramBuckets::FloatCounts(Vec::new())
+    } else {
+        NativeHistogramBuckets::IntegerDeltas(Vec::new())
+    };
+
+    let reset_hint = match ResetHint::try_from(h.reset_hint).unwrap_or(ResetHint::Unknown) {
+        ResetHint::Unknown => NativeHistogramResetHint::Unknown,
+        ResetHint::Yes => NativeHistogramResetHint::Yes,
+        ResetHint::No => NativeHistogramResetHint::No,
+        ResetHint::Gauge => NativeHistogramResetHint::Gauge,
+    };
+
+    MetricValue::NativeHistogram {
+        count,
+        sum: h.sum,
+        schema: h.schema,
+        zero_threshold: h.zero_threshold,
+        zero_count,
+        positive_spans: h
+            .positive_spans
+            .into_iter()
+            .map(|s| NativeHistogramSpan {
+                offset: s.offset,
+                length: s.length,
+            })
+            .collect(),
+        positive_buckets,
+        negative_spans: h
+            .negative_spans
+            .into_iter()
+            .map(|s| NativeHistogramSpan {
+                offset: s.offset,
+                length: s.length,
+            })
+            .collect(),
+        negative_buckets,
+        reset_hint,
+    }
 }
 
 #[cfg(feature = "sources-prometheus-remote-write")]

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -367,6 +367,7 @@ mod test {
                     value: 42.0,
                     timestamp: chrono::Utc::now().timestamp_millis(),
                 }],
+                histograms: vec![],
             }],
         };
 
@@ -405,6 +406,7 @@ mod test {
                     value: 42.0,
                     timestamp: chrono::Utc::now().timestamp_millis(),
                 }],
+                histograms: vec![],
             }],
         };
 
@@ -542,6 +544,7 @@ mod test {
                             value: 42.0,
                             timestamp: chrono::Utc::now().timestamp_millis(),
                         }],
+                        histograms: vec![],
                     },
                     proto::TimeSeries {
                         labels: vec![proto::Label {
@@ -552,6 +555,7 @@ mod test {
                             value: f64::NAN,
                             timestamp: chrono::Utc::now().timestamp_millis(),
                         }],
+                        histograms: vec![],
                     },
                 ],
             };
@@ -613,6 +617,7 @@ mod test {
                             value: 42.0,
                             timestamp: chrono::Utc::now().timestamp_millis(),
                         }],
+                        histograms: vec![],
                     },
                     proto::TimeSeries {
                         labels: vec![proto::Label {
@@ -623,6 +628,7 @@ mod test {
                             value: f64::NAN,
                             timestamp: chrono::Utc::now().timestamp_millis(),
                         }],
+                        histograms: vec![],
                     },
                 ],
             };

--- a/src/test_util/mock/transforms/basic.rs
+++ b/src/test_util/mock/transforms/basic.rs
@@ -99,6 +99,7 @@ impl FunctionTransform for BasicTransform {
                     MetricValue::AggregatedHistogram { .. } => None,
                     MetricValue::AggregatedSummary { .. } => None,
                     MetricValue::Sketch { .. } => None,
+                    MetricValue::NativeHistogram { .. } => None,
                     MetricValue::Set { .. } => {
                         let mut values = BTreeSet::new();
                         values.insert(self.suffix.clone());

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1601,6 +1601,7 @@ mod tests {
         out.primary.into_events().next()
     }
 
+    #[allow(clippy::result_large_err)]
     fn transform_one_fallible(
         ft: &mut dyn SyncTransform,
         event: Event,

--- a/website/cue/reference/components/sources/generated/static_metrics.cue
+++ b/website/cue/reference/components/sources/generated/static_metrics.cue
@@ -177,6 +177,183 @@ generated: components: sources: static_metrics: configuration: {
 								type: float: {}
 							}
 						}
+						native_histogram: {
+							description: """
+																			A Prometheus-style native (exponential) histogram.
+
+																			Native histograms use exponential bucket boundaries determined by a `schema` parameter, allowing for high
+																			resolution at low cost. Unlike `AggregatedHistogram` which uses fixed bucket boundaries, native histograms use
+																			sparse buckets indexed by integer keys, where adjacent buckets grow by a factor of `2^(2^-schema)`.
+
+																			See <https://prometheus.io/docs/specs/native_histograms/> for details.
+																			"""
+							required: true
+							type: object: options: {
+								count: {
+									description: """
+																							The total number of observations.
+
+																							May be a float to support gauge histograms where resets can cause fractional counts.
+																							"""
+									required: true
+									type: object: options: {
+										float: {
+											description: "Floating-point count value."
+											required:    true
+											type: float: {}
+										}
+										integer: {
+											description: "Integer count value."
+											required:    true
+											type: uint: {}
+										}
+									}
+								}
+								negative_buckets: {
+									description: """
+																							Bucket values for negative buckets.
+
+																							For integer counts, these are deltas from the previous bucket (first is absolute). For float counts, these
+																							are absolute values. The interpretation depends on the `count` type.
+																							"""
+									required: true
+									type: object: options: {
+										float_counts: {
+											description: "Absolute floating-point bucket counts."
+											required:    true
+											type: array: items: type: float: {}
+										}
+										integer_deltas: {
+											description: """
+																											Delta-encoded integer bucket counts.
+
+																											The first value is the absolute count of the first bucket; subsequent values are the delta from the previous
+																											bucket's count.
+																											"""
+											required: true
+											type: array: items: type: int: {}
+										}
+									}
+								}
+								negative_spans: {
+									description: """
+																							A span of consecutive populated buckets in a native histogram.
+
+																							Spans of populated negative buckets.
+																							"""
+									required: true
+									type: array: items: type: object: options: {
+										length: {
+											description: "Number of consecutive buckets in this span."
+											required:    true
+											type: uint: {}
+										}
+										offset: {
+											description: "Gap in bucket indices from the previous span (or from zero for the first span)."
+											required:    true
+											type: int: {}
+										}
+									}
+								}
+								positive_buckets: {
+									description: """
+																							Bucket values for positive buckets.
+
+																							For integer counts, these are deltas from the previous bucket (first is absolute). For float counts, these
+																							are absolute values. The interpretation depends on the `count` type.
+																							"""
+									required: true
+									type: object: options: {
+										float_counts: {
+											description: "Absolute floating-point bucket counts."
+											required:    true
+											type: array: items: type: float: {}
+										}
+										integer_deltas: {
+											description: """
+																											Delta-encoded integer bucket counts.
+
+																											The first value is the absolute count of the first bucket; subsequent values are the delta from the previous
+																											bucket's count.
+																											"""
+											required: true
+											type: array: items: type: int: {}
+										}
+									}
+								}
+								positive_spans: {
+									description: """
+																							A span of consecutive populated buckets in a native histogram.
+
+																							Spans of populated positive buckets.
+																							"""
+									required: true
+									type: array: items: type: object: options: {
+										length: {
+											description: "Number of consecutive buckets in this span."
+											required:    true
+											type: uint: {}
+										}
+										offset: {
+											description: "Gap in bucket indices from the previous span (or from zero for the first span)."
+											required:    true
+											type: int: {}
+										}
+									}
+								}
+								reset_hint: {
+									description: "Hint about whether this represents a counter reset."
+									required:    true
+									type: string: enum: {
+										gauge:   "This histogram is a gauge histogram (no reset semantics)."
+										no:      "This histogram is known not to be the first after a reset."
+										unknown: "No hint; receiver should detect resets from the data."
+										yes:     "This histogram is the first after a reset (or the very first observation)."
+									}
+								}
+								schema: {
+									description: """
+																							The resolution parameter.
+
+																							Valid values are from -4 to 8 for standard exponential schemas. Higher values give finer resolution.
+																							Bucket boundaries are at `(2^(2^-schema))^n` for positive buckets.
+																							"""
+									required: true
+									type: int: {}
+								}
+								sum: {
+									description: "The sum of all observations."
+									required:    true
+									type: float: {}
+								}
+								zero_count: {
+									description: "Count of observations in the zero bucket."
+									required:    true
+									type: object: options: {
+										float: {
+											description: "Floating-point count value."
+											required:    true
+											type: float: {}
+										}
+										integer: {
+											description: "Integer count value."
+											required:    true
+											type: uint: {}
+										}
+									}
+								}
+								zero_threshold: {
+									description: """
+																							The width of the "zero bucket".
+
+																							Observations in `[-zero_threshold, zero_threshold]` are counted in the zero bucket rather than in positive
+																							or negative exponential buckets.
+																							"""
+									required: true
+									type: float: {}
+								}
+							}
+						}
 						set: {
 							description: "A set of (unordered) unique values for a key."
 							required:    true


### PR DESCRIPTION
## Summary

This PR adds support for **Prometheus native histograms** (also known as sparse/exponential histograms), enabling lossless pass-through of native histogram data between Prometheus-compatible systems via the remote write protocol.

### What's included

- **New `MetricValue::NativeHistogram` variant** with supporting types:
  - `NativeHistogramCount` — integer (counter) or float (gauge) count
  - `NativeHistogramSpan` — sparse bucket span (offset + length)
  - `NativeHistogramBuckets` — delta-encoded integer or absolute float bucket counts
  - `NativeHistogramResetHint` — reset hint per Prometheus spec
- **Proto definitions** in both Vector's internal event proto (disk buffers) and the Prometheus remote write proto, matching the upstream [prompb/types.proto](https://github.com/prometheus/prometheus/blob/main/prompb/types.proto) definition
- **`prometheus_remote_write` source**: parses incoming `Histogram` proto messages from `TimeSeries.histograms` and emits them as native histogram metrics
- **`prometheus_remote_write` sink**: emits native histograms as proper `Histogram` proto messages
- **Lossy fallback conversion** (`native_histogram_to_agg_histogram()`) for sinks without native support:
  - `prometheus_exporter` (text exposition format)
  - `influxdb`
  - `greptimedb`
  - `datadog_metrics` (converted via aggregated histogram → DDSketch)
- **Unit tests** covering bucket bound computation, delta decoding, span iteration, and both encoding paths (text fallback + remote write proto)

### Design notes

Native histograms use exponential bucket boundaries determined by a `schema` parameter (`2^(2^-schema)` growth factor), with a sparse representation using spans rather than storing every bucket. The implementation preserves:

- Both integer (delta-encoded) and float (absolute) bucket representations
- Separate positive/negative bucket spans
- Zero bucket with configurable threshold
- Reset hint for counter reset detection

For sinks without native support, the conversion computes explicit bucket upper bounds from `(schema, index)` pairs, yielding a classic aggregated histogram. This is lossy (collapses the sparse exponential structure into fixed buckets) but allows existing pipelines to continue operating.

Native histograms are **not** added to `add()`/`subtract()` — they return `false` (reinitialize), which is the same pattern used for mismatched aggregated histograms. Proper merging would require schema alignment and span merging, which can be added in a follow-up if needed.

## Test plan

- [x] `cargo test -p prometheus-parser` — 18 tests pass including new `parse_request_native_histogram`
- [x] `cargo test -p vector-core --lib event::metric` — 28 tests pass including 11 native histogram tests
- [x] `cargo test -p vector sinks::prometheus::collector` — 25 tests pass including `encodes_native_histogram_as_text_fallback` and `encodes_native_histogram_as_remote_write`
- [x] `cargo clippy --workspace --all-targets --all-features` — passes
- [x] `cargo fmt --all --check` — passes
- [x] `./scripts/check_changelog_fragments.sh` — passes
