### PR TITLE
chore(vdev): add linux arm64 to publish matrix and bump to 0.3.2

### DIFF
--- a/.github/workflows/vdev_publish.yml
+++ b/.github/workflows/vdev_publish.yml
@@ -18,6 +18,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout Vector

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12241,7 +12241,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -39,7 +39,7 @@ CARGO_LLVM_COV_VERSION="0.8.4"
 WASM_PACK_VERSION="0.13.1"
 # npm tool versions are defined in scripts/environment/npm-tools/package.json
 # and pinned (including transitive deps) in npm-tools/package-lock.json.
-VDEV_VERSION="0.3.0"
+VDEV_VERSION="0.3.2"
 
 ALL_MODULES=(
   rustup

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"


### PR DESCRIPTION
## Summary

Adds `aarch64-unknown-linux-gnu` to the `vdev_publish` workflow matrix via a native `ubuntu-24.04-arm` runner, bumps `vdev` to `0.3.2`, and updates `VDEV_VERSION` in `scripts/environment/prepare.sh` to match.

Publishing this version produces a Linux arm64 artifact for the first time, so `prepare.sh`'s `cargo binstall vdev` step will be able to fetch a native binary on ARM runners once the tag is pushed.

## Vector configuration

NA

## How did you test this PR?

Verified `scripts/environment/bootstrap-ubuntu-24.04.sh` has no x86_64-only hardcoded package URLs that would block the ARM job (Cue is downloaded as x86_64, but it is not invoked during the vdev build, so the bootstrap still completes).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA