### PR TITLE
enhancement(tag_cardinality_limit transform): Add setting for per-metric vs global tag cardinality tracking

### DIFF
--- a/changelog.d/tag_cardinality_limit_tracking_scope.enhancement.md
+++ b/changelog.d/tag_cardinality_limit_tracking_scope.enhancement.md
@@ -1,18 +1,6 @@
-The `tag_cardinality_limit` transform gained two new top-level settings:
+The `tag_cardinality_limit` transform gained two new settings:
 
-- **`tracking_scope`** controls how tag tracking state is partitioned across metrics:
-  - `global` (default — preserves existing behavior): all metrics share a single
-    tracking bucket, and the global `value_limit` caps the combined set of tag values
-    across them.
-  - `per_metric`: every distinct metric gets its own tracking bucket, providing tag
-    cardinality limiting for each metric in isolation at the cost of higher memory.
-
-- **`max_tracked_keys`** caps the total number of distinct (metric, tag-key) pairs
-  tracked across the entire transform. When the cap is reached, additional pairs are
-  not allocated and tag values for those pairs pass through unchecked (they are
-  *not* dropped). Operators can detect this via the new
-  `tag_cardinality_untracked_events_total` counter (incremented once per event with at
-  least one untracked tag) and the `tag_cardinality_tracked_keys` gauge (current size
-  of the cardinality cache). Defaults to unlimited, preserving existing behavior.
+- **`tracking_scope`**: isolate tag tracking per metric (`per_metric`) instead of sharing a single bucket across all metrics (`global`, the default).
+- **`max_tracked_keys`**: cap the total number of tag keys tracked to bound memory usage.
 
 authors: ArunPiduguDD

--- a/changelog.d/tag_cardinality_limit_tracking_scope.enhancement.md
+++ b/changelog.d/tag_cardinality_limit_tracking_scope.enhancement.md
@@ -1,0 +1,18 @@
+The `tag_cardinality_limit` transform gained two new top-level settings:
+
+- **`tracking_scope`** controls how tag tracking state is partitioned across metrics:
+  - `global` (default — preserves existing behavior): all metrics share a single
+    tracking bucket, and the global `value_limit` caps the combined set of tag values
+    across them.
+  - `per_metric`: every distinct metric gets its own tracking bucket, providing tag
+    cardinality limiting for each metric in isolation at the cost of higher memory.
+
+- **`max_tracked_keys`** caps the total number of distinct (metric, tag-key) pairs
+  tracked across the entire transform. When the cap is reached, additional pairs are
+  not allocated and tag values for those pairs pass through unchecked (they are
+  *not* dropped). Operators can detect this via the new
+  `tag_cardinality_untracked_events_total` counter (incremented once per event with at
+  least one untracked tag) and the `tag_cardinality_tracked_keys` gauge (current size
+  of the cardinality cache). Defaults to unlimited, preserving existing behavior.
+
+authors: ArunPiduguDD

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -76,6 +76,7 @@ pub enum CounterName {
     StaleEventsFlushedTotal,
     StartedTotal,
     StoppedTotal,
+    TagCardinalityUntrackedEventsTotal,
     TagValueLimitExceededTotal,
     ValueLimitReachedTotal,
     WebsocketBytesSentTotal,
@@ -190,6 +191,7 @@ pub enum GaugeName {
     ActiveClients,
     MemoryEnrichmentTableObjectsCount,
     MemoryEnrichmentTableByteSize,
+    TagCardinalityTrackedKeys,
 }
 
 impl GaugeName {
@@ -220,6 +222,7 @@ impl GaugeName {
             Self::ActiveClients => "active_clients",
             Self::MemoryEnrichmentTableObjectsCount => "memory_enrichment_table_objects_count",
             Self::MemoryEnrichmentTableByteSize => "memory_enrichment_table_byte_size",
+            Self::TagCardinalityTrackedKeys => "tag_cardinality_tracked_keys",
         }
     }
 }
@@ -304,6 +307,7 @@ impl CounterName {
             Self::StaleEventsFlushedTotal => "stale_events_flushed_total",
             Self::StartedTotal => "started_total",
             Self::StoppedTotal => "stopped_total",
+            Self::TagCardinalityUntrackedEventsTotal => "tag_cardinality_untracked_events_total",
             Self::TagValueLimitExceededTotal => "tag_value_limit_exceeded_total",
             Self::ValueLimitReachedTotal => "value_limit_reached_total",
             Self::WebsocketBytesSentTotal => "websocket_bytes_sent_total",

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -1,6 +1,6 @@
 use vector_lib::{
-    NamedInternalEvent, counter,
-    internal_event::{ComponentEventsDropped, CounterName, INTENTIONAL, InternalEvent},
+    NamedInternalEvent, counter, gauge,
+    internal_event::{ComponentEventsDropped, CounterName, GaugeName, INTENTIONAL, InternalEvent},
 };
 
 #[derive(NamedInternalEvent)]
@@ -78,5 +78,28 @@ impl InternalEvent for TagCardinalityValueLimitReached<'_> {
             key = %self.key,
         );
         counter!(CounterName::ValueLimitReachedTotal).increment(1);
+    }
+}
+
+#[derive(NamedInternalEvent)]
+pub struct TagCardinalityLimitUntracked;
+
+impl InternalEvent for TagCardinalityLimitUntracked {
+    fn emit(self) {
+        debug!(
+            message = "max_tracked_keys reached; one or more tags on this event are passing through untracked."
+        );
+        counter!(CounterName::TagCardinalityUntrackedEventsTotal).increment(1);
+    }
+}
+
+#[derive(NamedInternalEvent)]
+pub struct TagCardinalityTrackedKeys {
+    pub count: usize,
+}
+
+impl InternalEvent for TagCardinalityTrackedKeys {
+    fn emit(self) {
+        gauge!(GaugeName::TagCardinalityTrackedKeys).set(self.count as f64);
     }
 }

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -87,7 +87,7 @@ pub struct TagCardinalityLimitUntracked;
 impl InternalEvent for TagCardinalityLimitUntracked {
     fn emit(self) {
         debug!(
-            message = "Max tracked keys reached; one or more tags on this event are passing through untracked."
+            message = "Max tracked keys limit reached; forwarding one or more metric tags without cardinality checks."
         );
         counter!(CounterName::TagCardinalityUntrackedEventsTotal).increment(1);
     }

--- a/src/internal_events/tag_cardinality_limit.rs
+++ b/src/internal_events/tag_cardinality_limit.rs
@@ -87,7 +87,7 @@ pub struct TagCardinalityLimitUntracked;
 impl InternalEvent for TagCardinalityLimitUntracked {
     fn emit(self) {
         debug!(
-            message = "max_tracked_keys reached; one or more tags on this event are passing through untracked."
+            message = "Max tracked keys reached; one or more tags on this event are passing through untracked."
         );
         counter!(CounterName::TagCardinalityUntrackedEventsTotal).increment(1);
     }

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -43,12 +43,13 @@ pub struct Config {
     /// Maximum number of distinct (metric, tag-key) pairs to track across the entire
     /// transform. When this cap is reached, additional tag keys on new metrics or new
     /// tag keys on existing metrics are not tracked, and tag values for those pairs
-    /// pass through unchecked. Operators can detect this via the
+    /// pass through unchecked. Users can detect this via the
     /// `tag_cardinality_untracked_events_total` counter and the
     /// `tag_cardinality_tracked_keys` gauge.
     ///
     /// When unset (default), there is no cap and the transform tracks all pairs it
-    /// encounters.
+    /// encounters. In `global` tracking scope mode, this limit still applies (the
+    /// metric key is set to `None` unless there is a per-metric override).
     #[configurable(derived)]
     #[serde(default)]
     pub max_tracked_keys: Option<usize>,
@@ -68,8 +69,8 @@ pub struct Config {
 #[serde(rename_all = "snake_case")]
 pub enum TrackingScope {
     /// All metrics share a single tracking bucket. Tag values pool across metrics,
-    /// and the global `value_limit` caps the combined set. Lower memory but
-    /// cross-metric pollution.
+    /// and the global `value_limit` caps the combined set. Lower memory requirements
+    /// but cardinality per metric is not tracked unless a per-metric override is configured.
     #[default]
     Global,
 

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -35,6 +35,24 @@ pub struct Config {
     #[serde(flatten)]
     pub global: Inner,
 
+    /// Controls how tag tracking state is partitioned across metrics.
+    #[configurable(derived)]
+    #[serde(default)]
+    pub tracking_scope: TrackingScope,
+
+    /// Maximum number of distinct (metric, tag-key) pairs to track across the entire
+    /// transform. When this cap is reached, additional tag keys on new metrics or new
+    /// tag keys on existing metrics are not tracked, and tag values for those pairs
+    /// pass through unchecked. Operators can detect this via the
+    /// `tag_cardinality_untracked_events_total` counter and the
+    /// `tag_cardinality_tracked_keys` gauge.
+    ///
+    /// When unset (default), there is no cap and the transform tracks all pairs it
+    /// encounters.
+    #[configurable(derived)]
+    #[serde(default)]
+    pub max_tracked_keys: Option<usize>,
+
     /// Tag cardinality limits configuration per metric name.
     #[configurable(
         derived,
@@ -42,6 +60,23 @@ pub struct Config {
     )]
     #[serde(default)]
     pub per_metric_limits: HashMap<String, PerMetricConfig>,
+}
+
+/// Controls how tag tracking state is partitioned across metrics.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackingScope {
+    /// All metrics share a single tracking bucket. Tag values pool across metrics,
+    /// and the global `value_limit` caps the combined set. Lower memory but
+    /// cross-metric pollution.
+    #[default]
+    Global,
+
+    /// Every distinct metric gets its own tracking bucket, providing tag
+    /// cardinality limiting for each metric in isolation at the cost of higher
+    /// memory.
+    PerMetric,
 }
 
 /// Configuration for the `tag_cardinality_limit` transform for a specific group of metrics.
@@ -150,6 +185,8 @@ impl GenerateConfig for Config {
                 limit_exceeded_action: default_limit_exceeded_action(),
                 internal_metrics: InternalMetricsConfig::default(),
             },
+            tracking_scope: TrackingScope::default(),
+            max_tracked_keys: None,
             per_metric_limits: HashMap::default(),
         })
         .unwrap()

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -68,15 +68,14 @@ pub struct Config {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TrackingScope {
-    /// All metrics share a single tracking bucket. Tag values pool across metrics,
-    /// and the global `value_limit` caps the combined set. Lower memory requirements
-    /// but cardinality per metric is not tracked unless a per-metric override is configured.
+    /// All metrics share a single tracking bucket. Tag values pool across metrics
+    /// and the global `value_limit` caps the combined set.
     #[default]
     Global,
 
     /// Every distinct metric gets its own tracking bucket, providing tag
     /// cardinality limiting for each metric in isolation at the cost of higher
-    /// memory.
+    /// memory usage.
     PerMetric,
 }
 

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -6,7 +6,7 @@ use vector_lib::{event::Event, transform::TaskTransform};
 
 use crate::internal_events::{
     TagCardinalityLimitRejectingEvent, TagCardinalityLimitRejectingTag,
-    TagCardinalityValueLimitReached,
+    TagCardinalityLimitUntracked, TagCardinalityTrackedKeys, TagCardinalityValueLimitReached,
 };
 
 pub mod config;
@@ -15,17 +15,34 @@ mod tag_value_set;
 #[cfg(test)]
 mod tests;
 
-pub use config::{BloomFilterConfig, Config, Inner, LimitExceededAction, Mode, PerMetricConfig};
+pub use config::{
+    BloomFilterConfig, Config, Inner, LimitExceededAction, Mode, PerMetricConfig, TrackingScope,
+};
 use tag_value_set::AcceptedTagValueSet;
 
 use crate::event::metric::TagValueSet;
 
 type MetricId = (Option<String>, String);
 
+/// Outcome of attempting to accept a tag value.
+#[derive(Debug, Eq, PartialEq)]
+enum AcceptResult {
+    /// Tag value is tracked and accepted (under the configured `value_limit`).
+    Accepted,
+    /// Tag value is tracked but exceeds `value_limit`; caller should drop the tag.
+    Rejected,
+    /// `max_tracked_keys` was reached and the (metric, tag-key) pair could not be
+    /// allocated; caller should pass the tag through unchecked.
+    Untracked,
+}
+
 #[derive(Debug)]
 pub struct TagCardinalityLimit {
     config: Config,
     accepted_tags: HashMap<Option<MetricId>, HashMap<String, AcceptedTagValueSet>>,
+    /// Total count of currently-tracked (metric_bucket, tag_key) pairs.
+    /// Used to enforce `config.max_tracked_keys`.
+    tracked_keys_count: usize,
 }
 
 impl TagCardinalityLimit {
@@ -33,7 +50,26 @@ impl TagCardinalityLimit {
         Self {
             config,
             accepted_tags: HashMap::new(),
+            tracked_keys_count: 0,
         }
+    }
+
+    /// Returns true if a new tag-key bucket can be allocated without exceeding
+    /// `config.max_tracked_keys`. Always returns true when `max_tracked_keys` is unset.
+    const fn can_allocate_new_key(&self) -> bool {
+        match self.config.max_tracked_keys {
+            Some(max) => self.tracked_keys_count < max,
+            None => true,
+        }
+    }
+
+    /// Bumps the tracked-keys counter and emits the gauge sample. Call after a
+    /// successful new-key allocation in `accepted_tags`.
+    fn record_new_key_allocation(&mut self) {
+        self.tracked_keys_count += 1;
+        emit!(TagCardinalityTrackedKeys {
+            count: self.tracked_keys_count,
+        });
     }
 
     fn get_config_for_metric(&self, metric_key: Option<&MetricId>) -> &Inner {
@@ -51,29 +87,46 @@ impl TagCardinalityLimit {
         }
     }
 
-    /// Takes in key and a value corresponding to a tag on an incoming Metric
-    /// Event.  If that value is already part of set of accepted values for that
-    /// key, then simply returns true.  If that value is not yet part of the
-    /// accepted values for that key, checks whether we have hit the value_limit
-    /// for that key yet and if not adds the value to the set of accepted values
-    /// for the key and returns true, otherwise returns false.  A false return
-    /// value indicates to the caller that the value is not accepted for this
-    /// key, and the configured limit_exceeded_action should be taken.
+    /// Attempts to accept a tag value for a (metric, tag-key) pair.
+    ///
+    /// Returns:
+    /// - `Accepted` if the value is already tracked, or fits under the configured
+    ///   `value_limit` and is now recorded.
+    /// - `Rejected` if the value would exceed `value_limit`; the caller should drop
+    ///   the tag.
+    /// - `Untracked` if a new (metric, tag-key) pair would have to be allocated but
+    ///   `max_tracked_keys` has been reached; the caller should pass the tag through
+    ///   unchecked and emit the warning metric.
     fn try_accept_tag(
         &mut self,
         metric_key: Option<&MetricId>,
         key: &str,
         value: &TagValueSet,
-    ) -> bool {
+    ) -> AcceptResult {
         let config = *self.get_config_for_metric(metric_key);
-        let metric_accepted_tags = self.accepted_tags.entry(metric_key.cloned()).or_default();
+        let metric_key_owned = metric_key.cloned();
+
+        // Determine whether this (metric, tag-key) pair already has a bucket.
+        let pair_exists = self
+            .accepted_tags
+            .get(&metric_key_owned)
+            .is_some_and(|m| m.contains_key(key));
+
+        if !pair_exists {
+            if !self.can_allocate_new_key() {
+                return AcceptResult::Untracked;
+            }
+            self.record_new_key_allocation();
+        }
+
+        let metric_accepted_tags = self.accepted_tags.entry(metric_key_owned).or_default();
         let tag_value_set = metric_accepted_tags
             .entry_ref(key)
             .or_insert_with(|| AcceptedTagValueSet::new(config.value_limit, &config.mode));
 
         if tag_value_set.contains(value) {
             // Tag value has already been accepted, nothing more to do.
-            return true;
+            return AcceptResult::Accepted;
         }
 
         // Tag value not yet part of the accepted set.
@@ -85,10 +138,10 @@ impl TagCardinalityLimit {
                 emit!(TagCardinalityValueLimitReached { key });
             }
 
-            true
+            AcceptResult::Accepted
         } else {
             // New tag value is rejected.
-            false
+            AcceptResult::Rejected
         }
     }
 
@@ -112,29 +165,64 @@ impl TagCardinalityLimit {
     }
 
     /// Record a key and value corresponding to a tag on an incoming Metric.
-    fn record_tag_value(&mut self, metric_key: Option<&MetricId>, key: &str, value: &TagValueSet) {
+    ///
+    /// Returns `true` if the (metric, tag-key) pair could not be allocated due to
+    /// `max_tracked_keys` (and therefore the value is not recorded), `false` otherwise.
+    fn record_tag_value(
+        &mut self,
+        metric_key: Option<&MetricId>,
+        key: &str,
+        value: &TagValueSet,
+    ) -> bool {
         let config = *self.get_config_for_metric(metric_key);
-        let metric_accepted_tags = self.accepted_tags.entry(metric_key.cloned()).or_default();
+        let metric_key_owned = metric_key.cloned();
+
+        let pair_exists = self
+            .accepted_tags
+            .get(&metric_key_owned)
+            .is_some_and(|m| m.contains_key(key));
+
+        if !pair_exists {
+            if !self.can_allocate_new_key() {
+                return true;
+            }
+            self.record_new_key_allocation();
+        }
+
+        let metric_accepted_tags = self.accepted_tags.entry(metric_key_owned).or_default();
         metric_accepted_tags
             .entry_ref(key)
             .or_insert_with(|| AcceptedTagValueSet::new(config.value_limit, &config.mode))
             .insert(value.clone());
+        false
     }
 
     pub fn transform_one(&mut self, mut event: Event) -> Option<Event> {
         let metric = event.as_mut_metric();
         let metric_name = metric.name().to_string();
         let metric_namespace = metric.namespace().map(|n| n.to_string());
-        let has_per_metric_config = self.config.per_metric_limits.iter().any(|(name, config)| {
-            *name == metric_name
-                && (config.namespace.is_none() || config.namespace == metric_namespace)
-        });
-        let metric_key = if has_per_metric_config {
-            Some((metric_namespace, metric_name.clone()))
-        } else {
-            None
+        let metric_key = match self.config.tracking_scope {
+            TrackingScope::PerMetric => Some((metric_namespace, metric_name.clone())),
+            TrackingScope::Global => {
+                let has_per_metric_config =
+                    self.config.per_metric_limits.iter().any(|(name, config)| {
+                        *name == metric_name
+                            && (config.namespace.is_none() || config.namespace == metric_namespace)
+                    });
+                if has_per_metric_config {
+                    Some((metric_namespace, metric_name.clone()))
+                } else {
+                    None
+                }
+            }
         };
         if let Some(tags_map) = metric.tags_mut() {
+            let include_extended_tags = self
+                .get_config_for_metric(metric_key.as_ref())
+                .internal_metrics
+                .include_extended_tags;
+            let mut any_untracked = false;
+
             match self
                 .get_config_for_metric(metric_key.as_ref())
                 .limit_exceeded_action
@@ -145,39 +233,45 @@ impl TagCardinalityLimit {
 
                     for (key, value) in tags_map.iter_sets() {
                         if self.tag_limit_exceeded(metric_key.as_ref(), key, value) {
-                            let config = self.get_config_for_metric(metric_key.as_ref());
                             emit!(TagCardinalityLimitRejectingEvent {
-                                metric_name: &metric_name,
-                                tag_key: key,
-                                tag_value: &value.to_string(),
-                                include_extended_tags: config
-                                    .internal_metrics
-                                    .include_extended_tags,
-                            });
-                            return None;
-                        }
-                    }
-                    for (key, value) in tags_map.iter_sets() {
-                        self.record_tag_value(metric_key.as_ref(), key, value);
-                    }
-                }
-                LimitExceededAction::DropTag => {
-                    let config = self.get_config_for_metric(metric_key.as_ref());
-                    let include_extended_tags = config.internal_metrics.include_extended_tags;
-                    tags_map.retain(|key, value| {
-                        if self.try_accept_tag(metric_key.as_ref(), key, value) {
-                            true
-                        } else {
-                            emit!(TagCardinalityLimitRejectingTag {
                                 metric_name: &metric_name,
                                 tag_key: key,
                                 tag_value: &value.to_string(),
                                 include_extended_tags,
                             });
-                            false
+                            return None;
+                        }
+                    }
+                    for (key, value) in tags_map.iter_sets() {
+                        if self.record_tag_value(metric_key.as_ref(), key, value) {
+                            any_untracked = true;
+                        }
+                    }
+                }
+                LimitExceededAction::DropTag => {
+                    tags_map.retain(|key, value| {
+                        match self.try_accept_tag(metric_key.as_ref(), key, value) {
+                            AcceptResult::Accepted => true,
+                            AcceptResult::Rejected => {
+                                emit!(TagCardinalityLimitRejectingTag {
+                                    metric_name: &metric_name,
+                                    tag_key: key,
+                                    tag_value: &value.to_string(),
+                                    include_extended_tags,
+                                });
+                                false
+                            }
+                            AcceptResult::Untracked => {
+                                any_untracked = true;
+                                true // pass through unchecked
+                            }
                         }
                     });
                 }
+            }
+
+            if any_untracked {
+                emit!(TagCardinalityLimitUntracked);
             }
         }
         Some(event)

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -24,15 +24,14 @@ use crate::event::metric::TagValueSet;
 
 type MetricId = (Option<String>, String);
 
-/// Outcome of attempting to accept a tag value.
+/// Outcome of applying tag cardinality tracking to a tag value.
 #[derive(Debug, Eq, PartialEq)]
 enum AcceptResult {
-    /// Tag value is tracked and accepted (under the configured `value_limit`).
-    Accepted,
-    /// Tag value is tracked but exceeds `value_limit`; caller should drop the tag.
-    Rejected,
-    /// `max_tracked_keys` was reached and the (metric, tag-key) pair could not be
-    /// allocated; caller should pass the tag through unchecked.
+    /// The tag value was tracked and is within the configured `value_limit`.
+    Tracked,
+    /// The tag value was tracked and exceeded the configured `value_limit`.
+    Dropped,
+    /// The tag value was not tracked because tracking capacity is exhausted.
     Untracked,
 }
 
@@ -90,9 +89,9 @@ impl TagCardinalityLimit {
     /// Attempts to accept a tag value for a (metric, tag-key) pair.
     ///
     /// Returns:
-    /// - `Accepted` if the value is already tracked, or fits under the configured
+    /// - `Tracked` if the value is already tracked, or fits under the configured
     ///   `value_limit` and is now recorded.
-    /// - `Rejected` if the value would exceed `value_limit`; the caller should drop
+    /// - `Dropped` if the value would exceed `value_limit`; the caller should drop
     ///   the tag.
     /// - `Untracked` if a new (metric, tag-key) pair would have to be allocated but
     ///   `max_tracked_keys` has been reached; the caller should pass the tag through
@@ -126,7 +125,7 @@ impl TagCardinalityLimit {
 
         if tag_value_set.contains(value) {
             // Tag value has already been accepted, nothing more to do.
-            return AcceptResult::Accepted;
+            return AcceptResult::Tracked;
         }
 
         // Tag value not yet part of the accepted set.
@@ -138,10 +137,10 @@ impl TagCardinalityLimit {
                 emit!(TagCardinalityValueLimitReached { key });
             }
 
-            AcceptResult::Accepted
+            AcceptResult::Tracked
         } else {
-            // New tag value is rejected.
-            AcceptResult::Rejected
+            // New tag value exceeds the configured limit.
+            AcceptResult::Dropped
         }
     }
 
@@ -251,8 +250,8 @@ impl TagCardinalityLimit {
                 LimitExceededAction::DropTag => {
                     tags_map.retain(|key, value| {
                         match self.try_accept_tag(metric_key.as_ref(), key, value) {
-                            AcceptResult::Accepted => true,
-                            AcceptResult::Rejected => {
+                            AcceptResult::Tracked => true,
+                            AcceptResult::Dropped => {
                                 emit!(TagCardinalityLimitRejectingTag {
                                     metric_name: &metric_name,
                                     tag_key: key,

--- a/src/transforms/tag_cardinality_limit/tests.rs
+++ b/src/transforms/tag_cardinality_limit/tests.rs
@@ -57,6 +57,8 @@ fn make_transform_hashset(
             mode: Mode::Exact,
             internal_metrics: InternalMetricsConfig::default(),
         },
+        tracking_scope: TrackingScope::default(),
+        max_tracked_keys: None,
         per_metric_limits: HashMap::new(),
     }
 }
@@ -71,6 +73,8 @@ fn make_transform_bloom(value_limit: usize, limit_exceeded_action: LimitExceeded
             }),
             internal_metrics: InternalMetricsConfig::default(),
         },
+        tracking_scope: TrackingScope::default(),
+        max_tracked_keys: None,
         per_metric_limits: HashMap::new(),
     }
 }
@@ -87,6 +91,8 @@ fn make_transform_hashset_with_per_metric_limits(
             mode: Mode::Exact,
             internal_metrics: InternalMetricsConfig::default(),
         },
+        tracking_scope: TrackingScope::default(),
+        max_tracked_keys: None,
         per_metric_limits,
     }
 }
@@ -105,6 +111,8 @@ fn make_transform_bloom_with_per_metric_limits(
             }),
             internal_metrics: InternalMetricsConfig::default(),
         },
+        tracking_scope: TrackingScope::default(),
+        max_tracked_keys: None,
         per_metric_limits,
     }
 }
@@ -594,4 +602,139 @@ async fn separate_value_limit_per_metric_name(config: Config) {
         );
     })
     .await;
