### PR TITLE
chore(ci): remove Chocolatey from Windows bootstrap

### DIFF
--- a/scripts/environment/bootstrap-windows-2025.ps1
+++ b/scripts/environment/bootstrap-windows-2025.ps1
@@ -2,30 +2,6 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-# Helper: download a file with exponential backoff retry.
-function Invoke-DownloadWithRetry {
-    param(
-        [string]$Url,
-        [string]$Destination,
-        [int]$MaxRetries = 5
-    )
-
-    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
-        try {
-            Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
-            return
-        } catch {
-            if ($attempt -lt $MaxRetries) {
-                $delay = 5 * [math]::Pow(2, $attempt)  # 10, 20, 40, 80 seconds
-                Write-Host "Download of $Url failed (attempt $attempt of $MaxRetries): $($_.Exception.Message). Retrying in $delay seconds..."
-                Start-Sleep -Seconds $delay
-            } else {
-                throw "Download of $Url failed after $MaxRetries attempts: $($_.Exception.Message)"
-            }
-        }
-    }
-}
-
 # Set up our Cargo path so we can do Rust-y things.
 echo "$HOME\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
@@ -35,19 +11,15 @@ if ($env:RELEASE_BUILDER -ne "true") {
     bash scripts/environment/prepare.sh --modules=rustup
 }
 
-# Install protoc directly from the upstream GitHub release. This matches the
-# pinned version used on Linux/macOS (see scripts/environment/install-protoc.sh)
-# and avoids the recurring Chocolatey CDN failures ("Chocolatey installed 0/0
-# packages") that used to block Windows CI jobs.
-$ProtocVersion = "21.12"
-$ProtocDir = Join-Path $env:RUNNER_TEMP "protoc"
-$ProtocZip = Join-Path $env:RUNNER_TEMP "protoc.zip"
-$ProtocUrl = "https://github.com/protocolbuffers/protobuf/releases/download/v${ProtocVersion}/protoc-${ProtocVersion}-win64.zip"
-
-Write-Host "Downloading protoc v${ProtocVersion} from ${ProtocUrl}"
-Invoke-DownloadWithRetry -Url $ProtocUrl -Destination $ProtocZip
-Expand-Archive -Path $ProtocZip -DestinationPath $ProtocDir -Force
-echo "$ProtocDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+# Install protoc via the shared cross-platform script. It pins the same version
+# used on Linux/macOS and downloads directly from the upstream GitHub release,
+# so we avoid the recurring Chocolatey CDN failures.
+$ProtocInstallDir = Join-Path $env:RUNNER_TEMP "protoc-bin"
+bash scripts/environment/install-protoc.sh "$ProtocInstallDir"
+if ($LASTEXITCODE -ne 0) {
+    throw "install-protoc.sh failed with exit code $LASTEXITCODE"
+}
+echo "$ProtocInstallDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
 # GNU make is already on PATH on the windows-2025 runner image via the
 # pre-installed MinGW toolchain at C:\mingw64\bin, so no extra install is

