### PR TITLE
fix(vdev): emit channel-suffixed version from publish-metadata

### DIFF
--- a/vdev/src/commands/build/publish_metadata.rs
+++ b/vdev/src/commands/build/publish_metadata.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use chrono::prelude::*;
 
-use crate::utils::{cargo, git};
+use crate::{app, utils::git};
 use std::{
     env,
     fs::OpenOptions,
@@ -20,8 +20,9 @@ pub struct Cli {}
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        // Generate the Vector version and build description.
-        let version = cargo::get_version()?;
+        // Use `app::version()` so the emitted `vector_version` matches archive filenames
+        // (which include `.custom.<sha>` on custom-channel runs).
+        let version = app::version()?;
 
         let git_sha = git::get_git_sha()?;
         let current_date = Local::now().naive_local().to_string();


### PR DESCRIPTION
## Summary

`cargo vdev build publish-metadata` was emitting `vector_version` without the channel suffix because it called `cargo::get_version()` (which only reads `VERSION` env / `Cargo.toml`). The packaging Makefile and `cargo vdev version` go through `app::version()`, which appends `.custom.<sha>` for custom-channel builds.

The mismatch breaks deb/rpm packaging in custom-channel CI runs:
- `make package-...-all` produces archives named `vector-<ver>.custom.<sha>-<target>.tar.gz` (via `cargo vdev version`).
- `package-deb.sh` looks for `vector-<ver>-<target>.tar.gz` using the suffix-stripped `VECTOR_VERSION` env from publish-metadata.

Result: tar fails with `Cannot open: No such file or directory` and the deb/rpm packaging step blows up on every custom-channel build that gets that far.

Release-channel runs are unaffected because the suffix is empty there.

## Vector configuration

NA. Build-tooling change.

## How did you test this PR?

Repro: trigger a custom build, watch the packaging step in the previous run produce one filename and the deb/rpm step look for another.

After this fix: `app::version()` is the single source of truth, so `vector_version` (CI output), `cargo vdev version`, and the archive filename all agree.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

Build-tooling fix; no user-visible behavior change.

## References

- Related: #25387 (the EL8 install fix that surfaced this latent bug)