### PR TITLE
fix(ci): skip dd-sts federation on fork PRs via ACTIONS_ID_TOKEN_REQUEST_URL guard

### DIFF
--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -26,6 +26,7 @@ runs:
     - name: Federate Datadog token
       id: dd-sts
       if: ${{ steps.oidc.outputs.available == 'true' }}
+      continue-on-error: true
       uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
       with:
         policy: ${{ inputs.policy }}

--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -10,11 +10,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Fork PRs don't get `id-token: write`, so federation cannot succeed.
-    # Allow the step to fail and let downstream steps run without DD credentials.
+    # Fork PRs don't get `id-token: write`, so ACTIONS_ID_TOKEN_REQUEST_URL is
+    # unset and federation will fail. Skip the step entirely in that case.
     - name: Federate Datadog token
       id: dd-sts
-      continue-on-error: true
+      if: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}
       uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
       with:
         policy: ${{ inputs.policy }}

--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -11,10 +11,21 @@ runs:
   using: "composite"
   steps:
     # Fork PRs don't get `id-token: write`, so ACTIONS_ID_TOKEN_REQUEST_URL is
-    # unset and federation will fail. Skip the step entirely in that case.
+    # unset. Read it via shell (env context only covers YAML-declared vars) and
+    # skip federation when absent to avoid a hard failure.
+    - name: Check OIDC token availability
+      id: oidc
+      shell: bash
+      run: |
+        if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Federate Datadog token
       id: dd-sts
-      if: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}
+      if: ${{ steps.oidc.outputs.available == 'true' }}
       uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
       with:
         policy: ${{ inputs.policy }}


### PR DESCRIPTION
## Summary

Fork PRs from external contributors cause the `test / Tests` job to fail at the `dd-token` action. GitHub sets `id-token: none` for fork PRs regardless of what the workflow declares, so `ACTIONS_ID_TOKEN_REQUEST_URL` is unset and `dd-sts-action` errors. The previous `continue-on-error: true` on the inner composite action step does not prevent the composite action itself from being marked as failed, causing all subsequent steps (`setup`, `Run tests`) to be skipped.

Fix: guard the federation step with `if: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}` so it is skipped entirely on fork PRs instead of failing.

## Vector configuration

NA

## How did you test this PR?

Verified against the failing run: 

Tested over at https://github.com/vectordotdev/ci-sandbox/pull/28

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/24966254869/job/75063045392?pr=24929