### PR TITLE
docs(deprecations): add datadog_metrics series v1 deprecation entry

### DIFF
--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -17,6 +17,7 @@ For example:
 - `v0.50.0` | `http-server-encoding` | The `encoding` field will be removed. Use `decoding` and `framing` instead.
 - `v0.53.0` | `buffer-bytes-events-metrics` | The `buffer_byte_size` and `buffer_events` gauges are deprecated in favor of the `buffer_size_bytes`/`buffer_size_events` metrics described in `docs/specs/buffer.md`.
 - `v0.58.0` | `azure-monitor-logs-sink` | The `azure_monitor_logs` sink is deprecated in favor of the new `azure_logs_ingestion` sink, which uses the Azure Monitor Logs Ingestion API. Users should migrate before Microsoft ends support for the old Data Collector API (scheduled for September 2026).
+- `v0.58.0` | `datadog-metrics-series-v1` | The `series_api_version: v1` option on the `datadog_metrics` sink is deprecated in favor of `v2` (the default). The v1 series endpoint (`/api/v1/series`) is a legacy endpoint; users should remove `series_api_version: v1` from their configuration or set it to `v2`.
 
 ## To be migrated
 


### PR DESCRIPTION
## Summary

Kicks off the deprecation of the `series_api_version: v1` option on the `datadog_metrics` sink, per [our deprecation policy](https://github.com/vectordotdev/vector/blob/master/docs/DEPRECATION.md). The `v1` series endpoint (`/api/v1/series`) is a legacy endpoint; `v2` has been the default since 0.55.0. Targeting `v0.58.0` for the deprecation notice to give users plenty of time to migrate.

## Vector configuration

N/A (docs-only change).

## How did you test this PR?

- ``make check-markdown``

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the ``no-changelog`` label to this PR.

## References

N/A