### PR TITLE
chore(ci): use debug profile for k8s e2e build

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -70,11 +70,7 @@ jobs:
     needs: changes
     # Run this job even if `changes` job is skipped
     if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' }}
-    # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
-      CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-      CARGO_PROFILE_RELEASE_LTO: thin # fat LTO OOMs/timeouts on standard 16GB runners; thin is sufficient to verify linking
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
       CARGO_INCREMENTAL: 0
       DISABLE_MOLD: true
     steps:

--- a/Makefile.packaging
+++ b/Makefile.packaging
@@ -11,20 +11,25 @@
 # packaging and release targets here automatically.
 
 VDEV := cargo vdev
+PROFILE ?= release
 
 # Set version — only evaluated when this Makefile is loaded
 export VERSION ?= $(shell command -v cargo >/dev/null && $(VDEV) version || echo unknown)
 
 # Delegate cross-compilation prerequisites to the main Makefile
-target/%/release/vector.tar.gz:
+target/%/vector.tar.gz:
 	unset TRIPLE && $(MAKE) $@
+
+# .SECONDEXPANSION allows prerequisites to reference $* (the pattern stem) and
+# $(PROFILE) (a variable) by escaping them as $$* and $$(PROFILE). Without it,
+# both would expand to empty at parse time before any target is matched.
+.SECONDEXPANSION:
 
 ##@ Packaging
 
 # archives
 target/artifacts/vector-${VERSION}-%.tar.gz: export TRIPLE :=$(@:target/artifacts/vector-${VERSION}-%.tar.gz=%)
-target/artifacts/vector-${VERSION}-%.tar.gz: override PROFILE =release
-target/artifacts/vector-${VERSION}-%.tar.gz: target/%/release/vector.tar.gz
+target/artifacts/vector-${VERSION}-%.tar.gz: target/$$*/$$(PROFILE)/vector.tar.gz
 	@echo "Built to ${<}, relocating to ${@}"
 	@mkdir -p target/artifacts/
 	@cp -v \

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -13,6 +13,7 @@ set -x
 #   $TARGET         a target triple. ex: arm64-apple-darwin (no default)
 
 TARGET="${TARGET:?"You must specify a target triple, ex: arm64-apple-darwin"}"
+PROFILE="${PROFILE:-release}"
 
 #
 # Local vars
@@ -39,8 +40,8 @@ echo "TARGET: $TARGET"
 td="$(mktemp -d)"
 pushd "$td"
 tar -xvf "$ABSOLUTE_ARCHIVE_PATH"
-mkdir -p "$PROJECT_ROOT/target/$TARGET/release"
-mv "vector-$TARGET/bin/vector" "$PROJECT_ROOT/target/$TARGET/release"
+mkdir -p "$PROJECT_ROOT/target/$TARGET/$PROFILE"
+mv "vector-$TARGET/bin/vector" "$PROJECT_ROOT/target/$TARGET/$PROFILE"
 popd
 rm -rf "$td"
 
@@ -71,7 +72,7 @@ cat LICENSE NOTICE >"$PROJECT_ROOT/target/debian-license.txt"
 #   --no-build
 #     because this step should follow a build
 
-cargo deb --target "$TARGET" --deb-version "${PACKAGE_VERSION}-1" --variant "$TARGET" --no-build --no-strip
+cargo deb --target "$TARGET" --deb-version "${PACKAGE_VERSION}-1" --variant "$TARGET" --no-build --no-strip --profile "$PROFILE"
 
 # Rename the resulting .deb file to remove TARGET from name.
 for file in target/"${TARGET}"/debian/*.deb; do


### PR DESCRIPTION
## Summary

The k8s e2e build job was using a release build with optimizations disabled via `CARGO_PROFILE_RELEASE_OPT_LEVEL=0` and `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256` as a workaround to get fast compile times. This switches to an actual debug build by making `Makefile.packaging` and `package-deb.sh` respect the `PROFILE` env variable (defaulting to `release`), and sets `PROFILE=debug` in the workflow.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References