### PR TITLE
fix(website): use parent site for RUM to resolve intake host

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -95,7 +95,7 @@ discord = "https://chat.vector.dev"
 [params.datadog_config]
 application_id = "894af722-5919-4a62-97fc-33f49bc52803"
 client_token = "pubcee1dc56e7f5bd03397cc3624eb7961c"
-site = "cose.datadoghq.com"
+site = "datadoghq.com"
 service_name = "vector"
 
 ## Menus


### PR DESCRIPTION
## Summary

Onboarding the website's RUM to the `cose.datadoghq.com` sub-org. Sub-orgs share the parent site's intake endpoints, so `site` must be the canonical site string (`datadoghq.com`) — passing the sub-org subdomain made the SDK build `browser-intake-cose-datadoghq.com`, which does not resolve.

## Vector configuration

NA

## How did you test this PR?

Website preview

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA