### PR TITLE
enhancement(metrics): Add remove tag function for metrics which returns entire tag set

### DIFF
--- a/lib/vector-core/src/event/metric/tags.rs
+++ b/lib/vector-core/src/event/metric/tags.rs
@@ -528,6 +528,12 @@ impl MetricTags {
         self.0.remove(name).and_then(TagValueSet::into_single)
     }
 
+    /// Remove a tag and return its full [`TagValueSet`], preserving all values rather than reducing
+    /// to a single string like [`Self::remove`].
+    pub fn remove_set(&mut self, name: &str) -> Option<TagValueSet> {
+        self.0.remove(name)
+    }
+
     pub fn keys(&self) -> impl Iterator<Item = &str> {
         self.0.keys().map(String::as_str)
     }
@@ -639,6 +645,33 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    fn make_tags(pairs: &[(&str, &str)]) -> MetricTags {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn remove_set_returns_full_value_set() {
+        let mut tags = MetricTags::default();
+        tags.insert("k".to_string(), TagValue::Value("a".to_string()));
+        tags.insert("k".to_string(), TagValue::Value("b".to_string()));
+
+        let removed = tags.remove_set("k").expect("tag should exist");
+        assert_eq!(removed.len(), 2);
+        assert!(removed.contains(&TagValue::Value("a".to_string())));
+        assert!(removed.contains(&TagValue::Value("b".to_string())));
+        assert!(!tags.contains_key("k"));
+    }
+
+    #[test]
+    fn remove_set_missing_returns_none() {
+        let mut tags = make_tags(&[("a", "1")]);
+        assert!(tags.remove_set("missing").is_none());
+        assert!(tags.contains_key("a"));
+    }
 
     proptest! {
         #[test]


### PR DESCRIPTION
## Summary

Add a helper function to remove a tag in a metric and return the entire associated tag set (current remove function only returns a single tag)

## How did you test this PR?
Added unit tests

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
