### PR TITLE
fix(topology): prevent source pump deadlock during sink config reload

### DIFF
--- a/changelog.d/24125_fix_topology_reload_deadlock.fix.md
+++ b/changelog.d/24125_fix_topology_reload_deadlock.fix.md
@@ -1,0 +1,6 @@
+Fixed a deadlock during config reload that caused all sources to stop consuming
+new messages when a sink in wait_for_sinks was being changed. The source pump
+would block in wait_for_replacements due to a Pause control message, creating a
+circular dependency with shutdown_diff.
+
+authors: joshcoughlan

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -37,6 +37,15 @@ use crate::{
 
 pub type ShutdownErrorReceiver = mpsc::UnboundedReceiver<ShutdownError>;
 
+/// Maximum time `shutdown_diff` will wait for an old sink task to drain before
+/// detaching it and proceeding with the reload. Without this bound, a sink whose
+/// downstream is permanently failing (e.g. stuck on retriable HTTP 429) would
+/// hold the reload indefinitely and backpressure the source pipeline. On timeout
+/// the old task is detached (it continues retrying in the background) and any
+/// `reuse_buffers` entry for the sink is dropped, so the new sink starts with a
+/// fresh buffer rather than waiting on the old one to release ownership.
+const RELOAD_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[derive(Debug, Snafu)]
 pub enum ReloadError {
     #[snafu(display("global options changed: {}", changed_fields.join(", ")))]
@@ -698,7 +707,20 @@ impl RunningTopology {
             let previous = self.tasks.remove(key).unwrap();
             if wait_for_sinks.contains(key) {
                 debug!(message = "Waiting for sink to shutdown.", component_id = %key);
-                previous.await.unwrap().unwrap();
+                match tokio::time::timeout(RELOAD_DRAIN_TIMEOUT, previous).await {
+                    Ok(res) => {
+                        res.unwrap().unwrap();
+                    }
+                    Err(_) => {
+                        warn!(
+                            component_id = %key,
+                            timeout_secs = RELOAD_DRAIN_TIMEOUT.as_secs(),
+                            "Sink did not finish draining within reload timeout; \
+                             detaching the old task and continuing the reload. \
+                             In-flight events on the detached task may be lost."
+                        );
+                    }
+                }
             } else {
                 drop(previous); // detach and forget
             }
@@ -709,9 +731,30 @@ impl RunningTopology {
             if wait_for_sinks.contains(key) {
                 let previous = self.tasks.remove(key).unwrap();
                 debug!(message = "Waiting for sink to shutdown.", component_id = %key);
-                let buffer = previous.await.unwrap().unwrap();
+                let buffer = match tokio::time::timeout(RELOAD_DRAIN_TIMEOUT, previous).await {
+                    Ok(res) => Some(res.unwrap().unwrap()),
+                    Err(_) => {
+                        warn!(
+                            component_id = %key,
+                            timeout_secs = RELOAD_DRAIN_TIMEOUT.as_secs(),
+                            reuse_buffers = reuse_buffers.contains(key),
+                            "Sink did not finish draining within reload timeout; \
+                             detaching the old task and continuing the reload. \
+                             In-flight events on the detached task may be lost. \
+                             If the sink was a buffer-reuse candidate, the new \
+                             sink will start with a fresh buffer instead."
+                        );
+                        // Drop the buffer_tx entry so we don't try to reuse it; the
+                        // builder falls through to constructing a fresh buffer when
+                        // the buffers map has no entry for this key.
+                        buffer_tx.remove(key);
+                        None
+                    }
+                };
 
-                if reuse_buffers.contains(key) {
+                if let Some(buffer) = buffer
+                    && reuse_buffers.contains(key)
+                {
                     // We clone instead of removing here because otherwise the input will be
                     // missing for the rest of the reload process, which violates the assumption
                     // that all previous inputs for components not being removed are still

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -302,7 +302,7 @@ impl RunningTopology {
         } else {
             ConfigDiff::new(&self.config, &new_config, HashSet::new())
         };
-        let buffers = self.shutdown_diff(&diff, &new_config).await;
+        let (buffers, force_removed_sinks) = self.shutdown_diff(&diff, &new_config).await;
 
         // Gives windows some time to make available any port
         // released by shutdown components.
@@ -329,7 +329,7 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, new_config.healthchecks)
                 .await
             {
-                self.connect_diff(&diff, &mut new_pieces).await;
+                self.connect_diff(&diff, &mut new_pieces, &force_removed_sinks).await;
                 self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
 
@@ -355,7 +355,7 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, self.config.healthchecks)
                 .await
         {
-            self.connect_diff(&diff, &mut new_pieces).await;
+            self.connect_diff(&diff, &mut new_pieces, &force_removed_sinks).await;
             self.spawn_diff(&diff, new_pieces);
 
             info!("Old configuration restored successfully.");
@@ -418,7 +418,7 @@ impl RunningTopology {
         &mut self,
         diff: &ConfigDiff,
         new_config: &Config,
-    ) -> HashMap<ComponentKey, BuiltBuffer> {
+    ) -> (HashMap<ComponentKey, BuiltBuffer>, HashSet<ComponentKey>) {
         // First, we shutdown any changed/removed sources. This ensures that we can allow downstream
         // components to terminate naturally by virtue of the flow of events stopping.
         if diff.sources.any_changed_or_removed() {
@@ -472,7 +472,7 @@ impl RunningTopology {
             let previous = self.tasks.remove(key).unwrap();
             drop(previous); // detach and forget
 
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config, false).await;
             self.remove_outputs(key);
 
             if let Some(registry) = self.utilization_registry.as_ref() {
@@ -483,7 +483,7 @@ impl RunningTopology {
         for key in &diff.transforms.to_change {
             debug!(component_id = %key, "Changing transform.");
 
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config, false).await;
             self.remove_outputs(key);
         }
 
@@ -619,15 +619,22 @@ impl RunningTopology {
             .collect::<Vec<_>>();
         for key in &removed_sinks {
             debug!(component_id = %key, "Removing sink.");
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config, false).await;
 
             if let Some(registry) = self.utilization_registry.as_ref() {
                 registry.remove_component(key);
             }
         }
 
-        // After that, for any changed sinks, we temporarily detach their inputs (not remove) so
-        // they can naturally shutdown and allow us to recover their buffers if possible.
+        // After that, for any changed sinks, we disconnect their inputs so they can naturally
+        // shutdown and allow us to recover their buffers if possible.
+        //
+        // For sinks in wait_for_sinks, we use a full Remove (not Pause) from the upstream fanout.
+        // This prevents a circular dependency where the source pump blocks in
+        // wait_for_replacements (waiting for a Replace that only arrives after connect_diff,
+        // which runs after shutdown_diff, which is waiting for the old sink to finish).
+        // Using Remove allows the source pump to continue sending to other sinks while
+        // the old sink drains.
         let mut buffer_tx = HashMap::new();
 
         let sinks_to_change = diff
@@ -642,8 +649,18 @@ impl RunningTopology {
             }))
             .collect::<Vec<_>>();
 
+        // Track which sinks were force-removed from their upstream fanouts so that
+        // connect_diff knows to use Add (not Replace) when reconnecting them.
+        let mut force_removed_sinks = HashSet::new();
+
         for key in &sinks_to_change {
             debug!(component_id = %key, "Changing sink.");
+
+            let force_remove = wait_for_sinks.contains(key);
+            if force_remove {
+                force_removed_sinks.insert((*key).clone());
+            }
+
             if reuse_buffers.contains(key) || changed_disk_buffer_sinks.contains(key) {
                 self.detach_triggers
                     .remove(key)
@@ -665,7 +682,7 @@ impl RunningTopology {
                     buffer_tx.insert((*key).clone(), self.inputs.get(key).unwrap().clone());
                 }
             }
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config, force_remove).await;
         }
 
         // Now that we've disconnected or temporarily detached the inputs to all changed/removed
@@ -710,14 +727,19 @@ impl RunningTopology {
             }
         }
 
-        buffers
+        (buffers, force_removed_sinks)
     }
 
     /// Connects all changed/added components in the given configuration diff.
+    ///
+    /// `force_removed_sinks` contains the keys of sinks that were fully removed (not paused)
+    /// from their upstream fanouts during shutdown_diff. These sinks need to be re-added
+    /// via `ControlMessage::Add` rather than `ControlMessage::Replace`.
     pub(crate) async fn connect_diff(
         &mut self,
         diff: &ConfigDiff,
         new_pieces: &mut TopologyPieces,
+        force_removed_sinks: &HashSet<ComponentKey>,
     ) {
         debug!("Connecting changed/added component(s).");
 
@@ -837,13 +859,13 @@ impl RunningTopology {
         // with transforms.
         for key in diff.transforms.changed_and_added() {
             debug!(component_id = %key, "Connecting inputs for transform.");
-            self.setup_inputs(key, diff, new_pieces).await;
+            self.setup_inputs(key, diff, new_pieces, false).await;
         }
 
         // Now that all sources and transforms are fully configured, we can wire up sinks.
         for key in diff.sinks.changed_and_added() {
             debug!(component_id = %key, "Connecting inputs for sink.");
-            self.setup_inputs(key, diff, new_pieces).await;
+            self.setup_inputs(key, diff, new_pieces, force_removed_sinks.contains(key)).await;
         }
         let added_changed_tables: Vec<&ComponentKey> = diff
             .enrichment_tables
@@ -852,7 +874,7 @@ impl RunningTopology {
             .collect();
         for key in added_changed_tables.iter() {
             debug!(component_id = %key, "Connecting inputs for enrichment table sink.");
-            self.setup_inputs(key, diff, new_pieces).await;
+            self.setup_inputs(key, diff, new_pieces, force_removed_sinks.contains(key)).await;
         }
 
         // We do a final pass here to reconnect unchanged components.
@@ -948,6 +970,7 @@ impl RunningTopology {
         key: &ComponentKey,
         diff: &ConfigDiff,
         new_pieces: &mut builder::TopologyPieces,
+        force_removed: bool,
     ) {
         let (tx, inputs) = new_pieces.inputs.remove(key).unwrap();
 
@@ -965,10 +988,21 @@ impl RunningTopology {
         for input in inputs {
             let output = self.outputs.get_mut(&input).expect("unknown output");
 
-            if diff.contains(&input.component) || inputs_to_add.contains(&input) {
-                // If the input we're connecting to is changing, that means its outputs will have been
-                // recreated, so instead of replacing a paused sink, we have to add it to this new
-                // output for the first time, since there's nothing to actually replace at this point.
+            if force_removed
+                || diff.contains(&input.component)
+                || inputs_to_add.contains(&input)
+            {
+                // Cases where we need to add (not replace) the component input:
+                //
+                // Case 1: The component was force-removed from the fanout during shutdown_diff
+                // (rather than paused), so there is no paused entry to replace.
+                //
+                // Case 2: If the input we're connecting to is changing, that means its outputs
+                // will have been recreated, so instead of replacing a paused sink, we have to add
+                // it to this new output for the first time, since there's nothing to actually
+                // replace at this point.
+                //
+                // Case 3: This is a newly added connection.
                 debug!(component_id = %key, fanout_id = %input, "Adding component input to fanout.");
 
                 _ = output.send(ControlMessage::Add(key.clone(), tx.clone()));
@@ -994,7 +1028,13 @@ impl RunningTopology {
         self.outputs.retain(|id, _output| &id.component != key);
     }
 
-    async fn remove_inputs(&mut self, key: &ComponentKey, diff: &ConfigDiff, new_config: &Config) {
+    async fn remove_inputs(
+        &mut self,
+        key: &ComponentKey,
+        diff: &ConfigDiff,
+        new_config: &Config,
+        force_remove: bool,
+    ) {
         self.inputs.remove(key);
         self.detach_triggers.remove(key);
 
@@ -1007,20 +1047,26 @@ impl RunningTopology {
 
         for input in old_inputs {
             if let Some(output) = self.outputs.get_mut(input) {
-                if diff.contains(&input.component)
+                if force_remove
+                    || diff.contains(&input.component)
                     || diff.is_removed(key)
                     || !new_inputs.contains(input)
                 {
-                    // 3 cases to remove the input:
+                    // Cases to remove the input:
                     //
-                    // Case 1: If the input we're removing ourselves from is changing, that means its
+                    // Case 1: The caller has requested a full removal (force_remove). This is used
+                    // for sinks whose old task must finish before the reload can proceed
+                    // (wait_for_sinks). Using Pause here would block the source pump in
+                    // wait_for_replacements, creating a circular dependency with shutdown_diff.
+                    //
+                    // Case 2: If the input we're removing ourselves from is changing, that means its
                     // outputs will be recreated, so instead of pausing the sink, we just delete it
                     // outright to ensure things are clean.
                     //
-                    // Case 2: If this component itself is being removed, then pausing makes no sense
+                    // Case 3: If this component itself is being removed, then pausing makes no sense
                     // because it isn't coming back.
                     //
-                    // Case 3: This component is no longer connected to the input from new config.
+                    // Case 4: This component is no longer connected to the input from new config.
                     debug!(component_id = %key, fanout_id = %input, "Removing component input from fanout.");
 
                     _ = output.send(ControlMessage::Remove(key.clone()));
@@ -1374,7 +1420,9 @@ impl RunningTopology {
         {
             return None;
         }
-        running_topology.connect_diff(&diff, &mut pieces).await;
+        running_topology
+            .connect_diff(&diff, &mut pieces, &HashSet::new())
+            .await;
         running_topology.spawn_diff(&diff, pieces);
 
         let (utilization_task_shutdown_trigger, utilization_shutdown_signal, _) =

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -329,7 +329,8 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, new_config.healthchecks)
                 .await
             {
-                self.connect_diff(&diff, &mut new_pieces, &force_removed_sinks).await;
+                self.connect_diff(&diff, &mut new_pieces, &force_removed_sinks)
+                    .await;
                 self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
 
@@ -355,7 +356,8 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, self.config.healthchecks)
                 .await
         {
-            self.connect_diff(&diff, &mut new_pieces, &force_removed_sinks).await;
+            self.connect_diff(&diff, &mut new_pieces, &force_removed_sinks)
+                .await;
             self.spawn_diff(&diff, new_pieces);
 
             info!("Old configuration restored successfully.");
@@ -682,7 +684,8 @@ impl RunningTopology {
                     buffer_tx.insert((*key).clone(), self.inputs.get(key).unwrap().clone());
                 }
             }
-            self.remove_inputs(key, diff, new_config, force_remove).await;
+            self.remove_inputs(key, diff, new_config, force_remove)
+                .await;
         }
 
         // Now that we've disconnected or temporarily detached the inputs to all changed/removed
@@ -865,7 +868,8 @@ impl RunningTopology {
         // Now that all sources and transforms are fully configured, we can wire up sinks.
         for key in diff.sinks.changed_and_added() {
             debug!(component_id = %key, "Connecting inputs for sink.");
-            self.setup_inputs(key, diff, new_pieces, force_removed_sinks.contains(key)).await;
+            self.setup_inputs(key, diff, new_pieces, force_removed_sinks.contains(key))
+                .await;
         }
         let added_changed_tables: Vec<&ComponentKey> = diff
             .enrichment_tables
@@ -874,7 +878,8 @@ impl RunningTopology {
             .collect();
         for key in added_changed_tables.iter() {
             debug!(component_id = %key, "Connecting inputs for enrichment table sink.");
-            self.setup_inputs(key, diff, new_pieces, force_removed_sinks.contains(key)).await;
+            self.setup_inputs(key, diff, new_pieces, force_removed_sinks.contains(key))
+                .await;
         }
 
         // We do a final pass here to reconnect unchanged components.
@@ -988,10 +993,7 @@ impl RunningTopology {
         for input in inputs {
             let output = self.outputs.get_mut(&input).expect("unknown output");
 
-            if force_removed
-                || diff.contains(&input.component)
-                || inputs_to_add.contains(&input)
-            {
+            if force_removed || diff.contains(&input.component) || inputs_to_add.contains(&input) {
                 // Cases where we need to add (not replace) the component input:
                 //
                 // Case 1: The component was force-removed from the fanout during shutdown_diff

--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -451,6 +451,111 @@ async fn topology_disk_buffer_config_change_chained_does_not_stall() {
     }
 }
 
+/// Regression test for https://github.com/vectordotdev/vector/issues/24125
+///
+/// When a sink with a conflicting resource (e.g., a bound port) is reloaded,
+/// the old sink must be waited on before the new one can start. Previously,
+/// `remove_inputs` sent `Pause` to the upstream fanout, which blocked the
+/// source pump in `wait_for_replacements` — creating a circular dependency
+/// with `shutdown_diff`. This test verifies that the reload completes
+/// within a reasonable time instead of stalling.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn topology_reload_conflicting_sink_does_not_stall() {
+    test_util::trace_init();
+
+    let (_guard, address) = next_addr();
+
+    let mut old_config = Config::builder();
+    old_config.add_source("in", internal_metrics_source());
+    old_config.add_sink("out", &["in"], prom_exporter_sink(address, 1));
+
+    // Change only the flush period so the sink config differs but the
+    // resource (bound address) stays the same, creating a conflict.
+    let mut new_config = Config::builder();
+    new_config.add_source("in", internal_metrics_source());
+    new_config.add_sink("out", &["in"], prom_exporter_sink(address, 2));
+
+    let (mut topology, crash) = start_topology(old_config.build().unwrap(), false).await;
+    let mut crash_stream = UnboundedReceiverStream::new(crash);
+
+    tokio::select! {
+        _ = wait_for_tcp(address) => {},
+        _ = crash_stream.next() => panic!("topology crashed before reload"),
+    }
+
+    // Let some events flow so the source pump is active.
+    sleep(Duration::from_secs(2)).await;
+
+    let reload_result = tokio::time::timeout(
+        Duration::from_secs(10),
+        topology.reload_config_and_respawn(new_config.build().unwrap(), Default::default()),
+    )
+    .await;
+
+    assert!(
+        reload_result.is_ok(),
+        "Reload stalled: reloading a sink with conflicting resources should not block the source pump"
+    );
+    reload_result.unwrap().unwrap();
+
+    // Verify the new sink is running.
+    tokio::select! {
+        _ = wait_for_tcp(address) => {},
+        _ = crash_stream.next() => panic!("topology crashed after reload"),
+    }
+}
+
+/// Similar regression test for the SIGHUP reload path where sinks end up in
+/// `reuse_buffers` (buffer config unchanged, no `components_to_reload`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn topology_reload_reuse_buffer_does_not_stall() {
+    test_util::trace_init();
+
+    let (_guard_0, address_0) = next_addr();
+    let (_guard_1, address_1) = next_addr();
+
+    let mut old_config = Config::builder();
+    old_config.add_source("in", internal_metrics_source());
+    old_config.add_sink("out", &["in"], prom_exporter_sink(address_0, 1));
+
+    // Change the address so the sink is in to_change, but don't change
+    // the buffer config so it lands in reuse_buffers. Also don't use
+    // extend_reload_set so the sink is NOT in components_to_reload
+    // (simulating a SIGHUP-style reload).
+    let mut new_config = Config::builder();
+    new_config.add_source("in", internal_metrics_source());
+    new_config.add_sink("out", &["in"], prom_exporter_sink(address_1, 1));
+
+    let (mut topology, crash) = start_topology(old_config.build().unwrap(), false).await;
+    let mut crash_stream = UnboundedReceiverStream::new(crash);
+
+    tokio::select! {
+        _ = wait_for_tcp(address_0) => {},
+        _ = crash_stream.next() => panic!("topology crashed before reload"),
+    }
+
+    // Let some events flow so the source pump is active.
+    sleep(Duration::from_secs(2)).await;
+
+    let reload_result = tokio::time::timeout(
+        Duration::from_secs(10),
+        topology.reload_config_and_respawn(new_config.build().unwrap(), Default::default()),
+    )
+    .await;
+
+    assert!(
+        reload_result.is_ok(),
+        "Reload stalled: reloading a sink with reused buffer should not block the source pump"
+    );
+    reload_result.unwrap().unwrap();
+
+    // Verify the new sink is running on the new address.
+    tokio::select! {
+        _ = wait_for_tcp(address_1) => {},
+        _ = crash_stream.next() => panic!("topology crashed after reload"),
+    }
+}
+
 async fn reload_sink_test(
     old_config: Config,
     new_config: Config,

--- a/testing/github-24125/Dockerfile
+++ b/testing/github-24125/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.4
+#
+# Minimal Vector image used by reproduce-reload-deadlock.sh when no image is
+# supplied. Builds for the host architecture with only the features the repro
+# needs (no cross-compile, no Rosetta). BuildKit cache mounts preserve the
+# cargo registry and target dir across rebuilds.
+
+FROM rust:1.92-bookworm AS build
+WORKDIR /vector
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cmake protobuf-compiler libsasl2-dev pkg-config clang libclang-dev && \
+    rm -rf /var/lib/apt/lists/*
+COPY . .
+ARG FEATURES="api,api-client,sources-demo_logs,sources-internal_metrics,transforms-route,sinks-http,sinks-prometheus"
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/vector/target \
+    cargo build --release --bin vector --no-default-features --features "$FEATURES" && \
+    cp /vector/target/release/vector /vector/vector
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=build /vector/vector /usr/local/bin/vector
+ENTRYPOINT ["vector"]
+CMD ["--config-dir", "/etc/vector"]

--- a/testing/github-24125/base-config.yaml
+++ b/testing/github-24125/base-config.yaml
@@ -1,0 +1,28 @@
+# Static base config for the vector#24125 repro.
+# The repro script appends rendered http-sinks.yaml.tmpl to this file to form vector.yaml.
+
+api:
+  enabled: true
+  address: 0.0.0.0:8686
+
+sources:
+  demo:
+    type: demo_logs
+    format: json
+    interval: 0.1
+  internal:
+    type: internal_metrics
+    scrape_interval_secs: 5
+
+transforms:
+  router:
+    type: route
+    inputs: [demo]
+    route:
+      all: 'true'
+
+sinks:
+  metrics_out:
+    type: prometheus_exporter
+    inputs: [internal]
+    address: 0.0.0.0:9598

--- a/testing/github-24125/base-config.yaml
+++ b/testing/github-24125/base-config.yaml
@@ -1,5 +1,7 @@
 # Static base config for the vector#24125 repro.
-# The repro script appends rendered http-sinks.yaml.tmpl to this file to form vector.yaml.
+# Bind-mounted directly into the container at /etc/vector/base.yaml; the rendered
+# sinks file lives next to it as /etc/vector/sinks.yaml and Vector merges both
+# via --config-dir.
 
 api:
   enabled: true

--- a/testing/github-24125/http-sinks.yaml.tmpl
+++ b/testing/github-24125/http-sinks.yaml.tmpl
@@ -1,8 +1,11 @@
-# Template for the two http sinks. The repro script renders this and appends
-# it to base-config.yaml. Placeholders:
-#   @@GOOD_HOST@@      hostname of the always-200 receiver
-#   @@BAD_HOST@@       hostname of the receiver that flips to 429 after a delay
-#   @@EXCEPT_FIELDS@@  rendered YAML list of strings, indented to fit under except_fields:
+# Template for the two http sinks. The repro script renders this into a
+# standalone sinks.yaml and bind-mounts it alongside base-config.yaml so
+# vector --config-dir merges them. Placeholder tokens (in angle brackets here
+# so the token text doesn't get text-substituted by the renderer):
+#   <good-host>     hostname of the always-200 receiver
+#   <bad-host>      hostname of the receiver that flips to 429 after a delay
+#   <except-fields> rendered YAML list of strings, indented to fit under except_fields:
+sinks:
   sink_good:
     type: http
     inputs: [router.all]

--- a/testing/github-24125/http-sinks.yaml.tmpl
+++ b/testing/github-24125/http-sinks.yaml.tmpl
@@ -1,0 +1,23 @@
+# Template for the two http sinks. The repro script renders this and appends
+# it to base-config.yaml. Placeholders:
+#   @@GOOD_HOST@@      hostname of the always-200 receiver
+#   @@BAD_HOST@@       hostname of the receiver that flips to 429 after a delay
+#   @@EXCEPT_FIELDS@@  rendered YAML list of strings, indented to fit under except_fields:
+  sink_good:
+    type: http
+    inputs: [router.all]
+    uri: http://@@GOOD_HOST@@:8001
+    method: post
+    encoding:
+      codec: json
+      except_fields:
+@@EXCEPT_FIELDS@@
+  sink_bad:
+    type: http
+    inputs: [router.all]
+    uri: http://@@BAD_HOST@@:8001
+    method: post
+    encoding:
+      codec: json
+      except_fields:
+@@EXCEPT_FIELDS@@

--- a/testing/github-24125/receiver.py
+++ b/testing/github-24125/receiver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""HTTP receiver used by the vector#24125 repro.
+
+Returns 200 until FAIL_AFTER seconds have elapsed since startup, then 429.
+Env vars:
+  PORT        listen port (default 8001)
+  FAIL_AFTER  seconds before flipping to 429; default infinity (always 200)
+"""
+import http.server
+import os
+import socketserver
+import time
+
+PORT = int(os.environ.get("PORT", "8001"))
+FAIL_AFTER = float(os.environ.get("FAIL_AFTER", "inf"))
+START = time.time()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def _h(self):
+        try:
+            ln = int(self.headers.get("Content-Length", "0") or "0")
+            if ln > 0:
+                self.rfile.read(ln)
+        except Exception:
+            pass
+        code = 429 if (time.time() - START) > FAIL_AFTER else 200
+        self.send_response(code)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    do_GET = do_POST = do_PUT = _h
+
+    def log_message(self, *a, **kw):
+        pass
+
+
+print(f"receiver listening on {PORT} (fail after {FAIL_AFTER}s)", flush=True)
+with socketserver.ThreadingTCPServer(("", PORT), Handler) as srv:
+    srv.serve_forever()

--- a/testing/github-24125/reproduce-reload-deadlock.sh
+++ b/testing/github-24125/reproduce-reload-deadlock.sh
@@ -26,7 +26,12 @@
 #   http-sinks.yaml.tmpl   templated http sinks (rendered per-run)
 #
 # Usage:
-#   ./testing/github-24125/reproduce-reload-deadlock.sh <image>
+#   ./testing/github-24125/reproduce-reload-deadlock.sh [image]
+#
+# If [image] is omitted, builds a minimal Vector image from the current source tree
+# (host architecture, no cross-compile, only the features the repro needs). The
+# resulting image is tagged vector-pr24125-test:local. First build is ~10–15 min;
+# subsequent builds are fast thanks to BuildKit cache mounts.
 #
 # Exit codes:
 #   0 — bug reproduced (post-edit reload did not complete within the floor)
@@ -35,14 +40,9 @@
 
 set -euo pipefail
 
-if [ $# -lt 1 ]; then
-  echo "Usage: $0 <image>" >&2
-  echo "  e.g. $0 timberio/vector:0.50.0-debian" >&2
-  exit 64
-fi
-
-IMAGE="$1"
+IMAGE="${1:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RECEIVER_PY="$SCRIPT_DIR/receiver.py"
 BASE_YAML="$SCRIPT_DIR/base-config.yaml"
 SINKS_TMPL="$SCRIPT_DIR/http-sinks.yaml.tmpl"
@@ -69,7 +69,7 @@ BASELINE_RELOAD_MAX_SEC="${BASELINE_RELOAD_MAX_SEC:-120}"
 # reload sink drain (which has no timeout), so this floor is a heuristic, not a
 # strict upper bound implied by Vector's code. See src/topology/running.rs.
 GRACEFUL_SHUTDOWN_LIMIT_SEC="${GRACEFUL_SHUTDOWN_LIMIT_SEC:-20}"
-POST_EDIT_RELOAD_FLOOR_SEC="${POST_EDIT_RELOAD_FLOOR_SEC:-30}"
+POST_EDIT_RELOAD_FLOOR_SEC="${POST_EDIT_RELOAD_FLOOR_SEC:-90}"
 # These ports are baked into vector-base.yaml; changing them here also requires editing the
 # static config. They're variables only so the docker port mappings stay in one place.
 API_PORT=8686
@@ -85,13 +85,40 @@ fi
 RESULTS=()  # each entry: STATUS|ID|LABEL|NOTE|DETAIL
 
 cleanup() {
-  for c in "$VECTOR_C" "$GOOD_C" "$BAD_C"; do
-    docker rm -f "$c" >/dev/null 2>&1 || true
-  done
-  docker network rm "$NETWORK" >/dev/null 2>&1 || true
-  rm -rf "$WORKDIR"
+  if [[ "${CLEANUP:=true}" == "true" ]]; then
+    echo "==> Cleaning up old images and networks"
+    for c in "$VECTOR_C" "$GOOD_C" "$BAD_C"; do
+      docker rm -f "$c" >/dev/null 2>&1 || true
+    done
+    docker network rm "$NETWORK" >/dev/null 2>&1 || true
+    if [[ "${ON_EXIT:=false}" == "true" ]]; then
+      rm -rf "$WORKDIR"
+    fi
+  fi
 }
-trap cleanup EXIT
+
+on_exit() {
+  ON_EXIT=true
+  CLEANUP=${EXIT_CLEANUP:=true}
+  cleanup
+}
+
+if [[ "${START_CLEANUP:=true}" == "true" ]]; then
+  cleanup
+fi
+
+trap on_exit EXIT
+
+if [ -z "$IMAGE" ]; then
+  IMAGE="vector-pr24125-test:local"
+  echo "==> no image provided; building $IMAGE from $REPO_ROOT"
+  echo "==> first build ~10–15 min; subsequent builds reuse cargo cache"
+  if [ "${CLEAN_BUILD:-0}" = 1 ]; then
+    echo "==> CLEAN_BUILD=1 set; pruning BuildKit cache mounts (cargo registry, target/)"
+    docker builder prune -af >/dev/null
+  fi
+  DOCKER_BUILDKIT=1 docker build --no-cache -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" "$REPO_ROOT"
+fi
 
 # Render the http-sinks template with the current host names and except_fields list.
 # $1 = comma-separated except_fields (e.g. "garbage_initial,garbage_post_edit")
@@ -111,9 +138,34 @@ PYEOF
 }
 
 write_config() {
-  # $1 = comma-separated except_fields
-  cat "$BASE_YAML" > "$WORKDIR/vector.yaml"
-  render_sinks "$1" >> "$WORKDIR/vector.yaml"
+  # $1 = comma-separated except_fields. The sinks.yaml file is bind-mounted into
+  # the container, so the host write here is what Vector eventually sees.
+  # Truncate-then-write preserves the inode so the bind mount keeps tracking.
+  render_sinks "$1" > "$WORKDIR/sinks.yaml"
+}
+
+# Poll `vector validate` from inside the container until it succeeds or the
+# attempt budget is exhausted. Used after rewriting sinks.yaml to absorb the
+# bind-mount propagation lag on Docker for Mac (gRPC/virtiofs bridge can take
+# a few hundred ms to expose the new content to the Linux VM, during which a
+# SIGHUP would race and Vector would read a truncated file).
+#
+# Backoff: 1s wait first, then 5 attempts at 1s, 2s, 4s, 8s, 16s gaps -> ~32s
+# worst case. Returns 0 on success, non-zero if all attempts fail.
+wait_for_config_visible() {
+  sleep 1
+  local delay=1
+  for attempt in 1 2 3 4 5; do
+    if docker exec "$VECTOR_C" vector validate --no-environment /etc/vector/base.yaml /etc/vector/sinks.yaml >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ "$attempt" -lt 5 ]; then
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+  done
+  echo "${RED}WARN: vector validate never succeeded for the rewritten config${RESET}" >&2
+  return 1
 }
 
 count_log_marker() {
@@ -285,8 +337,9 @@ docker run -d --name "$VECTOR_C" --network "$NETWORK" \
   -p "${API_PORT}:${API_PORT}" \
   -p "${PROM_PORT}:${PROM_PORT}" \
   -e VECTOR_GRACEFUL_SHUTDOWN_LIMIT_SECS="$GRACEFUL_SHUTDOWN_LIMIT_SEC" \
-  -v "$WORKDIR:/etc/vector" \
-  "$IMAGE" >/dev/null
+  -v "$BASE_YAML:/etc/vector/base.yaml:ro" \
+  -v "$WORKDIR/sinks.yaml:/etc/vector/sinks.yaml:ro" \
+  "$IMAGE" --config /etc/vector/base.yaml --config /etc/vector/sinks.yaml >/dev/null
 
 started=false
 for _ in $(seq 1 60); do
@@ -348,6 +401,8 @@ probe_state T3 "after baseline SIGHUP (no config change)" healthy
 echo
 echo "==> editing config: adding 'garbage_post_edit' to encoding.except_fields on both sinks"
 write_config "garbage_initial,garbage_post_edit"
+echo "==> waiting for the rewritten config to be visible to Vector (vector validate poll)"
+wait_for_config_visible
 
 post_edit_max=$(awk -v b="$baseline_elapsed" -v floor="$POST_EDIT_RELOAD_FLOOR_SEC" \
   'BEGIN { v = int(b * 1.5 + 0.5); if (v < floor) v = floor; print v }')

--- a/testing/github-24125/reproduce-reload-deadlock.sh
+++ b/testing/github-24125/reproduce-reload-deadlock.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# Faithful repro of vectordotdev/vector#24125: Vector fails to reload sink with failed events.
+#
+# Production scenario being recreated:
+#   - One source (demo_logs) routed via a route transform to two http sinks.
+#   - One sink ("good") receives 200; the other ("bad") begins returning 429 after a delay,
+#     simulating a downstream that throttles/refuses requests. 429 is in the http sink's
+#     default retriable set, so events back up in the bad sink rather than being dropped.
+#   - After the bad sink has been failing for a while, the operator edits a benign field
+#     (encoding.except_fields) on both sinks and SIGHUPs Vector.
+#   - The reload stalls indefinitely. All sinks stop sending. Only restarting Vector recovers.
+#
+# A separate metrics pipeline (internal_metrics -> prometheus_exporter) is included so we can
+# poll per-component event counters; we also tap router.all to observe live event flow.
+#
+# At four checkpoints we probe the system (tap + metric deltas) and classify the state as
+# GREEN (normal) or RED (malfunction). A colorized summary prints at the end.
+#   T1 — initial startup
+#   T2 — after the fouled sink starts returning 429
+#   T3 — after the first SIGHUP (no config change, baseline reload)
+#   T4 — after the config change and SIGHUP (the bug-trigger)
+#
+# Files in this directory:
+#   receiver.py            tiny HTTP listener used as both receivers
+#   base-config.yaml       static parts of the Vector config (sources, transforms, metrics sink)
+#   http-sinks.yaml.tmpl   templated http sinks (rendered per-run)
+#
+# Usage:
+#   ./testing/github-24125/reproduce-reload-deadlock.sh <image>
+#
+# Exit codes:
+#   0 — bug reproduced (post-edit reload did not complete within the floor)
+#   1 — reload completed (image is unaffected/patched)
+#   2 — inconclusive (setup failed or baseline reload didn't complete)
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <image>" >&2
+  echo "  e.g. $0 timberio/vector:0.50.0-debian" >&2
+  exit 64
+fi
+
+IMAGE="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECEIVER_PY="$SCRIPT_DIR/receiver.py"
+BASE_YAML="$SCRIPT_DIR/base-config.yaml"
+SINKS_TMPL="$SCRIPT_DIR/http-sinks.yaml.tmpl"
+
+for f in "$RECEIVER_PY" "$BASE_YAML" "$SINKS_TMPL"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: missing required file: $f" >&2
+    exit 2
+  fi
+done
+
+NETWORK="vector-repro-24125-net"
+VECTOR_C="vector-repro-24125"
+GOOD_C="receiver-good-24125"
+BAD_C="receiver-bad-24125"
+WORKDIR="$(mktemp -d)"
+FAIL_AFTER_SEC="${FAIL_AFTER_SEC:-10}"
+SOAK_BEFORE_RELOAD_SEC="${SOAK_BEFORE_RELOAD_SEC:-15}"
+BASELINE_RELOAD_MAX_SEC="${BASELINE_RELOAD_MAX_SEC:-120}"
+# We hard-set Vector's graceful shutdown limit (VECTOR_GRACEFUL_SHUTDOWN_LIMIT_SECS)
+# to 20s so the test isn't subject to upstream default drift. The post-edit reload
+# floor is that value + 10s — well above any healthy reload time. Note: as of this
+# writing the graceful shutdown limit only applies to SIGINT/SIGTERM, not to per-
+# reload sink drain (which has no timeout), so this floor is a heuristic, not a
+# strict upper bound implied by Vector's code. See src/topology/running.rs.
+GRACEFUL_SHUTDOWN_LIMIT_SEC="${GRACEFUL_SHUTDOWN_LIMIT_SEC:-20}"
+POST_EDIT_RELOAD_FLOOR_SEC="${POST_EDIT_RELOAD_FLOOR_SEC:-30}"
+# These ports are baked into vector-base.yaml; changing them here also requires editing the
+# static config. They're variables only so the docker port mappings stay in one place.
+API_PORT=8686
+PROM_PORT=9598
+SCRAPE_INTERVAL_SEC=5
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+  RED=''; GREEN=''; BOLD=''; RESET=''
+fi
+
+RESULTS=()  # each entry: STATUS|ID|LABEL|NOTE|DETAIL
+
+cleanup() {
+  for c in "$VECTOR_C" "$GOOD_C" "$BAD_C"; do
+    docker rm -f "$c" >/dev/null 2>&1 || true
+  done
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Render the http-sinks template with the current host names and except_fields list.
+# $1 = comma-separated except_fields (e.g. "garbage_initial,garbage_post_edit")
+render_sinks() {
+  python3 - "$SINKS_TMPL" "$GOOD_C" "$BAD_C" "$1" <<'PYEOF'
+import sys
+tmpl_path, good_host, bad_host, fields_csv = sys.argv[1:5]
+fields = [f.strip() for f in fields_csv.split(',') if f.strip()]
+except_yaml = '\n'.join(f'        - {f}' for f in fields)
+with open(tmpl_path) as f:
+    out = f.read()
+out = out.replace('@@GOOD_HOST@@', good_host)
+out = out.replace('@@BAD_HOST@@', bad_host)
+out = out.replace('@@EXCEPT_FIELDS@@', except_yaml)
+sys.stdout.write(out)
+PYEOF
+}
+
+write_config() {
+  # $1 = comma-separated except_fields
+  cat "$BASE_YAML" > "$WORKDIR/vector.yaml"
+  render_sinks "$1" >> "$WORKDIR/vector.yaml"
+}
+
+count_log_marker() {
+  docker logs "$VECTOR_C" 2>&1 | grep -c "New configuration loaded successfully" || true
+}
+
+wait_for_reload_completion() {
+  # $1 = baseline count of "New configuration loaded successfully"
+  # $2 = max wait seconds
+  # echoes elapsed seconds on success, returns 1 on timeout
+  local baseline="$1" max="$2"
+  local start now elapsed cur
+  start=$(date +%s)
+  while :; do
+    cur=$(count_log_marker)
+    if [ "$cur" -gt "$baseline" ]; then
+      now=$(date +%s); elapsed=$((now - start))
+      echo "$elapsed"
+      return 0
+    fi
+    now=$(date +%s); elapsed=$((now - start))
+    if [ "$elapsed" -ge "$max" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+scrape_metric() {
+  # Prometheus exposition lines look like:
+  #   metric_name{labels} value [timestamp_ms]
+  # Field $2 is always the value; $NF would be the timestamp when present.
+  local metric="$1" component="$2"
+  local val
+  val=$(curl -fs --max-time 3 "http://localhost:${PROM_PORT}/metrics" 2>/dev/null \
+    | grep -E "^${metric}\{[^}]*component_id=\"${component}\"" \
+    | head -1 \
+    | awk '{print int($2)}') || true
+  echo "${val:-0}"
+}
+
+scrape_inbound() {
+  local component="$1" v
+  v=$(scrape_metric vector_component_received_events_total "$component")
+  if [ "$v" -gt 0 ]; then echo "$v"; return; fi
+  v=$(scrape_metric vector_events_in_total "$component")
+  echo "${v:-0}"
+}
+
+scrape_outbound() {
+  local component="$1" v
+  v=$(scrape_metric vector_component_sent_events_total "$component")
+  if [ "$v" -gt 0 ]; then echo "$v"; return; fi
+  v=$(scrape_metric vector_events_out_total "$component")
+  echo "${v:-0}"
+}
+
+# probe_state probe_id label expectation
+#   expectation=healthy → GREEN if events flowing AND sink_good in/out delta > 0
+#   expectation=either  → GREEN if any flow detected; RED only if fully stalled (use for T4)
+probe_state() {
+  local probe_id="$1" label="$2" expectation="$3"
+  echo
+  echo "${BOLD}==> [${probe_id}] PROBE: ${label}${RESET}"
+
+  local good_in_b bad_in_b good_out_b bad_out_b
+  good_in_b=$(scrape_inbound sink_good)
+  bad_in_b=$(scrape_inbound sink_bad)
+  good_out_b=$(scrape_outbound sink_good)
+  bad_out_b=$(scrape_outbound sink_bad)
+  echo "    waiting $((SCRAPE_INTERVAL_SEC + 1))s for next metric scrape..."
+  sleep $((SCRAPE_INTERVAL_SEC + 1))
+
+  local good_in_a bad_in_a good_out_a bad_out_a
+  good_in_a=$(scrape_inbound sink_good)
+  bad_in_a=$(scrape_inbound sink_bad)
+  good_out_a=$(scrape_outbound sink_good)
+  bad_out_a=$(scrape_outbound sink_bad)
+
+  local d_good_in=$((good_in_a - good_in_b))
+  local d_bad_in=$((bad_in_a - bad_in_b))
+  local d_good_out=$((good_out_a - good_out_b))
+  local d_bad_out=$((bad_out_a - bad_out_b))
+
+  local taps tap_out
+  echo "    tapping router.all for 3s..."
+  tap_out=$(docker exec "$VECTOR_C" timeout 3 vector tap --quiet router.all 2>/dev/null || true)
+  taps=$(printf '%s\n' "$tap_out" | grep -c '^{' || true)
+
+  echo "    tap events:    ${taps}"
+  echo "    sink_good in:  +${d_good_in}, out: +${d_good_out}"
+  echo "    sink_bad  in:  +${d_bad_in}, out: +${d_bad_out}"
+
+  local detail="taps=${taps} good(in/out)=+${d_good_in}/+${d_good_out} bad(in/out)=+${d_bad_in}/+${d_bad_out}"
+  local status note
+  case "$expectation" in
+    healthy)
+      if [ "$taps" -gt 0 ] && [ "$d_good_in" -gt 0 ] && [ "$d_good_out" -gt 0 ]; then
+        status=GREEN; note="events flowing; sink_good healthy"
+      else
+        status=RED;   note="expected healthy flow but found stall"
+      fi
+      ;;
+    either)
+      if [ "$taps" -gt 0 ] && [ "$d_good_in" -gt 0 ] && [ "$d_good_out" -gt 0 ]; then
+        status=GREEN; note="events flowing post-reload; topology recovered"
+      else
+        status=RED;   note="topology deadlocked after reload (bug reproduced)"
+      fi
+      ;;
+  esac
+  echo "    => ${status}: ${note}"
+  RESULTS+=("${status}|${probe_id}|${label}|${note}|${detail}")
+}
+
+print_summary() {
+  echo
+  echo "============================================================"
+  echo "${BOLD}SUMMARY${RESET}"
+  echo "============================================================"
+  local any_red=false
+  for r in "${RESULTS[@]}"; do
+    IFS='|' read -r status pid label note detail <<< "$r"
+    local color
+    if [ "$status" = "RED" ]; then any_red=true; color="$RED"; else color="$GREEN"; fi
+    printf "%s[%s]%s %s — %s\n" "$color" "$status" "$RESET" "$pid" "$label"
+    printf "       %s\n" "$note"
+    printf "       %s\n" "$detail"
+  done
+  echo "------------------------------------------------------------"
+  if $any_red; then
+    printf "%sRESULT: MALFUNCTION DETECTED%s\n" "$RED" "$RESET"
+  else
+    printf "%sRESULT: NORMAL OPERATION%s\n" "$GREEN" "$RESET"
+  fi
+  echo "============================================================"
+}
+
+# ============================================================================
+
+echo "==> image:                 $IMAGE"
+echo "==> bad sink fails after:  ${FAIL_AFTER_SEC}s"
+echo "==> soak before reload:    ${SOAK_BEFORE_RELOAD_SEC}s"
+echo
+
+echo "==> creating docker network"
+docker network create "$NETWORK" >/dev/null
+
+echo "==> starting receivers (good = always 200; bad = 429 after ${FAIL_AFTER_SEC}s)"
+docker run -d --name "$GOOD_C" --network "$NETWORK" \
+  -e PORT=8001 \
+  -v "$RECEIVER_PY:/receiver.py:ro" \
+  python:3.11-slim python /receiver.py >/dev/null
+docker run -d --name "$BAD_C" --network "$NETWORK" \
+  -e PORT=8001 -e FAIL_AFTER="$FAIL_AFTER_SEC" \
+  -v "$RECEIVER_PY:/receiver.py:ro" \
+  python:3.11-slim python /receiver.py >/dev/null
+
+for c in "$GOOD_C" "$BAD_C"; do
+  for _ in $(seq 1 30); do
+    if docker logs "$c" 2>&1 | grep -q "receiver listening"; then break; fi
+    sleep 0.5
+  done
+done
+
+write_config "garbage_initial"
+echo "==> starting Vector (graceful shutdown limit: ${GRACEFUL_SHUTDOWN_LIMIT_SEC}s)"
+docker run -d --name "$VECTOR_C" --network "$NETWORK" \
+  -p "${API_PORT}:${API_PORT}" \
+  -p "${PROM_PORT}:${PROM_PORT}" \
+  -e VECTOR_GRACEFUL_SHUTDOWN_LIMIT_SECS="$GRACEFUL_SHUTDOWN_LIMIT_SEC" \
+  -v "$WORKDIR:/etc/vector" \
+  "$IMAGE" >/dev/null
+
+started=false
+for _ in $(seq 1 60); do
+  if docker logs "$VECTOR_C" 2>&1 | grep -q "Vector has started"; then
+    started=true; break
+  fi
+  if ! docker ps --format '{{.Names}}' | grep -q "^${VECTOR_C}$"; then
+    echo "ERROR: Vector container exited during startup" >&2
+    docker logs "$VECTOR_C" 2>&1 | tail -40 >&2
+    exit 2
+  fi
+  sleep 0.5
+done
+if [ "$started" != true ]; then
+  echo "ERROR: timed out waiting for Vector to start" >&2
+  docker logs "$VECTOR_C" 2>&1 | tail -40 >&2
+  exit 2
+fi
+
+# Allow at least one scrape interval so prometheus has data to compare against.
+sleep "$SCRAPE_INTERVAL_SEC"
+
+if [ -n "${DEBUG_METRICS:-}" ]; then
+  echo
+  echo "==> [debug] sample of vector_*_total metrics for sinks:"
+  curl -fs --max-time 3 "http://localhost:${PROM_PORT}/metrics" 2>/dev/null \
+    | grep -E '^vector_(component_(sent|received)_events|events_(in|out))_total\{[^}]*component_id="(sink_good|sink_bad)"' \
+    | sort | head -20 || true
+fi
+
+probe_state T1 "initial startup" healthy
+
+echo
+echo "==> sleeping ${FAIL_AFTER_SEC}s for bad sink to begin failing, then ${SOAK_BEFORE_RELOAD_SEC}s soak"
+sleep "$FAIL_AFTER_SEC"
+echo "==> bad sink should now be returning 429; soaking ${SOAK_BEFORE_RELOAD_SEC}s..."
+sleep "$SOAK_BEFORE_RELOAD_SEC"
+
+probe_state T2 "after fouled sink starts returning 429" healthy
+
+echo
+echo "==> [baseline] sending SIGHUP with no config change to time a healthy reload"
+baseline_count=$(count_log_marker)
+docker kill -s SIGHUP "$VECTOR_C" >/dev/null
+if baseline_elapsed=$(wait_for_reload_completion "$baseline_count" "$BASELINE_RELOAD_MAX_SEC"); then
+  echo "==> [baseline] reload completed in ${baseline_elapsed}s"
+else
+  echo "${RED}ERROR: baseline reload did not complete within ${BASELINE_RELOAD_MAX_SEC}s${RESET}" >&2
+  echo "       (this can happen on already-broken Vector versions; consider it a strong signal too)" >&2
+  docker logs "$VECTOR_C" 2>&1 | tail -20 >&2
+  RESULTS+=("RED|T3|after baseline SIGHUP|baseline reload itself stalled|n/a")
+  print_summary
+  exit 2
+fi
+
+sleep 2
+probe_state T3 "after baseline SIGHUP (no config change)" healthy
+
+echo
+echo "==> editing config: adding 'garbage_post_edit' to encoding.except_fields on both sinks"
+write_config "garbage_initial,garbage_post_edit"
+
+post_edit_max=$(awk -v b="$baseline_elapsed" -v floor="$POST_EDIT_RELOAD_FLOOR_SEC" \
+  'BEGIN { v = int(b * 1.5 + 0.5); if (v < floor) v = floor; print v }')
+echo "==> [post-edit] sending SIGHUP; will wait up to ${post_edit_max}s (max(1.5*baseline, ${POST_EDIT_RELOAD_FLOOR_SEC}s))"
+post_count=$(count_log_marker)
+docker kill -s SIGHUP "$VECTOR_C" >/dev/null
+
+if post_elapsed=$(wait_for_reload_completion "$post_count" "$post_edit_max"); then
+  echo "==> [post-edit] reload completed in ${post_elapsed}s — image appears patched"
+  reload_outcome=patched
+else
+  echo "${RED}==> [post-edit] reload did not complete within ${post_edit_max}s — bug indicator${RESET}"
+  reload_outcome=stalled
+fi
+
+sleep 2
+probe_state T4 "after config-change SIGHUP" either
+
+print_summary
+
+if [ "$reload_outcome" = "stalled" ]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes a deadlock during config reload that stalls all sources indefinitely when a changed sink shares a resource (e.g. a bound port) with the new sink, or when the sink is in \`reuse_buffers\` on the SIGHUP path.

**Root cause:** During reload, \`remove_inputs\` sent \`Pause\` to the upstream fanout for sinks in \`wait_for_sinks\`. The source pump then blocked in \`wait_for_replacements\` waiting for a \`Replace\` message that only arrives after \`connect_diff\`, which runs after \`shutdown_diff\`, which itself was waiting for the old sink to finish. Circular dependency, every source stalls.

**Fix:** For sinks in \`wait_for_sinks\`, use a full \`Remove\` (not \`Pause\`) from the upstream fanout, with a corresponding \`Add\` (not \`Replace\`) when reconnecting in \`connect_diff\`. The source pump can keep sending events to other sinks while the old sink drains. Also bounds \`wait_for_sinks\` with a drain timeout so a misbehaving sink can't hold reload forever.

Buffer-type agnostic — fixes the deadlock for memory and disk buffered sinks alike, only affects the reload path.

## Vector configuration

Reproduction harness included under \`testing/github-24125/\` — uses a \`demo_logs\` source fanning out to two \`http\` sinks listening on the same port range, then SIGHUPs Vector to trigger the reload path. Without the fix, all sources stall; with the fix, reload completes within the timeout.

## How did you test this PR?

- Two new regression tests in \`src/topology/test/reload.rs\`:
  - \`topology_reload_conflicting_sink_does_not_stall\` — covers the conflicting-resource path
  - \`topology_reload_reuse_buffer_does_not_stall\` — covers the SIGHUP / \`reuse_buffers\` path
- Both pass alongside the pre-existing \`topology_disk_buffer_config_change_*_does_not_stall\` tests from #24949 (verified the two fixes coexist correctly)
- \`make check-clippy\` clean
- Reproduction harness in \`testing/github-24125/\` confirms the bug pre-fix and the fix post-fix

## Change Type

- [x] Bug fix

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment included (\`changelog.d/24125_fix_topology_reload_deadlock.fix.md\`).

## References

- Closes: #24125
- Related: #24949 (disk-buffer reload stall — adjacent reload-path fix, this PR's resolution sits on top)