### PR TITLE
fix(vrl): restore stdlib functions in CLI and playground

### DIFF
--- a/changelog.d/25267_vrl_get_env_var_playground.fix.md
+++ b/changelog.d/25267_vrl_get_env_var_playground.fix.md
@@ -1,0 +1,2 @@
+Restored the full VRL stdlib, including `get_env_var`, in the standalone VRL CLI and web playground by default.
+authors: pront

--- a/lib/vector-vrl/cli/Cargo.toml
+++ b/lib/vector-vrl/cli/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[features]
+# Enable the full VRL stdlib, which includes all available VRL functions.
+default = ["vrl/stdlib"]
+
 [dependencies]
 clap.workspace = true
 vector-vrl-functions.workspace = true

--- a/lib/vector-vrl/web-playground/Cargo.toml
+++ b/lib/vector-vrl/web-playground/Cargo.toml
@@ -11,6 +11,10 @@ license = "MPL-2.0"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+# Enable the full VRL stdlib, which includes all available VRL functions.
+default = ["vrl/stdlib"]
+
 [dependencies]
 wasm-bindgen = "0.2"
 vrl.workspace = true


### PR DESCRIPTION
## Summary

- Restore the full VRL stdlib by default for the standalone VRL CLI and web playground.
- Enable that default directly with `default = ["vrl/stdlib"]` in both standalone crates.
- Preserve `--no-default-features` as the restricted build path for library consumers that intentionally avoid the full stdlib.

## Root Cause

After the VRL feature split, the standalone VRL crates inherited the workspace `vrl` dependency with `stdlib-base` only. That unintentionally changed the default behavior for the standalone VRL CLI and web playground: functions from the full stdlib, such as `get_env_var`, were no longer available unless the build explicitly enabled `vrl/stdlib`.

Production Vector already enables `vrl/stdlib` through the root `base` feature. This change aligns the standalone CLI and web playground with that default production behavior, while consumers embedding Vector crates with `default-features = false` still do not enable the full stdlib unless they opt in.

Fixes #25267.

## Validation

- Reproduced the `get_env_var` undefined-function error on `v0.55.0` before the fix.
- `cargo run -q -p vector-vrl-cli -- -q '.xxx = get_env_var("NODE_NAME") ?? "no_host"'`
- `cargo run -q -p vector-vrl-cli --no-default-features -- -q '.xxx = get_env_var("NODE_NAME") ?? "no_host"'` still fails with `E105`
- `cargo check -q -p vector-vrl-cli`
- `cargo check -q -p vector-vrl-web-playground`
- `cargo check -q -p vector-vrl-web-playground --no-default-features`
- `./scripts/check_changelog_fragments.sh`
- `make check-clippy`
