### PR TITLE
feat(startup): add --raise-fd-limit CLI flag to raise file descriptor soft limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,7 +473,8 @@ quick-xml = { version = "0.31", default-features = false, features = ["serialize
 rdkafka = { workspace = true, features = ["cmake_build"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["socket", "signal", "fs"] }
+libc.workspace = true
+nix = { version = "0.31", default-features = false, features = ["socket", "signal", "fs", "resource"] }
 tikv-jemallocator = { version = "0.7.0", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/changelog.d/raise_fd_limit_cli_flag.fix.md
+++ b/changelog.d/raise_fd_limit_cli_flag.fix.md
@@ -1,7 +1,7 @@
 A new `--raise-fd-limit` CLI flag (or `VECTOR_RAISE_FD_LIMIT` environment variable)
-raises the file descriptor soft limit (RLIMIT_NOFILE) to the hard limit at startup.
-This prevents "Too many open files" errors when Vector monitors large numbers of log
-files. On macOS, Vector falls back to the kernel-enforced `kern.maxfilesperproc` limit
-if the hard limit is too high.
+raises the file descriptor soft limit to the hard limit at startup. This prevents
+"Too many open files" errors when Vector monitors large numbers of log files. On
+macOS, Vector falls back to the kernel-enforced per-process file limit if the hard
+limit is too high.
 
 authors: vparfonov

--- a/changelog.d/raise_fd_limit_cli_flag.fix.md
+++ b/changelog.d/raise_fd_limit_cli_flag.fix.md
@@ -1,0 +1,7 @@
+A new `--raise-fd-limit` CLI flag (or `VECTOR_RAISE_FD_LIMIT` environment variable)
+raises the file descriptor soft limit (RLIMIT_NOFILE) to the hard limit at startup.
+This prevents "Too many open files" errors when Vector monitors large numbers of log
+files. On macOS, Vector falls back to the kernel-enforced `kern.maxfilesperproc` limit
+if the hard limit is too high.
+
+authors: vparfonov

--- a/src/app.rs
+++ b/src/app.rs
@@ -214,6 +214,11 @@ impl Application {
             opts.root.internal_log_rate_limit,
         );
 
+        #[cfg(unix)]
+        if opts.root.raise_fd_limit {
+            crate::cli::raise_file_descriptor_limit();
+        }
+
         // Set global color preference for downstream modules
         crate::set_global_color(color);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -296,11 +296,6 @@ impl RootOpts {
             }
         }
 
-        #[cfg(unix)]
-        if self.raise_fd_limit {
-            raise_file_descriptor_limit();
-        }
-
         crate::metrics::init_global().expect("metrics initialization failed");
     }
 }
@@ -315,7 +310,7 @@ impl RootOpts {
 /// On macOS, the hard limit can be RLIM_INFINITY, so we first try the hard limit,
 /// then fall back to the kernel-enforced `kern.maxfilesperproc` (typically 10240).
 #[cfg(unix)]
-fn raise_file_descriptor_limit() {
+pub(crate) fn raise_file_descriptor_limit() {
     use nix::sys::resource::{Resource, getrlimit, setrlimit};
     use tracing::{info, warn};
 
@@ -525,53 +520,61 @@ pub fn handle_config_errors(errors: Vec<String>) -> exitcode::ExitCode {
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
-    static RLIMIT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    fn run_in_subprocess(test_name: &str) {
+        let exe = std::env::current_exe().unwrap();
+        let output = std::process::Command::new(exe)
+            .env("__VECTOR_SUBPROCESS_TEST", "1")
+            .args(["--exact", test_name, "--nocapture"])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "subprocess test failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
 
     #[test]
     #[cfg(unix)]
     fn test_raise_file_descriptor_limit() {
+        if std::env::var("__VECTOR_SUBPROCESS_TEST").is_err() {
+            run_in_subprocess("cli::tests::test_raise_file_descriptor_limit");
+            return;
+        }
+
         use nix::sys::resource::{Resource, getrlimit, setrlimit};
 
-        let _lock = RLIMIT_MUTEX.lock().unwrap();
-
-        // Save original limits
         let (original_soft, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
-
-        // Lower the soft limit to simulate a constrained environment
         let lowered = std::cmp::min(original_soft, 256);
         if lowered < hard {
             setrlimit(Resource::RLIMIT_NOFILE, lowered, hard).unwrap();
 
-            // Verify it was lowered
             let (soft_before, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
             assert_eq!(soft_before, lowered);
 
-            // Call the function under test
             super::raise_file_descriptor_limit();
 
-            // Verify the soft limit was raised above the lowered value
             let (soft_after, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
             assert!(
                 soft_after > lowered,
                 "Expected soft limit to be raised above {lowered}, got {soft_after}"
             );
-
-            // Restore original limits
-            setrlimit(Resource::RLIMIT_NOFILE, original_soft, hard).unwrap();
         }
     }
 
     #[test]
     #[cfg(unix)]
     fn test_raise_file_descriptor_limit_already_at_max() {
+        if std::env::var("__VECTOR_SUBPROCESS_TEST").is_err() {
+            run_in_subprocess("cli::tests::test_raise_file_descriptor_limit_already_at_max");
+            return;
+        }
+
         use nix::sys::resource::{Resource, getrlimit, setrlimit};
 
-        let _lock = RLIMIT_MUTEX.lock().unwrap();
+        let (_, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
 
-        // Save original limits
-        let (original_soft, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
-
-        // Set soft = hard so there's nothing to raise
         if setrlimit(Resource::RLIMIT_NOFILE, hard, hard).is_err() {
             #[cfg(target_os = "macos")]
             if let Some(maxfiles) = super::macos_maxfilesperproc() {
@@ -581,14 +584,10 @@ mod tests {
 
         let (soft_before, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
 
-        // Call the function — should be a no-op
         super::raise_file_descriptor_limit();
 
         let (soft_after, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
         assert_eq!(soft_before, soft_after);
-
-        // Restore original limits
-        setrlimit(Resource::RLIMIT_NOFILE, original_soft, hard).unwrap();
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,6 +260,15 @@ pub struct RootOpts {
     /// `--watch-config`.
     #[arg(long, env = "VECTOR_ALLOW_EMPTY_CONFIG", default_value = "false")]
     pub allow_empty_config: bool,
+
+    /// Raise the file descriptor soft limit (RLIMIT_NOFILE) to the hard limit at startup.
+    ///
+    /// Many systems default the soft limit to 1024 (Linux) or 256 (macOS), which is too low
+    /// when Vector monitors large numbers of log files. This flag raises the soft limit to
+    /// prevent "Too many open files" errors without requiring manual sysadmin intervention.
+    #[cfg(unix)]
+    #[arg(long, env = "VECTOR_RAISE_FD_LIMIT", default_value = "false")]
+    pub raise_fd_limit: bool,
 }
 
 impl RootOpts {
@@ -287,7 +296,95 @@ impl RootOpts {
             }
         }
 
+        #[cfg(unix)]
+        if self.raise_fd_limit {
+            raise_file_descriptor_limit();
+        }
+
         crate::metrics::init_global().expect("metrics initialization failed");
+    }
+}
+
+/// Raise the soft file descriptor limit (RLIMIT_NOFILE) as high as the OS allows.
+///
+/// Many systems default the soft limit to 1024 (Linux) or 256 (macOS), which is too low
+/// for Vector when it monitors large numbers of log files. Raising it prevents
+/// "Too many open files (os error 24)" errors without requiring manual sysadmin intervention.
+///
+/// On Linux, the soft limit is raised to the hard limit (typically 65536+).
+/// On macOS, the hard limit can be RLIM_INFINITY, so we first try the hard limit,
+/// then fall back to the kernel-enforced `kern.maxfilesperproc` (typically 10240).
+#[cfg(unix)]
+fn raise_file_descriptor_limit() {
+    use nix::sys::resource::{Resource, getrlimit, setrlimit};
+    use tracing::{info, warn};
+
+    let (soft, hard) = match getrlimit(Resource::RLIMIT_NOFILE) {
+        Ok(limits) => limits,
+        Err(err) => {
+            warn!(message = "Failed to get file descriptor limit.", %err);
+            return;
+        }
+    };
+
+    if soft >= hard {
+        return; // Already at maximum
+    }
+
+    // Try setting soft limit to hard limit (works on Linux, may fail on macOS)
+    if setrlimit(Resource::RLIMIT_NOFILE, hard, hard).is_ok() {
+        info!(
+            message = "Raised file descriptor limit.",
+            from = soft,
+            to = hard,
+        );
+        return;
+    }
+
+    // On macOS, the hard limit can be RLIM_INFINITY which setrlimit rejects.
+    // Fall back to the kernel-enforced kern.maxfilesperproc.
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(maxfiles) = macos_maxfilesperproc()
+            && maxfiles > soft
+            && setrlimit(Resource::RLIMIT_NOFILE, maxfiles, hard).is_ok()
+        {
+            info!(
+                message = "Raised file descriptor limit.",
+                from = soft,
+                to = maxfiles,
+            );
+            return;
+        }
+    }
+
+    warn!(
+        message = "Failed to raise file descriptor limit.",
+        current = soft,
+        attempted = hard,
+    );
+}
+
+/// Query the macOS kernel limit on per-process open files.
+#[cfg(target_os = "macos")]
+fn macos_maxfilesperproc() -> Option<libc::rlim_t> {
+    let mut maxfiles: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::size_t;
+    // Safety: sysctlbyname with a valid null-terminated name and correctly sized output buffer.
+    // No safe wrapper exists for this macOS-specific call.
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c"kern.maxfilesperproc".as_ptr(),
+            &mut maxfiles as *mut libc::c_int as *mut libc::c_void,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret == 0 && maxfiles > 0 {
+        Some(maxfiles as libc::rlim_t)
+    } else {
+        None
     }
 }
 
@@ -423,4 +520,81 @@ pub fn handle_config_errors(errors: Vec<String>) -> exitcode::ExitCode {
     }
 
     exitcode::CONFIG
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(unix)]
+    fn test_raise_file_descriptor_limit() {
+        use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+        // Save original limits
+        let (original_soft, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+
+        // Lower the soft limit to simulate a constrained environment
+        let lowered = std::cmp::min(original_soft, 256);
+        if lowered < hard {
+            setrlimit(Resource::RLIMIT_NOFILE, lowered, hard).unwrap();
+
+            // Verify it was lowered
+            let (soft_before, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+            assert_eq!(soft_before, lowered);
+
+            // Call the function under test
+            super::raise_file_descriptor_limit();
+
+            // Verify the soft limit was raised above the lowered value
+            let (soft_after, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+            assert!(
+                soft_after > lowered,
+                "Expected soft limit to be raised above {lowered}, got {soft_after}"
+            );
+
+            // Restore original limits
+            setrlimit(Resource::RLIMIT_NOFILE, original_soft, hard).unwrap();
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_raise_file_descriptor_limit_already_at_max() {
+        use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+        // Save original limits
+        let (original_soft, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+
+        // Set soft = hard so there's nothing to raise
+        if setrlimit(Resource::RLIMIT_NOFILE, hard, hard).is_err() {
+            #[cfg(target_os = "macos")]
+            if let Some(maxfiles) = super::macos_maxfilesperproc() {
+                let _ = setrlimit(Resource::RLIMIT_NOFILE, maxfiles, hard);
+            }
+        }
+
+        let (soft_before, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+
+        // Call the function — should be a no-op
+        super::raise_file_descriptor_limit();
+
+        let (soft_after, _) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+        assert_eq!(soft_before, soft_after);
+
+        // Restore original limits
+        setrlimit(Resource::RLIMIT_NOFILE, original_soft, hard).unwrap();
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_macos_maxfilesperproc_returns_positive() {
+        let result = super::macos_maxfilesperproc();
+        assert!(
+            result.is_some(),
+            "macos_maxfilesperproc() should return Some on macOS"
+        );
+        assert!(
+            result.unwrap() > 0,
+            "kern.maxfilesperproc should be positive"
+        );
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -524,10 +524,15 @@ pub fn handle_config_errors(errors: Vec<String>) -> exitcode::ExitCode {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    static RLIMIT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     #[cfg(unix)]
     fn test_raise_file_descriptor_limit() {
         use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+        let _lock = RLIMIT_MUTEX.lock().unwrap();
 
         // Save original limits
         let (original_soft, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
@@ -560,6 +565,8 @@ mod tests {
     #[cfg(unix)]
     fn test_raise_file_descriptor_limit_already_at_max() {
         use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+        let _lock = RLIMIT_MUTEX.lock().unwrap();
 
         // Save original limits
         let (original_soft, hard) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();


### PR DESCRIPTION
## Summary

Add an opt-in `--raise-fd-limit` CLI flag (and `VECTOR_RAISE_FD_LIMIT` env var) that raises the RLIMIT_NOFILE soft limit to the hard limit at startup, preventing "Too many open files (os error 24)" errors when Vector monitors large numbers of log files — common in Kubernetes environments.

- On Linux, raises the soft limit to the hard limit (typically 65536+)
- On macOS, falls back to `kern.maxfilesperproc` if the hard limit is `RLIM_INFINITY`
- Opt-in by design: no behavior change unless the flag is explicitly set

**Changes:**
- `Cargo.toml`: add `libc` dep and `"resource"` feature to `nix` for rlimit access
- `src/cli.rs`: add `--raise-fd-limit` flag to `RootOpts`, call `raise_file_descriptor_limit()`
  only when enabled, with macOS `kern.maxfilesperproc` fallback

## Vector configuration

No configuration file changes. Enable at startup:

```bash
vector --raise-fd-limit
# or
VECTOR_RAISE_FD_LIMIT=true vector
```

## How did you test this PR?

- Unit tests: 3 tests in `cli::tests` (raise limit, already-at-max, macOS sysctl)
- Manual: verified on macOS (soft 256 → 10240) and Linux (soft 1024 → 65536)
- Clippy clean with `cargo clippy -p vector --no-default-features --features "sources-file" --lib --tests -- -D warnings`

## Change Type

- [x] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25241 (original combined PR, split per reviewer feedback)


## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
