### PR TITLE
feat(vdev): add `release verify` command with post-release artifact probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12250,6 +12250,7 @@ dependencies = [
  "clap-verbosity-flag",
  "clap_complete",
  "directories",
+ "flate2",
  "git2",
  "glob",
  "hex",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -23,6 +23,7 @@ clap.workspace = true
 clap-verbosity-flag = "3.0.4"
 clap_complete.workspace = true
 directories = "6.0.0"
+flate2.workspace = true
 glob.workspace = true
 hex = "0.4.3"
 indexmap.workspace = true

--- a/vdev/src/commands/release/check.rs
+++ b/vdev/src/commands/release/check.rs
@@ -1,0 +1,210 @@
+use std::{io::Read, time::Duration};
+
+use anyhow::{Context as _, Result, bail};
+use flate2::read::GzDecoder;
+
+use crate::utils::git;
+
+const DEFAULT_BASE_URL: &str = "https://apt.vector.dev";
+const DEFAULT_COMPONENT: &str = "vector-0";
+const DEFAULT_SUITE: &str = "stable";
+
+// Architectures the Datadog APT repo actually serves a Vector deb for. `binary-all` and
+// `binary-i386` exist in the repo layout but have always been empty for Vector, so we skip them.
+// `x86_64` is a legacy Datadog alias that points at the same amd64 deb.
+const ARCHES: &[&str] = &["amd64", "arm64", "armhf", "x86_64"];
+
+/// Check that a Vector release is fully published to the Datadog APT repo.
+///
+/// For each expected architecture, fetches `Packages.gz`, confirms the version is
+/// indexed, and verifies the referenced `.deb` is reachable.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to check (e.g. `0.55.0`). Defaults to the most recent `v*` git tag,
+    /// since `Cargo.toml`'s version is bumped to the next development version
+    /// immediately after a release.
+    version: Option<String>,
+
+    /// Base URL of the APT repo.
+    #[arg(long, default_value = DEFAULT_BASE_URL)]
+    url: String,
+
+    /// APT suite name.
+    #[arg(long, default_value = DEFAULT_SUITE)]
+    suite: String,
+
+    /// APT component name.
+    #[arg(long, default_value = DEFAULT_COMPONENT)]
+    component: String,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = if let Some(v) = self.version {
+            v
+        } else {
+            latest_release_tag()?
+        };
+        let debian_version = format!("{version}-1");
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?;
+
+        info!(
+            "Checking Vector {version} in {}/dists/{}/{}",
+            self.url, self.suite, self.component
+        );
+
+        let mut failures = 0usize;
+        for arch in ARCHES {
+            match check_arch(
+                &client,
+                &self.url,
+                &self.suite,
+                &self.component,
+                arch,
+                &debian_version,
+            ) {
+                Ok(ArchResult { filename, deb_size }) => {
+                    println!("  {arch:<8} OK    {filename} ({deb_size} bytes)");
+                }
+                Err(e) => {
+                    failures += 1;
+                    println!("  {arch:<8} FAIL  {e:#}");
+                }
+            }
+        }
+
+        if failures > 0 {
+            bail!("{failures}/{} architectures missing {version}", ARCHES.len());
+        }
+        Ok(())
+    }
+}
+
+struct ArchResult {
+    filename: String,
+    deb_size: u64,
+}
+
+// Return the most recent Vector release tag (e.g. `0.55.0`) with the leading `v` stripped.
+//
+// We use `for-each-ref` sorted by creation date rather than `git describe`, because Vector
+// tags releases on release branches (not master), so HEAD-reachability is the wrong signal.
+// The glob `v[0-9]*` matches tags like `v0.55.0` while excluding `vdev-v*` (second char is
+// `d`, not a digit).
+fn latest_release_tag() -> Result<String> {
+    let tag = git::run_and_check_output(&[
+        "for-each-ref",
+        "--sort=-creatordate",
+        "--count=1",
+        "--format=%(refname:short)",
+        "refs/tags/v[0-9]*",
+    ])
+    .context("finding latest Vector release tag via `git for-each-ref`")?;
+    let tag = tag.trim();
+    if tag.is_empty() {
+        bail!("no matching release tags found (pattern: `v[0-9]*`)");
+    }
+    let version = tag
+        .strip_prefix('v')
+        .ok_or_else(|| anyhow::anyhow!("expected tag {tag:?} to start with 'v'"))?;
+    Ok(version.to_string())
+}
+
+fn check_arch(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    suite: &str,
+    component: &str,
+    arch: &str,
+    debian_version: &str,
+) -> Result<ArchResult> {
+    let index_url = format!("{base_url}/dists/{suite}/{component}/binary-{arch}/Packages.gz");
+    let body = client
+        .get(&index_url)
+        .send()
+        .with_context(|| format!("fetching {index_url}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {index_url}"))?
+        .bytes()
+        .with_context(|| format!("reading {index_url}"))?;
+
+    let mut decoded = String::new();
+    GzDecoder::new(body.as_ref())
+        .read_to_string(&mut decoded)
+        .with_context(|| format!("gunzipping {index_url}"))?;
+
+    let filename = find_filename(&decoded, debian_version)
+        .with_context(|| format!("version {debian_version} not found in {index_url}"))?;
+
+    let deb_url = format!("{base_url}/{filename}");
+    let head = client
+        .head(&deb_url)
+        .send()
+        .with_context(|| format!("HEAD {deb_url}"))?
+        .error_for_status()
+        .with_context(|| format!("HEAD {deb_url}"))?;
+    let deb_size = head
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    Ok(ArchResult { filename, deb_size })
+}
+
+// Walk the Packages stanzas (separated by blank lines) and return the `Filename:` of
+// the one whose `Version:` matches.
+fn find_filename(packages: &str, debian_version: &str) -> Option<String> {
+    for stanza in packages.split("\n\n") {
+        let mut version = None;
+        let mut filename = None;
+        for line in stanza.lines() {
+            if let Some(rest) = line.strip_prefix("Version:") {
+                version = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("Filename:") {
+                filename = Some(rest.trim().to_string());
+            }
+        }
+        if version.as_deref() == Some(debian_version) {
+            return filename;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_filename;
+
+    #[test]
+    fn finds_matching_stanza() {
+        let packages = "\
+Package: vector
+Version: 0.54.0-1
+Filename: pool/v/ve/vector_0.54.0-1_amd64.deb
+
+Package: vector
+Version: 0.55.0-1
+Filename: pool/v/ve/vector_0.55.0-1_amd64.deb
+";
+        assert_eq!(
+            find_filename(packages, "0.55.0-1").as_deref(),
+            Some("pool/v/ve/vector_0.55.0-1_amd64.deb"),
+        );
+        assert_eq!(
+            find_filename(packages, "0.54.0-1").as_deref(),
+            Some("pool/v/ve/vector_0.54.0-1_amd64.deb"),
+        );
+        assert_eq!(find_filename(packages, "0.56.0-1"), None);
+    }
+
+    #[test]
+    fn empty_index_has_no_match() {
+        assert_eq!(find_filename("", "0.55.0-1"), None);
+    }
+}

--- a/vdev/src/commands/release/mod.rs
+++ b/vdev/src/commands/release/mod.rs
@@ -1,15 +1,14 @@
 mod channel;
-mod check;
 mod github;
 mod homebrew;
 mod prepare;
 mod push;
+mod verify;
 
 crate::cli_subcommands! {
     "Manage the release process..."
     generate_cue,
     channel,
-    check,
     commit,
     docker,
     github,
@@ -17,6 +16,7 @@ crate::cli_subcommands! {
     prepare,
     push,
     s3,
+    verify,
 }
 
 crate::script_wrapper! {

--- a/vdev/src/commands/release/mod.rs
+++ b/vdev/src/commands/release/mod.rs
@@ -1,4 +1,5 @@
 mod channel;
+mod check;
 mod github;
 mod homebrew;
 mod prepare;
@@ -8,6 +9,7 @@ crate::cli_subcommands! {
     "Manage the release process..."
     generate_cue,
     channel,
+    check,
     commit,
     docker,
     github,

--- a/vdev/src/commands/release/verify/apt.rs
+++ b/vdev/src/commands/release/verify/apt.rs
@@ -3,7 +3,7 @@ use std::{io::Read, time::Duration};
 use anyhow::{Context as _, Result, bail};
 use flate2::read::GzDecoder;
 
-use crate::utils::git;
+use super::{VerifyOutcome, resolve_version};
 
 const DEFAULT_BASE_URL: &str = "https://apt.vector.dev";
 const DEFAULT_COMPONENT: &str = "vector-0";
@@ -14,16 +14,11 @@ const DEFAULT_SUITE: &str = "stable";
 // `x86_64` is a legacy Datadog alias that points at the same amd64 deb.
 const ARCHES: &[&str] = &["amd64", "arm64", "armhf", "x86_64"];
 
-/// Check that a Vector release is fully published to the Datadog APT repo.
-///
-/// For each expected architecture, fetches `Packages.gz`, confirms the version is
-/// indexed, and verifies the referenced `.deb` is reachable.
+/// Verify the Datadog APT repo serves a Vector release across every expected architecture.
 #[derive(clap::Args, Debug)]
 #[command()]
 pub struct Cli {
-    /// Version to check (e.g. `0.55.0`). Defaults to the most recent `v*` git tag,
-    /// since `Cargo.toml`'s version is bumped to the next development version
-    /// immediately after a release.
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
     version: Option<String>,
 
     /// Base URL of the APT repo.
@@ -41,77 +36,57 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let version = if let Some(v) = self.version {
-            v
-        } else {
-            latest_release_tag()?
-        };
-        let debian_version = format!("{version}-1");
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version, &self.url, &self.suite, &self.component) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
 
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()?;
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version, DEFAULT_BASE_URL, DEFAULT_SUITE, DEFAULT_COMPONENT) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
 
-        info!(
-            "Checking Vector {version} in {}/dists/{}/{}",
-            self.url, self.suite, self.component
-        );
+fn verify_inner(version: &str, base_url: &str, suite: &str, component: &str) -> Result<String> {
+    let debian_version = format!("{version}-1");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
 
-        let mut failures = 0usize;
-        for arch in ARCHES {
-            match check_arch(
-                &client,
-                &self.url,
-                &self.suite,
-                &self.component,
-                arch,
-                &debian_version,
-            ) {
-                Ok(ArchResult { filename, deb_size }) => {
-                    println!("  {arch:<8} OK    {filename} ({deb_size} bytes)");
-                }
-                Err(e) => {
-                    failures += 1;
-                    println!("  {arch:<8} FAIL  {e:#}");
-                }
+    info!("Checking Vector {version} in {base_url}/dists/{suite}/{component}");
+
+    let mut failures = 0usize;
+    for arch in ARCHES {
+        match check_arch(&client, base_url, suite, component, arch, &debian_version) {
+            Ok(ArchResult { filename, deb_size }) => {
+                println!("  {arch:<8} OK    {filename} ({deb_size} bytes)");
+            }
+            Err(e) => {
+                failures += 1;
+                println!("  {arch:<8} FAIL  {e:#}");
             }
         }
-
-        if failures > 0 {
-            bail!("{failures}/{} architectures missing {version}", ARCHES.len());
-        }
-        Ok(())
     }
+
+    if failures > 0 {
+        bail!(
+            "{failures}/{} architectures missing {version}",
+            ARCHES.len()
+        );
+    }
+    Ok(format!("{}/{} arches OK", ARCHES.len(), ARCHES.len()))
 }
 
 struct ArchResult {
     filename: String,
     deb_size: u64,
-}
-
-// Return the most recent Vector release tag (e.g. `0.55.0`) with the leading `v` stripped.
-//
-// We use `for-each-ref` sorted by creation date rather than `git describe`, because Vector
-// tags releases on release branches (not master), so HEAD-reachability is the wrong signal.
-// The glob `v[0-9]*` matches tags like `v0.55.0` while excluding `vdev-v*` (second char is
-// `d`, not a digit).
-fn latest_release_tag() -> Result<String> {
-    let tag = git::run_and_check_output(&[
-        "for-each-ref",
-        "--sort=-creatordate",
-        "--count=1",
-        "--format=%(refname:short)",
-        "refs/tags/v[0-9]*",
-    ])
-    .context("finding latest Vector release tag via `git for-each-ref`")?;
-    let tag = tag.trim();
-    if tag.is_empty() {
-        bail!("no matching release tags found (pattern: `v[0-9]*`)");
-    }
-    let version = tag
-        .strip_prefix('v')
-        .ok_or_else(|| anyhow::anyhow!("expected tag {tag:?} to start with 'v'"))?;
-    Ok(version.to_string())
 }
 
 fn check_arch(

--- a/vdev/src/commands/release/verify/apt.rs
+++ b/vdev/src/commands/release/verify/apt.rs
@@ -1,9 +1,6 @@
-use std::{io::Read, time::Duration};
-
 use anyhow::{Context as _, Result, bail};
-use flate2::read::GzDecoder;
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
 const DEFAULT_BASE_URL: &str = "https://apt.vector.dev";
 const DEFAULT_COMPONENT: &str = "vector-0";
@@ -37,35 +34,26 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version, &self.url, &self.suite, &self.component) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify_with(&version, &self.url, &self.suite, &self.component)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version, DEFAULT_BASE_URL, DEFAULT_SUITE, DEFAULT_COMPONENT) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
+pub fn verify(version: &str) -> Result<String> {
+    verify_with(version, DEFAULT_BASE_URL, DEFAULT_SUITE, DEFAULT_COMPONENT)
 }
 
-fn verify_inner(version: &str, base_url: &str, suite: &str, component: &str) -> Result<String> {
+fn verify_with(version: &str, base_url: &str, suite: &str, component: &str) -> Result<String> {
     let debian_version = format!("{version}-1");
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()?;
+    let client = util::client()?;
 
     info!("Checking Vector {version} in {base_url}/dists/{suite}/{component}");
 
     let mut failures = 0usize;
     for arch in ARCHES {
         match check_arch(&client, base_url, suite, component, arch, &debian_version) {
-            Ok(ArchResult { filename, deb_size }) => {
+            Ok((filename, deb_size)) => {
                 println!("  {arch:<8} OK    {filename} ({deb_size} bytes)");
             }
             Err(e) => {
@@ -84,11 +72,6 @@ fn verify_inner(version: &str, base_url: &str, suite: &str, component: &str) -> 
     Ok(format!("{}/{} arches OK", ARCHES.len(), ARCHES.len()))
 }
 
-struct ArchResult {
-    filename: String,
-    deb_size: u64,
-}
-
 fn check_arch(
     client: &reqwest::blocking::Client,
     base_url: &str,
@@ -96,40 +79,14 @@ fn check_arch(
     component: &str,
     arch: &str,
     debian_version: &str,
-) -> Result<ArchResult> {
+) -> Result<(String, u64)> {
     let index_url = format!("{base_url}/dists/{suite}/{component}/binary-{arch}/Packages.gz");
-    let body = client
-        .get(&index_url)
-        .send()
-        .with_context(|| format!("fetching {index_url}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {index_url}"))?
-        .bytes()
-        .with_context(|| format!("reading {index_url}"))?;
-
-    let mut decoded = String::new();
-    GzDecoder::new(body.as_ref())
-        .read_to_string(&mut decoded)
-        .with_context(|| format!("gunzipping {index_url}"))?;
-
-    let filename = find_filename(&decoded, debian_version)
+    let packages = util::fetch_gz_text(client, &index_url)?;
+    let filename = find_filename(&packages, debian_version)
         .with_context(|| format!("version {debian_version} not found in {index_url}"))?;
-
     let deb_url = format!("{base_url}/{filename}");
-    let head = client
-        .head(&deb_url)
-        .send()
-        .with_context(|| format!("HEAD {deb_url}"))?
-        .error_for_status()
-        .with_context(|| format!("HEAD {deb_url}"))?;
-    let deb_size = head
-        .headers()
-        .get(reqwest::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(0);
-
-    Ok(ArchResult { filename, deb_size })
+    let size = util::head_size(client, &deb_url)?;
+    Ok((filename, size))
 }
 
 // Walk the Packages stanzas (separated by blank lines) and return the `Filename:` of

--- a/vdev/src/commands/release/verify/docker.rs
+++ b/vdev/src/commands/release/verify/docker.rs
@@ -1,9 +1,7 @@
-use std::time::Duration;
-
 use anyhow::{Context as _, Result, bail};
 use serde_json::Value;
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
 // Repos that `publish-docker` in `.github/workflows/publish.yml` pushes to.
 //
@@ -126,28 +124,14 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify(&version)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
-}
-
-fn verify_inner(version: &str) -> Result<String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .user_agent("vdev-release-verify-docker")
-        .build()?;
+pub fn verify(version: &str) -> Result<String> {
+    let client = util::client()?;
 
     let aliases = tag_aliases(version)?;
     info!(

--- a/vdev/src/commands/release/verify/docker.rs
+++ b/vdev/src/commands/release/verify/docker.rs
@@ -1,0 +1,351 @@
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use serde_json::Value;
+
+use super::{VerifyOutcome, resolve_version};
+
+// Repos that `publish-docker` in `.github/workflows/publish.yml` pushes to.
+//
+// Each tuple is `(human-readable label, registry host, image repo)`. The label is what we print;
+// the other two are what we pass to the registry v2 API.
+const REGISTRIES: &[Registry] = &[
+    Registry {
+        label: "docker.io",
+        auth: "https://auth.docker.io/token?service=registry.docker.io&scope=repository:timberio/vector:pull",
+        manifest_host: "registry-1.docker.io",
+        repo: "timberio/vector",
+    },
+    Registry {
+        label: "ghcr.io",
+        auth: "https://ghcr.io/token?service=ghcr.io&scope=repository:vectordotdev/vector:pull",
+        manifest_host: "ghcr.io",
+        repo: "vectordotdev/vector",
+    },
+];
+
+// Image variants the release docker script builds (see `scripts/build-docker.sh`). Each variant
+// pushes under the version tag plus the `0.Y.X`, `0.X`, and `latest` aliases.
+//
+// `alpine` and `debian` ship all four platforms. `distroless-static` and `distroless-libc` skip
+// `linux/arm/v6` because no upstream distroless base exists for that platform (see
+// `SUPPORTED_PLATFORMS` in `scripts/build-docker.sh`).
+const VARIANTS: &[Variant] = &[
+    Variant {
+        name: "alpine",
+        platforms: ALL_PLATFORMS,
+    },
+    Variant {
+        name: "debian",
+        platforms: ALL_PLATFORMS,
+    },
+    Variant {
+        name: "distroless-static",
+        platforms: DISTROLESS_PLATFORMS,
+    },
+    Variant {
+        name: "distroless-libc",
+        platforms: DISTROLESS_PLATFORMS,
+    },
+];
+
+const ALL_PLATFORMS: &[Platform] = &[
+    Platform::LINUX_AMD64,
+    Platform::LINUX_ARM64,
+    Platform::LINUX_ARM_V7,
+    Platform::LINUX_ARM_V6,
+];
+
+const DISTROLESS_PLATFORMS: &[Platform] = &[
+    Platform::LINUX_AMD64,
+    Platform::LINUX_ARM64,
+    Platform::LINUX_ARM_V7,
+];
+
+const ACCEPT_MANIFEST_LIST: &str = "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json";
+
+struct Registry {
+    label: &'static str,
+    auth: &'static str,
+    manifest_host: &'static str,
+    repo: &'static str,
+}
+
+struct Variant {
+    name: &'static str,
+    platforms: &'static [Platform],
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct Platform {
+    display: &'static str,
+    os: &'static str,
+    architecture: &'static str,
+    variant: Option<&'static str>,
+}
+
+impl Platform {
+    const LINUX_AMD64: Self = Self {
+        display: "linux/amd64",
+        os: "linux",
+        architecture: "amd64",
+        variant: None,
+    };
+    const LINUX_ARM64: Self = Self {
+        display: "linux/arm64",
+        os: "linux",
+        architecture: "arm64",
+        variant: None,
+    };
+    const LINUX_ARM_V7: Self = Self {
+        display: "linux/arm/v7",
+        os: "linux",
+        architecture: "arm",
+        variant: Some("v7"),
+    };
+    const LINUX_ARM_V6: Self = Self {
+        display: "linux/arm/v6",
+        os: "linux",
+        architecture: "arm",
+        variant: Some("v6"),
+    };
+
+    fn matches(self, os: &str, architecture: &str, variant: Option<&str>) -> bool {
+        self.os == os && self.architecture == architecture && self.variant == variant
+    }
+}
+
+/// Verify Vector Docker images on Docker Hub and ghcr.io.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
+
+fn verify_inner(version: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent("vdev-release-verify-docker")
+        .build()?;
+
+    let aliases = tag_aliases(version)?;
+    info!(
+        "Checking Vector {version} Docker images (aliases: {})",
+        aliases.join(", "),
+    );
+
+    let mut total = 0usize;
+    let mut failures = 0usize;
+
+    for registry in REGISTRIES {
+        println!("  {}/{}:", registry.label, registry.repo);
+        let token = fetch_token(&client, registry)
+            .with_context(|| format!("fetching auth token for {}", registry.label))?;
+
+        for alias in &aliases {
+            for variant in VARIANTS {
+                total += 1;
+                let tag = format!("{alias}-{}", variant.name);
+                match check_tag(&client, registry, &token, &tag, variant.platforms) {
+                    Ok(covered) => {
+                        println!("    {tag:<36} OK    [{}]", covered.join(", "));
+                    }
+                    Err(e) => {
+                        failures += 1;
+                        println!("    {tag:<36} FAIL  {e:#}");
+                    }
+                }
+            }
+        }
+    }
+
+    if failures > 0 {
+        bail!("{failures}/{total} tag(s) missing or incomplete");
+    }
+    Ok(format!(
+        "{total}/{total} tags OK across {} registries",
+        REGISTRIES.len(),
+    ))
+}
+
+// Expected release tag aliases, in the same order that `scripts/build-docker.sh` pushes them.
+//
+// For a semver release like `0.55.0` we expect `0.55.0`, `0.55.X`, `0.X`, and `latest`.
+// Anything outside `MAJOR.MINOR.PATCH` (e.g. a pre-release suffix) is rejected because the
+// release script only handles that shape.
+fn tag_aliases(version: &str) -> Result<Vec<String>> {
+    let parts: Vec<&str> = version.split('.').collect();
+    let [major, minor, patch] = parts.as_slice() else {
+        bail!(
+            "expected version in MAJOR.MINOR.PATCH form, got {version:?} \
+             (release-docker.sh only publishes tags for that shape)",
+        );
+    };
+    let all_digits = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit());
+    if [*major, *minor, *patch].iter().any(|s| !all_digits(s)) {
+        bail!(
+            "expected version in MAJOR.MINOR.PATCH form with numeric segments, got {version:?} \
+             (release-docker.sh does not publish pre-release tags)",
+        );
+    }
+    Ok(vec![
+        version.to_string(),
+        format!("{major}.{minor}.X"),
+        format!("{major}.X"),
+        "latest".to_string(),
+    ])
+}
+
+fn fetch_token(client: &reqwest::blocking::Client, registry: &Registry) -> Result<String> {
+    let body: Value = client
+        .get(registry.auth)
+        .send()
+        .with_context(|| format!("GET {}", registry.auth))?
+        .error_for_status()
+        .with_context(|| format!("GET {}", registry.auth))?
+        .json()
+        .with_context(|| format!("parsing token JSON from {}", registry.auth))?;
+
+    // Both docker.io and ghcr.io return `{"token": "..."}`; ghcr.io additionally includes
+    // `access_token` with the same value. Only `token` is guaranteed.
+    body.get("token")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("no `token` field in response from {}", registry.auth))
+}
+
+// Returns the list of expected platforms that were found in the manifest list, in the
+// canonical order defined by `expected`. Errors if any expected platform is missing.
+fn check_tag(
+    client: &reqwest::blocking::Client,
+    registry: &Registry,
+    token: &str,
+    tag: &str,
+    expected: &[Platform],
+) -> Result<Vec<&'static str>> {
+    let url = format!(
+        "https://{}/v2/{}/manifests/{tag}",
+        registry.manifest_host, registry.repo,
+    );
+    let response = client
+        .get(&url)
+        .bearer_auth(token)
+        .header(reqwest::header::ACCEPT, ACCEPT_MANIFEST_LIST)
+        .send()
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?;
+
+    let body: Value = response
+        .json()
+        .with_context(|| format!("parsing manifest JSON from {url}"))?;
+
+    let manifests = body
+        .get("manifests")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{url} returned a single-arch manifest (no `manifests` array); \
+             expected a manifest list / OCI image index",
+            )
+        })?;
+
+    let mut covered = Vec::with_capacity(expected.len());
+    let mut missing = Vec::new();
+    for platform in expected {
+        if manifest_covers(manifests, *platform) {
+            covered.push(platform.display);
+        } else {
+            missing.push(platform.display);
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(covered)
+    } else {
+        bail!("missing platform(s): {}", missing.join(", "));
+    }
+}
+
+fn manifest_covers(manifests: &[Value], expected: Platform) -> bool {
+    manifests.iter().any(|entry| {
+        let Some(plat) = entry.get("platform") else {
+            return false;
+        };
+        let os = plat.get("os").and_then(Value::as_str).unwrap_or("");
+        let architecture = plat
+            .get("architecture")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let variant = plat.get("variant").and_then(Value::as_str);
+        expected.matches(os, architecture, variant)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{Platform, manifest_covers, tag_aliases};
+
+    #[test]
+    fn aliases_cover_version_series() {
+        assert_eq!(
+            tag_aliases("0.55.0").unwrap(),
+            vec!["0.55.0", "0.55.X", "0.X", "latest"],
+        );
+        assert_eq!(
+            tag_aliases("1.2.3").unwrap(),
+            vec!["1.2.3", "1.2.X", "1.X", "latest"],
+        );
+    }
+
+    #[test]
+    fn aliases_reject_non_semver() {
+        assert!(tag_aliases("0.55").is_err());
+        assert!(tag_aliases("0.55.0-rc1").is_err());
+        assert!(tag_aliases("nightly").is_err());
+    }
+
+    #[test]
+    fn manifest_covers_matches_arm_variants() {
+        let manifests = vec![
+            json!({"platform": {"os": "linux", "architecture": "amd64"}}),
+            json!({"platform": {"os": "linux", "architecture": "arm64"}}),
+            json!({"platform": {"os": "linux", "architecture": "arm", "variant": "v7"}}),
+        ];
+        assert!(manifest_covers(&manifests, Platform::LINUX_AMD64));
+        assert!(manifest_covers(&manifests, Platform::LINUX_ARM64));
+        assert!(manifest_covers(&manifests, Platform::LINUX_ARM_V7));
+        assert!(!manifest_covers(&manifests, Platform::LINUX_ARM_V6));
+    }
+
+    #[test]
+    fn manifest_covers_ignores_attestation_entries() {
+        // buildx pushes attestation manifests with architecture/os = "unknown"; they
+        // must not satisfy any expected platform.
+        let manifests = vec![json!({"platform": {"os": "unknown", "architecture": "unknown"}})];
+        assert!(!manifest_covers(&manifests, Platform::LINUX_AMD64));
+    }
+}

--- a/vdev/src/commands/release/verify/github.rs
+++ b/vdev/src/commands/release/verify/github.rs
@@ -1,11 +1,9 @@
-use std::{collections::HashMap, env, time::Duration};
+use std::{collections::HashMap, env};
 
 use anyhow::{Context as _, Result, bail};
-use sha2::{Digest, Sha256};
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
-const USER_AGENT: &str = "vdev-release-verify";
 const API_BASE: &str = "https://api.github.com";
 const REPO: &str = "vectordotdev/vector";
 
@@ -37,28 +35,14 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify(&version)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
-}
-
-fn verify_inner(version: &str) -> Result<String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(300))
-        .user_agent(USER_AGENT)
-        .build()?;
+pub fn verify(version: &str) -> Result<String> {
+    let client = util::stream_client()?;
 
     info!("Fetching GitHub release v{version} from {REPO}");
 
@@ -87,20 +71,11 @@ fn verify_inner(version: &str) -> Result<String> {
         );
     }
 
-    // SHA256SUMS is already in `expected`/`assets`, but grab its URL for download.
     let sums_name = format!("vector-{version}-SHA256SUMS");
     let sums_url = assets
         .get(&sums_name)
         .ok_or_else(|| anyhow::anyhow!("{sums_name} missing from assets"))?;
-    let sums_body = client
-        .get(sums_url)
-        .send()
-        .with_context(|| format!("fetching {sums_name}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {sums_name}"))?
-        .text()
-        .with_context(|| format!("reading {sums_name}"))?;
-    let sums = parse_sha256sums(&sums_body);
+    let sums = util::parse_sha256sums(&util::fetch_text(&client, sums_url)?);
 
     let samples = [
         format!("vector_{version}-1_amd64.deb"),
@@ -209,23 +184,6 @@ fn parse_assets(release: &serde_json::Value) -> Result<HashMap<String, String>> 
     Ok(out)
 }
 
-// Lines look like: `<hex>  <filename>` (two spaces, coreutils style).
-fn parse_sha256sums(body: &str) -> HashMap<String, String> {
-    let mut out = HashMap::new();
-    for line in body.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        let Some((digest, name)) = line.split_once("  ") else {
-            continue;
-        };
-        let name = name.trim_start_matches('*').trim();
-        out.insert(name.to_string(), digest.trim().to_string());
-    }
-    out
-}
-
 fn verify_sample(
     client: &reqwest::blocking::Client,
     name: &str,
@@ -238,19 +196,7 @@ fn verify_sample(
     let expected = sums
         .get(name)
         .ok_or_else(|| anyhow::anyhow!("{name} not in SHA256SUMS"))?;
-
-    let mut resp = client
-        .get(url)
-        .send()
-        .with_context(|| format!("downloading {name}"))?
-        .error_for_status()
-        .with_context(|| format!("downloading {name}"))?;
-
-    let mut hasher = Sha256Writer(Sha256::new());
-    resp.copy_to(&mut hasher)
-        .with_context(|| format!("streaming {name} into hasher"))?;
-    let actual = hex::encode(hasher.0.finalize());
-
+    let actual = util::stream_sha256(client, url)?;
     if actual.eq_ignore_ascii_case(expected) {
         Ok(actual)
     } else {
@@ -258,23 +204,9 @@ fn verify_sample(
     }
 }
 
-// Thin `io::Write` adapter so `Response::copy_to` can stream into a Sha256 hasher
-// without buffering the asset in memory.
-struct Sha256Writer(Sha256);
-
-impl std::io::Write for Sha256Writer {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.update(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{expected_assets, parse_sha256sums};
+    use super::expected_assets;
 
     #[test]
     fn expected_asset_list_is_complete() {
@@ -287,35 +219,5 @@ mod tests {
         assert!(names.contains(&"vector-0.55.0-x86_64-pc-windows-msvc.zip".to_string()));
         assert!(names.contains(&"vector-0.55.0-x64.msi".to_string()));
         assert!(names.contains(&"vector-0.55.0-SHA256SUMS".to_string()));
-    }
-
-    #[test]
-    fn parses_coreutils_sha256sums() {
-        let body = "\
-abc123  vector-0.55.0-x64.msi
-deadbeef  vector_0.55.0-1_amd64.deb
-# comment line
-";
-        let sums = parse_sha256sums(body);
-        assert_eq!(
-            sums.get("vector-0.55.0-x64.msi").map(String::as_str),
-            Some("abc123")
-        );
-        assert_eq!(
-            sums.get("vector_0.55.0-1_amd64.deb").map(String::as_str),
-            Some("deadbeef"),
-        );
-        assert_eq!(sums.len(), 2);
-    }
-
-    #[test]
-    fn parses_binary_mode_sha256sums() {
-        // coreutils writes `*filename` for binary mode; strip the leading `*`.
-        let body = "feedface  *vector-0.55.0-x64.msi\n";
-        let sums = parse_sha256sums(body);
-        assert_eq!(
-            sums.get("vector-0.55.0-x64.msi").map(String::as_str),
-            Some("feedface")
-        );
     }
 }

--- a/vdev/src/commands/release/verify/github.rs
+++ b/vdev/src/commands/release/verify/github.rs
@@ -1,0 +1,321 @@
+use std::{collections::HashMap, env, time::Duration};
+
+use anyhow::{Context as _, Result, bail};
+use sha2::{Digest, Sha256};
+
+use super::{VerifyOutcome, resolve_version};
+
+const USER_AGENT: &str = "vdev-release-verify";
+const API_BASE: &str = "https://api.github.com";
+const REPO: &str = "vectordotdev/vector";
+
+// Linux/macOS targets that publish `vector-<ver>-<target>.tar.gz` per publish.yml's
+// build-linux / build-apple-darwin matrices.
+const TARBALL_TARGETS: &[&str] = &[
+    "x86_64-unknown-linux-musl",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
+    "aarch64-unknown-linux-gnu",
+    "armv7-unknown-linux-gnueabihf",
+    "armv7-unknown-linux-musleabihf",
+    "arm-unknown-linux-gnueabi",
+    "arm-unknown-linux-musleabi",
+    "arm64-apple-darwin",
+];
+
+const DEB_ARCHES: &[&str] = &["amd64", "arm64", "armhf", "armel"];
+const RPM_ARCHES: &[&str] = &["x86_64", "aarch64", "armv7hl"];
+
+/// Verify GitHub release assets and SHA256SUMS for a Vector release.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
+
+fn verify_inner(version: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .user_agent(USER_AGENT)
+        .build()?;
+
+    info!("Fetching GitHub release v{version} from {REPO}");
+
+    let release = fetch_release(&client, version)?;
+    let assets =
+        parse_assets(&release).with_context(|| format!("parsing assets for release v{version}"))?;
+
+    let expected = expected_assets(version);
+
+    let mut missing = Vec::new();
+    for name in &expected {
+        if assets.contains_key(name) {
+            println!("  OK    {name}");
+        } else {
+            println!("  MISS  {name}");
+            missing.push(name.clone());
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!(
+            "{}/{} expected assets missing: {}",
+            missing.len(),
+            expected.len(),
+            missing.join(", "),
+        );
+    }
+
+    // SHA256SUMS is already in `expected`/`assets`, but grab its URL for download.
+    let sums_name = format!("vector-{version}-SHA256SUMS");
+    let sums_url = assets
+        .get(&sums_name)
+        .ok_or_else(|| anyhow::anyhow!("{sums_name} missing from assets"))?;
+    let sums_body = client
+        .get(sums_url)
+        .send()
+        .with_context(|| format!("fetching {sums_name}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {sums_name}"))?
+        .text()
+        .with_context(|| format!("reading {sums_name}"))?;
+    let sums = parse_sha256sums(&sums_body);
+
+    let samples = [
+        format!("vector_{version}-1_amd64.deb"),
+        format!("vector-{version}-x86_64-unknown-linux-gnu.tar.gz"),
+        format!("vector-{version}-arm64-apple-darwin.tar.gz"),
+    ];
+
+    let mut sum_failures = 0usize;
+    for sample in &samples {
+        match verify_sample(&client, sample, &assets, &sums) {
+            Ok(digest) => println!("  SHA   {sample} {digest}"),
+            Err(e) => {
+                sum_failures += 1;
+                println!("  SHA   {sample} FAIL {e:#}");
+            }
+        }
+    }
+
+    if sum_failures > 0 {
+        bail!("{sum_failures}/{} sampled checksums failed", samples.len());
+    }
+
+    Ok(format!(
+        "{} assets present, {}/{} sampled checksums match",
+        expected.len(),
+        samples.len(),
+        samples.len(),
+    ))
+}
+
+fn expected_assets(version: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for target in TARBALL_TARGETS {
+        out.push(format!("vector-{version}-{target}.tar.gz"));
+    }
+    for arch in DEB_ARCHES {
+        out.push(format!("vector_{version}-1_{arch}.deb"));
+    }
+    for arch in RPM_ARCHES {
+        out.push(format!("vector-{version}-1.{arch}.rpm"));
+    }
+    out.push(format!("vector-{version}-x86_64-pc-windows-msvc.zip"));
+    out.push(format!("vector-{version}-x64.msi"));
+    out.push(format!("vector-{version}-SHA256SUMS"));
+    out
+}
+
+fn fetch_release(client: &reqwest::blocking::Client, version: &str) -> Result<serde_json::Value> {
+    let url = format!("{API_BASE}/repos/{REPO}/releases/tags/v{version}");
+    let mut req = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json");
+    if let Ok(token) = env::var("GITHUB_TOKEN")
+        && !token.is_empty()
+    {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+    let resp = req.send().with_context(|| format!("fetching {url}"))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::FORBIDDEN || status == reqwest::StatusCode::UNAUTHORIZED {
+        // Fall back to `gh api`, which uses the user's auth.
+        return fetch_release_via_gh(version)
+            .with_context(|| format!("GitHub API returned {status} for {url}; gh fallback"));
+    }
+    let body = resp
+        .error_for_status()
+        .with_context(|| format!("GitHub API status for {url}"))?
+        .text()
+        .with_context(|| format!("reading body of {url}"))?;
+    serde_json::from_str(&body).with_context(|| format!("parsing JSON from {url}"))
+}
+
+fn fetch_release_via_gh(version: &str) -> Result<serde_json::Value> {
+    let path = format!("repos/{REPO}/releases/tags/v{version}");
+    let output = std::process::Command::new("gh")
+        .args(["api", &path])
+        .output()
+        .context("invoking `gh api` (is the GitHub CLI installed and authenticated?)")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("`gh api {path}` failed: {stderr}");
+    }
+    serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("parsing JSON from `gh api {path}`"))
+}
+
+// Returns a map of asset name -> browser_download_url.
+fn parse_assets(release: &serde_json::Value) -> Result<HashMap<String, String>> {
+    let assets = release
+        .get("assets")
+        .and_then(serde_json::Value::as_array)
+        .context("release JSON has no `assets` array")?;
+    let mut out = HashMap::with_capacity(assets.len());
+    for asset in assets {
+        let name = asset
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .context("asset missing `name`")?;
+        let url = asset
+            .get("browser_download_url")
+            .and_then(serde_json::Value::as_str)
+            .context("asset missing `browser_download_url`")?;
+        out.insert(name.to_string(), url.to_string());
+    }
+    Ok(out)
+}
+
+// Lines look like: `<hex>  <filename>` (two spaces, coreutils style).
+fn parse_sha256sums(body: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((digest, name)) = line.split_once("  ") else {
+            continue;
+        };
+        let name = name.trim_start_matches('*').trim();
+        out.insert(name.to_string(), digest.trim().to_string());
+    }
+    out
+}
+
+fn verify_sample(
+    client: &reqwest::blocking::Client,
+    name: &str,
+    assets: &HashMap<String, String>,
+    sums: &HashMap<String, String>,
+) -> Result<String> {
+    let url = assets
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("asset {name} not in release"))?;
+    let expected = sums
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("{name} not in SHA256SUMS"))?;
+
+    let mut resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("downloading {name}"))?
+        .error_for_status()
+        .with_context(|| format!("downloading {name}"))?;
+
+    let mut hasher = Sha256Writer(Sha256::new());
+    resp.copy_to(&mut hasher)
+        .with_context(|| format!("streaming {name} into hasher"))?;
+    let actual = hex::encode(hasher.0.finalize());
+
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(actual)
+    } else {
+        bail!("checksum mismatch: got {actual}, expected {expected}");
+    }
+}
+
+// Thin `io::Write` adapter so `Response::copy_to` can stream into a Sha256 hasher
+// without buffering the asset in memory.
+struct Sha256Writer(Sha256);
+
+impl std::io::Write for Sha256Writer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.update(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expected_assets, parse_sha256sums};
+
+    #[test]
+    fn expected_asset_list_is_complete() {
+        let names = expected_assets("0.55.0");
+        // 9 tarballs + 4 debs + 3 rpms + zip + msi + SHA256SUMS = 19.
+        assert_eq!(names.len(), 19);
+        assert!(names.contains(&"vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz".to_string()));
+        assert!(names.contains(&"vector_0.55.0-1_amd64.deb".to_string()));
+        assert!(names.contains(&"vector-0.55.0-1.x86_64.rpm".to_string()));
+        assert!(names.contains(&"vector-0.55.0-x86_64-pc-windows-msvc.zip".to_string()));
+        assert!(names.contains(&"vector-0.55.0-x64.msi".to_string()));
+        assert!(names.contains(&"vector-0.55.0-SHA256SUMS".to_string()));
+    }
+
+    #[test]
+    fn parses_coreutils_sha256sums() {
+        let body = "\
+abc123  vector-0.55.0-x64.msi
+deadbeef  vector_0.55.0-1_amd64.deb
+# comment line
+";
+        let sums = parse_sha256sums(body);
+        assert_eq!(
+            sums.get("vector-0.55.0-x64.msi").map(String::as_str),
+            Some("abc123")
+        );
+        assert_eq!(
+            sums.get("vector_0.55.0-1_amd64.deb").map(String::as_str),
+            Some("deadbeef"),
+        );
+        assert_eq!(sums.len(), 2);
+    }
+
+    #[test]
+    fn parses_binary_mode_sha256sums() {
+        // coreutils writes `*filename` for binary mode; strip the leading `*`.
+        let body = "feedface  *vector-0.55.0-x64.msi\n";
+        let sums = parse_sha256sums(body);
+        assert_eq!(
+            sums.get("vector-0.55.0-x64.msi").map(String::as_str),
+            Some("feedface")
+        );
+    }
+}

--- a/vdev/src/commands/release/verify/homebrew.rs
+++ b/vdev/src/commands/release/verify/homebrew.rs
@@ -1,0 +1,217 @@
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use sha2::{Digest, Sha256};
+
+use super::{VerifyOutcome, resolve_version};
+
+const DEFAULT_FORMULA_URL: &str =
+    "https://raw.githubusercontent.com/vectordotdev/homebrew-brew/master/Formula/vector.rb";
+
+/// Verify the Homebrew formula (`vectordotdev/homebrew-brew`) references the release.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+
+    /// Raw URL of the `vector.rb` Homebrew formula.
+    #[arg(long, default_value = DEFAULT_FORMULA_URL)]
+    formula_url: String,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version, &self.formula_url) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version, DEFAULT_FORMULA_URL) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
+
+fn verify_inner(version: &str, formula_url: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .build()?;
+
+    info!("Fetching Homebrew formula from {formula_url}");
+    let formula = client
+        .get(formula_url)
+        .send()
+        .with_context(|| format!("fetching {formula_url}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {formula_url}"))?
+        .text()
+        .with_context(|| format!("reading {formula_url}"))?;
+
+    let formula_version =
+        extract_version(&formula).context("no `version \"...\"` line found in formula")?;
+    if formula_version != version {
+        bail!("formula version mismatch: formula says {formula_version:?}, expected {version:?}");
+    }
+    println!("  version {formula_version} OK");
+
+    let pairs = extract_url_sha_pairs(&formula);
+    if pairs.is_empty() {
+        bail!("no url+sha256 pairs found in formula");
+    }
+
+    let version_segment = format!("/vector/{version}/");
+    let mut verified = 0usize;
+    let mut failures = 0usize;
+    let mut skipped = 0usize;
+    for (url, sha) in &pairs {
+        if !url.contains(&version_segment) {
+            println!("  SKIP  {url} (not for {version})");
+            skipped += 1;
+            continue;
+        }
+        if !is_hex64(sha) {
+            failures += 1;
+            println!("  FAIL  {url}: sha256 {sha:?} is not a 64-char hex digest");
+            continue;
+        }
+        match download_and_digest(&client, url) {
+            Ok(digest) => {
+                if digest.eq_ignore_ascii_case(sha) {
+                    verified += 1;
+                    println!("  OK    {url} sha256={digest}");
+                } else {
+                    failures += 1;
+                    println!("  FAIL  {url}: digest mismatch (formula={sha}, computed={digest})");
+                }
+            }
+            Err(e) => {
+                failures += 1;
+                println!("  FAIL  {url}: {e:#}");
+            }
+        }
+    }
+
+    if failures > 0 {
+        bail!("{failures} url+sha pair(s) failed verification");
+    }
+    if verified == 0 {
+        bail!(
+            "no url lines referenced /vector/{version}/ in formula ({skipped} url+sha pair(s) skipped)"
+        );
+    }
+    Ok(format!(
+        "formula at version {version}, {verified} url+sha pair(s) verified"
+    ))
+}
+
+fn extract_version(formula: &str) -> Option<String> {
+    for line in formula.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("version \"")
+            && let Some(end) = rest.find('"')
+        {
+            return Some(rest[..end].to_string());
+        }
+    }
+    None
+}
+
+// Walk the formula line by line. When we see a `url "..."` line, pair it with the first
+// subsequent `sha256 "..."` line (which is the convention Homebrew formulas follow).
+fn extract_url_sha_pairs(formula: &str) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    let mut pending_url: Option<String> = None;
+    for line in formula.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("url \"") {
+            if let Some(end) = rest.find('"') {
+                pending_url = Some(rest[..end].to_string());
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("sha256 \"")
+            && let Some(end) = rest.find('"')
+            && let Some(url) = pending_url.take()
+        {
+            pairs.push((url, rest[..end].to_string()));
+        }
+    }
+    pairs
+}
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn download_and_digest(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+    let mut resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?;
+    let mut hasher = Sha256::new();
+    resp.copy_to(&mut hasher)
+        .with_context(|| format!("streaming {url}"))?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_url_sha_pairs, extract_version, is_hex64};
+
+    const SAMPLE: &str = r#"class Vector < Formula
+  version "0.55.0"
+
+  on_macos do
+    on_intel do
+      url "https://packages.timber.io/vector/0.50.0/vector-0.50.0-x86_64-apple-darwin.tar.gz" # x86_64 url
+      sha256 "14b7525b9fda86856e24ac9f52035852ae4168511709080d8081ad9f01f3dec4" # x86_64 sha256
+    end
+
+    on_arm do
+      url "https://packages.timber.io/vector/0.55.0/vector-0.55.0-arm64-apple-darwin.tar.gz" # arm64 url
+      sha256 "0691862ffa7c1135f0be5258ea34e3edf11288cc192bb67a3cd8d8cad914e8c3" # arm64 sha256
+    end
+  end
+end
+"#;
+
+    #[test]
+    fn extracts_version() {
+        assert_eq!(extract_version(SAMPLE).as_deref(), Some("0.55.0"));
+    }
+
+    #[test]
+    fn extracts_url_sha_pairs() {
+        let pairs = extract_url_sha_pairs(SAMPLE);
+        assert_eq!(pairs.len(), 2);
+        assert!(pairs[0].0.contains("0.50.0"));
+        assert_eq!(
+            pairs[0].1,
+            "14b7525b9fda86856e24ac9f52035852ae4168511709080d8081ad9f01f3dec4"
+        );
+        assert!(pairs[1].0.contains("0.55.0"));
+        assert_eq!(
+            pairs[1].1,
+            "0691862ffa7c1135f0be5258ea34e3edf11288cc192bb67a3cd8d8cad914e8c3"
+        );
+    }
+
+    #[test]
+    fn hex64_validator() {
+        assert!(is_hex64(
+            "0691862ffa7c1135f0be5258ea34e3edf11288cc192bb67a3cd8d8cad914e8c3"
+        ));
+        assert!(!is_hex64("short"));
+        assert!(!is_hex64(
+            "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+        ));
+    }
+}

--- a/vdev/src/commands/release/verify/homebrew.rs
+++ b/vdev/src/commands/release/verify/homebrew.rs
@@ -1,9 +1,6 @@
-use std::time::Duration;
-
 use anyhow::{Context as _, Result, bail};
-use sha2::{Digest, Sha256};
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
 const DEFAULT_FORMULA_URL: &str =
     "https://raw.githubusercontent.com/vectordotdev/homebrew-brew/master/Formula/vector.rb";
@@ -23,37 +20,21 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version, &self.formula_url) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify_with_url(&version, &self.formula_url)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version, DEFAULT_FORMULA_URL) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
+pub fn verify(version: &str) -> Result<String> {
+    verify_with_url(version, DEFAULT_FORMULA_URL)
 }
 
-fn verify_inner(version: &str, formula_url: &str) -> Result<String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(300))
-        .build()?;
+fn verify_with_url(version: &str, formula_url: &str) -> Result<String> {
+    let client = util::stream_client()?;
 
     info!("Fetching Homebrew formula from {formula_url}");
-    let formula = client
-        .get(formula_url)
-        .send()
-        .with_context(|| format!("fetching {formula_url}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {formula_url}"))?
-        .text()
-        .with_context(|| format!("reading {formula_url}"))?;
+    let formula = util::fetch_text(&client, formula_url)?;
 
     let formula_version =
         extract_version(&formula).context("no `version \"...\"` line found in formula")?;
@@ -82,15 +63,14 @@ fn verify_inner(version: &str, formula_url: &str) -> Result<String> {
             println!("  FAIL  {url}: sha256 {sha:?} is not a 64-char hex digest");
             continue;
         }
-        match download_and_digest(&client, url) {
+        match util::stream_sha256(&client, url) {
+            Ok(digest) if digest.eq_ignore_ascii_case(sha) => {
+                verified += 1;
+                println!("  OK    {url} sha256={digest}");
+            }
             Ok(digest) => {
-                if digest.eq_ignore_ascii_case(sha) {
-                    verified += 1;
-                    println!("  OK    {url} sha256={digest}");
-                } else {
-                    failures += 1;
-                    println!("  FAIL  {url}: digest mismatch (formula={sha}, computed={digest})");
-                }
+                failures += 1;
+                println!("  FAIL  {url}: digest mismatch (formula={sha}, computed={digest})");
             }
             Err(e) => {
                 failures += 1;
@@ -147,19 +127,6 @@ fn extract_url_sha_pairs(formula: &str) -> Vec<(String, String)> {
 
 fn is_hex64(s: &str) -> bool {
     s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
-}
-
-fn download_and_digest(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
-    let mut resp = client
-        .get(url)
-        .send()
-        .with_context(|| format!("GET {url}"))?
-        .error_for_status()
-        .with_context(|| format!("GET {url}"))?;
-    let mut hasher = Sha256::new();
-    resp.copy_to(&mut hasher)
-        .with_context(|| format!("streaming {url}"))?;
-    Ok(hex::encode(hasher.finalize()))
 }
 
 #[cfg(test)]

--- a/vdev/src/commands/release/verify/mod.rs
+++ b/vdev/src/commands/release/verify/mod.rs
@@ -28,7 +28,8 @@ use crate::utils::git;
 #[derive(clap::Args, Debug)]
 #[command()]
 pub(super) struct Cli {
-    /// Version to verify (e.g. `0.55.0`). Only used when no subcommand is specified.
+    /// Version to verify (e.g. `0.55.0`). Only valid when no subcommand is specified;
+    /// pass the version to the subcommand otherwise (`vdev release verify apt 0.55.0`).
     /// Defaults to the most recent `v*` git tag.
     version: Option<String>,
 
@@ -57,6 +58,13 @@ enum Commands {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
+        if self.version.is_some() && self.command.is_some() {
+            bail!(
+                "cannot combine a top-level [VERSION] with a subcommand; \
+                 pass the version to the subcommand instead \
+                 (e.g. `vdev release verify apt 0.55.0`)",
+            );
+        }
         match self.command {
             Some(Commands::Apt(cli)) => cli.exec(),
             Some(Commands::Docker(cli)) => cli.exec(),
@@ -77,29 +85,44 @@ pub enum VerifyOutcome {
 
 type ProbeFn = fn(&str) -> VerifyOutcome;
 
+struct Probe {
+    name: &'static str,
+    run: ProbeFn,
+    // Probes the release pipeline does not guarantee (e.g. `homebrew`, which is updated
+    // by a manual `vdev release homebrew` run — not by `publish.yml`). Their failures
+    // are reported as WARN so `vdev release verify` immediately post-release isn't a
+    // false negative.
+    best_effort: bool,
+}
+
+const PROBES: &[Probe] = &[
+    Probe { name: "apt",       run: apt::verify,       best_effort: false },
+    Probe { name: "docker",    run: docker::verify,    best_effort: false },
+    Probe { name: "github",    run: github::verify,    best_effort: false },
+    Probe { name: "homebrew",  run: homebrew::verify,  best_effort: true  },
+    Probe { name: "rpm",       run: rpm::verify,       best_effort: false },
+    Probe { name: "timber-io", run: timber_io::verify, best_effort: false },
+    Probe { name: "website",   run: website::verify,   best_effort: false },
+];
+
 fn run_all(version: &str) -> Result<()> {
     println!("Verifying Vector {version}");
 
-    let probes: &[(&str, ProbeFn)] = &[
-        ("apt", apt::verify),
-        ("docker", docker::verify),
-        ("github", github::verify),
-        ("homebrew", homebrew::verify),
-        ("rpm", rpm::verify),
-        ("timber-io", timber_io::verify),
-        ("website", website::verify),
-    ];
-
     let mut ok = 0usize;
+    let mut warn = 0usize;
     let mut failed = 0usize;
 
-    for (name, probe) in probes {
+    for probe in PROBES {
         println!();
-        println!("== {name} ==");
-        match probe(version) {
+        println!("== {} ==", probe.name);
+        match (probe.run)(version) {
             VerifyOutcome::Ok(summary) => {
                 ok += 1;
                 println!("  -> OK: {summary}");
+            }
+            VerifyOutcome::Failed(e) if probe.best_effort => {
+                warn += 1;
+                println!("  -> WARN (best-effort): {e:#}");
             }
             VerifyOutcome::Failed(e) => {
                 failed += 1;
@@ -109,10 +132,10 @@ fn run_all(version: &str) -> Result<()> {
     }
 
     println!();
-    println!("Summary: {ok} OK, {failed} FAIL");
+    println!("Summary: {ok} OK, {warn} WARN, {failed} FAIL");
 
     if failed > 0 {
-        bail!("{failed} probe(s) failed");
+        bail!("{failed} required probe(s) failed");
     }
     Ok(())
 }

--- a/vdev/src/commands/release/verify/mod.rs
+++ b/vdev/src/commands/release/verify/mod.rs
@@ -5,8 +5,8 @@
 //
 //   * `pub struct Cli` — clap args; the user can run a probe directly with
 //     `vdev release verify <probe> [VERSION]`.
-//   * `pub fn verify(version: &str) -> VerifyOutcome` — called by `run_all`; prints detail
-//     inline and returns a short summary string on success.
+//   * `pub fn verify(version: &str) -> Result<String>` — called by `run_all`; prints
+//     detail inline and returns a short summary string on success.
 //
 // `vdev release verify` with no subcommand runs every probe and prints a summary.
 
@@ -16,6 +16,7 @@ mod github;
 mod homebrew;
 mod rpm;
 mod timber_io;
+mod util;
 mod website;
 
 use anyhow::{Context as _, Result, bail};
@@ -78,18 +79,13 @@ impl Cli {
     }
 }
 
-pub enum VerifyOutcome {
-    Ok(String),
-    Failed(anyhow::Error),
-}
-
-type ProbeFn = fn(&str) -> VerifyOutcome;
+type ProbeFn = fn(&str) -> Result<String>;
 
 struct Probe {
     name: &'static str,
     run: ProbeFn,
     // Probes the release pipeline does not guarantee (e.g. `homebrew`, which is updated
-    // by a manual `vdev release homebrew` run — not by `publish.yml`). Their failures
+    // by a manual `vdev release homebrew` run, not by `publish.yml`). Their failures
     // are reported as WARN so `vdev release verify` immediately post-release isn't a
     // false negative.
     best_effort: bool,
@@ -116,15 +112,15 @@ fn run_all(version: &str) -> Result<()> {
         println!();
         println!("== {} ==", probe.name);
         match (probe.run)(version) {
-            VerifyOutcome::Ok(summary) => {
+            Ok(summary) => {
                 ok += 1;
                 println!("  -> OK: {summary}");
             }
-            VerifyOutcome::Failed(e) if probe.best_effort => {
+            Err(e) if probe.best_effort => {
                 warn += 1;
                 println!("  -> WARN (best-effort): {e:#}");
             }
-            VerifyOutcome::Failed(e) => {
+            Err(e) => {
                 failed += 1;
                 println!("  -> FAIL: {e:#}");
             }

--- a/vdev/src/commands/release/verify/mod.rs
+++ b/vdev/src/commands/release/verify/mod.rs
@@ -1,0 +1,152 @@
+// Post-release verification probes.
+//
+// Each submodule is a single probe that asserts a release artifact is present and reachable
+// in a publishing target (APT repo, Docker registries, Homebrew tap, etc.). Probes expose:
+//
+//   * `pub struct Cli` — clap args; the user can run a probe directly with
+//     `vdev release verify <probe> [VERSION]`.
+//   * `pub fn verify(version: &str) -> VerifyOutcome` — called by `run_all`; prints detail
+//     inline and returns a short summary string on success.
+//
+// `vdev release verify` with no subcommand runs every probe and prints a summary.
+
+mod apt;
+mod docker;
+mod github;
+mod homebrew;
+mod rpm;
+mod timber_io;
+mod website;
+
+use anyhow::{Context as _, Result, bail};
+
+use crate::utils::git;
+
+/// Verify a Vector release is fully published across every target.
+///
+/// Runs every probe when invoked without a subcommand.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub(super) struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Only used when no subcommand is specified.
+    /// Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum Commands {
+    /// Datadog APT repo (apt.vector.dev).
+    Apt(apt::Cli),
+    /// Docker Hub and GitHub Container Registry images.
+    Docker(docker::Cli),
+    /// GitHub release assets and SHA256SUMS.
+    Github(github::Cli),
+    /// Homebrew formula (vectordotdev/homebrew-brew).
+    Homebrew(homebrew::Cli),
+    /// Datadog YUM repo (yum.vector.dev).
+    Rpm(rpm::Cli),
+    /// packages.timber.io artifact bucket.
+    #[command(name = "timber-io")]
+    TimberIo(timber_io::Cli),
+    /// vector.dev release page.
+    Website(website::Cli),
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        match self.command {
+            Some(Commands::Apt(cli)) => cli.exec(),
+            Some(Commands::Docker(cli)) => cli.exec(),
+            Some(Commands::Github(cli)) => cli.exec(),
+            Some(Commands::Homebrew(cli)) => cli.exec(),
+            Some(Commands::Rpm(cli)) => cli.exec(),
+            Some(Commands::TimberIo(cli)) => cli.exec(),
+            Some(Commands::Website(cli)) => cli.exec(),
+            None => run_all(&resolve_version(self.version)?),
+        }
+    }
+}
+
+pub enum VerifyOutcome {
+    Ok(String),
+    Failed(anyhow::Error),
+}
+
+type ProbeFn = fn(&str) -> VerifyOutcome;
+
+fn run_all(version: &str) -> Result<()> {
+    println!("Verifying Vector {version}");
+
+    let probes: &[(&str, ProbeFn)] = &[
+        ("apt", apt::verify),
+        ("docker", docker::verify),
+        ("github", github::verify),
+        ("homebrew", homebrew::verify),
+        ("rpm", rpm::verify),
+        ("timber-io", timber_io::verify),
+        ("website", website::verify),
+    ];
+
+    let mut ok = 0usize;
+    let mut failed = 0usize;
+
+    for (name, probe) in probes {
+        println!();
+        println!("== {name} ==");
+        match probe(version) {
+            VerifyOutcome::Ok(summary) => {
+                ok += 1;
+                println!("  -> OK: {summary}");
+            }
+            VerifyOutcome::Failed(e) => {
+                failed += 1;
+                println!("  -> FAIL: {e:#}");
+            }
+        }
+    }
+
+    println!();
+    println!("Summary: {ok} OK, {failed} FAIL");
+
+    if failed > 0 {
+        bail!("{failed} probe(s) failed");
+    }
+    Ok(())
+}
+
+/// Resolve a version argument, falling back to the most recent `v[0-9]*` git tag.
+///
+/// We can't use `Cargo.toml`'s version because it's bumped to the next development
+/// version immediately after a release.
+pub fn resolve_version(version: Option<String>) -> Result<String> {
+    match version {
+        Some(v) => Ok(v),
+        None => latest_release_tag(),
+    }
+}
+
+// We use `for-each-ref` sorted by creation date rather than `git describe`, because Vector
+// tags releases on release branches (not master), so HEAD-reachability is the wrong signal.
+// The glob `v[0-9]*` matches tags like `v0.55.0` while excluding `vdev-v*` (second char is
+// `d`, not a digit).
+fn latest_release_tag() -> Result<String> {
+    let tag = git::run_and_check_output(&[
+        "for-each-ref",
+        "--sort=-creatordate",
+        "--count=1",
+        "--format=%(refname:short)",
+        "refs/tags/v[0-9]*",
+    ])
+    .context("finding latest Vector release tag via `git for-each-ref`")?;
+    let tag = tag.trim();
+    if tag.is_empty() {
+        bail!("no matching release tags found (pattern: `v[0-9]*`)");
+    }
+    let version = tag
+        .strip_prefix('v')
+        .ok_or_else(|| anyhow::anyhow!("expected tag {tag:?} to start with 'v'"))?;
+    Ok(version.to_string())
+}

--- a/vdev/src/commands/release/verify/rpm.rs
+++ b/vdev/src/commands/release/verify/rpm.rs
@@ -1,9 +1,6 @@
-use std::{io::Read, time::Duration};
-
 use anyhow::{Context as _, Result, bail};
-use flate2::read::GzDecoder;
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
 const DEFAULT_BASE_URL: &str = "https://yum.vector.dev";
 const DEFAULT_SUITE: &str = "stable";
@@ -40,34 +37,25 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version, &self.url, &self.suite, &self.component) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify_with(&version, &self.url, &self.suite, &self.component)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version, DEFAULT_BASE_URL, DEFAULT_SUITE, DEFAULT_COMPONENT) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
+pub fn verify(version: &str) -> Result<String> {
+    verify_with(version, DEFAULT_BASE_URL, DEFAULT_SUITE, DEFAULT_COMPONENT)
 }
 
-fn verify_inner(version: &str, base_url: &str, suite: &str, component: &str) -> Result<String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()?;
+fn verify_with(version: &str, base_url: &str, suite: &str, component: &str) -> Result<String> {
+    let client = util::client()?;
 
     info!("Checking Vector {version} in {base_url}/{suite}/{component}");
 
     let mut failures = 0usize;
     for arch in ARCHES {
         match check_arch(&client, base_url, suite, component, arch, version) {
-            Ok(ArchResult { filename, rpm_size }) => {
+            Ok((filename, rpm_size)) => {
                 println!("  {arch:<8} OK    {filename} ({rpm_size} bytes)");
             }
             Err(e) => {
@@ -86,11 +74,6 @@ fn verify_inner(version: &str, base_url: &str, suite: &str, component: &str) -> 
     Ok(format!("{}/{} arches OK", ARCHES.len(), ARCHES.len()))
 }
 
-struct ArchResult {
-    filename: String,
-    rpm_size: u64,
-}
-
 fn check_arch(
     client: &reqwest::blocking::Client,
     base_url: &str,
@@ -98,54 +81,22 @@ fn check_arch(
     component: &str,
     arch: &str,
     version: &str,
-) -> Result<ArchResult> {
+) -> Result<(String, u64)> {
     let arch_base = format!("{base_url}/{suite}/{component}/{arch}");
-    let repomd_url = format!("{arch_base}/repodata/repomd.xml");
-    let repomd = client
-        .get(&repomd_url)
-        .send()
-        .with_context(|| format!("fetching {repomd_url}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {repomd_url}"))?
-        .text()
-        .with_context(|| format!("reading {repomd_url}"))?;
 
+    let repomd_url = format!("{arch_base}/repodata/repomd.xml");
+    let repomd = util::fetch_text(client, &repomd_url)?;
     let primary_href = find_primary_href(&repomd)
         .with_context(|| format!("no primary data entry in {repomd_url}"))?;
 
     let primary_url = format!("{arch_base}/{primary_href}");
-    let primary_body = client
-        .get(&primary_url)
-        .send()
-        .with_context(|| format!("fetching {primary_url}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {primary_url}"))?
-        .bytes()
-        .with_context(|| format!("reading {primary_url}"))?;
-
-    let mut primary = String::new();
-    GzDecoder::new(primary_body.as_ref())
-        .read_to_string(&mut primary)
-        .with_context(|| format!("gunzipping {primary_url}"))?;
-
+    let primary = util::fetch_gz_text(client, &primary_url)?;
     let filename = find_rpm_location(&primary, version)
         .with_context(|| format!("version {version}-1 not found in {primary_url}"))?;
 
     let rpm_url = format!("{arch_base}/{filename}");
-    let head = client
-        .head(&rpm_url)
-        .send()
-        .with_context(|| format!("HEAD {rpm_url}"))?
-        .error_for_status()
-        .with_context(|| format!("HEAD {rpm_url}"))?;
-    let rpm_size = head
-        .headers()
-        .get(reqwest::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(0);
-
-    Ok(ArchResult { filename, rpm_size })
+    let size = util::head_size(client, &rpm_url)?;
+    Ok((filename, size))
 }
 
 // Pull the `<location href="..."/>` out of the `<data type="primary">` block of a repomd.xml.

--- a/vdev/src/commands/release/verify/rpm.rs
+++ b/vdev/src/commands/release/verify/rpm.rs
@@ -1,0 +1,283 @@
+use std::{io::Read, time::Duration};
+
+use anyhow::{Context as _, Result, bail};
+use flate2::read::GzDecoder;
+
+use super::{VerifyOutcome, resolve_version};
+
+const DEFAULT_BASE_URL: &str = "https://yum.vector.dev";
+const DEFAULT_SUITE: &str = "stable";
+const DEFAULT_COMPONENT: &str = "vector-0";
+
+// Architectures the Datadog YUM repo actually serves a Vector rpm for. Derived from the
+// `build-linux-packages` matrix in `.github/workflows/publish.yml`: every `-linux-gnu` /
+// `-linux-gnueabihf` target that builds an rpm maps to one of these YUM arch names.
+//   x86_64-unknown-linux-gnu        -> x86_64
+//   aarch64-unknown-linux-gnu       -> aarch64
+//   armv7-unknown-linux-gnueabihf   -> armv7hl
+const ARCHES: &[&str] = &["x86_64", "aarch64", "armv7hl"];
+
+/// Verify the Datadog YUM repo serves a Vector release across every expected architecture.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+
+    /// Base URL of the YUM repo.
+    #[arg(long, default_value = DEFAULT_BASE_URL)]
+    url: String,
+
+    /// YUM suite name.
+    #[arg(long, default_value = DEFAULT_SUITE)]
+    suite: String,
+
+    /// YUM component name.
+    #[arg(long, default_value = DEFAULT_COMPONENT)]
+    component: String,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version, &self.url, &self.suite, &self.component) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version, DEFAULT_BASE_URL, DEFAULT_SUITE, DEFAULT_COMPONENT) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
+
+fn verify_inner(version: &str, base_url: &str, suite: &str, component: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+
+    info!("Checking Vector {version} in {base_url}/{suite}/{component}");
+
+    let mut failures = 0usize;
+    for arch in ARCHES {
+        match check_arch(&client, base_url, suite, component, arch, version) {
+            Ok(ArchResult { filename, rpm_size }) => {
+                println!("  {arch:<8} OK    {filename} ({rpm_size} bytes)");
+            }
+            Err(e) => {
+                failures += 1;
+                println!("  {arch:<8} FAIL  {e:#}");
+            }
+        }
+    }
+
+    if failures > 0 {
+        bail!(
+            "{failures}/{} architectures missing {version}",
+            ARCHES.len()
+        );
+    }
+    Ok(format!("{}/{} arches OK", ARCHES.len(), ARCHES.len()))
+}
+
+struct ArchResult {
+    filename: String,
+    rpm_size: u64,
+}
+
+fn check_arch(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    suite: &str,
+    component: &str,
+    arch: &str,
+    version: &str,
+) -> Result<ArchResult> {
+    let arch_base = format!("{base_url}/{suite}/{component}/{arch}");
+    let repomd_url = format!("{arch_base}/repodata/repomd.xml");
+    let repomd = client
+        .get(&repomd_url)
+        .send()
+        .with_context(|| format!("fetching {repomd_url}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {repomd_url}"))?
+        .text()
+        .with_context(|| format!("reading {repomd_url}"))?;
+
+    let primary_href = find_primary_href(&repomd)
+        .with_context(|| format!("no primary data entry in {repomd_url}"))?;
+
+    let primary_url = format!("{arch_base}/{primary_href}");
+    let primary_body = client
+        .get(&primary_url)
+        .send()
+        .with_context(|| format!("fetching {primary_url}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {primary_url}"))?
+        .bytes()
+        .with_context(|| format!("reading {primary_url}"))?;
+
+    let mut primary = String::new();
+    GzDecoder::new(primary_body.as_ref())
+        .read_to_string(&mut primary)
+        .with_context(|| format!("gunzipping {primary_url}"))?;
+
+    let filename = find_rpm_location(&primary, version)
+        .with_context(|| format!("version {version}-1 not found in {primary_url}"))?;
+
+    let rpm_url = format!("{arch_base}/{filename}");
+    let head = client
+        .head(&rpm_url)
+        .send()
+        .with_context(|| format!("HEAD {rpm_url}"))?
+        .error_for_status()
+        .with_context(|| format!("HEAD {rpm_url}"))?;
+    let rpm_size = head
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    Ok(ArchResult { filename, rpm_size })
+}
+
+// Pull the `<location href="..."/>` out of the `<data type="primary">` block of a repomd.xml.
+// repomd.xml is small and well-formed; scanning for literal tags is plenty here.
+fn find_primary_href(repomd: &str) -> Option<String> {
+    let start = repomd.find(r#"<data type="primary">"#)?;
+    let tail = &repomd[start..];
+    let end = tail.find("</data>")?;
+    extract_href(&tail[..end])
+}
+
+// Scan primary.xml for the `<package type="rpm">` stanza matching `ver="{version}" rel="1"`
+// and return its `<location href="..."/>` (the relative rpm path inside the arch dir).
+fn find_rpm_location(primary: &str, version: &str) -> Option<String> {
+    let wanted_version = format!(r#"ver="{version}""#);
+    // Split on `<package type=` rather than `<package` — the latter also matches `<packager>`
+    // tags, which appear inside every package stanza and would split it mid-body.
+    for stanza in primary.split("<package type=") {
+        // Each `<package>...</package>` contains a single `<version epoch="0" ver="X" rel="Y"/>`
+        // line. We look for both `ver="X"` and `rel="1"` on the same `<version>` line.
+        if !stanza.contains(&wanted_version) {
+            continue;
+        }
+        let version_line = stanza
+            .lines()
+            .find(|line| line.contains("<version ") && line.contains(&wanted_version))?;
+        if !version_line.contains(r#" rel="1""#) {
+            continue;
+        }
+        return extract_href(stanza);
+    }
+    None
+}
+
+// Extract the first `href="..."` attribute from a `<location ... />` element within `block`.
+fn extract_href(block: &str) -> Option<String> {
+    let loc_start = block.find("<location ")?;
+    let rest = &block[loc_start..];
+    let tag_end = rest.find("/>")?;
+    let tag = &rest[..tag_end];
+    let href_start = tag.find(r#"href=""#)? + r#"href=""#.len();
+    let value = &tag[href_start..];
+    let href_end = value.find('"')?;
+    Some(value[..href_end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_primary_href, find_rpm_location};
+
+    #[test]
+    fn extracts_primary_href_from_repomd() {
+        let repomd = r#"<?xml version="1.0"?>
+<repomd>
+<data type="filelists">
+  <location href="repodata/abc-filelists.xml.gz"/>
+</data>
+<data type="primary">
+  <checksum type="sha256">deadbeef</checksum>
+  <location href="repodata/abc-primary.xml.gz"/>
+</data>
+</repomd>"#;
+        assert_eq!(
+            find_primary_href(repomd).as_deref(),
+            Some("repodata/abc-primary.xml.gz"),
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_primary_block() {
+        let repomd = r#"<repomd><data type="other"><location href="x.xml.gz"/></data></repomd>"#;
+        assert_eq!(find_primary_href(repomd), None);
+    }
+
+    #[test]
+    fn finds_matching_package_stanza() {
+        let primary = r#"<?xml version="1.0"?>
+<metadata>
+<package type="rpm">
+  <name>vector</name>
+  <arch>x86_64</arch>
+  <version epoch="0" ver="0.54.0" rel="1"/>
+<location href="vector-0.54.0-1.x86_64.rpm"/>
+</package>
+<package type="rpm">
+  <name>vector</name>
+  <arch>x86_64</arch>
+  <version epoch="0" ver="0.55.0" rel="1"/>
+<location href="vector-0.55.0-1.x86_64.rpm"/>
+</package>
+</metadata>"#;
+        assert_eq!(
+            find_rpm_location(primary, "0.55.0").as_deref(),
+            Some("vector-0.55.0-1.x86_64.rpm"),
+        );
+        assert_eq!(
+            find_rpm_location(primary, "0.54.0").as_deref(),
+            Some("vector-0.54.0-1.x86_64.rpm"),
+        );
+        assert_eq!(find_rpm_location(primary, "0.56.0"), None);
+    }
+
+    // Real `primary.xml` stanzas include a `<packager></packager>` tag, which contains the
+    // literal prefix `<package`. A naive split on `<package` would chop the stanza in half
+    // mid-body, losing the `<location>` tag that comes after it.
+    #[test]
+    fn packager_tag_does_not_break_split() {
+        let primary = r#"<metadata>
+<package type="rpm">
+  <name>vector</name>
+  <version epoch="0" ver="0.55.0" rel="1"/>
+  <packager></packager>
+<location href="vector-0.55.0-1.x86_64.rpm"/>
+</package>
+</metadata>"#;
+        assert_eq!(
+            find_rpm_location(primary, "0.55.0").as_deref(),
+            Some("vector-0.55.0-1.x86_64.rpm"),
+        );
+    }
+
+    #[test]
+    fn ignores_non_rel_1_builds() {
+        let primary = r#"<package type="rpm">
+  <version epoch="0" ver="0.55.0" rel="2"/>
+<location href="vector-0.55.0-2.x86_64.rpm"/>
+</package>"#;
+        assert_eq!(find_rpm_location(primary, "0.55.0"), None);
+    }
+
+    #[test]
+    fn empty_index_has_no_match() {
+        assert_eq!(find_rpm_location("", "0.55.0"), None);
+    }
+}

--- a/vdev/src/commands/release/verify/timber_io.rs
+++ b/vdev/src/commands/release/verify/timber_io.rs
@@ -1,9 +1,6 @@
-use std::time::Duration;
-
 use anyhow::{Context as _, Result, bail};
-use sha2::{Digest, Sha256};
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
 const DEFAULT_BASE_URL: &str = "https://packages.timber.io/vector";
 
@@ -75,34 +72,22 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version, &self.url) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify_with_url(&version, &self.url)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version, DEFAULT_BASE_URL) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
+pub fn verify(version: &str) -> Result<String> {
+    verify_with_url(version, DEFAULT_BASE_URL)
 }
 
-fn verify_inner(version: &str, base_url: &str) -> Result<String> {
+fn verify_with_url(version: &str, base_url: &str) -> Result<String> {
     info!("Checking Vector {version} at {base_url}/{version}/");
 
-    // Short timeout for HEADs; the sha256 GETs stream large bodies so they get their own
-    // client with a generous timeout.
-    let head_client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()?;
-    let stream_client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(300))
-        .build()?;
+    // HEADs are quick; SHA256 GETs stream multi-MB bodies and need a generous timeout.
+    let head_client = util::client()?;
+    let stream_client = util::stream_client()?;
 
     let expected: Vec<String> = ARTIFACT_TEMPLATES
         .iter()
@@ -139,7 +124,7 @@ fn check_exact_path(
     let mut missing = 0usize;
     for filename in expected {
         let url = format!("{base_url}/{version}/{filename}");
-        match head_size(client, &url) {
+        match util::head_size(client, &url) {
             Ok(size) => println!("  exact    OK    {filename} ({size} bytes)"),
             Err(e) => {
                 missing += 1;
@@ -165,46 +150,37 @@ fn check_aliases(
         "latest".to_string(),
     ];
     let versioned_alias_file = ALIAS_PROBE_TEMPLATE.replace("{v}", version);
-    let latest_named_file = ALIAS_PROBE_LATEST_TEMPLATE;
 
     let mut failures = 0usize;
     for alias in &aliases {
-        // The versioned filename should be served directly (200) at every alias path.
+        // Versioned filename served directly (200) at every alias path.
         let url = format!("{base_url}/{alias}/{versioned_alias_file}");
-        match head_size(client, &url) {
-            Ok(size) => println!("  {alias:<8} OK    {versioned_alias_file} ({size} bytes)"),
-            Err(e) => {
-                failures += 1;
-                println!("  {alias:<8} FAIL  {versioned_alias_file}: {e:#}");
-            }
-        }
+        failures += report_alias(alias, &versioned_alias_file, util::head_size(client, &url));
 
-        // Versionless-stripped redirect: created by `release-s3.sh` in every alias path.
-        // Follows a website-redirect to the versioned file.
+        // Versionless-stripped redirect, created by `release-s3.sh` in every alias path.
         let stripped_url = format!("{base_url}/{alias}/{ALIAS_PROBE_STRIPPED}");
-        match head_follow(client, &stripped_url) {
-            Ok(size) => {
-                println!("  {alias:<8} OK    {ALIAS_PROBE_STRIPPED} -> 200 ({size} bytes)");
-            }
-            Err(e) => {
-                failures += 1;
-                println!("  {alias:<8} FAIL  {ALIAS_PROBE_STRIPPED}: {e:#}");
-            }
-        }
+        failures += report_alias(alias, ALIAS_PROBE_STRIPPED, util::head_size(client, &stripped_url));
     }
 
     // The `latest`-named alias (e.g. `vector-latest-...`) is a website-redirect -> 200,
     // only present under `/vector/latest/`.
-    let url = format!("{base_url}/latest/{latest_named_file}");
-    match head_follow(client, &url) {
-        Ok(size) => println!("  latest   OK    {latest_named_file} -> 200 ({size} bytes)"),
-        Err(e) => {
-            failures += 1;
-            println!("  latest   FAIL  {latest_named_file}: {e:#}");
-        }
-    }
+    let url = format!("{base_url}/latest/{ALIAS_PROBE_LATEST_TEMPLATE}");
+    failures += report_alias("latest", ALIAS_PROBE_LATEST_TEMPLATE, util::head_size(client, &url));
 
     Ok(failures)
+}
+
+fn report_alias(alias: &str, filename: &str, result: Result<u64>) -> usize {
+    match result {
+        Ok(size) => {
+            println!("  {alias:<8} OK    {filename} ({size} bytes)");
+            0
+        }
+        Err(e) => {
+            println!("  {alias:<8} FAIL  {filename}: {e:#}");
+            1
+        }
+    }
 }
 
 // Fetch SHA256SUMS and stream-hash the CHECKSUM_SAMPLES files against it. Returns
@@ -216,28 +192,20 @@ fn check_checksums(
     version: &str,
 ) -> Result<(usize, usize)> {
     let sha_url = format!("{base_url}/{version}/vector-{version}-SHA256SUMS");
-    let sha_body = client
-        .get(&sha_url)
-        .send()
-        .with_context(|| format!("fetching {sha_url}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {sha_url}"))?
-        .text()
-        .with_context(|| format!("reading {sha_url}"))?;
-    let sums = parse_sha256sums(&sha_body);
+    let sums = util::parse_sha256sums(&util::fetch_text(client, &sha_url)?);
 
     let mut ok = 0usize;
     let mut fail = 0usize;
     for template in CHECKSUM_SAMPLES {
         let filename = template.replace("{v}", version);
-        let Some((_, expected_hex)) = sums.iter().find(|(name, _)| name == &filename) else {
+        let Some(expected_hex) = sums.get(&filename) else {
             fail += 1;
             println!("  checksum FAIL  {filename}: not listed in SHA256SUMS");
             continue;
         };
         let url = format!("{base_url}/{version}/{filename}");
-        match stream_sha256(client, &url) {
-            Ok(actual) if &actual == expected_hex => {
+        match util::stream_sha256(client, &url) {
+            Ok(actual) if actual.eq_ignore_ascii_case(expected_hex) => {
                 ok += 1;
                 println!("  checksum OK    {filename} sha256={expected_hex}");
             }
@@ -252,83 +220,6 @@ fn check_checksums(
         }
     }
     Ok((ok, fail))
-}
-
-fn head_size(client: &reqwest::blocking::Client, url: &str) -> Result<u64> {
-    let resp = client
-        .head(url)
-        .send()
-        .with_context(|| format!("HEAD {url}"))?
-        .error_for_status()
-        .with_context(|| format!("HEAD {url}"))?;
-    Ok(content_length(&resp).unwrap_or(0))
-}
-
-// HEAD with redirects followed; expects a final 200. Used for the `latest`-named alias
-// that points at a website-redirect to the real file.
-fn head_follow(client: &reqwest::blocking::Client, url: &str) -> Result<u64> {
-    // reqwest's blocking client follows redirects on HEAD by default (up to 10 hops).
-    let resp = client
-        .head(url)
-        .send()
-        .with_context(|| format!("HEAD {url}"))?
-        .error_for_status()
-        .with_context(|| format!("HEAD {url}"))?;
-    Ok(content_length(&resp).unwrap_or(0))
-}
-
-fn content_length(resp: &reqwest::blocking::Response) -> Option<u64> {
-    resp.headers()
-        .get(reqwest::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-}
-
-// Stream-download `url` through SHA-256 without buffering the whole body. Returns the
-// lowercase hex digest. Uses an 8 KiB copy buffer via `io::copy`.
-fn stream_sha256(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
-    use std::io::Write;
-
-    struct Hasher(Sha256);
-    impl Write for Hasher {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0.update(buf);
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    let mut resp = client
-        .get(url)
-        .send()
-        .with_context(|| format!("GET {url}"))?
-        .error_for_status()
-        .with_context(|| format!("GET {url}"))?;
-
-    let mut hasher = Hasher(Sha256::new());
-    std::io::copy(&mut resp, &mut hasher).with_context(|| format!("streaming {url}"))?;
-    Ok(hex::encode(hasher.0.finalize()))
-}
-
-// Parse GNU `sha256sum`-style output: each line is `<hex>  <filename>` (two spaces between).
-// Tolerates `<hex> *<filename>` (binary-mode marker) and trims blank lines.
-fn parse_sha256sums(body: &str) -> Vec<(String, String)> {
-    let mut out = Vec::new();
-    for line in body.lines() {
-        let line = line.trim_end_matches('\r');
-        if line.trim().is_empty() {
-            continue;
-        }
-        let mut parts = line.splitn(2, "  ");
-        let (Some(hex), Some(rest)) = (parts.next(), parts.next()) else {
-            continue;
-        };
-        let filename = rest.strip_prefix('*').unwrap_or(rest).to_string();
-        out.push((filename, hex.to_string()));
-    }
-    out
 }
 
 // Split "0.55.0" -> ("0", "55"). We don't care about the patch digit here; the aliases
@@ -348,42 +239,10 @@ fn parse_major_minor(version: &str) -> Result<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_major_minor, parse_sha256sums};
+    use super::parse_major_minor;
 
     #[test]
-    fn parses_sha256sums_two_space_delimited() {
-        let body = "\
-abc123  vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz
-deadbeef  vector_0.55.0-1_amd64.deb
-
-";
-        let parsed = parse_sha256sums(body);
-        assert_eq!(parsed.len(), 2);
-        assert_eq!(
-            parsed[0],
-            (
-                "vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz".to_string(),
-                "abc123".to_string()
-            )
-        );
-        assert_eq!(
-            parsed[1],
-            (
-                "vector_0.55.0-1_amd64.deb".to_string(),
-                "deadbeef".to_string()
-            )
-        );
-    }
-
-    #[test]
-    fn parses_sha256sums_binary_marker() {
-        let body = "abc123  *vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz\n";
-        let parsed = parse_sha256sums(body);
-        assert_eq!(parsed[0].0, "vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz");
-    }
-
-    #[test]
-    fn parses_major_minor() {
+    fn parses_major_minor_basic() {
         assert_eq!(parse_major_minor("0.55.0").unwrap(), ("0", "55"));
         assert_eq!(parse_major_minor("1.2.3-pre").unwrap(), ("1", "2"));
         assert!(parse_major_minor("1").is_err());

--- a/vdev/src/commands/release/verify/timber_io.rs
+++ b/vdev/src/commands/release/verify/timber_io.rs
@@ -1,0 +1,372 @@
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+use sha2::{Digest, Sha256};
+
+use super::{VerifyOutcome, resolve_version};
+
+const DEFAULT_BASE_URL: &str = "https://packages.timber.io/vector";
+
+// Expected artifacts for every versioned release of Vector, parameterised by `{version}`.
+// Derived from the `build-linux-packages` / `build-apple-darwin-packages` /
+// `build-x86_64-pc-windows-msvc-packages` / `generate-sha256sum` jobs in
+// `.github/workflows/publish.yml` and the matching `make package-*` targets. Keep this list
+// in sync with the `github` probe's expected asset list.
+const ARTIFACT_TEMPLATES: &[&str] = &[
+    // Linux tarballs
+    "vector-{v}-x86_64-unknown-linux-gnu.tar.gz",
+    "vector-{v}-x86_64-unknown-linux-musl.tar.gz",
+    "vector-{v}-aarch64-unknown-linux-gnu.tar.gz",
+    "vector-{v}-aarch64-unknown-linux-musl.tar.gz",
+    "vector-{v}-armv7-unknown-linux-gnueabihf.tar.gz",
+    "vector-{v}-armv7-unknown-linux-musleabihf.tar.gz",
+    "vector-{v}-arm-unknown-linux-gnueabi.tar.gz",
+    "vector-{v}-arm-unknown-linux-musleabi.tar.gz",
+    // Debian packages (only produced for targets whose `package-%-all` target includes a .deb)
+    "vector_{v}-1_amd64.deb",
+    "vector_{v}-1_arm64.deb",
+    "vector_{v}-1_armhf.deb",
+    "vector_{v}-1_armel.deb",
+    // RPM packages
+    "vector-{v}-1.x86_64.rpm",
+    "vector-{v}-1.aarch64.rpm",
+    "vector-{v}-1.armv7hl.rpm",
+    // Windows
+    "vector-{v}-x86_64-pc-windows-msvc.zip",
+    "vector-{v}-x64.msi",
+    // macOS
+    "vector-{v}-arm64-apple-darwin.tar.gz",
+    // Checksum manifest
+    "vector-{v}-SHA256SUMS",
+];
+
+// Representative artifacts checksummed end-to-end. One deb (the most-downloaded package
+// format) and one Linux tarball (the canonical `install.sh` target) give decent coverage
+// without paying for ~30 MB per sample x18.
+const CHECKSUM_SAMPLES: &[&str] = &[
+    "vector_{v}-1_amd64.deb",
+    "vector-{v}-x86_64-unknown-linux-gnu.tar.gz",
+];
+
+// Representative file used for aliased-path probes. Picked because the release-s3.sh
+// verification step uses this exact file, so we mirror its contract.
+const ALIAS_PROBE_TEMPLATE: &str = "vector-{v}-x86_64-unknown-linux-gnu.tar.gz";
+const ALIAS_PROBE_LATEST_TEMPLATE: &str = "vector-latest-x86_64-unknown-linux-gnu.tar.gz";
+
+/// Verify `packages.timber.io/vector/` has every release artifact at the exact-version
+/// path AND at the aliased paths (`{major}.X`, `{major}.{minor}.X`, `latest`).
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+
+    /// Base URL of the artifact bucket (no trailing slash).
+    #[arg(long, default_value = DEFAULT_BASE_URL)]
+    url: String,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version, &self.url) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version, DEFAULT_BASE_URL) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
+
+fn verify_inner(version: &str, base_url: &str) -> Result<String> {
+    info!("Checking Vector {version} at {base_url}/{version}/");
+
+    // Short timeout for HEADs; the sha256 GETs stream large bodies so they get their own
+    // client with a generous timeout.
+    let head_client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let stream_client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .build()?;
+
+    let expected: Vec<String> = ARTIFACT_TEMPLATES
+        .iter()
+        .map(|t| t.replace("{v}", version))
+        .collect();
+
+    let missing = check_exact_path(&head_client, base_url, version, &expected);
+    let alias_failures = check_aliases(&head_client, base_url, version)?;
+    let (checksum_ok, checksum_fail) = check_checksums(&stream_client, base_url, version)?;
+
+    if missing > 0 || alias_failures > 0 || checksum_fail > 0 {
+        bail!(
+            "{missing}/{} files missing at exact path, {alias_failures} alias failure(s), {checksum_fail}/{} checksum failure(s)",
+            expected.len(),
+            CHECKSUM_SAMPLES.len(),
+        );
+    }
+
+    Ok(format!(
+        "{}/{} files present + {checksum_ok}/{} checksums verified",
+        expected.len(),
+        expected.len(),
+        CHECKSUM_SAMPLES.len(),
+    ))
+}
+
+// HEAD every expected file at `/<version>/`. Returns the number missing/unreachable.
+fn check_exact_path(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    version: &str,
+    expected: &[String],
+) -> usize {
+    let mut missing = 0usize;
+    for filename in expected {
+        let url = format!("{base_url}/{version}/{filename}");
+        match head_size(client, &url) {
+            Ok(size) => println!("  exact    OK    {filename} ({size} bytes)"),
+            Err(e) => {
+                missing += 1;
+                println!("  exact    FAIL  {filename}: {e:#}");
+            }
+        }
+    }
+    missing
+}
+
+// Probe the three aliased paths (`<major>.<minor>.X`, `<major>.X`, `latest`). Returns
+// the number of failed probes across both the versioned-filename and the alias-named
+// redirect form.
+fn check_aliases(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    version: &str,
+) -> Result<usize> {
+    let (major, minor) = parse_major_minor(version)?;
+    let aliases = [
+        format!("{major}.{minor}.X"),
+        format!("{major}.X"),
+        "latest".to_string(),
+    ];
+    let versioned_alias_file = ALIAS_PROBE_TEMPLATE.replace("{v}", version);
+    let latest_named_file = ALIAS_PROBE_LATEST_TEMPLATE;
+
+    let mut failures = 0usize;
+    for alias in &aliases {
+        // The versioned filename should be served directly (200) at every alias path.
+        let url = format!("{base_url}/{alias}/{versioned_alias_file}");
+        match head_size(client, &url) {
+            Ok(size) => println!("  {alias:<8} OK    {versioned_alias_file} ({size} bytes)"),
+            Err(e) => {
+                failures += 1;
+                println!("  {alias:<8} FAIL  {versioned_alias_file}: {e:#}");
+            }
+        }
+    }
+
+    // The `latest`-named alias (e.g. `vector-latest-...`) is a website-redirect -> 200.
+    let url = format!("{base_url}/latest/{latest_named_file}");
+    match head_follow(client, &url) {
+        Ok(size) => println!("  latest   OK    {latest_named_file} -> 200 ({size} bytes)"),
+        Err(e) => {
+            failures += 1;
+            println!("  latest   FAIL  {latest_named_file}: {e:#}");
+        }
+    }
+
+    Ok(failures)
+}
+
+// Fetch SHA256SUMS and stream-hash the CHECKSUM_SAMPLES files against it. Returns
+// (ok_count, fail_count). Failures include: sample missing from SHA256SUMS, download
+// failure, and digest mismatch.
+fn check_checksums(
+    client: &reqwest::blocking::Client,
+    base_url: &str,
+    version: &str,
+) -> Result<(usize, usize)> {
+    let sha_url = format!("{base_url}/{version}/vector-{version}-SHA256SUMS");
+    let sha_body = client
+        .get(&sha_url)
+        .send()
+        .with_context(|| format!("fetching {sha_url}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {sha_url}"))?
+        .text()
+        .with_context(|| format!("reading {sha_url}"))?;
+    let sums = parse_sha256sums(&sha_body);
+
+    let mut ok = 0usize;
+    let mut fail = 0usize;
+    for template in CHECKSUM_SAMPLES {
+        let filename = template.replace("{v}", version);
+        let Some((_, expected_hex)) = sums.iter().find(|(name, _)| name == &filename) else {
+            fail += 1;
+            println!("  checksum FAIL  {filename}: not listed in SHA256SUMS");
+            continue;
+        };
+        let url = format!("{base_url}/{version}/{filename}");
+        match stream_sha256(client, &url) {
+            Ok(actual) if &actual == expected_hex => {
+                ok += 1;
+                println!("  checksum OK    {filename} sha256={expected_hex}");
+            }
+            Ok(actual) => {
+                fail += 1;
+                println!("  checksum FAIL  {filename}: expected {expected_hex}, got {actual}");
+            }
+            Err(e) => {
+                fail += 1;
+                println!("  checksum FAIL  {filename}: {e:#}");
+            }
+        }
+    }
+    Ok((ok, fail))
+}
+
+fn head_size(client: &reqwest::blocking::Client, url: &str) -> Result<u64> {
+    let resp = client
+        .head(url)
+        .send()
+        .with_context(|| format!("HEAD {url}"))?
+        .error_for_status()
+        .with_context(|| format!("HEAD {url}"))?;
+    Ok(content_length(&resp).unwrap_or(0))
+}
+
+// HEAD with redirects followed; expects a final 200. Used for the `latest`-named alias
+// that points at a website-redirect to the real file.
+fn head_follow(client: &reqwest::blocking::Client, url: &str) -> Result<u64> {
+    // reqwest's blocking client follows redirects on HEAD by default (up to 10 hops).
+    let resp = client
+        .head(url)
+        .send()
+        .with_context(|| format!("HEAD {url}"))?
+        .error_for_status()
+        .with_context(|| format!("HEAD {url}"))?;
+    Ok(content_length(&resp).unwrap_or(0))
+}
+
+fn content_length(resp: &reqwest::blocking::Response) -> Option<u64> {
+    resp.headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+}
+
+// Stream-download `url` through SHA-256 without buffering the whole body. Returns the
+// lowercase hex digest. Uses an 8 KiB copy buffer via `io::copy`.
+fn stream_sha256(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+    use std::io::Write;
+
+    struct Hasher(Sha256);
+    impl Write for Hasher {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.update(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?;
+
+    let mut hasher = Hasher(Sha256::new());
+    std::io::copy(&mut resp, &mut hasher).with_context(|| format!("streaming {url}"))?;
+    Ok(hex::encode(hasher.0.finalize()))
+}
+
+// Parse GNU `sha256sum`-style output: each line is `<hex>  <filename>` (two spaces between).
+// Tolerates `<hex> *<filename>` (binary-mode marker) and trims blank lines.
+fn parse_sha256sums(body: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(2, "  ");
+        let (Some(hex), Some(rest)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let filename = rest.strip_prefix('*').unwrap_or(rest).to_string();
+        out.push((filename, hex.to_string()));
+    }
+    out
+}
+
+// Split "0.55.0" -> ("0", "55"). We don't care about the patch digit here; the aliases
+// `{major}.X` and `{major}.{minor}.X` only use the first two components.
+fn parse_major_minor(version: &str) -> Result<(&str, &str)> {
+    let mut parts = version.splitn(3, '.');
+    let major = parts
+        .next()
+        .filter(|s| !s.is_empty())
+        .with_context(|| format!("version {version:?} has no major component"))?;
+    let minor = parts
+        .next()
+        .filter(|s| !s.is_empty())
+        .with_context(|| format!("version {version:?} has no minor component"))?;
+    Ok((major, minor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_major_minor, parse_sha256sums};
+
+    #[test]
+    fn parses_sha256sums_two_space_delimited() {
+        let body = "\
+abc123  vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz
+deadbeef  vector_0.55.0-1_amd64.deb
+
+";
+        let parsed = parse_sha256sums(body);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(
+            parsed[0],
+            (
+                "vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz".to_string(),
+                "abc123".to_string()
+            )
+        );
+        assert_eq!(
+            parsed[1],
+            (
+                "vector_0.55.0-1_amd64.deb".to_string(),
+                "deadbeef".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn parses_sha256sums_binary_marker() {
+        let body = "abc123  *vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz\n";
+        let parsed = parse_sha256sums(body);
+        assert_eq!(parsed[0].0, "vector-0.55.0-x86_64-unknown-linux-gnu.tar.gz");
+    }
+
+    #[test]
+    fn parses_major_minor() {
+        assert_eq!(parse_major_minor("0.55.0").unwrap(), ("0", "55"));
+        assert_eq!(parse_major_minor("1.2.3-pre").unwrap(), ("1", "2"));
+        assert!(parse_major_minor("1").is_err());
+        assert!(parse_major_minor("").is_err());
+    }
+}

--- a/vdev/src/commands/release/verify/timber_io.rs
+++ b/vdev/src/commands/release/verify/timber_io.rs
@@ -51,6 +51,12 @@ const CHECKSUM_SAMPLES: &[&str] = &[
 // Representative file used for aliased-path probes. Picked because the release-s3.sh
 // verification step uses this exact file, so we mirror its contract.
 const ALIAS_PROBE_TEMPLATE: &str = "vector-{v}-x86_64-unknown-linux-gnu.tar.gz";
+// Versionless-stripped form (`${file/-$VERSION_EXACT/}` in release-s3.sh): a website
+// redirect that `release-s3.sh` creates in *every* alias path (exact, `{major}.{minor}.X`,
+// `{major}.X`, `latest`). Must resolve to 200 after following the redirect.
+const ALIAS_PROBE_STRIPPED: &str = "vector-x86_64-unknown-linux-gnu.tar.gz";
+// `latest`-substitution form (`${file/$VERSION_EXACT/latest}` in release-s3.sh): only
+// created under `/vector/latest/`.
 const ALIAS_PROBE_LATEST_TEMPLATE: &str = "vector-latest-x86_64-unknown-linux-gnu.tar.gz";
 
 /// Verify `packages.timber.io/vector/` has every release artifact at the exact-version
@@ -172,9 +178,23 @@ fn check_aliases(
                 println!("  {alias:<8} FAIL  {versioned_alias_file}: {e:#}");
             }
         }
+
+        // Versionless-stripped redirect: created by `release-s3.sh` in every alias path.
+        // Follows a website-redirect to the versioned file.
+        let stripped_url = format!("{base_url}/{alias}/{ALIAS_PROBE_STRIPPED}");
+        match head_follow(client, &stripped_url) {
+            Ok(size) => {
+                println!("  {alias:<8} OK    {ALIAS_PROBE_STRIPPED} -> 200 ({size} bytes)");
+            }
+            Err(e) => {
+                failures += 1;
+                println!("  {alias:<8} FAIL  {ALIAS_PROBE_STRIPPED}: {e:#}");
+            }
+        }
     }
 
-    // The `latest`-named alias (e.g. `vector-latest-...`) is a website-redirect -> 200.
+    // The `latest`-named alias (e.g. `vector-latest-...`) is a website-redirect -> 200,
+    // only present under `/vector/latest/`.
     let url = format!("{base_url}/latest/{latest_named_file}");
     match head_follow(client, &url) {
         Ok(size) => println!("  latest   OK    {latest_named_file} -> 200 ({size} bytes)"),

--- a/vdev/src/commands/release/verify/util.rs
+++ b/vdev/src/commands/release/verify/util.rs
@@ -1,0 +1,142 @@
+// Shared helpers for release-verification probes.
+
+use std::{collections::HashMap, io::Read, time::Duration};
+
+use anyhow::{Context as _, Result};
+use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
+
+const USER_AGENT: &str = "vdev-release-verify";
+
+/// Blocking HTTP client with sane defaults for short requests (HEAD, small GETs).
+pub fn client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(Into::into)
+}
+
+/// Blocking HTTP client tuned for large streaming downloads (e.g. SHA256 sampling
+/// of multi-MB artifacts).
+pub fn stream_client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(Into::into)
+}
+
+/// HEAD `url` and return the advertised Content-Length (0 if the server omits it).
+/// Follows redirects (reqwest's default policy is up to 10 hops).
+pub fn head_size(client: &reqwest::blocking::Client, url: &str) -> Result<u64> {
+    let resp = client
+        .head(url)
+        .send()
+        .with_context(|| format!("HEAD {url}"))?
+        .error_for_status()
+        .with_context(|| format!("HEAD {url}"))?;
+    Ok(content_length(&resp).unwrap_or(0))
+}
+
+/// GET `url` and return the body as a UTF-8 string. Bails on non-2xx.
+pub fn fetch_text(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+    client
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?
+        .text()
+        .with_context(|| format!("reading body of {url}"))
+}
+
+/// GET `url`, gunzip the body, and return the decompressed text.
+pub fn fetch_gz_text(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+    let body = client
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?
+        .bytes()
+        .with_context(|| format!("reading body of {url}"))?;
+    let mut decoded = String::new();
+    GzDecoder::new(body.as_ref())
+        .read_to_string(&mut decoded)
+        .with_context(|| format!("gunzipping {url}"))?;
+    Ok(decoded)
+}
+
+/// Stream `url` through SHA-256 without buffering the whole body. Returns the
+/// lowercase hex digest. Suitable for multi-MB release artifacts.
+pub fn stream_sha256(client: &reqwest::blocking::Client, url: &str) -> Result<String> {
+    struct Hasher(Sha256);
+    impl std::io::Write for Hasher {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.update(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?;
+    let mut hasher = Hasher(Sha256::new());
+    std::io::copy(&mut resp, &mut hasher).with_context(|| format!("streaming {url}"))?;
+    Ok(hex::encode(hasher.0.finalize()))
+}
+
+/// Parse coreutils-style `sha256sum` output into a `{filename: hex_digest}` map.
+///
+/// Handles both text mode (`<hex>  <filename>`, two spaces) and binary mode
+/// (`<hex> *<filename>`, one space + asterisk). Skips blank and comment lines.
+pub fn parse_sha256sums(body: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for line in body.lines() {
+        let line = line.trim_end_matches('\r').trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((digest, rest)) = line.split_once(char::is_whitespace) else {
+            continue;
+        };
+        let name = rest.trim_start();
+        let name = name.strip_prefix('*').unwrap_or(name).trim();
+        out.insert(name.to_string(), digest.to_string());
+    }
+    out
+}
+
+fn content_length(resp: &reqwest::blocking::Response) -> Option<u64> {
+    resp.headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_sha256sums;
+
+    #[test]
+    fn parses_coreutils_style() {
+        let body = "\
+abc123  vector-amd64.deb
+def456 *vector.tar.gz
+
+# comment
+789ghi  vector.rpm
+";
+        let map = parse_sha256sums(body);
+        assert_eq!(map.get("vector-amd64.deb").map(String::as_str), Some("abc123"));
+        assert_eq!(map.get("vector.tar.gz").map(String::as_str), Some("def456"));
+        assert_eq!(map.get("vector.rpm").map(String::as_str), Some("789ghi"));
+    }
+}

--- a/vdev/src/commands/release/verify/website.rs
+++ b/vdev/src/commands/release/verify/website.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
-
 use anyhow::{Context as _, Result, bail};
 
-use super::{VerifyOutcome, resolve_version};
+use super::{resolve_version, util};
 
 const DEFAULT_BASE_URL: &str = "https://vector.dev";
 
@@ -25,27 +23,18 @@ pub struct Cli {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let version = resolve_version(self.version)?;
-        match verify_inner(&version, &self.url) {
-            Ok(summary) => {
-                println!("OK: {summary}");
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        let summary = verify_with_url(&version, &self.url)?;
+        println!("OK: {summary}");
+        Ok(())
     }
 }
 
-pub fn verify(version: &str) -> VerifyOutcome {
-    match verify_inner(version, DEFAULT_BASE_URL) {
-        Ok(summary) => VerifyOutcome::Ok(summary),
-        Err(e) => VerifyOutcome::Failed(e),
-    }
+pub fn verify(version: &str) -> Result<String> {
+    verify_with_url(version, DEFAULT_BASE_URL)
 }
 
-fn verify_inner(version: &str, base_url: &str) -> Result<String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()?;
+fn verify_with_url(version: &str, base_url: &str) -> Result<String> {
+    let client = util::client()?;
 
     info!("Checking Vector {version} on {base_url}");
 
@@ -54,29 +43,21 @@ fn verify_inner(version: &str, base_url: &str) -> Result<String> {
 
     // Per-release page: `/releases/<ver>/` must 200 and mention `<ver>`.
     let release_page = format!("{base_url}/releases/{version}/");
-    match fetch_page_containing(&client, &release_page, version) {
-        Ok(PageResult { status, bytes }) => {
-            println!("  release page    OK    {status} {release_page} ({bytes} bytes)");
-        }
-        Err(e) => {
-            failures += 1;
-            println!("  release page    FAIL  {release_page} -- {e:#}");
-        }
-    }
+    failures += report(
+        "release page",
+        &release_page,
+        fetch_page_containing(&client, &release_page, version),
+    );
 
     // Releases index: must include a link to the per-release page, not just the bare
     // version string (which appears in unrelated changelog blurbs on the page).
     let releases_index = format!("{base_url}/releases/");
     let release_link = format!("/releases/{version}/");
-    match fetch_page_containing(&client, &releases_index, &release_link) {
-        Ok(PageResult { status, bytes }) => {
-            println!("  releases index  OK    {status} {releases_index} ({bytes} bytes)");
-        }
-        Err(e) => {
-            failures += 1;
-            println!("  releases index  FAIL  {releases_index} -- {e:#}");
-        }
-    }
+    failures += report(
+        "releases index",
+        &releases_index,
+        fetch_page_containing(&client, &releases_index, &release_link),
+    );
 
     // Download page: the first non-nightly version in the selector must equal `<ver>`.
     // See `website/layouts/partials/download/version-selector.html`: the range runs over
@@ -86,15 +67,11 @@ fn verify_inner(version: &str, base_url: &str) -> Result<String> {
     // emits its own `setVersion('X')` button, so an older release page can contain the
     // new version string before Hugo rebuilds.
     let download_page = format!("{base_url}/download/");
-    match check_download_page(&client, &download_page, version) {
-        Ok(PageResult { status, bytes }) => {
-            println!("  download page   OK    {status} {download_page} ({bytes} bytes)");
-        }
-        Err(e) => {
-            failures += 1;
-            println!("  download page   FAIL  {download_page} -- {e:#}");
-        }
-    }
+    failures += report(
+        "download page",
+        &download_page,
+        check_download_page(&client, &download_page, version),
+    );
 
     if failures > 0 {
         bail!("{failures}/{total} website pages missing or stale for {version}");
@@ -102,35 +79,38 @@ fn verify_inner(version: &str, base_url: &str) -> Result<String> {
     Ok(format!("{total}/{total} pages OK"))
 }
 
-struct PageResult {
-    status: u16,
-    bytes: usize,
+// Pretty-print a per-check line and return 1 if the check failed, 0 otherwise.
+fn report(label: &str, url: &str, result: Result<usize>) -> usize {
+    match result {
+        Ok(bytes) => {
+            println!("  {label:<15} OK    {url} ({bytes} bytes)");
+            0
+        }
+        Err(e) => {
+            println!("  {label:<15} FAIL  {url} -- {e:#}");
+            1
+        }
+    }
 }
 
 fn fetch_page_containing(
     client: &reqwest::blocking::Client,
     url: &str,
     needle: &str,
-) -> Result<PageResult> {
-    let (status, body) = fetch(client, url)?;
+) -> Result<usize> {
+    let body = util::fetch_text(client, url)?;
     if !body.contains(needle) {
-        bail!(
-            "body did not contain {needle:?} (status {status}, {} bytes)",
-            body.len()
-        );
+        bail!("body did not contain {needle:?} ({} bytes)", body.len());
     }
-    Ok(PageResult {
-        status,
-        bytes: body.len(),
-    })
+    Ok(body.len())
 }
 
 fn check_download_page(
     client: &reqwest::blocking::Client,
     url: &str,
     version: &str,
-) -> Result<PageResult> {
-    let (status, body) = fetch(client, url)?;
+) -> Result<usize> {
+    let body = util::fetch_text(client, url)?;
     let latest = latest_selector_version(&body).with_context(|| {
         format!("no `setVersion('<ver>')` button found on {url} (template changed?)")
     })?;
@@ -139,24 +119,7 @@ fn check_download_page(
             "download page lists {latest:?} as the latest release, expected {version:?} (Hugo still stale?)"
         );
     }
-    Ok(PageResult {
-        status,
-        bytes: body.len(),
-    })
-}
-
-fn fetch(client: &reqwest::blocking::Client, url: &str) -> Result<(u16, String)> {
-    let resp = client
-        .get(url)
-        .send()
-        .with_context(|| format!("fetching {url}"))?
-        .error_for_status()
-        .with_context(|| format!("fetching {url}"))?;
-    let status = resp.status().as_u16();
-    let body = resp
-        .text()
-        .with_context(|| format!("reading body of {url}"))?;
-    Ok((status, body))
+    Ok(body.len())
 }
 
 // Scan the download page for the first `setVersion('X')` call whose argument is not

--- a/vdev/src/commands/release/verify/website.rs
+++ b/vdev/src/commands/release/verify/website.rs
@@ -1,0 +1,127 @@
+use std::time::Duration;
+
+use anyhow::{Context as _, Result, bail};
+
+use super::{VerifyOutcome, resolve_version};
+
+const DEFAULT_BASE_URL: &str = "https://vector.dev";
+
+/// Verify `vector.dev` serves the release page and docs reference the release.
+///
+/// Checks that Hugo has rebuilt the site post-release: the per-release page at
+/// `/releases/<ver>/` is live, the releases index lists it, and the download page
+/// points at `<ver>`.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Version to verify (e.g. `0.55.0`). Defaults to the most recent `v*` git tag.
+    version: Option<String>,
+
+    /// Base URL of the website.
+    #[arg(long, default_value = DEFAULT_BASE_URL)]
+    url: String,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        let version = resolve_version(self.version)?;
+        match verify_inner(&version, &self.url) {
+            Ok(summary) => {
+                println!("OK: {summary}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub fn verify(version: &str) -> VerifyOutcome {
+    match verify_inner(version, DEFAULT_BASE_URL) {
+        Ok(summary) => VerifyOutcome::Ok(summary),
+        Err(e) => VerifyOutcome::Failed(e),
+    }
+}
+
+// Each check is a (label, url, required-substring). The substring must appear in the
+// body of the 200 response; we don't parse the HTML since a plain `contains` is enough
+// to distinguish "Hugo has rebuilt with the new version" from "stale site".
+fn verify_inner(version: &str, base_url: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+
+    info!("Checking Vector {version} on {base_url}");
+
+    let release_page = format!("{base_url}/releases/{version}/");
+    let releases_index = format!("{base_url}/releases/");
+    let download_page = format!("{base_url}/download/");
+    // The releases index should link to the per-release page, not merely mention the
+    // version string (which might appear in unrelated changelog blurbs on the page).
+    let release_link = format!("/releases/{version}/");
+
+    let checks: [(&str, &str, &str); 3] = [
+        ("release page", release_page.as_str(), version),
+        (
+            "releases index",
+            releases_index.as_str(),
+            release_link.as_str(),
+        ),
+        ("download page", download_page.as_str(), version),
+    ];
+
+    let total = checks.len();
+    let mut failures = 0usize;
+    for (label, url, needle) in checks {
+        match check_page(&client, url, needle) {
+            Ok(CheckResult { status, bytes }) => {
+                println!("  {label:<15} OK    {status} {url} ({bytes} bytes, found {needle:?})");
+            }
+            Err(e) => {
+                failures += 1;
+                println!("  {label:<15} FAIL  {url} -- {e:#}");
+            }
+        }
+    }
+
+    if failures > 0 {
+        bail!("{failures}/{total} website pages missing or stale for {version}");
+    }
+    Ok(format!("{total}/{total} pages OK"))
+}
+
+struct CheckResult {
+    status: u16,
+    bytes: usize,
+}
+
+fn check_page(client: &reqwest::blocking::Client, url: &str, needle: &str) -> Result<CheckResult> {
+    let resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("fetching {url}"))?
+        .error_for_status()
+        .with_context(|| format!("fetching {url}"))?;
+    let status = resp.status().as_u16();
+    let body = resp
+        .text()
+        .with_context(|| format!("reading body of {url}"))?;
+    let bytes = body.len();
+    if !body.contains(needle) {
+        bail!("body did not contain {needle:?} (status {status}, {bytes} bytes)");
+    }
+    Ok(CheckResult { status, bytes })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn needle_contains_is_enough() {
+        // Sanity: the "search for a substring" rule we rely on in `check_page` is the
+        // plain `str::contains`, which is case-sensitive. Document that expectation
+        // here so a future refactor doesn't silently loosen it.
+        let body = "<a href=\"/releases/0.55.0/\">0.55.0</a>";
+        assert!(body.contains("0.55.0"));
+        assert!(body.contains("/releases/0.55.0/"));
+        assert!(!body.contains("0.55.1"));
+    }
+}

--- a/vdev/src/commands/release/verify/website.rs
+++ b/vdev/src/commands/release/verify/website.rs
@@ -10,7 +10,7 @@ const DEFAULT_BASE_URL: &str = "https://vector.dev";
 ///
 /// Checks that Hugo has rebuilt the site post-release: the per-release page at
 /// `/releases/<ver>/` is live, the releases index lists it, and the download page
-/// points at `<ver>`.
+/// treats `<ver>` as the current release.
 #[derive(clap::Args, Debug)]
 #[command()]
 pub struct Cli {
@@ -42,9 +42,6 @@ pub fn verify(version: &str) -> VerifyOutcome {
     }
 }
 
-// Each check is a (label, url, required-substring). The substring must appear in the
-// body of the 200 response; we don't parse the HTML since a plain `contains` is enough
-// to distinguish "Hugo has rebuilt with the new version" from "stale site".
 fn verify_inner(version: &str, base_url: &str) -> Result<String> {
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(30))
@@ -52,34 +49,50 @@ fn verify_inner(version: &str, base_url: &str) -> Result<String> {
 
     info!("Checking Vector {version} on {base_url}");
 
-    let release_page = format!("{base_url}/releases/{version}/");
-    let releases_index = format!("{base_url}/releases/");
-    let download_page = format!("{base_url}/download/");
-    // The releases index should link to the per-release page, not merely mention the
-    // version string (which might appear in unrelated changelog blurbs on the page).
-    let release_link = format!("/releases/{version}/");
-
-    let checks: [(&str, &str, &str); 3] = [
-        ("release page", release_page.as_str(), version),
-        (
-            "releases index",
-            releases_index.as_str(),
-            release_link.as_str(),
-        ),
-        ("download page", download_page.as_str(), version),
-    ];
-
-    let total = checks.len();
+    let total = 3usize;
     let mut failures = 0usize;
-    for (label, url, needle) in checks {
-        match check_page(&client, url, needle) {
-            Ok(CheckResult { status, bytes }) => {
-                println!("  {label:<15} OK    {status} {url} ({bytes} bytes, found {needle:?})");
-            }
-            Err(e) => {
-                failures += 1;
-                println!("  {label:<15} FAIL  {url} -- {e:#}");
-            }
+
+    // Per-release page: `/releases/<ver>/` must 200 and mention `<ver>`.
+    let release_page = format!("{base_url}/releases/{version}/");
+    match fetch_page_containing(&client, &release_page, version) {
+        Ok(PageResult { status, bytes }) => {
+            println!("  release page    OK    {status} {release_page} ({bytes} bytes)");
+        }
+        Err(e) => {
+            failures += 1;
+            println!("  release page    FAIL  {release_page} -- {e:#}");
+        }
+    }
+
+    // Releases index: must include a link to the per-release page, not just the bare
+    // version string (which appears in unrelated changelog blurbs on the page).
+    let releases_index = format!("{base_url}/releases/");
+    let release_link = format!("/releases/{version}/");
+    match fetch_page_containing(&client, &releases_index, &release_link) {
+        Ok(PageResult { status, bytes }) => {
+            println!("  releases index  OK    {status} {releases_index} ({bytes} bytes)");
+        }
+        Err(e) => {
+            failures += 1;
+            println!("  releases index  FAIL  {releases_index} -- {e:#}");
+        }
+    }
+
+    // Download page: the first non-nightly version in the selector must equal `<ver>`.
+    // See `website/layouts/partials/download/version-selector.html`: the range runs over
+    // `site.Data.docs.versions` in order, and `$latest := index $versions 0`, so the
+    // first non-nightly `setVersion('...')` button in the HTML corresponds to $latest.
+    // A plain `contains(version)` match is not enough — every release in `versions.yaml`
+    // emits its own `setVersion('X')` button, so an older release page can contain the
+    // new version string before Hugo rebuilds.
+    let download_page = format!("{base_url}/download/");
+    match check_download_page(&client, &download_page, version) {
+        Ok(PageResult { status, bytes }) => {
+            println!("  download page   OK    {status} {download_page} ({bytes} bytes)");
+        }
+        Err(e) => {
+            failures += 1;
+            println!("  download page   FAIL  {download_page} -- {e:#}");
         }
     }
 
@@ -89,12 +102,50 @@ fn verify_inner(version: &str, base_url: &str) -> Result<String> {
     Ok(format!("{total}/{total} pages OK"))
 }
 
-struct CheckResult {
+struct PageResult {
     status: u16,
     bytes: usize,
 }
 
-fn check_page(client: &reqwest::blocking::Client, url: &str, needle: &str) -> Result<CheckResult> {
+fn fetch_page_containing(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    needle: &str,
+) -> Result<PageResult> {
+    let (status, body) = fetch(client, url)?;
+    if !body.contains(needle) {
+        bail!(
+            "body did not contain {needle:?} (status {status}, {} bytes)",
+            body.len()
+        );
+    }
+    Ok(PageResult {
+        status,
+        bytes: body.len(),
+    })
+}
+
+fn check_download_page(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    version: &str,
+) -> Result<PageResult> {
+    let (status, body) = fetch(client, url)?;
+    let latest = latest_selector_version(&body).with_context(|| {
+        format!("no `setVersion('<ver>')` button found on {url} (template changed?)")
+    })?;
+    if latest != version {
+        bail!(
+            "download page lists {latest:?} as the latest release, expected {version:?} (Hugo still stale?)"
+        );
+    }
+    Ok(PageResult {
+        status,
+        bytes: body.len(),
+    })
+}
+
+fn fetch(client: &reqwest::blocking::Client, url: &str) -> Result<(u16, String)> {
     let resp = client
         .get(url)
         .send()
@@ -105,23 +156,63 @@ fn check_page(client: &reqwest::blocking::Client, url: &str, needle: &str) -> Re
     let body = resp
         .text()
         .with_context(|| format!("reading body of {url}"))?;
-    let bytes = body.len();
-    if !body.contains(needle) {
-        bail!("body did not contain {needle:?} (status {status}, {bytes} bytes)");
+    Ok((status, body))
+}
+
+// Scan the download page for the first `setVersion('X')` call whose argument is not
+// `nightly` — that is, the first release version in the selector's range loop, which
+// Hugo renders in the same order as `site.Data.docs.versions` (latest first).
+fn latest_selector_version(body: &str) -> Option<&str> {
+    const MARKER: &str = "setVersion('";
+    let mut search_from = 0;
+    while let Some(rel) = body[search_from..].find(MARKER) {
+        let start = search_from + rel + MARKER.len();
+        let end = start + body[start..].find('\'')?;
+        let v = &body[start..end];
+        if v != "nightly" {
+            return Some(v);
+        }
+        search_from = end + 1;
     }
-    Ok(CheckResult { status, bytes })
+    None
 }
 
 #[cfg(test)]
 mod tests {
+    use super::latest_selector_version;
+
     #[test]
-    fn needle_contains_is_enough() {
-        // Sanity: the "search for a substring" rule we rely on in `check_page` is the
-        // plain `str::contains`, which is case-sensitive. Document that expectation
-        // here so a future refactor doesn't silently loosen it.
-        let body = "<a href=\"/releases/0.55.0/\">0.55.0</a>";
-        assert!(body.contains("0.55.0"));
-        assert!(body.contains("/releases/0.55.0/"));
-        assert!(!body.contains("0.55.1"));
+    fn finds_first_non_nightly_version() {
+        let body = r#"
+            <button @click="$store.global.setVersion('nightly'); open = false">nightly</button>
+            <button @click="$store.global.setVersion('0.55.0'); open = false">0.55.0</button>
+            <button @click="$store.global.setVersion('0.54.0'); open = false">0.54.0</button>
+        "#;
+        assert_eq!(latest_selector_version(body), Some("0.55.0"));
+    }
+
+    #[test]
+    fn skips_nightly_even_when_it_appears_multiple_times() {
+        let body = r#"setVersion('nightly') setVersion('nightly') setVersion('0.55.0')"#;
+        assert_eq!(latest_selector_version(body), Some("0.55.0"));
+    }
+
+    #[test]
+    fn returns_none_when_only_nightly_present() {
+        let body = r#"setVersion('nightly')"#;
+        assert_eq!(latest_selector_version(body), None);
+    }
+
+    #[test]
+    fn returns_none_when_marker_absent() {
+        assert_eq!(latest_selector_version(""), None);
+    }
+
+    #[test]
+    fn detects_stale_download_page() {
+        // When Hugo still thinks 0.54.0 is latest, `setVersion('0.54.0')` appears before
+        // `setVersion('0.55.0')` — the probe should see 0.54.0 as the latest and flag it.
+        let stale = r#"setVersion('nightly') setVersion('0.54.0') setVersion('0.55.0')"#;
+        assert_eq!(latest_selector_version(stale), Some("0.54.0"));
     }
 }


### PR DESCRIPTION
## Summary

Adds `vdev release verify [VERSION]` — a post-release suite that asserts a given Vector release (defaults to the latest `v[0-9]*` tag) is fully published across every target. Individual probes are also runnable: `vdev release verify {apt,docker,github,homebrew,rpm,timber-io,website}`.

| Probe | Check |
|---|---|
| apt | Datadog APT repo across amd64/arm64/armhf/x86_64: `Packages.gz` stanza + HEAD the deb |
| docker | 32 tags (4 variants × 4 aliases × 2 registries) — registry v2 manifest lists, asserting every expected platform is indexed |
| github | All expected release assets + streaming SHA256 against the release's SHA256SUMS |
| homebrew | `Formula/vector.rb` from `vectordotdev/homebrew-brew` — version + URL/SHA pairs (streamed digest match) |
| rpm | Datadog YUM repo across x86_64/aarch64/armv7hl — `repomd.xml` → `primary.xml.gz` → HEAD the rpm |
| timber-io | `packages.timber.io/vector/{ver}/` + aliased paths + checksum sampling |
| website | `vector.dev/releases/{ver}/`, releases index, download page |

## Vector configuration

NA

## How did you test this PR?

- `cargo build -p vdev`, `cargo clippy -p vdev --bin vdev --no-deps`, `cargo test -p vdev --bin vdev release::verify` — 22/22 pass, pedantic-clean
- End-to-end: `cargo run -q -p vdev -- release verify 0.55.0` → 7 OK, 0 FAIL (every probe green against the real release)
- Failure-path: `release verify <subcommand> 99.99.99` bails with a descriptive error and exit 1

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA