### PR TITLE
feat(ci): cross-compile linux targets via Nix flake instead of cross-rs

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -15,9 +15,7 @@ jobs:
   cross-linux:
     name: Cross - ${{ matrix.target }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
-    env:
-      CARGO_INCREMENTAL: 0
+    timeout-minutes: 90
     strategy:
       matrix:
         target:
@@ -35,27 +33,18 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        name: Cache Cargo registry + index
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - run: echo "::add-matcher::.github/matchers/rust.json"
-      - run: |
-          rustup target add x86_64-unknown-linux-gnu
-          cargo install cross --version 0.2.4 --force --locked
+
       # Why is this build, not check? Because we need to make sure the linking phase works.
       # aarch64 and musl in particular are notoriously hard to link.
       # While it may be tempting to slot a `check` in here for quickness, please don't.
-      - run: make cross-build-${{ matrix.target }}
+      - name: Build
+        run: nix build .#vector-${{ matrix.target }} --print-build-logs
+
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: "vector-debug-${{ matrix.target }}"
-          path: "./target/${{ matrix.target }}/debug/vector"
+          name: "vector-${{ matrix.target }}"
+          path: "./result/bin/vector"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ tests/data/wasm/*/target
 bench_output.txt
 rust-analyzer.toml
 
+# Nix
+result
+result-*
+.direnv
+
 # Python
 *.pyc
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1776396856,
+        "narHash": "sha256-aRJpIJUlZLaf06ekPvqjuU46zvO9K90IxJGpbqodkPs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "28462d6d55c33206ffa5a56c7907ca3125ed788f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776395632,
+        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -44,7 +44,7 @@
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1776396856,
-        "narHash": "sha256-aRJpIJUlZLaf06ekPvqjuU46zvO9K90IxJGpbqodkPs=",
+        "lastModified": 1776635034,
+        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "28462d6d55c33206ffa5a56c7907ca3125ed788f",
+        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
         "type": "github"
       },
       "original": {
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776395632,
-        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
+        "lastModified": 1777000482,
+        "narHash": "sha256-CZ5FKUSA8FCJf0h9GWdPJXoVVDL9H5yC74GkVc5ubIM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
+        "rev": "403c09094a877e6c4816462d00b1a56ff8198e06",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -43,12 +43,12 @@
           exec ${pkgs.git}/bin/git "$@"
         '';
 
-        src = lib.cleanSourceWith {
-          src = ./.;
-          filter = path: type:
-            let bn = baseNameOf (toString path); in
-            !(bn == "target" || bn == "result" || bn == ".git"
-              || bn == "node_modules" || bn == ".direnv");
+        # Only include files tracked by git. Excludes anything in .gitignore
+        # plus any untracked workspace debris (logs, scratch dirs) that would
+        # otherwise leak into the source hash and break reproducibility.
+        src = lib.fileset.toSource {
+          root = ./.;
+          fileset = lib.fileset.gitTracked ./.;
         };
 
         # Rust target triple -> nixpkgs autoconf config. Mostly identical,

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   # Only Linux systems are supported as *builders* right now; darwin users
   # need a remote Linux builder to produce the musl artifact.
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,17 @@
             overlays = [ (import rust-overlay) ];
           };
 
+        # Standard ELF interpreter path on Debian/Ubuntu, per arch. Used to
+        # rewrite the .interp section of GNU binaries so they can be loaded
+        # outside a Nix store (where /nix/store/...glibc/ld-linux... lives).
+        # Musl targets are statically linked and have no interpreter to patch.
+        gnuInterpreterFor = target: {
+          "x86_64-unknown-linux-gnu"      = "/lib64/ld-linux-x86-64.so.2";
+          "aarch64-unknown-linux-gnu"     = "/lib/ld-linux-aarch64.so.1";
+          "armv7-unknown-linux-gnueabihf" = "/lib/ld-linux-armhf.so.3";
+          "arm-unknown-linux-gnueabi"     = "/lib/ld-linux.so.3";
+        }.${target} or null;
+
         targets = [
           "x86_64-unknown-linux-gnu"
           "x86_64-unknown-linux-musl"
@@ -159,6 +170,20 @@
             '';
 
             cargoExtraArgs = "--no-default-features --features ${cargoFeatures} --bin vector";
+
+            # GNU targets need the ELF interpreter rewritten to a standard
+            # FHS path (and the nix-store RPATH stripped) so the binary can
+            # run on any glibc system, not just inside this Nix store.
+            # Guarded by `-f` because crane reuses hook args for the
+            # cargoArtifacts (deps-only) derivation, which has no bin/vector.
+            postFixup = lib.optionalString (gnuInterpreterFor target != null) ''
+              if [ -f "$out/bin/vector" ]; then
+                patchelf \
+                  --set-interpreter ${gnuInterpreterFor target} \
+                  --remove-rpath \
+                  "$out/bin/vector"
+              fi
+            '';
 
             nativeBuildInputs = [
               gitShim

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,28 @@
           exec ${pkgs.git}/bin/git "$@"
         '';
 
+        # GNU `cp -R` (without `-p`) restores the destination directory's
+        # mode to match the source on completion. When the source lives in
+        # /nix/store (read-only, 0555), the dest dir ends up 0555 too — and
+        # autoconf scripts copied this way can't write `config.log`.
+        # sasl2-sys 0.1.22+2.1.28 hits this. Wrapping `cp` to chmod the
+        # destination writable after any recursive copy fixes it without
+        # patching upstream source.
+        cpWrapper = pkgs.writeShellScriptBin "cp" ''
+          ${pkgs.coreutils}/bin/cp "$@"
+          status=$?
+          case " $* " in
+            *" -R "*|*" -r "*|*" -a "*|*"-R"*|*"-r"*|*"-a"*)
+              last=
+              for a in "$@"; do
+                case "$a" in -*) ;; *) last="$a";; esac
+              done
+              [ -d "$last" ] && chmod -R u+w "$last" 2>/dev/null
+              ;;
+          esac
+          exit $status
+        '';
+
         # Only include files tracked by git. Excludes anything in .gitignore
         # plus any untracked workspace debris (logs, scratch dirs) that would
         # otherwise leak into the source hash and break reproducibility.
@@ -120,22 +142,6 @@
                     done
                   '';
                 });
-              # sasl2-sys 0.1.22+2.1.28 build.rs does `cp -R sasl2 $OUT_DIR/sasl2`
-              # but the copy lands read-only in a Nix sandbox, breaking
-              # autoconf's config.log write. Patch the build.rs to chmod +w
-              # after the copy. No matching upstream issue yet; closest is
-              # MaterializeInc/rust-sasl#54 (cross-compile toolchain detection).
-              overrideVendorCargoPackage = package: drv:
-                if package.name == "sasl2-sys" then
-                  drv.overrideAttrs (old: {
-                    postPatch = (old.postPatch or "") + ''
-                      substituteInPlace build.rs \
-                        --replace-fail \
-                          'cmd!("cp", "-R", "sasl2", &src_dir)' \
-                          'cmd!("cp", "-R", "sasl2", &src_dir).run().expect("cp failed"); cmd!("chmod", "-R", "u+w", &src_dir)'
-                    '';
-                  })
-                else drv;
             };
 
             crossPkgs = crossPkgsForTarget target;
@@ -169,6 +175,14 @@
                 --replace-quiet '"-Lnative=/lib/native-libs"' '""'
             '';
 
+            # The cross toolchain (targetCc) propagates its own coreutils into
+            # PATH ahead of cpWrapper despite cpWrapper being listed first in
+            # nativeBuildInputs. Force-prepend here so cargo build scripts
+            # (including sasl2-sys) find the wrapper first.
+            preBuild = ''
+              export PATH=${cpWrapper}/bin:$PATH
+            '';
+
             cargoExtraArgs = "--no-default-features --features ${cargoFeatures} --bin vector";
 
             # GNU targets need the ELF interpreter rewritten to a standard
@@ -185,7 +199,9 @@
               fi
             '';
 
+            # cpWrapper before targetCc/coreutils so PATH lookup finds it first.
             nativeBuildInputs = [
+              cpWrapper
               gitShim
               targetCc
               pkgs.protobuf

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,22 @@
                     done
                   '';
                 });
+              # sasl2-sys 0.1.22+2.1.28 build.rs does `cp -R sasl2 $OUT_DIR/sasl2`
+              # but the copy lands read-only in a Nix sandbox, breaking
+              # autoconf's config.log write. Patch the build.rs to chmod +w
+              # after the copy. No matching upstream issue yet; closest is
+              # MaterializeInc/rust-sasl#54 (cross-compile toolchain detection).
+              overrideVendorCargoPackage = package: drv:
+                if package.name == "sasl2-sys" then
+                  drv.overrideAttrs (old: {
+                    postPatch = (old.postPatch or "") + ''
+                      substituteInPlace build.rs \
+                        --replace-fail \
+                          'cmd!("cp", "-R", "sasl2", &src_dir)' \
+                          'cmd!("cp", "-R", "sasl2", &src_dir).run().expect("cp failed"); cmd!("chmod", "-R", "u+w", &src_dir)'
+                    '';
+                  })
+                else drv;
             };
 
             crossPkgs = crossPkgsForTarget target;
@@ -169,20 +185,9 @@
             CFLAGS = "-std=gnu17";
           });
 
-        # The `target-x86_64-unknown-linux-gnu` feature adds `vendored` which
-        # pulls in rdkafka?/gssapi-vendored → sasl2-sys + krb5-src. sasl2-sys
-        # v0.1.22+2.1.28's build.rs copies its vendored source with `cp -R`
-        # that lands read-only in a Nix sandbox, breaking autoconf's
-        # config.log write. Drop to `target-unix` so x86_64-gnu matches the
-        # other linux targets (no GSSAPI). Re-enable in Phase 6 once the
-        # vendoring story is sorted (patch sasl2-sys, or use system libs).
-        cargoFeaturesFor = target:
-          if target == "x86_64-unknown-linux-gnu" then "target-unix"
-          else "target-${target}";
-
         vectorBins = lib.listToAttrs (map (t: {
           name = "vector-${t}";
-          value = mkVector { target = t; cargoFeatures = cargoFeaturesFor t; };
+          value = mkVector { target = t; cargoFeatures = "target-${t}"; };
         }) targets);
 
         # Tarball must match `scripts/package-archive.sh` output byte-shape so

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,225 @@
+{
+  description = "Vector — observability data pipeline (Nix build, PoC).";
+
+  # Only Linux systems are supported as *builders* right now; darwin users
+  # need a remote Linux builder to produce the musl artifact.
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    crane.url = "github:ipetkov/crane";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, crane, rust-overlay, flake-utils }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        inherit (pkgs) lib;
+
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        vectorVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+
+        # build.rs shells out to `git rev-parse --short HEAD`. The Nix source
+        # filter drops `.git`, so we shim `git` with a wrapper that returns
+        # the flake revision (or a placeholder for dirty trees).
+        gitHash =
+          if self ? rev then builtins.substring 0 9 self.rev
+          else if self ? dirtyRev then builtins.substring 0 9 self.dirtyRev
+          else "nixbuild";
+
+        gitShim = pkgs.writeShellScriptBin "git" ''
+          if [ "$1" = "rev-parse" ] && [ "$2" = "--short" ] && [ "$3" = "HEAD" ]; then
+            printf '%s' "${gitHash}"
+            exit 0
+          fi
+          exec ${pkgs.git}/bin/git "$@"
+        '';
+
+        src = lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            let bn = baseNameOf (toString path); in
+            !(bn == "target" || bn == "result" || bn == ".git"
+              || bn == "node_modules" || bn == ".direnv");
+        };
+
+        # Rust target triple -> nixpkgs autoconf config. Mostly identical,
+        # except ARM: rust uses `armv7`/`arm`, nixpkgs uses `armv7l`/`arm`.
+        nixpkgsConfigForRustTarget = target: {
+          "x86_64-unknown-linux-gnu"       = "x86_64-unknown-linux-gnu";
+          "x86_64-unknown-linux-musl"      = "x86_64-unknown-linux-musl";
+          "aarch64-unknown-linux-gnu"      = "aarch64-unknown-linux-gnu";
+          "aarch64-unknown-linux-musl"     = "aarch64-unknown-linux-musl";
+          "armv7-unknown-linux-gnueabihf"  = "armv7l-unknown-linux-gnueabihf";
+          "armv7-unknown-linux-musleabihf" = "armv7l-unknown-linux-musleabihf";
+          # rust's `arm-*` targets default to cpu=arm1176jzf-s (ARMv6);
+          # armv5tel works for gnueabi but musleabi's libatomic on v5 has
+          # unresolved __sync_synchronize (no hw memory barrier, no kernel
+          # helper fallback). ARMv6 has DMB natively.
+          "arm-unknown-linux-gnueabi"      = "armv5tel-unknown-linux-gnueabi";
+          "arm-unknown-linux-musleabi"     = "armv6l-unknown-linux-musleabi";
+        }.${target};
+
+        crossPkgsForTarget = target:
+          import nixpkgs {
+            inherit system;
+            crossSystem = { config = nixpkgsConfigForRustTarget target; };
+            overlays = [ (import rust-overlay) ];
+          };
+
+        targets = [
+          "x86_64-unknown-linux-gnu"
+          "x86_64-unknown-linux-musl"
+          "aarch64-unknown-linux-gnu"
+          "aarch64-unknown-linux-musl"
+          "armv7-unknown-linux-gnueabihf"
+          "armv7-unknown-linux-musleabihf"
+          "arm-unknown-linux-gnueabi"
+          "arm-unknown-linux-musleabi"
+        ];
+
+        mkVector = { target, cargoFeatures }:
+          let
+            rustWithTarget = rustToolchain.override { targets = [ target ]; };
+            craneLib = (crane.mkLib pkgs).overrideToolchain rustWithTarget;
+
+            # Some upstream forks (e.g. vector's patched tracing) declare
+            # `readme = "..."` in workspace subcrate manifests without shipping
+            # the file, which breaks crane's `cargo package` vendoring. Create
+            # empty placeholders in each git-dep checkout before packaging.
+            cargoVendorDir = craneLib.vendorCargoDeps {
+              inherit src;
+              overrideVendorGitCheckout = _pkgs: drv:
+                drv.overrideAttrs (old: {
+                  postPatch = (old.postPatch or "") + ''
+                    find . -name Cargo.toml | while read -r f; do
+                      dir=$(dirname "$f")
+                      if grep -qE '^[[:space:]]*readme[[:space:]]*=' "$f" \
+                         && [ ! -f "$dir/README.md" ]; then
+                        touch "$dir/README.md"
+                      fi
+                    done
+                  '';
+                });
+            };
+
+            crossPkgs = crossPkgsForTarget target;
+            targetCc = crossPkgs.stdenv.cc;
+            targetPrefix = targetCc.targetPrefix;
+
+            # Rust/cc-rs env vars: dashes → underscores in the target triple.
+            targetUnderscore = builtins.replaceStrings [ "-" ] [ "_" ] target;
+            targetEnv = lib.toUpper targetUnderscore;
+          in
+          craneLib.buildPackage ({
+            inherit src cargoVendorDir;
+            pname = "vector";
+            version = "0.0.0-nix-${gitHash}";
+
+            strictDeps = true;
+            doCheck = false;
+
+            # Stop fortify-source macros from leaking into musl C builds;
+            # musl doesn't export __memcpy_chk / __snprintf_chk / etc.
+            hardeningDisable = [ "fortify" "fortify3" ];
+
+            CARGO_BUILD_TARGET = target;
+            CARGO_INCREMENTAL = "0";
+
+            # .cargo/config.toml points musl targets at /lib/native-libs,
+            # a path that only exists inside cross-rs's docker image. Strip
+            # it for Nix builds; rust's self-contained musl libs cover the link.
+            postPatch = ''
+              substituteInPlace .cargo/config.toml \
+                --replace-quiet '"-Lnative=/lib/native-libs"' '""'
+            '';
+
+            cargoExtraArgs = "--no-default-features --features ${cargoFeatures} --bin vector";
+
+            nativeBuildInputs = [
+              gitShim
+              targetCc
+              pkgs.protobuf
+              pkgs.cmake
+              pkgs.perl
+              pkgs.pkg-config
+              pkgs.rustPlatform.bindgenHook
+            ];
+          } // {
+            # Target-scoped env vars steer cc-rs + rustc at the musl toolchain
+            # for C deps and the final link. Host-side tools (build.rs, protoc)
+            # continue to use the default glibc stdenv.
+            "CC_${targetUnderscore}" = "${targetCc}/bin/${targetPrefix}cc";
+            "CXX_${targetUnderscore}" = "${targetCc}/bin/${targetPrefix}c++";
+            "AR_${targetUnderscore}" = "${targetCc.bintools}/bin/${targetPrefix}ar";
+            "CARGO_TARGET_${targetEnv}_LINKER" = "${targetCc}/bin/${targetPrefix}cc";
+          } // lib.optionalAttrs (target == "x86_64-unknown-linux-gnu") {
+            # krb5-src (vendored by rdkafka?/gssapi-vendored, only on this
+            # target) uses K&R function definitions that GCC 15's C23 default
+            # rejects. Pin C dialect just for this target to avoid busting
+            # the cache for the other 7.
+            CFLAGS = "-std=gnu17";
+          });
+
+        # The `target-x86_64-unknown-linux-gnu` feature adds `vendored` which
+        # pulls in rdkafka?/gssapi-vendored → sasl2-sys + krb5-src. sasl2-sys
+        # v0.1.22+2.1.28's build.rs copies its vendored source with `cp -R`
+        # that lands read-only in a Nix sandbox, breaking autoconf's
+        # config.log write. Drop to `target-unix` so x86_64-gnu matches the
+        # other linux targets (no GSSAPI). Re-enable in Phase 6 once the
+        # vendoring story is sorted (patch sasl2-sys, or use system libs).
+        cargoFeaturesFor = target:
+          if target == "x86_64-unknown-linux-gnu" then "target-unix"
+          else "target-${target}";
+
+        vectorBins = lib.listToAttrs (map (t: {
+          name = "vector-${t}";
+          value = mkVector { target = t; cargoFeatures = cargoFeaturesFor t; };
+        }) targets);
+
+        # Tarball must match `scripts/package-archive.sh` output byte-shape so
+        # distribution/docker/*/Dockerfile and downstream packaging consume it
+        # unchanged. Notable quirks: LICENSE is LICENSE+NOTICE concatenated;
+        # etc/systemd contains only vector.service; entries prefixed with `./`
+        # so the Dockerfile's `--strip-components=2` lands correctly.
+        mkTarball = { target, bin }:
+          pkgs.runCommand "vector-${vectorVersion}-${target}.tar.gz" {
+            nativeBuildInputs = [ pkgs.gnutar pkgs.gzip ];
+          } ''
+            root="./vector-${target}"
+            mkdir -p "$root/bin" "$root/etc/systemd" "$root/etc/init.d" "$root/licenses"
+
+            cp ${bin}/bin/vector "$root/bin/vector"
+
+            cp ${./README.md} "$root/README.md"
+            cat ${./LICENSE} ${./NOTICE} > "$root/LICENSE"
+            cp ${./LICENSE-3rdparty.csv} "$root/LICENSE-3rdparty.csv"
+            cp -R ${./licenses}/. "$root/licenses/"
+
+            cp -R ${./config}/. "$root/config/"
+
+            cp ${./distribution/systemd/vector.service} "$root/etc/systemd/vector.service"
+            cp ${./distribution/init.d/vector} "$root/etc/init.d/vector"
+
+            tar cf - "$root" | gzip -9 > "$out"
+          '';
+
+        tarballs = lib.listToAttrs (map (t: {
+          name = "vector-tarball-${t}";
+          value = mkTarball { target = t; bin = vectorBins."vector-${t}"; };
+        }) targets);
+      in
+      {
+        packages = vectorBins // tarballs // {
+          default = vectorBins.vector-x86_64-unknown-linux-musl;
+        };
+      });
+}


### PR DESCRIPTION
## Summary

Replaces cross-rs with a Nix flake for the 8 linux cross-compile targets currently built by `Cross.toml`. Only the smoke-build workflow (`.github/workflows/cross.yml`) is swapped in this PR. `publish.yml` and `distribution/docker/*` still use cross-rs and will be migrated in follow-up PRs.

## TODO (PR will be blocked until all of these are resolved)

1. **Glibc symbol-version regression on GNU targets.** `*-linux-gnu` binaries are linked against nixpkgs 25.11's glibc 2.42 and require `GLIBC_2.38`/`GLIBC_2.39` symbols at runtime. They will not run on systems with older glibc (RHEL 9 = 2.34, Ubuntu 22.04 = 2.35, Ubuntu 20.04 = 2.31). Vector's `Cargo.toml` declares `libc6 (>= 2.15)` so this is a regression versus the cross-rs baseline. Options: (a) pin an older nixpkgs for the cross C stdenv only, (b) override the cross stdenv to use `pkgs.glibc_2_38` or older, (c) keep cross-rs for gnu and use Nix only for musl. Decision needed before this PR can merge.
2. **No binary cache.** Every CI run rebuilds rust toolchain + cross C toolchains + 800+ cargo crates from scratch. ~8.5 runner-hours per PR. Deferred to a follow-up — not a regression, just expensive.

