### PR TITLE
fix(internal docs): remove type-level default on StatusCode

### DIFF
--- a/lib/vector-config/src/http.rs
+++ b/lib/vector-config/src/http.rs
@@ -28,7 +28,6 @@ impl Configurable for StatusCode {
     fn metadata() -> Metadata {
         let mut metadata = Metadata::default();
         metadata.set_description("HTTP response status code");
-        metadata.set_default_value(StatusCode::OK);
         metadata.add_custom_attribute(CustomAttribute::kv(
             constants::DOCS_META_NUMERIC_TYPE,
             NumberClass::Unsigned,

--- a/website/cue/reference/components/sinks/generated/appsignal.cue
+++ b/website/cue/reference/components/sinks/generated/appsignal.cue
@@ -337,7 +337,7 @@ generated: components: sinks: appsignal: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/axiom.cue
+++ b/website/cue/reference/components/sinks/generated/axiom.cue
@@ -319,7 +319,7 @@ generated: components: sinks: axiom: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/azure_logs_ingestion.cue
+++ b/website/cue/reference/components/sinks/generated/azure_logs_ingestion.cue
@@ -422,7 +422,7 @@ generated: components: sinks: azure_logs_ingestion: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/generated/azure_monitor_logs.cue
@@ -328,7 +328,7 @@ generated: components: sinks: azure_monitor_logs: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/datadog_events.cue
+++ b/website/cue/reference/components/sinks/generated/datadog_events.cue
@@ -256,7 +256,7 @@ generated: components: sinks: datadog_events: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_stackdriver_logs.cue
@@ -434,7 +434,7 @@ generated: components: sinks: gcp_stackdriver_logs: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_stackdriver_metrics.cue
@@ -348,7 +348,7 @@ generated: components: sinks: gcp_stackdriver_metrics: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/honeycomb.cue
+++ b/website/cue/reference/components/sinks/generated/honeycomb.cue
@@ -335,7 +335,7 @@ generated: components: sinks: honeycomb: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/http.cue
+++ b/website/cue/reference/components/sinks/generated/http.cue
@@ -1038,7 +1038,7 @@ generated: components: sinks: http: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/keep.cue
+++ b/website/cue/reference/components/sinks/generated/keep.cue
@@ -300,7 +300,7 @@ generated: components: sinks: keep: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/generated/opentelemetry.cue
@@ -1039,7 +1039,7 @@ generated: components: sinks: opentelemetry: configuration: protocol: {
 					description:   "Retry on these specific HTTP status codes"
 					relevant_when: "type = \"custom\""
 					required:      true
-					type: array: items: type: uint: default: 200
+					type: array: items: type: uint: {}
 				}
 				type: {
 					description: "The retry strategy enum."

--- a/website/cue/reference/components/sinks/generated/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/generated/prometheus_remote_write.cue
@@ -553,7 +553,7 @@ generated: components: sinks: prometheus_remote_write: configuration: {
 				description:   "Retry on these specific HTTP status codes"
 				relevant_when: "type = \"custom\""
 				required:      true
-				type: array: items: type: uint: default: 200
+				type: array: items: type: uint: {}
 			}
 			type: {
 				description: "The retry strategy enum."


### PR DESCRIPTION
## Summary

Master's website build (`make cue-build`) is broken: every http-based sink fails CUE schema validation after #25057 introduced `RetryStrategy::Custom { status_codes: Vec<StatusCode> }`.

```
components.sinks.<sink>.configuration.retry_strategy.type.object: field not allowed
```

12 sinks affected: appsignal, axiom, azure_logs_ingestion, azure_monitor_logs, datadog_events, gcp_stackdriver_logs, gcp_stackdriver_metrics, honeycomb, http, keep, opentelemetry, prometheus_remote_write.

### Fix

Drop the type-level default on `Configurable for http::StatusCode` in `lib/vector-config/src/http.rs`. The only `StatusCode` config field in the tree (`sources::http_server::response_code`) sets its own default at the field level, so user-facing schemas don't change.

### How did this reach master?

Rust CI did not catch it. `make generate-component-docs` regenerates the `.cue` files, and the workflow checks them in for review, but it does not run `make cue-build` — the step that unifies the generated files against `website/cue/reference.cue` and surfaces this kind of schema violation. The generated files are valid CUE in isolation (`cue eval` is fine); the failure only appears when the schema constraints are applied during the website build.

Follow-up: wire `cue-build` into PR-blocking CI so a generated-docs change that violates the schema can't merge. Happy to open a tracking issue.

## How did you test this PR?

- `make generate-component-docs`
- `cd website && make cue-build` — clean.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25057