### PR TITLE
feat(http_server source): allow custom auth to enrich events via metadata writes

### DIFF
--- a/changelog.d/25391_http_server_custom_auth_write_metadata.enhancement.md
+++ b/changelog.d/25391_http_server_custom_auth_write_metadata.enhancement.md
@@ -1,0 +1,6 @@
+The `custom` auth strategy for the `http_server` source now supports event enrichment via metadata
+writes. VRL programs can write `%field = value` during authentication; those values are injected
+into every successfully authenticated event. The event body (`.field`) remains read-only. Existing
+`custom` programs that do not write metadata are unaffected.
+
+authors: 20agbekodo

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -57,7 +57,7 @@ pub enum HttpServerAuthConfig {
     ///
     /// Takes in request and validates it using VRL code. The VRL program must return a boolean.
     /// Metadata fields written via `%field = value` in the VRL program are extracted and injected
-    /// into every authenticated event.
+    /// into the log's body if log namespacing is enabled.
     Custom {
         /// The VRL boolean expression. May write `%field = value` to enrich events.
         source: String,

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -56,10 +56,8 @@ pub enum HttpServerAuthConfig {
     /// Custom authentication using VRL code.
     ///
     /// Takes in request and validates it using VRL code. The VRL program must return a boolean.
-    /// Metadata fields written via `%field = value` in the VRL program are extracted and injected
-    /// into the log's body if log namespacing is enabled.
     Custom {
-        /// The VRL boolean expression. May write `%field = value` to enrich events.
+        /// The VRL boolean expression.
         source: String,
     },
 }

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -12,6 +12,7 @@ use vector_config::configurable_component;
 use vector_lib::{
     TimeZone, compile_vrl,
     event::{Event, LogEvent, VrlTarget},
+    lookup::OwnedTargetPath,
     sensitive_string::SensitiveString,
 };
 use vector_vrl_metrics::MetricsStorage;
@@ -54,9 +55,11 @@ pub enum HttpServerAuthConfig {
 
     /// Custom authentication using VRL code.
     ///
-    /// Takes in request and validates it using VRL code.
+    /// Takes in request and validates it using VRL code. The VRL program must return a boolean.
+    /// Metadata fields written via `%field = value` in the VRL program are extracted and injected
+    /// into every authenticated event.
     Custom {
-        /// The VRL boolean expression.
+        /// The VRL boolean expression. May write `%field = value` to enrich events.
         source: String,
     },
 }
@@ -151,7 +154,9 @@ impl HttpServerAuthConfig {
                 let mut config = CompileConfig::default();
                 config.set_custom(enrichment_tables.clone());
                 config.set_custom(metrics_storage.clone());
-                config.set_read_only();
+                // Lock the event body (.field) as read-only, but leave metadata (%field) writable
+                // so the VRL program can enrich authenticated events via %field = value.
+                config.set_read_only_path(OwnedTargetPath::event_root(), true);
 
                 let CompilationResult {
                     program,
@@ -182,7 +187,9 @@ impl HttpServerAuthConfig {
 pub enum HttpServerAuthMatcher {
     /// Matcher for comparing exact value of Authorization header
     AuthHeader(HeaderValue, &'static str),
-    /// Matcher for running VRL script for requests, to allow for custom validation
+    /// Matcher for running VRL script for requests, to allow for custom validation.
+    /// Metadata (`%field`) writes in the program are extracted and returned to the caller
+    /// for injection into authenticated events.
     Vrl {
         /// Compiled VRL script
         program: Program,
@@ -190,18 +197,19 @@ pub enum HttpServerAuthMatcher {
 }
 
 impl HttpServerAuthMatcher {
-    /// Compares passed headers to the matcher
+    /// Validates the request. Returns `Ok(Some(enrichment))` when auth passes and the VRL program
+    /// wrote `%field` values; returns `Ok(None)` when auth passes with no metadata enrichment.
     pub fn handle_auth(
         &self,
         address: Option<&SocketAddr>,
         headers: &HeaderMap<HeaderValue>,
         path: &str,
-    ) -> Result<(), ErrorMessage> {
+    ) -> Result<Option<ObjectMap>, ErrorMessage> {
         match self {
             HttpServerAuthMatcher::AuthHeader(expected, err_message) => {
                 if let Some(header) = headers.get(AUTHORIZATION) {
                     if expected == header {
-                        Ok(())
+                        Ok(None)
                     } else {
                         Err(ErrorMessage::new(
                             StatusCode::UNAUTHORIZED,
@@ -227,7 +235,7 @@ impl HttpServerAuthMatcher {
         headers: &HeaderMap<HeaderValue>,
         path: &str,
         program: &Program,
-    ) -> Result<(), ErrorMessage> {
+    ) -> Result<Option<ObjectMap>, ErrorMessage> {
         let mut target = VrlTarget::new(
             Event::Log(LogEvent::from_map(
                 ObjectMap::from([
@@ -263,16 +271,22 @@ impl HttpServerAuthMatcher {
             warn!("Handling auth failed: {}", e);
             ErrorMessage::new(StatusCode::UNAUTHORIZED, "Auth failed".to_owned())
         })? {
-            vrl::core::Value::Boolean(result) => {
-                if result {
-                    Ok(())
+            vrl::core::Value::Boolean(true) => {
+                let enrichment = if let VrlTarget::LogEvent(_, metadata) = &target {
+                    metadata
+                        .value()
+                        .as_object()
+                        .filter(|m| !m.is_empty())
+                        .cloned()
                 } else {
-                    Err(ErrorMessage::new(
-                        StatusCode::UNAUTHORIZED,
-                        "Auth failed".to_owned(),
-                    ))
-                }
+                    None
+                };
+                Ok(enrichment)
             }
+            vrl::core::Value::Boolean(false) => Err(ErrorMessage::new(
+                StatusCode::UNAUTHORIZED,
+                "Auth failed".to_owned(),
+            )),
             _ => Err(ErrorMessage::new(
                 StatusCode::UNAUTHORIZED,
                 "Invalid return value".to_owned(),
@@ -642,5 +656,76 @@ mod tests {
         let error = result.unwrap_err();
         assert_eq!(401, error.code());
         assert_eq!("Auth failed", error.message());
+    }
+
+    // Backward-compat: existing `custom` scripts that don't write metadata still work and return
+    // Ok(None) — no enrichment, no change in behavior.
+    #[test]
+    fn custom_auth_matcher_returns_none_enrichment_when_no_metadata_written() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: r#".headers.authorization == "Bearer token""#.to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer token"));
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_ok());
+        assert_eq!(
+            None,
+            result.unwrap(),
+            "no metadata written => no enrichment"
+        );
+    }
+
+    // Existing `custom` scripts that write metadata via `%field = value` now enrich events.
+    #[test]
+    fn custom_auth_matcher_returns_enrichment_when_metadata_written() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: indoc! {r#"
+                %tenant_id = "acme"
+                true
+                "#}
+            .to_string(),
+        };
+
+        let matcher = custom_auth
+            .build(&Default::default(), &Default::default())
+            .unwrap();
+
+        let headers = HeaderMap::new();
+        let (_guard, addr) = next_addr();
+        let result = matcher.handle_auth(Some(&addr), &headers, "/");
+
+        assert!(result.is_ok());
+        let enrichment = result.unwrap().expect("expected enrichment map");
+        assert_eq!(
+            enrichment.get("tenant_id").cloned(),
+            Some(vrl::core::Value::from("acme")),
+        );
+    }
+
+    // Existing `custom` scripts still cannot mutate event body fields.
+    #[test]
+    fn custom_auth_build_fails_when_event_body_write_attempted() {
+        let custom_auth = HttpServerAuthConfig::Custom {
+            source: indoc! {r#"
+                .new_field = "value"
+                true
+                "#}
+            .to_string(),
+        };
+
+        assert!(
+            custom_auth
+                .build(&Default::default(), &Default::default())
+                .is_err(),
+            "writing to event body (.field) must be rejected at compile time"
+        );
     }
 }

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -16,7 +16,7 @@ use vector_lib::{
     lookup::{lookup_v2::OptionalValuePath, owned_value_path, path},
     schema::Definition,
 };
-use vrl::value::{Kind, kind::Collection};
+use vrl::value::{Kind, ObjectMap, kind::Collection};
 use warp::http::HeaderMap;
 
 use crate::{
@@ -520,6 +520,25 @@ impl HttpSource for SimpleHttpSource {
 
     fn enable_source_ip(&self) -> bool {
         self.host_key.path.is_some()
+    }
+
+    /// Injects `%field` enrichment from a `custom` auth VRL program into events.
+    /// Legacy namespace: inserted into the event body (no-op if key already exists).
+    /// Vector namespace: inserted into event metadata under `http_server.<field>`.
+    fn inject_auth_enrichment(&self, events: &mut [Event], enrichment: ObjectMap) {
+        for event in events.iter_mut() {
+            if let Event::Log(log) = event {
+                for (key, value) in &enrichment {
+                    self.log_namespace.insert_source_metadata(
+                        SimpleHttpConfig::NAME,
+                        log,
+                        Some(LegacyKey::InsertIfEmpty(path!(key.as_str()))),
+                        path!(key.as_str()),
+                        value.clone(),
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -13,10 +13,13 @@ use vector_lib::{
     },
     config::{DataType, LegacyKey, LogNamespace},
     configurable::configurable_component,
-    lookup::{lookup_v2::OptionalValuePath, owned_value_path, path},
+    lookup::{PathPrefix, lookup_v2::OptionalValuePath, owned_value_path, path},
     schema::Definition,
 };
-use vrl::value::{Kind, ObjectMap, kind::Collection};
+use vrl::{
+    path::ValuePath as _,
+    value::{Kind, ObjectMap, kind::Collection},
+};
 use warp::http::HeaderMap;
 
 use crate::{
@@ -523,19 +526,29 @@ impl HttpSource for SimpleHttpSource {
     }
 
     /// Injects `%field` enrichment from a `custom` auth VRL program into events.
-    /// Legacy namespace: inserted into the event body (no-op if key already exists).
+    /// Both namespaces use insert-if-empty semantics so auth enrichment never
+    /// overwrites built-in source metadata (`path`, `host`, `headers`, …) that
+    /// `enrich_events` already populated.
+    /// Legacy namespace: inserted into the event body.
     /// Vector namespace: inserted into event metadata under `http_server.<field>`.
     fn inject_auth_enrichment(&self, events: &mut [Event], enrichment: ObjectMap) {
         for event in events.iter_mut() {
             if let Event::Log(log) = event {
                 for (key, value) in &enrichment {
-                    self.log_namespace.insert_source_metadata(
-                        SimpleHttpConfig::NAME,
-                        log,
-                        Some(LegacyKey::InsertIfEmpty(path!(key.as_str()))),
-                        path!(key.as_str()),
-                        value.clone(),
-                    );
+                    match self.log_namespace {
+                        LogNamespace::Vector => {
+                            log.try_insert(
+                                (
+                                    PathPrefix::Metadata,
+                                    path!(SimpleHttpConfig::NAME).concat(path!(key.as_str())),
+                                ),
+                                value.clone(),
+                            );
+                        }
+                        LogNamespace::Legacy => {
+                            log.try_insert((PathPrefix::Event, path!(key.as_str())), value.clone());
+                        }
+                    }
                 }
             }
         }
@@ -562,11 +575,15 @@ mod tests {
         config::LogNamespace,
         event::LogEvent,
         lookup::{
-            OwnedTargetPath, PathPrefix, event_path, lookup_v2::OptionalValuePath, owned_value_path,
+            OwnedTargetPath, PathPrefix, event_path, lookup_v2::OptionalValuePath,
+            owned_value_path, path,
         },
         schema::Definition,
     };
-    use vrl::value::{Kind, ObjectMap, kind::Collection};
+    use vrl::{
+        path::ValuePath as _,
+        value::{Kind, ObjectMap, kind::Collection},
+    };
 
     use super::{SimpleHttpConfig, remove_duplicates};
     use crate::{
@@ -1742,6 +1759,69 @@ mod tests {
                 list_dedup
             );
         }
+    }
+
+    #[test]
+    fn inject_auth_enrichment_does_not_clobber_vector_namespace_builtin_fields() {
+        use crate::{codecs::DecodingConfig, sources::util::HttpSource as _};
+        use vector_lib::codecs::BytesDeserializerConfig;
+        use vrl::value::KeyString;
+
+        let decoder = DecodingConfig::new(
+            BytesDecoderConfig::new().into(),
+            BytesDeserializerConfig::new().into(),
+            LogNamespace::Vector,
+        )
+        .build()
+        .unwrap()
+        .with_log_namespace(LogNamespace::Vector);
+
+        let source = super::SimpleHttpSource {
+            headers: vec![],
+            query_parameters: vec![],
+            path_key: OptionalValuePath::none(),
+            host_key: OptionalValuePath::none(),
+            decoder,
+            log_namespace: LogNamespace::Vector,
+        };
+
+        let mut log = LogEvent::default();
+        // Pre-populate %http_server.path as enrich_events would.
+        log.insert(
+            (
+                PathPrefix::Metadata,
+                path!(SimpleHttpConfig::NAME).concat(path!("path")),
+            ),
+            "/real/path",
+        );
+
+        let mut events = vec![Event::Log(log)];
+        let mut enrichment = ObjectMap::new();
+        // Attempt to clobber the built-in `path` field and inject a new field.
+        enrichment.insert(KeyString::from("path"), Value::from("/clobbered"));
+        enrichment.insert(KeyString::from("tenant_id"), Value::from("t-123"));
+
+        source.inject_auth_enrichment(&mut events, enrichment);
+
+        let Event::Log(log) = &events[0] else {
+            panic!("expected log event");
+        };
+        assert_eq!(
+            log.get((
+                PathPrefix::Metadata,
+                path!(SimpleHttpConfig::NAME).concat(path!("path")),
+            )),
+            Some(&Value::from("/real/path")),
+            "auth enrichment must not overwrite built-in source metadata"
+        );
+        assert_eq!(
+            log.get((
+                PathPrefix::Metadata,
+                path!(SimpleHttpConfig::NAME).concat(path!("tenant_id")),
+            )),
+            Some(&Value::from("t-123")),
+            "new auth enrichment field must be injected"
+        );
     }
 
     impl ValidatableComponent for SimpleHttpConfig {

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -433,12 +433,6 @@ struct SimpleHttpSource {
     log_namespace: LogNamespace,
 }
 
-/// Built-in `http_server` metadata keys written by `enrich_events` with a trusted value.
-/// Auth enrichment must not overwrite these; all other keys are auth-derived and may override
-/// client-supplied metadata from decoded events (e.g. a native-codec request).
-const RESERVED_HTTP_SERVER_METADATA_KEYS: &[&str] =
-    &["path", "host", "headers", "query_parameters"];
-
 impl HttpSource for SimpleHttpSource {
     /// Enriches the log events with metadata for the `request_path` and for each of the headers.
     /// Non-log events are skipped.
@@ -554,24 +548,11 @@ impl HttpSource for SimpleHttpSource {
                     let meta = event.metadata_mut().value_mut();
                     for (key, value) in &enrichment {
                         let key_str = key.as_str();
-                        if RESERVED_HTTP_SERVER_METADATA_KEYS.contains(&key_str) {
-                            // Built-in source key: skip if already written by enrich_events.
-                            if meta
-                                .get(path!(SimpleHttpConfig::NAME).concat(path!(key_str)))
-                                .is_none()
-                            {
-                                meta.insert(
-                                    path!(SimpleHttpConfig::NAME).concat(path!(key_str)),
-                                    value.clone(),
-                                );
-                            }
-                        } else {
-                            // Auth-derived key: overwrite any client-supplied value so
-                            // clients cannot spoof fields the auth program sets.
-                            meta.insert(
-                                path!(SimpleHttpConfig::NAME).concat(path!(key_str)),
-                                value.clone(),
-                            );
+                        let name_part = path!(SimpleHttpConfig::NAME);
+                        let key_part = path!(key_str);
+                        let full_path = name_part.concat(key_part);
+                        if meta.get(full_path.clone()).is_none() {
+                            meta.insert(full_path, value.clone());
                         }
                     }
                 }
@@ -1858,7 +1839,7 @@ mod tests {
     }
 
     #[test]
-    fn inject_auth_enrichment_overwrites_client_supplied_metadata_in_vector_namespace() {
+    fn inject_auth_enrichment_does_not_overwrite_existing_metadata_in_vector_namespace() {
         use crate::{codecs::DecodingConfig, sources::util::HttpSource as _};
         use vector_lib::codecs::BytesDeserializerConfig;
         use vrl::value::KeyString;
@@ -1882,18 +1863,18 @@ mod tests {
         };
 
         let mut log = LogEvent::default();
-        // Simulate a client pre-populating an auth-derived key (e.g. via native codec).
+        // Pre-populate a key (e.g. already written by enrich_events or the decoded event).
         log.insert(
             (
                 PathPrefix::Metadata,
                 path!(SimpleHttpConfig::NAME).concat(path!("tenant_id")),
             ),
-            "attacker",
+            "existing",
         );
 
         let mut events = vec![Event::Log(log)];
         let mut enrichment = ObjectMap::new();
-        enrichment.insert(KeyString::from("tenant_id"), Value::from("trusted"));
+        enrichment.insert(KeyString::from("tenant_id"), Value::from("auth-value"));
 
         source.inject_auth_enrichment(&mut events, enrichment);
 
@@ -1905,8 +1886,8 @@ mod tests {
                 PathPrefix::Metadata,
                 path!(SimpleHttpConfig::NAME).concat(path!("tenant_id")),
             )),
-            Some(&Value::from("trusted")),
-            "auth enrichment must overwrite client-supplied metadata for auth-derived keys"
+            Some(&Value::from("existing")),
+            "auth enrichment must not overwrite already-present metadata keys"
         );
     }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -220,9 +220,16 @@ impl SimpleHttpConfig {
             )
             .with_standard_vector_source_metadata();
 
-        // for metadata that is added to the events dynamically from config options
+        // For metadata that is added to the events dynamically from config options.
         if log_namespace == LogNamespace::Legacy {
-            schema_definition = schema_definition.unknown_fields(Kind::bytes());
+            // Custom auth programs can inject any VRL value, not just bytes; widen the unknown
+            // field kind accordingly so schema-aware downstream components don't reject events.
+            let unknown_kind = if matches!(self.auth, Some(HttpServerAuthConfig::Custom { .. })) {
+                Kind::any()
+            } else {
+                Kind::bytes()
+            };
+            schema_definition = schema_definition.unknown_fields(unknown_kind);
         }
 
         schema_definition
@@ -426,6 +433,12 @@ struct SimpleHttpSource {
     log_namespace: LogNamespace,
 }
 
+/// Built-in `http_server` metadata keys written by `enrich_events` with a trusted value.
+/// Auth enrichment must not overwrite these; all other keys are auth-derived and may override
+/// client-supplied metadata from decoded events (e.g. a native-codec request).
+const RESERVED_HTTP_SERVER_METADATA_KEYS: &[&str] =
+    &["path", "host", "headers", "query_parameters"];
+
 impl HttpSource for SimpleHttpSource {
     /// Enriches the log events with metadata for the `request_path` and for each of the headers.
     /// Non-log events are skipped.
@@ -529,23 +542,43 @@ impl HttpSource for SimpleHttpSource {
     /// Both namespaces use insert-if-empty semantics so auth enrichment never
     /// overwrites built-in source metadata (`path`, `host`, `headers`, …) that
     /// `enrich_events` already populated.
-    /// Legacy namespace: inserted into the event body.
-    /// Vector namespace: inserted into event metadata under `http_server.<field>`.
+    /// Vector namespace: inserted into event metadata under `http_server.<field>` for
+    ///   all event types (Log, Metric, Trace).
+    /// Legacy namespace: inserted into the Log event body only (Metric/Trace are skipped).
     fn inject_auth_enrichment(&self, events: &mut [Event], enrichment: ObjectMap) {
         for event in events.iter_mut() {
-            if let Event::Log(log) = event {
-                for (key, value) in &enrichment {
-                    match self.log_namespace {
-                        LogNamespace::Vector => {
-                            log.try_insert(
-                                (
-                                    PathPrefix::Metadata,
-                                    path!(SimpleHttpConfig::NAME).concat(path!(key.as_str())),
-                                ),
+            match self.log_namespace {
+                LogNamespace::Vector => {
+                    // metadata_mut() dispatches to Log, Metric, and Trace so every
+                    // decoded event type receives the auth enrichment fields.
+                    let meta = event.metadata_mut().value_mut();
+                    for (key, value) in &enrichment {
+                        let key_str = key.as_str();
+                        if RESERVED_HTTP_SERVER_METADATA_KEYS.contains(&key_str) {
+                            // Built-in source key: skip if already written by enrich_events.
+                            if meta
+                                .get(path!(SimpleHttpConfig::NAME).concat(path!(key_str)))
+                                .is_none()
+                            {
+                                meta.insert(
+                                    path!(SimpleHttpConfig::NAME).concat(path!(key_str)),
+                                    value.clone(),
+                                );
+                            }
+                        } else {
+                            // Auth-derived key: overwrite any client-supplied value so
+                            // clients cannot spoof fields the auth program sets.
+                            meta.insert(
+                                path!(SimpleHttpConfig::NAME).concat(path!(key_str)),
                                 value.clone(),
                             );
                         }
-                        LogNamespace::Legacy => {
+                    }
+                }
+                LogNamespace::Legacy => {
+                    // Legacy enrichment targets the event body; only Log events have one.
+                    if let Event::Log(log) = event {
+                        for (key, value) in &enrichment {
                             log.try_insert((PathPrefix::Event, path!(key.as_str())), value.clone());
                         }
                     }
@@ -1821,6 +1854,111 @@ mod tests {
             )),
             Some(&Value::from("t-123")),
             "new auth enrichment field must be injected"
+        );
+    }
+
+    #[test]
+    fn inject_auth_enrichment_overwrites_client_supplied_metadata_in_vector_namespace() {
+        use crate::{codecs::DecodingConfig, sources::util::HttpSource as _};
+        use vector_lib::codecs::BytesDeserializerConfig;
+        use vrl::value::KeyString;
+
+        let decoder = DecodingConfig::new(
+            BytesDecoderConfig::new().into(),
+            BytesDeserializerConfig::new().into(),
+            LogNamespace::Vector,
+        )
+        .build()
+        .unwrap()
+        .with_log_namespace(LogNamespace::Vector);
+
+        let source = super::SimpleHttpSource {
+            headers: vec![],
+            query_parameters: vec![],
+            path_key: OptionalValuePath::none(),
+            host_key: OptionalValuePath::none(),
+            decoder,
+            log_namespace: LogNamespace::Vector,
+        };
+
+        let mut log = LogEvent::default();
+        // Simulate a client pre-populating an auth-derived key (e.g. via native codec).
+        log.insert(
+            (
+                PathPrefix::Metadata,
+                path!(SimpleHttpConfig::NAME).concat(path!("tenant_id")),
+            ),
+            "attacker",
+        );
+
+        let mut events = vec![Event::Log(log)];
+        let mut enrichment = ObjectMap::new();
+        enrichment.insert(KeyString::from("tenant_id"), Value::from("trusted"));
+
+        source.inject_auth_enrichment(&mut events, enrichment);
+
+        let Event::Log(log) = &events[0] else {
+            panic!("expected log event");
+        };
+        assert_eq!(
+            log.get((
+                PathPrefix::Metadata,
+                path!(SimpleHttpConfig::NAME).concat(path!("tenant_id")),
+            )),
+            Some(&Value::from("trusted")),
+            "auth enrichment must overwrite client-supplied metadata for auth-derived keys"
+        );
+    }
+
+    #[test]
+    fn inject_auth_enrichment_applies_to_non_log_events_in_vector_namespace() {
+        use crate::{codecs::DecodingConfig, sources::util::HttpSource as _};
+        use vector_lib::{
+            codecs::BytesDeserializerConfig,
+            event::{Metric, MetricKind, MetricValue},
+        };
+        use vrl::value::KeyString;
+
+        let decoder = DecodingConfig::new(
+            BytesDecoderConfig::new().into(),
+            BytesDeserializerConfig::new().into(),
+            LogNamespace::Vector,
+        )
+        .build()
+        .unwrap()
+        .with_log_namespace(LogNamespace::Vector);
+
+        let source = super::SimpleHttpSource {
+            headers: vec![],
+            query_parameters: vec![],
+            path_key: OptionalValuePath::none(),
+            host_key: OptionalValuePath::none(),
+            decoder,
+            log_namespace: LogNamespace::Vector,
+        };
+
+        let metric = Metric::new(
+            "requests",
+            MetricKind::Incremental,
+            MetricValue::Counter { value: 1.0 },
+        );
+        let mut events = vec![Event::Metric(metric)];
+
+        let mut enrichment = ObjectMap::new();
+        enrichment.insert(KeyString::from("tenant_id"), Value::from("t-456"));
+
+        source.inject_auth_enrichment(&mut events, enrichment);
+
+        let Event::Metric(metric) = &events[0] else {
+            panic!("expected metric event");
+        };
+        assert_eq!(
+            metric
+                .metadata()
+                .value()
+                .get(path!(SimpleHttpConfig::NAME).concat(path!("tenant_id")),),
+            Some(&Value::from("t-456")),
+            "auth enrichment must be written to non-log event metadata"
         );
     }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -117,6 +117,14 @@ pub struct SimpleHttpConfig {
     #[configurable(metadata(docs::examples = "*"))]
     query_parameters: Vec<String>,
 
+    /// HTTP authentication configuration.
+    ///
+    /// Use HTTP authentication with HTTPS only. The authentication credentials are passed as an
+    /// HTTP header without any additional encryption beyond what is provided by the transport itself.
+    ///
+    /// When using the `custom` strategy, the VRL program may write `%field = value` to enrich
+    /// authenticated events. These metadata fields are injected into the event body (legacy
+    /// namespace) or under `http_server.<field>` in event metadata (Vector namespace).
     #[configurable(derived)]
     auth: Option<HttpServerAuthConfig>,
 

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -11,6 +11,7 @@ use vector_lib::{
     config::SourceAcknowledgementsConfig,
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event},
 };
+use vrl::value::ObjectMap;
 use warp::{
     Filter,
     filters::{
@@ -55,6 +56,9 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         query_parameters: &HashMap<String, String>,
         path: &str,
     ) -> Result<Vec<Event>, ErrorMessage>;
+
+    /// Called after `enrich_events` when `custom` auth returned metadata enrichment fields.
+    fn inject_auth_enrichment(&self, _events: &mut [Event], _enrichment: ObjectMap) {}
 
     fn decode(&self, encoding_header: Option<&str>, body: Bytes) -> Result<Bytes, ErrorMessage> {
         decompress_body(encoding_header, body)
@@ -132,23 +136,27 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                         let http_path = path.as_str();
                         let events = auth_matcher
                             .as_ref()
-                            .map_or(Ok(()), |a| {
+                            .map_or(Ok(None), |a| {
                                 a.handle_auth(
                                     addr.as_ref().map(|a| a.0).as_ref(),
                                     &headers,
                                     path.as_str(),
                                 )
                             })
-                            .and_then(|()| self.decode(encoding_header.as_deref(), body))
-                            .and_then(|body| {
+                            .and_then(|auth_enrichment| {
+                                self.decode(encoding_header.as_deref(), body)
+                                    .map(|body| (body, auth_enrichment))
+                            })
+                            .and_then(|(body, auth_enrichment)| {
                                 emit!(HttpBytesReceived {
                                     byte_size: body.len(),
                                     http_path,
                                     protocol,
                                 });
                                 self.build_events(body, &headers, &query_parameters, path.as_str())
+                                    .map(|events| (events, auth_enrichment))
                             })
-                            .map(|mut events| {
+                            .map(|(mut events, auth_enrichment)| {
                                 emit!(HttpEventsReceived {
                                     count: events.len(),
                                     byte_size: events.estimated_json_encoded_size_of(),
@@ -165,6 +173,10 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                                         .map(|PeerAddr(inner_addr)| inner_addr)
                                         .as_ref(),
                                 );
+
+                                if let Some(enrichment) = auth_enrichment {
+                                    self.inject_auth_enrichment(&mut events, enrichment);
+                                }
 
                                 events
                             });

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -58,7 +58,16 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
     ) -> Result<Vec<Event>, ErrorMessage>;
 
     /// Called after `enrich_events` when `custom` auth returned metadata enrichment fields.
-    fn inject_auth_enrichment(&self, _events: &mut [Event], _enrichment: ObjectMap) {}
+    /// Sources that do not override this will emit a warning and drop the enrichment.
+    fn inject_auth_enrichment(&self, _events: &mut [Event], enrichment: ObjectMap) {
+        if !enrichment.is_empty() {
+            warn!(
+                message = "Auth metadata enrichment is not supported by this source and will be dropped. \
+                           Remove %field writes from the custom auth VRL program or switch to a source that supports enrichment.",
+                fields = ?enrichment.keys().collect::<Vec<_>>(),
+            );
+        }
+    }
 
     fn decode(&self, encoding_header: Option<&str>, body: Bytes) -> Result<Bytes, ErrorMessage> {
         decompress_body(encoding_header, body)

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -52,7 +52,7 @@ generated: components: sinks: websocket_server: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
+				description:   "The VRL boolean expression."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -72,8 +72,6 @@ generated: components: sinks: websocket_server: configuration: {
 						Custom authentication using VRL code.
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
-						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -52,7 +52,7 @@ generated: components: sinks: websocket_server: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression."
+				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -71,7 +71,9 @@ generated: components: sinks: websocket_server: configuration: {
 					custom: """
 						Custom authentication using VRL code.
 
-						Takes in request and validates it using VRL code.
+						Takes in request and validates it using VRL code. The VRL program must return a boolean.
+						Metadata fields written via `%field = value` in the VRL program are extracted and injected
+						into every authenticated event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -73,7 +73,7 @@ generated: components: sinks: websocket_server: configuration: {
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
 						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into every authenticated event.
+						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/heroku_logs.cue
+++ b/website/cue/reference/components/sources/generated/heroku_logs.cue
@@ -43,7 +43,7 @@ generated: components: sources: heroku_logs: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
+				description:   "The VRL boolean expression."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -63,8 +63,6 @@ generated: components: sources: heroku_logs: configuration: {
 						Custom authentication using VRL code.
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
-						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/heroku_logs.cue
+++ b/website/cue/reference/components/sources/generated/heroku_logs.cue
@@ -64,7 +64,7 @@ generated: components: sources: heroku_logs: configuration: {
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
 						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into every authenticated event.
+						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/heroku_logs.cue
+++ b/website/cue/reference/components/sources/generated/heroku_logs.cue
@@ -43,7 +43,7 @@ generated: components: sources: heroku_logs: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression."
+				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -62,7 +62,9 @@ generated: components: sources: heroku_logs: configuration: {
 					custom: """
 						Custom authentication using VRL code.
 
-						Takes in request and validates it using VRL code.
+						Takes in request and validates it using VRL code. The VRL program must return a boolean.
+						Metadata fields written via `%field = value` in the VRL program are extracted and injected
+						into every authenticated event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -33,10 +33,14 @@ generated: components: sources: http: configuration: {
 	}
 	auth: {
 		description: """
-			Configuration of the authentication strategy for server mode sinks and sources.
+			HTTP authentication configuration.
 
-			Use the HTTP authentication with HTTPS only. The authentication credentials are passed as an
+			Use HTTP authentication with HTTPS only. The authentication credentials are passed as an
 			HTTP header without any additional encryption beyond what is provided by the transport itself.
+
+			When using the `custom` strategy, the VRL program may write `%field = value` to enrich
+			authenticated events. These metadata fields are injected into the event body (legacy
+			namespace) or under `http_server.<field>` in event metadata (Vector namespace).
 			"""
 		required: false
 		type: object: options: {
@@ -47,7 +51,7 @@ generated: components: sources: http: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
+				description:   "The VRL boolean expression."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -67,8 +71,6 @@ generated: components: sources: http: configuration: {
 						Custom authentication using VRL code.
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
-						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -47,7 +47,7 @@ generated: components: sources: http: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression."
+				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -66,7 +66,9 @@ generated: components: sources: http: configuration: {
 					custom: """
 						Custom authentication using VRL code.
 
-						Takes in request and validates it using VRL code.
+						Takes in request and validates it using VRL code. The VRL program must return a boolean.
+						Metadata fields written via `%field = value` in the VRL program are extracted and injected
+						into every authenticated event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -68,7 +68,7 @@ generated: components: sources: http: configuration: {
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
 						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into every authenticated event.
+						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -47,7 +47,7 @@ generated: components: sources: http_server: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression."
+				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -66,7 +66,9 @@ generated: components: sources: http_server: configuration: {
 					custom: """
 						Custom authentication using VRL code.
 
-						Takes in request and validates it using VRL code.
+						Takes in request and validates it using VRL code. The VRL program must return a boolean.
+						Metadata fields written via `%field = value` in the VRL program are extracted and injected
+						into every authenticated event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -33,10 +33,14 @@ generated: components: sources: http_server: configuration: {
 	}
 	auth: {
 		description: """
-			Configuration of the authentication strategy for server mode sinks and sources.
+			HTTP authentication configuration.
 
-			Use the HTTP authentication with HTTPS only. The authentication credentials are passed as an
+			Use HTTP authentication with HTTPS only. The authentication credentials are passed as an
 			HTTP header without any additional encryption beyond what is provided by the transport itself.
+
+			When using the `custom` strategy, the VRL program may write `%field = value` to enrich
+			authenticated events. These metadata fields are injected into the event body (legacy
+			namespace) or under `http_server.<field>` in event metadata (Vector namespace).
 			"""
 		required: false
 		type: object: options: {
@@ -47,7 +51,7 @@ generated: components: sources: http_server: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
+				description:   "The VRL boolean expression."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -67,8 +71,6 @@ generated: components: sources: http_server: configuration: {
 						Custom authentication using VRL code.
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
-						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -68,7 +68,7 @@ generated: components: sources: http_server: configuration: {
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
 						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into every authenticated event.
+						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_pushgateway.cue
@@ -57,7 +57,7 @@ generated: components: sources: prometheus_pushgateway: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression."
+				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -76,7 +76,9 @@ generated: components: sources: prometheus_pushgateway: configuration: {
 					custom: """
 						Custom authentication using VRL code.
 
-						Takes in request and validates it using VRL code.
+						Takes in request and validates it using VRL code. The VRL program must return a boolean.
+						Metadata fields written via `%field = value` in the VRL program are extracted and injected
+						into every authenticated event.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_pushgateway.cue
@@ -57,7 +57,7 @@ generated: components: sources: prometheus_pushgateway: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
+				description:   "The VRL boolean expression."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -77,8 +77,6 @@ generated: components: sources: prometheus_pushgateway: configuration: {
 						Custom authentication using VRL code.
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
-						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_pushgateway.cue
@@ -78,7 +78,7 @@ generated: components: sources: prometheus_pushgateway: configuration: {
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
 						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into every authenticated event.
+						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_remote_write.cue
@@ -47,7 +47,7 @@ generated: components: sources: prometheus_remote_write: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
+				description:   "The VRL boolean expression."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -67,8 +67,6 @@ generated: components: sources: prometheus_remote_write: configuration: {
 						Custom authentication using VRL code.
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
-						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_remote_write.cue
@@ -68,7 +68,7 @@ generated: components: sources: prometheus_remote_write: configuration: {
 
 						Takes in request and validates it using VRL code. The VRL program must return a boolean.
 						Metadata fields written via `%field = value` in the VRL program are extracted and injected
-						into every authenticated event.
+						into the log's body if log namespacing is enabled.
 						"""
 				}
 			}

--- a/website/cue/reference/components/sources/generated/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_remote_write.cue
@@ -47,7 +47,7 @@ generated: components: sources: prometheus_remote_write: configuration: {
 				type: string: examples: ["${PASSWORD}", "password"]
 			}
 			source: {
-				description:   "The VRL boolean expression."
+				description:   "The VRL boolean expression. May write `%field = value` to enrich events."
 				relevant_when: "strategy = \"custom\""
 				required:      true
 				type: string: {}
@@ -66,7 +66,9 @@ generated: components: sources: prometheus_remote_write: configuration: {
 					custom: """
 						Custom authentication using VRL code.
 
-						Takes in request and validates it using VRL code.
+						Takes in request and validates it using VRL code. The VRL program must return a boolean.
+						Metadata fields written via `%field = value` in the VRL program are extracted and injected
+						into every authenticated event.
 						"""
 				}
 			}


### PR DESCRIPTION
## Summary

This PR extends the existing `custom` auth strategy for `http_server` source to support event enrichment via metadata writes.

Previously, `custom` auth used `set_read_only()` which locked both event body (`.field`) and metadata (`%field`). This change switches to `set_read_only_path(event_root)`, which keeps the event body read-only while allowing the VRL program to write `%field = value`. Any metadata written during auth is extracted and injected into every authenticated event.

This avoids introducing a separate `custom_enriching` strategy — the enrichment capability is folded directly into `custom`, keeping the UX surface minimal. Existing `custom` configs that don't write metadata are unaffected (they still return no enrichment).

### Behavior

| Strategy | Event body (`.field`) | Metadata (`%field`) | Enriches events? |
|---|---|---|---|
| `basic` | n/a | n/a | No |
| `custom` | read-only | **writable** | Yes, if `%field` written |

### Example

```yaml
auth:
  strategy: custom
  source: |
    %tenant_id = .headers."x-tenant-id"
    .headers.authorization == "Bearer secret"
```

Any authenticated event will have `tenant_id` injected from the auth VRL program.

## Vector configuration

```yaml
sources:
  my_source:
    type: http_server
    address: 0.0.0.0:8080
    auth:
      strategy: custom
      source: |
        %tenant_id = .headers."x-tenant-id"
        .headers.authorization == "Bearer secret"
```

## How did you test this PR?

- Unit tests in `src/common/http/server_auth.rs` covering:
  - Backward compat: existing `custom` scripts without metadata writes still return `Ok(None)` (no enrichment, no behavior change)
  - Metadata writes via `%field = value` are captured and returned as enrichment
  - Attempting to write event body fields (`.field`) still fails at compile time
- `make check-clippy` passes

## Change Type

- [x] New feature

## Is this a breaking change?

- [x] No

The existing `custom` strategy gains new capability (metadata writes allowed), but all previously valid `custom` programs continue to work identically.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).

## References

- Closes: #25391 (review feedback: fold enrichment into existing `custom` strategy instead of adding `custom_enriching`)