### PR TITLE
chore(deps): drop gssapi from default cargo feature

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -209,6 +209,7 @@ greptime
 greptimecloud
 greptimedb
 GSM
+gssapi
 gvisor
 gws
 gzip'd

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -287,6 +287,7 @@ keybinds
 Kingcom
 Kolkata
 konqueror
+krb
 Kruno
 Ktouch
 KTtech

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -215,6 +215,7 @@ jobs:
         env:
           TARGET: "${{ matrix.architecture }}-apple-darwin"
           NATIVE_BUILD: true
+          FEATURES: "target-aarch64-apple-darwin"
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
           make package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -516,14 +516,35 @@ zstd = { version = "0.13.0", default-features = false }
 ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e38e5f154e6011dc9b270da6" }
 
 [features]
-# Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["enable-unix", "rdkafka?/gssapi"]
+# Default features for *-unknown-linux-gnu and *-apple-darwin.
+#
+# Note on kafka: the `gssapi` feature is intentionally NOT enabled here. Linux GA releases
+# pick it up through the `vendored` feature on the x86_64-unknown-linux-gnu target, and
+# macOS releases pick it up through the `target-aarch64-apple-darwin` feature (see target
+# table below). Local dev builds skip it so they don't need `libsasl2-dev` / cyrus-sasl
+# installed, and so rdkafka's build script doesn't link GSSAPI.
+default = ["enable-unix"]
 # Default features for `cargo docs`. We're not using `gssapi` which would require installing libsasl2 in our doc environment.
 docs = ["enable-unix"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
 default-cmake = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
 
-vendored = ["rdkafka?/gssapi-vendored"]
+# Enables Kerberos / GSSAPI SASL support for kafka via dynamic linkage to a
+# system-provided libsasl2 (and the host's GSS implementation). Requires
+# `libsasl2-dev` / cyrus-sasl at compile time and a libsasl2 dylib at runtime.
+# This mirrors pre-PR `default` behavior on macOS, where the runner ships
+# libsasl2 + Apple's GSS framework.
+gssapi = ["rdkafka?/gssapi"]
+
+# Static-bundled variant of `gssapi`: builds libsasl2 (via `sasl2-sys`) and
+# `krb5-src` from source. Self-contained at runtime; produces larger binaries.
+# Note: the bundled libsasl2 + krb5 path does not currently link on
+# macOS arm64 (unresolved gss_* symbols), so this is Linux-only in practice.
+gssapi-vendored = ["gssapi", "rdkafka?/gssapi-vendored"]
+
+# Umbrella feature that opts into all bundled/static C dependencies. Currently
+# just `gssapi-vendored`; intended to grow as more vendored deps are introduced.
+vendored = ["gssapi-vendored"]
 
 # Default features for *-pc-windows-msvc
 # TODO: Enable SASL https://github.com/vectordotdev/vector/pull/3081#issuecomment-659298042
@@ -562,6 +583,10 @@ target-arm-unknown-linux-gnueabi =      ["target-unix"]
 target-arm-unknown-linux-musleabi =     ["target-base"]
 target-x86_64-unknown-linux-gnu =       ["target-unix", "vendored"]
 target-x86_64-unknown-linux-musl =      ["target-unix"]
+# Apple targets opt into `gssapi` (dynamic linkage to system libsasl2 + Apple's
+# GSS framework). The `gssapi-vendored` path does not currently link on
+# macOS arm64 (unresolved gss_* symbols).
+target-aarch64-apple-darwin =           ["enable-unix", "gssapi"]
 
 # Enables features that work only on systems providing `cfg(unix)`
 unix = ["tikv-jemallocator", "allocation-tracing"]

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -46,18 +46,10 @@ To build Vector on your own host will require a fairly complete development envi
 Loosely, you'll need the following:
 
 - **To build Vector:** Have working Rustup, Protobuf tools, C++/C build tools (LLVM, GCC, or MSVC), Python, and Perl, `make` (the GNU one preferably), `bash`, `cmake`, `GNU coreutils`, and `autotools`.
-  - You may also need to install `libsasl2` if you are compiling with default features or with any `kafka`-related features.
-    - Installing libsasl2 on Ubuntu
-      - Run `sudo apt-get install -y libsasl2-dev`
-    - Installing libsasl2 on MacOS
-      - Run `brew install cyrus-sasl`
-      - You will need to set the following environment variables:
-
-        ```bash
-        export LDFLAGS="-L$(brew --prefix cyrus-sasl)/lib $LDFLAGS"
-        export CPPFLAGS="-I$(brew --prefix cyrus-sasl)/include $CPPFLAGS"
-        export PKG_CONFIG_PATH="$(brew --prefix cyrus-sasl)/lib/pkgconfig:$PKG_CONFIG_PATH"
-        ```
+  - The `default` feature does not enable Kerberos/GSSAPI SASL for kafka, so local dev builds (`cargo build`, `make build`) have no extra system prerequisites beyond the C build tools above.
+  - To enable GSSAPI for kafka, choose one of:
+    - `gssapi`: dynamically links against system `libsasl2`. Requires `libsasl2-dev` (Ubuntu: `sudo apt-get install -y libsasl2-dev`) or `cyrus-sasl` (macOS: `brew install cyrus-sasl`) installed.
+    - `gssapi-vendored` (or `vendored`, which includes it): builds `libsasl2` and `krb5` from bundled source. No system install needed. Linux only; the bundled path does not currently link on macOS arm64.
 
 - **To run `make test`:** Install [`cargo-nextest`](https://nexte.st/)
 - **To run integration tests:** Have `docker` available, or a real live version of that service. (Use `AUTOSPAWN=false`)


### PR DESCRIPTION
## Summary

Drops `rdkafka?/gssapi` from the `default` Cargo feature so dev builds (`cargo build`, `make build`) compile librdkafka **without** GSSAPI/Kerberos SASL support. As a direct consequence, `libsasl2-dev` / `cyrus-sasl` no longer needs to be installed for local development.

### Cargo feature changes

The previous single `vendored` umbrella is split into three composable features:

- `gssapi`: dynamic linkage against system libsasl2. Reuses pre-PR `default` semantics on macOS (where Apple ships libsasl2 + GSS framework).
- `gssapi-vendored`: static-bundled libsasl2 + krb5-src. Linux-only in practice; the bundled path does not link on macOS arm64 (unresolved `gss_*` symbols).
- `vendored`: umbrella for static C deps, currently just `gssapi-vendored`. Intended to grow as more vendored deps land.

Release feature resolution for `target-x86_64-unknown-linux-gnu` and other release entry points inheriting `vendored` is unchanged: still resolves to `rdkafka?/gssapi-vendored` → `sasl2-sys/vendored`.

### What this means for a dev binary

- SASL `PLAIN`, `SCRAM-SHA-256/512`, and `OAUTHBEARER` continue to work. They're implemented inside librdkafka and don't go through libsasl2.
- SASL `GSSAPI` (Kerberos) is unavailable at runtime. Anyone testing against a Kerberos-authed Kafka cluster locally needs to build with `--features gssapi` (and have libsasl2 installed) or `--features vendored` (Linux only).

## Vector configuration

N/A — build-system change only.

## How did you test this PR?

`cargo tree -e features` on the vector crate, confirming `sasl2-sys` placement for every release entry point:

| features | sasl2-sys in graph? | linkage | expected |
| --- | --- | --- | --- |
| `default + sources-kafka` | no | n/a | no (dev, no GSSAPI compiled) |
| `default,gssapi + sources-kafka` | yes | dynamic | yes (matches pre-PR macOS publish) |
| `gssapi-vendored + sources-kafka` | yes | static | yes |
| `vendored + sources-kafka` | yes | static | yes |
| `default-cmake` | yes | static | yes |
| `default-musl` | yes | static | yes |
| `target-x86_64-unknown-linux-gnu` | yes | static | yes |

Local smoke test on aarch64-apple-darwin: `cargo check --release --no-default-features --features default,gssapi` passes.

Also ran `make check-markdown` and it passes.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

Release binaries' runtime behavior is unchanged. Linux x86_64-gnu archives are byte-equivalent (same vendored static linkage). macOS archives now route through `FEATURES=default,gssapi` instead of bare `default`, but that resolves to the same dynamic libsasl2 linkage as pre-PR. Dev binaries lose the GSSAPI SASL mechanism; other SASL mechanisms are unaffected. The workaround (`--features gssapi` plus libsasl2-dev, or `--features vendored` on Linux) is documented in `docs/DEVELOPING.md`.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

Developer-facing only: Cargo feature wiring and build prerequisites for non-release builds. Release binaries and end-user-observable behavior are unchanged.

## Notes

- `Cargo.lock` is unchanged (no version bumps, only feature-graph tweaks).
- **Follow-up:** flip `default` to `rdkafka?/dynamic_linking` so dev builds link to a system librdkafka and skip the multi-minute source compile entirely. An earlier attempt on this branch was reverted because Ubuntu 24.04's apt `librdkafka-dev` ships 2.3.0 but `rdkafka-sys 4.10.0+2.12.1` requires 2.12.1+. The follow-up PR will install/cache a compatible librdkafka in the setup action (via `actions/cache`) so the flip is viable in CI.