### PR TITLE
fix(website): improve docs search ranking for component pages

### DIFF
--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -5,6 +5,7 @@
       "file_path": "./public/search.json",
       "synonyms": [],
       "schema": {
+        "token_separators": ["_", "-"],
         "fields": [
           {
             "facet": false,
@@ -142,8 +143,10 @@
         {
           "name": "vector_docs_search",
           "search_parameters": {
-            "sort_by": "level:desc,ranking:desc,_text_match:desc",
-            "query_by": "pageTitle,title,hierarchy,content,tags"
+            "sort_by": "_text_match:desc,ranking:desc,level:desc",
+            "query_by": "pageTitle,title,hierarchy,content,tags",
+            "query_by_weights": "4,3,2,1,2",
+            "text_match_type": "sum_score"
           }
         }
       ]


### PR DESCRIPTION
## Summary

Component pages were ranked poorly (or not surfaced at all) for queries like `remap transform` or `splunk_hec`. Three Typesense config changes:

- `token_separators: ["_", "-"]` so slug-style queries (`splunk_hec`, `aws_s3`) tokenize the same way as the page titles/tags they should match.
- `sort_by: _text_match:desc,ranking:desc,level:desc` (was `level:desc,ranking:desc,_text_match:desc`) so text relevance is the primary signal instead of every h1 tying first.
- `query_by_weights: 4,3,2,1,2` + `text_match_type: sum_score` so hits in pageTitle/title/tags add up and dominate body-content matches.

## Vector configuration

NA

## How did you test this PR?

Validated the JSON locally. Live verification requires the Typesense index rebuild that runs in `ci-production-build` / `ci-preview-build` (`website/Makefile:49,60`).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
