### PR TITLE
chore(ci): retry apt fetches in deb-verify to reduce flakes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,8 +204,8 @@ jobs:
       image: ${{ matrix.container }}
     steps:
       - run: |
-          apt-get update && \
-          apt-get install -y \
+          apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
+          apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
           ca-certificates \
           curl \
           git \


### PR DESCRIPTION
## Summary

The `deb-verify` job in `publish.yml` runs `apt-get update && apt-get install` inside fresh Ubuntu/Debian containers. Stock apt has no retry policy, so a single dropped connection to `archive.ubuntu.com` or `security.ubuntu.com` fails the whole job. 

Example: https://github.com/vectordotdev/vector/actions/runs/25360327643/job/74363331098.

## Vector configuration

N/A (CI-only change).

## How did you test this PR?

Confirmed the diff is limited to the `deb-verify` step. The retry options are standard apt configuration; verified by running `apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update` locally in an `ubuntu:20.04` container.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A