### PR TITLE
fix(aws_s3 source, aws_sqs source): cap poll_secs at AWS limit of 20

### DIFF
--- a/changelog.d/22934_sqs_poll_secs_range_validation.fix.md
+++ b/changelog.d/22934_sqs_poll_secs_range_validation.fix.md
@@ -1,0 +1,3 @@
+Constrained the `aws_s3` source's `sqs.poll_secs` and the `aws_sqs` source's `poll_secs` configuration fields to the AWS-imposed maximum of 20 seconds. These fields map to SQS `ReceiveMessage`'s `WaitTimeSeconds` parameter; previously, values above 20 caused AWS to reject the call, manifesting as silent ingestion failure with no error or hint in the documentation. The field documentation now states the limit explicitly, and `vector validate` rejects out-of-range configurations.
+
+authors: st-omarkhalid

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -106,11 +106,18 @@ pub(super) struct Config {
     ///
     /// Generally, this should not be changed unless instructed to do so, as if messages are available,
     /// they are always consumed, regardless of the value of `poll_secs`.
+    ///
+    /// Maps to the SQS `ReceiveMessage` `WaitTimeSeconds` parameter, which is
+    /// [capped at 20 seconds by AWS][aws_docs]. Values above 20 are rejected by AWS and result in
+    /// silent ingestion failure, so this field is constrained to the same range.
+    ///
+    /// [aws_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
     // NOTE: We restrict this to u32 for safe conversion to i32 later.
     // NOTE: This value isn't used as a `Duration` downstream, so we don't bother using `serde_with`
     #[serde(default = "default_poll_secs")]
     #[derivative(Default(value = "default_poll_secs()"))]
     #[configurable(metadata(docs::type_unit = "seconds"))]
+    #[configurable(validation(range(max = 20)))]
     pub(super) poll_secs: u32,
 
     /// The visibility timeout to use for messages, in seconds.

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -41,12 +41,19 @@ pub struct AwsSqsConfig {
     ///
     /// Generally, this should not be changed unless instructed to do so, as if messages are available,
     /// they are always consumed, regardless of the value of `poll_secs`.
+    ///
+    /// Maps to the SQS `ReceiveMessage` `WaitTimeSeconds` parameter, which is
+    /// [capped at 20 seconds by AWS][aws_docs]. Values above 20 are rejected by AWS and result in
+    /// silent ingestion failure, so this field is constrained to the same range.
+    ///
+    /// [aws_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
     // NOTE: We restrict this to u32 for safe conversion to i32 later.
     // NOTE: This value isn't used as a `Duration` downstream, so we don't bother using `serde_with`
     #[serde(default = "default_poll_secs")]
     #[derivative(Default(value = "default_poll_secs()"))]
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::human_name = "Poll Wait Time"))]
+    #[configurable(validation(range(max = 20)))]
     pub poll_secs: u32,
 
     /// The visibility timeout to use for messages, in seconds.

--- a/website/cue/reference/components/sources/generated/aws_s3.cue
+++ b/website/cue/reference/components/sources/generated/aws_s3.cue
@@ -871,6 +871,12 @@ generated: components: sources: aws_s3: configuration: {
 
 					Generally, this should not be changed unless instructed to do so, as if messages are available,
 					they are always consumed, regardless of the value of `poll_secs`.
+
+					Maps to the SQS `ReceiveMessage` `WaitTimeSeconds` parameter, which is
+					[capped at 20 seconds by AWS][aws_docs]. Values above 20 are rejected by AWS and result in
+					silent ingestion failure, so this field is constrained to the same range.
+
+					[aws_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
 					"""
 				required: false
 				type: uint: {

--- a/website/cue/reference/components/sources/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sources/generated/aws_sqs.cue
@@ -682,6 +682,12 @@ generated: components: sources: aws_sqs: configuration: {
 
 			Generally, this should not be changed unless instructed to do so, as if messages are available,
 			they are always consumed, regardless of the value of `poll_secs`.
+
+			Maps to the SQS `ReceiveMessage` `WaitTimeSeconds` parameter, which is
+			[capped at 20 seconds by AWS][aws_docs]. Values above 20 are rejected by AWS and result in
+			silent ingestion failure, so this field is constrained to the same range.
+
+			[aws_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
 			"""
 		required: false
 		type: uint: {


### PR DESCRIPTION
## Summary

Fixes #22934. Both the `aws_s3` source's `sqs.poll_secs` and the `aws_sqs` source's `poll_secs` are forwarded to AWS SQS's `ReceiveMessage` API as the `WaitTimeSeconds` parameter, which is [hard-capped at 20 seconds by AWS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html). Setting a higher value silently breaks ingestion (AWS rejects the call; Vector logs nothing user-visible) and the field documentation gave no hint of the limit.

This PR:

- Adds `#[configurable(validation(range(max = 20)))]` to both fields so `vector validate` rejects out-of-range configs before startup.
- Updates the field doc comments to state the AWS-imposed 0-20s range explicitly, with a link to the AWS API reference.
- Regenerates the component CUE files (`website/cue/reference/components/sources/generated/aws_s3.cue` and `aws_sqs.cue`) via `make generate-docs` so the user-facing docs surface the new prose. (Per the established pattern, e.g. `decrease_ratio` in `adaptive_concurrency`, `validation(range(...))` is reflected in user docs as prose; the numeric constraint itself is enforced via the JSON schema.)

The `aws_sqs` source is included alongside `aws_s3` because it has the identical bug at `src/sources/aws_sqs/config.rs:50` → `src/sources/aws_sqs/source.rs:111`. Happy to split into two PRs if maintainers prefer.

## Vector configuration

Existing aws_s3/aws_sqs configurations are unchanged in behavior for any value 0..=20; values >20 will now fail config validation with a clear schema error instead of silently breaking at runtime.

## How did you test this PR?

All checks run inside the official `timberio/vector-dev:latest` Docker image (linux/amd64 under emulation on Apple Silicon, with `OPENSSL_NO_VENDOR=1` to use the image's system OpenSSL):

- `cargo check -p vector --no-default-features --features sources-aws_s3,sources-aws_sqs` — clean (1m 40s)
- `cargo clippy -p vector --no-default-features --features sources-aws_s3,sources-aws_sqs -- -D warnings` — clean (1m 12s, no warnings)
- `cargo nextest run -p vector --no-default-features --features sources-aws_s3 -E "test(/sources::aws_s3/)"` — **6 passed, 0 failed**
- `cargo nextest run -p vector --no-default-features --features sources-aws_sqs -E "test(/sources::aws_sqs/)"` — **3 passed, 0 failed**
- `make check-generated-docs` — clean post-`make generate-docs` and commit of the regenerated CUE files

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

A `validation(range(max = 20))` only rejects configurations that were already broken at runtime against AWS's API; valid configurations are unaffected.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

Changelog fragment added: `changelog.d/22934_sqs_poll_secs_range_validation.fix.md`.

## References

- Closes: #22934