+}
+
+/// With `tracking_scope: per_metric`, two metrics without explicit `per_metric_limits` entries
+/// each get their own tracking bucket, so one hitting the limit does not affect the other.
+#[test]
+fn tracking_scope_per_metric_isolates_metrics() {
+    let mut config = make_transform_hashset(2, LimitExceededAction::DropEvent);
+    config.tracking_scope = TrackingScope::PerMetric;
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // Fill metric_a's bucket to its limit (2 distinct values).
+    let a1 = make_metric_with_name(metric_tags!("tag" => "v1"), "metric_a");
+    let a2 = make_metric_with_name(metric_tags!("tag" => "v2"), "metric_a");
+    // metric_b should be tracked in its own bucket — not affected by metric_a.
+    let b1 = make_metric_with_name(metric_tags!("tag" => "v3"), "metric_b");
+    let b2 = make_metric_with_name(metric_tags!("tag" => "v4"), "metric_b");
+    // A 3rd unique value on metric_a should be rejected (its bucket is full).
+    let a3 = make_metric_with_name(metric_tags!("tag" => "v5"), "metric_a");
+
+    assert_eq!(transform.transform_one(a1.clone()), Some(a1));
+    assert_eq!(transform.transform_one(a2.clone()), Some(a2));
+    assert_eq!(transform.transform_one(b1.clone()), Some(b1));
+    assert_eq!(transform.transform_one(b2.clone()), Some(b2));
+    assert_eq!(transform.transform_one(a3), None);
+}
+
+/// With the default `tracking_scope: global`, metrics without explicit `per_metric_limits`
+/// entries share a single tracking bucket — so values from different metrics pool together.
+#[test]
+fn tracking_scope_global_pools_metrics() {
+    // Default `tracking_scope` is `Global`.
+    let config = make_transform_hashset(2, LimitExceededAction::DropEvent);
+    let mut transform = TagCardinalityLimit::new(config);
+
+    let a1 = make_metric_with_name(metric_tags!("tag" => "v1"), "metric_a");
+    // Different metric, but values pool into the shared bucket → 2/2 used.
+    let b1 = make_metric_with_name(metric_tags!("tag" => "v2"), "metric_b");
+    // 3rd unique value across the shared bucket → rejected.
+    let a2 = make_metric_with_name(metric_tags!("tag" => "v3"), "metric_a");
+
+    assert_eq!(transform.transform_one(a1.clone()), Some(a1));
+    assert_eq!(transform.transform_one(b1.clone()), Some(b1));
+    assert_eq!(transform.transform_one(a2), None);
+}
+
+/// With `max_tracked_keys: 2`, only 2 distinct (metric, tag-key) pairs get tracking
+/// buckets. Tag values for additional pairs pass through unchecked rather than being
+/// rejected. The tag values for tracked pairs are still subject to `value_limit`.
+#[test]
+fn max_tracked_keys_caps_pair_allocation() {
+    let mut config = make_transform_hashset(1, LimitExceededAction::DropTag);
+    config.max_tracked_keys = Some(2);
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // First 2 distinct (metric, tag-key) pairs allocate buckets.
+    // (None, "tag1") — bucket 1
+    let e1 = transform
+        .transform_one(make_metric(metric_tags!("tag1" => "v1")))
+        .unwrap();
+    assert_eq!("v1", e1.as_metric().tags().unwrap().get("tag1").unwrap());
+
+    // (None, "tag2") — bucket 2
+    let e2 = transform
+        .transform_one(make_metric(metric_tags!("tag2" => "v1")))
+        .unwrap();
+    assert_eq!("v1", e2.as_metric().tags().unwrap().get("tag2").unwrap());
+
+    // tag1 value_limit hit at 1 → second value rejected (drop_tag).
+    let e3 = transform
+        .transform_one(make_metric(metric_tags!("tag1" => "v2")))
+        .unwrap();
+    assert!(!e3.as_metric().tags().unwrap().contains_key("tag1"));
+
+    // (None, "tag3") would need a 3rd bucket — cap is 2, so it passes through
+    // unchecked. The tag is retained even though we can't enforce a value_limit on it.
+    let e4 = transform
+        .transform_one(make_metric(metric_tags!("tag3" => "v1")))
+        .unwrap();
+    assert_eq!("v1", e4.as_metric().tags().unwrap().get("tag3").unwrap());
+    let e5 = transform
+        .transform_one(make_metric(metric_tags!("tag3" => "v2")))
+        .unwrap();
+    assert_eq!("v2", e5.as_metric().tags().unwrap().get("tag3").unwrap());
+}
+
+/// With `max_tracked_keys` unset (default), cardinality limiting works normally and
+/// new pairs are always tracked.
+#[test]
+fn max_tracked_keys_unlimited_by_default() {
+    let config = make_transform_hashset(1, LimitExceededAction::DropTag);
+    assert!(config.max_tracked_keys.is_none());
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // Many distinct tag keys all get tracked; each enforces value_limit=1.
+    for i in 0..10 {
+        let key = format!("tag{i}");
+        let _ = transform
+            .transform_one(make_metric(metric_tags!(key.clone() => "v1")))
+            .unwrap();
+        // Second value for the same tag key should be rejected.
+        let e = transform
+            .transform_one(make_metric(metric_tags!(key.clone() => "v2")))
+            .unwrap();
+        assert!(!e.as_metric().tags().unwrap().contains_key(key.as_str()));
+    }
+}
+
+/// With `tracking_scope: per_metric`, the cap is enforced across *all* per-metric
+/// buckets — not per bucket. Once the cap is hit, further metrics pass through
+/// unchecked.
+#[test]
+fn max_tracked_keys_caps_across_per_metric_buckets() {
+    let mut config = make_transform_hashset(1, LimitExceededAction::DropTag);
+    config.tracking_scope = TrackingScope::PerMetric;
+    config.max_tracked_keys = Some(2);
+    let mut transform = TagCardinalityLimit::new(config);
+
+    // metric_a, tag "k" → pair 1 of 2
+    let _ = transform
+        .transform_one(make_metric_with_name(metric_tags!("k" => "v1"), "metric_a"))
+        .unwrap();
+    // metric_b, tag "k" → pair 2 of 2 (different bucket because per_metric scope)
+    let _ = transform
+        .transform_one(make_metric_with_name(metric_tags!("k" => "v1"), "metric_b"))
+        .unwrap();
+    // metric_c, tag "k" → would be pair 3, cap is 2 → untracked passthrough.
+    let e = transform
+        .transform_one(make_metric_with_name(metric_tags!("k" => "v1"), "metric_c"))
+        .unwrap();
+    assert_eq!("v1", e.as_metric().tags().unwrap().get("k").unwrap());
+    // Multiple distinct values on metric_c also pass through (no enforcement).
+    let e = transform
+        .transform_one(make_metric_with_name(metric_tags!("k" => "v2"), "metric_c"))
+        .unwrap();
+    assert_eq!("v2", e.as_metric().tags().unwrap().get("k").unwrap());
 }