--- a/scripts/environment/bootstrap-windows-2025.ps1
+++ b/scripts/environment/bootstrap-windows-2025.ps1
@@ -2,28 +2,26 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-# Helper function to install choco packages with exponential backoff retry
-function Install-ChocoPackage {
+# Helper: download a file with exponential backoff retry.
+function Invoke-DownloadWithRetry {
     param(
-        [string]$Package,
+        [string]$Url,
+        [string]$Destination,
         [int]$MaxRetries = 5
     )
 
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
-        choco install $Package --execution-timeout=7200 -y
-        # Both `choco install` and `choco list` can exit 0 even on 5xx errors
-        # from the feed, so verify install by matching a "name|version" line
-        # in the list output. --limit-output strips headers/warnings.
-        if ((choco list --limit-output -e $Package) -match "^$([regex]::Escape($Package))\|") {
+        try {
+            Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
             return
-        }
-
-        if ($attempt -lt $MaxRetries) {
-            $delay = 5 * [math]::Pow(2, $attempt)  # Exponential: 10, 20, 40, 80 seconds
-            Write-Host "choco install $Package failed (attempt $attempt of $MaxRetries). Retrying in $delay seconds..."
-            Start-Sleep -Seconds $delay
-        } else {
-            throw "choco install $Package failed after $MaxRetries attempts"
+        } catch {
+            if ($attempt -lt $MaxRetries) {
+                $delay = 5 * [math]::Pow(2, $attempt)  # 10, 20, 40, 80 seconds
+                Write-Host "Download of $Url failed (attempt $attempt of $MaxRetries): $($_.Exception.Message). Retrying in $delay seconds..."
+                Start-Sleep -Seconds $delay
+            } else {
+                throw "Download of $Url failed after $MaxRetries attempts: $($_.Exception.Message)"
+            }
         }
     }
 }
@@ -37,9 +35,23 @@ if ($env:RELEASE_BUILDER -ne "true") {
     bash scripts/environment/prepare.sh --modules=rustup
 }
 
-# Install Chocolatey packages with exponential backoff retry
-Install-ChocoPackage "make"
-Install-ChocoPackage "protoc"
+# Install protoc directly from the upstream GitHub release. This matches the
+# pinned version used on Linux/macOS (see scripts/environment/install-protoc.sh)
+# and avoids the recurring Chocolatey CDN failures ("Chocolatey installed 0/0
+# packages") that used to block Windows CI jobs.
+$ProtocVersion = "21.12"
+$ProtocDir = Join-Path $env:RUNNER_TEMP "protoc"
+$ProtocZip = Join-Path $env:RUNNER_TEMP "protoc.zip"
+$ProtocUrl = "https://github.com/protocolbuffers/protobuf/releases/download/v${ProtocVersion}/protoc-${ProtocVersion}-win64.zip"
+
+Write-Host "Downloading protoc v${ProtocVersion} from ${ProtocUrl}"
+Invoke-DownloadWithRetry -Url $ProtocUrl -Destination $ProtocZip
+Expand-Archive -Path $ProtocZip -DestinationPath $ProtocDir -Force
+echo "$ProtocDir\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+# GNU make is already on PATH on the windows-2025 runner image via the
+# pre-installed MinGW toolchain at C:\mingw64\bin, so no extra install is
+# needed here.
 
 # Set a specific override path for libclang.
 echo "LIBCLANG_PATH=$( (gcm clang).source -replace "clang.exe" )" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -69,8 +69,10 @@ install_protoc() {
   local download_path="${TMP_DIR}/protoc.zip"
 
   echo "Downloading ${url}"
-  # --retry-all-errors covers transient CDN blips without masking 4xx that should fail fast.
-  curl --retry 5 --retry-delay 10 --retry-all-errors -fsSL "${url}" -o "${download_path}"
+  # Stay compatible with the curl shipped by Ubuntu 20.04 focal (7.68.x) used
+  # in the ghcr.io/cross-rs/* base images: --retry-all-errors was only added
+  # in curl 7.71.0, so rely on the transport-level retry that --retry covers.
+  curl --retry 5 --retry-delay 10 -fsSL "${url}" -o "${download_path}"
 
   unzip -qq "${download_path}" -d "${TMP_DIR}"
   mv -f -v "${TMP_DIR}/bin/$(get_bin_name)" "${install_path}"

--- a/scripts/environment/install-protoc.sh
+++ b/scripts/environment/install-protoc.sh
@@ -23,13 +23,12 @@ trap 'rm -rf "${TMP_DIR?}"' EXIT
 get_platform() {
   local os
   os=$(uname)
-  if [[ "${os}" == "Darwin" ]]; then
-    echo "osx"
-  elif [[ "${os}" == "Linux" ]]; then
-    echo "linux"
-  else
-    >&2 echo "unsupported os: ${os}" && exit 1
-  fi
+  case "${os}" in
+    Darwin) echo "osx" ;;
+    Linux) echo "linux" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "win64" ;;
+    *) >&2 echo "unsupported os: ${os}" && exit 1 ;;
+  esac
 }
 
 get_arch() {
@@ -47,20 +46,34 @@ get_arch() {
   fi
 }
 
+get_bin_name() {
+  if [[ "$(get_platform)" == "win64" ]]; then
+    echo "protoc.exe"
+  else
+    echo "protoc"
+  fi
+}
+
 install_protoc() {
   local version=$1
   local install_path=$2
 
   local base_url="https://github.com/protocolbuffers/protobuf/releases/download"
   local url
-  url="${base_url}/v${version}/protoc-${version}-$(get_platform)-$(get_arch).zip"
+  if [[ "$(get_platform)" == "win64" ]]; then
+    # Windows release assets are named without an explicit arch suffix.
+    url="${base_url}/v${version}/protoc-${version}-win64.zip"
+  else
+    url="${base_url}/v${version}/protoc-${version}-$(get_platform)-$(get_arch).zip"
+  fi
   local download_path="${TMP_DIR}/protoc.zip"
 
   echo "Downloading ${url}"
-  curl -fsSL "${url}" -o "${download_path}"
+  # --retry-all-errors covers transient CDN blips without masking 4xx that should fail fast.
+  curl --retry 5 --retry-delay 10 --retry-all-errors -fsSL "${url}" -o "${download_path}"
 
   unzip -qq "${download_path}" -d "${TMP_DIR}"
-  mv -f -v "${TMP_DIR}/bin/protoc" "${install_path}"
+  mv -f -v "${TMP_DIR}/bin/$(get_bin_name)" "${install_path}"
 }
 
-install_protoc "21.12" "${INSTALL_PATH}/protoc"
+install_protoc "21.12" "${INSTALL_PATH}/$(get_bin_name)"


### PR DESCRIPTION
## Summary

Removes the Chocolatey dependency from `scripts/environment/bootstrap-windows-2025.ps1`:

- `protoc` installation now delegates to the existing `scripts/environment/install-protoc.sh`
- `make` no longer needs to be installed at all: GNU make is already on the default PATH of the `windows-2025` runner image via `C:\mingw64\bin\make.exe` (GNU Make 4.4.1).
- The `Install-ChocoPackage` helper and both `choco install` calls are removed.

### Motivation
Windows CI jobs have been failing intermittently with `Chocolatey installed 0/0 packages` when the Chocolatey community CDN has hiccups. The retry/verify logic added recently helped catch silent failures, but the underlying dependency on Chocolatey is itself the flaky bit. GitHub Releases is on the same CDN the runner already depends on for `actions/checkout` and the runner image itself, so if it is down the job was not going to run anyway.

## Vector configuration

N/A (CI-only change).

## How did you test this PR?

End-to-end on a scratch repo (`vectordotdev/ci-sandbox`) on the real `windows-2025` runner before opening this PR:

- Branch: https://github.com/vectordotdev/ci-sandbox/tree/pavlos/windows-bootstrap-drop-choco
- Three consecutive runs were green (26s, 20s, 19s). The final run exercised the shared `install-protoc.sh` path:
  - `protoc` resolves to `D:\a\_temp\protoc-bin\protoc.exe` -> `libprotoc 3.21.12`
  - `make` resolves to `C:\mingw64\bin\make.exe` -> `GNU Make 4.4.1`
  - A trivial Makefile target executed successfully to confirm the runtime works, not just `--version`.

Once this PR is opened, the existing `unit_windows.yml` and `integration_windows.yml` workflows will exercise the real Vector build path on Windows with the new bootstrap.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A