### PR TITLE
fix(tests): skip Windows UDP-excluded ports in next_addr_for_ip

### DIFF
--- a/src/test_util/addr.rs
+++ b/src/test_util/addr.rs
@@ -8,13 +8,13 @@
 //!
 //! This ensures no race window between port allocation and registration.
 
+#[cfg(windows)]
+use std::net::UdpSocket as StdUdpSocket;
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener as StdTcpListener},
     sync::{LazyLock, Mutex},
 };
-#[cfg(windows)]
-use std::net::UdpSocket as StdUdpSocket;
 
 /// Maximum number of attempts to allocate a unique port before panicking.
 /// This should be far more than needed since port collisions are rare,

--- a/src/test_util/addr.rs
+++ b/src/test_util/addr.rs
@@ -9,7 +9,7 @@
 //! This ensures no race window between port allocation and registration.
 
 #[cfg(windows)]
-use std::net::UdpSocket as StdUdpSocket;
+use std::net::UdpSocket;
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener as StdTcpListener},
@@ -85,7 +85,7 @@ pub fn next_addr_for_ip(ip: IpAddr) -> (PortGuard, SocketAddr) {
         // TCP bind(0) may return such a port, but UDP bind to the same port will fail with
         // WSAEACCES (10013). Probe with a UDP socket and retry if it is excluded.
         #[cfg(windows)]
-        if StdUdpSocket::bind(addr).is_err() {
+        if UdpSocket::bind(addr).is_err() {
             continue;
         }
 

--- a/src/test_util/addr.rs
+++ b/src/test_util/addr.rs
@@ -13,6 +13,8 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener as StdTcpListener},
     sync::{LazyLock, Mutex},
 };
+#[cfg(windows)]
+use std::net::UdpSocket as StdUdpSocket;
 
 /// Maximum number of attempts to allocate a unique port before panicking.
 /// This should be far more than needed since port collisions are rare,
@@ -76,6 +78,14 @@ pub fn next_addr_for_ip(ip: IpAddr) -> (PortGuard, SocketAddr) {
         if reserved.contains(&port) {
             // OS recycled a port that's still reserved by another test.
             // Lock and listener will be dropped implicitly after continuing
+            continue;
+        }
+
+        // On Windows, certain ports are in OS-excluded ranges (e.g. set by Hyper-V/WSL).
+        // TCP bind(0) may return such a port, but UDP bind to the same port will fail with
+        // WSAEACCES (10013). Probe with a UDP socket and retry if it is excluded.
+        #[cfg(windows)]
+        if StdUdpSocket::bind(addr).is_err() {
             continue;
         }
 


### PR DESCRIPTION
## Summary

On Windows, OS-excluded port ranges (set by Hyper-V, WSL, Docker) can be returned by TCP `bind(0)` but deny subsequent UDP `bind` with `WSAEACCES` (error 10013). This caused intermittent failures in `sinks::socket::test::udp_ipv6` and `sinks::statsd::tests::test_send_to_statsd` on Windows CI.

The fix probes a UDP socket on the candidate port before reserving it. If the probe fails, `next_addr_for_ip` retries with a new port. The probe is `#[cfg(windows)]`-gated, so there is no impact on Linux/macOS.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- https://github.com/vectordotdev/vector/actions/runs/25461445718/job/74704413424