### PR TITLE
chore(deps): bump vrl to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "regex",
@@ -2784,7 +2784,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3765,7 +3765,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5671,7 +5671,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -8727,7 +8727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -8747,8 +8747,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -8781,7 +8781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -8794,7 +8794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -9993,7 +9993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -10872,7 +10872,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -10884,7 +10884,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -11521,10 +11521,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -13576,7 +13576,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.32.0"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=main#8a5b4711f37d0b3bd4d0d2ea8bbb500942bd8e98"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=main#704351cc3fdec4415bbf89653b9ca2cd0dc20212"
 dependencies = [
  "aes",
  "aes-siv",

--- a/lib/codecs/src/encoding/format/otlp.rs
+++ b/lib/codecs/src/encoding/format/otlp.rs
@@ -64,6 +64,7 @@ impl OtlpSerializer {
     pub fn new() -> vector_common::Result<Self> {
         let options = Options {
             use_json_names: true,
+            allow_lossy_string_coercion: true,
         };
 
         let logs_descriptor = ProtobufSerializer::new_from_bytes(

--- a/lib/codecs/src/encoding/format/proto_batch.rs
+++ b/lib/codecs/src/encoding/format/proto_batch.rs
@@ -94,6 +94,7 @@ impl ProtoBatchSerializer {
             descriptor: Arc::new(descriptor),
             options: Options {
                 use_json_names: false,
+                allow_lossy_string_coercion: true,
             },
         })
     }

--- a/lib/codecs/src/encoding/format/protobuf.rs
+++ b/lib/codecs/src/encoding/format/protobuf.rs
@@ -32,6 +32,7 @@ impl ProtobufSerializerConfig {
             message_descriptor,
             options: Options {
                 use_json_names: self.protobuf.use_json_names,
+                allow_lossy_string_coercion: true,
             },
         })
     }

--- a/tests/e2e/opentelemetry/mod.rs
+++ b/tests/e2e/opentelemetry/mod.rs
@@ -69,6 +69,7 @@ where
         vrl_value,
         &vrl::protobuf::encode::Options {
             use_json_names: true,
+            allow_lossy_string_coercion: true,
         },
     )
     .map_err(|e| format!("Failed to encode VRL value to protobuf: {e}"))?;


### PR DESCRIPTION
## Summary

Routine bump of the `vrl` git dependency to the latest commit on `main` (`8a5b4711` -> `704351cc`).

The new vrl revision adds an `allow_lossy_string_coercion` field on
`vrl::protobuf::encode::Options`. All Vector call sites set it to `true`
to preserve current behavior (matches vrl's `Default`).

## Vector configuration

N/A — dependency bump.

## How did you test this PR?

- `cargo check --workspace`
- `cargo check --workspace --no-default-features`
- `cargo check --workspace --tests`
- `cargo fmt --check`
- `make build-licenses` (no diff)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A