### PR TITLE
fix(aws_sqs source): scope HistogramName import to s3 module

### DIFF
--- a/src/internal_events/aws_sqs.rs
+++ b/src/internal_events/aws_sqs.rs
@@ -6,7 +6,7 @@ use vector_lib::counter;
 #[cfg(any(feature = "sources-aws_s3", feature = "sources-aws_sqs"))]
 use vector_lib::{
     NamedInternalEvent,
-    internal_event::{CounterName, HistogramName, InternalEvent, error_stage, error_type},
+    internal_event::{CounterName, InternalEvent, error_stage, error_type},
 };
 
 #[cfg(feature = "sources-aws_s3")]
@@ -18,6 +18,7 @@ mod s3 {
         SendMessageBatchRequestEntry, SendMessageBatchResultEntry,
     };
     use vector_lib::histogram;
+    use vector_lib::internal_event::HistogramName;
 
     use super::*;
     use crate::sources::aws_s3::sqs::ProcessingError;


### PR DESCRIPTION
## Summary

Fixes a `#[deny(warnings)]` build break introduced by #25342 when running `cargo check --features sources-aws_sqs` (without `sources-aws_s3`).

Failing check: https://github.com/vectordotdev/vector/actions/runs/25314508522/attempts/1

## Vector configuration

N/A — build fix.

## How did you test this PR?

```
cargo check --tests --bin vector --no-default-features --features sources-aws_sqs
```

Reproduces the failure on master, passes on this branch.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25342

🤖 Generated with [Claude Code](https://claude.com/claude-code)