### PR TITLE
fix(sources): add windows_event_log source metadata

### DIFF
--- a/changelog.d/25332_windows_event_log_source_metadata.fix.md
+++ b/changelog.d/25332_windows_event_log_source_metadata.fix.md
@@ -1,0 +1,3 @@
+The `windows_event_log` source now adds standard source metadata, including `source_type`, to emitted log events.
+
+authors: tot19

--- a/src/sources/windows_event_log/mod.rs
+++ b/src/sources/windows_event_log/mod.rs
@@ -25,6 +25,7 @@ cfg_if::cfg_if! {
         use std::path::PathBuf;
         use std::sync::Arc;
 
+        use chrono::Utc;
         use futures::StreamExt;
         use vector_lib::EstimatedJsonEncodedSizeOf;
         use vector_lib::finalizer::OrderedFinalizer;
@@ -166,6 +167,7 @@ impl Finalizer {
 async fn process_event_batch(
     events: Vec<WindowsEvent>,
     parser: &EventLogParser,
+    log_namespace: LogNamespace,
     acknowledgements: bool,
     subscription: &EventLogSubscription,
     out: &mut SourceSender,
@@ -189,6 +191,12 @@ async fn process_event_batch(
         let event_id = event.event_id;
         match parser.parse_event(event) {
             Ok(mut log_event) => {
+                log_namespace.insert_standard_vector_source_metadata(
+                    &mut log_event,
+                    WindowsEventLogConfig::NAME,
+                    Utc::now(),
+                );
+
                 let byte_size = log_event.estimated_json_encoded_size_of();
                 total_byte_size += byte_size.get();
                 if let Some(ref batch) = batch {
@@ -416,6 +424,7 @@ impl WindowsEventLogSource {
                             if process_event_batch(
                                 events,
                                 &parser,
+                                self.log_namespace,
                                 acknowledgements,
                                 &subscription,
                                 &mut out,
@@ -516,6 +525,7 @@ impl WindowsEventLogSource {
                             if process_event_batch(
                                 events,
                                 &parser,
+                                self.log_namespace,
                                 acknowledgements,
                                 &subscription,
                                 &mut out,
@@ -664,8 +674,11 @@ impl SourceConfig for WindowsEventLogConfig {
                     ),
                 ])),
                 [LogNamespace::Vector],
-            ),
-            LogNamespace::Legacy => vector_lib::schema::Definition::any(),
+            )
+            .with_standard_vector_source_metadata(),
+            LogNamespace::Legacy => {
+                vector_lib::schema::Definition::any().with_standard_vector_source_metadata()
+            }
         };
 
         vec![SourceOutput::new_maybe_logs(


### PR DESCRIPTION
## Summary

Adds standard Vector source metadata to `windows_event_log` events. In the Legacy namespace this restores the expected top-level `source_type = "windows_event_log"` field, and in the Vector namespace it records the standard metadata under the Vector metadata path.

The source output schema is also updated to advertise the standard source metadata.

## Vector configuration

```toml
data_dir = 'C:\Users\rustdev\vector\vector-data'

[sources.win_events]
type = "windows_event_log"
channels = ["Application"]
read_existing_events = false
log_namespace = false

[sinks.out]
type = "console"
inputs = ["win_events"]

[sinks.out.encoding]
codec = "json"

[sinks.out.encoding.json]
pretty = true
```

## How did you test this PR?

- `cargo check --no-default-features --features sources-windows_event_log`
- `make check-clippy`
- `./scripts/check_changelog_fragments.sh`
- Windows ARM64 VM: built Vector with `cargo build --no-default-features --features "sources-windows_event_log,sinks-console"`, emitted an `Application` event with `eventcreate`, and verified the console output included `"source_type": "windows_event_log"`.
- Windows ARM64 VM: ran `cargo nextest run --workspace --no-fail-fast --no-default-features --features "default-msvc" --build-jobs 1 --test-threads 1`; 2782 tests ran, 2772 passed, 10 failed, 10 skipped. The failures were unrelated to `windows_event_log` and appear to be Windows test-environment issues around symlinked TLS fixtures and exec/python tests.
- `make check-markdown` was attempted locally but blocked by a missing markdown-check tool with `No such file or directory`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25332