### PR TITLE
fix(databricks_zerobus sink): defer Unity Catalog schema fetch out of build()

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -127,7 +127,6 @@ jobs:
             aws service
             azure service
             confluent service
-            databricks_zerobus sink
             datadog service
             elastic service
             gcp service

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -222,6 +222,7 @@ jobs:
             blackhole sink
             clickhouse sink
             console sink
+            databricks_zerobus sink
             datadog_archives sink
             datadog_common sink
             datadog_events sink

--- a/changelog.d/25408_databricks_zerobus_lazy_schema.fix.md
+++ b/changelog.d/25408_databricks_zerobus_lazy_schema.fix.md
@@ -1,3 +1,0 @@
-The `databricks_zerobus` sink no longer exits Vector at startup when the Unity Catalog table is missing or OAuth credentials are invalid. Schema resolution and stream creation are now deferred to the healthcheck (and to the first batch when `healthcheck.enabled = false`), so failures surface per-batch via the existing retry/event-status path instead of as a fatal config error. Process exit on a misconfigured target is now opt-in via `require_healthy: true`, matching the behavior of `aws_s3` and `kafka`.
-
-authors: flaviocruz

--- a/changelog.d/25408_databricks_zerobus_lazy_schema.fix.md
+++ b/changelog.d/25408_databricks_zerobus_lazy_schema.fix.md
@@ -1,0 +1,3 @@
+The `databricks_zerobus` sink no longer exits Vector at startup when the Unity Catalog table is missing or OAuth credentials are invalid. Schema resolution and stream creation are now deferred to the healthcheck (and to the first batch when `healthcheck.enabled = false`), so failures surface per-batch via the existing retry/event-status path instead of as a fatal config error. Process exit on a misconfigured target is now opt-in via `require_healthy: true`, matching the behavior of `aws_s3` and `kafka`.
+
+authors: flaviocruz

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -9,15 +9,7 @@ use crate::sinks::{
     util::{BatchConfig, RealtimeSizeBasedDefaultBatchSettings},
 };
 
-use vector_lib::codecs::encoding::{
-    BatchEncoder, BatchSerializerConfig, ProtoBatchSerializerConfig,
-};
-
-use super::{
-    error::ZerobusSinkError,
-    service::{StreamMode, ZerobusService},
-    sink::ZerobusSink,
-};
+use super::{error::ZerobusSinkError, service::ZerobusService, sink::ZerobusSink};
 
 /// Authentication configuration for Databricks.
 #[configurable_component]
@@ -163,27 +155,12 @@ impl SinkConfig for ZerobusSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         self.validate()?;
 
-        let descriptor = ZerobusService::resolve_descriptor(self, cx.proxy()).await?;
-
-        // The zerobus sink always encodes in proto_batch form — the stream
-        // descriptor is the one we just resolved from Unity Catalog.
-        let descriptor_proto = std::sync::Arc::new(descriptor.descriptor_proto().clone());
-        let stream_mode = StreamMode::Proto { descriptor_proto };
-
-        let proto_config = ProtoBatchSerializerConfig {
-            descriptor: Some(descriptor),
-        };
-        let batch_serializer = BatchSerializerConfig::ProtoBatch(proto_config)
-            .build_batch_serializer()
-            .map_err(|e| format!("Failed to build batch serializer: {}", e))?;
-        let encoder = BatchEncoder::new(batch_serializer);
-
-        let service = ZerobusService::new(self.clone(), stream_mode, cx.proxy()).await?;
+        let service = ZerobusService::new(self.clone(), cx.proxy()).await?;
         let healthcheck_service = service.clone();
 
         let request_limits = self.request.into_settings();
 
-        let sink = ZerobusSink::new(service, request_limits, self.batch, encoder)?;
+        let sink = ZerobusSink::new(service, request_limits, self.batch)?;
 
         let healthcheck = async move {
             healthcheck_service

--- a/src/sinks/databricks_zerobus/error.rs
+++ b/src/sinks/databricks_zerobus/error.rs
@@ -38,6 +38,35 @@ pub enum ZerobusSinkError {
     /// will create a fresh stream via `get_or_create_stream`.
     #[snafu(display("Zerobus stream was closed concurrently"))]
     StreamClosed,
+
+    /// Resolving the table schema from Unity Catalog failed. `retryable`
+    /// distinguishes transient failures (network, 5xx, 408, 429) from
+    /// permanent ones (404, 401, 403, ...).
+    #[snafu(display("Schema resolution failed: {}", message))]
+    SchemaError { message: String, retryable: bool },
+}
+
+impl ZerobusSinkError {
+    /// Whether this error should be retried.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::ZerobusError { source }
+            | Self::StreamInitError { source }
+            | Self::IngestionError { source } => source.is_retryable(),
+            Self::StreamClosed => true,
+            Self::SchemaError { retryable, .. } => *retryable,
+            Self::ConfigError { .. } | Self::EncodingError { .. } | Self::MissingAckOffset => false,
+        }
+    }
+
+    /// Event status to apply to a batch's finalizers when this error occurs.
+    pub fn event_status(&self) -> EventStatus {
+        if self.is_retryable() {
+            EventStatus::Errored
+        } else {
+            EventStatus::Rejected
+        }
+    }
 }
 
 impl From<ZerobusError> for ZerobusSinkError {
@@ -46,24 +75,9 @@ impl From<ZerobusError> for ZerobusSinkError {
     }
 }
 
-/// Convert Zerobus errors to Vector event status.
 impl From<ZerobusSinkError> for EventStatus {
     fn from(error: ZerobusSinkError) -> Self {
-        match error {
-            ZerobusSinkError::ConfigError { .. }
-            | ZerobusSinkError::EncodingError { .. }
-            | ZerobusSinkError::MissingAckOffset => EventStatus::Rejected,
-            ZerobusSinkError::StreamClosed => EventStatus::Errored,
-            ZerobusSinkError::ZerobusError { source }
-            | ZerobusSinkError::StreamInitError { source }
-            | ZerobusSinkError::IngestionError { source } => {
-                if source.is_retryable() {
-                    EventStatus::Errored
-                } else {
-                    EventStatus::Rejected
-                }
-            }
-        }
+        error.event_status()
     }
 }
 
@@ -169,5 +183,25 @@ mod tests {
             message: "bad".to_string(),
         };
         assert!(!logic.is_retriable_error(&error));
+    }
+
+    #[test]
+    fn retryable_schema_error_maps_to_errored() {
+        let error = ZerobusSinkError::SchemaError {
+            message: "UC 503".to_string(),
+            retryable: true,
+        };
+        assert!(ZerobusRetryLogic.is_retriable_error(&error));
+        assert_eq!(EventStatus::from(error), EventStatus::Errored);
+    }
+
+    #[test]
+    fn non_retryable_schema_error_maps_to_rejected() {
+        let error = ZerobusSinkError::SchemaError {
+            message: "UC 404".to_string(),
+            retryable: false,
+        };
+        assert!(!ZerobusRetryLogic.is_retriable_error(&error));
+        assert_eq!(EventStatus::from(error), EventStatus::Rejected);
     }
 }

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -9,7 +9,7 @@ use databricks_zerobus_ingest_sdk::{ConnectorFactory, ProxyConnector, ZerobusSdk
 use futures::future::BoxFuture;
 use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell, RwLock};
