### PR TITLE
fix(releasing): enable codecs-parquet in all release feature sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -509,23 +509,23 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["enable-unix", "codecs-parquet", "rdkafka?/gssapi"]
+default = ["enable-unix", "rdkafka?/gssapi"]
 # Default features for `cargo docs`. We're not using `gssapi` which would require installing libsasl2 in our doc environment.
 docs = ["enable-unix"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["enable-unix", "codecs-parquet", "vendored", "rdkafka?/cmake_build"]
+default-cmake = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
 
 vendored = ["rdkafka?/gssapi-vendored"]
 
 # Default features for *-pc-windows-msvc
 # TODO: Enable SASL https://github.com/vectordotdev/vector/pull/3081#issuecomment-659298042
-base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets", "vrl/stdlib"]
+base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets", "vrl/stdlib", "codecs-parquet"]
 enable-api-client = ["base", "api-client"]
 enable-unix = ["enable-api-client", "sources-dnstap", "unix"]
 
-default-msvc = ["enable-api-client", "codecs-parquet", "rdkafka?/cmake_build"]
-default-musl = ["enable-unix", "codecs-parquet", "vendored", "rdkafka?/cmake_build"]
-default-no-api-client = ["base", "sources-dnstap", "unix", "vendored", "codecs-parquet"]
+default-msvc = ["enable-api-client", "rdkafka?/cmake_build"]
+default-musl = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
+default-no-api-client = ["base", "sources-dnstap", "unix", "vendored"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
@@ -544,7 +544,7 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]
 # Target specific release features.
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
-target-base = ["enable-api-client", "codecs-parquet", "rdkafka?/cmake_build", "sources-dnstap"]
+target-base = ["enable-api-client", "rdkafka?/cmake_build", "sources-dnstap"]
 target-unix = ["target-base", "unix"]
 target-aarch64-unknown-linux-gnu =      ["target-unix"]
 target-aarch64-unknown-linux-musl =     ["target-unix"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -509,11 +509,11 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 
 [features]
 # Default features for *-unknown-linux-gnu and *-apple-darwin
-default = ["enable-unix", "rdkafka?/gssapi"]
+default = ["enable-unix", "codecs-parquet", "rdkafka?/gssapi"]
 # Default features for `cargo docs`. We're not using `gssapi` which would require installing libsasl2 in our doc environment.
 docs = ["enable-unix"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
+default-cmake = ["enable-unix", "codecs-parquet", "vendored", "rdkafka?/cmake_build"]
 
 vendored = ["rdkafka?/gssapi-vendored"]
 
@@ -523,9 +523,9 @@ base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets",
 enable-api-client = ["base", "api-client"]
 enable-unix = ["enable-api-client", "sources-dnstap", "unix"]
 
-default-msvc = ["enable-api-client", "rdkafka?/cmake_build"]
-default-musl = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
-default-no-api-client = ["base", "sources-dnstap", "unix", "vendored"]
+default-msvc = ["enable-api-client", "codecs-parquet", "rdkafka?/cmake_build"]
+default-musl = ["enable-unix", "codecs-parquet", "vendored", "rdkafka?/cmake_build"]
+default-no-api-client = ["base", "sources-dnstap", "unix", "vendored", "codecs-parquet"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
@@ -544,7 +544,7 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]
 # Target specific release features.
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
-target-base = ["enable-api-client", "rdkafka?/cmake_build", "sources-dnstap"]
+target-base = ["enable-api-client", "codecs-parquet", "rdkafka?/cmake_build", "sources-dnstap"]
 target-unix = ["target-base", "unix"]
 target-aarch64-unknown-linux-gnu =      ["target-unix"]
 target-aarch64-unknown-linux-musl =     ["target-unix"]

--- a/changelog.d/25313_enable_codecs_parquet_in_releases.fix.md
+++ b/changelog.d/25313_enable_codecs_parquet_in_releases.fix.md
@@ -1,3 +1,3 @@
 The `codecs-parquet` Cargo feature is now enabled in all official release artifacts (Linux GNU/musl on x86_64/aarch64/armv7/arm, macOS, and Windows). Previously the precompiled binaries rejected the AWS S3 sink's `batch_encoding` field with `unknown field 'batch_encoding'`, even though the field is documented and the feature was advertised in the v0.55.0 release notes. Users no longer need to compile Vector from source to use Parquet encoding in the AWS S3 sink.
 
-authors: prontidis
+authors: pront

--- a/changelog.d/25313_enable_codecs_parquet_in_releases.fix.md
+++ b/changelog.d/25313_enable_codecs_parquet_in_releases.fix.md
@@ -1,3 +1,3 @@
-The `codecs-parquet` Cargo feature is now enabled in all official release artifacts (Linux GNU/musl on x86_64/aarch64/armv7/arm, macOS, and Windows). Previously the precompiled binaries rejected the AWS S3 sink's `batch_encoding` field with `unknown field 'batch_encoding'`, even though the field is documented and the feature was advertised in the v0.55.0 release notes. Users no longer need to compile Vector from source to use Parquet encoding in the AWS S3 sink.
+Parquet encoding in the `aws_s3` sink (`batch_encoding`) now works out of the box in the official release binaries. Previously it required compiling Vector from source with the `codecs-parquet` feature.
 
 authors: pront

--- a/changelog.d/25313_enable_codecs_parquet_in_releases.fix.md
+++ b/changelog.d/25313_enable_codecs_parquet_in_releases.fix.md
@@ -1,0 +1,3 @@
+The `codecs-parquet` Cargo feature is now enabled in all official release artifacts (Linux GNU/musl on x86_64/aarch64/armv7/arm, macOS, and Windows). Previously the precompiled binaries rejected the AWS S3 sink's `batch_encoding` field with `unknown field 'batch_encoding'`, even though the field is documented and the feature was advertised in the v0.55.0 release notes. Users no longer need to compile Vector from source to use Parquet encoding in the AWS S3 sink.
+
+authors: prontidis

--- a/lib/codecs/src/encoding/format/arrow.rs
+++ b/lib/codecs/src/encoding/format/arrow.rs
@@ -40,12 +40,12 @@ pub struct ArrowStreamSerializerConfig {
 
     /// Allow null values for non-nullable fields in the schema.
     ///
-    /// When enabled, missing or incompatible values will be encoded as null even for fields
+    /// When enabled, missing or incompatible values are encoded as null, even for fields
     /// marked as non-nullable in the Arrow schema. This is useful when working with downstream
     /// systems that can handle null values through defaults, computed columns, or other mechanisms.
     ///
-    /// When disabled (default), missing values for non-nullable fields will cause encoding errors,
-    /// ensuring all required data is present before sending to the sink.
+    /// When disabled (default), missing values for non-nullable fields results in encoding errors. This is to
+    /// help ensure all required data is present before sending it to the sink.
     #[serde(default)]
     #[configurable(derived)]
     pub allow_nullable_fields: bool,

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -35,6 +35,9 @@ type EventsDroppedError = ComponentEventsDropped<'static, UNINTENTIONAL>;
 /// Compression algorithm and optional level for archive objects.
 #[configurable_component]
 #[derive(Default, Copy, Clone, Debug, PartialEq)]
+#[configurable(metadata(
+    docs::enum_tag_description = "Compression codec applied per column page inside the Parquet file."
+))]
 #[serde(tag = "algorithm", rename_all = "snake_case")]
 pub enum ParquetCompression {
     /// Zstd compression. Level must be between 1 and 21.

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -42,13 +42,13 @@ type EventsDroppedError = ComponentEventsDropped<'static, UNINTENTIONAL>;
 pub enum ParquetCompression {
     /// Zstd compression. Level must be between 1 and 21.
     Zstd {
-        /// Compression level (1–21). This is the range Vector currently supports; higher values compress more but are slower.
+        /// Compression level (1–21). This is the range Vector supports; higher values compress more but are slower.
         #[configurable(validation(range(min = 1, max = 21)))]
         level: u8,
     },
     /// Gzip compression. Level must be between 1 and 9.
     Gzip {
-        /// Compression level (1–9). This is the range Vector currently supports; higher values compress more but are slower.
+        /// Compression level (1–9). This is the range Vector supports; higher values compress more but are slower.
         #[configurable(validation(range(min = 1, max = 9)))]
         level: u8,
     },

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -114,6 +114,8 @@ pub struct S3SinkConfig {
     /// When set, events are encoded together as a batch in a columnar format (for example, Parquet)
     /// instead of the standard per-event framing-based encoding. The columnar format handles
     /// its own internal compression, so the top-level `compression` setting is bypassed.
+    ///
+    /// Only the `parquet` codec is supported by the AWS S3 sink.
     #[cfg(feature = "codecs-parquet")]
     #[configurable(derived)]
     #[serde(default)]

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -111,7 +111,7 @@ pub struct S3SinkConfig {
 
     /// Batch encoding configuration for columnar formats.
     ///
-    /// When set, events are encoded together as a batch in a columnar format (e.g., Parquet)
+    /// When set, events are encoded together as a batch in a columnar format (for example, Parquet)
     /// instead of the standard per-event framing-based encoding. The columnar format handles
     /// its own internal compression, so the top-level `compression` setting is bypassed.
     #[cfg(feature = "codecs-parquet")]

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -104,6 +104,8 @@ pub struct ClickhouseConfig {
     ///
     /// When specified, events are encoded together as a single batch.
     /// This is mutually exclusive with per-event encoding based on the `format` field.
+    ///
+    /// Only the `arrow_stream` codec is supported by the ClickHouse sink.
     #[configurable(derived)]
     #[serde(default)]
     pub batch_encoding: Option<BatchSerializerConfig>,

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -260,7 +260,7 @@ generated: components: sinks: aws_s3: configuration: {
 		description: """
 			Batch encoding configuration for columnar formats.
 
-			When set, events are encoded together as a batch in a columnar format (e.g., Parquet)
+			When set, events are encoded together as a batch in a columnar format (for example, Parquet)
 			instead of the standard per-event framing-based encoding. The columnar format handles
 			its own internal compression, so the top-level `compression` setting is bypassed.
 			"""
@@ -270,12 +270,12 @@ generated: components: sinks: aws_s3: configuration: {
 				description: """
 					Allow null values for non-nullable fields in the schema.
 
-					When enabled, missing or incompatible values will be encoded as null even for fields
+					When enabled, missing or incompatible values are encoded as null, even for fields
 					marked as non-nullable in the Arrow schema. This is useful when working with downstream
 					systems that can handle null values through defaults, computed columns, or other mechanisms.
 
-					When disabled (default), missing values for non-nullable fields will cause encoding errors,
-					ensuring all required data is present before sending to the sink.
+					When disabled (default), missing values for non-nullable fields results in encoding errors. This is to
+					help ensure all required data is present before sending it to the sink.
 					"""
 				relevant_when: "codec = \"arrow_stream\""
 				required:      false
@@ -320,7 +320,7 @@ generated: components: sinks: aws_s3: configuration: {
 						}
 					}
 					level: {
-						description:   "Compression level (1–21). This is the range Vector currently supports; higher values compress more but are slower."
+						description:   "Compression level (1–21). This is the range Vector supports; higher values compress more but are slower."
 						relevant_when: "algorithm = \"zstd\" or algorithm = \"gzip\""
 						required:      true
 						type: uint: {}

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -256,6 +256,103 @@ generated: components: sinks: aws_s3: configuration: {
 			}
 		}
 	}
+	batch_encoding: {
+		description: """
+			Batch encoding configuration for columnar formats.
+
+			When set, events are encoded together as a batch in a columnar format (e.g., Parquet)
+			instead of the standard per-event framing-based encoding. The columnar format handles
+			its own internal compression, so the top-level `compression` setting is bypassed.
+			"""
+		required: false
+		type: object: options: {
+			allow_nullable_fields: {
+				description: """
+					Allow null values for non-nullable fields in the schema.
+
+					When enabled, missing or incompatible values will be encoded as null even for fields
+					marked as non-nullable in the Arrow schema. This is useful when working with downstream
+					systems that can handle null values through defaults, computed columns, or other mechanisms.
+
+					When disabled (default), missing values for non-nullable fields will cause encoding errors,
+					ensuring all required data is present before sending to the sink.
+					"""
+				relevant_when: "codec = \"arrow_stream\""
+				required:      false
+				type: bool: default: false
+			}
+			codec: {
+				description: "The codec to use for batch encoding events."
+				required:    true
+				type: string: enum: {
+					arrow_stream: """
+						Encodes events in [Apache Arrow][apache_arrow] IPC streaming format.
+
+						This is the streaming variant of the Arrow IPC format, which writes
+						a continuous stream of record batches.
+
+						[apache_arrow]: https://arrow.apache.org/
+						"""
+					parquet: """
+						Encodes events in [Apache Parquet][apache_parquet] columnar format.
+
+						[apache_parquet]: https://parquet.apache.org/
+						"""
+				}
+			}
+			compression: {
+				description:   "Compression codec applied per column page inside the Parquet file."
+				relevant_when: "codec = \"parquet\""
+				required:      false
+				type: object: options: {
+					algorithm: {
+						description: "Compression codec applied per column page inside the Parquet file."
+						required:    false
+						type: string: {
+							default: "snappy"
+							enum: {
+								gzip:   "Gzip compression. Level must be between 1 and 9."
+								lz4:    "LZ4 raw compression"
+								none:   "No compression"
+								snappy: "Snappy compression (no level)."
+								zstd:   "Zstd compression. Level must be between 1 and 21."
+							}
+						}
+					}
+					level: {
+						description:   "Compression level (1–21). This is the range Vector currently supports; higher values compress more but are slower."
+						relevant_when: "algorithm = \"zstd\" or algorithm = \"gzip\""
+						required:      true
+						type: uint: {}
+					}
+				}
+			}
+			schema_file: {
+				description: """
+					Path to a native Parquet schema file (`.schema`).
+
+					Required unless `schema_mode` is `auto_infer`. The file must contain a valid
+					Parquet message type definition.
+					"""
+				relevant_when: "codec = \"parquet\""
+				required:      false
+				type: string: {}
+			}
+			schema_mode: {
+				description:   "Controls how events with fields not present in the schema are handled."
+				relevant_when: "codec = \"parquet\""
+				required:      false
+				type: string: {
+					default: "relaxed"
+					enum: {
+						auto_infer: "Auto infer schema based on the batch. No schema file needed."
+						relaxed:    "Missing fields become null. Extra fields are silently dropped."
+						strict:     "Missing fields become null. Extra fields cause an error."
+					}
+				}
+			}
+		}
+	}
 	bucket: {
 		description: """
 			The S3 bucket name.

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -263,6 +263,8 @@ generated: components: sinks: aws_s3: configuration: {
 			When set, events are encoded together as a batch in a columnar format (for example, Parquet)
 			instead of the standard per-event framing-based encoding. The columnar format handles
 			its own internal compression, so the top-level `compression` setting is bypassed.
+
+			Only the `parquet` codec is supported by the AWS S3 sink.
 			"""
 		required: false
 		type: object: options: {

--- a/website/cue/reference/components/sinks/generated/clickhouse.cue
+++ b/website/cue/reference/components/sinks/generated/clickhouse.cue
@@ -249,6 +249,8 @@ generated: components: sinks: clickhouse: configuration: {
 
 			When specified, events are encoded together as a single batch.
 			This is mutually exclusive with per-event encoding based on the `format` field.
+
+			Only the `arrow_stream` codec is supported by the ClickHouse sink.
 			"""
 		required: false
 		type: object: options: {

--- a/website/cue/reference/components/sinks/generated/clickhouse.cue
+++ b/website/cue/reference/components/sinks/generated/clickhouse.cue
@@ -256,12 +256,12 @@ generated: components: sinks: clickhouse: configuration: {
 				description: """
 					Allow null values for non-nullable fields in the schema.
 
-					When enabled, missing or incompatible values will be encoded as null even for fields
+					When enabled, missing or incompatible values are encoded as null, even for fields
 					marked as non-nullable in the Arrow schema. This is useful when working with downstream
 					systems that can handle null values through defaults, computed columns, or other mechanisms.
 
-					When disabled (default), missing values for non-nullable fields will cause encoding errors,
-					ensuring all required data is present before sending to the sink.
+					When disabled (default), missing values for non-nullable fields results in encoding errors. This is to
+					help ensure all required data is present before sending it to the sink.
 					"""
 				relevant_when: "codec = \"arrow_stream\""
 				required:      false
@@ -306,7 +306,7 @@ generated: components: sinks: clickhouse: configuration: {
 						}
 					}
 					level: {
-						description:   "Compression level (1–21). This is the range Vector currently supports; higher values compress more but are slower."
+						description:   "Compression level (1–21). This is the range Vector supports; higher values compress more but are slower."
 						relevant_when: "algorithm = \"zstd\" or algorithm = \"gzip\""
 						required:      true
 						type: uint: {}

--- a/website/cue/reference/components/sinks/generated/clickhouse.cue
+++ b/website/cue/reference/components/sinks/generated/clickhouse.cue
@@ -263,27 +263,79 @@ generated: components: sinks: clickhouse: configuration: {
 					When disabled (default), missing values for non-nullable fields will cause encoding errors,
 					ensuring all required data is present before sending to the sink.
 					"""
-				required: false
+				relevant_when: "codec = \"arrow_stream\""
+				required:      false
 				type: bool: default: false
 			}
 			codec: {
+				description: "The codec to use for batch encoding events."
+				required:    true
+				type: string: enum: {
+					arrow_stream: """
+						Encodes events in [Apache Arrow][apache_arrow] IPC streaming format.
+
+						This is the streaming variant of the Arrow IPC format, which writes
+						a continuous stream of record batches.
+
+						[apache_arrow]: https://arrow.apache.org/
+						"""
+					parquet: """
+						Encodes events in [Apache Parquet][apache_parquet] columnar format.
+
+						[apache_parquet]: https://parquet.apache.org/
+						"""
+				}
+			}
+			compression: {
+				description:   "Compression codec applied per column page inside the Parquet file."
+				relevant_when: "codec = \"parquet\""
+				required:      false
+				type: object: options: {
+					algorithm: {
+						description: "Compression codec applied per column page inside the Parquet file."
+						required:    false
+						type: string: {
+							default: "snappy"
+							enum: {
+								gzip:   "Gzip compression. Level must be between 1 and 9."
+								lz4:    "LZ4 raw compression"
+								none:   "No compression"
+								snappy: "Snappy compression (no level)."
+								zstd:   "Zstd compression. Level must be between 1 and 21."
+							}
+						}
+					}
+					level: {
+						description:   "Compression level (1–21). This is the range Vector currently supports; higher values compress more but are slower."
+						relevant_when: "algorithm = \"zstd\" or algorithm = \"gzip\""
+						required:      true
+						type: uint: {}
+					}
+				}
+			}
+			schema_file: {
 				description: """
-					Encodes events in [Apache Arrow][apache_arrow] IPC streaming format.
+					Path to a native Parquet schema file (`.schema`).
 
-					This is the streaming variant of the Arrow IPC format, which writes
-					a continuous stream of record batches.
-
-					[apache_arrow]: https://arrow.apache.org/
+					Required unless `schema_mode` is `auto_infer`. The file must contain a valid
+					Parquet message type definition.
 					"""
-				required: true
-				type: string: enum: arrow_stream: """
-					Encodes events in [Apache Arrow][apache_arrow] IPC streaming format.
-
-					This is the streaming variant of the Arrow IPC format, which writes
-					a continuous stream of record batches.
-
-					[apache_arrow]: https://arrow.apache.org/
-					"""
+				relevant_when: "codec = \"parquet\""
+				required:      false
+				type: string: {}
+			}
+			schema_mode: {
+				description:   "Controls how events with fields not present in the schema are handled."
+				relevant_when: "codec = \"parquet\""
+				required:      false
+				type: string: {
+					default: "relaxed"
+					enum: {
+						auto_infer: "Auto infer schema based on the batch. No schema file needed."
+						relaxed:    "Missing fields become null. Extra fields are silently dropped."
+						strict:     "Missing fields become null. Extra fields cause an error."
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The `aws_s3` sink's `batch_encoding` field (added in v0.55.0 to support Parquet output) is gated behind the `codecs-parquet` Cargo feature. That feature was not enabled in any of the release feature aggregators, so the precompiled binaries shipped without Parquet support: users following the v0.55.0 release notes hit `unknown field 'batch_encoding'` and had no way to use the feature without rebuilding from source.

This PR turn on `codecs-parquet` for all releases.

## Vector configuration

```yaml
sources:
  demo:
    type: demo_logs
    format: apache_common
    interval: 0.1

sinks:
  s3_parquet:
    type: aws_s3
    inputs: [demo]
    bucket: test-wow-s3
    region: ap-northeast-1
    compression: none
    encoding:
      codec: text
    batch_encoding:
      codec: parquet
      schema_mode: auto_infer
      compression:
        algorithm: gzip
        level: 9
```

## How did you test this PR?

Reproduced the failure and verified the fix locally:

```
$ cargo run --no-default-features --features "base" -- validate /tmp/issue_25313.yaml
x unknown field `batch_encoding` in `sinks.s3_parquet`

$ cargo run --no-default-features --features "base,codecs-parquet" -- validate /tmp/issue_25313.yaml
√ Loaded
√ Component configuration
```

Also ran `cargo metadata` to confirm the feature graph still resolves, and `./scripts/check_changelog_fragments.sh` to confirm the fragment validates.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25313