### PR TITLE
fix(ci): grant issues:write to remove_wip_label workflow

### DIFF
--- a/.github/workflows/remove_wip_label.yml
+++ b/.github/workflows/remove_wip_label.yml
@@ -1,6 +1,7 @@
 name: Remove Work In Progress Label
 
 permissions:
+  issues: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
## Summary

Grant `issues: write` to the `Remove Work In Progress Label` workflow so the `removeLabel` REST call succeeds.

The `DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}` endpoint requires `issues: write` per the GitHub REST API docs.

This was first observed when run [25135003048](https://github.com/vectordotdev/vector/actions/runs/25135003048/job/73936673580) attempted the call against #25057 — the first time all three preconditions held simultaneously: MEMBER reviewer, "work in progress" label present, and an approving review. Prior runs all bailed out earlier (CONTRIBUTOR reviewer or label not present).

## How did you test this PR?

Tested in ci-sandbox: 
- https://github.com/vectordotdev/ci-sandbox/pull/21
- vectordotdev/ci-sandbox#23.

## Change Type

- [x] Bug fix

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [ ] Yes
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25057 (the PR whose review triggered the original failure)