### PR TITLE
fix(website): include page title in docs search query fields

### DIFF
--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -143,7 +143,7 @@
           "name": "vector_docs_search",
           "search_parameters": {
             "sort_by": "level:desc,ranking:desc,_text_match:desc",
-            "query_by": "content,hierarchy,title,tags"
+            "query_by": "pageTitle,title,hierarchy,content,tags"
           }
         }
       ]


### PR DESCRIPTION
## Summary
The Typesense `query_by` preset omitted the `pageTitle` field, so searches never matched against the canonical page title (e.g. "Remap transform"). Only section headings, body content, hierarchy, and tags were searched. Adding `pageTitle` to `query_by` (with highest priority) makes pages discoverable by their title.

## Vector configuration
NA

## How did you test this PR?
Change is to the Typesense collection preset consumed at query time. Verified the `pageTitle` field already exists in the schema (`website/typesense.config.json:53`) and is populated by the indexer (`website/scripts/typesense-index.ts:94`).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA