### PR TITLE
chore(config): Fix unstable name collision with Mergeable::merge

### DIFF
--- a/lib/vector-config/src/schema/visitors/merge.rs
+++ b/lib/vector-config/src/schema/visitors/merge.rs
@@ -262,7 +262,7 @@ where
     K: Clone + Eq + Ord,
     V: Clone + Mergeable,
 {
-    destination.merge(source);
+    Mergeable::merge(destination, source);
 }
 
 fn merge_optional<T: Clone>(destination: &mut Option<T>, source: Option<&T>) {


### PR DESCRIPTION
## Summary
With rust 1.95.0 the build fails due to an unstable name collision in vector-config:
```
   Compiling vector-config v0.1.0 (/build/vector/src/vector/lib/vector-config)
error: a method with this name may be added to the standard library in the future
   --> lib/vector-config/src/schema/visitors/merge.rs:265:17
    |
265 |     destination.merge(source);
    |                 ^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <[https://github.com/rust-lang/rust/issues/48919](https://github.com/rust-lang/rust/issues/48919)>
    = help: call with fully qualified syntax `Mergeable::merge(...)` to keep using the current method
note: the lint level is defined here
   --> lib/vector-config/src/lib.rs:104:9
    |
104 | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(unstable_name_collisions)]` implied by `#[deny(warnings)]`

error: could not compile `vector-config` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

This fixes that.

## How did you test this PR?

Included in the [latest Arch Linux PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/vector/-/commit/a41530846277bfe6130c71b59ee2c2fe7564d9fc) to build with `rust` instead of `rustup`.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [X] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the `no-changelog` label to this PR.

## References

https://gitlab.archlinux.org/archlinux/packaging/packages/vector/-/merge_requests/2