--- a/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
@@ -162,14 +162,13 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 			default: "global"
 			enum: {
 				global: """
-					All metrics share a single tracking bucket. Tag values pool across metrics,
-					and the global `value_limit` caps the combined set. Lower memory requirements
-					but cardinality per metric is not tracked unless a per-metric override is configured.
+					All metrics share a single tracking bucket. Tag values pool across metrics
+					and the global `value_limit` caps the combined set.
 					"""
 				per_metric: """
 					Every distinct metric gets its own tracking bucket, providing tag
 					cardinality limiting for each metric in isolation at the cost of higher
-					memory.
+					memory usage.
 					"""
 			}
 		}

--- a/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
@@ -40,6 +40,21 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 			}
 		}
 	}
+	max_tracked_keys: {
+		description: """
+			Maximum number of distinct (metric, tag-key) pairs to track across the entire
+			transform. When this cap is reached, additional tag keys on new metrics or new
+			tag keys on existing metrics are not tracked, and tag values for those pairs
+			pass through unchecked. Operators can detect this via the
+			`tag_cardinality_untracked_events_total` counter and the
+			`tag_cardinality_tracked_keys` gauge.
+
+			When unset (default), there is no cap and the transform tracks all pairs it
+			encounters.
+			"""
+		required: false
+		type: uint: {}
+	}
 	mode: {
 		description: "Controls the approach taken for tracking tag cardinality."
 		required:    true
@@ -136,6 +151,25 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 					required:    false
 					type: uint: default: 500
 				}
+			}
+		}
+	}
+	tracking_scope: {
+		description: "Controls how tag tracking state is partitioned across metrics."
+		required:    false
+		type: string: {
+			default: "global"
+			enum: {
+				global: """
+					All metrics share a single tracking bucket. Tag values pool across metrics,
+					and the global `value_limit` caps the combined set. Lower memory but
+					cross-metric pollution.
+					"""
+				per_metric: """
+					Every distinct metric gets its own tracking bucket, providing tag
+					cardinality limiting for each metric in isolation at the cost of higher
+					memory.
+					"""
 			}
 		}
 	}

--- a/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/generated/tag_cardinality_limit.cue
@@ -45,12 +45,13 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 			Maximum number of distinct (metric, tag-key) pairs to track across the entire
 			transform. When this cap is reached, additional tag keys on new metrics or new
 			tag keys on existing metrics are not tracked, and tag values for those pairs
-			pass through unchecked. Operators can detect this via the
+			pass through unchecked. Users can detect this via the
 			`tag_cardinality_untracked_events_total` counter and the
 			`tag_cardinality_tracked_keys` gauge.
 
 			When unset (default), there is no cap and the transform tracks all pairs it
-			encounters.
+			encounters. In `global` tracking scope mode, this limit still applies (the
+			metric key is set to `None` unless there is a per-metric override).
 			"""
 		required: false
 		type: uint: {}
@@ -162,8 +163,8 @@ generated: components: transforms: tag_cardinality_limit: configuration: {
 			enum: {
 				global: """
 					All metrics share a single tracking bucket. Tag values pool across metrics,
-					and the global `value_limit` caps the combined set. Lower memory but
-					cross-metric pollution.
+					and the global `value_limit` caps the combined set. Lower memory requirements
+					but cardinality per metric is not tracked unless a per-metric override is configured.
 					"""
 				per_metric: """
 					Every distinct metric gets its own tracking bucket, providing tag


### PR DESCRIPTION
## Summary
When metrics do not have an explicit `per_metric_limits` entry, their tag values were always pooled into a single shared bucket. This can lead to some of the following example scenarios:
- If `metric1` and `metric2` have the `host` tag, but `metric1` has a high cardinality for the `host` tag (above the limit), the `host` tag will be dropped on `metric2` (even if the tag on `metric2` only has 1-2 cardinality)
- If there are ~100 metrics with the `host tag`, and each tag has 1-2 unique values per metric, then a cardinality limit of 50 will drop this tag across all metrics.

The new `tracking_scope` setting lets users opt into per-metric tracking buckets instead, providing isolation at the cost of higher memory.

Default is `global` (current behavior); `per_metric` gives every distinct (namespace, name) its own bucket regardless of `per_metric_limits` membership.

Also adds a new `max_tracked_keys` option to cap the total number of tag keys tracked to bound memory usage as the new per-metric tracking scope has much higher memory requirements. When this limit is exceeded any new tag keys will pass through unchecked/unlimited (future additions can be made to configure the exceed-limit strategy, such as LRU replacement). Related to this added 2 new metrics:
- `tag_cardinality_untracked_events_total` => Total count of tag keys passing through this processor untracked
- `tag_cardinality_tracked_keys` => Current number of tracked keys in the processor

## Vector configuration

```
sources:
  otel:
    type: opentelemetry
    grpc:
      address: "0.0.0.0:4317"
    http:
      address: "0.0.0.0:4318"

  cardinality:
    type: tag_cardinality_limit
    inputs: ["otel.metrics"]
    value_limit: 5
    mode: exact
    limit_exceeded_action: drop_event

    # The new setting under test. Try toggling between `global` (current behavior:
    # all metrics without a `per_metric_limits` entry share one bucket) and
    # `per_metric` (every metric name gets its own bucket).
    tracking_scope: per_metric

    per_metric_limits:
      # Tighter override on this specific metric — applies regardless of `tracking_scope`.
      demo_value_gauge:
        value_limit: 2
        mode: exact
        limit_exceeded_action: drop_event

      demo_value_counter:
        value_limit: 6
        mode: exact
        limit_exceeded_action: drop_tag

sinks:
  console:
    type: console
    inputs: ["cardinality"]
    encoding:
      codec: json
```

## How did you test this PR?
Tested with above configuration. Simulated an Otel Collector with the following Python script:

```
import random
import string
from uuid import uuid4

from opentelemetry import metrics
from opentelemetry.metrics import Observation
from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
from opentelemetry.sdk.metrics import MeterProvider
from opentelemetry.sdk.metrics.export import InMemoryMetricReader, MetricExportResult
from opentelemetry.sdk.metrics.view import View, DropAggregation
from opentelemetry.sdk.resources import Resource


VECTOR_METRICS_ENDPOINT = "http://localhost:4318/v1/metrics"


def rand_token(prefix: str, n: int = 8) -> str:
    return f"{prefix}-{''.join(random.choices(string.ascii_lowercase + string.digits, k=n))}"


def random_trace_id() -> str:
    return uuid4().hex + uuid4().hex


def random_environment() -> str:
    return rand_token(random.choice(["dev", "staging", "prod", "local", "qa"]))


def build_common_tags() -> dict[str, str]:
    return {
        "trace_id": random_trace_id(),
        "environment": random_environment(),
    }


def build_system_process_tags() -> dict[str, str]:
    tags = build_common_tags()
    tags.update(
        {
            "host_id": rand_token("host"),
            "process_group": rand_token("pg"),
            "shard": rand_token("shard"),
            "worker": rand_token("worker"),
        }
    )
    return tags


def main() -> None:
    resource = Resource.create(
        {
            "service.name": "vector-http-metrics-demo",
            "service.version": "1.0.0",
        }
    )

    reader = InMemoryMetricReader()

    provider = MeterProvider(
        resource=resource,
        metric_readers=[reader],
        views=[
            View(instrument_name="*", aggregation=DropAggregation()),
            View(instrument_name="demo_value_gauge"),
            View(instrument_name="system.process.count"),
            View(instrument_name="demo_value_counter"),
            View(instrument_name="demo_value_secondary_gauge"),
            View(instrument_name="demo_value_secondary_counter"),
        ],
    )
    metrics.set_meter_provider(provider)

    exporter = OTLPMetricExporter(
        endpoint=VECTOR_METRICS_ENDPOINT,
        timeout=3000,
    )

    meter = metrics.get_meter("demo-meter")

    state = {
        "demo_value_gauge": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
        "system.process.count": {
            "value": 0.0,
            "tags": build_system_process_tags(),
        },
        "demo_value_counter": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
        "demo_value_secondary_gauge": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
        "demo_value_secondary_counter": {
            "value": 0.0,
            "tags": build_common_tags(),
        },
    }

    def demo_value_gauge_callback(_options):
        s = state["demo_value_gauge"]
        return [Observation(s["value"], s["tags"])]

    def system_process_count_callback(_options):
        s = state["system.process.count"]
        return [Observation(s["value"], s["tags"])]

    def demo_value_counter_callback(_options):
        s = state["demo_value_counter"]
        return [Observation(s["value"], s["tags"])]

    def demo_value_secondary_gauge_callback(_options):
        s = state["demo_value_secondary_gauge"]
        return [Observation(s["value"], s["tags"])]

    def demo_value_secondary_counter_callback(_options):
        s = state["demo_value_secondary_counter"]
        return [Observation(s["value"], s["tags"])]

    meter.create_observable_gauge(
        name="demo_value_gauge",
        callbacks=[demo_value_gauge_callback],
        description="Gauge metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_gauge(
        name="system.process.count",
        callbacks=[system_process_count_callback],
        description="Process count metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_counter(
        name="demo_value_counter",
        callbacks=[demo_value_counter_callback],
        description="Counter metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_gauge(
        name="demo_value_secondary_gauge",
        callbacks=[demo_value_secondary_gauge_callback],
        description="Second demo gauge metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    meter.create_observable_counter(
        name="demo_value_secondary_counter",
        callbacks=[demo_value_secondary_counter_callback],
        description="Second demo counter metric exported to Vector over OTLP/HTTP",
        unit="1",
    )

    print(f"Configured OTLP/HTTP metrics endpoint: {VECTOR_METRICS_ENDPOINT}")
    print("Press Enter to send all five metrics with random values and random tags.")
    print("Type q and press Enter to quit.")

    try:
        while True:
            user_input = input("> ").strip().lower()
            if user_input in {"q", "quit", "exit"}:
                break

            state["demo_value_gauge"]["value"] = round(random.uniform(0, 100), 2)
            state["system.process.count"]["value"] = float(random.randint(1, 500))
            state["demo_value_counter"]["value"] += float(random.randint(1, 20))
            state["demo_value_secondary_gauge"]["value"] = round(random.uniform(-50, 50), 2)
            state["demo_value_secondary_counter"]["value"] += float(random.randint(1, 10))

            state["demo_value_gauge"]["tags"] = build_common_tags()
            state["system.process.count"]["tags"] = build_system_process_tags()
            state["demo_value_counter"]["tags"] = build_common_tags()
            state["demo_value_secondary_gauge"]["tags"] = build_common_tags()
            state["demo_value_secondary_counter"]["tags"] = build_common_tags()

            metrics_data = reader.get_metrics_data()
            if metrics_data is None:
                print("send failed: no metrics data collected")
                continue

            result = exporter.export(metrics_data)

            if result is MetricExportResult.SUCCESS:
                print("sent all metrics")
                print(
                    f"  demo_value_gauge value={state['demo_value_gauge']['value']} "
                    f"tags={state['demo_value_gauge']['tags']}"
                )
                print(
                    f"  system.process.count value={state['system.process.count']['value']} "
                    f"tags={state['system.process.count']['tags']}"
                )
                print(
                    f"  demo_value_counter value={state['demo_value_counter']['value']} "
                    f"tags={state['demo_value_counter']['tags']}"
                )
                print(
                    f"  demo_value_secondary_gauge value={state['demo_value_secondary_gauge']['value']} "
                    f"tags={state['demo_value_secondary_gauge']['tags']}"
                )
                print(
                    f"  demo_value_secondary_counter value={state['demo_value_secondary_counter']['value']} "
                    f"tags={state['demo_value_secondary_counter']['tags']}"
                )
            else:
                print("send failed for this export batch")

    finally:
        exporter.shutdown()
        provider.shutdown()


if __name__ == "__main__":
    main()
 ```

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
