### PR TITLE
chore(website): render release date on per-version release page

### DIFF
--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -18,6 +18,15 @@
       {{ partial "hero.html" . }}
     </div>
 
+    {{ with $release.date }}
+    {{ $date := . | dateFormat "January 2, 2006" }}
+    <div class="mt-3 flex items-center space-x-3 text-gray-500 dark:text-gray-300">
+      <time datetime="{{ $date }}" class="text-sm">
+        {{ $date }}
+      </time>
+    </div>
+    {{ end }}
+
     <div>
       {{ with $release.codename }}
       <p class="inline-flex space-x-4 border dark:border-gray-700 rounded-md py-2 px-3.5">


### PR DESCRIPTION
## Summary

Render `\$release.date` under the hero on `/releases/<version>/` pages, mirroring the date block used by the highlights/guides content header. The date is already present in each release's CUE file (e.g. `date: "2026-04-22"` in `website/cue/reference/releases/0.55.0.cue`) but until now was only surfaced on the `/releases/` index via `releases/li.html`.

## Vector configuration

N/A.

## How did you test this PR?

- Ran `cd website && make serve` locally and confirmed `/releases/0.55.0/` now renders `April 22, 2026` and `/releases/0.54.0/` renders `March 10, 2026`, both as a `<time>` element under the page title.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A.