### PR TITLE
feat(config): graduated deprecation policy for removed config fields

### DIFF
--- a/changelog.d/api_playground_graphql_soft_deprecation.fix.md
+++ b/changelog.d/api_playground_graphql_soft_deprecation.fix.md
@@ -1,0 +1,9 @@
+Configurations carrying the removed `api.playground` or `api.graphql` fields no longer fail to load. Both options were dropped in 0.55.0 along with the GraphQL observability API; setting them now is accepted at deserialize time but logs a deprecation warning at startup, and the values are otherwise ignored. This makes upgrades from 0.54.0 and earlier non-breaking when those fields are still present in pinned configs.
+
+The deprecation follows a graduated policy: the field is accepted with a `warn!` at startup for `WARN_WINDOW_MINORS = 12` minor releases after the version in which it was removed (about a year at Vector's monthly cadence), and the warning text names the exact future version in which the field becomes a hard configuration error. Once that future version ships, an attempt to load a config that still sets the field fails fast with a clear "remove this field" message — no silent breaking changes. Operators have a deterministic deadline for cleanup.
+
+The policy lives in a new reusable module, `src/config/deprecation`, so future field removals can opt into the same behavior with a single call site rather than reimplementing per-field warnings.
+
+Remove `api.playground` / `api.graphql` from your configuration to silence the warning — they have no runtime effect.
+
+authors: joshcoughlan

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,7 +101,15 @@ impl ApplicationConfig {
         extra_context: ExtraContext,
     ) -> Result<Self, ExitCode> {
         #[cfg(feature = "api")]
-        let api = config.api;
+        let api = {
+            if let Err(errors) = config.api.check_deprecated_fields() {
+                for e in &errors {
+                    error!(message = %e, internal_log_rate_limit = false);
+                }
+                return Err(exitcode::CONFIG);
+            }
+            config.api
+        };
 
         let (topology, graceful_crash_receiver) =
             RunningTopology::start_init_validated(config, extra_context.clone())

--- a/src/config/api.rs
+++ b/src/config/api.rs
@@ -24,6 +24,26 @@ pub struct Options {
     #[configurable(metadata(docs::examples = "127.0.0.1:1234"))]
     #[configurable(metadata(docs::common = true, docs::required = false))]
     pub address: Option<SocketAddr>,
+
+    /// Removed in 0.55.0. Accepted but ignored for backwards compatibility.
+    ///
+    /// The GraphQL Playground UI was removed when the observability API migrated
+    /// from GraphQL to gRPC. Setting this option has no effect; remove it from
+    /// your configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[configurable(deprecated)]
+    #[configurable(metadata(docs::hidden))]
+    pub playground: Option<bool>,
+
+    /// Removed in 0.55.0. Accepted but ignored for backwards compatibility.
+    ///
+    /// The GraphQL endpoint was removed when the observability API migrated to
+    /// gRPC. Setting this option has no effect; remove it from your
+    /// configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[configurable(deprecated)]
+    #[configurable(metadata(docs::hidden))]
+    pub graphql: Option<bool>,
 }
 
 impl_generate_config_from_default!(Options);
@@ -33,6 +53,8 @@ impl Default for Options {
         Self {
             enabled: default_enabled(),
             address: default_address(),
+            playground: None,
+            graphql: None,
         }
     }
 }
@@ -77,10 +99,55 @@ impl Options {
         let options = Options {
             address,
             enabled: self.enabled | other.enabled,
+            playground: self.playground.or(other.playground),
+            graphql: self.graphql.or(other.graphql),
         };
 
         *self = options;
         Ok(())
+    }
+
+    /// Check deprecated, ignored fields the user has set.
+    ///
+    /// `playground` and `graphql` were removed in 0.55.0 along with the GraphQL
+    /// observability API. They are still accepted at deserialize time so configs
+    /// that carry them don't break on upgrade, but the values have no effect.
+    /// While in the warn window (see [`crate::config::deprecation`]) a `warn!`
+    /// fires; once past the window each set field becomes a config-load error.
+    ///
+    /// Returns `Err` with one message per still-set field that has reached the
+    /// error stage, so callers can surface every failure in a single load
+    /// attempt.
+    pub fn check_deprecated_fields(&self) -> Result<(), Vec<String>> {
+        use crate::config::deprecation::{VectorMinor, check_deprecated_field};
+
+        const REMOVED_IN: VectorMinor = VectorMinor::new(0, 55);
+        let mut errors = Vec::new();
+
+        if self.playground.is_some()
+            && let Err(e) = check_deprecated_field(
+                "api.playground",
+                REMOVED_IN,
+                "The GraphQL Playground was removed when the observability API migrated to gRPC.",
+            )
+        {
+            errors.push(e);
+        }
+        if self.graphql.is_some()
+            && let Err(e) = check_deprecated_field(
+                "api.graphql",
+                REMOVED_IN,
+                "The GraphQL endpoint was removed when the observability API migrated to gRPC.",
+            )
+        {
+            errors.push(e);
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }
 
@@ -89,6 +156,7 @@ fn bool_merge() {
     let mut a = Options {
         enabled: true,
         address: None,
+        ..Options::default()
     };
 
     a.merge(Options::default()).unwrap();
@@ -98,6 +166,7 @@ fn bool_merge() {
         Options {
             enabled: true,
             address: default_address(),
+            ..Options::default()
         }
     );
 }
@@ -108,6 +177,7 @@ fn bind_merge() {
     let mut a = Options {
         enabled: true,
         address: Some(address),
+        ..Options::default()
     };
 
     a.merge(Options::default()).unwrap();
@@ -117,8 +187,55 @@ fn bind_merge() {
         Options {
             enabled: true,
             address: Some(address),
+            ..Options::default()
         }
     );
+}
+
+#[test]
+fn deprecated_fields_default_to_none() {
+    let opts = Options::default();
+    assert!(opts.playground.is_none());
+    assert!(opts.graphql.is_none());
+}
+
+#[test]
+fn deprecated_fields_round_trip_through_toml() {
+    // Setting either deprecated field must not be a config error.
+    let opts: Options = toml::from_str(
+        r#"
+        enabled = true
+        playground = false
+        graphql = false
+    "#,
+    )
+    .expect("config with deprecated api.playground/api.graphql must still parse");
+    assert_eq!(opts.playground, Some(false));
+    assert_eq!(opts.graphql, Some(false));
+    assert!(opts.enabled);
+}
+
+#[test]
+fn deprecated_fields_carry_through_merge() {
+    let mut a = Options {
+        playground: Some(false),
+        ..Options::default()
+    };
+    let b = Options {
+        graphql: Some(true),
+        ..Options::default()
+    };
+    a.merge(b).unwrap();
+    assert_eq!(a.playground, Some(false));
+    assert_eq!(a.graphql, Some(true));
+}
+
+#[test]
+fn check_deprecated_fields_ok_when_nothing_set() {
+    // Default config has neither field set; must return Ok without producing
+    // any error messages (and without printing a warning, though that's a
+    // tracing-side observation we don't try to assert here).
+    assert!(Options::default().check_deprecated_fields().is_ok());
 }
 
 #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -1,0 +1,251 @@
+//! Graduated deprecation policy for configuration fields.
+//!
+//! When a field is removed upstream, dropping it cold breaks every config that
+//! still mentions it — even though the value is no longer doing anything. This
+//! module lets a removed field stay accepted (and ignored) for a window of
+//! minor releases, with a `warn!` at startup that names the *exact Vector
+//! version* in which the field will become a hard config-load error. Operators
+//! get a clear deadline; nobody is surprised by a silent breaking change.
+//!
+//! The policy is per-field: declare it once at the call site by calling
+//! [`check_deprecated_field`] with the field's path and the minor version in
+//! which it was removed. Reuse the same function for any future deprecations.
+//!
+//! # Versioning model
+//!
+//! Vector versions are `<major>.<minor>.<patch>`. This module compares only
+//! `(major, minor)` (parsed from `CARGO_PKG_VERSION` at compile time).
+//!
+//! Given a field deprecated in minor `D`:
+//!
+//! * Current minor in `D..=D + WARN_WINDOW_MINORS` (≈one year of releases) →
+//!   log a `warn!` and treat the field as ignored. Caller proceeds normally.
+//! * Current minor `> D + WARN_WINDOW_MINORS` → return an `Err` with a clear
+//!   "remove this field" message. Callers should propagate to a config-load
+//!   failure.
+//!
+//! The warning text always names `breaks_in = D + WARN_WINDOW_MINORS + 1` so
+//! operators know exactly which release will reject their config.
+
+/// Number of minor releases the field is accepted-with-warning after the
+/// version in which it was removed (inclusive of the removal minor itself).
+///
+/// At Vector's roughly-monthly minor cadence, 12 corresponds to about a year
+/// of advance notice before the field becomes a hard configuration error.
+pub const WARN_WINDOW_MINORS: u64 = 12;
+
+/// A `(major, minor)` Vector version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VectorMinor {
+    pub major: u64,
+    pub minor: u64,
+}
+
+impl VectorMinor {
+    pub const fn new(major: u64, minor: u64) -> Self {
+        Self { major, minor }
+    }
+
+    /// First minor at which a field deprecated in `self` becomes a hard error.
+    pub const fn breaks_in(self) -> Self {
+        Self {
+            major: self.major,
+            minor: self.minor + WARN_WINDOW_MINORS + 1,
+        }
+    }
+}
+
+impl std::fmt::Display for VectorMinor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Patch is always 0 for the version reference shown to users.
+        write!(f, "{}.{}.0", self.major, self.minor)
+    }
+}
+
+/// Stage of deprecation a field is in given the current Vector version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeprecationStage {
+    /// In the warn window. The field is accepted at deserialize time but
+    /// has no effect at runtime; a `warn!` should fire at startup.
+    Warn { breaks_in: VectorMinor },
+    /// Past the warn window. The field must be rejected.
+    Error,
+}
+
+/// Compute the deprecation stage for a field that was removed in `deprecated_in`,
+/// given the running Vector binary's `(major, minor)`.
+///
+/// Pure function; takes `current` so it can be unit-tested without depending on
+/// the build's actual version.
+pub fn stage_for(deprecated_in: VectorMinor, current: VectorMinor) -> DeprecationStage {
+    let breaks_in = deprecated_in.breaks_in();
+    let past_break = (current.major, current.minor) >= (breaks_in.major, breaks_in.minor);
+    if past_break {
+        DeprecationStage::Error
+    } else {
+        DeprecationStage::Warn { breaks_in }
+    }
+}
+
+/// `(major, minor)` of the running binary, parsed from `CARGO_PKG_VERSION`.
+pub fn current_minor() -> VectorMinor {
+    let v = env!("CARGO_PKG_VERSION");
+    let mut parts = v.split('.');
+    let major = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    // CARGO_PKG_VERSION can carry a pre-release suffix on `minor` (e.g. "55-rc1");
+    // strip anything after the first non-digit so we still parse cleanly.
+    let minor_raw = parts.next().unwrap_or("0");
+    let minor_str: String = minor_raw
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let minor = minor_str.parse().unwrap_or(0);
+    VectorMinor { major, minor }
+}
+
+/// Check a deprecated field that the user has set, using the running binary's
+/// version.
+///
+/// * `field_path` — user-facing dotted path, e.g. `"api.playground"`.
+/// * `deprecated_in` — minor version in which the field stopped having any
+///   effect.
+/// * `note` — short, field-specific context appended to the message
+///   (e.g. *"The GraphQL Playground was removed when the API moved to gRPC."*).
+///
+/// Returns `Ok(())` after emitting a `warn!` while in the warn window;
+/// returns `Err` with a config-load–ready message once past the window.
+pub fn check_deprecated_field(
+    field_path: &'static str,
+    deprecated_in: VectorMinor,
+    note: &str,
+) -> Result<(), String> {
+    check_deprecated_field_at(field_path, deprecated_in, note, current_minor())
+}
+
+/// Same as [`check_deprecated_field`] but takes an explicit current version,
+/// for tests.
+pub fn check_deprecated_field_at(
+    field_path: &'static str,
+    deprecated_in: VectorMinor,
+    note: &str,
+    current: VectorMinor,
+) -> Result<(), String> {
+    match stage_for(deprecated_in, current) {
+        DeprecationStage::Warn { breaks_in } => {
+            warn!(
+                message = format!(
+                    "`{field_path}` is deprecated and ignored. {note} \
+                     It will be rejected as a configuration error in Vector {breaks_in}. \
+                     Remove `{field_path}` from your configuration to silence this warning."
+                ),
+                internal_log_rate_limit = false,
+            );
+            Ok(())
+        }
+        DeprecationStage::Error => Err(format!(
+            "`{field_path}` was removed and is no longer accepted. {note} \
+             Remove `{field_path}` from your configuration."
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REMOVED_IN: VectorMinor = VectorMinor::new(0, 55);
+
+    #[test]
+    fn breaks_in_is_window_plus_one() {
+        assert_eq!(
+            REMOVED_IN.breaks_in(),
+            VectorMinor::new(0, 55 + WARN_WINDOW_MINORS + 1)
+        );
+    }
+
+    #[test]
+    fn warn_at_removal_minor() {
+        assert!(matches!(
+            stage_for(REMOVED_IN, VectorMinor::new(0, 55)),
+            DeprecationStage::Warn { .. }
+        ));
+    }
+
+    #[test]
+    fn warn_throughout_window() {
+        for delta in 0..=WARN_WINDOW_MINORS {
+            let current = VectorMinor::new(0, 55 + delta);
+            assert!(
+                matches!(
+                    stage_for(REMOVED_IN, current),
+                    DeprecationStage::Warn { .. }
+                ),
+                "expected Warn at {current}"
+            );
+        }
+    }
+
+    #[test]
+    fn error_at_first_post_window_minor() {
+        assert_eq!(
+            stage_for(
+                REMOVED_IN,
+                VectorMinor::new(0, 55 + WARN_WINDOW_MINORS + 1)
+            ),
+            DeprecationStage::Error
+        );
+    }
+
+    #[test]
+    fn error_far_past_window() {
+        assert_eq!(
+            stage_for(REMOVED_IN, VectorMinor::new(1, 0)),
+            DeprecationStage::Error
+        );
+    }
+
+    #[test]
+    fn check_returns_ok_with_warning_in_window() {
+        let r = check_deprecated_field_at(
+            "api.playground",
+            REMOVED_IN,
+            "GraphQL Playground was removed.",
+            VectorMinor::new(0, 60),
+        );
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn check_returns_err_past_window() {
+        let r = check_deprecated_field_at(
+            "api.playground",
+            REMOVED_IN,
+            "GraphQL Playground was removed.",
+            VectorMinor::new(0, 55 + WARN_WINDOW_MINORS + 1),
+        );
+        let msg = r.expect_err("must err past the window");
+        assert!(msg.contains("api.playground"));
+        assert!(msg.contains("removed"));
+    }
+
+    #[test]
+    fn warn_message_names_breaks_in_version() {
+        // Confirm the breaks_in version reaches Display formatting cleanly.
+        // (The macro emits to tracing; we assert formatting on VectorMinor itself.)
+        assert_eq!(
+            format!("{}", REMOVED_IN.breaks_in()),
+            format!("0.{}.0", 55 + WARN_WINDOW_MINORS + 1)
+        );
+    }
+
+    #[test]
+    fn current_minor_parses_pkg_version() {
+        // We can't assert specific numbers without coupling to the version,
+        // but we can at least confirm parsing returns nonzero for a real build.
+        let v = current_minor();
+        assert!(
+            v.major > 0 || v.minor > 0,
+            "CARGO_PKG_VERSION should yield non-zero major or minor"
+        );
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,7 @@ pub mod api;
 mod builder;
 mod cmd;
 mod compiler;
+pub mod deprecation;
 mod diff;
 pub mod dot_graph;
 mod enrichment_table;


### PR DESCRIPTION
Adds a small reusable mechanism for handling configuration fields that have been removed upstream but may still appear in user configs. Rather than breaking those configs cold, a removed field stays accepted for a window of minor releases (12, ~one year at Vector's monthly cadence) with a warn! at startup that names the exact future Vector version in which the field will become a hard configuration error. Past that window, loading a config that still sets the field fails fast with a "remove this field" message.

Operators get a deterministic deadline; nobody is surprised by a silent breaking change.

The policy lives in a new module, src/config/deprecation, so future removals can opt into the same behavior with a single call site. Per-field metadata is just (path, deprecated_in_minor, note).

First user: api.playground and api.graphql, both removed in 0.55.0 with the GraphQL-to-gRPC migration. They were previously rejected outright, which broke any config still carrying them after upgrade. With this change they parse as Option<bool>, are silently ignored at runtime, and emit a deprecation warning naming the future version in which they will be rejected.

Implementation:
  * src/config/deprecation.rs: VectorMinor, DeprecationStage, stage_for(deprecated, current), current_minor() (parses CARGO_PKG_VERSION), check_deprecated_field(path, deprecated_in, note). 9 unit tests covering every transition.
  * src/config/api.rs: playground/graphql restored as Option<bool>
    with #[configurable(deprecated)] and docs::hidden so they don't appear in the schema. Options::check_deprecated_fields() collects all errors so users see every issue at once.
  * src/app.rs: Application::from_config calls check_deprecated_fields() and returns exitcode::CONFIG if any field has reached the error stage.

WARN_WINDOW_MINORS = 12 is a tunable constant. Tests are written against the constant so changing it does not require updating hard-coded version assertions.

authors: joshcoughlan

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
