### PR TITLE
feat(website): improve search ranking for component reference pages

### DIFF
--- a/website/scripts/typesense-index.ts
+++ b/website/scripts/typesense-index.ts
@@ -33,6 +33,8 @@ type AlgoliaRecord = {
   ranking: number;
   section: string;
   content: string;
+  componentWithType: string;
+  component: string;
 };
 
 type Section = {
@@ -94,6 +96,14 @@ async function indexHTMLFiles(
     const pageTitle = $("meta[name='algolia:title']").attr("content") || "";
     const pageTagsString = $("meta[name='keywords']").attr("content") || "";
     const pageTags: string[] = pageTagsString === "" ? [] : pageTagsString.split(",");
+    const pageUrl = getPageUrl(file);
+    const componentKindMatch = pageUrl.match(/\/docs\/reference\/configuration\/(sources|sinks|transforms)\//);
+    const componentKindMap: Record<string, string> = { sources: "source", sinks: "sink", transforms: "transform" };
+    const componentName = componentKindMatch ? (pageUrl.split("/").filter(Boolean).pop() || "") : "";
+    const pageComponentWithType = componentKindMatch
+      ? `${componentName} ${componentKindMap[componentKindMatch[1]]}`
+      : "";
+    const pageComponent = componentName;
 
     // @ts-ignore
     $(".algolia-no-index").each((_, d) => $(d).remove());
@@ -130,7 +140,6 @@ async function indexHTMLFiles(
     let activeRecord: AlgoliaRecord | null = null;
 
     for (const item of payload) {
-      const pageUrl = getPageUrl(file);
       const itemUrl = getItemUrl(file, item);
       const hashedId = hashString(itemUrl);
 
@@ -146,7 +155,9 @@ async function indexHTMLFiles(
           ranking,
           hierarchy: [],
           tags: pageTags,
-          content: ""
+          content: "",
+          componentWithType: pageComponentWithType,
+          component: pageComponent
         };
       } else if (item.level === 1) {
         // h1 logic
@@ -165,7 +176,9 @@ async function indexHTMLFiles(
           ranking,
           hierarchy: [...activeRecord.hierarchy, activeRecord.title.trim()],
           tags: pageTags,
-          content: ""
+          content: "",
+          componentWithType: pageComponentWithType,
+          component: pageComponent
         };
       } else {
         // h2-h6 logic
@@ -186,7 +199,9 @@ async function indexHTMLFiles(
           ranking,
           hierarchy: [...activeRecord.hierarchy.slice(0, lastIndex)],
           tags: pageTags,
-          content: ""
+          content: "",
+          componentWithType: pageComponentWithType,
+          component: pageComponent
         };
       }
 

--- a/website/scripts/typesense-index.ts
+++ b/website/scripts/typesense-index.ts
@@ -97,13 +97,10 @@ async function indexHTMLFiles(
     const pageTagsString = $("meta[name='keywords']").attr("content") || "";
     const pageTags: string[] = pageTagsString === "" ? [] : pageTagsString.split(",");
     const pageUrl = getPageUrl(file);
-    const componentKindMatch = pageUrl.match(/\/docs\/reference\/configuration\/(sources|sinks|transforms)\//);
+    const componentMatch = pageUrl.match(/\/docs\/reference\/configuration\/(sources|sinks|transforms)\/([^/]+)/);
     const componentKindMap: Record<string, string> = { sources: "source", sinks: "sink", transforms: "transform" };
-    const componentName = componentKindMatch ? (pageUrl.split("/").filter(Boolean).pop() || "") : "";
-    const pageComponentWithType = componentKindMatch
-      ? `${componentName} ${componentKindMap[componentKindMatch[1]]}`
-      : "";
-    const pageComponent = componentName;
+    const pageComponent = componentMatch ? componentMatch[2] : "";
+    const pageComponentWithType = componentMatch ? `${componentMatch[2]} ${componentKindMap[componentMatch[1]]}` : "";
 
     // @ts-ignore
     $(".algolia-no-index").each((_, d) => $(d).remove());

--- a/website/typesense.config.json
+++ b/website/typesense.config.json
@@ -136,6 +136,32 @@
             "type": "string[]",
             "stem_dictionary": "",
             "store": true
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "componentWithType",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string",
+            "stem_dictionary": "",
+            "store": true
+          },
+          {
+            "facet": false,
+            "index": true,
+            "infix": false,
+            "locale": "",
+            "name": "component",
+            "optional": true,
+            "sort": false,
+            "stem": false,
+            "type": "string",
+            "stem_dictionary": "",
+            "store": true
           }
         ]
       },
@@ -144,8 +170,8 @@
           "name": "vector_docs_search",
           "search_parameters": {
             "sort_by": "_text_match:desc,ranking:desc,level:desc",
-            "query_by": "pageTitle,title,hierarchy,content,tags",
-            "query_by_weights": "4,3,2,1,2",
+            "query_by": "componentWithType,component,pageTitle,title,hierarchy,content,tags",
+            "query_by_weights": "5,4,4,3,2,1,2",
             "text_match_type": "sum_score"
           }
         }


### PR DESCRIPTION
## Summary

Adds two new fields to the Typesense search index — `componentWithType` (e.g. `splunk_hec source`) and `component` (e.g. `splunk_hec`) — populated only for source/sink/transform reference pages. These fields are given the highest query weights in the search preset, so that searching a component name like `splunk_hec` or `file source` reliably surfaces the matching reference page above unrelated results.

The root issue was that BM25 scoring favors shorter fields: the sink page title "Splunk HEC logs sink" (4 tokens, 2 matching) outscored the source page title "Splunk HTTP Event Collector (HEC) source" (6 tokens, 2 matching) for the query "splunk_hec". The new fields provide a precise, short signal that correctly ranks exact-name matches first.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->