### PR TITLE
chore(ci): make regression/Dockerfile self-contained

### DIFF
--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -1,8 +1,36 @@
 #
 # VECTOR BUILDER
 #
-FROM docker.io/timberio/vector-dev:latest AS builder
+ARG RUST_VERSION=1
+FROM docker.io/rust:${RUST_VERSION}-slim-trixie AS builder
+
+# TODO: unify this apt list with tests/e2e/Dockerfile.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    cmake \
+    curl \
+    git \
+    libclang-dev \
+    libsasl2-dev \
+    libssl-dev \
+    libxxhash-dev \
+    perl \
+    pkg-config \
+    unzip \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy the whole scripts/environment/ tree so prepare.sh can source its sibling
+# scripts on older checkouts in regression baseline builds.
+COPY scripts/environment/ /scripts/environment/
+
 WORKDIR /vector
+COPY rust-toolchain.toml .
+
+RUN bash /scripts/environment/prepare.sh --modules=rustup
+RUN bash /scripts/environment/install-protoc.sh
+
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
## Summary

Switches the regression detector's builder stage from `timberio/vector-dev:latest` to `rust:1-slim-trixie` with inline apt + protoc setup, mirroring `tests/e2e/Dockerfile`.

This removes the SMP regression detector's dependency on the published dev environment image — second of three PRs to retire `timberio/vector-dev`. After this lands, only `make environment` itself still references the image; that machinery + the publishing workflow will go in the final PR.

Worth keeping in mind for follow-up work: a unified `install-build-deps.sh` (TODO comment in this PR) or any other new file under `scripts/environment/` has the same ~7-day baseline-compat window after it lands.

## Vector configuration

N/A — internal CI change.

## How did you test this PR?

- `/ci-run-regression` review trigger — both baseline and comparison Dockerfile builds succeeded and images uploaded to ECR. Submit-job step was canceled (no need to spend on SMP experiments just to validate the Dockerfile).
- Regression workflow's existing smoke test: `RUN ["/usr/bin/vector", "--version"]` in the target stage.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A

## Note on baselines and the cross-source-tree contract

The regression workflow uses the **PR-head Dockerfile** for both baseline and comparison builds (via `file: regression/Dockerfile` resolving to `GITHUB_WORKSPACE`). Each build gets its own source tree (baseline-vector/ vs comparison-vector/) but the Dockerfile is constant. This is intentional — it isolates source-code changes as the only variable, so SMP doesn't see spurious "regressions" caused by build-environment drift.

The tradeoff: anything the PR-head Dockerfile pulls out of `scripts/environment/` must be backward-compatible with source trees up to as old as the baseline (default: 7 days). When this PR was first opened the COPY of `prepare.sh` to `/` exposed exactly this — older baseline checkouts had a `prepare.sh` that sourced `release-flags.sh` from `${SCRIPT_DIR}` (removed in #24828). Fixed here by `COPY scripts/environment/ /scripts/environment/` (whole directory), which preserves sibling-script layout for both old and new shapes of `prepare.sh`.