-use tower::Service;
+use tower::{Layer, Service};
 use tracing::warn;
 use vector_lib::codecs::encoding::{
     BatchEncoder, BatchOutput, BatchSerializerConfig, ProtoBatchSerializerConfig,
@@ -71,14 +71,40 @@ pub struct ZerobusRequest {
 }
 
 /// Response type for the Zerobus service.
+///
+/// Carries the final `EventStatus` so the driver can mark finalizers correctly:
+/// `Delivered` on success, `Errored` when the retry budget was exhausted on a
+/// transient failure (asking the source / disk buffer to replay), and `Err`
+/// from `Service::call` reserved for permanent failures (driver maps to
+/// `Rejected`).
 #[derive(Debug)]
 pub struct ZerobusResponse {
     pub events_byte_size: GroupedCountByteSize,
+    pub status: vector_lib::event::EventStatus,
+}
+
+impl ZerobusResponse {
+    const fn delivered(events_byte_size: GroupedCountByteSize) -> Self {
+        Self {
+            events_byte_size,
+            status: vector_lib::event::EventStatus::Delivered,
+        }
+    }
+
+    /// Synthesize a response signalling a transient failure that exhausted the
+    /// retry budget. Carries a telemetry-aware zero `events_byte_size` because
+    /// the driver only consumes `events_sent()` on the `Delivered` path.
+    fn errored() -> Self {
+        Self {
+            events_byte_size: vector_lib::config::telemetry().create_request_count_byte_size(),
+            status: vector_lib::event::EventStatus::Errored,
+        }
+    }
 }
 
 impl DriverResponse for ZerobusResponse {
     fn event_status(&self) -> vector_lib::event::EventStatus {
-        vector_lib::event::EventStatus::Delivered
+        self.status
     }
 
     fn events_sent(&self) -> &GroupedCountByteSize {
@@ -441,7 +467,7 @@ impl ZerobusService {
         };
 
         match result {
-            Ok(()) => Ok(ZerobusResponse { events_byte_size }),
+            Ok(()) => Ok(ZerobusResponse::delivered(events_byte_size)),
             Err(e) => {
                 if e.is_retryable() {
                     // Clear the slot so the next attempt creates a fresh stream,
@@ -556,6 +582,80 @@ impl RetryLogic for ZerobusRetryLogic {
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         error.is_retryable()
+    }
+}
+
+/// Tower layer that converts retry-budget-exhausted retryable errors into a
+/// successful `ZerobusResponse` carrying `EventStatus::Errored`.
+///
+/// Wraps the retry layer from the outside. When the retry layer returns:
+/// - `Ok(resp)` — pass through unchanged.
+/// - `Err(e)` where `e.is_retryable()` — convert to `Ok(ZerobusResponse::errored())`
+///   so the driver marks finalizers `Errored` (transient — source / disk
+///   buffer may replay) rather than `Rejected` (permanent drop).
+/// - `Err(e)` permanent — propagate so the driver maps to `Rejected`.
+///
+/// Without this layer the driver maps every `Err` from `Service::call` to
+/// `EventStatus::Rejected`, which would drop transient-but-exhausted failures
+/// as if they were permanent.
+#[derive(Clone, Debug, Default)]
+pub struct RetryableErrorAsErroredLayer;
+
+impl<S> Layer<S> for RetryableErrorAsErroredLayer {
+    type Service = RetryableErrorAsErrored<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RetryableErrorAsErrored { inner }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RetryableErrorAsErrored<S> {
+    inner: S,
+}
+
+impl<S> Service<ZerobusRequest> for RetryableErrorAsErrored<S>
+where
+    S: Service<ZerobusRequest, Response = ZerobusResponse, Error = crate::Error>,
+    S::Future: Send + 'static,
+{
+    type Response = ZerobusResponse;
+    type Error = crate::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: ZerobusRequest) -> Self::Future {
+        let fut = self.inner.call(req);
+        Box::pin(async move {
+            match fut.await {
+                Ok(resp) => Ok(resp),
+                Err(e) => {
+                    // The Tower stack boxes errors above us (retry, timeout,
+                    // adaptive-concurrency). Downcast to inspect retryability;
+                    // anything that isn't a `ZerobusSinkError` (e.g. a timeout
+                    // `Elapsed`) is conservatively treated as transient.
+                    let retryable = match e.downcast_ref::<ZerobusSinkError>() {
+                        Some(zb) => zb.is_retryable(),
+                        None => true,
+                    };
+                    if retryable {
+                        warn!(
+                            message = "Zerobus retry budget exhausted on transient error; signaling Errored so source or buffer may replay.",
+                            error = %e,
+                        );
+                        Ok(ZerobusResponse::errored())
+                    } else {
+                        Err(e)
+                    }
+                }
+            }
+        })
     }
 }
 
@@ -808,5 +908,103 @@ mod tests {
         );
         // And the slot was cleared so the next ingest creates a fresh stream.
         assert!(!service.has_active_stream().await);
+    }
+
+    fn dummy_request() -> ZerobusRequest {
+        ZerobusRequest {
+            events: Arc::new(vec![]),
+            metadata: RequestMetadata::default(),
+            finalizers: EventFinalizers::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn retryable_err_after_exhaustion_becomes_ok_errored() {
+        use tower::ServiceExt;
+        let inner = tower::service_fn(|_req: ZerobusRequest| async move {
+            let err: crate::Error = Box::new(ZerobusSinkError::SchemaError {
+                message: "UC 503".to_string(),
+                retryable: true,
+            });
+            Err::<ZerobusResponse, _>(err)
+        });
+        let mut svc = RetryableErrorAsErrored { inner };
+        let resp = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(dummy_request())
+            .await
+            .unwrap();
+        assert_eq!(resp.status, vector_lib::event::EventStatus::Errored);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_err_propagates() {
+        use tower::ServiceExt;
+        let inner = tower::service_fn(|_req: ZerobusRequest| async move {
+            let err: crate::Error = Box::new(ZerobusSinkError::EncodingError {
+                message: "bad".to_string(),
+            });
+            Err::<ZerobusResponse, _>(err)
+        });
+        let mut svc = RetryableErrorAsErrored { inner };
+        let err = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(dummy_request())
+            .await
+            .unwrap_err();
+        let zb = err.downcast_ref::<ZerobusSinkError>().unwrap();
+        assert!(matches!(zb, ZerobusSinkError::EncodingError { .. }));
+    }
+
+    #[tokio::test]
+    async fn unknown_err_treated_as_transient() {
+        use tower::ServiceExt;
+        // Simulate a Tower-layer error that isn't a ZerobusSinkError (e.g.
+        // timeout `Elapsed`): conservatively becomes Errored, not Rejected.
+        #[derive(Debug)]
+        struct Other;
+        impl std::fmt::Display for Other {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "other")
+            }
+        }
+        impl std::error::Error for Other {}
+
+        let inner = tower::service_fn(|_req: ZerobusRequest| async move {
+            let err: crate::Error = Box::new(Other);
+            Err::<ZerobusResponse, _>(err)
+        });
+        let mut svc = RetryableErrorAsErrored { inner };
+        let resp = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(dummy_request())
+            .await
+            .unwrap();
+        assert_eq!(resp.status, vector_lib::event::EventStatus::Errored);
+    }
+
+    #[tokio::test]
+    async fn ok_response_passes_through() {
+        use tower::ServiceExt;
+        let inner = tower::service_fn(|_req: ZerobusRequest| async move {
+            Ok::<_, crate::Error>(ZerobusResponse::delivered(
+                GroupedCountByteSize::new_untagged(),
+            ))
+        });
+        let mut svc = RetryableErrorAsErrored { inner };
+        let resp = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(dummy_request())
+            .await
+            .unwrap();
+        assert_eq!(resp.status, vector_lib::event::EventStatus::Delivered);
     }
 }

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -600,7 +600,11 @@ mod tests {
 
         let stream = current_stream(&service).await;
         let result = service
-            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
+            .ingest(
+                stream,
+                dummy_records(),
+                GroupedCountByteSize::new_untagged(),
+            )
             .await;
 
         assert!(result.is_ok());
@@ -620,7 +624,11 @@ mod tests {
 
         let stream = current_stream(&service).await;
         let err = service
-            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
+            .ingest(
+                stream,
+                dummy_records(),
+                GroupedCountByteSize::new_untagged(),
+            )
             .await
             .unwrap_err();
 
@@ -641,7 +649,11 @@ mod tests {
 
         let stream = current_stream(&service).await;
         let err = service
-            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
+            .ingest(
+                stream,
+                dummy_records(),
+                GroupedCountByteSize::new_untagged(),
+            )
             .await
             .unwrap_err();
 
@@ -663,7 +675,11 @@ mod tests {
         let stream = current_stream(&service).await;
         assert!(
             service
-                .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
+                .ingest(
+                    stream,
+                    dummy_records(),
+                    GroupedCountByteSize::new_untagged()
+                )
                 .await
                 .is_ok()
         );
@@ -682,7 +698,11 @@ mod tests {
         // Second ingest fails and clears the stream.
         let stream = current_stream(&service).await;
         let err = service
-            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
+            .ingest(
+                stream,
+                dummy_records(),
+                GroupedCountByteSize::new_untagged(),
+            )
             .await
             .unwrap_err();
         assert!(ZerobusRetryLogic.is_retriable_error(&err));
@@ -696,7 +716,11 @@ mod tests {
         let stream = current_stream(&service).await;
         assert!(
             service
-                .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
+                .ingest(
+                    stream,
+                    dummy_records(),
+                    GroupedCountByteSize::new_untagged()
+                )
                 .await
                 .is_ok()
         );
@@ -744,14 +768,22 @@ mod tests {
         let s1 = service.clone();
         let t1 = tokio::spawn(async move {
             let stream = current_stream(&s1).await;
-            s1.ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
-                .await
+            s1.ingest(
+                stream,
+                dummy_records(),
+                GroupedCountByteSize::new_untagged(),
+            )
+            .await
         });
         let s2 = service.clone();
         let t2 = tokio::spawn(async move {
             let stream = current_stream(&s2).await;
-            s2.ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
-                .await
+            s2.ingest(
+                stream,
+                dummy_records(),
+                GroupedCountByteSize::new_untagged(),
+            )
+            .await
         });
 
         // Wait until both ingests are inside the gate (both `Arc`s alive).

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -59,12 +59,13 @@ fn build_connector_factory(proxy: &ProxyConfig) -> Result<ConnectorFactory, Zero
 /// Request type for the Zerobus service.
 ///
 /// Carries the *unencoded* batch — encoding happens inside `Service::call` so
-/// that schema-fetch failures (which are needed to build the encoder) flow
-/// through the Tower retry layer. The Tower retry policy requires `Clone` so
-/// the request can be re-issued on retry.
+/// that schema-fetch failures flow through the Tower retry layer. Events live
+/// behind an `Arc` because Tower's retry policy clones the request before
+/// every call (not just on retry), and a deep clone of `Vec<Event>` per call
+/// would be wasteful.
 #[derive(Clone)]
 pub struct ZerobusRequest {
-    pub events: Vec<Event>,
+    pub events: Arc<Vec<Event>>,
     pub metadata: RequestMetadata,
     pub finalizers: EventFinalizers,
 }
@@ -333,7 +334,6 @@ impl ZerobusService {
             .await
     }
 
-    /// Encode a batch of events into protobuf records using a resolved schema.
     pub(super) fn encode_records(
         schema: &ResolvedSchema,
         events: &[Event],

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -589,7 +589,7 @@ mod tests {
     }
 
     async fn current_stream(service: &ZerobusService) -> Arc<ActiveStream> {
-        service.stream.lock().await.as_ref().unwrap().clone()
+        Arc::clone(service.stream.lock().await.as_ref().unwrap())
     }
 
     #[tokio::test]

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -1,13 +1,22 @@
 //! Zerobus service wrapper for Vector sink integration.
 
 use crate::config::ProxyConfig;
+use crate::event::Event;
+use crate::http::HttpClient;
+use crate::sinks::util::metadata::RequestMetadataBuilder;
 use crate::sinks::util::retries::RetryLogic;
+use crate::tls::TlsSettings;
 use databricks_zerobus_ingest_sdk::{ConnectorFactory, ProxyConnector, ZerobusSdk, ZerobusStream};
 use futures::future::BoxFuture;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OnceCell, RwLock};
 use tower::Service;
 use tracing::warn;
+use vector_lib::codecs::encoding::{
+    BatchEncoder, BatchOutput, BatchSerializerConfig, ProtoBatchSerializerConfig,
+};
+use vector_lib::event::EventStatus;
 use vector_lib::finalization::{EventFinalizers, Finalizable};
 use vector_lib::request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata};
 use vector_lib::stream::DriverResponse;
@@ -97,18 +106,6 @@ impl MetaDescriptive for ZerobusRequest {
     fn metadata_mut(&mut self) -> &mut RequestMetadata {
         &mut self.metadata
     }
-}
-
-/// Determines what kind of stream the service creates and how payloads are ingested.
-///
-/// The sink only supports proto streams today; this is kept as an enum to
-/// leave room for future stream modes without reshaping all the call sites.
-#[derive(Clone)]
-pub enum StreamMode {
-    /// Proto stream using `ZerobusStream::ingest_records_offset`.
-    Proto {
-        descriptor_proto: Arc<prost_reflect::prost_types::DescriptorProto>,
-    },
 }
 
 /// The active stream.
@@ -257,18 +254,24 @@ impl MockStream {
     }
 }
 
+/// Schema and encoding state derived from the Unity Catalog table.
+pub(super) struct ResolvedSchema {
+    encoder: BatchEncoder,
+    descriptor_proto: Arc<prost_reflect::prost_types::DescriptorProto>,
+}
+
 /// Service for handling Zerobus requests.
 pub struct ZerobusService {
     sdk: Arc<ZerobusSdk>,
     config: Arc<ZerobusSinkConfig>,
+    http_client: HttpClient,
     stream: Arc<Mutex<Option<Arc<ActiveStream>>>>,
-    stream_mode: StreamMode,
+    schema: Arc<OnceCell<ResolvedSchema>>,
 }
 
 impl ZerobusService {
     pub async fn new(
         config: ZerobusSinkConfig,
-        stream_mode: StreamMode,
         proxy: &ProxyConfig,
     ) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
@@ -279,18 +282,25 @@ impl ZerobusService {
             message: format!("Failed to create Zerobus SDK: {}", e),
         })?;
 
+        let http_client = HttpClient::new(TlsSettings::default(), proxy).map_err(|e| {
+            ZerobusSinkError::ConfigError {
+                message: format!("Failed to create HTTP client: {}", e),
+            }
+        })?;
+
         Ok(Self {
             sdk: Arc::new(sdk),
             config: Arc::new(config),
+            http_client,
             stream: Arc::new(Mutex::new(None)),
-            stream_mode,
+            schema: Arc::new(OnceCell::new()),
         })
     }
 
-    /// Resolve the protobuf message descriptor from the schema configuration.
-    pub async fn resolve_descriptor(
+    /// Resolve the protobuf message descriptor from Unity Catalog.
+    async fn resolve_descriptor(
         config: &ZerobusSinkConfig,
-        proxy: &crate::config::ProxyConfig,
+        http_client: &HttpClient,
     ) -> Result<prost_reflect::MessageDescriptor, ZerobusSinkError> {
         let (client_id, client_secret) = config.auth.credentials();
 
@@ -299,51 +309,118 @@ impl ZerobusService {
             &config.table_name,
             client_id,
             client_secret,
-            proxy,
+            http_client,
         )
         .await?;
 
         unity_catalog_schema::generate_descriptor_from_schema(&table_schema)
     }
 
+    /// Resolve the schema on first use; cache the result.
+    pub(super) async fn ensure_schema(&self) -> Result<&ResolvedSchema, ZerobusSinkError> {
+        self.schema
+            .get_or_try_init(|| async {
+                let descriptor = Self::resolve_descriptor(&self.config, &self.http_client).await?;
+                let descriptor_proto = Arc::new(descriptor.descriptor_proto().clone());
+
+                let batch_serializer =
+                    BatchSerializerConfig::ProtoBatch(ProtoBatchSerializerConfig {
+                        descriptor: Some(descriptor),
+                    })
+                    .build_batch_serializer()
+                    .map_err(|e| ZerobusSinkError::ConfigError {
+                        message: format!("Failed to build batch serializer: {}", e),
+                    })?;
+
+                Ok(ResolvedSchema {
+                    encoder: BatchEncoder::new(batch_serializer),
+                    descriptor_proto,
+                })
+            })
+            .await
+    }
+
+    /// Encode a batch of events into a `ZerobusRequest`.
+    ///
+    /// Pure: the schema is assumed to already be resolved. Encoding failures
+    /// mark the batch's finalizers as `Rejected` before returning.
+    pub(super) fn encode_batch(
+        schema: &ResolvedSchema,
+        mut events: Vec<Event>,
+    ) -> Result<ZerobusRequest, ZerobusSinkError> {
+        let finalizers = events.take_finalizers();
+        let metadata_builder = RequestMetadataBuilder::from_events(&events);
+
+        let batch_output = schema.encoder.encode_batch(&events).map_err(|e| {
+            finalizers.update_status(EventStatus::Rejected);
+            ZerobusSinkError::EncodingError {
+                message: format!("Failed to encode batch: {}", e),
+            }
+        })?;
+
+        let (payload, byte_size) = match batch_output {
+            BatchOutput::Records(records) => {
+                let size = records.iter().map(|r| r.len()).sum::<usize>();
+                (ZerobusPayload::Records(records), size)
+            }
+            #[cfg(feature = "codecs-arrow")]
+            BatchOutput::Arrow(_) => {
+                finalizers.update_status(EventStatus::Rejected);
+                return Err(ZerobusSinkError::EncodingError {
+                    message: "The Databricks Zerobus sink only supports proto-batch output."
+                        .into(),
+                });
+            }
+        };
+
+        let request_size = NonZeroUsize::new(byte_size).unwrap_or(NonZeroUsize::MIN);
+        let metadata = metadata_builder.with_request_size(request_size);
+
+        Ok(ZerobusRequest {
+            payload,
+            metadata,
+            finalizers,
+        })
+    }
+
     /// Ensure we have an active stream, creating one if necessary.
     ///
-    /// Also used as the healthcheck: eagerly creating a stream verifies
-    /// OAuth credentials, endpoint connectivity, and table validity.
+    /// Also used as the healthcheck: resolving the schema verifies the table
+    /// and credentials against Unity Catalog, and creating the stream verifies
+    /// connectivity to the Zerobus endpoint.
     pub async fn ensure_stream(&self) -> Result<(), ZerobusSinkError> {
-        self.get_or_create_stream().await.map(|_| ())
+        let schema = self.ensure_schema().await?;
+        self.get_or_create_stream(schema).await.map(|_| ())
     }
 
     /// Return an `Arc` handle to the active stream, creating one if needed.
     ///
     /// The lock is held only while checking/creating the stream; callers can
     /// then use the returned `Arc` without holding the lock.
-    async fn get_or_create_stream(&self) -> Result<Arc<ActiveStream>, ZerobusSinkError> {
+    async fn get_or_create_stream(
+        &self,
+        schema: &ResolvedSchema,
+    ) -> Result<Arc<ActiveStream>, ZerobusSinkError> {
         let mut stream_guard = self.stream.lock().await;
 
         if stream_guard.is_none() {
             let (client_id, client_secret) = self.config.auth.credentials();
             let (client_id, client_secret) = (client_id.to_string(), client_secret.to_string());
 
-            let active_stream = match &self.stream_mode {
-                StreamMode::Proto { descriptor_proto } => {
-                    let stream_options = &self.config.stream_options;
-                    let stream = self
-                        .sdk
-                        .stream_builder()
-                        .table(self.config.table_name.clone())
-                        .oauth(client_id, client_secret)
-                        .compiled_proto((**descriptor_proto).clone())
-                        .server_lack_of_ack_timeout_ms(stream_options.server_lack_of_ack_timeout_ms)
-                        .flush_timeout_ms(stream_options.flush_timeout_ms)
-                        .build()
-                        .await
-                        .map_err(|e| ZerobusSinkError::StreamInitError { source: e })?;
-                    ActiveStream::proto(stream)
-                }
-            };
+            let stream_options = &self.config.stream_options;
+            let stream = self
+                .sdk
+                .stream_builder()
+                .table(self.config.table_name.clone())
+                .oauth(client_id, client_secret)
+                .compiled_proto((*schema.descriptor_proto).clone())
+                .server_lack_of_ack_timeout_ms(stream_options.server_lack_of_ack_timeout_ms)
+                .flush_timeout_ms(stream_options.flush_timeout_ms)
+                .build()
+                .await
+                .map_err(|e| ZerobusSinkError::StreamInitError { source: e })?;
 
-            *stream_guard = Some(Arc::new(active_stream));
+            *stream_guard = Some(Arc::new(ActiveStream::proto(stream)));
         }
 
         Ok(Arc::clone(stream_guard.as_ref().unwrap()))
@@ -377,7 +454,8 @@ impl ZerobusService {
         payload: ZerobusPayload,
         events_byte_size: GroupedCountByteSize,
     ) -> Result<ZerobusResponse, ZerobusSinkError> {
-        let stream = self.get_or_create_stream().await?;
+        let schema = self.ensure_schema().await?;
+        let stream = self.get_or_create_stream(schema).await?;
 
         // Slot lock is not held here — concurrent ingests acquire read guards
         // on the inner `RwLock` and run truly in parallel.
@@ -450,8 +528,9 @@ impl Clone for ZerobusService {
         Self {
             sdk: Arc::clone(&self.sdk),
             config: Arc::clone(&self.config),
+            http_client: self.http_client.clone(),
             stream: Arc::clone(&self.stream),
-            stream_mode: self.stream_mode.clone(),
+            schema: Arc::clone(&self.schema),
         }
     }
 }
@@ -482,13 +561,17 @@ impl ZerobusService {
                 message: format!("Failed to create Zerobus SDK: {}", e),
             })?;
 
+        let http_client = HttpClient::new(TlsSettings::default(), &ProxyConfig::default())
+            .map_err(|e| ZerobusSinkError::ConfigError {
+                message: format!("Failed to create HTTP client: {}", e),
+            })?;
+
         Ok(Self {
             sdk: Arc::new(sdk),
             config: Arc::new(config),
+            http_client,
             stream: Arc::new(Mutex::new(Some(Arc::new(ActiveStream::Mock(mock))))),
-            stream_mode: StreamMode::Proto {
-                descriptor_proto: Arc::new(Default::default()),
-            },
+            schema: Arc::new(OnceCell::new()),
         })
     }
 

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -3,12 +3,10 @@
 use crate::config::ProxyConfig;
 use crate::event::Event;
 use crate::http::HttpClient;
-use crate::sinks::util::metadata::RequestMetadataBuilder;
 use crate::sinks::util::retries::RetryLogic;
 use crate::tls::TlsSettings;
 use databricks_zerobus_ingest_sdk::{ConnectorFactory, ProxyConnector, ZerobusSdk, ZerobusStream};
 use futures::future::BoxFuture;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell, RwLock};
 use tower::Service;
@@ -16,7 +14,6 @@ use tracing::warn;
 use vector_lib::codecs::encoding::{
     BatchEncoder, BatchOutput, BatchSerializerConfig, ProtoBatchSerializerConfig,
 };
-use vector_lib::event::EventStatus;
 use vector_lib::finalization::{EventFinalizers, Finalizable};
 use vector_lib::request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata};
 use vector_lib::stream::DriverResponse;
@@ -59,19 +56,15 @@ fn build_connector_factory(proxy: &ProxyConfig) -> Result<ConnectorFactory, Zero
     }))
 }
 
-/// The payload for a Zerobus request.
-///
-/// The zerobus sink only supports proto-encoded records.
-#[derive(Clone, Debug)]
-pub enum ZerobusPayload {
-    /// Pre-encoded protobuf records (one byte buffer per event).
-    Records(Vec<Vec<u8>>),
-}
-
 /// Request type for the Zerobus service.
-#[derive(Clone, Debug)]
+///
+/// Carries the *unencoded* batch — encoding happens inside `Service::call` so
+/// that schema-fetch failures (which are needed to build the encoder) flow
+/// through the Tower retry layer. The Tower retry policy requires `Clone` so
+/// the request can be re-issued on retry.
+#[derive(Clone)]
 pub struct ZerobusRequest {
-    pub payload: ZerobusPayload,
+    pub events: Vec<Event>,
     pub metadata: RequestMetadata,
     pub finalizers: EventFinalizers,
 }
@@ -340,47 +333,23 @@ impl ZerobusService {
             .await
     }
 
-    /// Encode a batch of events into a `ZerobusRequest`.
-    ///
-    /// Pure: the schema is assumed to already be resolved. Encoding failures
-    /// mark the batch's finalizers as `Rejected` before returning.
-    pub(super) fn encode_batch(
+    /// Encode a batch of events into protobuf records using a resolved schema.
+    pub(super) fn encode_records(
         schema: &ResolvedSchema,
-        mut events: Vec<Event>,
-    ) -> Result<ZerobusRequest, ZerobusSinkError> {
-        let finalizers = events.take_finalizers();
-        let metadata_builder = RequestMetadataBuilder::from_events(&events);
-
-        let batch_output = schema.encoder.encode_batch(&events).map_err(|e| {
-            finalizers.update_status(EventStatus::Rejected);
-            ZerobusSinkError::EncodingError {
+        events: &[Event],
+    ) -> Result<Vec<Vec<u8>>, ZerobusSinkError> {
+        match schema
+            .encoder
+            .encode_batch(events)
+            .map_err(|e| ZerobusSinkError::EncodingError {
                 message: format!("Failed to encode batch: {}", e),
-            }
-        })?;
-
-        let (payload, byte_size) = match batch_output {
-            BatchOutput::Records(records) => {
-                let size = records.iter().map(|r| r.len()).sum::<usize>();
-                (ZerobusPayload::Records(records), size)
-            }
+            })? {
+            BatchOutput::Records(records) => Ok(records),
             #[cfg(feature = "codecs-arrow")]
-            BatchOutput::Arrow(_) => {
-                finalizers.update_status(EventStatus::Rejected);
-                return Err(ZerobusSinkError::EncodingError {
-                    message: "The Databricks Zerobus sink only supports proto-batch output."
-                        .into(),
-                });
-            }
-        };
-
-        let request_size = NonZeroUsize::new(byte_size).unwrap_or(NonZeroUsize::MIN);
-        let metadata = metadata_builder.with_request_size(request_size);
-
-        Ok(ZerobusRequest {
-            payload,
-            metadata,
-            finalizers,
-        })
+            BatchOutput::Arrow(_) => Err(ZerobusSinkError::EncodingError {
+                message: "The Databricks Zerobus sink only supports proto-batch output.".into(),
+            }),
+        }
     }
 
     /// Ensure we have an active stream, creating one if necessary.
@@ -441,26 +410,20 @@ impl ZerobusService {
         }
     }
 
-    /// Ingest a payload (proto records or Arrow batch).
-    ///
-    /// Obtains an `Arc` handle to the stream (creating one if needed) and
-    /// then releases the lock before calling into the SDK so that concurrent
-    /// ingests are not serialized.
+    /// Send encoded records to an already-resolved stream.
     ///
     /// On retryable errors the active stream is removed from the slot so that
     /// the next attempt (driven by Tower retry) creates a fresh one.
-    pub async fn ingest(
+    async fn ingest(
         &self,
-        payload: ZerobusPayload,
+        stream: Arc<ActiveStream>,
+        records: Vec<Vec<u8>>,
         events_byte_size: GroupedCountByteSize,
     ) -> Result<ZerobusResponse, ZerobusSinkError> {
-        let schema = self.ensure_schema().await?;
-        let stream = self.get_or_create_stream(schema).await?;
-
         // Slot lock is not held here — concurrent ingests acquire read guards
         // on the inner `RwLock` and run truly in parallel.
-        let result = match (payload, stream.as_ref()) {
-            (ZerobusPayload::Records(records), ActiveStream::Proto(lock)) => {
+        let result = match stream.as_ref() {
+            ActiveStream::Proto(lock) => {
                 let guard = lock.read().await;
                 let Some(s) = guard.as_ref() else {
                     return Err(ZerobusSinkError::StreamClosed);
@@ -474,7 +437,7 @@ impl ZerobusService {
                 }
             }
             #[cfg(test)]
-            (ZerobusPayload::Records(_), ActiveStream::Mock(mock)) => mock.try_ingest().await,
+            ActiveStream::Mock(mock) => mock.try_ingest().await,
         };
 
         match result {
@@ -519,7 +482,12 @@ impl Service<ZerobusRequest> for ZerobusService {
         let events_byte_size =
             std::mem::take(request.metadata_mut()).into_events_estimated_json_encoded_byte_size();
 
-        Box::pin(async move { service.ingest(request.payload, events_byte_size).await })
+        Box::pin(async move {
+            let schema = service.ensure_schema().await?;
+            let records = Self::encode_records(schema, &request.events)?;
+            let stream = service.get_or_create_stream(schema).await?;
+            service.ingest(stream, records, events_byte_size).await
+        })
     }
 }
 
@@ -587,15 +555,7 @@ impl RetryLogic for ZerobusRetryLogic {
     type Response = ZerobusResponse;
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        match error {
-            ZerobusSinkError::ZerobusError { source }
-            | ZerobusSinkError::StreamInitError { source }
-            | ZerobusSinkError::IngestionError { source } => source.is_retryable(),
-            ZerobusSinkError::StreamClosed => true,
-            ZerobusSinkError::ConfigError { .. }
-            | ZerobusSinkError::EncodingError { .. }
-            | ZerobusSinkError::MissingAckOffset => false,
-        }
+        error.is_retryable()
     }
 }
 
@@ -624,8 +584,12 @@ mod tests {
         }
     }
 
-    fn dummy_payload() -> ZerobusPayload {
-        ZerobusPayload::Records(vec![vec![1, 2, 3]])
+    fn dummy_records() -> Vec<Vec<u8>> {
+        vec![vec![1, 2, 3]]
+    }
+
+    async fn current_stream(service: &ZerobusService) -> Arc<ActiveStream> {
+        service.stream.lock().await.as_ref().unwrap().clone()
     }
 
     #[tokio::test]
@@ -634,8 +598,9 @@ mod tests {
             .await
             .unwrap();
 
+        let stream = current_stream(&service).await;
         let result = service
-            .ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
             .await;
 
         assert!(result.is_ok());
@@ -653,8 +618,9 @@ mod tests {
 
         assert!(service.has_active_stream().await);
 
+        let stream = current_stream(&service).await;
         let err = service
-            .ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
             .await
             .unwrap_err();
 
@@ -673,8 +639,9 @@ mod tests {
 
         assert!(service.has_active_stream().await);
 
+        let stream = current_stream(&service).await;
         let err = service
-            .ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
             .await
             .unwrap_err();
 
@@ -693,9 +660,10 @@ mod tests {
             .unwrap();
 
         // First ingest succeeds.
+        let stream = current_stream(&service).await;
         assert!(
             service
-                .ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+                .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
                 .await
                 .is_ok()
         );
@@ -712,8 +680,9 @@ mod tests {
         }
 
         // Second ingest fails and clears the stream.
+        let stream = current_stream(&service).await;
         let err = service
-            .ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+            .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
             .await
             .unwrap_err();
         assert!(ZerobusRetryLogic.is_retriable_error(&err));
@@ -724,9 +693,10 @@ mod tests {
         *service.stream.lock().await = Some(Arc::new(ActiveStream::Mock(MockStream::succeeding())));
 
         // Third ingest succeeds on the new stream.
+        let stream = current_stream(&service).await;
         assert!(
             service
-                .ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+                .ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
                 .await
                 .is_ok()
         );
@@ -769,16 +739,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Spawn two concurrent ingests. Each will obtain its own `Arc` clone
-        // from `get_or_create_stream`, then block in the gate.
+        // Spawn two concurrent ingests. Each clones the same stream `Arc`,
+        // then blocks in the gate.
         let s1 = service.clone();
         let t1 = tokio::spawn(async move {
-            s1.ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+            let stream = current_stream(&s1).await;
+            s1.ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
                 .await
         });
         let s2 = service.clone();
         let t2 = tokio::spawn(async move {
-            s2.ingest(dummy_payload(), GroupedCountByteSize::new_untagged())
+            let stream = current_stream(&s2).await;
+            s2.ingest(stream, dummy_records(), GroupedCountByteSize::new_untagged())
                 .await
         });
 

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -1,27 +1,21 @@
 //! The main Zerobus sink implementation.
 
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-
 use futures::stream::BoxStream;
 
-use vector_lib::codecs::encoding::{BatchEncoder, BatchOutput};
 use vector_lib::event::EventStatus;
 use vector_lib::finalization::Finalizable;
 
 use crate::sinks::prelude::*;
-use crate::sinks::util::metadata::RequestMetadataBuilder;
 use crate::sinks::util::request_builder::default_request_builder_concurrency_limit;
 use crate::sinks::util::{RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings};
 
-use super::service::{ZerobusPayload, ZerobusRequest, ZerobusRetryLogic, ZerobusService};
+use super::service::{ZerobusRetryLogic, ZerobusService};
 
 /// The main Zerobus sink.
 pub struct ZerobusSink {
     service: ZerobusService,
     request_limits: TowerRequestSettings,
     batch_settings: BatcherSettings,
-    encoder: BatchEncoder,
 }
 
 impl ZerobusSink {
@@ -29,7 +23,6 @@ impl ZerobusSink {
         service: ZerobusService,
         request_limits: TowerRequestSettings,
         batch_config: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
-        encoder: BatchEncoder,
     ) -> Result<Self, crate::Error> {
         let batch_settings = batch_config.into_batcher_settings()?;
 
@@ -37,63 +30,29 @@ impl ZerobusSink {
             service,
             request_limits,
             batch_settings,
-            encoder,
-        })
-    }
-
-    fn encode_batch(
-        encoder: &BatchEncoder,
-        mut events: Vec<Event>,
-    ) -> Result<ZerobusRequest, String> {
-        let finalizers = events.take_finalizers();
-        let metadata_builder = RequestMetadataBuilder::from_events(&events);
-
-        let batch_output = match encoder.encode_batch(&events) {
-            Ok(output) => output,
-            Err(e) => {
-                finalizers.update_status(EventStatus::Rejected);
-                return Err(format!("Failed to encode batch: {}", e));
-            }
-        };
-
-        let (payload, byte_size) = match batch_output {
-            BatchOutput::Records(records) => {
-                let size = records.iter().map(|r| r.len()).sum::<usize>();
-                (ZerobusPayload::Records(records), size)
-            }
-            // The sink only builds a proto-batch encoder, so this arm is
-            // only reachable if the shared codec adds a new `BatchOutput`
-            // variant without a corresponding zerobus payload type.
-            #[cfg(feature = "codecs-arrow")]
-            BatchOutput::Arrow(_) => {
-                finalizers.update_status(EventStatus::Rejected);
-                return Err("The Databricks Zerobus sink only supports proto-batch output.".into());
-            }
-        };
-
-        let request_size = NonZeroUsize::new(byte_size).unwrap_or(NonZeroUsize::MIN);
-        let metadata = metadata_builder.with_request_size(request_size);
-
-        Ok(ZerobusRequest {
-            payload,
-            metadata,
-            finalizers,
         })
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let encoder = Arc::new(self.encoder.clone());
-
         let result = {
             let tower_service = ServiceBuilder::new()
                 .settings(self.request_limits, ZerobusRetryLogic)
                 .service(self.service.clone());
 
+            let encoding_service = self.service.clone();
             input
                 .batched(self.batch_settings.as_byte_size_config())
-                .concurrent_map(default_request_builder_concurrency_limit(), move |events| {
-                    let encoder = Arc::clone(&encoder);
-                    Box::pin(async move { Self::encode_batch(&encoder, events) })
+                .concurrent_map(default_request_builder_concurrency_limit(), move |mut events| {
+                    let service = encoding_service.clone();
+                    Box::pin(async move {
+                        match service.ensure_schema().await {
+                            Ok(schema) => ZerobusService::encode_batch(schema, events),
+                            Err(e) => {
+                                events.take_finalizers().update_status(EventStatus::Rejected);
+                                Err(e)
+                            }
+                        }
+                    })
                 })
                 .filter_map(|result| async move {
                     match result {

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -12,7 +12,9 @@ use crate::sinks::prelude::*;
 use crate::sinks::util::metadata::RequestMetadataBuilder;
 use crate::sinks::util::{RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings};
 
-use super::service::{ZerobusRequest, ZerobusRetryLogic, ZerobusService};
+use super::service::{
+    RetryableErrorAsErroredLayer, ZerobusRequest, ZerobusRetryLogic, ZerobusService,
+};
 
 /// The main Zerobus sink.
 pub struct ZerobusSink {
@@ -39,6 +41,7 @@ impl ZerobusSink {
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         let result = {
             let tower_service = ServiceBuilder::new()
+                .layer(RetryableErrorAsErroredLayer)
                 .settings(self.request_limits, ZerobusRetryLogic)
                 .service(self.service.clone());
 

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -45,8 +45,8 @@ impl ZerobusSink {
                 .batched(self.batch_settings.as_byte_size_config())
                 .map(|mut events| {
                     let finalizers = events.take_finalizers();
-                    let metadata =
-                        RequestMetadataBuilder::from_events(&events).with_request_size(NonZeroUsize::MIN);
+                    let metadata = RequestMetadataBuilder::from_events(&events)
+                        .with_request_size(NonZeroUsize::MIN);
                     ZerobusRequest {
                         events,
                         metadata,

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -1,15 +1,17 @@
 //! The main Zerobus sink implementation.
 
+use std::num::NonZeroUsize;
+
+use futures::StreamExt;
 use futures::stream::BoxStream;
 
-use vector_lib::event::EventStatus;
 use vector_lib::finalization::Finalizable;
 
 use crate::sinks::prelude::*;
-use crate::sinks::util::request_builder::default_request_builder_concurrency_limit;
+use crate::sinks::util::metadata::RequestMetadataBuilder;
 use crate::sinks::util::{RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings};
 
-use super::service::{ZerobusRetryLogic, ZerobusService};
+use super::service::{ZerobusRequest, ZerobusRetryLogic, ZerobusService};
 
 /// The main Zerobus sink.
 pub struct ZerobusSink {
@@ -39,28 +41,16 @@ impl ZerobusSink {
                 .settings(self.request_limits, ZerobusRetryLogic)
                 .service(self.service.clone());
 
-            let encoding_service = self.service.clone();
             input
                 .batched(self.batch_settings.as_byte_size_config())
-                .concurrent_map(default_request_builder_concurrency_limit(), move |mut events| {
-                    let service = encoding_service.clone();
-                    Box::pin(async move {
-                        match service.ensure_schema().await {
-                            Ok(schema) => ZerobusService::encode_batch(schema, events),
-                            Err(e) => {
-                                events.take_finalizers().update_status(EventStatus::Rejected);
-                                Err(e)
-                            }
-                        }
-                    })
-                })
-                .filter_map(|result| async move {
-                    match result {
-                        Err(error) => {
-                            emit!(SinkRequestBuildError { error });
-                            None
-                        }
-                        Ok(req) => Some(req),
+                .map(|mut events| {
+                    let finalizers = events.take_finalizers();
+                    let metadata =
+                        RequestMetadataBuilder::from_events(&events).with_request_size(NonZeroUsize::MIN);
+                    ZerobusRequest {
+                        events,
+                        metadata,
+                        finalizers,
                     }
                 })
                 .into_driver(tower_service)

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -1,6 +1,7 @@
 //! The main Zerobus sink implementation.
 
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use futures::StreamExt;
 use futures::stream::BoxStream;
@@ -45,10 +46,14 @@ impl ZerobusSink {
                 .batched(self.batch_settings.as_byte_size_config())
                 .map(|mut events| {
                     let finalizers = events.take_finalizers();
+                    // The encoded request size isn't known until `Service::call`
+                    // encodes the batch, and nothing in the zerobus path reads
+                    // `RequestMetadata::request_encoded_size`, so a placeholder
+                    // is fine here.
                     let metadata = RequestMetadataBuilder::from_events(&events)
                         .with_request_size(NonZeroUsize::MIN);
                     ZerobusRequest {
-                        events,
+                        events: Arc::new(events),
                         metadata,
                         finalizers,
                     }

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -20,7 +20,9 @@ use crate::http::HttpClient;
 ///
 /// 5xx, 408 (Request Timeout), and 429 (Too Many Requests) are transient;
 /// other 4xx statuses (404, 401, 403, ...) indicate permanent configuration
-/// problems that won't fix themselves on retry.
+/// problems that won't fix themselves on retry. The canonical list of
+/// retryable statuses for HTTP-based sinks lives at
+/// [`crate::sinks::util::http::RetryStrategy::Default`].
 fn status_is_retryable(status: StatusCode) -> bool {
     status.is_server_error()
         || status == StatusCode::REQUEST_TIMEOUT

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -46,8 +46,13 @@ pub async fn fetch_table_schema(
     client_secret: &str,
     http_client: &HttpClient,
 ) -> Result<UnityCatalogTableSchema, ZerobusSinkError> {
-    let token = get_oauth_token(http_client, unity_catalog_endpoint, client_id, client_secret)
-        .await?;
+    let token = get_oauth_token(
+        http_client,
+        unity_catalog_endpoint,
+        client_id,
+        client_secret,
+    )
+    .await?;
 
     // Fetch table schema.
     // Encode each segment of the fully-qualified table name (catalog.schema.table)

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -14,9 +14,7 @@ use prost_reflect::prost_types;
 use serde::Deserialize;
 
 use super::error::ZerobusSinkError;
-use crate::config::ProxyConfig;
 use crate::http::HttpClient;
-use crate::tls::TlsSettings;
 
 // Alias the SDK types under the names the rest of the sink already uses.
 #[cfg(test)]
@@ -35,22 +33,10 @@ pub async fn fetch_table_schema(
     table_name: &str,
     client_id: &str,
     client_secret: &str,
-    proxy: &ProxyConfig,
+    http_client: &HttpClient,
 ) -> Result<UnityCatalogTableSchema, ZerobusSinkError> {
-    let http_client = HttpClient::new(TlsSettings::default(), proxy).map_err(|e| {
-        ZerobusSinkError::ConfigError {
-            message: format!("Failed to create HTTP client: {}", e),
-        }
-    })?;
-
-    // First, get OAuth token
-    let token = get_oauth_token(
-        &http_client,
-        unity_catalog_endpoint,
-        client_id,
-        client_secret,
-    )
-    .await?;
+    let token = get_oauth_token(http_client, unity_catalog_endpoint, client_id, client_secret)
+        .await?;
 
     // Fetch table schema.
     // Encode each segment of the fully-qualified table name (catalog.schema.table)

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -18,15 +18,17 @@ use crate::http::HttpClient;
 
 /// Whether a Unity Catalog HTTP response status should be retried.
 ///
-/// 5xx, 408 (Request Timeout), and 429 (Too Many Requests) are transient;
-/// other 4xx statuses (404, 401, 403, ...) indicate permanent configuration
-/// problems that won't fix themselves on retry. The canonical list of
-/// retryable statuses for HTTP-based sinks lives at
-/// [`crate::sinks::util::http::RetryStrategy::Default`].
+/// Delegates to the canonical Vector HTTP retry policy
+/// [`crate::sinks::util::http::RetryStrategy::Default`] so this sink stays in
+/// lock-step with other HTTP-based sinks: 5xx (except 501 Not Implemented),
+/// 408 (Request Timeout), and 429 (Too Many Requests) are transient; 4xx
+/// otherwise (404, 401, 403, ...) and 501 are permanent.
 fn status_is_retryable(status: StatusCode) -> bool {
-    status.is_server_error()
-        || status == StatusCode::REQUEST_TIMEOUT
-        || status == StatusCode::TOO_MANY_REQUESTS
+    use crate::sinks::util::{http::RetryStrategy, retries::RetryAction};
+    matches!(
+        RetryStrategy::Default.retry_action::<()>(status),
+        RetryAction::Retry(_) | RetryAction::RetryPartial(_)
+    )
 }
 
 // Alias the SDK types under the names the rest of the sink already uses.
@@ -389,6 +391,24 @@ fn sanitize_package_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn status_is_retryable_matches_canonical_policy() {
+        // Transient — must retry.
+        assert!(status_is_retryable(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(status_is_retryable(StatusCode::BAD_GATEWAY));
+        assert!(status_is_retryable(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(status_is_retryable(StatusCode::GATEWAY_TIMEOUT));
+        assert!(status_is_retryable(StatusCode::REQUEST_TIMEOUT));
+        assert!(status_is_retryable(StatusCode::TOO_MANY_REQUESTS));
+        // Permanent — must not retry. 501 in particular: the server doesn't
+        // support the requested functionality; retry won't change that.
+        assert!(!status_is_retryable(StatusCode::NOT_IMPLEMENTED));
+        assert!(!status_is_retryable(StatusCode::NOT_FOUND));
+        assert!(!status_is_retryable(StatusCode::UNAUTHORIZED));
+        assert!(!status_is_retryable(StatusCode::FORBIDDEN));
+        assert!(!status_is_retryable(StatusCode::BAD_REQUEST));
+    }
 
     /// Smoke test: the wrapper calls into the SDK and builds a usable
     /// `MessageDescriptor` via the descriptor pool.

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -6,7 +6,7 @@
 
 use bytes::Buf;
 use databricks_zerobus_ingest_sdk::schema::descriptor_from_uc_schema;
-use http::{Request, Uri};
+use http::{Request, StatusCode, Uri};
 use http_body::Body as HttpBody;
 use hyper::Body;
 use percent_encoding::{NON_ALPHANUMERIC, percent_encode};
@@ -15,6 +15,17 @@ use serde::Deserialize;
 
 use super::error::ZerobusSinkError;
 use crate::http::HttpClient;
+
+/// Whether a Unity Catalog HTTP response status should be retried.
+///
+/// 5xx, 408 (Request Timeout), and 429 (Too Many Requests) are transient;
+/// other 4xx statuses (404, 401, 403, ...) indicate permanent configuration
+/// problems that won't fix themselves on retry.
+fn status_is_retryable(status: StatusCode) -> bool {
+    status.is_server_error()
+        || status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+}
 
 // Alias the SDK types under the names the rest of the sink already uses.
 #[cfg(test)]
@@ -68,8 +79,9 @@ pub async fn fetch_table_schema(
     let response = http_client
         .send(request)
         .await
-        .map_err(|e| ZerobusSinkError::ConfigError {
+        .map_err(|e| ZerobusSinkError::SchemaError {
             message: format!("Failed to fetch table schema: {}", e),
+            retryable: true,
         })?;
 
     let status = response.status();
@@ -81,11 +93,12 @@ pub async fn fetch_table_schema(
             .map(|c| c.to_bytes())
             .unwrap_or_default();
         let error_text = String::from_utf8_lossy(&body_bytes);
-        return Err(ZerobusSinkError::ConfigError {
+        return Err(ZerobusSinkError::SchemaError {
             message: format!(
                 "Unity Catalog API returned error {}: {}",
                 status, error_text
             ),
+            retryable: status_is_retryable(status),
         });
     }
 
@@ -94,8 +107,9 @@ pub async fn fetch_table_schema(
         .collect()
         .await
         .map(|c| c.to_bytes())
-        .map_err(|e| ZerobusSinkError::ConfigError {
+        .map_err(|e| ZerobusSinkError::SchemaError {
             message: format!("Failed to read response body: {}", e),
+            retryable: true,
         })?;
 
     let schema: UnityCatalogTableSchema =
@@ -143,8 +157,9 @@ async fn get_oauth_token(
     let response = http_client
         .send(request)
         .await
-        .map_err(|e| ZerobusSinkError::ConfigError {
+        .map_err(|e| ZerobusSinkError::SchemaError {
             message: format!("Failed to get OAuth token: {}", e),
+            retryable: true,
         })?;
 
     let status = response.status();
@@ -156,8 +171,9 @@ async fn get_oauth_token(
             .map(|c| c.to_bytes())
             .unwrap_or_default();
         let error_text = String::from_utf8_lossy(&body_bytes);
-        return Err(ZerobusSinkError::ConfigError {
+        return Err(ZerobusSinkError::SchemaError {
             message: format!("OAuth token request failed {}: {}", status, error_text),
+            retryable: status_is_retryable(status),
         });
     }
 
@@ -166,8 +182,9 @@ async fn get_oauth_token(
         .collect()
         .await
         .map(|c| c.to_bytes())
-        .map_err(|e| ZerobusSinkError::ConfigError {
+        .map_err(|e| ZerobusSinkError::SchemaError {
             message: format!("Failed to read OAuth response body: {}", e),
+            retryable: true,
         })?;
 
     let token_response: OAuthTokenResponse =


### PR DESCRIPTION

## Summary
`databricks_zerobus`'s `SinkConfig::build()` synchronously calls Unity Catalog to fetch the table's protobuf descriptor. If the table doesn't exist or credentials are wrong, the call fails inside build() and Vector exits before the sink even starts — even when `healthcheck.enabled` = false.

This aligns the sink with the convention used by AWS S3, Kafka, etc.: `build()` does only local setup, the healthcheck does the remote probe, and runtime failures surface per-batch via the existing retry/event-status path.

Changes:
- UC descriptor + encoder + stream-mode are resolved lazily via tokio::sync::OnceCell on first use (and re-attempted on each failure).
- Event encoding moves from ZerobusSink into ZerobusService::encode_batch, since the encoder now depends on the lazily-resolved descriptor.
- ZerobusService::new only builds the SDK client and the HTTP client (both local).
- ensure_stream (the healthcheck) is the natural gate: it triggers schema resolution + stream creation, and runs the same way on first ingest if the healthcheck is disabled.
- Replaced the eager-ProxyConfig-stash with an HttpClient built once in new, so fetch_table_schema takes &HttpClient and doesn't reconstruct it per retry.
- Added logic to decide whether schema fetch errors should be treated as retryable or not. If UC is transiently failing, we will try again during ingestion. Potentially this opens the door to dynamically re-fetch the schema as time goes on.


## Vector configuration

```
  sinks:
    zb:
      type: databricks_zerobus
      inputs: [demo]
      ingestion_endpoint: "https://ingest.dev.databricks.com"
      unity_catalog_endpoint: "https://workspace.cloud.databricks.com"
      table_name: "main.default.does_not_exist"
      auth:
        strategy: oauth
        client_id: "${DATABRICKS_CLIENT_ID}"
        client_secret: "${DATABRICKS_CLIENT_SECRET}"
      healthcheck:
        enabled: false
```

Before: Vector exits at startup with Unity Catalog API returned error 404: ....
After: Vector starts; batches are rejected at ingest time with the same error logged per batch.

## How did you test this PR?
- Manual smoke tests still to do:
- Non-existent table with default settings → sink starts, events rejected.
- Bad OAuth credentials → sink starts, events rejected.
- healthcheck.enabled = false with unreachable UC → sink starts.
- require_healthy = true → Vector exits (opt-in fail-fast preserved).


## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
