### PR TITLE
chore(ci): make nightly S3 verify resilient to CDN staleness

### DIFF
--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -59,15 +59,6 @@ if [[ "$CHANNEL" == "nightly" ]]; then
   aws s3 cp "$td_nightly" "s3://packages.timber.io/vector/nightly/latest" --recursive --sse --acl public-read
   echo "Uploaded archives"
 
-  echo "Redirecting old artifact names"
-  for file in $(aws s3api list-objects-v2 --bucket packages.timber.io --prefix "vector/$i/" --query 'Contents[*].Key' --output text  | tr "\t" "\n" | grep '\-nightly'); do
-    file=$(basename "$file")
-    # vector-nightly-amd64.deb -> vector-amd64.deb
-    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/nightly/$DATE/${file/-nightly/}" --website-redirect "/vector/nightly/$DATE/$file" --acl public-read
-    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/nightly/latest/${file/-nightly/}" --website-redirect "/vector/nightly/latest/$file" --acl public-read
-  done
-  echo "Redirected old artifact names"
-
   # Verify that the files exist and can be downloaded
   echo "Waiting for $VERIFY_TIMEOUT seconds before running the verifications"
   sleep "$VERIFY_TIMEOUT"

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -36,11 +36,27 @@ ls "$td_nightly"
 #
 # A helper function for verifying a published artifact.
 #
+# Retries a content mismatch as well as a 404, since packages.timber.io is
+# fronted by a CDN and an object we just overwrote via `aws s3 rm` + `cp` can
+# serve stale bytes at the edge for a while.
 verify_artifact() {
   local URL="$1"
   local FILENAME="$2"
+  local attempts=7
+  local delay=1
   echo "Verifying $URL"
-  cmp <(wget -qO- --retry-on-http-error=404 --wait 10 --tries "$VERIFY_RETRIES" "$URL") "$FILENAME"
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if cmp <(wget -qO- --retry-on-http-error=404 --wait 10 --tries "$VERIFY_RETRIES" "$URL") "$FILENAME"; then
+      return 0
+    fi
+    if (( attempt < attempts )); then
+      echo "Attempt $attempt/$attempts did not match (likely stale CDN cache); retrying in ${delay}s"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+  echo "Verification of $URL failed after $attempts attempts"
+  return 1
 }
 
 #


### PR DESCRIPTION
## Summary

Two small fixes to `scripts/release-s3.sh` for the nightly publish job:

1. **Remove dead nightly artifact-redirect loop.** The loop referenced an unset `$i` (copy/paste from the release branch, where `$i` iterates over version tags). Under `set -u` the subshell errored, the `for` received an empty list, and the body never ran — so it's been a no-op since it was introduced in 2021. Removing rather than fixing: resurrecting it would start creating a new set of redirect objects in S3 that nothing has relied on in years.

2. **Retry `verify_artifact` on content mismatch.** `packages.timber.io` is fronted by a CDN; after `aws s3 rm --recursive` + `cp --recursive` on `nightly/latest`, the edge can keep serving stale bytes for longer than the 30s `VERIFY_TIMEOUT`. `wget --retry-on-http-error=404` only retries 404s, not a 200 with stale content, so one miss fails the whole publish. Wrap the `cmp` in an exponential-backoff retry loop (1, 2, 4, 8, 16, 32s — 7 attempts, ~63s total sleep).

Motivating failure: https://github.com/vectordotdev/vector/actions/runs/24874521137/job/72833763564 — passed on manual re-run without code changes, confirming transient CDN staleness.

## Vector configuration

N/A.

## How did you test this PR?

- Ran `bash -n scripts/release-s3.sh` to confirm syntax.
- Traced the retry schedule by hand: delays 1, 2, 4, 8, 16, 32 across 6 sleeps + 7 `cmp` attempts.
- The full path can only be exercised end-to-end by the nightly `publish-s3` job.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A.