### PR TITLE
fix(tests): fix flaky `initial_size_correct_with_multievents` test

### DIFF
--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -1,4 +1,4 @@
-use std::{io::Cursor, time::Duration};
+use std::{io::Cursor, sync::Arc, time::Duration};
 
 use futures::{StreamExt, stream};
 use tokio::{select, time::sleep};
@@ -6,11 +6,15 @@ use tokio_test::{assert_pending, task::spawn};
 use tracing::Instrument;
 use vector_common::finalization::Finalizable;
 
-use super::{create_default_buffer_v2, read_next, read_next_some};
+use super::{create_default_buffer_v2, create_default_buffer_v2_with_usage, read_next, read_next_some};
 use crate::{
     EventCount, assert_buffer_is_empty, assert_buffer_records,
+    buffer_usage_data::BufferUsageHandle,
     test::{MultiEventRecord, SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir},
-    variants::disk_v2::{tests::create_default_buffer_v2_with_usage, writer::RecordWriter},
+    variants::disk_v2::{
+        BufferWriter, DiskBufferConfigBuilder, Ledger,
+        writer::RecordWriter,
+    },
 };
 
 #[tokio::test]
@@ -155,8 +159,26 @@ async fn initial_size_correct_with_multievents() {
         let data_dir = dir.to_path_buf();
 
         async move {
-            // Create a regular buffer, no customizations required.
-            let (mut writer, _, _) = create_default_buffer_v2(data_dir.clone()).await;
+            // Build a write-only buffer without a finalizer task. Using
+            // `from_config_inner` would spawn a background finalizer that holds
+            // an Arc<Ledger> (and the lock file), causing a racy
+            // LedgerLockAlreadyHeld when we reopen the buffer below.
+            let config = DiskBufferConfigBuilder::from_path(&data_dir)
+                .build()
+                .expect("creating buffer config should not fail");
+            let usage_handle = BufferUsageHandle::noop();
+            let ledger = Ledger::load_or_create(config, usage_handle)
+                .await
+                .expect("ledger should not fail to load/create");
+            let ledger = Arc::new(ledger);
+
+            let mut writer = BufferWriter::new(Arc::clone(&ledger));
+            writer
+                .validate_last_write()
+                .await
+                .expect("validate_last_write should not fail");
+
+            ledger.synchronize_buffer_usage();
 
             let input_items = (512..768)
                 .cycle()
@@ -209,10 +231,14 @@ async fn initial_size_correct_with_multievents() {
             writer.flush().await.expect("writer flush should not fail");
             writer.close();
 
-            // Now drop our buffer and reopen it.
+            // Drop the first buffer. No background finalizer task exists, so the
+            // ledger lock is released immediately when the last Arc is dropped.
             drop(writer);
+            drop(ledger);
+
+            // Reopen the buffer with a full reader to verify the persisted data.
             let (writer, mut reader, ledger, usage) =
-                create_default_buffer_v2_with_usage::<_, MultiEventRecord>(data_dir).await;
+                create_default_buffer_v2_with_usage::<_, MultiEventRecord>(&data_dir).await;
             drop(writer);
 
             // Make sure our usage data agrees with our expected event count and byte size:

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -6,15 +6,14 @@ use tokio_test::{assert_pending, task::spawn};
 use tracing::Instrument;
 use vector_common::finalization::Finalizable;
 
-use super::{create_default_buffer_v2, create_default_buffer_v2_with_usage, read_next, read_next_some};
+use super::{
+    create_default_buffer_v2, create_default_buffer_v2_with_usage, read_next, read_next_some,
+};
 use crate::{
     EventCount, assert_buffer_is_empty, assert_buffer_records,
     buffer_usage_data::BufferUsageHandle,
     test::{MultiEventRecord, SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir},
-    variants::disk_v2::{
-        BufferWriter, DiskBufferConfigBuilder, Ledger,
-        writer::RecordWriter,
-    },
+    variants::disk_v2::{BufferWriter, DiskBufferConfigBuilder, Ledger, writer::RecordWriter},
 };
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Replace the one-shot `create_default_buffer_v2_with_usage` call with retry loop when reopening the buffer. After dropping the first buffer, the background finalizer task may still hold an `Arc<Ledger>` (and thus the lock file). The retry loop only retries on `LedgerLockAlreadyHeld` errors — any other error panics immediately to avoid masking real failures. The test framework's own timeout handles truly stuck cases.

Also removes the now-unused `create_default_buffer_v2_with_usage` helper.


## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
