### PR TITLE
fix(ci): correct cross-build artifact name and path

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -57,5 +57,5 @@ jobs:
       - run: make cross-build-${{ matrix.target }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: "vector-debug-${{ matrix.target }}"
-          path: "./target/${{ matrix.target }}/debug/vector"
+          name: "vector-${{ matrix.target }}"
+          path: "./target/${{ matrix.target }}/release/vector"


### PR DESCRIPTION
## Summary

Cross-build artifacts were uploaded from the `debug` path under a `vector-debug-*` name, but the build target produces a release binary. Update the artifact name and path to match.

## Vector configuration

NA

## How did you test this PR?

`/ci-run-cross`

CI run: https://github.com/vectordotdev/vector/actions/runs/25004579386?pr=25282

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA