### PR TITLE
fix(ci): make publish-s3 wait for generate-sha256sum

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -382,6 +382,7 @@ jobs:
       - deb-verify
       - rpm-verify
       - macos-verify
+      - generate-sha256sum
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       CHANNEL: ${{ needs.generate-publish-metadata.outputs.vector_release_channel }}


### PR DESCRIPTION
## Summary

The `publish-s3` job uploads release artifacts to `packages.timber.io` but does not currently depend on `generate-sha256sum`, which produces `vector-<ver>-SHA256SUMS`. As a result, `publish-s3` can finish before the checksum file is generated, so downstream consumers that expect `SHA256SUMS` under `packages.timber.io/vector/<ver>/` (e.g. `install.sh` verification, post-release verification tooling) can race the workflow.

Fix by adding `generate-sha256sum` to `publish-s3`'s `needs:` list. `publish-github` already has this dependency.


This is a small/rare race condition.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA