### PR TITLE
fix(api): restore HTTP GET /health endpoint

### DIFF
--- a/src/api/grpc_server.rs
+++ b/src/api/grpc_server.rs
@@ -1,4 +1,19 @@
-use std::{error::Error as StdError, net::SocketAddr};
+use std::{
+    error::Error as StdError,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use axum::{
+    Router,
+    extract::State,
+    http::{StatusCode, header},
+    response::IntoResponse,
+    routing::get,
+};
 use tokio::sync::oneshot;
 use tonic::transport::Server as TonicServer;
 use tonic_health::server::{HealthReporter, health_reporter};
@@ -7,10 +22,15 @@ use vector_lib::tap::topology::WatchRx;
 use super::grpc::ObservabilityService;
 use crate::{config::Config, proto::observability::Server as ObservabilityServer};
 
+/// Shared flag backing the HTTP `/health` endpoint. Mirrors the gRPC
+/// `HealthReporter` serving status so HTTP and gRPC probes agree.
+type ServingState = Arc<AtomicBool>;
+
 /// gRPC API server for Vector observability.
 pub struct GrpcServer {
     _shutdown: oneshot::Sender<()>,
     health_reporter: HealthReporter,
+    serving: ServingState,
     addr: SocketAddr,
 }
 
@@ -45,15 +65,19 @@ impl GrpcServer {
         // The empty service ("") is registered as SERVING by default.
         let (health_reporter, health_service) = health_reporter();
 
+        let serving: ServingState = Arc::new(AtomicBool::new(true));
+
         let (_shutdown, rx) = oneshot::channel();
 
-        // Convert the tokio TcpListener into a std listener for axum/hyper's Server.
+        // Convert the tokio TcpListener into a std listener for hyper's Server.
         let std_listener = listener.into_std().map_err(|e| {
             crate::Error::from(format!("Failed to convert TCP listener: {}", e))
         })?;
         std_listener.set_nonblocking(true).map_err(|e| {
             crate::Error::from(format!("Failed to set TCP listener non-blocking: {}", e))
         })?;
+
+        let router_serving = Arc::clone(&serving);
 
         // Spawn the server with the already-bound listener
         tokio::spawn(async move {
@@ -66,14 +90,16 @@ impl GrpcServer {
                 .build()
                 .expect("Failed to build reflection service");
 
-            // Build the tonic router (gRPC services) and convert it to an axum Router
-            // so we can serve both gRPC and HTTP routes on the same port.
+            // Build the tonic router (gRPC services) and merge with the HTTP router
+            // so both protocols share the same port. `accept_http1(true)` lets plain
+            // HTTP/1.1 requests reach the merged axum routes.
             let router = TonicServer::builder()
                 .accept_http1(true)
                 .add_service(health_service)
                 .add_service(ObservabilityServer::new(service))
                 .add_service(reflection_service)
-                .into_router();
+                .into_router()
+                .merge(http_router(router_serving));
 
             let result = hyper::Server::from_tcp(std_listener)
                 .expect("Failed to build HTTP server from TCP listener")
@@ -99,6 +125,7 @@ impl GrpcServer {
         Ok(Self {
             _shutdown,
             health_reporter,
+            serving,
             addr: actual_addr,
         })
     }
@@ -106,9 +133,10 @@ impl GrpcServer {
     /// Signal that the server is no longer serving.
     ///
     /// Call this **before** draining the topology so that Kubernetes gRPC
-    /// readiness probes fail early and the pod is removed from endpoints
-    /// before the process exits.
+    /// readiness probes and HTTP `/health` probes fail early and the pod is
+    /// removed from endpoints before the process exits.
     pub async fn set_not_serving(&mut self) {
+        self.serving.store(false, Ordering::Relaxed);
         self.health_reporter
             .set_service_status("", tonic_health::ServingStatus::NotServing)
             .await;
@@ -117,5 +145,33 @@ impl GrpcServer {
     /// Get the address the server is listening on
     pub const fn addr(&self) -> SocketAddr {
         self.addr
+    }
+}
+
+/// Axum router exposing `GET`/`HEAD /health`.
+///
+/// Returns `200 {"ok":true}` while the server is serving and
+/// `503 {"ok":false}` once [`GrpcServer::set_not_serving`] has been called.
+/// Matches the response shape of the pre-gRPC GraphQL-era endpoint so
+/// existing HTTP health probes (Kubernetes, load balancers) keep working.
+fn http_router(state: ServingState) -> Router {
+    Router::new()
+        .route("/health", get(health_handler).head(health_handler))
+        .with_state(state)
+}
+
+async fn health_handler(State(state): State<ServingState>) -> impl IntoResponse {
+    if state.load(Ordering::Relaxed) {
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            r#"{"ok":true}"#,
+        )
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(header::CONTENT_TYPE, "application/json")],
+            r#"{"ok":false}"#,
+        )
     }
 }

--- a/src/api/grpc_server.rs
+++ b/src/api/grpc_server.rs
@@ -70,9 +70,9 @@ impl GrpcServer {
         let (_shutdown, rx) = oneshot::channel();
 
         // Convert the tokio TcpListener into a std listener for hyper's Server.
-        let std_listener = listener.into_std().map_err(|e| {
-            crate::Error::from(format!("Failed to convert TCP listener: {}", e))
-        })?;
+        let std_listener = listener
+            .into_std()
+            .map_err(|e| crate::Error::from(format!("Failed to convert TCP listener: {}", e)))?;
         std_listener.set_nonblocking(true).map_err(|e| {
             crate::Error::from(format!("Failed to set TCP listener non-blocking: {}", e))
         })?;

--- a/src/api/grpc_server.rs
+++ b/src/api/grpc_server.rs
@@ -1,6 +1,5 @@
 use std::{error::Error as StdError, net::SocketAddr};
 use tokio::sync::oneshot;
-use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server as TonicServer;
 use tonic_health::server::{HealthReporter, health_reporter};
 use vector_lib::tap::topology::WatchRx;
@@ -48,10 +47,16 @@ impl GrpcServer {
 
         let (_shutdown, rx) = oneshot::channel();
 
+        // Convert the tokio TcpListener into a std listener for axum/hyper's Server.
+        let std_listener = listener.into_std().map_err(|e| {
+            crate::Error::from(format!("Failed to convert TCP listener: {}", e))
+        })?;
+        std_listener.set_nonblocking(true).map_err(|e| {
+            crate::Error::from(format!("Failed to set TCP listener non-blocking: {}", e))
+        })?;
+
         // Spawn the server with the already-bound listener
         tokio::spawn(async move {
-            let incoming = TcpListenerStream::new(listener);
-
             // Build reflection service for tools like grpcurl
             let reflection_service = tonic_reflection::server::Builder::configure()
                 .register_encoded_file_descriptor_set(
@@ -61,11 +66,19 @@ impl GrpcServer {
                 .build()
                 .expect("Failed to build reflection service");
 
-            let result = TonicServer::builder()
+            // Build the tonic router (gRPC services) and convert it to an axum Router
+            // so we can serve both gRPC and HTTP routes on the same port.
+            let router = TonicServer::builder()
+                .accept_http1(true)
                 .add_service(health_service)
                 .add_service(ObservabilityServer::new(service))
                 .add_service(reflection_service)
-                .serve_with_incoming_shutdown(incoming, async {
+                .into_router();
+
+            let result = hyper::Server::from_tcp(std_listener)
+                .expect("Failed to build HTTP server from TCP listener")
+                .serve(router.into_make_service())
+                .with_graceful_shutdown(async {
                     rx.await.ok();
                     info!("GRPC API server shutting down.");
                 })

--- a/tests/vector_api/harness.rs
+++ b/tests/vector_api/harness.rs
@@ -133,6 +133,11 @@ impl TestHarness {
         &mut self.api_client
     }
 
+    /// Returns the TCP port the API server is bound to
+    pub fn api_port(&self) -> u16 {
+        self.api_port
+    }
+
     /// Reloads Vector configuration by sending SIGHUP or using watch mode
     ///
     /// Polls Vector to detect crashes early and succeed fast when reload completes.

--- a/tests/vector_api/health.rs
+++ b/tests/vector_api/health.rs
@@ -1,4 +1,7 @@
-//! Integration tests for the standard gRPC health check on the observability API.
+//! Integration tests for the health endpoints on the observability API:
+//!
+//! * the standard gRPC health check (`grpc.health.v1.Health/Check`)
+//! * the HTTP `/health` endpoint served on the same port
 
 use super::{common::*, harness::*};
 
@@ -22,4 +25,43 @@ async fn health_check_reports_serving() {
         .expect("health check should report SERVING");
 
     assert!(harness.check_running(), "Vector should still be running");
+}
+
+/// Verifies the HTTP `GET /health` endpoint returns 200 with `{"ok":true}` on a
+/// running Vector instance. This endpoint is load-balancer friendly and is
+/// shared with gRPC clients on the same API port.
+#[tokio::test]
+async fn http_health_endpoint_returns_200_when_serving() {
+    let config = single_source_config("demo", 1.0, None);
+    let harness = TestHarness::new(&config)
+        .await
+        .expect("Vector should start");
+
+    let url = format!("http://127.0.0.1:{}/health", harness.api_port());
+    let response = reqwest::get(&url)
+        .await
+        .expect("GET /health should succeed");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body = response.text().await.expect("body should be readable");
+    assert_eq!(body, r#"{"ok":true}"#);
+}
+
+/// Verifies HTTP `HEAD /health` returns 200 without a body. ALB/ELB style
+/// probes that prefer HEAD should work the same as GET.
+#[tokio::test]
+async fn http_health_endpoint_supports_head() {
+    let config = single_source_config("demo", 1.0, None);
+    let harness = TestHarness::new(&config)
+        .await
+        .expect("Vector should start");
+
+    let url = format!("http://127.0.0.1:{}/health", harness.api_port());
+    let response = reqwest::Client::new()
+        .head(&url)
+        .send()
+        .await
+        .expect("HEAD /health should succeed");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
 }

--- a/website/content/en/docs/reference/api.md
+++ b/website/content/en/docs/reference/api.md
@@ -21,6 +21,12 @@ instance. This page covers how to configure and enable Vector's API.
 The API exposes a gRPC service defined in [`proto/vector/observability.proto`](https://github.com/vectordotdev/vector/blob/master/proto/vector/observability.proto).
 You can interact with it using any standard gRPC tooling.
 
+For compatibility with Vector 0.54.0 and earlier, the HTTP `GET /health`
+endpoint continues to be served on the same port as the gRPC API, so
+existing HTTP probes (for example AWS ALB health checks and Kubernetes
+HTTP liveness/readiness probes) keep working without changes. See the
+[Endpoints](#endpoints) section above for details.
+
 ### Example using grpcurl
 
 ```bash
@@ -34,4 +40,11 @@ grpcurl -plaintext localhost:8686 vector.observability.v1.ObservabilityService/G
 grpcurl -plaintext \
   -d '{"outputs_patterns": ["*"], "limit": 100, "interval_ms": 500}' \
   localhost:8686 vector.observability.v1.ObservabilityService/StreamOutputEvents
+```
+
+### Example using curl (HTTP health)
+
+```bash
+# 200 with body {"ok":true} while serving, 503 {"ok":false} during drain
+curl -i http://localhost:8686/health
 ```

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -68,6 +68,7 @@ _values: {
 #Endpoints: [Path=string]: {
 	DELETE?: #Endpoint
 	GET?:    #Endpoint
+	HEAD?:   #Endpoint
 	POST?:   #Endpoint
 	PUT?:    #Endpoint
 }

--- a/website/cue/reference/api.cue
+++ b/website/cue/reference/api.cue
@@ -24,12 +24,33 @@ api: {
 		"/health": {
 			GET: {
 				description: """
-					Healthcheck endpoint. Useful to verify that
-					Vector is up and running.
+					HTTP healthcheck endpoint served on the same port as the
+					gRPC API, preserved for compatibility with Vector 0.54.0
+					and earlier so existing HTTP probes (for example AWS ALB
+					and Kubernetes HTTP probes) keep working unchanged.
+					The response body is `{"ok": true}` while Vector is
+					serving and `{"ok": false}` once Vector begins draining.
 					"""
 				responses: {
 					"200": {
 						description: "Vector is initialized and running."
+					}
+					"503": {
+						description: "Vector is draining or shutting down and should be removed from the load balancer."
+					}
+				}
+			}
+			HEAD: {
+				description: """
+					Same semantics as `GET /health` but returns no body.
+					Intended for load balancer probes that prefer `HEAD`.
+					"""
+				responses: {
+					"200": {
+						description: "Vector is initialized and running."
+					}
+					"503": {
+						description: "Vector is draining or shutting down and should be removed from the load balancer."
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Restores the HTTP `GET /health` endpoint on the Vector API to avoid user disruption. The endpoint is served on the same port as the gRPC API, so existing HTTP probes (AWS ALB health checks, Kubernetes HTTP liveness/readiness probes, etc.) keep working unchanged.

- Response matches the pre-0.55 shape: `200 {"ok":true}` while serving, `503 {"ok":false}` during drain.
- `HEAD /health` is also accepted for load balancers that prefer it.
- The standard gRPC health service (`grpc.health.v1.Health/Check`) is unchanged. Both probes share the same serving flag so they agree during shutdown.

Flagged in #25210.

**No changelog fragment:** no release has shipped without `/health`, so there is no user-visible change relative to 0.54.0. The `no-changelog` label applies.

### Implementation

`src/api/grpc_server.rs` now builds the tonic `Server` into an `axum::Router` via `into_router()`, merges an axum router exposing `GET`/`HEAD /health`, and serves the combined router via `hyper::Server` over the existing `TcpListener`. `accept_http1(true)` lets plain HTTP/1.1 requests reach the axum routes while gRPC continues to use HTTP/2. `set_not_serving()` now flips both the gRPC `HealthReporter` and the shared HTTP serving flag.

## Vector configuration

Any config with the API enabled works, e.g.:

```yaml
api:
  enabled: true
  address: 127.0.0.1:8686

sources:
  demo:
    type: demo_logs
    format: json

sinks:
  out:
    type: blackhole
    inputs: [demo]
```

## How did you test this PR?

- Added two integration tests in `tests/vector_api/health.rs` covering `GET /health` (200 + body) and `HEAD /health` (200). Existing gRPC `grpc.health.v1.Health/Check` test still passes.
- Manual: `curl -i http://127.0.0.1:8686/health` returns `200 {"ok":true}`; `grpcurl -plaintext 127.0.0.1:8686 grpc.health.v1.Health/Check` still returns `SERVING`.
- Local `make check-fmt`, `make check-clippy`, `make check-markdown`, and `website/` `make cue-build` all pass.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25210
- Related: #24364
- Related: #25229 (cherry-pick target for v0.55)