### PR TITLE
fix(ci): skip re-adding WIP label on synchronize if already approved

### DIFF
--- a/.github/workflows/add_wip_label.yml
+++ b/.github/workflows/add_wip_label.yml
@@ -17,6 +17,34 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
+      - name: Check member review state
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const allowed = ['MEMBER', 'OWNER'];
+            const latestByUser = new Map();
+            for (const r of reviews) {
+              if (!allowed.includes(r.author_association)) continue;
+              if (r.state === 'COMMENTED') continue;
+              latestByUser.set(r.user.id, r.state);
+            }
+
+            const states = [...latestByUser.values()];
+            const hasApproved = states.includes('APPROVED');
+            const hasChangesRequested = states.includes('CHANGES_REQUESTED');
+            const skip = hasApproved && !hasChangesRequested;
+
+            core.info(`Latest member review states: ${states.join(', ') || '(none)'}`);
+            core.info(`skip=${skip}`);
+            core.setOutput('skip', skip);
+      - if: steps.check.outputs.skip != 'true'
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: "work in progress"


### PR DESCRIPTION
## Summary

The `add_wip_label` workflow fires on `synchronize` to catch docs paths added in later pushes. However, it also re-adds the `work in progress` label after a reviewer has already approved and `remove_wip_label` cleared it (observed on #25242).

Guard against that by checking the latest review state per member:

- Reduce each member/owner reviewer's reviews to their latest non-COMMENTED state.
- Skip adding the label only when at least one member approved and none have a standing `CHANGES_REQUESTED` review.
- Otherwise proceed as before.

This preserves the original intent of `synchronize` (flag docs paths added in a later push) while avoiding label churn after approval.

## Vector configuration

N/A — CI workflow change.

## How did you test this PR?

Tested end-to-end in `vectordotdev/ci-sandbox` with the updated workflow merged to `main`. Ran five scenarios against live PRs:

- A. Open docs PR → label added.
- B. Approve → label removed.
- C. Push new commit after approval → workflow logs `Latest member review states: APPROVED` → `skip=true` → label stays off.
- D. Request changes, then push → `Latest member review states: CHANGES_REQUESTED` → `skip=false` → label re-added.
- E. Open non-docs PR, push docs later → label added (preserves the `synchronize` intent).

All five passed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25242