### PR TITLE
chore(dev): remove cargo vdev test --container runner

### DIFF
--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use clap::Args;
 use std::collections::BTreeMap;
 
-use crate::{testing::runner::get_agent_test_runner, utils::platform};
+use crate::{
+    testing::runner::{LocalTestRunner, TestRunner as _},
+    utils::platform,
+};
 
 /// Execute tests
 #[derive(Args, Debug)]
@@ -10,10 +13,6 @@ use crate::{testing::runner::get_agent_test_runner, utils::platform};
 pub struct Cli {
     /// Extra test command arguments
     args: Option<Vec<String>>,
-
-    /// Whether to run tests in a container
-    #[arg(short = 'C', long)]
-    container: bool,
 
     /// Environment variables in the form KEY[=VALUE]
     #[arg(short, long)]
@@ -34,8 +33,6 @@ fn parse_env(env: Vec<String>) -> BTreeMap<String, Option<String>> {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let runner = get_agent_test_runner(self.container)?;
-
         let mut args = vec!["--workspace".to_string()];
 
         if let Some(mut extra_args) = self.args {
@@ -47,7 +44,7 @@ impl Cli {
             args.extend(["--features".to_string(), features.to_string()]);
         }
 
-        runner.test(
+        LocalTestRunner.test(
             &parse_env(self.env.unwrap_or_default()),
             &BTreeMap::default(),
             None,

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::{collections::HashSet, env, process::Command};
+use std::{collections::HashSet, process::Command};
 
 use super::config::{IntegrationRunnerConfig, RustToolchainConfig};
 use crate::{
@@ -40,8 +40,6 @@ const COVERAGE_COMMAND: &[&str] = &[
 const COVERAGE_OUTPUT_DIR: &str = "/coverage";
 /// Coverage output path on the host (relative to project root).
 pub(crate) const LOCAL_COVERAGE_OUTPUT_DIR: &str = "target/coverage";
-// The upstream container we publish artifacts to on a successful master build.
-const UPSTREAM_IMAGE: &str = "docker.io/timberio/vector-dev:latest";
 
 pub enum RunnerState {
     Running,
@@ -52,14 +50,6 @@ pub enum RunnerState {
     Dead,
     Missing,
     Unknown,
-}
-
-pub fn get_agent_test_runner(container: bool) -> Result<Box<dyn TestRunner>> {
-    if container {
-        Ok(Box::new(DockerTestRunner))
-    } else {
-        Ok(Box::new(LocalTestRunner))
-    }
 }
 
 pub trait TestRunner {
@@ -407,30 +397,6 @@ impl ContainerTestRunner for IntegrationTestRunner {
 
     fn volumes(&self) -> Vec<String> {
         self.volumes.clone()
-    }
-}
-
-pub struct DockerTestRunner;
-
-impl ContainerTestRunner for DockerTestRunner {
-    fn network_name(&self) -> Option<&str> {
-        None
-    }
-
-    fn container_name(&self) -> String {
-        format!("vector-test-runner-{}", RustToolchainConfig::rust_version())
-    }
-
-    fn image_name(&self) -> String {
-        env::var("ENVIRONMENT_UPSTREAM").unwrap_or_else(|_| UPSTREAM_IMAGE.to_string())
-    }
-
-    fn needs_docker_socket(&self) -> bool {
-        false
-    }
-
-    fn volumes(&self) -> Vec<String> {
-        Vec::default()
     }
 }
 


### PR DESCRIPTION
## Summary

Removes the `--container` opt-in path from `cargo vdev test`, which ran unit tests inside the `timberio/vector-dev:latest` image. It duplicates the native `cargo vdev test` path, sees little use, and is a remaining consumer of the published dev environment image.

Integration tests (`cargo vdev int test ...`) are unaffected — they build their own runner image from `tests/e2e/Dockerfile`, independent of `timberio/vector-dev`.

This is the first of a small series of PRs to retire the `timberio/vector-dev` dev environment image. The next PR will switch `regression/Dockerfile` to a self-contained base, after which the publishing workflow and `make environment` machinery can be removed.

## Vector configuration

N/A — internal dev tooling change.

## How did you test this PR?

- `cargo check -p vdev`
- `cargo clippy -p vdev --all-targets`
- `cargo build -p vdev`

All clean. No external references to the removed flag/method anywhere in the repo (docs, scripts, workflows).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A