### PR TITLE
fix(releasing): restore Vector RPM/DEB install on EL8 family

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -274,6 +274,10 @@ runs:
           ./scripts/environment/prepare.sh --modules="${csm}"
         fi
 
+        if [[ "$NEEDS_RUST" == "true" ]]; then
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        fi
+
     - name: Set VDEV environment variable
       if: ${{ inputs.vdev == 'true' }}
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,12 @@ jobs:
   build-linux-gnu-native:
     name: Build Vector for ${{ matrix.target }} (native)
     runs-on: ${{ matrix.runner }}
-    container: almalinux:8@sha256:ca871b110064fe81bff0250ed5cc56fbb0a9840715f09811c33bbf9d72cef56c
+    container:
+      image: almalinux:8@sha256:ca871b110064fe81bff0250ed5cc56fbb0a9840715f09811c33bbf9d72cef56c
+      # Align HOME with the container's root user so rustup/sudo don't warn
+      # about $HOME (/github/home) differing from the euid-obtained home (/root).
+      env:
+        HOME: /root
     timeout-minutes: 90
     needs: generate-publish-metadata
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -205,7 +205,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust: true
-          rustup: true
           protoc: true
       - name: Build Vector
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,73 @@ jobs:
         id: generate-publish-metadata
         run: make ci-generate-publish-metadata
 
-  build-linux-packages:
+  build-linux-gnu-native:
+    name: Build Vector for ${{ matrix.target }} (native)
+    runs-on: ${{ matrix.runner }}
+    container: almalinux:8
+    timeout-minutes: 90
+    needs: generate-publish-metadata
+    env:
+      VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
+      VECTOR_BUILD_DESC: ${{ needs.generate-publish-metadata.outputs.vector_build_desc }}
+      CHANNEL: ${{ needs.generate-publish-metadata.outputs.vector_release_channel }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04-8core
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-8core-arm
+    steps:
+      - name: Install system dependencies
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            gcc gcc-c++ make cmake perl perl-IPC-Cmd \
+            openssl-devel cyrus-sasl-devel \
+            pkgconfig clang \
+            rpm-build sudo \
+            git tar gzip xz which findutils \
+            curl unzip
+      # TODO: generate the .deb description once in generate-publish-metadata and consume as an artifact, so all builders share the same output and this source build can go away.
+      - name: Build cmark-gfm from source
+        env:
+          CMARK_GFM_TAG: "0.29.0.gfm.13"
+          CMARK_GFM_SHA: "587a12bb54d95ac37241377e6ddc93ea0e45439b"
+        run: |
+          git clone --depth 1 --branch "$CMARK_GFM_TAG" https://github.com/github/cmark-gfm.git /tmp/cmark-gfm
+          actual_sha="$(git -C /tmp/cmark-gfm rev-parse HEAD)"
+          if [ "$actual_sha" != "$CMARK_GFM_SHA" ]; then
+            echo "::error::cmark-gfm tag $CMARK_GFM_TAG resolved to $actual_sha, expected $CMARK_GFM_SHA"
+            exit 1
+          fi
+          cmake -S /tmp/cmark-gfm -B /tmp/cmark-gfm/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=lib64
+          cmake --build /tmp/cmark-gfm/build -j "$(nproc)"
+          cmake --install /tmp/cmark-gfm/build
+          ldconfig
+          rm -rf /tmp/cmark-gfm
+          cmark-gfm --version
+      - name: Checkout Vector
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.git_ref }}
+      - uses: ./.github/actions/setup
+        with:
+          rust: true
+          cargo-deb: true
+          protoc: true
+      - name: Build Vector
+        run: make NATIVE=true package-${{ matrix.target }}-all
+      - name: Stage package artifacts for publish
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vector-${{ env.VECTOR_VERSION }}-${{ matrix.target }}
+          path: target/artifacts/vector*
+
+  build-linux-cross:
     name: Build Vector for ${{ matrix.target }}
     runs-on: release-builder-linux
     timeout-minutes: 60
