### PR TITLE
chore(website): add Docker support for local development

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:bookworm-slim
+
+ARG HUGO_VERSION=0.154.5
+ARG CUE_VERSION=0.10.0
+ARG NODE_VERSION=20
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Hugo extended (required for Sass/PostCSS processing)
+# uname -m: x86_64 -> amd64, aarch64 -> arm64
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+    curl -fsSL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${ARCH}.tar.gz \
+    | tar -xz -C /usr/local/bin hugo
+
+# CUE CLI
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+    curl -fsSL https://github.com/cue-lang/cue/releases/download/v${CUE_VERSION}/cue_v${CUE_VERSION}_linux_${ARCH}.tar.gz \
+    | tar -xz -C /usr/local/bin cue
+
+# Node.js + Yarn
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g yarn \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app/website
+
+EXPOSE 1313
+
+# generate-vrl-docs (requires Rust/vdev) must be run on the host first.
+# Call cue directly instead of scripts/cue.sh to avoid its `git rev-parse` dependency.
+ENTRYPOINT ["/bin/sh", "-c", \
+  "if [ -z \"$(find cue/reference/remap/functions -name '*.cue' 2>/dev/null | head -1)\" ]; then \
+     echo 'ERROR: cue/reference/remap/functions/ is empty.'; \
+     echo 'Run on the host first: make generate-vrl-docs'; \
+     exit 1; \
+   fi && \
+   yarn && \
+   cp -f /app/Cargo.lock data/cargo-lock.toml && \
+   rm -f data/docs.json && find cue -name '*.cue' | xargs cue export --all-errors --outfile data/docs.json && \
+   yarn config-examples && \
+   hugo server --bind 0.0.0.0 --port 1313 --buildDrafts --buildFuture --environment development"]

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 
 ARG HUGO_VERSION=0.154.5
 ARG CUE_VERSION=0.10.0
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git make \

--- a/website/README.md
+++ b/website/README.md
@@ -140,6 +140,8 @@ When you make changes to the Markdown sources, Sass/CSS, or JavaScript, the site
 
 If you don't want to install Hugo, CUE, or Node.js locally, you can use Docker instead. You still need Rust and [vdev] on the host for one step.
 
+> **Note:** This Docker setup is experimental and not currently enforced by CI. It may break as dependencies or the build process evolve.
+
 **Step 1:** Generate VRL function docs (required once; only re-run when VRL function signatures change):
 
 ```shell

--- a/website/README.md
+++ b/website/README.md
@@ -136,6 +136,28 @@ This builds all the necessary [prereqs](#prerequisites) for the site and starts 
 
 When you make changes to the Markdown sources, Sass/CSS, or JavaScript, the site re-builds and Hugo automatically reloads the page that you're on. If you make changes to the [structured data](#structured-data) sources, however, you need to stop the server and run `make serve` again.
 
+### Run the site with Docker
+
+If you don't want to install Hugo, CUE, or Node.js locally, you can use Docker instead. You still need Rust and [vdev] on the host for one step.
+
+**Step 1:** Generate VRL function docs (required once; only re-run when VRL function signatures change):
+
+```shell
+make generate-vrl-docs
+```
+
+This generates CUE files into `cue/reference/remap/functions/` from the Rust source. These files are gitignored and must exist before the site can build.
+
+**Step 2:** Build and start the site:
+
+```shell
+cd website
+docker compose build
+docker compose up
+```
+
+Navigate to http://localhost:1313. The site source is mounted as a volume so Hugo's live-reload works for Markdown, CSS, and JavaScript changes. If you modify [structured data](#structured-data) sources, restart the container.
+
 ### Add a new version of Vector
 
 1. Add the new version to the `versions` list in [`cue/reference/versions.cue`](./cue/reference/versions.cue). Make sure to preserve reverse ordering.

--- a/website/docker-compose.yml
+++ b/website/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  website:
+    build: .
+    ports:
+      - "1313:1313"
+    volumes:
+      - .:/app/website
+      - ../Cargo.lock:/app/Cargo.lock:ro
+      - ../scripts:/app/scripts:ro
+      - website_node_modules:/app/website/node_modules
+    environment:
+      - CI=false
+
+volumes:
+  website_node_modules:


### PR DESCRIPTION
Adds Dockerfile, docker-compose.yml, and README instructions so the Vector website can be previewed locally without installing Hugo, CUE, or Node.js. The image detects host architecture via uname -m to support both amd64 and arm64. VRL function docs still require a one-time `make generate-vrl-docs` on the host (needs Rust/vdev).

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
