### PR TITLE
chore(website): cherry-pick website fixes/improvements from master

### DIFF
--- a/website/assets/js/below.js
+++ b/website/assets/js/below.js
@@ -7,7 +7,10 @@ const tableOfContents = () => {
       tocSelector: "#toc",
       contentSelector: "#page-content",
       headingSelector: "h2,h3,h4,h5",
-      scrollSmoothDuration: 400
+      scrollSmoothDuration: 400,
+      headingsOffset: 80,
+      scrollSmoothOffset: -80,
+      hasInnerContainers: true
     });
   }
 };

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
   x-data="{ dark: $store.global.dark{{ if $hasBottomNav }}, slideover: false {{ end }} }"
   x-on:toggle-dark="dark = !dark"
   :class="{ 'dark': dark, 'light': !dark }"
-  class="h-screen">
+  class="min-h-full">
 
   <head>
     {{/* Make sure the page is always visible if JS is disabled */}}
@@ -37,7 +37,7 @@
     {{/* JS that needs to load at the start */}}
     {{ partial "javascript/head.html" . }}
   </head>
-  <body class="dark:bg-dark font-sans antialiased flex flex-col min-h-full{{ if $hasBottomNav }} pb-16 lg:pb-0{{ end }}" onload="showBody()" style="visibility: hidden;">
+  <body class="dark:bg-dark font-sans antialiased flex flex-col min-h-screen{{ if $hasBottomNav }} pb-16 lg:pb-0{{ end }}" onload="showBody()" style="visibility: hidden;">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M7MFKZ9" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -18,6 +18,15 @@
       {{ partial "hero.html" . }}
     </div>
 
+    {{ with $release.date }}
+    {{ $date := . | dateFormat "January 2, 2006" }}
+    <div class="mt-3 flex items-center space-x-3 text-gray-500 dark:text-gray-300">
+      <time datetime="{{ $date }}" class="text-sm">
+        {{ $date }}
+      </time>
+    </div>
+    {{ end }}
+
     <div>
       {{ with $release.codename }}
       <p class="inline-flex space-x-4 border dark:border-gray-700 rounded-md py-2 px-3.5">

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1641,11 +1641,11 @@ autoprefixer@^10.2.5:
     postcss-value-parser "^4.2.0"
 
 axios@^1.6.0, axios@^1.8.4:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -2382,7 +2382,7 @@ fn.name@1.x.x:
   resolved "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.15.11:
+follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==


### PR DESCRIPTION
## Summary

Cherry-picks three website PRs from master that weren't in the website branch:
- #25244: render release date on per-version release page
- #25359: adjust tocbot content tracking
- #25369: bump axios from 1.15.0 to 1.16.0

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25244
- Related: #25359
- Related: #25369