### PR TITLE
fix(ci): use CUE raw multi-line strings in release generator

### DIFF
--- a/scripts/generate-release-cue.rb
+++ b/scripts/generate-release-cue.rb
@@ -217,11 +217,14 @@ def generate_changelog!(new_version)
 
     # Note: `pr_numbers`, `scopes` and `breaking` are being omitted from the entries.
     #       These are currently not required for rendering in the website.
+    # Use CUE raw multi-line strings (#"""..."""#) so backslashes in the
+    # fragment (e.g. shell line continuations) are not interpreted as
+    # escape sequences.
     entry = "{\n" +
       "type: #{type.to_json}\n" +
-      "description: \"\"\"\n" +
+      "description: #\"\"\"\n" +
       "#{description}\n" +
-      "\"\"\"\n"
+      "\"\"\"#\n"
 
     if contributors.length() > 0
       entry += "contributors: #{contributors.to_json}\n"


### PR DESCRIPTION
## Summary

`scripts/generate-release-cue.rb` embeds each changelog fragment's description into a CUE `"""..."""` multi-line string. Backslashes inside that string are still interpreted as escape sequences, so any fragment containing e.g. a shell line-continuation (`\<newline>`) produces an `unknown escape sequence` error in `cue export`. That in turn makes the next `cargo vdev release prepare` run fail, because the generator parses prior release cue files at startup.

This PR switches the generated `description` blocks to CUE raw multi-line strings (`#"""..."""#`) so backslashes are literal and fragments can contain arbitrary shell snippets, regex examples, Windows paths, etc. without bespoke escaping.

## Vector configuration

N/A — release tooling only.

## How did you test this PR?

- Reproduced the original failure on `master` against `changelog.d/graphql_to_grpc_api.breaking.md` (which contains `grpcurl -plaintext \` line continuations).
- Applied the fix, deleted the pre-existing `website/cue/reference/releases/0.55.0.cue`, and reran `bundle exec ./scripts/generate-release-cue.rb --new-version 0.55.0 --no-interactive`. The script completes without any `unknown escape sequence:` output.
- Ran `cue export` on the regenerated `0.55.0.cue`. Previously this failed with `unexpected token at ''` (empty output from cue); now it returns valid JSON.
- Parsed the JSON and confirmed the backslash-newline line continuations are preserved literally in the resulting `description` field.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)