### PR TITLE
enhancement(tag_cardinality_limit transform): Add more fine grained controls tag cardinality

### DIFF
--- a/changelog.d/tag_cardinality_limit_per_tag_and_exclude.enhancement.md
+++ b/changelog.d/tag_cardinality_limit_per_tag_and_exclude.enhancement.md
@@ -1,20 +1,6 @@
 The `tag_cardinality_limit` transform gained two new configuration capabilities:
 
-- **Per-tag overrides**: each entry in `per_metric_limits` now supports a `per_tag_limits`
-  map whose entries can override settings for a specific tag key on that metric. The
-  following per-tag fields are available:
-  - `value_limit` (optional): caps distinct values for this tag key. Inherits from the
-    enclosing per-metric `value_limit` when unset.
-  - `excluded` (default `false`): when `true`, opts this tag out of cardinality tracking
-    entirely — all values pass through unchecked.
-
-  The tracking mode (`exact`/`probabilistic`), `cache_size_per_key`, `limit_exceeded_action`,
-  and `internal_metrics` are always inherited from the enclosing per-metric configuration
-  and cannot be overridden per-tag.
-
-- **Metric exclusion**: `mode: excluded` is now available in `per_metric_limits` entries
-  (not at the global level). When set, every tag on that metric is opted out of cardinality
-  control — all tag values pass through and nothing is tracked. Any `per_tag_limits`
-  overrides on an excluded metric are ignored.
+- **Per-tag overrides** (`per_tag_limits`): configure cardinality limits per tag key within a metric, or exclude individual tags from tracking.
+- **Metric exclusion**: opt entire metrics out of cardinality tracking via `mode: excluded` in `per_metric_limits`.
 
 authors: ArunPiduguDD

--- a/changelog.d/tag_cardinality_limit_per_tag_and_exclude.enhancement.md
+++ b/changelog.d/tag_cardinality_limit_per_tag_and_exclude.enhancement.md
@@ -1,0 +1,20 @@
+The `tag_cardinality_limit` transform gained two new configuration capabilities:
+
+- **Per-tag overrides**: each entry in `per_metric_limits` now supports a `per_tag_limits`
+  map whose entries can override settings for a specific tag key on that metric. The
+  following per-tag fields are available:
+  - `value_limit` (optional): caps distinct values for this tag key. Inherits from the
+    enclosing per-metric `value_limit` when unset.
+  - `excluded` (default `false`): when `true`, opts this tag out of cardinality tracking
+    entirely — all values pass through unchecked.
+
+  The tracking mode (`exact`/`probabilistic`), `cache_size_per_key`, `limit_exceeded_action`,
+  and `internal_metrics` are always inherited from the enclosing per-metric configuration
+  and cannot be overridden per-tag.
+
+- **Metric exclusion**: `mode: excluded` is now available in `per_metric_limits` entries
+  (not at the global level). When set, every tag on that metric is opted out of cardinality
+  control — all tag values pass through and nothing is tracked. Any `per_tag_limits`
+  overrides on an excluded metric are ignored.
+
+authors: ArunPiduguDD

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -11,19 +11,9 @@ use crate::{
     transforms::{Transform, tag_cardinality_limit::TagCardinalityLimit},
 };
 
-/// Configuration of internal metrics for the TagCardinalityLimit transform.
-#[configurable_component]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct InternalMetricsConfig {
-    /// Whether to include extended tags (metric_name, tag_key) in the `tag_value_limit_exceeded_total` metric.
-    ///
-    /// This helps identify which metrics and tag keys are hitting cardinality limits, but can significantly
-    /// increase metric cardinality. Defaults to `false` because these tags have potentially unbounded cardinality.
-    #[serde(default = "default_include_extended_tags")]
-    #[configurable(metadata(docs::human_name = "Include Extended Tags"))]
-    pub include_extended_tags: bool,
-}
+// =============================================================================
+// Top-level configuration
+// =============================================================================
 
 /// Configuration for the `tag_cardinality_limit` transform.
 #[configurable_component(transform(
@@ -79,7 +69,11 @@ pub enum TrackingScope {
     PerMetric,
 }
 
-/// Configuration for the `tag_cardinality_limit` transform for a specific group of metrics.
+// =============================================================================
+// Global-level configuration block
+// =============================================================================
+
+/// Configuration block used at the global level.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Inner {
@@ -99,7 +93,7 @@ pub struct Inner {
     pub internal_metrics: InternalMetricsConfig,
 }
 
-/// Controls the approach taken for tracking tag cardinality.
+/// Controls the approach taken for tracking tag cardinality at the global level.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
@@ -122,18 +116,130 @@ pub enum Mode {
     Probabilistic(BloomFilterConfig),
 }
 
-/// Bloom filter configuration in probabilistic mode.
+// =============================================================================
+// Per-metric configuration block
+// =============================================================================
+
+/// Tag cardinality limit configuration per metric name.
+#[configurable_component]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PerMetricConfig {
+    /// Namespace of the metric this configuration refers to.
+    #[serde(default)]
+    pub namespace: Option<String>,
+
+    /// Per-tag-key overrides scoped to this metric.
+    ///
+    /// Each entry may override `value_limit` for a specific tag key or opt it out of
+    /// tracking entirely with `excluded: true`. The tracking mode, `cache_size_per_key`,
+    /// `limit_exceeded_action`, and `internal_metrics` are always inherited from the
+    /// enclosing per-metric configuration and cannot be set per-tag.
+    /// Tags not listed here use the per-metric configuration.
+    #[configurable(
+        derived,
+        metadata(docs::additional_props_description = "An individual tag configuration.")
+    )]
+    #[serde(default)]
+    pub per_tag_limits: HashMap<String, PerTagConfig>,
+
+    #[serde(flatten)]
+    pub config: OverrideInner,
+}
+
+/// Configuration block used at per-metric level. Same shape as the global configuration but
+/// with `OverrideMode`, which adds `excluded` for opting that metric out of cardinality
+/// control entirely.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct BloomFilterConfig {
-    /// The size of the cache for detecting duplicate tags, in bytes.
-    ///
-    /// The larger the cache size, the less likely it is to have a false positive, or a case where
-    /// we allow a new value for tag even after we have reached the configured limits.
-    #[serde(default = "default_cache_size")]
-    #[configurable(metadata(docs::human_name = "Cache Size per Key"))]
-    pub cache_size_per_key: usize,
+pub struct OverrideInner {
+    /// How many distinct values to accept for any given key. Ignored when `mode: excluded`.
+    #[serde(default = "default_value_limit")]
+    pub value_limit: usize,
+
+    #[configurable(derived)]
+    #[serde(default = "default_limit_exceeded_action")]
+    pub limit_exceeded_action: LimitExceededAction,
+
+    #[serde(flatten)]
+    pub mode: OverrideMode,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub internal_metrics: InternalMetricsConfig,
 }
+
+/// Controls the approach taken for tracking tag cardinality at the per-metric level.
+/// Adds `excluded` to the global `Mode` variants to allow opting a metric out entirely.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+#[configurable(metadata(
+    docs::enum_tag_description = "Controls the approach taken for tracking tag cardinality."
+))]
+pub enum OverrideMode {
+    /// Tracks cardinality exactly. See `Mode::Exact` for details.
+    Exact,
+
+    /// Tracks cardinality probabilistically. See `Mode::Probabilistic` for details.
+    Probabilistic(BloomFilterConfig),
+
+    /// Skip cardinality tracking for this metric. All tag values pass through and nothing is
+    /// recorded. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
+    /// `internal_metrics`) are ignored when this is selected. Any `per_tag_limits` entries
+    /// on this metric are also ignored.
+    ///
+    /// Only valid in `per_metric_limits` entries; using it as the global `mode` is a
+    /// configuration error.
+    Excluded,
+}
+
+impl OverrideMode {
+    /// Returns the equivalent global `Mode` if this scope is tracked, or `None` if excluded.
+    pub const fn as_mode(&self) -> Option<Mode> {
+        match self {
+            OverrideMode::Exact => Some(Mode::Exact),
+            OverrideMode::Probabilistic(b) => Some(Mode::Probabilistic(*b)),
+            OverrideMode::Excluded => None,
+        }
+    }
+}
+
+// =============================================================================
+// Per-tag configuration block
+// =============================================================================
+
+/// Tag cardinality limit configuration for a specific tag key, scoped under a per-metric override.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PerTagConfig {
+    #[serde(flatten)]
+    pub config: PerTagInner,
+}
+
+/// Configuration block used at the per-tag level.
+///
+/// The tracking mode (`exact` or `probabilistic`) and `cache_size_per_key` are always
+/// inherited from the enclosing per-metric configuration and cannot be overridden per-tag.
+/// A tag can be opted out of cardinality tracking entirely with `excluded: true`.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PerTagInner {
+    /// How many distinct values to accept for this tag key. If unset, inherits
+    /// the `value_limit` from the enclosing per-metric (or global) configuration.
+    /// Ignored when `excluded: true`.
+    #[serde(default)]
+    pub value_limit: Option<usize>,
+
+    /// When `true`, opts this tag out of cardinality tracking entirely. All values
+    /// for this tag pass through without being recorded or checked against
+    /// `value_limit`. Defaults to `false`.
+    #[serde(default)]
+    pub excluded: bool,
+}
+
+// =============================================================================
+// Shared building blocks
+// =============================================================================
 
 /// Possible actions to take when an event arrives that would exceed the cardinality limit for one
 /// or more of its tags.
@@ -148,24 +254,43 @@ pub enum LimitExceededAction {
     DropEvent,
 }
 
-/// Tag cardinality limit configuration per metric name.
+/// Bloom filter configuration in probabilistic mode.
 #[configurable_component]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PerMetricConfig {
-    /// Namespace of the metric this configuration refers to.
-    #[serde(default)]
-    pub namespace: Option<String>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BloomFilterConfig {
+    /// The size of the cache for detecting duplicate tags, in bytes.
+    ///
+    /// The larger the cache size, the less likely it is to have a false positive, or a case where
+    /// we allow a new value for tag even after we have reached the configured limits.
+    #[serde(default = "default_cache_size")]
+    #[configurable(metadata(docs::human_name = "Cache Size per Key"))]
+    pub cache_size_per_key: usize,
+}
 
-    #[serde(flatten)]
-    pub config: Inner,
+/// Configuration of internal metrics for the TagCardinalityLimit transform.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct InternalMetricsConfig {
+    /// Whether to include extended tags (metric_name, tag_key) in the `tag_value_limit_exceeded_total` metric.
+    ///
+    /// This helps identify which metrics and tag keys are hitting cardinality limits, but can significantly
+    /// increase metric cardinality. Defaults to `false` because these tags have potentially unbounded cardinality.
+    #[serde(default = "default_include_extended_tags")]
+    #[configurable(metadata(docs::human_name = "Include Extended Tags"))]
+    pub include_extended_tags: bool,
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+const fn default_value_limit() -> usize {
+    500
 }
 
 const fn default_limit_exceeded_action() -> LimitExceededAction {
     LimitExceededAction::DropTag
-}
-
-const fn default_value_limit() -> usize {
-    500
 }
 
 const fn default_include_extended_tags() -> bool {
@@ -175,6 +300,10 @@ const fn default_include_extended_tags() -> bool {
 pub(crate) const fn default_cache_size() -> usize {
     5 * 1024 // 5KB
 }
+
+// =============================================================================
+// Transform plumbing
+// =============================================================================
 
 impl GenerateConfig for Config {
     fn generate_config() -> toml::Value {

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -128,12 +128,12 @@ pub struct PerMetricConfig {
     #[serde(default)]
     pub namespace: Option<String>,
 
-    /// Per-tag-key overrides scoped to this metric.
+    /// Per-tag-key overrides scoped to this metric. Each entry sets a `mode`:
+    /// - `mode: limit_override` + `value_limit: N` — track with a per-tag cap.
+    /// - `mode: excluded` — opt this tag out of tracking entirely.
     ///
-    /// Each entry may override `value_limit` for a specific tag key or opt it out of
-    /// tracking entirely with `excluded: true`. The tracking mode, `cache_size_per_key`,
-    /// `limit_exceeded_action`, and `internal_metrics` are always inherited from the
-    /// enclosing per-metric configuration and cannot be set per-tag.
+    ///  All other settings (tracking algorithm, `limit_exceeded_action`, etc.)
+    /// are inherited from the enclosing per-metric configuration.
     /// Tags not listed here use the per-metric configuration.
     #[configurable(
         derived,
@@ -184,12 +184,9 @@ pub enum OverrideMode {
     Probabilistic(BloomFilterConfig),
 
     /// Skip cardinality tracking for this metric. All tag values pass through and nothing is
-    /// recorded. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
+    /// limited. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
     /// `internal_metrics`) are ignored when this is selected. Any `per_tag_limits` entries
     /// on this metric are also ignored.
-    ///
-    /// Only valid in `per_metric_limits` entries; using it as the global `mode` is a
-    /// configuration error.
     Excluded,
 }
 
@@ -208,33 +205,46 @@ impl OverrideMode {
 // Per-tag configuration block
 // =============================================================================
 
-/// Tag cardinality limit configuration for a specific tag key, scoped under a per-metric override.
+/// Per-tag cardinality configuration.
+///
+/// Specify `mode` to control how this tag is handled:
+///
+/// Example:
+/// ```yaml
+/// per_tag_limits:
+///   environment:
+///     mode: limit_override  # track with a per-tag cap
+///     value_limit: 3
+///   trace_id:
+///     mode: excluded        # opt out of tracking entirely
+/// ```
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PerTagConfig {
+    #[configurable(derived)]
     #[serde(flatten)]
-    pub config: PerTagInner,
+    pub mode: PerTagMode,
 }
 
-/// Configuration block used at the per-tag level.
+/// Mode applied to a specific tag key within a per-metric override.
 ///
-/// The tracking mode (`exact` or `probabilistic`) and `cache_size_per_key` are always
-/// inherited from the enclosing per-metric configuration and cannot be overridden per-tag.
-/// A tag can be opted out of cardinality tracking entirely with `excluded: true`.
+/// The tracking algorithm (`exact`/`probabilistic`), `cache_size_per_key`,
+/// `limit_exceeded_action`, and `internal_metrics` are always inherited from the
+/// enclosing per-metric configuration regardless of the per-tag mode.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PerTagInner {
-    /// How many distinct values to accept for this tag key. If unset, inherits
-    /// the `value_limit` from the enclosing per-metric (or global) configuration.
-    /// Ignored when `excluded: true`.
-    #[serde(default)]
-    pub value_limit: Option<usize>,
-
-    /// When `true`, opts this tag out of cardinality tracking entirely. All values
-    /// for this tag pass through without being recorded or checked against
-    /// `value_limit`. Defaults to `false`.
-    #[serde(default)]
-    pub excluded: bool,
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+#[configurable(metadata(docs::enum_tag_description = "Controls how this tag key is handled."))]
+pub enum PerTagMode {
+    /// Track this tag with a per-tag value limit. The enclosing per-metric tracking
+    /// algorithm and all other settings still apply.
+    LimitOverride {
+        /// Maximum number of distinct values to accept for this tag key.
+        value_limit: usize,
+    },
+    /// Opt this tag out of cardinality tracking entirely. All values pass through
+    /// without being recorded or checked against any `value_limit`.
+    Excluded,
 }
 
 // =============================================================================

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -72,7 +72,6 @@ pub enum TrackingScope {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Inner {
     /// How many distinct values to accept for any given key.
-    #[configurable(validation(range(min = 1.0)))]
     #[serde(default = "default_value_limit")]
     pub value_limit: usize,
 
@@ -144,7 +143,6 @@ pub struct PerMetricConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct OverrideInner {
     /// How many distinct values to accept for any given key. Ignored when `mode: excluded`.
-    #[configurable(validation(range(min = 1.0)))]
     #[serde(default = "default_value_limit")]
     pub value_limit: usize,
 
@@ -226,7 +224,6 @@ pub enum PerTagMode {
     /// algorithm and all other settings still apply.
     LimitOverride {
         /// Maximum number of distinct values to accept for this tag key.
-        #[configurable(validation(range(min = 1.0)))]
         value_limit: usize,
     },
     /// Opt this tag out of cardinality tracking entirely. All values pass through

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -78,6 +78,7 @@ pub enum TrackingScope {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Inner {
     /// How many distinct values to accept for any given key.
+    #[configurable(validation(range(min = 1.0)))]
     #[serde(default = "default_value_limit")]
     pub value_limit: usize,
 
@@ -153,6 +154,7 @@ pub struct PerMetricConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct OverrideInner {
     /// How many distinct values to accept for any given key. Ignored when `mode: excluded`.
+    #[configurable(validation(range(min = 1.0)))]
     #[serde(default = "default_value_limit")]
     pub value_limit: usize,
 
@@ -184,9 +186,7 @@ pub enum OverrideMode {
     Probabilistic(BloomFilterConfig),
 
     /// Skip cardinality tracking for this metric. All tag values pass through and nothing is
-    /// limited. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
-    /// `internal_metrics`) are ignored when this is selected. Any `per_tag_limits` entries
-    /// on this metric are also ignored.
+    /// limited. Other fields in this per-metric configuration are ignored when this is selected.
     Excluded,
 }
 
@@ -230,7 +230,7 @@ pub struct PerTagConfig {
 ///
 /// The tracking algorithm (`exact`/`probabilistic`), `cache_size_per_key`,
 /// `limit_exceeded_action`, and `internal_metrics` are always inherited from the
-/// enclosing per-metric configuration regardless of the per-tag mode.
+/// enclosing per-metric configuration.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
@@ -240,6 +240,7 @@ pub enum PerTagMode {
     /// algorithm and all other settings still apply.
     LimitOverride {
         /// Maximum number of distinct values to accept for this tag key.
+        #[configurable(validation(range(min = 1.0)))]
         value_limit: usize,
     },
     /// Opt this tag out of cardinality tracking entirely. All values pass through

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -11,9 +11,7 @@ use crate::{
     transforms::{Transform, tag_cardinality_limit::TagCardinalityLimit},
 };
 
-// =============================================================================
 // Top-level configuration
-// =============================================================================
 
 /// Configuration for the `tag_cardinality_limit` transform.
 #[configurable_component(transform(
@@ -69,10 +67,6 @@ pub enum TrackingScope {
     PerMetric,
 }
 
-// =============================================================================
-// Global-level configuration block
-// =============================================================================
-
 /// Configuration block used at the global level.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -117,11 +111,7 @@ pub enum Mode {
     Probabilistic(BloomFilterConfig),
 }
 
-// =============================================================================
-// Per-metric configuration block
-// =============================================================================
-
-/// Tag cardinality limit configuration per metric name.
+/// Per-metric name tag cardinality limit configuration.
 #[configurable_component]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PerMetricConfig {
@@ -200,10 +190,6 @@ impl OverrideMode {
         }
     }
 }
-
-// =============================================================================
-// Per-tag configuration block
-// =============================================================================
 
 /// Per-tag cardinality configuration.
 ///

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -56,7 +56,7 @@ pub struct TagCardinalityLimit {
 }
 
 impl TagCardinalityLimit {
-    fn new(config: Config) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
             accepted_tags: HashMap::new(),

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -17,8 +17,9 @@ mod tests;
 
 pub use config::{
     BloomFilterConfig, Config, Inner, LimitExceededAction, Mode, OverrideInner, OverrideMode,
-    PerMetricConfig, PerTagConfig, PerTagInner, TrackingScope,
+    PerMetricConfig, PerTagConfig, PerTagMode, TrackingScope,
 };
+
 use tag_value_set::AcceptedTagValueSet;
 
 use crate::event::metric::TagValueSet;
@@ -83,15 +84,14 @@ impl TagCardinalityLimit {
 
     /// Resolve the configuration that applies to a specific (metric, tag) pair.
     ///
-    /// Lookup chain (per field):
-    /// - `value_limit`: per-tag override → per-metric → global.
-    /// - `mode`, `cache_size_per_key`, `limit_exceeded_action`, `internal_metrics`:
-    ///   per-metric → global. These fields cannot be overridden per-tag.
+    /// Per-tag entries support two modes:
+    /// - `mode: limit_override` — uses the per-tag `value_limit`; all other settings
+    ///   (`mode`, `cache_size_per_key`, `limit_exceeded_action`, `internal_metrics`)
+    ///   are inherited from the per-metric config.
+    /// - `mode: excluded` — opts the tag out entirely; all values pass through.
     ///
-    /// Per-tag exclusion: if the per-tag entry has `excluded: true`, the tag is opted out
-    /// regardless of the enclosing per-metric settings.
-    /// Per-metric exclusion is blanket: if the per-metric entry has `mode: excluded`,
-    /// every tag on the metric is excluded and `per_tag_limits` is ignored.
+    /// Per-metric exclusion is blanket: `mode: excluded` on a per-metric entry opts out
+    /// every tag on that metric and `per_tag_limits` is ignored.
     fn get_config_for_metric_tag(
         &self,
         metric_key: Option<&MetricId>,
@@ -115,20 +115,22 @@ impl TagCardinalityLimit {
         let metric_value_limit = per_metric.config.value_limit;
         let internal_metrics = per_metric.config.internal_metrics;
 
-        // Per-tag entry may exclude the tag or override `value_limit`.
-        // All other fields (mode, cache_size_per_key, etc.) are always inherited
-        // from the per-metric configuration.
+        // Per-tag entry: LimitOverride uses an explicit value_limit; Excluded opts
+        // the tag out. All other settings are always inherited from per-metric.
         if let Some(per_tag) = per_metric.per_tag_limits.get(tag_key) {
-            if per_tag.config.excluded {
-                return TagSettings::Excluded;
+            match per_tag.mode {
+                PerTagMode::Excluded => return TagSettings::Excluded,
+                PerTagMode::LimitOverride { value_limit } => {
+                    // Tracking algorithm and all other settings are always inherited
+                    // from the per-metric config.
+                    return TagSettings::Tracked(Inner {
+                        value_limit,
+                        limit_exceeded_action,
+                        mode: metric_mode,
+                        internal_metrics,
+                    });
+                }
             }
-            // Mode and cache_size_per_key are always inherited from the per-metric config.
-            return TagSettings::Tracked(Inner {
-                value_limit: per_tag.config.value_limit.unwrap_or(metric_value_limit),
-                limit_exceeded_action,
-                mode: metric_mode,
-                internal_metrics,
-            });
         }
         TagSettings::Tracked(Inner {
             value_limit: metric_value_limit,
@@ -156,7 +158,8 @@ impl TagCardinalityLimit {
     ///
     /// Returns:
     /// - `Tracked` if the value is already tracked, fits under the configured
-    ///   `value_limit` and is now recorded, or the tag is excluded (pass-through).
+    ///   `value_limit` and is now recorded, or the per-tag entry is `mode: excluded`
+    ///   (pass-through).
     /// - `Dropped` if the value would exceed `value_limit`; the caller should drop
     ///   the tag.
     /// - `Untracked` if a new (metric, tag-key) pair would have to be allocated but

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -228,14 +228,19 @@ impl TagCardinalityLimit {
             TagSettings::Excluded => return false,
             TagSettings::Tracked(inner) => inner,
         };
-        self.accepted_tags
+        match self
+            .accepted_tags
             .get(&metric_key.cloned())
-            .and_then(|metric_accepted_tags| {
-                metric_accepted_tags.get(key).map(|value_set| {
-                    !value_set.contains(value) && value_set.len() >= resolved.value_limit
-                })
-            })
-            .unwrap_or(false)
+            .and_then(|metric_accepted_tags| metric_accepted_tags.get(key))
+        {
+            // Already accepted — never exceeds.
+            Some(value_set) if value_set.contains(value) => false,
+            // Adding this value would push us at or past the configured cap. Treat a
+            // missing bucket as an empty set so `value_limit: 0` correctly rejects
+            // the first occurrence too.
+            Some(value_set) => value_set.len() >= resolved.value_limit,
+            None => resolved.value_limit == 0,
+        }
     }
 
     /// Record an accepted tag value (mutation-only, no limit check). Used by the `DropEvent`

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -16,7 +16,8 @@ mod tag_value_set;
 mod tests;
 
 pub use config::{
-    BloomFilterConfig, Config, Inner, LimitExceededAction, Mode, PerMetricConfig, TrackingScope,
+    BloomFilterConfig, Config, Inner, LimitExceededAction, Mode, OverrideInner, OverrideMode,
+    PerMetricConfig, PerTagConfig, PerTagInner, TrackingScope,
 };
 use tag_value_set::AcceptedTagValueSet;
 
@@ -27,12 +28,21 @@ type MetricId = (Option<String>, String);
 /// Outcome of applying tag cardinality tracking to a tag value.
 #[derive(Debug, Eq, PartialEq)]
 enum AcceptResult {
-    /// The tag value was tracked and is within the configured `value_limit`.
+    /// The tag value was tracked and is within the configured `value_limit`,
+    /// or the tag is excluded and passes through unconditionally.
     Tracked,
     /// The tag value was tracked and exceeded the configured `value_limit`.
     Dropped,
     /// The tag value was not tracked because tracking capacity is exhausted.
     Untracked,
+}
+
+/// Tag tracking settings for a single (metric, tag) pair.
+enum TagSettings {
+    /// The tag is excluded from cardinality control; pass values through unchanged.
+    Excluded,
+    /// The tag is tracked using these settings.
+    Tracked(Inner),
 }
 
 #[derive(Debug)]
@@ -71,26 +81,82 @@ impl TagCardinalityLimit {
         });
     }
 
-    fn get_config_for_metric(&self, metric_key: Option<&MetricId>) -> &Inner {
-        match metric_key {
-            Some(id) => self
-                .config
-                .per_metric_limits
-                .iter()
-                .find(|(name, config)| {
-                    **name == id.1 && (config.namespace.is_none() || config.namespace == id.0)
-                })
-                .map(|(_, c)| &c.config)
-                .unwrap_or(&self.config.global),
-            None => &self.config.global,
+    /// Resolve the configuration that applies to a specific (metric, tag) pair.
+    ///
+    /// Lookup chain (per field):
+    /// - `value_limit`: per-tag override → per-metric → global.
+    /// - `mode`, `cache_size_per_key`, `limit_exceeded_action`, `internal_metrics`:
+    ///   per-metric → global. These fields cannot be overridden per-tag.
+    ///
+    /// Per-tag exclusion: if the per-tag entry has `excluded: true`, the tag is opted out
+    /// regardless of the enclosing per-metric settings.
+    /// Per-metric exclusion is blanket: if the per-metric entry has `mode: excluded`,
+    /// every tag on the metric is excluded and `per_tag_limits` is ignored.
+    fn get_config_for_metric_tag(
+        &self,
+        metric_key: Option<&MetricId>,
+        tag_key: &str,
+    ) -> TagSettings {
+        // No matching per-metric override → use the global config as-is.
+        let Some((metric_namespace, metric_name)) = metric_key else {
+            return TagSettings::Tracked(self.config.global);
+        };
+        let Some((_, per_metric)) = self.config.per_metric_limits.iter().find(|(name, cfg)| {
+            *name == metric_name && (cfg.namespace.is_none() || cfg.namespace == *metric_namespace)
+        }) else {
+            return TagSettings::Tracked(self.config.global);
+        };
+
+        // Per-metric exclusion is blanket — per-tag overrides do not apply.
+        let Some(metric_mode) = per_metric.config.mode.as_mode() else {
+            return TagSettings::Excluded;
+        };
+        let limit_exceeded_action = per_metric.config.limit_exceeded_action;
+        let metric_value_limit = per_metric.config.value_limit;
+        let internal_metrics = per_metric.config.internal_metrics;
+
+        // Per-tag entry may exclude the tag or override `value_limit`.
+        // All other fields (mode, cache_size_per_key, etc.) are always inherited
+        // from the per-metric configuration.
+        if let Some(per_tag) = per_metric.per_tag_limits.get(tag_key) {
+            if per_tag.config.excluded {
+                return TagSettings::Excluded;
+            }
+            // Mode and cache_size_per_key are always inherited from the per-metric config.
+            return TagSettings::Tracked(Inner {
+                value_limit: per_tag.config.value_limit.unwrap_or(metric_value_limit),
+                limit_exceeded_action,
+                mode: metric_mode,
+                internal_metrics,
+            });
         }
+        TagSettings::Tracked(Inner {
+            value_limit: metric_value_limit,
+            limit_exceeded_action,
+            mode: metric_mode,
+            internal_metrics,
+        })
+    }
+
+    /// Returns the `limit_exceeded_action` that applies to this metric. Decided once per event:
+    /// per-metric override if any, else global.
+    fn metric_action(&self, metric_key: Option<&MetricId>) -> LimitExceededAction {
+        if let Some(id) = metric_key
+            && let Some((_, pmc)) =
+                self.config.per_metric_limits.iter().find(|(name, c)| {
+                    **name == id.1 && (c.namespace.is_none() || c.namespace == id.0)
+                })
+        {
+            return pmc.config.limit_exceeded_action;
+        }
+        self.config.global.limit_exceeded_action
     }
 
     /// Attempts to accept a tag value for a (metric, tag-key) pair.
     ///
     /// Returns:
-    /// - `Tracked` if the value is already tracked, or fits under the configured
-    ///   `value_limit` and is now recorded.
+    /// - `Tracked` if the value is already tracked, fits under the configured
+    ///   `value_limit` and is now recorded, or the tag is excluded (pass-through).
     /// - `Dropped` if the value would exceed `value_limit`; the caller should drop
     ///   the tag.
     /// - `Untracked` if a new (metric, tag-key) pair would have to be allocated but
@@ -102,7 +168,10 @@ impl TagCardinalityLimit {
         key: &str,
         value: &TagValueSet,
     ) -> AcceptResult {
-        let config = *self.get_config_for_metric(metric_key);
+        let config = match self.get_config_for_metric_tag(metric_key, key) {
+            TagSettings::Excluded => return AcceptResult::Tracked,
+            TagSettings::Tracked(inner) => inner,
+        };
         let metric_key_owned = metric_key.cloned();
 
         // Determine whether this (metric, tag-key) pair already has a bucket.
@@ -152,28 +221,37 @@ impl TagCardinalityLimit {
         key: &str,
         value: &TagValueSet,
     ) -> bool {
+        let resolved = match self.get_config_for_metric_tag(metric_key, key) {
+            TagSettings::Excluded => return false,
+            TagSettings::Tracked(inner) => inner,
+        };
         self.accepted_tags
             .get(&metric_key.cloned())
             .and_then(|metric_accepted_tags| {
                 metric_accepted_tags.get(key).map(|value_set| {
-                    !value_set.contains(value)
-                        && value_set.len() >= self.get_config_for_metric(metric_key).value_limit
+                    !value_set.contains(value) && value_set.len() >= resolved.value_limit
                 })
             })
             .unwrap_or(false)
     }
 
-    /// Record a key and value corresponding to a tag on an incoming Metric.
+    /// Record an accepted tag value (mutation-only, no limit check). Used by the `DropEvent`
+    /// path's record pass after a mutation-free pre-check has confirmed every tag has room.
+    /// Excluded tags are skipped — no storage allocated.
     ///
     /// Returns `true` if the (metric, tag-key) pair could not be allocated due to
-    /// `max_tracked_keys` (and therefore the value is not recorded), `false` otherwise.
+    /// `max_tracked_keys` (the value is then not recorded). Returns `false` for
+    /// successful records and for excluded tags.
     fn record_tag_value(
         &mut self,
         metric_key: Option<&MetricId>,
         key: &str,
         value: &TagValueSet,
     ) -> bool {
-        let config = *self.get_config_for_metric(metric_key);
+        let config = match self.get_config_for_metric_tag(metric_key, key) {
+            TagSettings::Excluded => return false,
+            TagSettings::Tracked(inner) => inner,
+        };
         let metric_key_owned = metric_key.cloned();
 
         let pair_exists = self
@@ -216,22 +294,21 @@ impl TagCardinalityLimit {
             }
         };
         if let Some(tags_map) = metric.tags_mut() {
-            let include_extended_tags = self
-                .get_config_for_metric(metric_key.as_ref())
-                .internal_metrics
-                .include_extended_tags;
             let mut any_untracked = false;
 
-            match self
-                .get_config_for_metric(metric_key.as_ref())
-                .limit_exceeded_action
-            {
+            match self.metric_action(metric_key.as_ref()) {
                 LimitExceededAction::DropEvent => {
-                    // This needs to check all the tags, to ensure that the ordering of tag names
-                    // doesn't change the behavior of the check.
-
+                    // This needs to check all the tags, to ensure that the ordering of tag
+                    // names doesn't change the behavior of the check.
                     for (key, value) in tags_map.iter_sets() {
+                        let TagSettings::Tracked(resolved) =
+                            self.get_config_for_metric_tag(metric_key.as_ref(), key)
+                        else {
+                            continue; // excluded tags can never trigger DropEvent
+                        };
                         if self.tag_limit_exceeded(metric_key.as_ref(), key, value) {
+                            let include_extended_tags =
+                                resolved.internal_metrics.include_extended_tags;
                             emit!(TagCardinalityLimitRejectingEvent {
                                 metric_name: &metric_name,
                                 tag_key: key,
@@ -252,6 +329,14 @@ impl TagCardinalityLimit {
                         match self.try_accept_tag(metric_key.as_ref(), key, value) {
                             AcceptResult::Tracked => true,
                             AcceptResult::Dropped => {
+                                let include_extended_tags = match self
+                                    .get_config_for_metric_tag(metric_key.as_ref(), key)
+                                {
+                                    TagSettings::Tracked(inner) => {
+                                        inner.internal_metrics.include_extended_tags
+                                    }
+                                    TagSettings::Excluded => false, // unreachable: excluded tags return Tracked
+                                };
                                 emit!(TagCardinalityLimitRejectingTag {
                                     metric_name: &metric_name,
                                     tag_key: key,

--- a/src/transforms/tag_cardinality_limit/tests.rs
+++ b/src/transforms/tag_cardinality_limit/tests.rs
@@ -1077,6 +1077,35 @@ fn per_tag_limit_override_caps_at_explicit_value() {
     assert!(!e3.as_metric().tags().unwrap().contains_key("tag1"));
 }
 
+#[test]
+fn per_tag_zero_limit_drop_event_drops_first_event() {
+    let config = make_transform_hashset_with_per_metric_limits(
+        500,
+        LimitExceededAction::DropTag,
+        HashMap::from([(
+            "metricA".to_string(),
+            make_per_metric(
+                10,
+                LimitExceededAction::DropEvent,
+                HashMap::from([("tag1".to_string(), make_per_tag(0))]),
+            ),
+        )]),
+    );
+    let mut transform = TagCardinalityLimit::new(config);
+
+    let dropped = transform.transform_one(make_metric_with_name(
+        metric_tags!("tag1" => "v0"),
+        "metricA",
+    ));
+    assert_eq!(dropped, None);
+
+    let passed = transform.transform_one(make_metric_with_name(
+        metric_tags!("tag1" => "v0"),
+        "metricB",
+    ));
+    assert!(passed.is_some());
+}
+
 /// Per-tag YAML syntax: `mode: limit_override` with `value_limit`, and `mode: excluded`.
 #[test]
 fn per_tag_modes_deserialize() {

--- a/src/transforms/tag_cardinality_limit/tests.rs
+++ b/src/transforms/tag_cardinality_limit/tests.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use config::PerMetricConfig;
+use config::{PerMetricConfig, PerTagConfig};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use vector_lib::{
@@ -415,6 +415,26 @@ fn drop_event_checks_all_tags(make_tags: impl Fn(&str, &str) -> MetricTags) {
     assert_eq!(new_event4, Some(event4));
 }
 
+fn override_inner_hashset(value_limit: usize, action: LimitExceededAction) -> OverrideInner {
+    OverrideInner {
+        value_limit,
+        limit_exceeded_action: action,
+        mode: OverrideMode::Exact,
+        internal_metrics: InternalMetricsConfig::default(),
+    }
+}
+
+fn override_inner_bloom(value_limit: usize, action: LimitExceededAction) -> OverrideInner {
+    OverrideInner {
+        value_limit,
+        limit_exceeded_action: action,
+        mode: OverrideMode::Probabilistic(BloomFilterConfig {
+            cache_size_per_key: default_cache_size(),
+        }),
+        internal_metrics: InternalMetricsConfig::default(),
+    }
+}
+
 #[tokio::test]
 async fn tag_cardinality_limit_separate_value_limit_per_metric_name_hashset() {
     separate_value_limit_per_metric_name(make_transform_hashset_with_per_metric_limits(
@@ -425,14 +445,16 @@ async fn tag_cardinality_limit_separate_value_limit_per_metric_name_hashset() {
                 "metricA".to_string(),
                 PerMetricConfig {
                     namespace: None,
-                    config: make_transform_hashset(1, LimitExceededAction::DropTag).global,
+                    per_tag_limits: HashMap::new(),
+                    config: override_inner_hashset(1, LimitExceededAction::DropTag),
                 },
             ),
             (
                 "metricB".to_string(),
                 PerMetricConfig {
                     namespace: None,
-                    config: make_transform_hashset(5, LimitExceededAction::DropTag).global,
+                    per_tag_limits: HashMap::new(),
+                    config: override_inner_hashset(5, LimitExceededAction::DropTag),
                 },
             ),
         ]),
@@ -450,14 +472,16 @@ async fn tag_cardinality_limit_separate_value_limit_per_metric_name_bloom() {
                 "metricA".to_string(),
                 PerMetricConfig {
                     namespace: None,
-                    config: make_transform_bloom(1, LimitExceededAction::DropTag).global,
+                    per_tag_limits: HashMap::new(),
+                    config: override_inner_bloom(1, LimitExceededAction::DropTag),
                 },
             ),
             (
                 "metricB".to_string(),
                 PerMetricConfig {
                     namespace: None,
-                    config: make_transform_bloom(5, LimitExceededAction::DropTag).global,
+                    per_tag_limits: HashMap::new(),
+                    config: override_inner_bloom(5, LimitExceededAction::DropTag),
                 },
             ),
         ]),
@@ -737,4 +761,363 @@ fn max_tracked_keys_caps_across_per_metric_buckets() {
         .transform_one(make_metric_with_name(metric_tags!("k" => "v2"), "metric_c"))
         .unwrap();
     assert_eq!("v2", e.as_metric().tags().unwrap().get("k").unwrap());
+}
+
+fn make_per_tag(value_limit: usize) -> PerTagConfig {
+    PerTagConfig {
+        config: PerTagInner {
+            value_limit: Some(value_limit),
+            excluded: false,
+        },
+    }
+}
+
+fn make_per_metric(
+    value_limit: usize,
+    action: LimitExceededAction,
+    per_tag_limits: HashMap<String, PerTagConfig>,
+) -> PerMetricConfig {
+    PerMetricConfig {
+        namespace: None,
+        per_tag_limits,
+        config: OverrideInner {
+            value_limit,
+            limit_exceeded_action: action,
+            mode: OverrideMode::Exact,
+            internal_metrics: InternalMetricsConfig::default(),
+        },
+    }
+}
+
+fn make_per_metric_excluded(per_tag_limits: HashMap<String, PerTagConfig>) -> PerMetricConfig {
+    PerMetricConfig {
+        namespace: None,
+        per_tag_limits,
+        config: OverrideInner {
+            value_limit: 0,
+            limit_exceeded_action: LimitExceededAction::DropTag,
+            mode: OverrideMode::Excluded,
+            internal_metrics: InternalMetricsConfig::default(),
+        },
+    }
+}
+
+fn make_per_tag_excluded() -> PerTagConfig {
+    PerTagConfig {
+        config: PerTagInner {
+            value_limit: None,
+            excluded: true,
+        },
+    }
+}
+
+/// A per-tag `value_limit` override caps that tag below the per-metric limit while sibling
+/// tags continue to use the per-metric limit.
+#[test]
+fn per_tag_value_limit() {
+    let config = make_transform_hashset_with_per_metric_limits(
+        500,
+        LimitExceededAction::DropTag,
+        HashMap::from([(
+            "metricA".to_string(),
+            make_per_metric(
+                5,
+                LimitExceededAction::DropTag,
+                HashMap::from([("tag1".to_string(), make_per_tag(2))]),
+            ),
+        )]),
+    );
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // Fill tag1 to its per-tag limit of 2 and tag2 to 2 of its per-metric limit of 5.
+    let e1 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v1", "tag2" => "v1"),
+            "metricA",
+        ))
+        .unwrap();
+    assert!(e1.as_metric().tags().unwrap().contains_key("tag1"));
+    assert!(e1.as_metric().tags().unwrap().contains_key("tag2"));
+
+    let e2 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v2", "tag2" => "v2"),
+            "metricA",
+        ))
+        .unwrap();
+    assert!(e2.as_metric().tags().unwrap().contains_key("tag1"));
+    assert!(e2.as_metric().tags().unwrap().contains_key("tag2"));
+
+    // tag1 is at its per-tag limit; new value should be dropped. tag2 still has room.
+    let e3 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v3", "tag2" => "v3"),
+            "metricA",
+        ))
+        .unwrap();
+    assert!(!e3.as_metric().tags().unwrap().contains_key("tag1"));
+    assert_eq!("v3", e3.as_metric().tags().unwrap().get("tag2").unwrap());
+
+    // Fill tag2 to the per-metric limit of 5.
+    let e4 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag2" => "v4"),
+            "metricA",
+        ))
+        .unwrap();
+    assert_eq!("v4", e4.as_metric().tags().unwrap().get("tag2").unwrap());
+
+    let e5 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag2" => "v5"),
+            "metricA",
+        ))
+        .unwrap();
+    assert_eq!("v5", e5.as_metric().tags().unwrap().get("tag2").unwrap());
+
+    // tag2 is now at its per-metric limit; new value should be dropped.
+    let e6 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag2" => "v6"),
+            "metricA",
+        ))
+        .unwrap();
+    assert!(!e6.as_metric().tags().unwrap().contains_key("tag2"));
+}
+
+/// Tags with no per-tag override fall back to the per-metric configuration; metrics with no
+/// per-metric override fall back to the global configuration.
+#[test]
+fn per_tag_falls_back_to_per_metric() {
+    let config = make_transform_hashset_with_per_metric_limits(
+        2,
+        LimitExceededAction::DropTag,
+        HashMap::from([(
+            "metricA".to_string(),
+            make_per_metric(
+                3,
+                LimitExceededAction::DropTag,
+                HashMap::from([("tag1".to_string(), make_per_tag(1))]),
+            ),
+        )]),
+    );
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // metricA: tag1 capped at 1 (per-tag), tag2 capped at 3 (per-metric).
+    transform.transform_one(make_metric_with_name(
+        metric_tags!("tag1" => "v1", "tag2" => "v1"),
+        "metricA",
+    ));
+    let e2 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v2", "tag2" => "v2"),
+            "metricA",
+        ))
+        .unwrap();
+    // tag1 already at its per-tag limit of 1 → dropped. tag2 accepted (now 2/3).
+    assert!(!e2.as_metric().tags().unwrap().contains_key("tag1"));
+    assert_eq!("v2", e2.as_metric().tags().unwrap().get("tag2").unwrap());
+
+    let e3 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag2" => "v3"),
+            "metricA",
+        ))
+        .unwrap();
+    assert_eq!("v3", e3.as_metric().tags().unwrap().get("tag2").unwrap());
+
+    // tag2 now at per-metric limit of 3 → dropped.
+    let e4 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag2" => "v4"),
+            "metricA",
+        ))
+        .unwrap();
+    assert!(!e4.as_metric().tags().unwrap().contains_key("tag2"));
+
+    // metricB has no per-metric entry → uses global limit of 2.
+    transform.transform_one(make_metric_with_name(
+        metric_tags!("tag1" => "v1"),
+        "metricB",
+    ));
+    transform.transform_one(make_metric_with_name(
+        metric_tags!("tag1" => "v2"),
+        "metricB",
+    ));
+    let b3 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v3"),
+            "metricB",
+        ))
+        .unwrap();
+    assert!(!b3.as_metric().tags().unwrap().contains_key("tag1"));
+}
+
+/// An excluded metric passes all tag values through unbounded; storage is never allocated for
+/// it, and other metrics are unaffected.
+#[test]
+fn metric_excluded_passes_through_unbounded() {
+    let config = make_transform_hashset_with_per_metric_limits(
+        1,
+        LimitExceededAction::DropTag,
+        HashMap::from([(
+            "metricA".to_string(),
+            make_per_metric_excluded(HashMap::new()),
+        )]),
+    );
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // Send 100 distinct values for metricA's tag — all should pass through.
+    for i in 0..100 {
+        let v = format!("v{i}");
+        let e = transform
+            .transform_one(make_metric_with_name(
+                metric_tags!("tag1" => v.clone()),
+                "metricA",
+            ))
+            .unwrap();
+        assert_eq!(
+            v.as_str(),
+            e.as_metric().tags().unwrap().get("tag1").unwrap()
+        );
+    }
+    // Excluded metric must not have allocated any storage.
+    assert!(
+        transform
+            .accepted_tags
+            .get(&Some((None, "metricA".to_string())))
+            .is_none()
+    );
+
+    // metricB has no per-metric override → uses global limit of 1.
+    transform.transform_one(make_metric_with_name(
+        metric_tags!("tag1" => "v1"),
+        "metricB",
+    ));
+    let e = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v2"),
+            "metricB",
+        ))
+        .unwrap();
+    assert!(!e.as_metric().tags().unwrap().contains_key("tag1"));
+}
+
+/// An excluded tag is unbounded; sibling tags on the same metric remain limited.
+#[test]
+fn tag_excluded_unbounded_sibling_limited() {
+    let config = make_transform_hashset_with_per_metric_limits(
+        500,
+        LimitExceededAction::DropTag,
+        HashMap::from([(
+            "metricA".to_string(),
+            make_per_metric(
+                2,
+                LimitExceededAction::DropTag,
+                HashMap::from([("trace_id".to_string(), make_per_tag_excluded())]),
+            ),
+        )]),
+    );
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // 100 distinct trace_id values pass; host capped at 2.
+    for i in 0..100 {
+        let trace = format!("t{i}");
+        let host = format!("h{}", i % 5);
+        let e = transform
+            .transform_one(make_metric_with_name(
+                metric_tags!("trace_id" => trace.clone(), "host" => host.clone()),
+                "metricA",
+            ))
+            .unwrap();
+        assert_eq!(
+            trace.as_str(),
+            e.as_metric().tags().unwrap().get("trace_id").unwrap(),
+            "trace_id should always be retained (excluded)"
+        );
+        if i >= 2 && (host != "h0" && host != "h1") {
+            assert!(
+                !e.as_metric().tags().unwrap().contains_key("host"),
+                "host {host} beyond limit should be dropped"
+            );
+        }
+    }
+}
+
+/// A per-tag entry with `value_limit` unset must inherit the per-metric `value_limit`
+/// rather than silently falling back to the serde default of 500.
+#[test]
+fn per_tag_value_limit_inherits_from_per_metric() {
+    let per_tag = PerTagConfig {
+        config: PerTagInner {
+            value_limit: None, // unset → should inherit from the per-metric (3)
+            excluded: false,
+        },
+    };
+    let config = make_transform_hashset_with_per_metric_limits(
+        500,
+        LimitExceededAction::DropTag,
+        HashMap::from([(
+            "metricA".to_string(),
+            make_per_metric(
+                3,
+                LimitExceededAction::DropTag,
+                HashMap::from([("tag1".to_string(), per_tag)]),
+            ),
+        )]),
+    );
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // First 3 distinct values for tag1 are accepted (inherits per-metric limit of 3).
+    for i in 0..3 {
+        let v = format!("v{i}");
+        let e = transform
+            .transform_one(make_metric_with_name(
+                metric_tags!("tag1" => v.clone()),
+                "metricA",
+            ))
+            .unwrap();
+        assert_eq!(
+            v.as_str(),
+            e.as_metric().tags().unwrap().get("tag1").unwrap()
+        );
+    }
+
+    // 4th value should be rejected — proves the per-tag entry did NOT silently widen
+    // the limit to 500.
+    let e4 = transform
+        .transform_one(make_metric_with_name(
+            metric_tags!("tag1" => "v3"),
+            "metricA",
+        ))
+        .unwrap();
+    assert!(!e4.as_metric().tags().unwrap().contains_key("tag1"));
+}
+
+/// A per-tag entry like `{ value_limit: 10 }` must deserialize successfully.
+#[test]
+fn per_tag_value_limit_only_deserializes() {
+    let yaml = r#"
+value_limit: 5
+mode: exact
+per_metric_limits:
+  metric_a:
+    mode: exact
+    per_tag_limits:
+      tag_only_value_limit:
+        value_limit: 10
+      excluded_tag:
+        excluded: true
+"#;
+    let parsed: Config = serde_yaml::from_str(yaml).expect("yaml should deserialize");
+    let per_metric = parsed.per_metric_limits.get("metric_a").unwrap();
+    let only_limit = per_metric
+        .per_tag_limits
+        .get("tag_only_value_limit")
+        .unwrap();
+    assert_eq!(only_limit.config.value_limit, Some(10));
+    assert!(!only_limit.config.excluded);
+
+    let excluded = per_metric.per_tag_limits.get("excluded_tag").unwrap();
+    assert!(excluded.config.excluded);
 }

--- a/src/transforms/tag_cardinality_limit/tests.rs
+++ b/src/transforms/tag_cardinality_limit/tests.rs
@@ -765,10 +765,7 @@ fn max_tracked_keys_caps_across_per_metric_buckets() {
 
 fn make_per_tag(value_limit: usize) -> PerTagConfig {
     PerTagConfig {
-        config: PerTagInner {
-            value_limit: Some(value_limit),
-            excluded: false,
-        },
+        mode: PerTagMode::LimitOverride { value_limit },
     }
 }
 
@@ -804,10 +801,7 @@ fn make_per_metric_excluded(per_tag_limits: HashMap<String, PerTagConfig>) -> Pe
 
 fn make_per_tag_excluded() -> PerTagConfig {
     PerTagConfig {
-        config: PerTagInner {
-            value_limit: None,
-            excluded: true,
-        },
+        mode: PerTagMode::Excluded,
     }
 }
 
@@ -1044,15 +1038,12 @@ fn tag_excluded_unbounded_sibling_limited() {
     }
 }
 
-/// A per-tag entry with `value_limit` unset must inherit the per-metric `value_limit`
-/// rather than silently falling back to the serde default of 500.
+/// A per-tag `LimitOverride` entry caps that tag at its explicit `value_limit`,
+/// independent of the per-metric limit.
 #[test]
-fn per_tag_value_limit_inherits_from_per_metric() {
+fn per_tag_limit_override_caps_at_explicit_value() {
     let per_tag = PerTagConfig {
-        config: PerTagInner {
-            value_limit: None, // unset → should inherit from the per-metric (3)
-            excluded: false,
-        },
+        mode: PerTagMode::LimitOverride { value_limit: 2 },
     };
     let config = make_transform_hashset_with_per_metric_limits(
         500,
@@ -1060,7 +1051,7 @@ fn per_tag_value_limit_inherits_from_per_metric() {
         HashMap::from([(
             "metricA".to_string(),
             make_per_metric(
-                3,
+                10,
                 LimitExceededAction::DropTag,
                 HashMap::from([("tag1".to_string(), per_tag)]),
             ),
@@ -1068,35 +1059,27 @@ fn per_tag_value_limit_inherits_from_per_metric() {
     );
     let mut transform = TagCardinalityLimit::new(config);
 
-    // First 3 distinct values for tag1 are accepted (inherits per-metric limit of 3).
-    for i in 0..3 {
-        let v = format!("v{i}");
+    // First 2 values pass (per-tag limit = 2).
+    for v in ["v0", "v1"] {
         let e = transform
-            .transform_one(make_metric_with_name(
-                metric_tags!("tag1" => v.clone()),
-                "metricA",
-            ))
+            .transform_one(make_metric_with_name(metric_tags!("tag1" => v), "metricA"))
             .unwrap();
-        assert_eq!(
-            v.as_str(),
-            e.as_metric().tags().unwrap().get("tag1").unwrap()
-        );
+        assert_eq!(v, e.as_metric().tags().unwrap().get("tag1").unwrap());
     }
 
-    // 4th value should be rejected — proves the per-tag entry did NOT silently widen
-    // the limit to 500.
-    let e4 = transform
+    // 3rd value dropped — proves the per-tag limit (2) applies, not the per-metric (10).
+    let e3 = transform
         .transform_one(make_metric_with_name(
-            metric_tags!("tag1" => "v3"),
+            metric_tags!("tag1" => "v2"),
             "metricA",
         ))
         .unwrap();
-    assert!(!e4.as_metric().tags().unwrap().contains_key("tag1"));
+    assert!(!e3.as_metric().tags().unwrap().contains_key("tag1"));
 }
 
-/// A per-tag entry like `{ value_limit: 10 }` must deserialize successfully.
+/// Per-tag YAML syntax: `mode: limit_override` with `value_limit`, and `mode: excluded`.
 #[test]
-fn per_tag_value_limit_only_deserializes() {
+fn per_tag_modes_deserialize() {
     let yaml = r#"
 value_limit: 5
 mode: exact
@@ -1104,20 +1087,18 @@ per_metric_limits:
   metric_a:
     mode: exact
     per_tag_limits:
-      tag_only_value_limit:
+      capped_tag:
+        mode: limit_override
         value_limit: 10
       excluded_tag:
-        excluded: true
+        mode: excluded
 "#;
     let parsed: Config = serde_yaml::from_str(yaml).expect("yaml should deserialize");
     let per_metric = parsed.per_metric_limits.get("metric_a").unwrap();
-    let only_limit = per_metric
-        .per_tag_limits
-        .get("tag_only_value_limit")
-        .unwrap();
-    assert_eq!(only_limit.config.value_limit, Some(10));
-    assert!(!only_limit.config.excluded);
+
+    let capped = per_metric.per_tag_limits.get("capped_tag").unwrap();
+    assert_eq!(capped.mode, PerTagMode::LimitOverride { value_limit: 10 });
 
     let excluded = per_metric.per_tag_limits.get("excluded_tag").unwrap();
-    assert!(excluded.config.excluded);
+    assert_eq!(excluded.mode, PerTagMode::Excluded);
 }

--- a/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
@@ -129,9 +129,7 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 						exact: "Tracks cardinality exactly. See `Mode::Exact` for details."
 						excluded: """
 																			Skip cardinality tracking for this metric. All tag values pass through and nothing is
-																			limited. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
-																			`internal_metrics`) are ignored when this is selected. Any `per_tag_limits` entries
-																			on this metric are also ignored.
+																			limited. Other fields in this per-metric configuration are ignored when this is selected.
 																			"""
 						probabilistic: "Tracks cardinality probabilistically. See `Mode::Probabilistic` for details."
 					}

--- a/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
@@ -126,20 +126,16 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 					description: "Controls the approach taken for tracking tag cardinality."
 					required:    true
 					type: string: enum: {
-						exact: """
-																			Tracks cardinality exactly.
+						exact: "Tracks cardinality exactly. See `Mode::Exact` for details."
+						excluded: """
+																			Skip cardinality tracking for this scope. All tag values pass through and nothing is
+																			recorded. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
+																			`internal_metrics`) are ignored when this is selected.
 
-																			This mode has higher memory requirements than `probabilistic`, but never falsely outputs
-																			metrics with new tags after the limit has been hit.
+																			Only valid in `per_metric_limits` and `per_tag_limits` entries; using it as the global
+																			`mode` is a configuration error.
 																			"""
-						probabilistic: """
-																			Tracks cardinality probabilistically.
-
-																			This mode has lower memory requirements than `exact`, but may occasionally allow metric
-																			events to pass through the transform even when they contain new tags that exceed the
-																			configured limit. The rate at which this happens can be controlled by changing the value of
-																			`cache_size_per_key`.
-																			"""
+						probabilistic: "Tracks cardinality probabilistically. See `Mode::Probabilistic` for details."
 					}
 				}
 				namespace: {
@@ -147,8 +143,43 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 					required:    false
 					type: string: {}
 				}
+				per_tag_limits: {
+					description: """
+						Per-tag-key overrides scoped to this metric.
+
+						Each entry may override `value_limit` and `mode` for a specific tag key.
+						`limit_exceeded_action` and `internal_metrics` are always inherited from the enclosing
+						per-metric (or global) configuration and cannot be set per-tag.
+						Tags not listed here use the per-metric configuration.
+						"""
+					required: false
+					type: object: options: "*": {
+						description: "An individual tag configuration."
+						required:    true
+						type: object: options: {
+							excluded: {
+								description: """
+																								When `true`, opts this tag out of cardinality tracking entirely. All values
+																								for this tag pass through without being recorded or checked against
+																								`value_limit`. Defaults to `false`.
+																								"""
+								required: false
+								type: bool: default: false
+							}
+							value_limit: {
+								description: """
+																								How many distinct values to accept for this tag key. If unset, inherits
+																								the `value_limit` from the enclosing per-metric (or global) configuration.
+																								Ignored when `excluded: true`.
+																								"""
+								required: false
+								type: uint: {}
+							}
+						}
+					}
+				}
 				value_limit: {
-					description: "How many distinct values to accept for any given key."
+					description: "How many distinct values to accept for any given key. Ignored when `mode: excluded`."
 					required:    false
 					type: uint: default: 500
 				}

--- a/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
@@ -128,12 +128,10 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 					type: string: enum: {
 						exact: "Tracks cardinality exactly. See `Mode::Exact` for details."
 						excluded: """
-																			Skip cardinality tracking for this scope. All tag values pass through and nothing is
-																			recorded. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
-																			`internal_metrics`) are ignored when this is selected.
-
-																			Only valid in `per_metric_limits` and `per_tag_limits` entries; using it as the global
-																			`mode` is a configuration error.
+																			Skip cardinality tracking for this metric. All tag values pass through and nothing is
+																			limited. Other tracking fields on the entry (`value_limit`, `limit_exceeded_action`,
+																			`internal_metrics`) are ignored when this is selected. Any `per_tag_limits` entries
+																			on this metric are also ignored.
 																			"""
 						probabilistic: "Tracks cardinality probabilistically. See `Mode::Probabilistic` for details."
 					}
@@ -145,11 +143,12 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 				}
 				per_tag_limits: {
 					description: """
-						Per-tag-key overrides scoped to this metric.
+						Per-tag-key overrides scoped to this metric. Each entry sets a `mode`:
+						- `mode: limit_override` + `value_limit: N` — track with a per-tag cap.
+						- `mode: excluded` — opt this tag out of tracking entirely.
 
-						Each entry may override `value_limit` and `mode` for a specific tag key.
-						`limit_exceeded_action` and `internal_metrics` are always inherited from the enclosing
-						per-metric (or global) configuration and cannot be set per-tag.
+						All other settings (tracking algorithm, `limit_exceeded_action`, etc.)
+						are inherited from the enclosing per-metric configuration.
 						Tags not listed here use the per-metric configuration.
 						"""
 					required: false
@@ -157,22 +156,24 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 						description: "An individual tag configuration."
 						required:    true
 						type: object: options: {
-							excluded: {
-								description: """
-																								When `true`, opts this tag out of cardinality tracking entirely. All values
-																								for this tag pass through without being recorded or checked against
-																								`value_limit`. Defaults to `false`.
-																								"""
-								required: false
-								type: bool: default: false
+							mode: {
+								description: "Controls how this tag key is handled."
+								required:    true
+								type: string: enum: {
+									excluded: """
+																											Opt this tag out of cardinality tracking entirely. All values pass through
+																											without being recorded or checked against any `value_limit`.
+																											"""
+									limit_override: """
+																											Track this tag with a per-tag value limit. The enclosing per-metric tracking
+																											algorithm and all other settings still apply.
+																											"""
+								}
 							}
 							value_limit: {
-								description: """
-																								How many distinct values to accept for this tag key. If unset, inherits
-																								the `value_limit` from the enclosing per-metric (or global) configuration.
-																								Ignored when `excluded: true`.
-																								"""
-								required: false
+								description:   "Maximum number of distinct values to accept for this tag key."
+								relevant_when: "mode = \"limit_override\""
+								required:      true
 								type: uint: {}
 							}
 						}

--- a/website/cue/reference/components/transforms/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/tag_cardinality_limit.cue
@@ -22,9 +22,7 @@ components: transforms: tag_cardinality_limit: {
 		stateful:      true
 	}
 
-	features: {
-		filter: {}
-	}
+	features: filter: {}
 
 	support: {
 		requirements: []
@@ -51,11 +49,7 @@ components: transforms: tag_cardinality_limit: {
 		traces: false
 	}
 
-	output: {
-		metrics: "": {
-			description: "The modified input `metric` event."
-		}
-	}
+	output: metrics: "": description: "The modified input `metric` event."
 
 	examples: [
 		{
@@ -74,41 +68,27 @@ components: transforms: tag_cardinality_limit: {
 				{metric: {
 					kind: "incremental"
 					name: "logins"
-					counter: {
-						value: 2.0
-					}
-					tags: {
-						user_id: "user_id_1"
-					}
+					counter: value: 2.0
+					tags: user_id:  "user_id_1"
 				}},
 				{metric: {
 					kind: "incremental"
 					name: "logins"
-					counter: {
-						value: 2.0
-					}
-					tags: {
-						user_id: "user_id_2"
-					}
+					counter: value: 2.0
+					tags: user_id:  "user_id_2"
 				}},
 			]
 			output: [
 				{metric: {
 					kind: "incremental"
 					name: "logins"
-					counter: {
-						value: 2.0
-					}
-					tags: {
-						user_id: "user_id_1"
-					}
+					counter: value: 2.0
+					tags: user_id:  "user_id_1"
 				}},
 				{metric: {
 					kind: "incremental"
 					name: "logins"
-					counter: {
-						value: 2.0
-					}
+					counter: value: 2.0
 					tags: {}
 				}},
 			]


### PR DESCRIPTION
## Summary

Adds additional fine-grained controls for the tag cardinality processor, allowing users to

(1) Add per tag limits within each metric
(2) Add the ability to exclude a specific metric or tag from tracking (if the metric is excluded the tag will be too regardless of any per tag config)

Each tag has it's own config in which either a custom limit for the tag can be configured, or the tag can be excluded from any limits

Also makes `TagCardinalityLimit::new` public for some future re-use

## Vector configuration

```
sources:
  otel:
    type: opentelemetry
    grpc:
      address: "0.0.0.0:4317"
    http:
      address: "0.0.0.0:4318"

transforms:
  cardinality:
    type: tag_cardinality_limit
    inputs: ["otel.metrics"]
    value_limit: 8
    mode: exact
    limit_exceeded_action: drop_event
    tracking_scope: per_metric

    per_metric_limits:
      # metric exclusion — all tags pass through, nothing tracked
      system.process.count:
        mode: excluded

      # metric override with drop_event and per-tag rules
      demo_value_gauge:
        value_limit: 10
        mode: exact
        limit_exceeded_action: drop_event
        per_tag_limits:
          # tag exclusion — trace_id is high-cardinality, skip tracking entirely
          trace_id:
            mode: excluded
          # tag override — tighter cap for this tag
          environment:
            mode: limit_override
            value_limit: 3

      # same tags as demo_value_gauge but drop_tag action for comparison
      demo_value_counter:
        value_limit: 10
        mode: exact
        limit_exceeded_action: drop_tag
        per_tag_limits:
          trace_id:
            mode: excluded
          environment:
            mode: limit_override
            value_limit: 3

sinks:
  console:
    type: console
    inputs: ["cardinality"]
    encoding:
      codec: json
```

## How did you test this PR?
Regression test run: https://github.com/vectordotdev/vector/actions/runs/25386735971

Unit tests + used the test config above. Simulated an Otel collector source with the following Python script:

```
import random
import string
from uuid import uuid4

from opentelemetry import metrics
from opentelemetry.metrics import Observation
from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
from opentelemetry.sdk.metrics import MeterProvider
from opentelemetry.sdk.metrics.export import InMemoryMetricReader, MetricExportResult
from opentelemetry.sdk.metrics.view import View, DropAggregation
from opentelemetry.sdk.resources import Resource


VECTOR_METRICS_ENDPOINT = "http://localhost:4318/v1/metrics"


def rand_token(prefix: str, n: int = 8) -> str:
    return f"{prefix}-{''.join(random.choices(string.ascii_lowercase + string.digits, k=n))}"


def random_trace_id() -> str:
    return uuid4().hex + uuid4().hex


def random_environment() -> str:
    return rand_token(random.choice(["dev", "staging", "prod", "local", "qa"]))


def build_common_tags() -> dict[str, str]:
    return {
        "trace_id": random_trace_id(),
        "environment": random_environment(),
    }


def build_system_process_tags() -> dict[str, str]:
    tags = build_common_tags()
    tags.update(
        {
            "host_id": rand_token("host"),
            "process_group": rand_token("pg"),
            "shard": rand_token("shard"),
            "worker": rand_token("worker"),
        }
    )
    return tags


def main() -> None:
    resource = Resource.create(
        {
            "service.name": "vector-http-metrics-demo",
            "service.version": "1.0.0",
        }
    )

    reader = InMemoryMetricReader()

    provider = MeterProvider(
        resource=resource,
        metric_readers=[reader],
        views=[
            View(instrument_name="*", aggregation=DropAggregation()),
            View(instrument_name="demo_value_gauge"),
            View(instrument_name="system.process.count"),
            View(instrument_name="demo_value_counter"),
            View(instrument_name="demo_value_secondary_gauge"),
            View(instrument_name="demo_value_secondary_counter"),
        ],
    )
    metrics.set_meter_provider(provider)

    exporter = OTLPMetricExporter(
        endpoint=VECTOR_METRICS_ENDPOINT,
        timeout=3000,
    )

    meter = metrics.get_meter("demo-meter")

    state = {
        "demo_value_gauge": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
        "system.process.count": {
            "value": 0.0,
            "tags": build_system_process_tags(),
        },
        "demo_value_counter": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
        "demo_value_secondary_gauge": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
        "demo_value_secondary_counter": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
    }

    def demo_value_gauge_callback(_options):
        s = state["demo_value_gauge"]
        return [Observation(s["value"], s["tags"])]

    def system_process_count_callback(_options):
        s = state["system.process.count"]
        return [Observation(s["value"], s["tags"])]

    def demo_value_counter_callback(_options):
        s = state["demo_value_counter"]
        return [Observation(s["value"], s["tags"])]

    def demo_value_secondary_gauge_callback(_options):
        s = state["demo_value_secondary_gauge"]
        return [Observation(s["value"], s["tags"])]

    def demo_value_secondary_counter_callback(_options):
        s = state["demo_value_secondary_counter"]
        return [Observation(s["value"], s["tags"])]

    meter.create_observable_gauge(
        name="demo_value_gauge",
        callbacks=[demo_value_gauge_callback],
        description="Gauge metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_gauge(
        name="system.process.count",
        callbacks=[system_process_count_callback],
        description="Process count metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_counter(
        name="demo_value_counter",
        callbacks=[demo_value_counter_callback],
        description="Counter metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_gauge(
        name="demo_value_secondary_gauge",
        callbacks=[demo_value_secondary_gauge_callback],
        description="Second demo gauge metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_counter(
        name="demo_value_secondary_counter",
        callbacks=[demo_value_secondary_counter_callback],
        description="Second demo counter metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    print(f"Configured OTLP/HTTP metrics endpoint: {VECTOR_METRICS_ENDPOINT}")
    print("Press Enter to send all five metrics with random values and random tags.")
    print("Type q and press Enter to quit.")

    try:
        while True:
            user_input = input("> ").strip().lower()
            if user_input in {"q", "quit", "exit"}:
                break

            state["demo_value_gauge"]["value"] = round(random.uniform(0, 100), 2)
            state["system.process.count"]["value"] = float(random.randint(1, 500))
            state["demo_value_counter"]["value"] += float(random.randint(1, 20))
            state["demo_value_secondary_gauge"]["value"] = round(random.uniform(-50, 50), 2)
            state["demo_value_secondary_counter"]["value"] += float(random.randint(1, 10))

            state["demo_value_gauge"]["tags"] = build_common_tags()
            state["system.process.count"]["tags"] = build_system_process_tags()
            state["demo_value_counter"]["tags"] = build_common_tags()
            state["demo_value_secondary_gauge"]["tags"] = build_common_tags()
            state["demo_value_secondary_counter"]["tags"] = build_common_tags()

            metrics_data = reader.get_metrics_data()
            if metrics_data is None:
                print("send failed: no metrics data collected")
                continue

            result = exporter.export(metrics_data)

            if result is MetricExportResult.SUCCESS:
                print("sent all metrics")
                print(
                    f"  demo_value_gauge value={state['demo_value_gauge']['value']} "
                    f"tags={state['demo_value_gauge']['tags']}"
                )
                print(
                    f"  system.process.count value={state['system.process.count']['value']} "
                    f"tags={state['system.process.count']['tags']}"
                )
                print(
                    f"  demo_value_counter value={state['demo_value_counter']['value']} "
                    f"tags={state['demo_value_counter']['tags']}"
                )
                print(
                    f"  demo_value_secondary_gauge value={state['demo_value_secondary_gauge']['value']} "
                    f"tags={state['demo_value_secondary_gauge']['tags']}"
                )
                print(
                    f"  demo_value_secondary_counter value={state['demo_value_secondary_counter']['value']} "
                    f"tags={state['demo_value_secondary_counter']['tags']}"
                )
            else:
                print("send failed for this export batch")

    finally:
        exporter.shutdown()
        provider.shutdown()


if __name__ == "__main__":
    main()
```

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
