### PR TITLE
fix(ci): allow dd-token federation to fail on fork PRs

### DIFF
--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -10,8 +10,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Fork PRs don't get `id-token: write`, so federation cannot succeed.
+    # Allow the step to fail and let downstream steps run without DD credentials.
     - name: Federate Datadog token
       id: dd-sts
+      continue-on-error: true
       uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
       with:
         policy: ${{ inputs.policy }}
@@ -22,7 +25,9 @@ runs:
         DD_STS_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
         DD_STS_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
       run: |
-        echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"
+        if [ -n "${DD_STS_API_KEY}" ]; then
+          echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"
+        fi
         if [ -n "${DD_STS_APP_KEY}" ]; then
           echo "DD_APP_KEY=${DD_STS_APP_KEY}" >> "$GITHUB_ENV"
         fi


### PR DESCRIPTION
## Summary

Fork PRs do not receive the `id-token: write` permission, so `DataDog/dd-sts-action` errors with "Missing required environment variables" and fails any job that calls the `dd-token` composite action. Mark the federation step `continue-on-error: true` and only export `DD_API_KEY` when present so downstream steps run without Datadog credentials. The existing `upload-test-results.sh` already swallows upload failures.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25235
- Observed on: #25230