### PR TITLE
fix(redis sink): treat PUBLISH with 0 subscribers as success

### DIFF
--- a/changelog.d/redis-channel-publish-zero-subscribers.fix.md
+++ b/changelog.d/redis-channel-publish-zero-subscribers.fix.md
@@ -1,0 +1,5 @@
+Fixed an issue where the `redis` sink using `data_type: channel` would enter an infinite retry
+loop when a `PUBLISH` command returned `0` (no subscribers currently connected). Redis pub/sub
+`PUBLISH` returns the number of subscribers that received the message; zero subscribers is a
+valid transient state (e.g. the consumer momentarily dropped its subscription) and should not
+be treated as a failure.

--- a/src/sinks/redis/service.rs
+++ b/src/sinks/redis/service.rs
@@ -1,7 +1,7 @@
 use std::task::{Context, Poll};
 
 use super::{
-    RedisRequest, RedisSinkError,
+    DataType, RedisRequest, RedisSinkError,
     config::{ListMethod, SortedSetMethod},
     sink::{ConnectionState, RedisConnection},
 };
@@ -72,6 +72,7 @@ impl Service<RedisRequest> for RedisService {
         }
 
         let byte_size = kvs.metadata.events_byte_size();
+        let data_type = self.data_type;
 
         Box::pin(async move {
             let ConnectionState {
@@ -82,6 +83,7 @@ impl Service<RedisRequest> for RedisService {
             match pipe.query_async(&mut conn).await {
                 Ok(event_status) => Ok(RedisResponse {
                     event_status,
+                    data_type,
                     events_byte_size: kvs.metadata.into_events_estimated_json_encoded_byte_size(),
                     byte_size,
                 }),
@@ -96,13 +98,17 @@ impl Service<RedisRequest> for RedisService {
 
 pub struct RedisResponse {
     pub event_status: Vec<bool>,
+    pub data_type: DataType,
     pub events_byte_size: GroupedCountByteSize,
     pub byte_size: usize,
 }
 
 impl RedisResponse {
     pub(super) fn is_successful(&self) -> bool {
-        self.event_status.iter().all(|x| *x)
+        // For Channel (pub/sub), PUBLISH returns the number of subscribers that received the
+        // message. Zero subscribers is valid — the consumer may have momentarily dropped its
+        // subscription — so we never treat it as a failure.
+        matches!(self.data_type, DataType::Channel) || self.event_status.iter().all(|x| *x)
     }
 }
 

--- a/src/sinks/redis/tests.rs
+++ b/src/sinks/redis/tests.rs
@@ -6,7 +6,12 @@ use vector_lib::{
     request_metadata::GroupedCountByteSize,
 };
 
-use super::{config::RedisSinkConfig, request_builder::encode_event};
+use super::{
+    DataType,
+    config::{ListMethod, RedisSinkConfig, SortedSetMethod},
+    request_builder::encode_event,
+    service::RedisResponse,
+};
 use crate::{
     codecs::{Encoder, Transformer},
     config::log_schema,
@@ -123,4 +128,40 @@ fn redis_log_scoring() {
     .score;
 
     assert_eq!(result, Some(64));
+}
+
+// Redis PUBLISH returns the number of subscribers that received the message as an integer.
+// redis-rs deserializes integer 0 as bool false, which would cause is_successful() to return
+// false and trigger an infinite retry loop when no subscribers are connected.
+#[test]
+fn redis_channel_publish_zero_subscribers_is_successful() {
+    let response = RedisResponse {
+        event_status: vec![false], // 0 subscribers → redis-rs deserializes as false
+        data_type: DataType::Channel,
+        events_byte_size: GroupedCountByteSize::new_untagged(),
+        byte_size: 0,
+    };
+    assert!(
+        response.is_successful(),
+        "Channel publish with 0 subscribers should be treated as success"
+    );
+}
+
+#[test]
+fn redis_list_and_sorted_set_still_check_event_status() {
+    for data_type in [
+        DataType::List(ListMethod::RPush),
+        DataType::SortedSet(SortedSetMethod::ZAdd),
+    ] {
+        let response = RedisResponse {
+            event_status: vec![false],
+            data_type,
+            events_byte_size: GroupedCountByteSize::new_untagged(),
+            byte_size: 0,
+        };
+        assert!(
+            !response.is_successful(),
+            "{data_type:?} with false event_status should not be successful"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The `redis` sink using `data_type: channel` enters an infinite retry loop when a `PUBLISH` command returns `0` (no subscribers currently connected).

### Root cause

Redis `PUBLISH` returns the number of subscribers that received the message as an integer. When no subscribers are connected, Redis returns `:0\r\n`. `redis-rs` deserializes this integer as `bool false` into `Vec<bool>`, causing `is_successful()` to return `false`, which triggers `should_retry_response` to return `Retry` — even though the connection and Redis server are both healthy.

This is fundamentally different from `List` and `SortedSet` operations, where a `0` response would indicate a genuine failure (`LPUSH`/`RPUSH` always returns the new list length ≥ 1 on success).

### Fix

Short-circuit `is_successful()` to `true` for `DataType::Channel`. A zero-subscriber publish is a valid transient state in pub/sub (the consumer may have momentarily dropped its subscription) and must not be treated as an error.

`List` and `SortedSet` behavior is unchanged.

## Test plan

- Added `redis_channel_publish_zero_subscribers_is_successful`: verifies that `is_successful()` returns `true` for `DataType::Channel` when `event_status` contains `false` (0 subscribers)
- Added `redis_list_and_sorted_set_still_check_event_status`: verifies that `List` and `SortedSet` still treat `false` event status as failure
- All 8 existing redis sink unit tests continue to pass