### PR TITLE
chore(ci): rename WIP label workflows to docs review label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 .github/workflows/regression.yml @vectordotdev/vector @vectordotdev/single-machine-performance
 regression/config.yaml @vectordotdev/vector @vectordotdev/single-machine-performance
 
-# Keep documentation team paths in sync with .github/workflows/add_wip_label.yml
+# Keep documentation team paths in sync with .github/workflows/add_docs_review_label.yml
 docs/ @vectordotdev/vector @vectordotdev/documentation
 website/ @vectordotdev/vector
 website/content @vectordotdev/vector @vectordotdev/documentation

--- a/.github/workflows/add_docs_review_label.yml
+++ b/.github/workflows/add_docs_review_label.yml
@@ -1,4 +1,7 @@
-name: Add Work In Progress Label
+# Adds a label to PRs that touch documentation paths until a maintainer approves.
+# Currently dedicated to the docs review flow. If a second use case appears, promote
+# this into a reusable workflow (`workflow_call`) with the label as an input.
+name: Add Docs Review Label
 
 permissions:
   pull-requests: write
@@ -12,8 +15,11 @@ on:
       - "website/content/**"
       - "website/cue/reference/**"
 
+env:
+  LABEL_NAME: "docs review on hold"
+
 jobs:
-  add_wip_label:
+  add_label:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -47,4 +53,4 @@ jobs:
       - if: steps.check.outputs.skip != 'true'
         uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
-          labels: "work in progress"
+          labels: ${{ env.LABEL_NAME }}

--- a/.github/workflows/remove_docs_review_label.yml
+++ b/.github/workflows/remove_docs_review_label.yml
@@ -1,4 +1,7 @@
-name: Remove Work In Progress Label
+# Removes the docs review label once a maintainer approves the PR.
+# Currently dedicated to the docs review flow. If a second use case appears, promote
+# this into a reusable workflow (`workflow_call`) with the label as an input.
+name: Remove Docs Review Label
 
 permissions:
   issues: write
@@ -8,8 +11,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  LABEL_NAME: "docs review on hold"
+
 jobs:
-  remove_wip_label:
+  remove_label:
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -27,20 +33,21 @@ jobs:
               return;
             }
 
+            const labelName = process.env.LABEL_NAME;
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
             });
-            const hasLabel = labels.some(l => l.name === 'work in progress');
+            const hasLabel = labels.some(l => l.name === labelName);
             if (!hasLabel) {
-              core.info('Label "work in progress" not found, skipping');
+              core.info(`Label "${labelName}" not found, skipping`);
               return;
             }
             await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              name: 'work in progress',
+              name: labelName,
             });
-            core.info('Removed "work in progress" label');
+            core.info(`Removed "${labelName}" label`);


### PR DESCRIPTION
## Summary

Renames the GitHub label managed by these workflows from `work in progress` to `docs review on hold`. Workflow files and job IDs are renamed to match, and the label string is hoisted to a workflow-level `LABEL_NAME` env var so future renames are a one-line edit.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)