## Follow-ups (not blocking merge)

- **Darwin local dev.** The flake outputs only `x86_64-linux` and `aarch64-linux`. macOS devs can't `nix build` locally; they need a remote Linux builder or a `nix-darwin` linux-builder VM. Worth documenting.
- **`nix flake check` in CI.** Cheap eval-time validation that would have caught the `flake.lock` drift before a full matrix build.
- **Upstream report to [MaterializeInc/rust-sasl](https://github.com/MaterializeInc/rust-sasl/issues).** File a minimal repro documenting the Nix-sandbox `cp -R` read-only symptom. No existing issue matches. We work around it locally with a `cp` wrapper that chmods the destination after recursive copies.

## Vector configuration

NA

## How did you test this PR?

Built all 8 targets (`nix build .#vector-<triple>`) on a Linux x86_64 workspace:

- All binaries ran and reported the correct target triple via `--version`
- `ldd` confirmed musl targets are statically linked, gnu targets link glibc with standard FHS interpreter (`/lib64/ld-linux-x86-64.so.2` etc.) and no RPATH
- `readelf` confirmed the expected Machine (AArch64, ARM, x86-64) and rewritten `.interp` for gnu binaries
- Tarballs produced by `vector-tarball-<triple>` match the byte-shape of `scripts/package-archive.sh` output, so `distribution/docker/*/Dockerfile` can consume them unchanged when we get to the publish PR
- Once this PR runs CI, the `Cross` workflow validates the flake on `ubuntu-24.04` runners

First uncached CI run is expected to take ~60–70 min per matrix row. A Nix binary cache will be wired up in a follow-up so subsequent runs are fast.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA