### PR TITLE
enhancement(aws_kinesis_streams sink): Re-randomize partition key on partial failure retry

### DIFF
--- a/changelog.d/kinesis_retry_partition_key_jitter.enhancement.md
+++ b/changelog.d/kinesis_retry_partition_key_jitter.enhancement.md
@@ -1,0 +1,3 @@
+The `aws_kinesis_streams` sink now re-randomizes the partition key when retrying records that failed due to partial `PutRecords` failures, but only when no explicit `partition_key_field` is configured. This improves retry success rates by distributing retried records across different shards, avoiding repeated throttling on the same shard.
+
+authors: hligit

--- a/src/sinks/aws_kinesis/request_builder.rs
+++ b/src/sinks/aws_kinesis/request_builder.rs
@@ -39,7 +39,7 @@ where
     pub key: KinesisKey,
     pub record: R,
     pub finalizers: EventFinalizers,
-    metadata: RequestMetadata,
+    pub(crate) metadata: RequestMetadata,
 }
 
 impl<R> Finalizable for KinesisRequest<R>

--- a/src/sinks/aws_kinesis/sink.rs
+++ b/src/sinks/aws_kinesis/sink.rs
@@ -125,7 +125,7 @@ pub(crate) fn process_log(
     })
 }
 
-fn gen_partition_key() -> String {
+pub(crate) fn gen_partition_key() -> String {
     random::<[char; 16]>()
         .iter()
         .fold(String::new(), |mut s, c| {

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -6,10 +6,13 @@ use futures::FutureExt;
 use snafu::Snafu;
 use vector_lib::configurable::{component::GenerateConfig, configurable_component};
 
+use bytes::Bytes;
+
 use super::{
     KinesisClient, KinesisError, KinesisRecord, KinesisResponse, KinesisSinkBaseConfig, build_sink,
     record::{KinesisStreamClient, KinesisStreamRecord},
-    sink::BatchKinesisRequest,
+    sink::{BatchKinesisRequest, KinesisKey, gen_partition_key},
+    Record,
 };
 use crate::{
     aws::{ClientBuilder, create_client, is_retriable_error},
@@ -141,6 +144,7 @@ impl SinkConfig for KinesisStreamsSinkConfig {
             KinesisStreamClient { client },
             KinesisRetryLogic {
                 retry_partial: self.base.request_retry_partial,
+                has_partition_key_field: self.base.partition_key_field.is_some(),
             },
         )?;
 
@@ -169,6 +173,11 @@ impl GenerateConfig for KinesisStreamsSinkConfig {
 #[derive(Default, Clone)]
 struct KinesisRetryLogic {
     retry_partial: bool,
+    /// When true, the user configured an explicit `partition_key_field`, so we
+    /// must preserve the original partition key on retry.  When false the key
+    /// was randomly generated and can safely be re-randomized to target a
+    /// different shard.
+    has_partition_key_field: bool,
 }
 
 impl RetryLogic for KinesisRetryLogic {
@@ -197,10 +206,28 @@ impl RetryLogic for KinesisRetryLogic {
     fn should_retry_response(&self, response: &Self::Response) -> RetryAction<Self::Request> {
         if response.failure_count > 0 && self.retry_partial && !response.failed_records.is_empty() {
             let failed_records = response.failed_records.clone();
+            let regenerate_keys = !self.has_partition_key_field;
             RetryAction::RetryPartial(Box::new(move |original_request| {
                 let failed_events: Vec<_> = failed_records
                     .iter()
-                    .filter_map(|r| original_request.events.get(r.index).cloned())
+                    .filter_map(|r| {
+                        original_request.events.get(r.index).cloned().map(|mut req| {
+                            // When no explicit partition_key_field was configured the
+                            // original key was randomly generated. Re-randomize it so
+                            // the retry has a chance of landing on a different (non-
+                            // throttled) shard.
+                            if regenerate_keys {
+                                let new_key = gen_partition_key();
+                                let payload =
+                                    Bytes::from(req.record.record.data.as_ref().to_vec());
+                                req.record = KinesisStreamRecord::new(&payload, &new_key);
+                                req.key = KinesisKey {
+                                    partition_key: new_key,
+                                };
+                            }
+                            req
+                        })
+                    })
                     .collect();
 
                 let metadata = RequestMetadata::from_batch(
@@ -220,10 +247,112 @@ impl RetryLogic for KinesisRetryLogic {
 
 #[cfg(test)]
 mod tests {
-    use super::KinesisStreamsSinkConfig;
+    use bytes::Bytes;
+    use vector_lib::request_metadata::{MetaDescriptive, RequestMetadata};
+
+    use super::{KinesisRetryLogic, KinesisStreamsSinkConfig};
+    use crate::sinks::{
+        aws_kinesis::{
+            record::Record,
+            request_builder::KinesisRequest,
+            service::{KinesisResponse, RecordResult},
+            sink::{BatchKinesisRequest, KinesisKey},
+            streams::record::KinesisStreamRecord,
+        },
+        util::retries::{RetryAction, RetryLogic},
+    };
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<KinesisStreamsSinkConfig>();
+    }
+
+    fn make_request(payload: &[u8], partition_key: &str) -> KinesisRequest<KinesisStreamRecord> {
+        let record = KinesisStreamRecord::new(&Bytes::from(payload.to_vec()), partition_key);
+        KinesisRequest {
+            key: KinesisKey {
+                partition_key: partition_key.to_string(),
+            },
+            record,
+            finalizers: Default::default(),
+            metadata: RequestMetadata::new(0, 0, 0, 0, Default::default()),
+        }
+    }
+
+    fn make_batch(items: &[(&[u8], &str)]) -> BatchKinesisRequest<KinesisStreamRecord> {
+        let events: Vec<_> = items.iter().map(|(p, k)| make_request(p, k)).collect();
+        let metadata =
+            RequestMetadata::from_batch(events.iter().map(|r| r.get_metadata().clone()));
+        BatchKinesisRequest { events, metadata }
+    }
+
+    fn make_response_with_failures(failed_indices: &[usize]) -> KinesisResponse {
+        let failed_records: Vec<RecordResult> = failed_indices
+            .iter()
+            .map(|&i| RecordResult {
+                index: i,
+                success: false,
+                error_code: Some("ProvisionedThroughputExceededException".to_string()),
+                error_message: Some("Rate exceeded".to_string()),
+            })
+            .collect();
+        KinesisResponse {
+            failure_count: failed_records.len(),
+            events_byte_size: Default::default(),
+            failed_records,
+        }
+    }
+
+    #[test]
+    fn retry_regenerates_partition_key_when_no_partition_key_field() {
+        let logic = KinesisRetryLogic {
+            retry_partial: true,
+            has_partition_key_field: false,
+        };
+
+        let original_key = "original-random-key";
+        let batch = make_batch(&[(b"hello", original_key)]);
+        let response = make_response_with_failures(&[0]);
+
+        match logic.should_retry_response(&response) {
+            RetryAction::RetryPartial(modify) => {
+                let retried = modify(batch);
+                assert_eq!(retried.events.len(), 1);
+                assert_ne!(
+                    retried.events[0].key.partition_key, original_key,
+                    "partition key should be re-randomized on retry"
+                );
+                assert_eq!(
+                    retried.events[0].record.record.data.as_ref(),
+                    b"hello",
+                    "payload data must be preserved"
+                );
+            }
+            other => panic!("expected RetryPartial, got {:?}", other.is_retryable()),
+        }
+    }
+
+    #[test]
+    fn retry_preserves_partition_key_when_partition_key_field_set() {
+        let logic = KinesisRetryLogic {
+            retry_partial: true,
+            has_partition_key_field: true,
+        };
+
+        let user_key = "user-specified-key";
+        let batch = make_batch(&[(b"hello", user_key)]);
+        let response = make_response_with_failures(&[0]);
+
+        match logic.should_retry_response(&response) {
+            RetryAction::RetryPartial(modify) => {
+                let retried = modify(batch);
+                assert_eq!(retried.events.len(), 1);
+                assert_eq!(
+                    retried.events[0].key.partition_key, user_key,
+                    "partition key should be preserved when partition_key_field is configured"
+                );
+            }
+            other => panic!("expected RetryPartial, got {:?}", other.is_retryable()),
+        }
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

When a Kinesis PutRecords call results in partial failures, retries now use a new random partition key to avoid repeatedly hitting the same throttled shard. This only applies when no explicit partition_key_field is configured; user-specified keys are always preserved.

## Motivation

AWS Kinesis `PutRecords` returns partial failures with error code `ProvisionedThroughputExceededException` when a shard is throttled. With the existing behaviour, the same randomly-generated partition key is reused on retry, which means the record is sent to the same throttled shard again, making the retry less likely to succeed. 

This is particularly problematic in shared Kinesis streams used by multiple different kinds of agents. If one misconfigured agent pins its writes to a fixed partition key (and therefore a fixed shard), it can saturate that shard's throughput quota. Other agents writing to the same stream — even with randomly generated keys — will then have their retries land on that same hot shard, compounding the throttling instead of routing around it.

Re-randomizing the partition key on retry lets Vector escape the hot shard and spread retried records across the remaining healthy shards, improving recovery in these mixed-producer scenarios.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Two new unit tests are added.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
