### PR TITLE
chore: add component maturity audit skill

### DIFF
--- a/.claude/skills/component-maturity-audit/SKILL.md
+++ b/.claude/skills/component-maturity-audit/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: component-maturity-audit
+description: Produce a report evaluating Vector sources/transforms/sinks against the alpha/beta/stable rubric. Use when reviewing component maturity on a cadence (quarterly/per-release) or when vetting a single component for promotion or demotion.
+disable-model-invocation: true
+argument-hint: [--component <name>] [--kind sources|transforms|sinks] [--only-changes] [--include-stable]
+allowed-tools: Bash(gh *), Bash(git log *), Bash(git diff *), Bash(git show *), Bash(cargo vdev int show), Bash(make *), Bash(.claude/skills/component-maturity-audit/scripts/*), Bash(grep *), Bash(rg *), Bash(find *), Bash(ls *), Bash(wc *), Bash(awk *), Bash(sort *), Bash(uniq *), Bash(jq *), Bash(mkdir *), Read, Write, Edit, Glob, Grep
+---
+
+Evaluate Vector component maturity (alpha/beta/stable) against a rubric and produce a report. Arguments: `$ARGUMENTS`
+
+## Scope
+
+**Stable components are out of scope by default.** Stable is the terminal tier and demoting is a rare, noisy event; spending audit effort on 80+ stable components each run wastes time and context. Skip them unless the user passes `--include-stable` or names a specific stable component via `--component <name>`. The default audit is effectively a promotion review of `alpha`, `unset`, `beta`, and `deprecated` entries.
+
+## Output
+
+Produce a markdown report at `docs/component-maturity/report-YYYY-MM-DD.md` grouped into three sections:
+
+- **Promote** — components whose signals justify a higher maturity tier
+- **Demote** — components showing regression signals for their current tier
+- **Unchanged** — everything else (one-line per component)
+
+Each Promote/Demote entry MUST include:
+
+1. Component name, kind (source/transform/sink), current tier, proposed tier
+2. Evidence: the specific signals that triggered the proposal (issue counts, test presence, fix density, etc.)
+3. The exact file + field to change (e.g., `website/cue/reference/components/sinks/postgres.cue` — `development: "beta"` → `"stable"`)
+4. Confidence: `high` (all criteria met/failed), `medium` (most), `low` (needs human judgment)
+
+NEVER edit CUE files yourself. The report is the output; a human flips the field.
+
+## Rubric
+
+If `docs/specs/component_maturity.md` exists in the repo, read it and use it as the source of truth. Otherwise fall back to this default:
+
+- **alpha** — compiles, unit tests present. No stability guarantees. Breaking changes allowed between minor releases.
+- **beta** — meets alpha + (a) integration test exists under `scripts/integration/<name>/` or component is trivial enough to not need one (document why), (b) user-facing docs complete per `docs/specs/component.md`, (c) has shipped in at least one release, (d) no open correctness bugs older than 90 days, (e) event instrumentation passes `cargo vdev check events`.
+- **stable** — meets beta + (a) has shipped in at least two minor releases, (b) no breaking config changes in last two minor releases, (c) fix-to-feature ratio over last 4 releases does not exceed 2:1, (d) no open correctness/data-loss bugs older than 180 days, (e) at least 3 months since last breaking change.
+- **deprecated** — replacement is documented in component support notes; removal release is targeted.
+
+**Regression (demotion) triggers:**
+- `stable` → `beta`: P0/P1 correctness bug open >180 days, or breaking config change shipped in last minor release.
+- `beta` → `alpha`: rubric fields in the CUE file are incomplete or the component has been silent (no commits, no changelog entries) for 4+ consecutive minor releases.
+
+## Steps
+
+### 1. Parse arguments
+
+- `--component <name>`: audit only this one component (match against CUE filename stem).
+- `--kind sources|transforms|sinks`: restrict to a single kind.
+- `--only-changes`: final report suppresses the Unchanged section.
+- No args: audit every component.
+
+### 2. Enumerate components and current tiers
+
+Run the collector script — it regenerates `website/data/docs.json` (via `make generate-component-docs` + `make -C website structured-data`) and emits a TSV of `<kind>\t<name>\t<tier>`:
+
+```bash
+.claude/skills/component-maturity-audit/scripts/collect-components.sh > /tmp/vmat-components.tsv
+```
+
+Use `--no-build` on repeat runs within a session to skip regeneration (the JSON is ~13 MB and regeneration takes minutes). Use `--json` if you want the structured form for further `jq` work.
+
+Filter the TSV per `--component` / `--kind` args before proceeding. The `tier` column is the authoritative current value; any component missing `development` is reported as `unset` and should be treated as alpha by the rubric.
+
+The CUE file for each component (needed later to cite the exact edit target in the report) lives at `website/cue/reference/components/<kind>/<name>.cue`.
+
+### 3. Collect signals (bulk, one pass)
+
+Gather all signals into an in-memory table before any LLM-style reasoning. Keep bash output compact — do not dump raw issue bodies into context.
+
+Per-component signals to collect:
+
+**GitHub issues** (via `gh`):
+```bash
+# Open issues for a component (label name matches the kind: "source: kafka", "sink: kafka", etc.)
+gh issue list --repo vectordotdev/vector --label "<kind-singular>: <name>" --state open --limit 200 \
+  --json number,title,createdAt,labels,updatedAt \
+  > /tmp/vmat-issues-<kind>-<name>.json
+
+# Derive: total_open, oldest_age_days, p0_p1_count (labels containing "priority: high" or "type: bug")
+```
+
+Do NOT fetch issues for every component upfront if unrestricted — that's 120+ API calls. Only fetch issues for components whose tier-shift is plausible from cheaper signals (integration-test presence, recent commits, changelog density). For a full audit without `--component`, batch the `gh` calls and cache to `/tmp/vmat-issues-*.json` so re-runs in the same day are cheap.
+
+**Integration-test presence**:
+```bash
+cargo vdev int show | tail -n +3 | awk '{print $1}' > /tmp/vmat-int-tests.txt
+# then grep each component name against this list
+```
+
+**Recent shipping history** — walk the last 4 release CUE files:
+```bash
+ls -1 website/cue/reference/releases/*.cue | sort -V | tail -4
+```
+Count changelog entries per component by matching the component name in the `description` of each entry, classified by fragment type (`fix`, `feature`, `enhancement`, `breaking`). A beta component with zero entries across 4 releases is a silence signal.
+
+**Git activity**:
+```bash
+git log --since="1 year ago" --oneline -- src/<kind>/<name>/ | wc -l
+git log -1 --format=%cI -- src/<kind>/<name>/
+```
+Note: some components live in single files (e.g. `src/sinks/<name>.rs`) rather than directories; try both paths and merge.
+
+**Unreleased changelog fragments**:
+```bash
+grep -l "<name>" changelog.d/*.{fix,feature,enhancement,breaking,deprecation,security}.md 2>/dev/null
+```
+
+### 4. Apply the rubric
+
+For each component, compare its current tier against the rubric using the collected signals. Classify as `promote`, `demote`, or `unchanged`, and assign confidence:
+
+- `high`: every criterion for the proposed tier has a definitive yes/no from the signals.
+- `medium`: one criterion requires human judgment (e.g., "docs complete" — you have heuristics but not certainty).
+- `low`: you are flagging a candidate but the rubric is ambiguous here; human should review.
+
+When `--component` is given, be thorough: read the component's CUE file and RS source to sanity-check the signals. When running across all components, stay in bulk-signal mode and only deep-dive on proposed promotions/demotions.
+
+### 5. Write the report
+
+Write to `docs/component-maturity/report-YYYY-MM-DD.md` (create the directory if missing). Use this structure:
+
+```markdown
+# Component Maturity Audit — YYYY-MM-DD
+
+Rubric source: `<docs/specs/component_maturity.md or "skill default">`
+Components audited: N
+Proposed promotions: N · Proposed demotions: N · Unchanged: N
+
+## Promote
+
+### <kind>/<name>: <current> → <proposed> (confidence: <level>)
+
+- **File:** `website/cue/reference/components/<kind>/<name>.cue`
+- **Change:** `development: "<current>"` → `"<proposed>"`
+- **Evidence:**
+  - <signal 1>
+  - <signal 2>
+
+## Demote
+
+<same structure>
+
+## Unchanged
+
+<one line per component: `- <kind>/<name> (<tier>)`>  (omit section if --only-changes)
+
+## Signal coverage
+
+- Integration tests matched: <count>
+- gh issue fetches: <count> (<cached_count> from cache)
+- Components with no git activity in last year: <count>
+```
+
+### 6. Summarize for the user
+
+After writing the file, print in the chat:
+- Path to the report
+- One-line summary: `N promotions, M demotions proposed`
+- Up to 5 highest-confidence proposed changes, as a preview
+
+Do NOT commit the report or stage it. The user decides what to do with it.
+
+## Constraints
+
+- This skill is read-only for the repo. It writes one new markdown file under `docs/component-maturity/`. It never edits CUE files, never commits, never pushes, never opens issues or PRs.
+- If `gh` is not authenticated, skip issue-based signals and note this in the report's "Signal coverage" section — do not abort.
+- If running a full audit, cap `gh issue list` calls at 200 components total; if the list is longer, prefer candidate filtering via cheaper signals first.
+- The report must be reproducible: any signal cited must be something a human can re-run the exact command for. Include the commands or issue numbers inline.

--- a/.claude/skills/component-maturity-audit/SKILL.md
+++ b/.claude/skills/component-maturity-audit/SKILL.md
@@ -39,17 +39,18 @@ If `docs/specs/component_maturity.md` exists in the repo, read it and use it as 
 - **deprecated** — replacement is documented in component support notes; removal release is targeted.
 
 **Regression (demotion) triggers:**
-- `stable` → `beta`: P0/P1 correctness bug open >180 days, or breaking config change shipped in last minor release.
+- `stable` → `beta`: P0/P1 correctness bug open >180 days, or breaking config change shipped in last minor release. Only evaluated when `--include-stable` (or a named stable `--component`) is passed.
 - `beta` → `alpha`: rubric fields in the CUE file are incomplete or the component has been silent (no commits, no changelog entries) for 4+ consecutive minor releases.
 
 ## Steps
 
 ### 1. Parse arguments
 
-- `--component <name>`: audit only this one component (match against CUE filename stem).
+- `--component <name>`: audit only this one component (match against CUE filename stem). Overrides the default stable-exclusion — a named stable component is audited.
 - `--kind sources|transforms|sinks`: restrict to a single kind.
 - `--only-changes`: final report suppresses the Unchanged section.
-- No args: audit every component.
+- `--include-stable`: include stable components in the audit (default: skip them, per the Scope section).
+- No args: audit every non-stable component.
 
 ### 2. Enumerate components and current tiers
 

--- a/.claude/skills/component-maturity-audit/scripts/classify.py
+++ b/.claude/skills/component-maturity-audit/scripts/classify.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Apply the maturity rubric to collected signals and propose promotions/demotions.
+
+Reads:
+  /tmp/vmat-signals.json
+  /tmp/vmat-issues-summary.tsv  (optional; issue signals skipped if missing)
+
+Writes:
+  /tmp/vmat-classification.json
+
+Rubric (from the skill default — edit if docs/specs/component_maturity.md exists):
+
+  alpha:
+    - compiles + unit tests present. No stability guarantees.
+
+  beta (requires alpha + all of):
+    a) integration test present OR trivial enough that one isn't needed (document why)
+    b) user-facing docs complete
+    c) shipped in ≥1 release
+    d) no open correctness bugs >90 days
+    e) event instrumentation passes `cargo vdev check events`
+
+  stable (requires beta + all of):
+    a) shipped in ≥2 minor releases
+    b) no breaking config changes in last 2 minor releases
+    c) fix-to-feature ratio over last 4 releases ≤ 2:1
+    d) no open correctness/data-loss bugs >180 days
+    e) ≥3 months since last breaking change
+
+  demotion triggers:
+    stable→beta: P0/P1 correctness bug open >180d, OR breaking config change
+                 shipped in last minor release
+    beta→alpha:  rubric fields in CUE file incomplete, OR component silent
+                 (no commits, no changelog) for 4+ consecutive minor releases
+"""
+
+import csv
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+
+SIGNALS = Path("/tmp/vmat-signals.json")
+ISSUES_SUMMARY = Path("/tmp/vmat-issues-summary.tsv")
+OUT = Path("/tmp/vmat-classification.json")
+
+
+@dataclass
+class Proposal:
+    kind: str
+    name: str
+    current: str
+    proposed: str
+    action: str  # promote / demote / unchanged
+    confidence: str  # high / medium / low
+    evidence: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+
+def load_issues() -> dict[tuple[str, str], dict]:
+    out: dict[tuple[str, str], dict] = {}
+    if not ISSUES_SUMMARY.exists():
+        return out
+    with ISSUES_SUMMARY.open() as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            key = (row["kind"], row["name"])
+            out[key] = {
+                "total_open": int(row["total_open"]),
+                "oldest_age_days": int(row["oldest_age_days"]),
+                "p0_p1_bugs": int(row["p0_p1_bugs"]),
+                "oldest_p0_p1_age": int(row["oldest_p0_p1_age"]),
+            }
+    return out
+
+
+def classify(sig: dict, issue: dict | None) -> Proposal:
+    kind = sig["kind"]
+    name = sig["name"]
+    current = sig["tier"]
+    r4_total = sig["recent4_entries"]
+    r4 = sig["recent4_by_type"]
+    feat_plus_enh = r4["feat"] + r4["enhancement"]
+    fix = r4["fix"]
+    breaking_recent = sig["breaking_recent4"]
+    shipped_minors = sig["shipped_minors_count"]
+    has_int = sig["has_int_test"]
+    commits_1yr = sig["git_commits_1yr"]
+    last_commit = sig["git_last_commit"]
+    unreleased = sig["unreleased_fragments"]
+
+    p = Proposal(kind=kind, name=name, current=current, proposed=current, action="unchanged", confidence="high")
+
+    # --- Detect silence (for beta→alpha demotion) ---
+    silent = (r4_total == 0) and (shipped_minors <= 1) and (not unreleased)
+    low_activity = commits_1yr < 5
+
+    # --- Evaluate promotion beta → stable ---
+    if current == "beta":
+        criteria = {}
+        criteria["shipped_≥2_minors"] = shipped_minors >= 2
+        criteria["no_breaking_in_recent4"] = len(breaking_recent) == 0
+        # fix-to-feature ratio ≤ 2:1 (treat 0/0 as "pass" since silent)
+        if feat_plus_enh == 0 and fix == 0:
+            criteria["fix_to_feat_ratio_ok"] = True  # no data, neutral
+            fix_ratio_note = "no changelog activity — neutral"
+        else:
+            # Avoid div by zero; if no features+enhancements, any fixes fail
+            ratio_ok = (fix <= 2 * feat_plus_enh) if feat_plus_enh > 0 else (fix == 0)
+            criteria["fix_to_feat_ratio_ok"] = ratio_ok
+            fix_ratio_note = f"{fix} fix / {feat_plus_enh} feat+enh in last 4 minors"
+        # beta precondition: int test exists OR component is trivial (transforms)
+        criteria["int_test_present"] = has_int or kind == "transforms"
+
+        # Issue-based criteria
+        p01_ok = True
+        p01_note = "no issue data"
+        if issue is not None:
+            # stable (d): no open correctness/data-loss bugs > 180 days
+            p01_ok = not (issue["oldest_p0_p1_age"] > 180)
+            p01_note = (
+                f"{issue['p0_p1_bugs']} confirmed/priority bugs, "
+                f"oldest {issue['oldest_p0_p1_age']}d"
+            )
+        criteria["no_p01_bugs_gt_180d"] = p01_ok
+
+        # Additional beta precondition d: no open correctness bugs >90 days
+        # We don't have issue priority granularity; rely on p0_p1 check.
+
+        all_pass = all(criteria.values())
+        evidence = []
+        for k, v in criteria.items():
+            evidence.append(f"{'PASS' if v else 'FAIL'} {k}")
+        evidence.append(f"shipping: {shipped_minors} minors, first_release={sig['first_release']}")
+        evidence.append(f"recent4_entries={r4_total} ({fix_ratio_note})")
+        evidence.append(f"breaking_recent4={breaking_recent or 'none'}")
+        evidence.append(f"int_test_match={sig['int_test_match'] or 'none'}")
+        evidence.append(f"git: {commits_1yr} commits past yr, last={last_commit}")
+        if issue is not None:
+            evidence.append(f"issues: {issue['total_open']} open, oldest {issue['oldest_age_days']}d, {p01_note}")
+        else:
+            evidence.append("issues: not fetched")
+
+        # Check for silent→alpha demotion
+        if silent and low_activity and last_commit and "2025" in (last_commit or ""):
+            p.action = "demote"
+            p.proposed = "alpha"
+            p.confidence = "medium"
+            p.evidence = evidence + ["silent: no changelog entries in last 4 minors, <5 commits/year"]
+            return p
+
+        if all_pass:
+            p.action = "promote"
+            p.proposed = "stable"
+            # Confidence: how many criteria passed with strong signal
+            strong = shipped_minors >= 3 and has_int and (issue is not None) and p01_ok
+            p.confidence = "high" if strong else ("medium" if shipped_minors >= 2 else "low")
+            p.evidence = evidence
+        else:
+            p.action = "unchanged"
+            p.proposed = "beta"
+            p.confidence = "high"
+            p.evidence = evidence
+            p.failures = [k for k, v in criteria.items() if not v]
+
+    elif current == "alpha" or current == "unset":
+        # Evaluate alpha → beta
+        criteria = {}
+        criteria["shipped_≥1_minor"] = shipped_minors >= 1
+        criteria["int_test_present"] = has_int
+        if issue is not None:
+            criteria["no_p01_bugs_gt_90d"] = not (issue["oldest_p0_p1_age"] > 90)
+        else:
+            criteria["no_p01_bugs_gt_90d"] = True  # neutral
+
+        evidence = [f"{'PASS' if v else 'FAIL'} {k}" for k, v in criteria.items()]
+        evidence.append(f"shipped in {shipped_minors} minors")
+        if issue is not None:
+            evidence.append(f"issues: {issue['total_open']} open, {issue['p0_p1_bugs']} confirmed bugs")
+
+        if all(criteria.values()):
+            p.action = "promote"
+            p.proposed = "beta"
+            p.confidence = "medium"  # doc completeness, events check not verified
+            p.evidence = evidence
+        else:
+            p.action = "unchanged"
+            p.proposed = current
+            p.confidence = "high"
+            p.evidence = evidence
+
+    else:
+        # stable / deprecated — skip (per user request)
+        p.action = "unchanged"
+        p.proposed = current
+        p.confidence = "high"
+        p.evidence = ["skipped: stable/deprecated components not audited"]
+
+    return p
+
+
+def main():
+    sigs = json.loads(SIGNALS.read_text())
+    issues = load_issues()
+
+    proposals = []
+    for sig in sigs:
+        issue = issues.get((sig["kind"], sig["name"]))
+        p = classify(sig, issue)
+        proposals.append({
+            "kind": p.kind,
+            "name": p.name,
+            "current": p.current,
+            "proposed": p.proposed,
+            "action": p.action,
+            "confidence": p.confidence,
+            "evidence": p.evidence,
+            "failures": p.failures,
+        })
+
+    OUT.write_text(json.dumps(proposals, indent=2))
+    promote = [x for x in proposals if x["action"] == "promote"]
+    demote = [x for x in proposals if x["action"] == "demote"]
+    unchanged = [x for x in proposals if x["action"] == "unchanged"]
+    print(f"Wrote {OUT}")
+    print(f"promote={len(promote)} demote={len(demote)} unchanged={len(unchanged)}")
+    print("\n=== PROMOTE ===")
+    for p in promote:
+        print(f"  {p['kind']}/{p['name']}: {p['current']}→{p['proposed']} ({p['confidence']})")
+    print("\n=== DEMOTE ===")
+    for p in demote:
+        print(f"  {p['kind']}/{p['name']}: {p['current']}→{p['proposed']} ({p['confidence']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/component-maturity-audit/scripts/collect-components.sh
+++ b/.claude/skills/component-maturity-audit/scripts/collect-components.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Collect every Vector component and its current maturity tier.
+#
+# Regenerates website/data/docs.json via the website structured-data pipeline
+# and emits a TSV to stdout: <kind>\t<name>\t<tier>
+#
+# Usage:
+#   collect-components.sh [--no-build]   # skip regeneration, read existing JSON
+#   collect-components.sh --json         # emit JSON array instead of TSV
+#
+# Must be run from the repo root.
+
+set -euo pipefail
+
+BUILD=1
+FORMAT=tsv
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) BUILD=0 ;;
+    --json) FORMAT=json ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -f Makefile || ! -d website ]]; then
+  echo "error: run from the repo root (Makefile + website/ must exist)" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
+JSON=website/data/docs.json
+
+if [[ "$BUILD" -eq 1 ]]; then
+  echo "regenerating $JSON ..." >&2
+  make generate-component-docs >&2
+  make -C website structured-data >&2
+fi
+
+if [[ ! -f "$JSON" ]]; then
+  echo "error: $JSON missing. Re-run without --no-build." >&2
+  exit 1
+fi
+
+# Emit one row per component across sources, transforms, sinks.
+# Tier is .classes.development; missing tiers are reported as "unset"
+# (the rubric treats unset as alpha).
+if [[ "$FORMAT" == "json" ]]; then
+  jq '
+    [
+      (.components | to_entries[]) as $kind
+      | ($kind.value | to_entries[]) as $comp
+      | {
+          kind: $kind.key,
+          name: $comp.key,
+          tier: ($comp.value.classes.development // "unset")
+        }
+    ]
+  ' "$JSON"
+else
+  jq -r '
+    .components
+    | to_entries[]
+    | .key as $kind
+    | .value | to_entries[]
+    | [$kind, .key, (.value.classes.development // "unset")]
+    | @tsv
+  ' "$JSON" | sort
+fi

--- a/.claude/skills/component-maturity-audit/scripts/collect-signals.py
+++ b/.claude/skills/component-maturity-audit/scripts/collect-signals.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Collect maturity signals for Vector components.
+
+Reads:
+  /tmp/vmat-components.tsv  (produced by collect-components.sh)
+  /tmp/vmat-int-tests.txt   (produced from `cargo vdev int show`)
+  website/data/docs.json    (produced by collect-components.sh via make)
+
+Writes:
+  /tmp/vmat-signals.json    structured data for downstream classification
+
+Also prints a compact table to stdout.
+
+Usage (from repo root):
+  python3 .claude/skills/component-maturity-audit/scripts/collect-signals.py [--tier beta|alpha|all]
+
+By default, only audits components with tier != "stable" and != "deprecated".
+"""
+
+import argparse
+import glob
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+DOCS_PATH = Path("website/data/docs.json")
+COMPONENTS_TSV = Path("/tmp/vmat-components.tsv")
+INT_TESTS_TXT = Path("/tmp/vmat-int-tests.txt")
+OUT_PATH = Path("/tmp/vmat-signals.json")
+
+
+# Some components live under a shared parent directory or with an unusual filename.
+# Map: (kind, name) -> list of candidate paths (under src/).
+PATH_OVERRIDES: dict[tuple[str, str], list[str]] = {
+    ("sinks", "gcp_chronicle_unstructured"): ["src/sinks/gcp_chronicle/"],
+    ("sinks", "gcp_stackdriver_logs"): ["src/sinks/gcp/stackdriver/logs/", "src/sinks/gcp/stackdriver/"],
+    ("sinks", "gcp_stackdriver_metrics"): ["src/sinks/gcp/stackdriver/metrics/", "src/sinks/gcp/stackdriver/"],
+    ("sinks", "gcp_pubsub"): ["src/sinks/gcp/pubsub.rs", "src/sinks/gcp/pubsub/"],
+    ("sinks", "gcp_cloud_storage"): ["src/sinks/gcp/cloud_storage.rs", "src/sinks/gcp/cloud_storage/"],
+    ("sinks", "greptimedb_logs"): ["src/sinks/greptimedb/logs/", "src/sinks/greptimedb/"],
+    ("sinks", "greptimedb_metrics"): ["src/sinks/greptimedb/metrics/", "src/sinks/greptimedb/"],
+    ("sinks", "datadog_events"): ["src/sinks/datadog/events/"],
+    ("sinks", "datadog_logs"): ["src/sinks/datadog/logs/"],
+    ("sinks", "datadog_metrics"): ["src/sinks/datadog/metrics/"],
+    ("sinks", "datadog_traces"): ["src/sinks/datadog/traces/"],
+    ("sinks", "prometheus_exporter"): ["src/sinks/prometheus/exporter/", "src/sinks/prometheus/"],
+    ("sinks", "prometheus_remote_write"): ["src/sinks/prometheus/remote_write/", "src/sinks/prometheus/"],
+    ("sources", "prometheus_scrape"): ["src/sources/prometheus/scrape.rs", "src/sources/prometheus/"],
+    ("sources", "prometheus_pushgateway"): ["src/sources/prometheus/pushgateway.rs", "src/sources/prometheus/"],
+    ("sources", "prometheus_remote_write"): ["src/sources/prometheus/remote_write.rs", "src/sources/prometheus/"],
+    ("sources", "aws_kinesis_firehose"): ["src/sources/aws_kinesis_firehose/"],
+}
+
+
+def candidate_paths(kind: str, name: str) -> list[str]:
+    if (kind, name) in PATH_OVERRIDES:
+        return PATH_OVERRIDES[(kind, name)]
+    return [
+        f"src/{kind}/{name}/",
+        f"src/{kind}/{name}.rs",
+    ]
+
+
+def component_in_description(desc: str, name: str, singular: str) -> bool:
+    """Return True when the description plausibly refers to this component."""
+    esc = re.escape(name)
+    # Canonical prefix: `name` source / `name` sink / `name` transform
+    if re.search(rf'`{esc}`\s+{singular}s?\b', desc):
+        return True
+    # Grouped mentions: `name1` and `name2` sinks
+    if re.search(rf'`{esc}`[^`]*?(?:and|,)\s*`[a-z0-9_]+`\s+{singular}s?\b', desc):
+        return True
+    if re.search(rf'`[a-z0-9_]+`\s*(?:and|,)\s*`{esc}`\s+{singular}s?\b', desc):
+        return True
+    return False
+
+
+def load_beta_components(tier_filter: str) -> list[tuple[str, str, str]]:
+    out = []
+    for line in COMPONENTS_TSV.read_text().splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        kind, name, tier = parts[0], parts[1], parts[2]
+        if tier_filter == "non-stable":
+            if tier in ("stable", "deprecated"):
+                continue
+        elif tier_filter != "all" and tier != tier_filter:
+            continue
+        out.append((kind, name, tier))
+    return out
+
+
+def load_int_tests() -> set[str]:
+    if not INT_TESTS_TXT.exists():
+        return set()
+    return {l.strip() for l in INT_TESTS_TXT.read_text().splitlines() if l.strip()}
+
+
+def has_int_test(name: str, int_tests: set[str]) -> tuple[bool, list[str]]:
+    cands = {
+        name,
+        name.replace("_", "-"),
+        name.split("_")[0],
+    }
+    matches = [c for c in cands if c in int_tests]
+    return bool(matches), matches
+
+
+def git_activity(kind: str, name: str) -> dict:
+    existing = [p for p in candidate_paths(kind, name) if Path(p).exists()]
+    if not existing:
+        return {"commits_1yr": 0, "last_commit": None, "paths": []}
+    last = subprocess.run(
+        ["git", "log", "-1", "--format=%cI", "--"] + existing,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    count = subprocess.run(
+        ["git", "log", "--since=1 year ago", "--oneline", "--"] + existing,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    return {
+        "commits_1yr": len([l for l in count.split("\n") if l.strip()]),
+        "last_commit": last,
+        "paths": existing,
+    }
+
+
+def unreleased_fragments(name: str) -> list[tuple[str, str]]:
+    matches = []
+    for ext in ("fix", "feature", "enhancement", "breaking", "deprecation", "security", "chore"):
+        for fpath in glob.glob(f"changelog.d/*.{ext}.md"):
+            try:
+                txt = Path(fpath).read_text()
+            except Exception:
+                continue
+            if re.search(rf'`{re.escape(name)}`', txt):
+                matches.append((fpath, ext))
+    return matches
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tier", default="non-stable",
+                    help="Filter: non-stable (default), beta, alpha, unset, or all")
+    args = ap.parse_args()
+
+    docs = json.loads(DOCS_PATH.read_text())
+
+    all_releases = sorted(
+        [v for v in docs["releases"].keys() if re.match(r'^\d+\.\d+\.\d+$', v)],
+        key=lambda s: tuple(int(p) for p in s.split(".")),
+    )
+    minors = [v for v in all_releases if v.endswith(".0")]
+    recent4 = minors[-4:]
+    recent8 = minors[-8:]
+    print(f"Recent 4 minors: {recent4}", flush=True)
+
+    beta = load_beta_components(args.tier)
+    print(f"Components to audit: {len(beta)}", flush=True)
+
+    int_tests = load_int_tests()
+
+    per_kind_counts: dict[tuple[str, str], dict[str, dict]] = {}
+    breaking_flags: dict[tuple[str, str], list[str]] = {}
+    first_release: dict[tuple[str, str], str] = {}
+
+    # Phrases in a "chore" entry that indicate a breaking config change.
+    breaking_phrases = re.compile(
+        r'(has been removed|have been removed|removed in this release|renamed|replaced|migrated|is now required|must now|now must|must be explicitly|no longer|breaking change)',
+        re.IGNORECASE,
+    )
+
+    for rver in all_releases:
+        entries = docs["releases"][rver].get("changelog", []) or []
+        for e in entries:
+            desc = e.get("description", "") or ""
+            etype = e.get("type", "")
+            breaking = e.get("breaking", False)
+            # Chore entries often encode breaking config changes without the flag set.
+            if etype == "chore" and breaking_phrases.search(desc):
+                breaking = True
+            for kind, name, _tier in beta:
+                singular = kind.rstrip("s")
+                if not component_in_description(desc, name, singular):
+                    continue
+                key = (kind, name)
+                bucket = per_kind_counts.setdefault(key, {}).setdefault(
+                    rver, {"total": 0, "types": {}},
+                )
+                bucket["total"] += 1
+                bucket["types"][etype] = bucket["types"].get(etype, 0) + 1
+                if breaking:
+                    breaking_flags.setdefault(key, []).append(rver)
+                if key not in first_release:
+                    first_release[key] = rver
+
+    # "New X source/sink" mentions in release descriptions
+    new_pat = re.compile(r'[Nn]ew\s+`([a-z0-9_]+)`\s+(source|sink|transform)')
+    beta_set = {(k, n) for k, n, _ in beta}
+    for rver in all_releases:
+        desc = docs["releases"][rver].get("description", "") or ""
+        for m in new_pat.finditer(desc):
+            key = (m.group(2) + "s", m.group(1))
+            if key in beta_set:
+                cur = first_release.get(key)
+                if cur is None or tuple(int(p) for p in rver.split(".")) < tuple(int(p) for p in cur.split(".")):
+                    first_release[key] = rver
+
+    results = []
+    for kind, name, tier in beta:
+        key = (kind, name)
+        prc = per_kind_counts.get(key, {})
+        all_shipped_minors = [r for r in minors if r in prc]
+
+        total = feat = enh = fix = 0
+        for r in recent4:
+            rdata = prc.get(r, {"total": 0, "types": {}})
+            total += rdata["total"]
+            t = rdata["types"]
+            feat += t.get("feat", 0)
+            enh += t.get("enhancement", 0)
+            fix += t.get("fix", 0)
+        breaking_recent4 = [r for r in breaking_flags.get(key, []) if r in recent4]
+
+        itest, itest_matches = has_int_test(name, int_tests)
+        git = git_activity(kind, name)
+        frags = unreleased_fragments(name)
+
+        results.append({
+            "kind": kind,
+            "name": name,
+            "tier": tier,
+            "first_release": first_release.get(key),
+            "shipped_minors_count": len(all_shipped_minors),
+            "shipped_minors": all_shipped_minors,
+            "recent4_entries": total,
+            "recent4_by_type": {"feat": feat, "enhancement": enh, "fix": fix},
+            "recent4_breakdown": {r: prc.get(r, {"total": 0})["total"] for r in recent4},
+            "breaking_recent4": breaking_recent4,
+            "has_int_test": itest,
+            "int_test_match": itest_matches,
+            "git_commits_1yr": git["commits_1yr"],
+            "git_last_commit": git["last_commit"],
+            "git_paths": git["paths"],
+            "unreleased_fragments": [[p, t] for p, t in frags],
+        })
+
+    OUT_PATH.write_text(json.dumps(results, indent=2))
+    print(f"\nWrote {OUT_PATH}", flush=True)
+    print(f"\n{'kind':<11} {'name':<30} {'shipN':>5} {'last_commit':<11} {'1yr':>4} {'r4ent':>5} {'brk':>3} {'int':>3} {'frag':>4}")
+    for r in results:
+        lc = (r["git_last_commit"] or "")[:10]
+        print(
+            f"{r['kind']:<11} {r['name']:<30} {r['shipped_minors_count']:>5} {lc:<11} "
+            f"{r['git_commits_1yr']:>4} {r['recent4_entries']:>5} "
+            f"{len(r['breaking_recent4']):>3} {'Y' if r['has_int_test'] else 'n':>3} "
+            f"{len(r['unreleased_fragments']):>4}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/component-maturity-audit/scripts/fetch-issues.sh
+++ b/.claude/skills/component-maturity-audit/scripts/fetch-issues.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Fetch open issues for every non-stable component and cache them to /tmp.
+#
+# Uses label "<kind-singular>: <name>" (e.g., "sink: amqp", "source: kafka", "transform: dedupe").
+# Caches to /tmp/vmat-issues-<kind>-<name>.json so repeat runs are cheap.
+# Pass --force to overwrite cache.
+#
+# Input:  /tmp/vmat-components.tsv
+# Output: /tmp/vmat-issues-<kind>-<name>.json for each non-stable component,
+#         plus /tmp/vmat-issues-summary.tsv
+
+set -euo pipefail
+
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI required" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq required" >&2
+  exit 1
+fi
+
+TSV=/tmp/vmat-components.tsv
+SUMMARY=/tmp/vmat-issues-summary.tsv
+echo -e "kind\tname\ttotal_open\toldest_age_days\tp0_p1_bugs\toldest_p0_p1_age" > "$SUMMARY"
+
+NOW=$(date +%s)
+
+fetch_one() {
+  local kind="$1" name="$2"
+  local singular="${kind%s}"
+  local out="/tmp/vmat-issues-${kind}-${name}.json"
+  if [[ "$FORCE" -eq 0 && -f "$out" ]]; then
+    return 0
+  fi
+  gh issue list --repo vectordotdev/vector \
+    --label "${singular}: ${name}" \
+    --state open --limit 200 \
+    --json number,title,createdAt,updatedAt,labels \
+    > "$out" 2>/dev/null || echo "[]" > "$out"
+}
+
+# Fetch in parallel batches (8 at a time) to stay under GH rate limits
+pids=()
+while IFS=$'\t' read -r kind name tier; do
+  if [[ "$tier" == "stable" || "$tier" == "deprecated" ]]; then
+    continue
+  fi
+  fetch_one "$kind" "$name" &
+  pids+=($!)
+  if (( ${#pids[@]} >= 8 )); then
+    wait "${pids[@]}" 2>/dev/null || true
+    pids=()
+  fi
+done < "$TSV"
+wait "${pids[@]}" 2>/dev/null || true
+
+# Build summary
+while IFS=$'\t' read -r kind name tier; do
+  if [[ "$tier" == "stable" || "$tier" == "deprecated" ]]; then
+    continue
+  fi
+  in="/tmp/vmat-issues-${kind}-${name}.json"
+  if [[ ! -f "$in" ]]; then
+    echo -e "${kind}\t${name}\t0\t0\t0\t0" >> "$SUMMARY"
+    continue
+  fi
+  total=$(jq 'length' "$in")
+  oldest=$(jq -r 'map(.createdAt) | sort | first // ""' "$in")
+  if [[ -n "$oldest" ]]; then
+    oldest_s=$(date -d "$oldest" +%s 2>/dev/null || echo "$NOW")
+    oldest_days=$(( (NOW - oldest_s) / 86400 ))
+  else
+    oldest_days=0
+  fi
+
+  # Count issues tagged as bug with priority high/critical OR just a confirmed bug
+  p01=$(jq '[ .[] | select(
+    ( [.labels[].name] | any(. == "type: bug") )
+    and ( [.labels[].name] | any(. == "priority: high" or . == "priority: critical" or . == "meta: confirmed") )
+  ) ] | length' "$in")
+
+  oldest_p01=$(jq -r '[ .[] | select(
+    ( [.labels[].name] | any(. == "type: bug") )
+    and ( [.labels[].name] | any(. == "priority: high" or . == "priority: critical" or . == "meta: confirmed") )
+  ) | .createdAt ] | sort | first // ""' "$in")
+  if [[ -n "$oldest_p01" ]]; then
+    oldest_p01_s=$(date -d "$oldest_p01" +%s 2>/dev/null || echo "$NOW")
+    oldest_p01_days=$(( (NOW - oldest_p01_s) / 86400 ))
+  else
+    oldest_p01_days=0
+  fi
+
+  echo -e "${kind}\t${name}\t${total}\t${oldest_days}\t${p01}\t${oldest_p01_days}" >> "$SUMMARY"
+done < "$TSV"
+
+echo "wrote $SUMMARY" >&2
+column -ts $'\t' "$SUMMARY"

--- a/.claude/skills/component-maturity-audit/scripts/write-report.py
+++ b/.claude/skills/component-maturity-audit/scripts/write-report.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Render the final audit report from the classification + signals JSON.
+
+Writes docs/component-maturity/report-YYYY-MM-DD.md.
+
+Usage:
+  write-report.py [--only-changes]
+"""
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+
+SIGNALS = Path("/tmp/vmat-signals.json")
+CLASSIFICATION = Path("/tmp/vmat-classification.json")
+ISSUES_SUMMARY = Path("/tmp/vmat-issues-summary.tsv")
+COMPONENTS_TSV = Path("/tmp/vmat-components.tsv")
+INT_TESTS_TXT = Path("/tmp/vmat-int-tests.txt")
+RUBRIC_PATH = Path("docs/specs/component_maturity.md")
+
+
+def load_issues():
+    import csv
+    out = {}
+    if not ISSUES_SUMMARY.exists():
+        return out
+    with ISSUES_SUMMARY.open() as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            out[(row["kind"], row["name"])] = {
+                "total_open": int(row["total_open"]),
+                "oldest_age_days": int(row["oldest_age_days"]),
+                "p0_p1_bugs": int(row["p0_p1_bugs"]),
+                "oldest_p0_p1_age": int(row["oldest_p0_p1_age"]),
+            }
+    return out
+
+
+def load_all_components() -> list[tuple[str, str, str]]:
+    out = []
+    for line in COMPONENTS_TSV.read_text().splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            out.append((parts[0], parts[1], parts[2]))
+    return out
+
+
+def render_entry(prop, sig, issue):
+    kind = prop["kind"]
+    name = prop["name"]
+    cue = f"website/cue/reference/components/{kind}/{name}.cue"
+    lines = [
+        f"### {kind}/{name}: {prop['current']} → {prop['proposed']} (confidence: {prop['confidence']})",
+        "",
+        f"- **File:** `{cue}`",
+        f"- **Change:** `development: \"{prop['current']}\"` → `\"{prop['proposed']}\"`",
+        "- **Evidence:**",
+    ]
+
+    shipped = sig["shipped_minors_count"]
+    minors = ", ".join(sig["shipped_minors"][-6:]) or "none in recent history"
+    lines.append(f"  - shipped in {shipped} minor releases (recent: {minors})")
+
+    r4 = sig["recent4_by_type"]
+    lines.append(
+        f"  - last 4 minors: {sig['recent4_entries']} changelog entries "
+        f"(feat={r4['feat']}, enhance={r4['enhancement']}, fix={r4['fix']})"
+    )
+
+    if sig["breaking_recent4"]:
+        lines.append(f"  - breaking in last 4 minors: {', '.join(sig['breaking_recent4'])}")
+    else:
+        lines.append("  - breaking in last 4 minors: none detected")
+
+    if sig["has_int_test"]:
+        lines.append(f"  - integration test match: `{', '.join(sig['int_test_match'])}` (under `scripts/integration/`)")
+    else:
+        if kind == "transforms":
+            lines.append("  - integration test: not required (transform is pure-Rust)")
+        else:
+            lines.append("  - integration test: **missing** under `scripts/integration/`")
+
+    lines.append(
+        f"  - git activity: {sig['git_commits_1yr']} commits past year, "
+        f"last commit {sig['git_last_commit'] or 'unknown'} "
+        f"(paths: {', '.join(sig['git_paths']) or 'none'})"
+    )
+
+    if issue is not None:
+        lines.append(
+            f"  - open issues: {issue['total_open']} total, oldest {issue['oldest_age_days']}d; "
+            f"confirmed/priority bugs: {issue['p0_p1_bugs']}, oldest {issue['oldest_p0_p1_age']}d "
+            f"(`gh issue list --repo vectordotdev/vector --label '{kind.rstrip('s')}: {name}' --state open`)"
+        )
+    else:
+        lines.append("  - open issues: not fetched")
+
+    if sig["unreleased_fragments"]:
+        frags = ", ".join(f"{Path(p).name}" for p, _t in sig["unreleased_fragments"])
+        lines.append(f"  - unreleased changelog fragments: {frags}")
+
+    # Rubric-check bullet list
+    if prop["action"] == "demote":
+        lines.append(
+            "  - demotion trigger: silent for 4+ consecutive minors "
+            "(no changelog entries) and low git activity — rubric says "
+            "`beta → alpha` when component has no commits/changelog for "
+            "4+ consecutive minor releases"
+        )
+    elif prop["failures"]:
+        lines.append(f"  - failed criteria: {', '.join(prop['failures'])}")
+    else:
+        lines.append("  - rubric: all promotion criteria satisfied")
+
+    # Pulled evidence from classify.py
+    if prop["evidence"]:
+        pass  # The headline summary above captures most; avoid duplication
+
+    lines.append("")
+    return lines
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only-changes", action="store_true")
+    args = ap.parse_args()
+
+    sigs = {(s["kind"], s["name"]): s for s in json.loads(SIGNALS.read_text())}
+    props = json.loads(CLASSIFICATION.read_text())
+    issues = load_issues()
+    all_components = load_all_components()
+
+    rubric_src = str(RUBRIC_PATH) if RUBRIC_PATH.exists() else "skill default (no `docs/specs/component_maturity.md` present)"
+
+    today = date.today().isoformat()
+    promote = [p for p in props if p["action"] == "promote"]
+    demote = [p for p in props if p["action"] == "demote"]
+    # Unchanged includes every component in the full registry, not just those evaluated.
+    # Per user guidance, stable components are not audited — they appear in Unchanged as-is.
+    evaluated_keys = {(p["kind"], p["name"]) for p in props}
+
+    out_dir = Path("docs/component-maturity")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"report-{today}.md"
+
+    lines: list[str] = []
+    lines.append(f"# Component Maturity Audit — {today}")
+    lines.append("")
+    lines.append(f"Rubric source: `{rubric_src}`")
+    lines.append(f"Components in registry: {len(all_components)}")
+    lines.append(f"Components audited: {len(props)} (stable and deprecated skipped per request)")
+    lines.append(f"Proposed promotions: {len(promote)} · Proposed demotions: {len(demote)} · Unchanged: {len(all_components) - len(promote) - len(demote)}")
+    lines.append("")
+    lines.append("> **Note:** This report is read-only output. A human reviewer flips the CUE `development:` field after reviewing each proposal. Do not merge promotions/demotions mechanically.")
+    lines.append("")
+
+    # Promote
+    lines.append("## Promote")
+    lines.append("")
+    if not promote:
+        lines.append("_No promotions proposed._")
+        lines.append("")
+    else:
+        # Sort: high confidence first, then by kind/name
+        conf_order = {"high": 0, "medium": 1, "low": 2}
+        promote.sort(key=lambda p: (conf_order[p["confidence"]], p["kind"], p["name"]))
+        for p in promote:
+            sig = sigs[(p["kind"], p["name"])]
+            issue = issues.get((p["kind"], p["name"]))
+            lines.extend(render_entry(p, sig, issue))
+
+    # Demote
+    lines.append("## Demote")
+    lines.append("")
+    if not demote:
+        lines.append("_No demotions proposed._")
+        lines.append("")
+    else:
+        demote.sort(key=lambda p: (p["kind"], p["name"]))
+        for p in demote:
+            sig = sigs[(p["kind"], p["name"])]
+            issue = issues.get((p["kind"], p["name"]))
+            lines.extend(render_entry(p, sig, issue))
+
+    # Unchanged
+    if not args.only_changes:
+        lines.append("## Unchanged")
+        lines.append("")
+        lines.append("Components that either passed without change or were skipped (stable/deprecated).")
+        lines.append("")
+        # List every component, marking source of "unchanged"
+        changed = {(p["kind"], p["name"]) for p in (promote + demote)}
+        audited = evaluated_keys
+        for kind, name, tier in sorted(all_components):
+            key = (kind, name)
+            if key in changed:
+                continue
+            if key in audited:
+                # Audited but unchanged — beta failed to promote, or alpha failed to promote
+                suffix = " (audited)"
+            else:
+                suffix = " (skipped)"
+            lines.append(f"- {kind}/{name} ({tier}){suffix}")
+        lines.append("")
+
+    # Signal coverage
+    lines.append("## Signal coverage")
+    lines.append("")
+    int_tests_count = len(INT_TESTS_TXT.read_text().split()) if INT_TESTS_TXT.exists() else 0
+    fetched = sum(1 for k in sigs if (k in issues))
+    lines.append(f"- Integration test suites enumerated via `cargo vdev int show`: {int_tests_count}")
+    lines.append(f"- `gh issue list` calls: {len(issues)} (cached in `/tmp/vmat-issues-*.json`)")
+    no_git = sum(1 for s in sigs.values() if s["git_commits_1yr"] == 0)
+    lines.append(f"- Components with no git activity in last year: {no_git}")
+    lines.append("- Release changelog scanned: last 4 minors from `website/data/docs.json`")
+    lines.append("- Breaking-change detection: `.breaking == true` OR chore entries matching `removed/renamed/replaced/migrated/must (now|be explicitly)/no longer/breaking change`")
+    lines.append("")
+    lines.append("### Reproduce")
+    lines.append("")
+    lines.append("```sh")
+    lines.append(".claude/skills/component-maturity-audit/scripts/collect-components.sh --no-build > /tmp/vmat-components.tsv")
+    lines.append("cargo vdev int show | tail -n +3 | awk '{print $1}' | sort -u > /tmp/vmat-int-tests.txt")
+    lines.append("python3 .claude/skills/component-maturity-audit/scripts/collect-signals.py")
+    lines.append(".claude/skills/component-maturity-audit/scripts/fetch-issues.sh          # reuses /tmp cache")
+    lines.append("python3 .claude/skills/component-maturity-audit/scripts/classify.py")
+    lines.append("python3 .claude/skills/component-maturity-audit/scripts/write-report.py")
+    lines.append("```")
+    lines.append("")
+
+    out_path.write_text("\n".join(lines))
+    print(f"Wrote {out_path}")
+    print(f"Promotions: {len(promote)}, Demotions: {len(demote)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/component-maturity/report-2026-04-22.md
+++ b/docs/component-maturity/report-2026-04-22.md
@@ -1,0 +1,413 @@
+# Component Maturity Audit — 2026-04-22
+
+Rubric source: `skill default (no `docs/specs/component_maturity.md` present)`
+Components in registry: 125
+Components audited: 40 (stable and deprecated skipped per request)
+Proposed promotions: 19 · Proposed demotions: 2 · Unchanged: 104
+
+> **Note:** This report is read-only output. A human reviewer flips the CUE `development:` field after reviewing each proposal. Do not merge promotions/demotions mechanically.
+
+## Promote
+
+### sinks/amqp: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sinks/amqp.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 5 minor releases (recent: 0.30.0, 0.34.0, 0.38.0, 0.47.0, 0.48.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `amqp` (under `scripts/integration/`)
+  - git activity: 10 commits past year, last commit 2026-03-13T21:17:33Z (paths: src/sinks/amqp/)
+  - open issues: 10 total, oldest 1128d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: amqp' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/axiom: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sinks/axiom.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 4 minor releases (recent: 0.24.0, 0.28.0, 0.42.0, 0.52.0)
+  - last 4 minors: 1 changelog entries (feat=1, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `axiom` (under `scripts/integration/`)
+  - git activity: 2 commits past year, last commit 2026-03-24T16:04:14Z (paths: src/sinks/axiom/)
+  - open issues: 0 total, oldest 0d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: axiom' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/datadog_traces: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sinks/datadog_traces.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 3 minor releases (recent: 0.21.0, 0.23.0, 0.35.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `datadog-traces` (under `scripts/integration/`)
+  - git activity: 11 commits past year, last commit 2026-03-17T18:29:20Z (paths: src/sinks/datadog/traces/)
+  - open issues: 9 total, oldest 1409d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: datadog_traces' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/gcp_stackdriver_logs: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sinks/gcp_stackdriver_logs.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 3 minor releases (recent: 0.21.0, 0.22.0, 0.46.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `gcp` (under `scripts/integration/`)
+  - git activity: 9 commits past year, last commit 2026-03-16T20:49:29Z (paths: src/sinks/gcp/stackdriver/logs/, src/sinks/gcp/stackdriver/)
+  - open issues: 6 total, oldest 2196d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: gcp_stackdriver_logs' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/gcp_stackdriver_metrics: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 3 minor releases (recent: 0.22.0, 0.30.0, 0.34.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `gcp` (under `scripts/integration/`)
+  - git activity: 9 commits past year, last commit 2026-03-16T20:49:29Z (paths: src/sinks/gcp/stackdriver/metrics/, src/sinks/gcp/stackdriver/)
+  - open issues: 3 total, oldest 1476d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: gcp_stackdriver_metrics' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/prometheus_remote_write: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sinks/prometheus_remote_write.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 4 minor releases (recent: 0.25.0, 0.31.0, 0.34.0, 0.54.0)
+  - last 4 minors: 2 changelog entries (feat=0, enhance=2, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `prometheus` (under `scripts/integration/`)
+  - git activity: 15 commits past year, last commit 2026-03-17T18:29:20Z (paths: src/sinks/prometheus/remote_write/, src/sinks/prometheus/)
+  - open issues: 18 total, oldest 1883d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: prometheus_remote_write' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/dnstap: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sources/dnstap.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 6 minor releases (recent: 0.37.0, 0.43.0, 0.44.0, 0.45.0, 0.48.0, 0.49.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `dnstap` (under `scripts/integration/`)
+  - git activity: 6 commits past year, last commit 2025-09-08T14:36:31Z (paths: src/sources/dnstap/)
+  - open issues: 4 total, oldest 1710d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: dnstap' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/gcp_pubsub: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sources/gcp_pubsub.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 3 minor releases (recent: 0.22.0, 0.23.0, 0.44.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `gcp` (under `scripts/integration/`)
+  - git activity: 5 commits past year, last commit 2025-12-09T17:05:19Z (paths: src/sources/gcp_pubsub.rs)
+  - open issues: 6 total, oldest 1345d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: gcp_pubsub' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/mqtt: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sources/mqtt.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 3 minor releases (recent: 0.47.0, 0.49.0, 0.53.0)
+  - last 4 minors: 1 changelog entries (feat=0, enhance=1, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `mqtt` (under `scripts/integration/`)
+  - git activity: 8 commits past year, last commit 2026-01-20T23:00:54Z (paths: src/sources/mqtt/)
+  - open issues: 2 total, oldest 503d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: mqtt' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/opentelemetry: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sources/opentelemetry.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 11 minor releases (recent: 0.48.0, 0.50.0, 0.51.0, 0.53.0, 0.54.0, 0.55.0)
+  - last 4 minors: 5 changelog entries (feat=0, enhance=2, fix=3)
+  - breaking in last 4 minors: none detected
+  - integration test match: `opentelemetry` (under `scripts/integration/`)
+  - git activity: 19 commits past year, last commit 2026-03-26T22:31:32Z (paths: src/sources/opentelemetry/)
+  - open issues: 10 total, oldest 1700d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: opentelemetry' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/prometheus_remote_write: beta → stable (confidence: high)
+
+- **File:** `website/cue/reference/components/sources/prometheus_remote_write.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 3 minor releases (recent: 0.35.0, 0.50.0, 0.51.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `prometheus` (under `scripts/integration/`)
+  - git activity: 12 commits past year, last commit 2025-12-09T17:05:19Z (paths: src/sources/prometheus/remote_write.rs, src/sources/prometheus/)
+  - open issues: 9 total, oldest 1874d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: prometheus_remote_write' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/appsignal: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sinks/appsignal.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.29.0, 0.30.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `appsignal` (under `scripts/integration/`)
+  - git activity: 5 commits past year, last commit 2025-11-13T21:19:00Z (paths: src/sinks/appsignal/)
+  - open issues: 0 total, oldest 0d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: appsignal' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/databend: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sinks/databend.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.29.0, 0.38.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `databend` (under `scripts/integration/`)
+  - git activity: 9 commits past year, last commit 2026-01-20T23:00:54Z (paths: src/sinks/databend/)
+  - open issues: 0 total, oldest 0d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: databend' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sinks/greptimedb_logs: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sinks/greptimedb_logs.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.41.0, 0.47.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `greptimedb` (under `scripts/integration/`)
+  - git activity: 7 commits past year, last commit 2026-03-17T18:29:20Z (paths: src/sinks/greptimedb/logs/, src/sinks/greptimedb/)
+  - open issues: 0 total, oldest 0d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: greptimedb_logs' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/amqp: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sources/amqp.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.29.0, 0.41.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `amqp` (under `scripts/integration/`)
+  - git activity: 10 commits past year, last commit 2026-03-13T21:17:33Z (paths: src/sources/amqp.rs)
+  - open issues: 6 total, oldest 1128d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: amqp' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/fluent: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sources/fluent.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.31.0, 0.51.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `fluent` (under `scripts/integration/`)
+  - git activity: 8 commits past year, last commit 2026-01-27T15:25:56Z (paths: src/sources/fluent/)
+  - open issues: 8 total, oldest 1798d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: fluent' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/http_client: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sources/http_client.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.25.0, 0.52.0)
+  - last 4 minors: 2 changelog entries (feat=0, enhance=1, fix=1)
+  - breaking in last 4 minors: none detected
+  - integration test match: `http-client` (under `scripts/integration/`)
+  - git activity: 17 commits past year, last commit 2026-01-20T23:00:54Z (paths: src/sources/http_client/)
+  - open issues: 7 total, oldest 1353d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: http_client' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### sources/pulsar: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/sources/pulsar.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 2 minor releases (recent: 0.27.0, 0.45.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `pulsar` (under `scripts/integration/`)
+  - git activity: 4 commits past year, last commit 2026-02-20T20:55:24Z (paths: src/sources/pulsar.rs)
+  - open issues: 1 total, oldest 651d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: pulsar' --state open`)
+  - rubric: all promotion criteria satisfied
+
+### transforms/tag_cardinality_limit: beta → stable (confidence: medium)
+
+- **File:** `website/cue/reference/components/transforms/tag_cardinality_limit.cue`
+- **Change:** `development: "beta"` → `"stable"`
+- **Evidence:**
+  - shipped in 4 minor releases (recent: 0.26.0, 0.35.0, 0.45.0, 0.54.0)
+  - last 4 minors: 1 changelog entries (feat=0, enhance=1, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test: not required (transform is pure-Rust)
+  - git activity: 6 commits past year, last commit 2026-02-27T16:06:39Z (paths: src/transforms/tag_cardinality_limit/)
+  - open issues: 10 total, oldest 2233d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'transform: tag_cardinality_limit' --state open`)
+  - rubric: all promotion criteria satisfied
+
+## Demote
+
+### sinks/webhdfs: beta → alpha (confidence: medium)
+
+- **File:** `website/cue/reference/components/sinks/webhdfs.cue`
+- **Change:** `development: "beta"` → `"alpha"`
+- **Evidence:**
+  - shipped in 1 minor releases (recent: 0.29.0)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `webhdfs` (under `scripts/integration/`)
+  - git activity: 2 commits past year, last commit 2025-09-08T14:36:31Z (paths: src/sinks/webhdfs/)
+  - open issues: 1 total, oldest 575d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'sink: webhdfs' --state open`)
+  - demotion trigger: silent for 4+ consecutive minors (no changelog entries) and low git activity — rubric says `beta → alpha` when component has no commits/changelog for 4+ consecutive minor releases
+
+### sources/eventstoredb_metrics: beta → alpha (confidence: medium)
+
+- **File:** `website/cue/reference/components/sources/eventstoredb_metrics.cue`
+- **Change:** `development: "beta"` → `"alpha"`
+- **Evidence:**
+  - shipped in 0 minor releases (recent: none in recent history)
+  - last 4 minors: 0 changelog entries (feat=0, enhance=0, fix=0)
+  - breaking in last 4 minors: none detected
+  - integration test match: `eventstoredb` (under `scripts/integration/`)
+  - git activity: 4 commits past year, last commit 2025-12-09T17:05:19Z (paths: src/sources/eventstoredb_metrics/)
+  - open issues: 0 total, oldest 0d; confirmed/priority bugs: 0, oldest 0d (`gh issue list --repo vectordotdev/vector --label 'source: eventstoredb_metrics' --state open`)
+  - demotion trigger: silent for 4+ consecutive minors (no changelog entries) and low git activity — rubric says `beta → alpha` when component has no commits/changelog for 4+ consecutive minor releases
+
+## Unchanged
+
+Components that either passed without change or were skipped (stable/deprecated).
+
+- sinks/aws_cloudwatch_logs (stable) (skipped)
+- sinks/aws_cloudwatch_metrics (stable) (skipped)
+- sinks/aws_kinesis_firehose (stable) (skipped)
+- sinks/aws_kinesis_streams (stable) (skipped)
+- sinks/aws_s3 (stable) (skipped)
+- sinks/aws_sns (stable) (skipped)
+- sinks/aws_sqs (stable) (skipped)
+- sinks/azure_blob (stable) (skipped)
+- sinks/azure_logs_ingestion (beta) (audited)
+- sinks/azure_monitor_logs (deprecated) (skipped)
+- sinks/blackhole (stable) (skipped)
+- sinks/clickhouse (stable) (skipped)
+- sinks/console (stable) (skipped)
+- sinks/datadog_events (stable) (skipped)
+- sinks/datadog_logs (stable) (skipped)
+- sinks/datadog_metrics (stable) (skipped)
+- sinks/doris (beta) (audited)
+- sinks/elasticsearch (stable) (skipped)
+- sinks/file (stable) (skipped)
+- sinks/gcp_chronicle_unstructured (beta) (audited)
+- sinks/gcp_cloud_storage (stable) (skipped)
+- sinks/gcp_pubsub (stable) (skipped)
+- sinks/greptimedb_metrics (beta) (audited)
+- sinks/honeycomb (stable) (skipped)
+- sinks/http (stable) (skipped)
+- sinks/humio_logs (stable) (skipped)
+- sinks/humio_metrics (stable) (skipped)
+- sinks/influxdb_logs (stable) (skipped)
+- sinks/influxdb_metrics (stable) (skipped)
+- sinks/kafka (stable) (skipped)
+- sinks/keep (beta) (audited)
+- sinks/loki (stable) (skipped)
+- sinks/mezmo (stable) (skipped)
+- sinks/mqtt (beta) (audited)
+- sinks/nats (stable) (skipped)
+- sinks/new_relic (beta) (audited)
+- sinks/opentelemetry (beta) (audited)
+- sinks/papertrail (stable) (skipped)
+- sinks/postgres (beta) (audited)
+- sinks/prometheus_exporter (stable) (skipped)
+- sinks/pulsar (stable) (skipped)
+- sinks/redis (stable) (skipped)
+- sinks/sematext_logs (stable) (skipped)
+- sinks/sematext_metrics (stable) (skipped)
+- sinks/socket (stable) (skipped)
+- sinks/splunk_hec_logs (stable) (skipped)
+- sinks/splunk_hec_metrics (stable) (skipped)
+- sinks/statsd (stable) (skipped)
+- sinks/vector (stable) (skipped)
+- sinks/websocket (beta) (audited)
+- sinks/websocket_server (beta) (audited)
+- sources/apache_metrics (stable) (skipped)
+- sources/aws_ecs_metrics (stable) (skipped)
+- sources/aws_kinesis_firehose (stable) (skipped)
+- sources/aws_s3 (stable) (skipped)
+- sources/aws_sqs (stable) (skipped)
+- sources/datadog_agent (stable) (skipped)
+- sources/demo_logs (stable) (skipped)
+- sources/docker_logs (stable) (skipped)
+- sources/exec (stable) (skipped)
+- sources/file (stable) (skipped)
+- sources/file_descriptor (stable) (skipped)
+- sources/heroku_logs (stable) (skipped)
+- sources/host_metrics (stable) (skipped)
+- sources/http_server (stable) (skipped)
+- sources/internal_logs (stable) (skipped)
+- sources/internal_metrics (stable) (skipped)
+- sources/journald (stable) (skipped)
+- sources/kafka (stable) (skipped)
+- sources/kubernetes_logs (stable) (skipped)
+- sources/logstash (stable) (skipped)
+- sources/mongodb_metrics (stable) (skipped)
+- sources/nats (stable) (skipped)
+- sources/nginx_metrics (stable) (skipped)
+- sources/okta (beta) (audited)
+- sources/postgresql_metrics (stable) (skipped)
+- sources/prometheus_pushgateway (beta) (audited)
+- sources/prometheus_scrape (stable) (skipped)
+- sources/redis (stable) (skipped)
+- sources/socket (stable) (skipped)
+- sources/splunk_hec (stable) (skipped)
+- sources/static_metrics (stable) (skipped)
+- sources/statsd (stable) (skipped)
+- sources/stdin (stable) (skipped)
+- sources/syslog (stable) (skipped)
+- sources/vector (stable) (skipped)
+- sources/websocket (beta) (audited)
+- sources/windows_event_log (beta) (audited)
+- transforms/aggregate (stable) (skipped)
+- transforms/aws_ec2_metadata (stable) (skipped)
+- transforms/dedupe (stable) (skipped)
+- transforms/exclusive_route (beta) (audited)
+- transforms/filter (stable) (skipped)
+- transforms/incremental_to_absolute (beta) (audited)
+- transforms/log_to_metric (stable) (skipped)
+- transforms/lua (stable) (skipped)
+- transforms/metric_to_log (stable) (skipped)
+- transforms/reduce (stable) (skipped)
+- transforms/remap (stable) (skipped)
+- transforms/route (stable) (skipped)
+- transforms/sample (stable) (skipped)
+- transforms/throttle (stable) (skipped)
+- transforms/trace_to_log (beta) (audited)
+- transforms/window (beta) (audited)
+
+## Signal coverage
+
+- Integration test suites enumerated via `cargo vdev int show`: 38
+- `gh issue list` calls: 40 (cached in `/tmp/vmat-issues-*.json`)
+- Components with no git activity in last year: 0
+- Release changelog scanned: last 4 minors from `website/data/docs.json`
+- Breaking-change detection: `.breaking == true` OR chore entries matching `removed/renamed/replaced/migrated/must (now|be explicitly)/no longer/breaking change`
+
+### Reproduce
+
+```sh
+.claude/skills/component-maturity-audit/scripts/collect-components.sh --no-build > /tmp/vmat-components.tsv
+cargo vdev int show | tail -n +3 | awk '{print $1}' | sort -u > /tmp/vmat-int-tests.txt
+python3 .claude/skills/component-maturity-audit/scripts/collect-signals.py
+.claude/skills/component-maturity-audit/scripts/fetch-issues.sh          # reuses /tmp cache
+python3 .claude/skills/component-maturity-audit/scripts/classify.py
+python3 .claude/skills/component-maturity-audit/scripts/write-report.py
+```


### PR DESCRIPTION
## Summary

Adds a Claude Code skill (`/component-maturity-audit`) that evaluates Vector component maturity (alpha/beta/stable) against a rubric and writes a reproducible markdown report under `docs/component-maturity/`. The report proposes promotions and demotions with confidence levels; a human still flips the CUE `development:` field.

## Vector configuration

NA

## How did you test this PR?

Ran `/component-maturity-audit` against the current tree. It audited 40 non-stable components and produced `docs/component-maturity/report-2026-04-22.md` with 19 proposed promotions and 2 proposed demotions. Verified that the breaking-change regex caught the `opentelemetry` and `azure_logs_ingestion` 0.55.0 chore entries (disqualifying both from stable promotion).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA