### PR TITLE
fix(ci): include lib/ workspace crates in coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ test-component-validation: ## Runs component validation tests
 
 .PHONY: coverage-report
 coverage-report: ## Generate lcov report after running tests with COVERAGE=true (outputs lcov.info)
-	cargo llvm-cov report --workspace --lcov --output-path lcov.info
+	cargo llvm-cov report --lcov --output-path lcov.info
 
 ##@ Benching (Supports `ENVIRONMENT=true`)
 

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ test-component-validation: ## Runs component validation tests
 
 .PHONY: coverage-report
 coverage-report: ## Generate lcov report after running tests with COVERAGE=true (outputs lcov.info)
-	cargo llvm-cov report --lcov --output-path lcov.info
+	cargo llvm-cov report --workspace --lcov --output-path lcov.info
 
 ##@ Benching (Supports `ENVIRONMENT=true`)
 

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -33,6 +33,7 @@ const COVERAGE_COMMAND: &[&str] = &[
     "cargo",
     "llvm-cov",
     "nextest",
+    "--workspace",
     "--no-fail-fast",
     "--no-default-features",
 ];


### PR DESCRIPTION
## Summary

`cargo llvm-cov report` and the integration test coverage command were both missing `--workspace`, so coverage data for `lib/` workspace crates was collected but then filtered out at report time — only the root `vector` package (`src/`) appeared in the output.

## Vector configuration

NA

## How did you test this PR?

`/ci-run-coverage`

CI run: https://github.com/vectordotdev/vector/actions/runs/25584248327?pr=25402

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25088