### PR TITLE
chore(dev): make -D warnings the default via .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,7 @@ JEMALLOC_SYS_WITH_LG_PAGE = "16"
 
 [target.'cfg(all())']
 rustflags = [
+  "-D", "warnings",
   "-Dclippy::print_stdout",
   "-Dclippy::print_stderr",
   "-Dclippy::dbg_macro",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,4 +36,4 @@ rustflags = ["-C", "link-args=-rdynamic"]
 
 [target.x86_64-pc-windows-msvc]
 # https://github.com/dtolnay/inventory/issues/58
-rustflags = ["-C", "codegen-units=1"]
+rustflags = ["-C", "codegen-units=1", "-Ctarget-feature=+crt-static"]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -149,17 +149,6 @@ runs:
       run: echo "::add-matcher::.github/matchers/rust.json"
       shell: bash
 
-    - name: Override warnings
-      if: ${{ env.NEEDS_RUST == 'true' }}
-      run: |
-        CARGO_OVERRIDE_DIR="${HOME}/.cargo"
-        CARGO_OVERRIDE_CONF="${CARGO_OVERRIDE_DIR}/config.toml"
-        cat <<EOF >>"$CARGO_OVERRIDE_CONF"
-        [target.'cfg(linux)']
-        rustflags = [ "-D", "warnings" ]
-        EOF
-      shell: bash
-
     - name: Cache Cargo registry, index, and git DB
       if: ${{ inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true' || env.VDEV_NEEDS_COMPILE == 'true' }}
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,6 @@ jobs:
       VECTOR_VERSION: ${{ needs.generate-publish-metadata.outputs.vector_version }}
       VECTOR_BUILD_DESC: ${{ needs.generate-publish-metadata.outputs.vector_build_desc }}
       CHANNEL: ${{ needs.generate-publish-metadata.outputs.vector_release_channel }}
-      RUSTFLAGS: "-D warnings -Ctarget-feature=+crt-static"
       RELEASE_BUILDER: "true"
     steps:
       - name: Checkout Vector

--- a/vdev/src/commands/check/rust.rs
+++ b/vdev/src/commands/check/rust.rs
@@ -36,12 +36,6 @@ impl Cli {
             Vec::default()
         };
 
-        let clippy_args = if self.clippy {
-            vec!["--", "-D", "warnings"]
-        } else {
-            Vec::default()
-        };
-
         let feature_args = if self.features.is_empty() {
             vec!["--all-features".to_string()]
         } else {
@@ -55,7 +49,6 @@ impl Cli {
         [tool.as_ref(), "--workspace", "--all-targets"]
             .chain_args(feature_args)
             .chain_args(pre_args)
-            .chain_args(clippy_args)
     }
 
     pub fn exec(self) -> Result<()> {


### PR DESCRIPTION
## Summary

Move `-D warnings` from the CI setup action and vdev's explicit clippy args into the `[target.'cfg(all())']` section of `.cargo/config.toml`. This makes warnings-as-errors the default for all targets and all cargo subcommands (build, test, clippy) in both local development and CI.

Previously, `-D warnings` was injected only for Linux targets in CI via a `~/.cargo/config.toml` override, and passed explicitly to clippy via vdev. Now it's in one place and covers all platforms.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA