### PR TITLE
docs(deprecations): add greptimedb v0 support deprecation entry

### DIFF
--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -21,3 +21,5 @@ For example:
 ## To be migrated
 
 ## To be removed
+
+- `v0.56.0` | `greptimedb-v0-support` | The `greptimedb_metrics` and `greptimedb_logs` sinks drop support for GreptimeDB v0.x. Users must upgrade their GreptimeDB instance to v1.x before upgrading Vector.


### PR DESCRIPTION
## Summary

Adds a deprecation entry for dropping GreptimeDB v0.x support in the `greptimedb_metrics` and `greptimedb_logs` sinks, scheduled for Vector v0.56.0.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA