### PR TITLE
chore(ci): centralize CARGO_INCREMENTAL=0 in setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -142,7 +142,7 @@ runs:
           echo "RUST_BACKTRACE=full" >> "$GITHUB_ENV"
           # Set nice CI colors
           echo "CARGO_TERM_COLOR=always" >> "$GITHUB_ENV"
-          # Incremental compilation is useless in CI: no state is shared between runs
+          # Incremental compilation has no benefit because in our CI we always start from a clean state.
           echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
         fi
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -142,6 +142,8 @@ runs:
           echo "RUST_BACKTRACE=full" >> "$GITHUB_ENV"
           # Set nice CI colors
           echo "CARGO_TERM_COLOR=always" >> "$GITHUB_ENV"
+          # Incremental compilation is useless in CI: no state is shared between runs
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
         fi
 
     - name: Enable rust matcher

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,6 @@ permissions:
   contents: read
 
 env:
-  CARGO_INCREMENTAL: "0" # Disable incremental compilation for coverage
   CI: true
 
 jobs:

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -72,10 +72,6 @@ jobs:
     if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' && needs.changes.outputs.website_only != 'true' && needs.changes.outputs.k8s != 'false' }}
     # cargo-deb requires a release build, but we don't need optimizations for tests
     env:
-      CARGO_PROFILE_RELEASE_OPT_LEVEL: 0
-      CARGO_PROFILE_RELEASE_LTO: thin # fat LTO OOMs/timeouts on standard 16GB runners; thin is sufficient to verify linking
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 256
-      CARGO_INCREMENTAL: 0
       DISABLE_MOLD: true
     steps:
       - name: Checkout branch
@@ -211,7 +207,6 @@ jobs:
         env:
           USE_MINIKUBE_CACHE: "true"
           SKIP_PACKAGE_DEB: "true"
-          CARGO_INCREMENTAL: 0
           HELM_CHART_REPO: ${{ github.workspace }}/helm-charts/charts/vector
         with:
           timeout_minutes: 45

--- a/.github/workflows/test-make-command.yml
+++ b/.github/workflows/test-make-command.yml
@@ -37,7 +37,6 @@ jobs:
       id-token: write
     timeout-minutes: 90
     env:
-      CARGO_INCREMENTAL: 0
       DD_ENV: "ci"
     steps:
       - name: Checkout branch

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,6 @@ permissions:
   contents: read
 
 env:
-  CARGO_INCREMENTAL: "0"
   CI: true
   DD_ENV: "ci"
 

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -15,8 +15,6 @@ jobs:
   unit-mac:
     runs-on: macos-14-xlarge
     timeout-minutes: 90
-    env:
-      CARGO_INCREMENTAL: 0
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Incremental compilation is only useful when intermediate artifacts are cached between builds. In CI, each run starts from a clean state, so incremental compilation adds overhead (extra bookkeeping, larger artifacts) without any benefit. It can also cause subtle cache poisoning issues where stale incremental state from a partially-warmed cache leads to build failures.

Previously, `CARGO_INCREMENTAL=0` was set independently in several workflow files, and some workflows didn't set it at all. This consolidates it into the shared setup action so it's applied uniformly across all CI jobs without requiring each workflow to remember to set it.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA