### PR TITLE
fix(ci): fix LTO settings after release-flags.sh removal

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -73,6 +73,7 @@ jobs:
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
+      CARGO_PROFILE_RELEASE_LTO: thin # fat LTO OOMs/timeouts on standard 16GB runners; thin is sufficient to verify linking
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
       CARGO_INCREMENTAL: 0
       DISABLE_MOLD: true

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -188,7 +188,7 @@ jobs:
   build-baseline:
     name: Build baseline Vector container
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - should-run-gate
       - resolve-inputs
@@ -231,7 +231,7 @@ jobs:
   build-comparison:
     name: Build comparison Vector container
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - should-run-gate
       - resolve-inputs


### PR DESCRIPTION
## Summary

- `release-flags.sh` removal (#24828) baked `lto = \"fat\"` into `Cargo.toml`, which now applies to Docker-based builds (regression detector) and any workflow that didn't previously get the fat LTO env vars
- Regression detector `build-baseline`/`build-comparison` jobs were timing out at 30 min because the Dockerfile-based build now picks up fat LTO from `Cargo.toml` — timeout bumped to 60 min since fat LTO is correct for accurate regression measurement
- k8s build job already disables optimizations (`OPT_LEVEL=0`, `CODEGEN_UNITS=256`) but was missing an LTO override; added `CARGO_PROFILE_RELEASE_LTO: thin` consistent with the fix applied to `cross.yml` in #24828

## Vector configuration

NA

## How did you test this PR?

Reviewed the diff from #24828 and traced which workflows were missing LTO overrides.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #24828