### PR TITLE
feat(codecs): Allow encoder to add avro schema id prefix

### DIFF
--- a/changelog.d/avro_encoder_add_schema_id_prefix.md
+++ b/changelog.d/avro_encoder_add_schema_id_prefix.md
@@ -1,0 +1,3 @@
+Add optional `schema_id` to be prepended to the Avro message.
+
+authors: yazasnyal

--- a/lib/codecs/src/decoding/format/avro.rs
+++ b/lib/codecs/src/decoding/format/avro.rs
@@ -82,6 +82,7 @@ impl From<&AvroDeserializerOptions> for AvroSerializerOptions {
     fn from(value: &AvroDeserializerOptions) -> Self {
         Self {
             schema: value.schema.clone(),
+            schema_id: None,
         }
     }
 }

--- a/lib/codecs/src/encoding/format/avro.rs
+++ b/lib/codecs/src/encoding/format/avro.rs
@@ -25,6 +25,13 @@ impl AvroSerializerConfig {
     pub fn build(&self) -> Result<AvroSerializer, BuildError> {
         let schema = apache_avro::Schema::parse_str(&self.avro.schema)
             .map_err(|error| format!("Failed building Avro serializer: {error}"))?;
+
+        if let Some(schema_id) = self.avro.schema_id
+            && schema_id < 0
+        {
+            return Err("Confluent Avro schema id must be a positive i32 number".into());
+        }
+
         Ok(AvroSerializer {
             schema,
             schema_id: self.avro.schema_id,

--- a/lib/codecs/src/encoding/format/avro.rs
+++ b/lib/codecs/src/encoding/format/avro.rs
@@ -15,9 +15,9 @@ pub struct AvroSerializerConfig {
 
 impl AvroSerializerConfig {
     /// Creates a new `AvroSerializerConfig`.
-    pub const fn new(schema: String) -> Self {
+    pub const fn new(schema: String, schema_id: Option<i32>) -> Self {
         Self {
-            avro: AvroSerializerOptions { schema },
+            avro: AvroSerializerOptions { schema, schema_id },
         }
     }
 
@@ -25,7 +25,10 @@ impl AvroSerializerConfig {
     pub fn build(&self) -> Result<AvroSerializer, BuildError> {
         let schema = apache_avro::Schema::parse_str(&self.avro.schema)
             .map_err(|error| format!("Failed building Avro serializer: {error}"))?;
-        Ok(AvroSerializer { schema })
+        Ok(AvroSerializer {
+            schema,
+            schema_id: self.avro.schema_id,
+        })
     }
 
     /// The data type of events that are accepted by `AvroSerializer`.
@@ -50,18 +53,27 @@ pub struct AvroSerializerOptions {
     ))]
     #[configurable(metadata(docs::human_name = "Schema JSON"))]
     pub schema: String,
+    /// Confluent Avro schema ID
+    ///
+    /// When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+    /// containing a magic byte and a 4-byte big-endian schema ID).
+    ///
+    /// [wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+    #[configurable(metadata(docs::examples = "42"))]
+    pub schema_id: Option<i32>,
 }
 
 /// Serializer that converts an `Event` to bytes using the Apache Avro format.
 #[derive(Debug, Clone)]
 pub struct AvroSerializer {
     schema: apache_avro::Schema,
+    schema_id: Option<i32>,
 }
 
 impl AvroSerializer {
     /// Creates a new `AvroSerializer`.
-    pub const fn new(schema: apache_avro::Schema) -> Self {
-        Self { schema }
+    pub const fn new(schema: apache_avro::Schema, schema_id: Option<i32>) -> Self {
+        Self { schema, schema_id }
     }
 }
 
@@ -73,7 +85,13 @@ impl Encoder<Event> for AvroSerializer {
         let value = apache_avro::to_value(log)?;
         let value = value.resolve(&self.schema)?;
         let bytes = apache_avro::to_avro_datum(&self.schema, value)?;
+
+        if let Some(schema_id) = self.schema_id {
+            buffer.put_slice(&[0x00]); // magic byte
+            buffer.put_slice(&schema_id.to_be_bytes()); // schema id data
+        }
         buffer.put_slice(&bytes);
+
         Ok(())
     }
 }
@@ -105,12 +123,39 @@ mod tests {
             }
         "#}
         .to_owned();
-        let config = AvroSerializerConfig::new(schema);
+        let config = AvroSerializerConfig::new(schema, None);
         let mut serializer = config.build().unwrap();
         let mut bytes = BytesMut::new();
 
         serializer.encode(event, &mut bytes).unwrap();
 
         assert_eq!(bytes.freeze(), b"\0\x06bar".as_slice());
+    }
+
+    #[test]
+    fn serialize_avro_with_schema_id() {
+        let event = Event::Log(LogEvent::from(btreemap! {
+            "foo" => Value::from("bar")
+        }));
+        let schema = indoc! {r#"
+            {
+                "type": "record",
+                "name": "Log",
+                "fields": [
+                    {
+                        "name": "foo",
+                        "type": ["string"]
+                    }
+                ]
+            }
+        "#}
+        .to_owned();
+        let config = AvroSerializerConfig::new(schema, Some(42));
+        let mut serializer = config.build().unwrap();
+        let mut bytes = BytesMut::new();
+
+        serializer.encode(event, &mut bytes).unwrap();
+
+        assert_eq!(bytes.freeze(), b"\0\0\0\0\x2A\0\x06bar".as_slice());
     }
 }

--- a/lib/codecs/src/encoding/format/avro.rs
+++ b/lib/codecs/src/encoding/format/avro.rs
@@ -27,7 +27,7 @@ impl AvroSerializerConfig {
             .map_err(|error| format!("Failed building Avro serializer: {error}"))?;
 
         if let Some(schema_id) = self.avro.schema_id
-            && schema_id < 0
+            && schema_id <= 0
         {
             return Err("Confluent Avro schema id must be a positive i32 number".into());
         }

--- a/lib/codecs/src/encoding/serializer.rs
+++ b/lib/codecs/src/encoding/serializer.rs
@@ -288,7 +288,7 @@ impl SerializerConfig {
     pub fn build(&self) -> Result<Serializer, Box<dyn std::error::Error + Send + Sync + 'static>> {
         match self {
             SerializerConfig::Avro { avro } => Ok(Serializer::Avro(
-                AvroSerializerConfig::new(avro.schema.clone()).build()?,
+                AvroSerializerConfig::new(avro.schema.clone(), avro.schema_id).build()?,
             )),
             SerializerConfig::Cef(config) => Ok(Serializer::Cef(config.build()?)),
             SerializerConfig::Csv(config) => Ok(Serializer::Csv(config.build()?)),
@@ -354,7 +354,7 @@ impl SerializerConfig {
     pub fn input_type(&self) -> DataType {
         match self {
             SerializerConfig::Avro { avro } => {
-                AvroSerializerConfig::new(avro.schema.clone()).input_type()
+                AvroSerializerConfig::new(avro.schema.clone(), avro.schema_id).input_type()
             }
             SerializerConfig::Cef(config) => config.input_type(),
             SerializerConfig::Csv(config) => config.input_type(),
@@ -377,7 +377,7 @@ impl SerializerConfig {
     pub fn schema_requirement(&self) -> schema::Requirement {
         match self {
             SerializerConfig::Avro { avro } => {
-                AvroSerializerConfig::new(avro.schema.clone()).schema_requirement()
+                AvroSerializerConfig::new(avro.schema.clone(), avro.schema_id).schema_requirement()
             }
             SerializerConfig::Cef(config) => config.schema_requirement(),
             SerializerConfig::Csv(config) => config.schema_requirement(),

--- a/lib/codecs/tests/avro.rs
+++ b/lib/codecs/tests/avro.rs
@@ -38,7 +38,9 @@ fn roundtrip_avro(data_path: PathBuf, schema_path: PathBuf, reserialize: bool) {
     let deserializer = AvroDeserializerConfig::new(schema.clone(), false)
         .build()
         .unwrap();
-    let mut serializer = AvroSerializerConfig::new(schema.clone()).build().unwrap();
+    let mut serializer = AvroSerializerConfig::new(schema.clone(), None)
+        .build()
+        .unwrap();
 
     let (buf, event) = load_deserialize(&data_path, &deserializer);
 

--- a/website/cue/reference/components/sinks/generated/amqp.cue
+++ b/website/cue/reference/components/sinks/generated/amqp.cue
@@ -55,10 +55,24 @@ generated: components: sinks: amqp: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
@@ -251,10 +251,24 @@ generated: components: sinks: aws_cloudwatch_logs: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/generated/aws_kinesis_firehose.cue
@@ -230,10 +230,24 @@ generated: components: sinks: aws_kinesis_firehose: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/generated/aws_kinesis_streams.cue
@@ -230,10 +230,24 @@ generated: components: sinks: aws_kinesis_streams: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -438,10 +438,24 @@ generated: components: sinks: aws_s3: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/aws_sns.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sns.cue
@@ -161,10 +161,24 @@ generated: components: sinks: aws_sns: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sqs.cue
@@ -161,10 +161,24 @@ generated: components: sinks: aws_sqs: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/azure_blob.cue
+++ b/website/cue/reference/components/sinks/generated/azure_blob.cue
@@ -323,10 +323,24 @@ generated: components: sinks: azure_blob: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/console.cue
+++ b/website/cue/reference/components/sinks/generated/console.cue
@@ -39,10 +39,24 @@ generated: components: sinks: console: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/doris.cue
+++ b/website/cue/reference/components/sinks/generated/doris.cue
@@ -315,10 +315,24 @@ generated: components: sinks: doris: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -59,10 +59,24 @@ generated: components: sinks: file: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
@@ -127,10 +127,24 @@ generated: components: sinks: gcp_chronicle_unstructured: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
@@ -231,10 +231,24 @@ generated: components: sinks: gcp_cloud_storage: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_pubsub.cue
@@ -106,10 +106,24 @@ generated: components: sinks: gcp_pubsub: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb_logs.cue
@@ -153,7 +153,8 @@ generated: components: sinks: greptimedb_logs: configuration: {
 			"""
 		required: false
 		type: object: {
-			examples: [{}]
+			examples: [{},
+			]
 			options: "*": {
 				description: "Extra header key-value pairs."
 				required:    true

--- a/website/cue/reference/components/sinks/generated/http.cue
+++ b/website/cue/reference/components/sinks/generated/http.cue
@@ -289,10 +289,24 @@ generated: components: sinks: http: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/humio_logs.cue
+++ b/website/cue/reference/components/sinks/generated/humio_logs.cue
@@ -105,10 +105,24 @@ generated: components: sinks: humio_logs: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/kafka.cue
+++ b/website/cue/reference/components/sinks/generated/kafka.cue
@@ -94,10 +94,24 @@ generated: components: sinks: kafka: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/loki.cue
+++ b/website/cue/reference/components/sinks/generated/loki.cue
@@ -291,10 +291,24 @@ generated: components: sinks: loki: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/mqtt.cue
+++ b/website/cue/reference/components/sinks/generated/mqtt.cue
@@ -49,10 +49,24 @@ generated: components: sinks: mqtt: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/nats.cue
+++ b/website/cue/reference/components/sinks/generated/nats.cue
@@ -139,10 +139,24 @@ generated: components: sinks: nats: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/generated/opentelemetry.cue
@@ -292,10 +292,24 @@ generated: components: sinks: opentelemetry: configuration: protocol: {
 					description:   "Apache Avro-specific encoder options."
 					relevant_when: "codec = \"avro\""
 					required:      true
-					type: object: options: schema: {
-						description: "The Avro schema."
-						required:    true
-						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					type: object: options: {
+						schema: {
+							description: "The Avro schema."
+							required:    true
+							type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+						}
+						schema_id: {
+							description: """
+																				Confluent Avro schema ID
+
+																				When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																				containing a magic byte and a 4-byte big-endian schema ID).
+
+																				[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																				"""
+							required: false
+							type: int: examples: ["42"]
+						}
 					}
 				}
 				cef: {

--- a/website/cue/reference/components/sinks/generated/papertrail.cue
+++ b/website/cue/reference/components/sinks/generated/papertrail.cue
@@ -39,10 +39,24 @@ generated: components: sinks: papertrail: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/pulsar.cue
+++ b/website/cue/reference/components/sinks/generated/pulsar.cue
@@ -173,10 +173,24 @@ generated: components: sinks: pulsar: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/redis.cue
+++ b/website/cue/reference/components/sinks/generated/redis.cue
@@ -98,10 +98,24 @@ generated: components: sinks: redis: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/socket.cue
+++ b/website/cue/reference/components/sinks/generated/socket.cue
@@ -51,10 +51,24 @@ generated: components: sinks: socket: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
@@ -155,10 +155,24 @@ generated: components: sinks: splunk_hec_logs: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/webhdfs.cue
+++ b/website/cue/reference/components/sinks/generated/webhdfs.cue
@@ -105,10 +105,24 @@ generated: components: sinks: webhdfs: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/websocket.cue
+++ b/website/cue/reference/components/sinks/generated/websocket.cue
@@ -218,10 +218,24 @@ generated: components: sinks: websocket: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -95,10 +95,24 @@ generated: components: sinks: websocket_server: configuration: {
 				description:   "Apache Avro-specific encoder options."
 				relevant_when: "codec = \"avro\""
 				required:      true
-				type: object: options: schema: {
-					description: "The Avro schema."
-					required:    true
-					type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+				type: object: options: {
+					schema: {
+						description: "The Avro schema."
+						required:    true
+						type: string: examples: ["{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"]
+					}
+					schema_id: {
+						description: """
+																Confluent Avro schema ID
+
+																When set, each message will use the [Confluent wire format][wire_format] (a 5-byte prefix
+																containing a magic byte and a 4-byte big-endian schema ID).
+
+																[wire_format]: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+																"""
+						required: false
+						type: int: examples: ["42"]
+					}
 				}
 			}
 			cef: {


### PR DESCRIPTION
## Summary
This change allows to add a schema_id to avro encoded messages.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

```yaml
sources:
  in:
    type: "stdin"

sinks:
  out:
    inputs:
      - "in"
    type: "console"
    encoding:
      codec: "avro"
      avro:
        schema: "{ \"type\": \"record\", \"name\": \"log\", \"fields\": [{ \"name\": \"message\", \"type\": \"string\" }] }"
        schema_id: 42

```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

I have created a unit test for this PR and tested it locally using stdin-stdout pipeline that produced properly encoded messages.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

Closes: #19872

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
