### PR TITLE
chore(dev): remove unused update_counter macro

### DIFF
--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -200,50 +200,6 @@ impl Controller {
     }
 }
 
-#[macro_export]
-/// This macro is used to emit metrics as a `counter` while simultaneously
-/// converting from absolute values to incremental values.
-///
-/// Values that do not arrive in strictly monotonically increasing order are
-/// ignored and will not be emitted.
-macro_rules! update_counter {
-    ($label:literal, $value:expr) => {{
-        use ::std::sync::atomic::{AtomicU64, Ordering};
-
-        static PREVIOUS_VALUE: AtomicU64 = AtomicU64::new(0);
-
-        let new_value = $value;
-        let mut previous_value = PREVIOUS_VALUE.load(Ordering::Relaxed);
-
-        loop {
-            // Either a new greater value has been emitted before this thread updated the counter
-            // or values were provided that are not in strictly monotonically increasing order.
-            // Ignore.
-            if new_value <= previous_value {
-                break;
-            }
-
-            match PREVIOUS_VALUE.compare_exchange_weak(
-                previous_value,
-                new_value,
-                Ordering::SeqCst,
-                Ordering::Relaxed,
-            ) {
-                // Another thread has written a new value before us. Re-enter loop.
-                Err(value) => previous_value = value,
-                // Calculate delta to last emitted value and emit it.
-                Ok(_) => {
-                    let delta = new_value - previous_value;
-                    // Albeit very unlikely, note that this sequence of deltas might be emitted in
-                    // a different order than they were calculated.
-                    counter!($label).increment(delta);
-                    break;
-                }
-            }
-        }
-    }};
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Removes the `update_counter!` macro from `lib/vector-core/src/metrics/mod.rs` as it is no longer used.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #19463