### PR TITLE
chore(ci): extract unit tests into reusable workflow

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -280,6 +280,7 @@ jobs:
               - ".github/workflows/changes.yml"
             test-yml:
               - ".github/workflows/test.yml"
+              - ".github/workflows/unit-tests.yml"
               - ".github/workflows/changes.yml"
             integration-yml:
               - ".github/workflows/integration.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,31 +56,13 @@ jobs:
       - run: make check-clippy
 
   test:
-    name: Unit and Component Validation tests - x86_64-unknown-linux-gnu
-    runs-on: ubuntu-24.04-8core
-    if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.test-yml == 'true' }}
     needs: changes
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup
-        with:
-          rust: true
-          cargo-nextest: true
-          datadog-ci: true
-          protoc: true
-          libsasl2: true
-      - name: Unit Test
-        run: make test
-        env:
-          CARGO_BUILD_JOBS: 5
-
-      # Validates components for adherence to the Component Specification
-      - name: Check Component Spec
-        run: make test-component-validation
-
-      - name: Upload test results
-        run: scripts/upload-test-results.sh
-        if: always()
+    if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.test-yml == 'true' }}
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      default: true
+      behavior: true
+    secrets: inherit
 
   check-scripts:
     name: Check scripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
     uses: ./.github/workflows/unit-tests.yml
     with:
       default: true
-      behavior: true
+      component-validation: true
     secrets: inherit
 
   check-scripts:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,108 @@
+# Reusable Workflow: Tests
+#
+# Runs test suites via the Makefile. By default runs unit tests and component
+# validation. Callers can enable additional suites (CLI, Vector API, behavior)
+# via boolean inputs.
+#
+# When `default` is true, all nextest-based suites run in a single `make test`
+# invocation with the relevant features enabled. When `default` is false, only
+# the explicitly enabled suites run, using a nextest filter expression to
+# select the matching tests.
+
+name: Tests
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to checkout"
+        required: false
+        type: string
+      default:
+        description: "Run the full default unit test suite (--workspace with default features)"
+        required: true
+        type: boolean
+      component-validation:
+        description: "Include component validation tests"
+        required: false
+        type: boolean
+        default: true
+      cli:
+        description: "Include CLI tests"
+        required: false
+        type: boolean
+        default: false
+      vector-api:
+        description: "Include Vector API tests"
+        required: false
+        type: boolean
+        default: false
+      behavior:
+        description: "Include behavior tests"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CI: true
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-24.04-8core
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup
+        with:
+          rust: true
+          cargo-nextest: true
+          datadog-ci: true
+          protoc: true
+          libsasl2: true
+
+      - name: Run tests
+        run: |
+          add_suite() {
+            local enabled="$1" feature="$2" filter="$3"
+            [[ "${enabled}" != "true" ]] && return
+            FEATURES="${FEATURES:+$FEATURES,}${feature}"
+            if [[ "${{ inputs.default }}" != "true" ]]; then
+              SCOPE="${SCOPE:+$SCOPE | }${filter}"
+            fi
+          }
+
+          if [[ "${{ inputs.default }}" == "true" ]]; then
+            FEATURES="default"
+          else
+            FEATURES=""
+          fi
+
+          add_suite "${{ inputs.component-validation }}" "component-validation-tests" "test(components::validation::tests)"
+          add_suite "${{ inputs.cli }}" "cli-tests" "package(vector) & binary(=integration)"
+          add_suite "${{ inputs.vector-api }}" "vector-api-tests" "binary(=vector_api)"
+
+          # Skip `make test` entirely if no nextest-based suite was selected
+          # (e.g. behavior-only runs). Running `make test` with empty FEATURES
+          # would otherwise execute the workspace-wide suite.
+          if [[ "${{ inputs.default }}" == "true" ]]; then
+            make test FEATURES="${FEATURES}"
+          elif [[ -n "${SCOPE}" ]]; then
+            make test FEATURES="${FEATURES}" SCOPE="-E '${SCOPE}'"
+          else
+            echo "No nextest suites selected; skipping 'make test'"
+          fi
+
+      - name: Behavior tests
+        if: ${{ inputs.behavior }}
+        run: make test-behavior
+
+      - name: Upload test results to Datadog
+        if: ${{ always() }}
+        run: scripts/upload-test-results.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -78,8 +78,16 @@ jobs:
             fi
           }
 
+          # Mirror the Makefile's OS-based default: `default-msvc` on Windows,
+          # `default` elsewhere. Keep in sync with the FEATURES defaults in Makefile.
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            DEFAULT_FEATURES="default-msvc"
+          else
+            DEFAULT_FEATURES="default"
+          fi
+
           if [[ "${{ inputs.default }}" == "true" ]]; then
-            FEATURES="default"
+            FEATURES="${DEFAULT_FEATURES}"
           else
             FEATURES=""
           fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,6 +49,8 @@ permissions:
 env:
   CARGO_INCREMENTAL: "0"
   CI: true
+  DD_ENV: "ci"
+  DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary

Extracts the `test` job from `test.yml` into a reusable `unit-tests.yml` workflow so other workflows can reuse it. Pure refactor with no behavior change for existing CI.

Follow up to this will be to migrate the master merge queue to use unit-tests.yml and the ci trigger too.

## Vector configuration

NA

## How did you test this PR?

Relying on CI.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25088