@@ -76,9 +142,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl # .tar.gz
-          - target: x86_64-unknown-linux-gnu # .tar.gz, .deb, .rpm
           - target: aarch64-unknown-linux-musl # .tar.gz
-          - target: aarch64-unknown-linux-gnu # .tar.gz, .deb, .rpm
           - target: armv7-unknown-linux-gnueabihf # .tar.gz, .deb, .rpm
           - target: armv7-unknown-linux-musleabihf # .tar.gz
           - target: arm-unknown-linux-gnueabi # .tar.gz, .deb
@@ -208,7 +272,8 @@ jobs:
     timeout-minutes: 5
     needs:
       - generate-publish-metadata
-      - build-linux-packages
+      - build-linux-gnu-native
+      - build-linux-cross
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       DD_PKG_VERSION: "latest"
@@ -256,13 +321,16 @@ jobs:
     timeout-minutes: 10
     needs:
       - generate-publish-metadata
-      - build-linux-packages
+      - build-linux-gnu-native
+      - build-linux-cross
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       DD_PKG_VERSION: "latest"
     strategy:
       matrix:
         container:
+          # Lowest supported glibc tier (EL8 family, glibc 2.28). Catches glibc-floor regressions.
+          - "almalinux:8"
           - "quay.io/centos/centos:stream9"
           - "amazonlinux:2023"
           - "fedora:39"
@@ -341,7 +409,8 @@ jobs:
       packages: write
     needs:
       - generate-publish-metadata
-      - build-linux-packages
+      - build-linux-gnu-native
+      - build-linux-cross
       - deb-verify
     env:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
@@ -399,7 +468,8 @@ jobs:
     timeout-minutes: 10
     needs:
       - generate-publish-metadata
-      - build-linux-packages
+      - build-linux-gnu-native
+      - build-linux-cross
       - build-apple-darwin-packages
       - build-x86_64-pc-windows-msvc-packages
       - deb-verify
@@ -440,7 +510,8 @@ jobs:
       contents: write
     needs:
       - generate-publish-metadata
-      - build-linux-packages
+      - build-linux-gnu-native
+      - build-linux-cross
       - build-apple-darwin-packages
       - build-x86_64-pc-windows-msvc-packages
       - deb-verify
@@ -474,7 +545,8 @@ jobs:
     timeout-minutes: 5
     needs:
       - generate-publish-metadata
-      - build-linux-packages
+      - build-linux-gnu-native
+      - build-linux-cross
       - build-apple-darwin-packages
       - build-x86_64-pc-windows-msvc-packages
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
   build-linux-gnu-native:
     name: Build Vector for ${{ matrix.target }} (native)
     runs-on: ${{ matrix.runner }}
-    container: almalinux:8
+    container: almalinux:8@sha256:ca871b110064fe81bff0250ed5cc56fbb0a9840715f09811c33bbf9d72cef56c
     timeout-minutes: 90
     needs: generate-publish-metadata
     env:
@@ -330,7 +330,7 @@ jobs:
       matrix:
         container:
           # Lowest supported glibc tier (EL8 family, glibc 2.28). Catches glibc-floor regressions.
-          - "almalinux:8"
+          - "almalinux:8@sha256:ca871b110064fe81bff0250ed5cc56fbb0a9840715f09811c33bbf9d72cef56c"
           - "quay.io/centos/centos:stream9"
           - "amazonlinux:2023"
           - "fedora:39"

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ CARGO_HANDLES_FRESHNESS:
 
 # Pinned digests for ghcr.io/cross-rs/<target>:edge.
 # Refresh with: crane digest ghcr.io/cross-rs/<target>:edge
+CROSS_DIGEST_x86_64-unknown-linux-gnu       := sha256:13f7a68e55cb05a19e840bce65834fc785dc069e0c2218d12b8fdb8f8a1519d5
 CROSS_DIGEST_aarch64-unknown-linux-gnu      := sha256:3bf094d22fc4f73c9bdce45ddd7a8bbae349efdbd51b4d4b5ee1bedd8454466b
 CROSS_DIGEST_x86_64-unknown-linux-musl      := sha256:c59deede3efcd7cb6f6a57641241ba1c63cfe35b7965be09a851242b4209639d
 CROSS_DIGEST_aarch64-unknown-linux-musl     := sha256:dad492e0f040c6e712d4be9b970c9de5f3b8ef9cde6b9a2b437d56d1dabeb808

--- a/Makefile
+++ b/Makefile
@@ -274,9 +274,7 @@ CARGO_HANDLES_FRESHNESS:
 	${EMPTY}
 
 # Pinned digests for ghcr.io/cross-rs/<target>:edge.
-# Source: cross-rs/cross @ f86fd03bb70b4c6802847c18087e21391498b0b4, built 2026-04-10 (Ubuntu 20.04 focal).
 # Refresh with: crane digest ghcr.io/cross-rs/<target>:edge
-CROSS_DIGEST_x86_64-unknown-linux-gnu       := sha256:13f7a68e55cb05a19e840bce65834fc785dc069e0c2218d12b8fdb8f8a1519d5
 CROSS_DIGEST_aarch64-unknown-linux-gnu      := sha256:3bf094d22fc4f73c9bdce45ddd7a8bbae349efdbd51b4d4b5ee1bedd8454466b
 CROSS_DIGEST_x86_64-unknown-linux-musl      := sha256:c59deede3efcd7cb6f6a57641241ba1c63cfe35b7965be09a851242b4209639d
 CROSS_DIGEST_aarch64-unknown-linux-musl     := sha256:dad492e0f040c6e712d4be9b970c9de5f3b8ef9cde6b9a2b437d56d1dabeb808
@@ -290,13 +288,17 @@ CROSS_DIGEST_arm-unknown-linux-musleabi     := sha256:0ca8f4afcc29fb5964aa63e482
 .PHONY: cross-image-%
 cross-image-%: export TRIPLE =$($(strip @):cross-image-%=%)
 cross-image-%:
-	$(if $(CROSS_DIGEST_$*),,$(error No CROSS_DIGEST pinned for $*. Add it to the digest table in Makefile.))
-	$(CONTAINER_TOOL) build \
-		--build-arg TARGET=${TRIPLE} \
-		--build-arg CROSS_DIGEST=$(CROSS_DIGEST_$*) \
-		--file scripts/cross/Dockerfile \
-		--tag vector-cross-env:${TRIPLE} \
-		.
+	@if [ -n "$(CROSS_DIGEST_$*)" ]; then \
+		$(CONTAINER_TOOL) build \
+			--build-arg TARGET=$* \
+			--build-arg CROSS_DIGEST=$(CROSS_DIGEST_$*) \
+			--file scripts/cross/Dockerfile \
+			--tag vector-cross-env:$* \
+			. ; \
+	else \
+		echo "No image digest pinned for $*. Add it to the digest table in Makefile." >&2 ; \
+		exit 1 ; \
+	fi
 
 # This is basically a shorthand for folks.
 # `cross-anything-triple` will call `cross anything --target triple` with the right features.
@@ -318,6 +320,14 @@ target/%/vector: export PAIR =$(subst /, ,$(@:target/%/vector=%))
 target/%/vector: export TRIPLE ?=$(word 1,${PAIR})
 target/%/vector: export PROFILE ?=$(word 2,${PAIR})
 target/%/vector: export CFLAGS += -g0 -O3
+ifeq ($(NATIVE),true)
+target/%/vector: CARGO_HANDLES_FRESHNESS
+	cargo build \
+		$(if $(findstring release,$(PROFILE)),--release,) \
+		--target ${TRIPLE} \
+		--no-default-features \
+		--features target-${TRIPLE}
+else
 target/%/vector: cargo-install-cross CARGO_HANDLES_FRESHNESS
 	$(MAKE) -k cross-image-${TRIPLE}
 	cross build \
@@ -325,6 +335,7 @@ target/%/vector: cargo-install-cross CARGO_HANDLES_FRESHNESS
 		--target ${TRIPLE} \
 		--no-default-features \
 		--features target-${TRIPLE}
+endif
 
 target/%/vector.tar.gz: export PAIR =$(subst /, ,$(@:target/%/vector.tar.gz=%))
 target/%/vector.tar.gz: export TRIPLE ?=$(word 1,${PAIR})

--- a/changelog.d/25253_el8_glibc_floor.fix.md
+++ b/changelog.d/25253_el8_glibc_floor.fix.md
@@ -1,0 +1,3 @@
+Restored support for installing Vector on RHEL 8, Rocky Linux 8, AlmaLinux 8, and CentOS Stream 8, which had been broken since v0.55.0 due to an inadvertent glibc requirement bump.
+
+authors: pront

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -69,6 +69,9 @@ case "$TARGET" in
   armv7-*-gnueabihf) STRIP_TOOL="arm-linux-gnueabihf-strip" ;;
   *) STRIP_TOOL="strip" ;;
 esac
+# Fall back to the host's strip when building natively on the target arch
+# (e.g., aarch64 native build doesn't have aarch64-linux-gnu-strip).
+command -v "$STRIP_TOOL" >/dev/null 2>&1 || STRIP_TOOL="strip"
 
 # Perform the build.
 rpmbuild \


### PR DESCRIPTION
## Summary

v0.55.0 unintentionally raised the glibc floor of Vector's GNU release binaries above what RHEL 8 / Rocky Linux 8 / AlmaLinux 8 / CentOS Stream 8 ship (glibc 2.28), breaking install on those distros. Reported in #25253.

This PR builds the `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` release binaries natively inside an `almalinux:8` container on GitHub-hosted larger runners. The build environment IS the install floor, so the binary cannot reference a glibc symbol newer than what install will see, by construction. The same `almalinux:8` image is also used by `rpm-verify`, making build and install symmetric.

The musl and 32-bit ARM targets keep using cross-rs. They have no glibc-floor obligation: musl is statically linked, and EL8 family does not ship for 32-bit ARM at all.

### What changed

- New `build-linux-gnu-native` job in `publish.yml`: matrix builds x86_64-gnu on `ubuntu-24.04-8core` and aarch64-gnu on `ubuntu-24.04-8core-arm`, both with `container: almalinux:8`, both compiling natively via plain `cargo build` (no `cross`). 32 GB RAM accommodates fat LTO link.
- Renamed the existing build job to `build-linux-cross` covering musl + 32-bit ARM via `cross-rs` on `release-builder-linux`.
- Added `NATIVE=true` mode to the Makefile's `target/%/vector` rule so `package-...-all` runs `cargo build` instead of `cross build`.
- Added `almalinux:8` to the `rpm-verify` container matrix so install on the floor distribution is exercised before publish.
- Built `cmark-gfm` from source inside the AlmaLinux 8 container (no EL8 package available; needed by `package-deb.sh`).
- Cleanups to `.github/actions/setup/action.yml`:
  - Removed the dead "Override warnings" step. It wrote `cfg(linux)` rustflags that cargo never recognized as a valid cfg predicate, and was crashing in pristine containers because it tried to write to `~/.cargo/config.toml` before that directory existed.
  - Added `$HOME/.cargo/bin` to `$GITHUB_PATH` after `prepare.sh` runs, so subsequent steps see `cargo` even on container images that don't pre-install rustup.

## Vector configuration

N/A. Build-tooling change.

## How did you test this PR?

Custom publish runs exercise the full matrix end-to-end:
- Native GNU build inside `almalinux:8` for x86_64 and aarch64.
- Cross builds for musl and 32-bit ARM on `release-builder-linux`.
- `rpm-verify` on `almalinux:8` (the floor) plus the rest of the verification matrix (rockylinux:9, centos:stream9, amazonlinux:2023, fedora 39/40).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

This restores behavior that was unintentionally regressed in v0.55.0.

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added at `changelog.d/25253_el8_glibc_floor.fix.md`.

## References

- Closes: #25253
- Related: #25215 (the build-tooling change that introduced the regression)
- Related: #21721 (formal platform support tiers)